### PR TITLE
feat(api): canonical finance read-only assistant

### DIFF
--- a/apps/api/src/assistant/assistant.service.spec.ts
+++ b/apps/api/src/assistant/assistant.service.spec.ts
@@ -2463,6 +2463,41 @@ describe('AssistantService - Strict Operational Questions', () => {
 
       expect(result).toBeNull();
     });
+
+    it('resuelve deuda global del condominio como tenant debt', async () => {
+      mockQueryExecutors.execute.mockResolvedValue({
+        answer: 'La administración tiene una deuda pendiente total de ARS 10.270,15.',
+        suggestedActions: [{ type: 'VIEW_PAYMENTS', payload: {} }],
+      });
+
+      const result = await (service as any).tryResolveStrictOperationalQuestion(
+        'tenant-1',
+        'deuda condominio',
+        ADMIN_ROLES,
+        'admin-user',
+      );
+
+      expect(result).not.toBeNull();
+      expect(result.answer).toContain('administración');
+      expect(mockQueryExecutors.execute).toHaveBeenCalledWith(expect.objectContaining({
+        tenantId: 'tenant-1',
+        userId: 'admin-user',
+        userRoles: ADMIN_ROLES,
+        plan: expect.objectContaining({ executor: 'tenant_debt' }),
+      }));
+    });
+
+    it('asks for clarification when debt scope is ambiguous', async () => {
+      const result = await (service as any).tryResolveStrictOperationalQuestion(
+        'tenant-1',
+        'deuda',
+        ADMIN_ROLES,
+        'admin-user',
+      );
+
+      expect(result).not.toBeNull();
+      expect(result.answer).toContain('unidad, un edificio o a la administración');
+    });
   });
 
   // ============================================================

--- a/apps/api/src/assistant/assistant.service.ts
+++ b/apps/api/src/assistant/assistant.service.ts
@@ -15,6 +15,7 @@ import type { Permission } from '../rbac/permissions';
 import { AssistantQueryPlanService } from './query-plan.service';
 import { AssistantQueryExecutorsService } from './query-executors.service';
 import { AssistantDebtCalculatorService } from './assistant-debt-calculator.service';
