### PR TITLE
fix(ai): close phase 5 assistant gateway gaps

### DIFF
--- a/apps/api/src/assistant/tools.service.spec.ts
+++ b/apps/api/src/assistant/tools.service.spec.ts
@@ -3,24 +3,27 @@ import { AssistantToolsService } from './tools.service';
 
 describe('AssistantToolsService', () => {
   const previousApiKeys = process.env.ASSISTANT_READONLY_API_KEYS;
+  const previousPermissions = process.env.ASSISTANT_TOOLS_ROLE_PERMISSIONS_JSON;
 
   beforeEach(() => {
     process.env.ASSISTANT_READONLY_API_KEYS = 'test-readonly-key';
+    delete process.env.ASSISTANT_TOOLS_ROLE_PERMISSIONS_JSON;
   });
 
   afterEach(() => {
     process.env.ASSISTANT_READONLY_API_KEYS = previousApiKeys;
+    process.env.ASSISTANT_TOOLS_ROLE_PERMISSIONS_JSON = previousPermissions;
   });
 
   const makeService = () => {
     const prisma = {
       membership: { findUnique: jest.fn() },
       building: { findMany: jest.fn() },
-      unit: { findMany: jest.fn(), findUniqueOrThrow: jest.fn() },
+      unit: { findMany: jest.fn(), findFirst: jest.fn(), findUniqueOrThrow: jest.fn() },
       charge: { findMany: jest.fn() },
       payment: { findMany: jest.fn() },
       ticket: { findMany: jest.fn() },
-      unitOccupant: { findMany: jest.fn() },
+      unitOccupant: { findMany: jest.fn(), findFirst: jest.fn() },
     } as any;
     const audit = { createLog: jest.fn() } as any;
     const service = new AssistantToolsService(prisma, audit);
@@ -78,6 +81,63 @@ describe('AssistantToolsService', () => {
     ).rejects.toBeInstanceOf(ForbiddenException);
   });
 
+  it('allows RESIDENT get_unit_balance only for self-scoped occupied unit', async () => {
+    const { service, prisma } = makeService();
+    prisma.membership.findUnique.mockResolvedValue({ roles: [{ role: 'RESIDENT' }] });
+    prisma.unitOccupant.findFirst.mockResolvedValue({ id: 'occ-1' });
+    prisma.unit.findFirst.mockResolvedValue({
+      id: 'u1',
+      code: '101',
+      label: 'Apt 101',
+      buildingId: 'b1',
+      building: { name: 'Torre A' },
+    });
+    prisma.unit.findUniqueOrThrow.mockResolvedValue({
+      id: 'u1',
+      code: '101',
+      label: 'Apt 101',
+      building: { name: 'Torre A' },
+    });
+    prisma.charge.findMany.mockResolvedValue([
+      { id: 'c1', amount: 50000, paymentAllocations: [] },
+    ]);
+
+    const result = await service.executeTool(
+      'get_unit_balance',
+      {
+        question: 'cuánto debo',
+        toolInput: { scope: 'self', unitId: 'u1', userId: 'resident-1' },
+        context: { tenantId: 'tenant-1', userId: 'resident-1', role: 'RESIDENT' },
+      },
+      { apiKey: 'test-readonly-key', tenantId: 'tenant-1', userId: 'resident-1', role: 'RESIDENT' },
+    );
+
+    expect(result.responseType).toBe('summary');
+    expect(result.metadata.unitId).toBe('u1');
+    expect(result.metadata.outstanding).toBe(50000);
+    expect(result.metadata.amount).toBe(50000);
+    expect(result.metadata.asOf).toEqual(expect.any(String));
+    expect(result.metadata.status).toBe('operativo');
+  });
+
+  it('denies RESIDENT get_unit_balance for a unit outside self scope', async () => {
+    const { service, prisma } = makeService();
+    prisma.membership.findUnique.mockResolvedValue({ roles: [{ role: 'RESIDENT' }] });
+    prisma.unitOccupant.findFirst.mockResolvedValue(null);
+
+    await expect(
+      service.executeTool(
+        'get_unit_balance',
+        {
+          question: 'cuánto debo',
+          toolInput: { scope: 'self', unitId: 'other-unit', userId: 'resident-1' },
+          context: { tenantId: 'tenant-1', userId: 'resident-1', role: 'RESIDENT' },
+        },
+        { apiKey: 'test-readonly-key', tenantId: 'tenant-1', userId: 'resident-1', role: 'RESIDENT' },
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
   it('asks for building when multi-building unit resolution is ambiguous', async () => {
     const { service, prisma } = makeService();
     prisma.membership.findUnique.mockResolvedValue({
@@ -109,5 +169,47 @@ describe('AssistantToolsService', () => {
     expect(result.responseType).toBe('clarification');
     expect(result.answer).toContain('indiques el edificio');
     expect(result.metadata.needsBuilding).toBe(true);
+  });
+
+  it('search_payments mode=last_payment returns latest building payment metadata', async () => {
+    const { service, prisma } = makeService();
+    prisma.membership.findUnique.mockResolvedValue({ roles: [{ role: 'TENANT_ADMIN' }] });
+    prisma.payment.findMany.mockResolvedValue([
+      {
+        id: 'p1',
+        amount: 152526,
+        currency: 'ARS',
+        status: 'APPROVED',
+        paidAt: new Date('2024-05-01T03:00:00.000Z'),
+        createdAt: new Date('2024-05-01T03:00:00.000Z'),
+        unit: { label: '101', code: '101', building: { name: 'Torre A' } },
+        building: { name: 'Torre A' },
+      },
+    ]);
+
+    const result = await service.executeTool(
+      'search_payments',
+      {
+        question: 'ultimo pago recibido global del edificio',
+        toolInput: { mode: 'last_payment', buildingId: 'b1', ranking: 1 },
+        context: { tenantId: 'tenant-1', userId: 'user-1', role: 'TENANT_ADMIN' },
+      },
+      { apiKey: 'test-readonly-key', tenantId: 'tenant-1', userId: 'user-1', role: 'TENANT_ADMIN' },
+    );
+
+    expect(prisma.payment.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          tenantId: 'tenant-1',
+          buildingId: 'b1',
+        }),
+        take: 1,
+      }),
+    );
+    expect(result.responseType).toBe('summary');
+    expect(result.metadata.lastPaymentAmount).toBe(152526);
+    expect(result.metadata.lastPaymentDate).toBe('2024-05-01');
+    expect(result.metadata.towerName).toBe('Torre A');
+    expect(result.metadata.status).toBe('APPROVED');
   });
 });

--- a/apps/api/src/assistant/tools.service.ts
+++ b/apps/api/src/assistant/tools.service.ts
@@ -45,7 +45,7 @@ export class AssistantToolsService {
     const startedAt = Date.now();
     this.assertApiKey(headers.apiKey);
     const context = this.normalizeAndValidateContext(request.context, headers);
-    await this.assertMembershipAndPermissions(context.tenantId, context.userId, context.role, toolName);
+    await this.assertMembershipAndPermissions(context.tenantId, context.userId, context.role, toolName, request.toolInput);
 
     let response: AssistantToolResponse;
     switch (toolName) {
@@ -92,6 +92,40 @@ export class AssistantToolsService {
     input?: Record<string, unknown>,
   ): Promise<AssistantToolResponse> {
     const ranking = this.pickRanking(input);
+    const directUnitId = this.pickString(input, 'unitId');
+    if (directUnitId) {
+      const unit = await this.prisma.unit.findFirst({
+        where: {
+          id: directUnitId,
+          building: { tenantId },
+        },
+        select: {
+          id: true,
+          code: true,
+          label: true,
+          buildingId: true,
+          building: { select: { name: true } },
+        },
+      });
+
+      if (!unit) {
+        return this.buildResponse('No encontré unidad para esa referencia.', 'clarification', {
+          noUnitMatch: true,
+        });
+      }
+
+      return this.buildResponse(
+        `Unidad resuelta: ${unit.building?.name ?? 'N/A'} ${unit.label ?? unit.code}.`,
+        'summary',
+        {
+          buildingId: unit.buildingId,
+          unitId: unit.id,
+          unitCode: unit.code,
+          ranking,
+        },
+      );
+    }
+
     const buildingFilter = this.pickString(input, 'buildingName') ?? this.extractTowerToken(question ?? '');
     const unitFilter =
       this.pickString(input, 'unitRef') ??
@@ -227,6 +261,11 @@ export class AssistantToolsService {
       unitId,
       debtStatus,
       outstanding,
+      amount: outstanding,
+      overdueAmount: outstanding,
+      currency: 'ARS',
+      asOf: now.toISOString().slice(0, 10),
+      status: 'operativo',
     });
   }
 
@@ -284,6 +323,54 @@ export class AssistantToolsService {
   ): Promise<AssistantToolResponse> {
     const ranking = this.pickRanking(input);
     const mode = (this.pickString(input, 'mode') ?? '').toLowerCase();
+
+    if (mode === 'last_payment') {
+      const buildingId = this.pickString(input, 'buildingId');
+      const rows = await this.prisma.payment.findMany({
+        where: {
+          tenantId,
+          ...(buildingId ? { buildingId } : {}),
+          status: { in: [PaymentStatus.APPROVED, PaymentStatus.RECONCILED] },
+          canceledAt: null,
+        },
+        include: {
+          unit: { select: { label: true, code: true, building: { select: { name: true } } } },
+          building: { select: { name: true } },
+        },
+        orderBy: [{ paidAt: 'desc' }, { createdAt: 'desc' }],
+        take: 1,
+      });
+
+      const lastPayment = rows[0];
+      if (!lastPayment) {
+        return this.buildResponse('No hay pagos aprobados para ese edificio.', 'no_data', {
+          mode,
+          ranking: 1,
+          buildingId,
+          count: 0,
+        });
+      }
+
+      const paymentDate = lastPayment.paidAt ?? lastPayment.createdAt;
+      const paymentDateIso = paymentDate.toISOString().slice(0, 10);
+      const towerName = lastPayment.building?.name ?? lastPayment.unit?.building?.name ?? 'N/A';
+
+      return this.buildResponse(
+        `Último pago recibido: ${this.formatMoney(lastPayment.amount)} el ${paymentDateIso} (${towerName}, estado ${String(lastPayment.status).toLowerCase()}).`,
+        'summary',
+        {
+          mode,
+          ranking: 1,
+          buildingId,
+          count: 1,
+          lastPaymentAmount: lastPayment.amount,
+          lastPaymentDate: paymentDateIso,
+          towerName,
+          status: lastPayment.status,
+          currency: lastPayment.currency,
+        },
+      );
+    }
 
     if (mode === 'overdue_units') {
       const now = new Date();
@@ -399,6 +486,7 @@ export class AssistantToolsService {
     userId: string,
     role: string,
     toolName: AssistantToolName,
+    toolInput?: Record<string, unknown>,
   ): Promise<void> {
     const membership = await this.prisma.membership.findUnique({
       where: { userId_tenantId: { userId, tenantId } },
@@ -413,11 +501,49 @@ export class AssistantToolsService {
       throw new ForbiddenException('Role does not match tenant membership');
     }
 
+    if (role === 'RESIDENT' && toolName === 'get_unit_balance') {
+      await this.assertResidentUnitSelfScope(tenantId, userId, toolInput);
+      return;
+    }
+
     const rolePermissions = this.getRolePermissionPolicy();
     const rolePerms = rolePermissions[role] ?? [];
     const requiredPermission = TOOL_PERMISSION[toolName];
     if (!rolePerms.includes(requiredPermission)) {
       throw new ForbiddenException(`Role not allowed for tool ${toolName}`);
+    }
+  }
+
+  private async assertResidentUnitSelfScope(
+    tenantId: string,
+    userId: string,
+    toolInput?: Record<string, unknown>,
+  ): Promise<void> {
+    const requestedUserId = this.pickString(toolInput, 'userId');
+    if (requestedUserId && requestedUserId !== userId) {
+      throw new ForbiddenException('Resident self-scope user mismatch');
+    }
+
+    const unitId = this.pickString(toolInput, 'unitId');
+    if (!unitId) {
+      throw new ForbiddenException('Resident self-scope unit is required');
+    }
+
+    const activeOccupancy = await this.prisma.unitOccupant.findFirst({
+      where: {
+        tenantId,
+        unitId,
+        endDate: null,
+        member: {
+          userId,
+          disabledAt: null,
+        },
+      },
+      select: { id: true },
+    });
+
+    if (!activeOccupancy) {
+      throw new ForbiddenException('Resident is not allowed for requested unit');
     }
   }
 


### PR DESCRIPTION
Closes #2

## Type
- [x] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary
- Closes the remaining Phase 5 MVP gateway gaps in BuildingOS without changing the AI stable contract.
- Adds ADMIN building-level payment history support through the existing `search_payments` gateway using `mode=last_payment`.
- Preserves RESIDENT strict self-scope by deriving canonical user/unit metadata before invoking local gateway logic.
- Adds focused tests for the local gateway coverage.

## Scope
| File | Purpose |
|------|---------|
| `apps/api/src/assistant/tools.service.ts` | Gateway/routing fixes for payment history, resident self-scope, and canonical metadata. |
| `apps/api/src/assistant/tools.service.spec.ts` | Focused regression coverage for the Phase 5 gateway gaps. |

## Explicitly unchanged
- No yoryi-ai-core changes.
- No stable contract expansion.
- No `resolvedPath` contract change.
- No UI/chat behavior rewrite.
- No DB/migration changes in this PR.
- No HITL bypass.
- No Sprint 2 scope.

## Test Plan
- [x] `npm run lint:ci`
- [x] `npm run test:ci`
- [x] No local build run, per repo instruction.
- [x] No `prisma migrate reset` or `--force-reset` used.

## Notes
- CI baseline fixes were separated and merged through PR #6.
- This PR is now intentionally clean: only assistant gateway/service coverage remains.

## Contributor Checklist
- [x] Linked an approved issue.
- [x] Added exactly one `type:*` label.
- [x] Ran relevant non-build verification.
- [x] Conventional commit format.
- [x] No `Co-Authored-By` trailers.