+import { AssistantDebtIntentInterpreter } from './debt-intent-interpreter';
 import {
   SuggestedActionType,
   SuggestedAction,
@@ -200,6 +201,7 @@ export class AssistantService implements OnModuleInit {
   private readonly _queryPlanner: QueryPlannerService;
   private readonly _queryExecutor: QueryExecutorService;
   private readonly _responseFormatter: ResponseFormatterService;
+  private readonly debtIntentInterpreter = new AssistantDebtIntentInterpreter();
 
   constructor(
     private readonly prisma: PrismaService,
@@ -1624,6 +1626,22 @@ export class AssistantService implements OnModuleInit {
     userRoles: string[],
     userId?: string,
   ): Promise<ChatResponse | null> {
+    const debtInterpretation = this.debtIntentInterpreter.interpret(message);
+
+    if (debtInterpretation.scope === 'tenant') {
+      const response = await this.tryResolveStrictTenantDebtQuestion(tenantId, userRoles, userId);
+      if (response) {
+        return response;
+      }
+    }
+
+    if (debtInterpretation.scope === 'ambiguous') {
+      return {
+        answer: '¿Te referís a una unidad, un edificio o a la administración?',
+        suggestedActions: [{ type: 'VIEW_REPORTS', payload: {} }],
+      };
+    }
+
     // Building-level queries first (when no unit is specified)
     const buildingChecks = [
       this.tryResolveStrictBuildingDebtQuestion(tenantId, message, userRoles, userId),
@@ -2356,6 +2374,34 @@ export class AssistantService implements OnModuleInit {
       answer: `El edificio ${building.name} no tiene deuda pendiente. Todas las unidades están al día.`,
       suggestedActions: [{ type: 'VIEW_PAYMENTS', payload: { buildingId: building.id } }],
     };
+  }
+
+  private async tryResolveStrictTenantDebtQuestion(
+    tenantId: string,
+    userRoles: string[],
+    userId?: string,
+  ): Promise<ChatResponse | null> {
+    if (!this.canAccessOperationalData(userRoles)) {
+      return null;
+    }
+
+    const response = await this.queryExecutors.execute({
+      tenantId,
+      userId: userId ?? '',
+      userRoles,
+      plan: {
+        intent: 'tenant_debt',
+        module: 'payments',
+        scope: 'tenant',
+        requiredPermission: 'payments.review',
+        executor: 'tenant_debt',
+        filters: {},
+        confidence: 0.9,
+        source: 'deterministic_rules',
+      },
+    });
+
+    return response;
   }
 
   private async tryResolveStrictBuildingTicketsQuestion(

--- a/apps/api/src/assistant/debt-intent-interpreter.ts
+++ b/apps/api/src/assistant/debt-intent-interpreter.ts
@@ -1,0 +1,159 @@
+import { AssistantQueryParser, type UnitToken } from './query-parser/assistant-query-parser';
+
+export type AssistantDebtScope = 'none' | 'ambiguous' | 'unit' | 'building' | 'tenant';
+
+export interface AssistantDebtInterpretation {
+  readonly scope: AssistantDebtScope;
+  readonly hasDebtSignal: boolean;
+  readonly hasGlobalSignal: boolean;
+  readonly hasUnitSignal: boolean;
+  readonly hasBuildingSignal: boolean;
+  readonly normalized: string;
+  readonly buildingToken?: string | null;
+  readonly unitToken?: UnitToken | null;
+  readonly reason: 'not_debt' | 'debt_without_scope' | 'unit_reference' | 'building_reference' | 'global_scope';
+}
+
+export class AssistantDebtIntentInterpreter {
+  private readonly parser = new AssistantQueryParser();
+
+  interpret(message: string): AssistantDebtInterpretation {
+    const normalized = this.normalize(message);
+    const unitToken = this.parser.parseUnitReference(message);
+    const buildingToken = this.parser.extractBuildingToken(message);
+    const genericBuildingToken = buildingToken ? this.isGenericBuildingToken(buildingToken) : false;
+
+    const hasDebtSignal = this.hasAnyWord(normalized, [
+      'deuda',
+      'deudas',
+      'debe',
+      'deben',
+      'adeuda',
+      'adeudan',
+      'saldo',
+      'saldos',
+      'morosidad',
+      'moroso',
+      'morosos',
+      'pendiente',
+      'pendientes',
+      'cobrar',
+      'cobro',
+    ]);
+
+    if (!hasDebtSignal) {
+      return {
+        scope: 'none',
+        hasDebtSignal: false,
+        hasGlobalSignal: false,
+        hasUnitSignal: false,
+        hasBuildingSignal: false,
+        normalized,
+        buildingToken,
+        unitToken,
+        reason: 'not_debt',
+      };
+    }
+
+    if (unitToken?.unitCode) {
+      return {
+        scope: 'unit',
+        hasDebtSignal: true,
+        hasGlobalSignal: false,
+        hasUnitSignal: true,
+        hasBuildingSignal: Boolean(buildingToken),
+        normalized,
+        buildingToken,
+        unitToken,
+        reason: 'unit_reference',
+      };
+    }
+
+    if (buildingToken && !genericBuildingToken) {
+      return {
+        scope: 'building',
+        hasDebtSignal: true,
+        hasGlobalSignal: false,
+        hasUnitSignal: false,
+        hasBuildingSignal: true,
+        normalized,
+        buildingToken,
+        unitToken,
+        reason: 'building_reference',
+      };
+    }
+
+    const hasGlobalSignal = genericBuildingToken || this.hasGlobalScope(normalized);
+    if (hasGlobalSignal) {
+      return {
+        scope: 'tenant',
+        hasDebtSignal: true,
+        hasGlobalSignal: true,
+        hasUnitSignal: false,
+        hasBuildingSignal: false,
+        normalized,
+        buildingToken,
+        unitToken,
+        reason: 'global_scope',
+      };
+    }
+
+    return {
+      scope: 'ambiguous',
+      hasDebtSignal: true,
+      hasGlobalSignal: false,
+      hasUnitSignal: false,
+      hasBuildingSignal: false,
+      normalized,
+      buildingToken,
+      unitToken,
+      reason: 'debt_without_scope',
+    };
+  }
+
+  private normalize(value: string): string {
+    return (value || '')
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  private hasGlobalScope(normalized: string): boolean {
+    if (this.hasAnyWord(normalized, [
+      'todo',
+      'todos',
+      'global',
+      'general',
+      'total',
+      'administracion',
+      'administradora',
+      'condominio',
+      'consorcio',
+      'comunidad',
+    ])) {
+      return true;
+    }
+
+    return (
+      normalized.includes('todos los edificios') ||
+      normalized.includes('todos los inmuebles') ||
+      normalized.includes('todos los departamentos') ||
+      normalized.includes('todos los apartamentos') ||
+      normalized.includes('de todo')
+    );
+  }
+
+  private isGenericBuildingToken(token: string): boolean {
+    return this.hasAnyWord(token, ['completo', 'general', 'global', 'total', 'todos', 'administracion', 'administradora']);
+  }
+
+  private hasAnyWord(normalized: string, words: string[]): boolean {
+    return words.some((word) => {
+      const escaped = word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      return new RegExp(`\\b${escaped}\\b`).test(normalized);
+    });
+  }
+}

--- a/apps/api/src/assistant/debt-intent-interpreter.ts
+++ b/apps/api/src/assistant/debt-intent-interpreter.ts
@@ -37,8 +37,6 @@ export class AssistantDebtIntentInterpreter {
       'morosos',
       'pendiente',
       'pendientes',
-      'cobrar',
-      'cobro',
     ]);
 
     if (!hasDebtSignal) {

--- a/apps/api/src/assistant/intent-engine/intent-extractor.service.ts
+++ b/apps/api/src/assistant/intent-engine/intent-extractor.service.ts
@@ -424,6 +424,10 @@ Intenciones disponibles:
 - unit_payments: listar pagos de una unidad
 - building_debt: consultar deuda total de un edificio
 - tenant_debt: consultar deuda total de la administracion
+- tenant_debt tambien aplica a frases globales como: deuda administracion, deuda condominio, deuda de todo, morosidad global, saldo general, cuanto deben todos
+- Si hay una unidad explicita, prioriza unit_debt.
+- Si hay un edificio explicito, prioriza building_debt.
+- Si la frase es ambigua, responde con confianza baja y no inventes el scope.
 - building_delinquents: listar morosos de un edificio
 - building_documents: listar documentos de un edificio
 - building_tickets: buscar tickets de un edificio

--- a/apps/api/src/assistant/intent-semantic-validator.service.spec.ts
+++ b/apps/api/src/assistant/intent-semantic-validator.service.spec.ts
@@ -83,7 +83,60 @@ describe('IntentSemanticValidatorService', () => {
 
     expect(result).toEqual({
       status: 'accepted',
-      reason: 'non_building_debt',
+      reason: 'global_debt_scope',
+    });
+  });
+
+  it('overrides building debt to tenant debt for global debt wording', async () => {
+    const result = await service.evaluate({
+      userText: 'deuda condominio',
+      deterministicPlan: {
+        intent: 'building_debt',
+        module: 'payments',
+        scope: 'building',
+        requiredPermission: 'payments.review',
+        executor: 'building_debt',
+        filters: {},
+        confidence: 0.9,
+        source: 'deterministic_rules',
+      },
+      extractedIntent: {
+        intent: 'building_debt',
+        entity: { type: 'building' },
+        filters: {},
+        confidence: 0.9,
+        source: 'deterministic',
+        llmProvider: 'none',
+        requiresClarification: false,
+        missingFields: [],
+      },
+      assistantContext: {},
+    });
+
+    expect(result).toEqual({
+      status: 'override_suggested',
+      reason: 'global_debt_scope',
+      intentOverride: 'tenant_debt',
+      entityOverride: {
+        type: 'building',
+        buildingAlias: undefined,
+        unitCode: undefined,
+      },
+    });
+  });
+
+  it('asks for scope clarification when the debt question is ambiguous', async () => {
+    const result = await service.evaluate({
+      userText: 'deuda',
+      deterministicPlan: buildPlan(),
+      extractedIntent: buildExtractedIntent(),
+      assistantContext: {},
+    });
+
+    expect(result).toEqual({
+      status: 'needs_clarification',
+      reason: 'debt_scope_ambiguous',
+      question: '¿Te referís a una unidad, un edificio o a la administración?',
     });
   });
 

--- a/apps/api/src/assistant/intent-semantic-validator.service.ts
+++ b/apps/api/src/assistant/intent-semantic-validator.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { z } from 'zod';
+import { AssistantDebtIntentInterpreter } from './debt-intent-interpreter';
 import type { ExtractedIntent } from './intent-engine/intent.types';
 import type { AssistantQueryIntent, AssistantQueryPlan } from './query-plan.types';
 
@@ -64,6 +65,7 @@ const semanticGeminiSchema = z.object({
 export class IntentSemanticValidatorService {
   private readonly logger = new Logger(IntentSemanticValidatorService.name);
   private readonly geminiBaseUrl = 'https://generativelanguage.googleapis.com/v1beta';
+  private readonly debtInterpreter = new AssistantDebtIntentInterpreter();
 
   async evaluate(input: IntentSemanticValidationInput): Promise<IntentSemanticValidationResult> {
     const normalized = this.normalize(input.userText);
@@ -73,6 +75,7 @@ export class IntentSemanticValidatorService {
       input.deterministicPlan?.filters.buildingAlias ??
       input.deterministicPlan?.filters.buildingToken;
     const period = input.extractedIntent.filters.period ?? input.deterministicPlan?.filters.period;
+    const debtInterpretation = this.debtInterpreter.interpret(input.userText);
     const isBuildingDebt = input.extractedIntent.intent === 'building_debt';
     const wantsAccumulatedDebt = /\b(acumulad[ao]s?|historic[ao]s?|hist[oó]rica|hist[oó]rico)\b/.test(normalized);
     const hasTemporalSignals = this.detectTemporalSignals(normalized);
@@ -94,6 +97,44 @@ export class IntentSemanticValidatorService {
           filterOverrides: period ? { period } : undefined,
         };
       }
+    }
+
+    if (debtInterpretation.scope === 'tenant') {
+      if (input.extractedIntent.intent !== 'tenant_debt') {
+        return {
+          status: 'override_suggested',
+          reason: 'global_debt_scope',
+          intentOverride: 'tenant_debt',
+          entityOverride: { type: 'building', buildingAlias: undefined, unitCode: undefined },
+        };
+      }
+
+      return { status: 'accepted', reason: 'global_debt_scope' };
+    }
+
+    if (debtInterpretation.scope === 'unit') {
+      if (input.extractedIntent.intent !== 'unit_debt') {
+        return {
+          status: 'override_suggested',
+          reason: 'unit_debt_scope',
+          intentOverride: 'unit_debt',
+          entityOverride: {
+            type: 'unit',
+            buildingAlias: debtInterpretation.buildingToken ?? explicitBuildingAlias,
+            unitCode: debtInterpretation.unitToken?.unitCode,
+          },
+        };
+      }
+
+      return { status: 'accepted', reason: 'unit_debt_scope' };
+    }
+
+    if (debtInterpretation.scope === 'ambiguous') {
+      return {
+        status: 'needs_clarification',
+        reason: 'debt_scope_ambiguous',
+        question: '¿Te referís a una unidad, un edificio o a la administración?',
+      };
     }
 
     if (!isBuildingDebt) {

--- a/apps/api/src/assistant/query-plan.service.spec.ts
+++ b/apps/api/src/assistant/query-plan.service.spec.ts
@@ -92,6 +92,12 @@ describe('AssistantQueryPlanService', () => {
     'saldo pendiente general',
     'cuanto deben todos los edificios',
     'deuda de todos los edificios',
+    'deuda administracion',
+    'deuda condominio',
+    'deuda total de todo',
+    'cuanto deben todos',
+    'morosidad global',
+    'saldo general',
   ])('maps "%s" to tenant_debt', (phrase) => {
     const plan = service.createPlan(phrase);
 
@@ -115,6 +121,7 @@ describe('AssistantQueryPlanService', () => {
 
   it('returns null for non-allowlisted or ambiguous questions', () => {
     expect(service.createPlan('hola como estas')).toBeNull();
+    expect(service.createPlan('deuda')).toBeNull();
   });
 
   it('detects building-level intent without explicit building token', () => {

--- a/apps/api/src/assistant/query-plan.service.spec.ts
+++ b/apps/api/src/assistant/query-plan.service.spec.ts
@@ -86,6 +86,21 @@ describe('AssistantQueryPlanService', () => {
   });
 
   it.each([
+    'anular pago',
+    'cancelar pago',
+    'crear gasto',
+    'editar gasto',
+    'eliminar gasto',
+    'borrar gasto',
+    'marcar apartamento 101 como pagado',
+    'registrar pago apartamento 101 por 50000',
+    'subir comprobante',
+    'cargar comprobante',
+  ])('rejects write phrase "%s"', (phrase) => {
+    expect(service.createPlan(phrase)).toBeNull();
+  });
+
+  it.each([
     'deuda de la administracion',
     'deuda total de la administracion',
     'deuda del condominio completo',
@@ -110,6 +125,20 @@ describe('AssistantQueryPlanService', () => {
     }));
   });
 
+  it.each([
+    ['deuda de este mes del condominio', 'current_month'],
+    ['deuda acumulada del condominio', 'accumulated'],
+    ['deuda total de este mes', 'current_month'],
+  ])('preserves tenant debt period for "%s"', (phrase, expectedPeriod) => {
+    const plan = service.createPlan(phrase);
+
+    expect(plan).toEqual(expect.objectContaining({
+      intent: 'tenant_debt',
+      scope: 'tenant',
+    }));
+    expect(plan?.filters.period).toBe(expectedPeriod);
+  });
+
   it('does not fall back to building_debt for tenant-wide debt phrases', () => {
     const plan = service.createPlan('deuda total de la administracion');
 
@@ -122,6 +151,17 @@ describe('AssistantQueryPlanService', () => {
   it('returns null for non-allowlisted or ambiguous questions', () => {
     expect(service.createPlan('hola como estas')).toBeNull();
     expect(service.createPlan('deuda')).toBeNull();
+  });
+
+  it.each([
+    'cuanto se cobro hoy',
+    'recaudacion del mes',
+    'ingresos del condominio',
+  ])('does not classify "%s" as debt', (phrase) => {
+    const plan = service.createPlan(phrase);
+
+    expect(plan?.intent).not.toBe('tenant_debt');
+    expect(plan?.intent).not.toBe('building_debt');
   });
 
   it('detects building-level intent without explicit building token', () => {

--- a/apps/api/src/assistant/query-plan.service.ts
+++ b/apps/api/src/assistant/query-plan.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { AssistantDebtIntentInterpreter } from './debt-intent-interpreter';
 import { AssistantQueryParser } from './query-parser/assistant-query-parser';
 import { AssistantSemanticLayerService } from './semantic-layer.service';
 import type { AssistantQueryIntent, AssistantQueryPlan } from './query-plan.types';
@@ -6,6 +7,7 @@ import type { AssistantQueryIntent, AssistantQueryPlan } from './query-plan.type
 @Injectable()
 export class AssistantQueryPlanService {
   private readonly parser = new AssistantQueryParser();
+  private readonly debtInterpreter = new AssistantDebtIntentInterpreter();
 
   constructor(private readonly semanticLayer: AssistantSemanticLayerService) {}
 
@@ -19,6 +21,7 @@ export class AssistantQueryPlanService {
     const extractedFilters = this.extractCommonFilters(normalized);
     const personName = this.extractPersonName(message, normalized);
     const referencesSomeone = this.hasAny(normalized, ['alguien', 'persona', 'quien', 'quién']);
+    const debtInterpretation = this.debtInterpreter.interpret(message);
 
     const hasExplicitUnitSyntax =
       /\b(unidad|apartamento|departamento|depto|apto|local|cochera|garage)\b/.test(normalized) ||
@@ -60,16 +63,19 @@ export class AssistantQueryPlanService {
       };
     }
 
-    const tenantIntent = this.pickTenantDebtIntent(normalized);
-    if (tenantIntent && (!buildingToken || this.isGenericBuildingToken(buildingToken))) {
-      const definition = this.semanticLayer.getDefinition(tenantIntent);
+    if (debtInterpretation.scope === 'tenant') {
+      const definition = this.semanticLayer.getDefinition('tenant_debt');
       return {
         ...definition,
-        executor: tenantIntent,
+        executor: 'tenant_debt',
         filters: { ...extractedFilters },
         confidence: 0.9,
         source: 'deterministic_rules',
       };
+    }
+
+    if (debtInterpretation.scope === 'ambiguous' && debtInterpretation.hasDebtSignal) {
+      return null;
     }
 
     const buildingIntent = this.pickBuildingIntent(normalized);
@@ -158,38 +164,6 @@ export class AssistantQueryPlanService {
       return 'building_stats';
     }
     return null;
-  }
-
-  private pickTenantDebtIntent(normalized: string): AssistantQueryIntent | null {
-    if (
-      this.hasAny(normalized, [
-        'deuda de la administracion',
-        'deuda total de la administracion',
-        'deuda de la administracion total',
-        'deuda del condominio completo',
-        'saldo pendiente general',
-        'cuanto deben todos los edificios',
-        'cuanto deben todos los inmuebles',
-        'deuda de todos los edificios',
-        'deuda general',
-        'deuda global',
-        'deuda total administracion',
-        'portfolio debt',
-        'administration debt',
-        'admin debt',
-        'tenant debt',
-        'general debt',
-        'administration_debt',
-        'portfolio_debt',
-      ])
-    ) {
-      return 'tenant_debt';
-    }
-    return null;
-  }
-
-  private isGenericBuildingToken(token: string): boolean {
-    return this.hasAny(token, ['completo', 'general', 'global', 'total', 'todos', 'administracion', 'administración']);
   }
 
   private hasAny(value: string, needles: string[]): boolean {

--- a/apps/api/src/assistant/query-plan.service.ts
+++ b/apps/api/src/assistant/query-plan.service.ts
@@ -16,12 +16,17 @@ export class AssistantQueryPlanService {
    */
   createPlan(message: string): AssistantQueryPlan | null {
     const normalized = this.normalize(message);
+    if (this.hasWriteIntentSignal(normalized)) {
+      return null;
+    }
+
     const parsedUnitToken = this.parser.parseUnitReference(message);
     const buildingToken = this.parser.extractBuildingToken(message);
     const extractedFilters = this.extractCommonFilters(normalized);
     const personName = this.extractPersonName(message, normalized);
     const referencesSomeone = this.hasAny(normalized, ['alguien', 'persona', 'quien', 'quién']);
     const debtInterpretation = this.debtInterpreter.interpret(message);
+    const tenantDebtPeriod = this.extractTenantDebtPeriod(normalized);
 
     const hasExplicitUnitSyntax =
       /\b(unidad|apartamento|departamento|depto|apto|local|cochera|garage)\b/.test(normalized) ||
@@ -68,7 +73,10 @@ export class AssistantQueryPlanService {
       return {
         ...definition,
         executor: 'tenant_debt',
-        filters: { ...extractedFilters },
+        filters: {
+          ...extractedFilters,
+          ...(tenantDebtPeriod ? { period: tenantDebtPeriod } : {}),
+        },
         confidence: 0.9,
         source: 'deterministic_rules',
       };
@@ -170,6 +178,29 @@ export class AssistantQueryPlanService {
     return needles.some((needle) => value.includes(needle));
   }
 
+  private hasWriteIntentSignal(normalized: string): boolean {
+    const writeVerbPattern = /\b(anular|cancelar|crear|editar|eliminar|borrar|registrar|cargar|subir|marcar)\b/;
+    const writeTargetPattern = /\b(pago|pagos|gasto|gastos|egreso|egresos|comprobante|comprobantes|recibo|recibos|pagado|pagada|pagados|pagadas)\b/;
+
+    if (writeVerbPattern.test(normalized) && writeTargetPattern.test(normalized)) {
+      return true;
+    }
+
+    if (/\bmarcar\b/.test(normalized) && /\bpagad[oa]s?\b/.test(normalized)) {
+      return true;
+    }
+
+    if (/\b(anular|cancelar)\b/.test(normalized) && /\b(pago|pagos|comprobante|comprobantes)\b/.test(normalized)) {
+      return true;
+    }
+
+    if (/\b(crear|editar|eliminar|borrar|registrar|cargar|subir)\b/.test(normalized) && /\b(gasto|gastos|egreso|egresos|pago|pagos|comprobante|comprobantes)\b/.test(normalized)) {
+      return true;
+    }
+
+    return false;
+  }
+
   private normalize(value: string): string {
     return value
       .normalize('NFD')
@@ -206,6 +237,18 @@ export class AssistantQueryPlanService {
       ...filters,
       ...amountFilters,
     };
+  }
+
+  private extractTenantDebtPeriod(normalized: string): string | undefined {
+    if (normalized.includes('este mes') || normalized.includes('mes actual') || normalized.includes('del mes actual')) {
+      return 'current_month';
+    }
+
+    if (/acumulad[ao]s?/.test(normalized) || /hist[oó]ric[ao]s?/.test(normalized) || /\btoda\b/.test(normalized) || /\btodo\b/.test(normalized)) {
+      return 'accumulated';
+    }
+
+    return undefined;
   }
 
   private extractPeriod(normalized: string): string | undefined {


### PR DESCRIPTION
## Intent\nIntroduce a canonical finance read-only assistant path with deterministic resolution first and bounded fallback.\n\n## Scope\n- Read-only finance queries only\n- debt / payments consulted / income / expenses consulted / delinquency / balance / accounts receivable\n- who paid / who did not pay / delinquent apartments\n\n## Out of scope\n- Any write operations (register/cancel payment, create/edit expense, mark as paid, upload receipt)\n\n## Verification\n- Focused assistant tests\n- TypeScript check