### PR TITLE
feat(api): wire read-only finance execution

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -120,6 +120,8 @@ jobs:
         run: npm run test:e2e -w apps/web -- --project=chromium
         env:
           BASE_URL: http://localhost:3000
+          PORT: 3000
+          NEXT_PUBLIC_API_URL: http://localhost:4000
 
       - name: Stop API server
         if: always()

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,6 +32,8 @@ jobs:
       S3_PUBLIC_BASE_URL: http://localhost:9000/buildingos-test
       S3_FORCE_PATH_STYLE: true
       MAIL_PROVIDER: none
+      FEATURE_PORTAL_RESIDENT: "true"
+      FEATURE_PAYMENTS_MVP: "true"
       PORT: 4000
 
     services:

--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -16,6 +16,8 @@ module.exports = {
   testEnvironment: 'node',
   moduleNameMapper: {
     '^src/(.*)$': '<rootDir>/$1',
+    '^@buildingos/contracts$': '<rootDir>/../../../packages/contracts/src/index.ts',
+    '^@buildingos/permissions$': '<rootDir>/../../../packages/permissions/src/index.ts',
   },
   testTimeout: 10000,
   globals: {

--- a/apps/api/prisma/seed.test.ts
+++ b/apps/api/prisma/seed.test.ts
@@ -292,6 +292,7 @@ async function main() {
     update: {},
     create: {
       tenantId: tenantA.id,
+      alias: "A",
       name: "Torre A Test",
       address: "Av. Test 1234, Ciudad A",
     },
@@ -302,6 +303,7 @@ async function main() {
     update: {},
     create: {
       tenantId: tenantA.id,
+      alias: "B",
       name: "Torre B Test",
       address: "Calle Test 567, Ciudad A",
     },
@@ -312,6 +314,7 @@ async function main() {
     update: {},
     create: {
       tenantId: tenantB.id,
+      alias: "A",
       name: "Edificio Test B",
       address: "Av. Demo 999, Ciudad B",
     },

--- a/apps/api/src/assistant/assistant.module.ts
+++ b/apps/api/src/assistant/assistant.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { PrismaModule } from '../prisma/prisma.module';
 import { AuditModule } from '../audit/audit.module';
 import { BillingModule } from '../billing/billing.module';
+import { FinanzasModule } from '../finanzas/finanzas.module';
 import { TenancyModule } from '../tenancy/tenancy.module';
 import { RedisModule } from '../redis/redis.module';
 import { AssistantService, MockAiProvider } from './assistant.service';
@@ -118,7 +119,7 @@ import { AssistantTenantDebtService } from './tenant-debt.service';
  * - AuditModule: Audit logging
  */
 @Module({
-  imports: [PrismaModule, TenancyModule, BillingModule, AuditModule, RedisModule, AiProviderModule.register(aiOptions)],
+  imports: [PrismaModule, TenancyModule, BillingModule, FinanzasModule, AuditModule, RedisModule, AiProviderModule.register(aiOptions)],
   controllers: [
     AssistantController,
     AiBudgetController,

--- a/apps/api/src/assistant/query-executors.service.spec.ts
+++ b/apps/api/src/assistant/query-executors.service.spec.ts
@@ -1,7 +1,6 @@
 import { PaymentStatus, UnitOccupantRole } from '@prisma/client';
 import { AssistantQueryExecutorsService } from './query-executors.service';
 import type { AssistantQueryPlan } from './query-plan.types';
-import { AssistantDebtCalculatorService } from './assistant-debt-calculator.service';
 
 describe('AssistantQueryExecutorsService', () => {
   const prisma = {
@@ -16,7 +15,11 @@ describe('AssistantQueryExecutorsService', () => {
   };
   const policy = { assertCanExecute: jest.fn() };
   const unitResolver = { resolve: jest.fn() };
-  const tenantDebtService = { resolveTenantDebtSummary: jest.fn() };
+  const finanzasService = {
+    getUnitLedger: jest.fn(),
+    getBuildingFinancialSummary: jest.fn(),
+    getTenantFinancialSummary: jest.fn(),
+  };
   let service: AssistantQueryExecutorsService;
 
   const resolvedUnit = {
@@ -31,8 +34,7 @@ describe('AssistantQueryExecutorsService', () => {
       prisma as never,
       policy as never,
       unitResolver as never,
-      new AssistantDebtCalculatorService(),
-      tenantDebtService as never,
+      finanzasService as never,
     );
     unitResolver.resolve.mockResolvedValue({ resolved: resolvedUnit, errorResponse: null });
     policy.assertCanExecute.mockResolvedValue(undefined);
@@ -50,15 +52,12 @@ describe('AssistantQueryExecutorsService', () => {
       source: 'deterministic_rules',
     };
     prisma.tenant.findUniqueOrThrow.mockResolvedValue({ currency: 'ARS' });
-    prisma.charge.findMany.mockResolvedValue([
-      {
-        amount: 100000,
-        paymentAllocations: [
-          { amount: 25000, payment: { status: PaymentStatus.APPROVED } },
-          { amount: 30000, payment: { status: PaymentStatus.SUBMITTED } },
-        ],
+    finanzasService.getUnitLedger.mockResolvedValue({
+      totals: {
+        balance: 75000,
+        currency: 'ARS',
       },
-    ]);
+    });
 
     const result = await service.execute({
       tenantId: 'tenant-1',
@@ -74,9 +73,14 @@ describe('AssistantQueryExecutorsService', () => {
       unitId: 'unit-1',
       plan,
     }));
-    expect(prisma.charge.findMany).toHaveBeenCalledWith(expect.objectContaining({
-      where: { tenantId: 'tenant-1', unitId: 'unit-1', canceledAt: null },
-    }));
+    expect(finanzasService.getUnitLedger).toHaveBeenCalledWith(
+      'tenant-1',
+      'unit-1',
+      undefined,
+      undefined,
+      ['OPERATOR'],
+      'operator-1',
+    );
     expect(result?.answer).toContain('deuda pendiente');
     expect(result?.suggestedActions[0].type).toBe('VIEW_PAYMENTS');
   });
@@ -149,20 +153,19 @@ describe('AssistantQueryExecutorsService', () => {
     };
     prisma.building.findMany.mockResolvedValue([{ id: 'building-1', name: 'Edificio A' }]);
     prisma.tenant.findUniqueOrThrow.mockResolvedValue({ currency: 'ARS' });
-    prisma.charge.findMany.mockResolvedValue([
-      {
-        amount: 150000,
-        unitId: 'unit-1',
-        paymentAllocations: [{ amount: 50000, payment: { status: PaymentStatus.RECONCILED } }],
-      },
-    ]);
+    finanzasService.getBuildingFinancialSummary.mockResolvedValue({
+      totalCharges: 150000,
+      totalPaid: 50000,
+      totalOutstanding: 100000,
+      delinquentUnitsCount: 1,
+      topDelinquentUnits: [],
+      currency: 'ARS',
+    });
 
     const result = await service.execute({ tenantId: 'tenant-1', userId: 'operator-1', userRoles: ['OPERATOR'], plan });
 
     expect(policy.assertCanExecute).toHaveBeenCalledWith(expect.objectContaining({ buildingId: 'building-1' }));
-    expect(prisma.charge.findMany).toHaveBeenCalledWith(expect.objectContaining({
-      where: { tenantId: 'tenant-1', buildingId: 'building-1', canceledAt: null },
-    }));
+    expect(finanzasService.getBuildingFinancialSummary).toHaveBeenCalledWith('tenant-1', 'building-1', undefined);
     expect(result?.answer).toContain('deuda pendiente total');
   });
 
@@ -177,18 +180,53 @@ describe('AssistantQueryExecutorsService', () => {
       confidence: 0.9,
       source: 'deterministic_rules',
     };
-    tenantDebtService.resolveTenantDebtSummary.mockResolvedValue({
-      totalDebt: 15801,
+    finanzasService.getTenantFinancialSummary.mockResolvedValue({
+      totalCharges: 30000,
+      totalPaid: 14199,
+      totalOutstanding: 15801,
+      delinquentUnitsCount: 2,
+      topDelinquentUnits: [],
       currency: 'ARS',
-      chargeCount: 12,
     });
 
     const result = await service.execute({ tenantId: 'tenant-1', userId: 'operator-1', userRoles: ['OPERATOR'], plan });
 
     expect(policy.assertCanExecute).toHaveBeenCalledWith(expect.objectContaining({ tenantId: 'tenant-1', plan }));
-    expect(tenantDebtService.resolveTenantDebtSummary).toHaveBeenCalledWith('tenant-1');
+    expect(finanzasService.getTenantFinancialSummary).toHaveBeenCalledWith('tenant-1');
     expect(result?.answer).toContain('administración');
     expect(result?.suggestedActions[0].type).toBe('VIEW_PAYMENTS');
+  });
+
+  it('executes building_delinquents through finance summary source of truth', async () => {
+    const plan: AssistantQueryPlan = {
+      intent: 'building_delinquents',
+      module: 'payments',
+      scope: 'building',
+      requiredPermission: 'payments.review',
+      executor: 'building_delinquents',
+      filters: { buildingToken: 'A' },
+      confidence: 0.9,
+      source: 'deterministic_rules',
+    };
+    prisma.building.findMany.mockResolvedValue([{ id: 'building-1', name: 'Edificio A' }]);
+    finanzasService.getBuildingFinancialSummary.mockResolvedValue({
+      totalCharges: 200000,
+      totalPaid: 50000,
+      totalOutstanding: 150000,
+      delinquentUnitsCount: 2,
+      topDelinquentUnits: [
+        { unitId: 'unit-1', unitLabel: 'Unidad 0101', buildingId: 'building-1', buildingName: 'Edificio A', outstanding: 90000 },
+        { unitId: 'unit-2', unitLabel: 'Unidad 0202', buildingId: 'building-1', buildingName: 'Edificio A', outstanding: 60000 },
+      ],
+      currency: 'ARS',
+    });
+
+    const result = await service.execute({ tenantId: 'tenant-1', userId: 'operator-1', userRoles: ['OPERATOR'], plan });
+
+    expect(finanzasService.getBuildingFinancialSummary).toHaveBeenCalledWith('tenant-1', 'building-1', undefined);
+    expect(result?.answer).toContain('Top deudores');
+    expect(result?.answer).toContain('Unidad 0101');
+    expect(prisma.charge.findMany).not.toHaveBeenCalled();
   });
 
   it('executes building_payments and resolves payment unit labels inside the same tenant', async () => {
@@ -207,6 +245,14 @@ describe('AssistantQueryExecutorsService', () => {
       { id: 'payment-1', amount: 100000, currency: 'ARS', status: PaymentStatus.APPROVED, method: 'TRANSFER', paidAt: new Date('2026-05-01'), createdAt: new Date(), unitId: 'unit-1' },
     ]);
     prisma.unit.findMany.mockResolvedValue([{ id: 'unit-1', code: '0101', label: 'Unidad 0101' }]);
+    finanzasService.getBuildingFinancialSummary.mockResolvedValue({
+      totalCharges: 150000,
+      totalPaid: 100000,
+      totalOutstanding: 50000,
+      delinquentUnitsCount: 1,
+      topDelinquentUnits: [],
+      currency: 'ARS',
+    });
 
     const result = await service.execute({ tenantId: 'tenant-1', userId: 'operator-1', userRoles: ['OPERATOR'], plan });
 
@@ -233,6 +279,14 @@ describe('AssistantQueryExecutorsService', () => {
     prisma.building.findMany.mockResolvedValue([{ id: 'building-1', name: 'Edificio A' }]);
     prisma.ticket.count.mockResolvedValue(1);
     prisma.ticket.findMany.mockResolvedValue([{ id: 'ticket-1', title: 'Ascensor', status: 'OPEN', priority: 'HIGH', unitId: null, createdAt: new Date() }]);
+    finanzasService.getBuildingFinancialSummary.mockResolvedValue({
+      totalCharges: 160000,
+      totalPaid: 90000,
+      totalOutstanding: 70000,
+      delinquentUnitsCount: 2,
+      topDelinquentUnits: [],
+      currency: 'ARS',
+    });
 
     const result = await service.execute({ tenantId: 'tenant-1', userId: 'operator-1', userRoles: ['OPERATOR'], plan });
 

--- a/apps/api/src/assistant/query-executors.service.ts
+++ b/apps/api/src/assistant/query-executors.service.ts
@@ -1,11 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { UnitOccupantRole } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { FinanzasService } from '../finanzas/finanzas.service';
 import { AssistantQueryParser, UnitToken } from './query-parser/assistant-query-parser';
 import { AssistantPolicyEnforcerService } from './policy-enforcer.service';
 import { AssistantUnitResolverService, ResolvedUnit } from './unit-resolver/assistant-unit-resolver.service';
-import { AssistantDebtCalculatorService } from './assistant-debt-calculator.service';
-import { AssistantTenantDebtService } from './tenant-debt.service';
 import type { ChatResponse } from './ai.types';
 import type { AssistantQueryExecutionContext } from './query-plan.types';
 
@@ -17,8 +16,7 @@ export class AssistantQueryExecutorsService {
     private readonly prisma: PrismaService,
     private readonly policy: AssistantPolicyEnforcerService,
     private readonly unitResolver: AssistantUnitResolverService,
-    private readonly debtCalculator: AssistantDebtCalculatorService,
-    private readonly tenantDebtService: AssistantTenantDebtService,
+    private readonly finanzasService: FinanzasService,
   ) {}
 
   /**
@@ -128,17 +126,16 @@ export class AssistantQueryExecutorsService {
       unitId: resolved.unit.id,
     });
 
-    const [tenant, charges] = await Promise.all([
-      this.prisma.tenant.findUniqueOrThrow({ where: { id: context.tenantId }, select: { currency: true } }),
-      this.prisma.charge.findMany({
-        where: { tenantId: context.tenantId, unitId: resolved.unit.id, canceledAt: null },
-        include: { paymentAllocations: { include: { payment: { select: { status: true } } } } },
-      }),
-    ]);
-
-    const outstanding = this.debtCalculator.calculateOutstanding(charges);
-
-    const amountText = this.formatMoney(outstanding, tenant.currency);
+    const ledger = await this.finanzasService.getUnitLedger(
+      context.tenantId,
+      resolved.unit.id,
+      undefined,
+      undefined,
+      context.userRoles,
+      context.userId,
+    );
+    const outstanding = ledger.totals.balance;
+    const amountText = this.formatMoney(outstanding, ledger.totals.currency);
     return this.response(
       outstanding > 0
         ? `La unidad ${resolved.displayCode} (${resolved.building.name}) tiene una deuda pendiente de ${amountText}.`
@@ -284,19 +281,16 @@ export class AssistantQueryExecutorsService {
       buildingId: building.id,
     });
 
-    const [tenant, charges] = await Promise.all([
-      this.prisma.tenant.findUniqueOrThrow({ where: { id: context.tenantId }, select: { currency: true } }),
-      this.prisma.charge.findMany({
-        where: { tenantId: context.tenantId, buildingId: building.id, canceledAt: null },
-        include: { paymentAllocations: { include: { payment: { select: { status: true } } } } },
-      }),
-    ]);
-
-    const outstanding = this.debtCalculator.calculateOutstanding(charges);
+    const summary = await this.finanzasService.getBuildingFinancialSummary(
+      context.tenantId,
+      building.id,
+      context.plan.filters.period,
+    );
+    const outstanding = summary.totalOutstanding;
     return {
       answer: outstanding > 0
-        ? `El edificio ${building.name} tiene una deuda pendiente total de ${this.formatMoney(outstanding, tenant.currency)}.`
-        : `El edificio ${building.name} no tiene deuda pendiente. Saldo actual: ${this.formatMoney(outstanding, tenant.currency)}.`,
+        ? `El edificio ${building.name} tiene una deuda pendiente total de ${this.formatMoney(outstanding, summary.currency)}.`
+        : `El edificio ${building.name} no tiene deuda pendiente. Saldo actual: ${this.formatMoney(outstanding, summary.currency)}.`,
       suggestedActions: [{ type: 'VIEW_PAYMENTS', payload: { buildingId: building.id } }],
     };
   }
@@ -309,11 +303,12 @@ export class AssistantQueryExecutorsService {
       plan: context.plan,
     });
 
-    const tenantDebt = await this.tenantDebtService.resolveTenantDebtSummary(context.tenantId);
+    const tenantDebt = await this.finanzasService.getTenantFinancialSummary(context.tenantId);
+    const totalDebt = tenantDebt.totalOutstanding;
     return {
-      answer: tenantDebt.totalDebt > 0
-        ? `La administración tiene una deuda pendiente total de ${this.formatMoney(tenantDebt.totalDebt, tenantDebt.currency)}.`
-        : `La administración no tiene deuda pendiente. Saldo actual: ${this.formatMoney(tenantDebt.totalDebt, tenantDebt.currency)}.`,
+      answer: totalDebt > 0
+        ? `La administración tiene una deuda pendiente total de ${this.formatMoney(totalDebt, tenantDebt.currency)}.`
+        : `La administración no tiene deuda pendiente. Saldo actual: ${this.formatMoney(totalDebt, tenantDebt.currency)}.`,
       suggestedActions: [{ type: 'VIEW_PAYMENTS', payload: {} }],
     };
   }
@@ -332,47 +327,25 @@ export class AssistantQueryExecutorsService {
       buildingId: building.id,
     });
 
-    const [tenant, units] = await Promise.all([
-      this.prisma.tenant.findUniqueOrThrow({ where: { id: context.tenantId }, select: { currency: true } }),
-      this.prisma.unit.findMany({
-        where: { tenantId: context.tenantId, buildingId: building.id },
-        select: { id: true, code: true, label: true },
-      }),
-    ]);
+    const summary = await this.finanzasService.getBuildingFinancialSummary(
+      context.tenantId,
+      building.id,
+      context.plan.filters.period,
+    );
 
-    const unitIds = units.map((unit) => unit.id);
-    const charges = await this.prisma.charge.findMany({
-      where: { tenantId: context.tenantId, unitId: { in: unitIds }, canceledAt: null },
-      include: { paymentAllocations: { include: { payment: { select: { status: true } } } } },
-    });
-
-    const debtByUnit = new Map<string, number>();
-    for (const charge of charges) {
-      const debt = this.debtCalculator.calculateChargeOutstanding(charge);
-      debtByUnit.set(charge.unitId, (debtByUnit.get(charge.unitId) ?? 0) + debt);
-    }
-
-    const topDebtors = Array.from(debtByUnit.entries())
-      .filter(([, debt]) => debt > 0)
-      .sort(([, left], [, right]) => right - left)
-      .slice(0, 10);
-
-    if (topDebtors.length === 0) {
+    if (summary.delinquentUnitsCount === 0) {
       return {
         answer: `El edificio ${building.name} no tiene unidades con deuda pendiente. Todas las unidades están al día.`,
         suggestedActions: [{ type: 'VIEW_PAYMENTS', payload: { buildingId: building.id } }],
       };
     }
 
-    const debtorList = topDebtors.map(([unitId, debt], index) => {
-      const unit = units.find((item) => item.id === unitId);
-      const unitLabel = unit ? (unit.label || unit.code) : 'Desconocida';
-      return `${index + 1}. ${unitLabel}: ${this.formatMoney(debt, tenant.currency)}`;
+    const debtorList = summary.topDelinquentUnits.map((unit, index) => {
+      return `${index + 1}. ${unit.unitLabel}: ${this.formatMoney(unit.outstanding, summary.currency)}`;
     }).join('\n');
-    const totalDebt = topDebtors.reduce((sum, [, debt]) => sum + debt, 0);
 
     return {
-      answer: `Top deudores del edificio ${building.name} (deuda total: ${this.formatMoney(totalDebt, tenant.currency)}):\n${debtorList}`,
+      answer: `Top deudores del edificio ${building.name} (deuda total: ${this.formatMoney(summary.totalOutstanding, summary.currency)}):\n${debtorList}`,
       suggestedActions: [{ type: 'VIEW_PAYMENTS', payload: { buildingId: building.id } }],
     };
   }
@@ -506,19 +479,15 @@ export class AssistantQueryExecutorsService {
       buildingId: building.id,
     });
 
-    const [tenant, units, openTickets, totalTickets, charges] = await Promise.all([
+    const [tenant, units, openTickets, totalTickets, summary] = await Promise.all([
       this.prisma.tenant.findUniqueOrThrow({ where: { id: context.tenantId }, select: { currency: true } }),
       this.prisma.unit.findMany({ where: { tenantId: context.tenantId, buildingId: building.id }, select: { id: true } }),
       this.prisma.ticket.count({ where: { tenantId: context.tenantId, buildingId: building.id, status: 'OPEN' } }),
       this.prisma.ticket.count({ where: { tenantId: context.tenantId, buildingId: building.id } }),
-      this.prisma.charge.findMany({
-        where: { tenantId: context.tenantId, buildingId: building.id, canceledAt: null },
-        include: { paymentAllocations: { include: { payment: { select: { status: true } } } } },
-      }),
+      this.finanzasService.getBuildingFinancialSummary(context.tenantId, building.id, context.plan.filters.period),
     ]);
 
-    const outstanding = this.debtCalculator.calculateOutstanding(charges);
-
+    const outstanding = summary.totalOutstanding;
     const averageDebt = units.length > 0 ? Math.round(outstanding / units.length) : 0;
     return {
       answer: `Estadísticas del edificio ${building.name}:\n- Unidades: ${units.length}\n- Tickets abiertos: ${openTickets} de ${totalTickets} totales\n- Deuda total: ${this.formatMoney(outstanding, tenant.currency)}\n- Deuda promedio por unidad: ${this.formatMoney(averageDebt, tenant.currency)}`,

--- a/apps/api/src/assistant/read-only-query.service.spec.ts
+++ b/apps/api/src/assistant/read-only-query.service.spec.ts
@@ -1,7 +1,5 @@
 import { ForbiddenException } from '@nestjs/common';
-import { PaymentStatus } from '@prisma/client';
 import { AssistantReadOnlyQueryService } from './read-only-query.service';
-import { AssistantDebtCalculatorService } from './assistant-debt-calculator.service';
 
 describe('AssistantReadOnlyQueryService', () => {
   const previousApiKeys = process.env.ASSISTANT_READONLY_API_KEYS;
@@ -37,42 +35,41 @@ describe('AssistantReadOnlyQueryService', () => {
       },
     } as any;
 
-    const tenantDebtService = {
-      resolveTenantDebtSummary: jest.fn(),
+    const finanzasService = {
+      getTenantFinancialSummary: jest.fn(),
+      listPendingPayments: jest.fn(),
+      getPaymentMetrics: jest.fn(),
     };
 
     const service = new AssistantReadOnlyQueryService(
       prisma,
-      new AssistantDebtCalculatorService(),
-      tenantDebtService as never,
+      finanzasService as never,
     );
-    return { service, prisma, tenantDebtService };
+    return { service, prisma, finanzasService };
   };
 
   it('maps legacy intents to canonical intent and executes one resolver', async () => {
-    const { service, prisma } = makeService();
+    const { service, prisma, finanzasService } = makeService();
 
     prisma.membership.findUnique.mockResolvedValue({
       roles: [{ role: 'TENANT_ADMIN' }],
     });
-    prisma.charge.findMany.mockResolvedValue([
-      {
-        id: 'c-1',
-        unitId: 'u-1',
-        amount: 10000,
-        paymentAllocations: [
-          {
-            amount: 2500,
-            payment: { status: PaymentStatus.APPROVED },
-          },
-        ],
-        unit: {
-          id: 'u-1',
-          label: 'A-101',
-          building: { name: 'Torre Norte' },
+    finanzasService.getTenantFinancialSummary.mockResolvedValue({
+      totalCharges: 10000,
+      totalPaid: 2500,
+      totalOutstanding: 7500,
+      delinquentUnitsCount: 1,
+      topDelinquentUnits: [
+        {
+          unitId: 'u-1',
+          unitLabel: 'A-101',
+          buildingId: 'b-1',
+          buildingName: 'Torre Norte',
+          outstanding: 7500,
         },
-      },
-    ]);
+      ],
+      currency: 'ARS',
+    });
 
     const result = await service.execute(
       {
@@ -95,8 +92,8 @@ describe('AssistantReadOnlyQueryService', () => {
     expect(result.answerSource).toBe('live_data');
     expect(result.metadata.intentCode).toBe('GET_OVERDUE_UNITS');
     expect(result.responseType).toBe('list');
-    expect(prisma.charge.findMany).toHaveBeenCalledTimes(1);
-    expect(prisma.payment.count).not.toHaveBeenCalled();
+    expect(finanzasService.getTenantFinancialSummary).toHaveBeenCalledWith('tenant-1');
+    expect(prisma.charge.findMany).not.toHaveBeenCalled();
   });
 
   it('blocks tenant spoofing mismatch between headers and body context', async () => {
@@ -190,15 +187,18 @@ describe('AssistantReadOnlyQueryService', () => {
   });
 
   it('resolves tenant_debt aliases to the tenant-wide debt resolver', async () => {
-    const { service, prisma, tenantDebtService } = makeService();
+    const { service, prisma, finanzasService } = makeService();
 
     prisma.membership.findUnique.mockResolvedValue({
       roles: [{ role: 'TENANT_ADMIN' }],
     });
-    tenantDebtService.resolveTenantDebtSummary.mockResolvedValue({
-      totalDebt: 474568,
+    finanzasService.getTenantFinancialSummary.mockResolvedValue({
+      totalCharges: 600000,
+      totalPaid: 125432,
+      totalOutstanding: 474568,
+      delinquentUnitsCount: 18,
+      topDelinquentUnits: [],
       currency: 'ARS',
-      chargeCount: 18,
     });
 
     const result = await service.execute(
@@ -219,7 +219,7 @@ describe('AssistantReadOnlyQueryService', () => {
       },
     );
 
-    expect(tenantDebtService.resolveTenantDebtSummary).toHaveBeenCalledWith('tenant-1');
+    expect(finanzasService.getTenantFinancialSummary).toHaveBeenCalledWith('tenant-1');
     expect(result.metadata.intentCode).toBe('GET_TENANT_DEBT');
     expect(result.responseType).toBe('summary');
     expect(result.answer).toContain('Deuda total de la administración');

--- a/apps/api/src/assistant/read-only-query.service.ts
+++ b/apps/api/src/assistant/read-only-query.service.ts
@@ -4,10 +4,9 @@ import {
   Injectable,
   UnauthorizedException,
 } from '@nestjs/common';
-import { ChargeStatus, PaymentStatus, TicketStatus } from '@prisma/client';
+import { PaymentStatus, TicketStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
-import { AssistantDebtCalculatorService } from './assistant-debt-calculator.service';
-import { AssistantTenantDebtService } from './tenant-debt.service';
+import { FinanzasService } from '../finanzas/finanzas.service';
 import {
   ASSISTANT_READ_ONLY_INTENTS,
   AssistantReadOnlyAction,
@@ -30,8 +29,7 @@ interface ResolverResult {
 export class AssistantReadOnlyQueryService {
   constructor(
     private readonly prisma: PrismaService,
-    private readonly debtCalculator: AssistantDebtCalculatorService,
-    private readonly tenantDebtService: AssistantTenantDebtService,
+    private readonly finanzasService: FinanzasService,
   ) {}
 
   /**
@@ -127,62 +125,14 @@ export class AssistantReadOnlyQueryService {
   private async overdueUnitsResolver(
     context: AssistantReadOnlyQueryContext,
   ): Promise<ResolverResult> {
-    const now = new Date();
-
-    const overdueCharges = await this.prisma.charge.findMany({
-      where: {
-        tenantId: context.tenantId,
-        canceledAt: null,
-        dueDate: { lt: now },
-        status: { in: [ChargeStatus.PENDING, ChargeStatus.PARTIAL] },
-      },
-      include: {
-        unit: {
-          select: {
-            id: true,
-            label: true,
-            building: {
-              select: {
-                name: true,
-              },
-            },
-          },
-        },
-        paymentAllocations: {
-          include: {
-            payment: {
-              select: {
-                status: true,
-              },
-            },
-          },
-        },
-      },
-      take: 5000,
-    });
-
-    const debtByUnit = new Map<
-      string,
-      { unitLabel: string; buildingName: string; outstanding: number }
-    >();
-
-    for (const charge of overdueCharges) {
-      const outstanding = this.debtCalculator.calculateChargeOutstanding(charge);
-      if (outstanding <= 0) {
-        continue;
-      }
-
-      const existing = debtByUnit.get(charge.unitId) ?? {
-        unitLabel: charge.unit?.label || charge.unitId,
-        buildingName: charge.unit?.building?.name || 'N/A',
-        outstanding: 0,
-      };
-      existing.outstanding += outstanding;
-      debtByUnit.set(charge.unitId, existing);
-    }
-
-    const rows = [...debtByUnit.entries()]
-      .map(([unitId, info]) => ({ unitId, ...info }))
+    const summary = await this.finanzasService.getTenantFinancialSummary(context.tenantId);
+    const rows = summary.topDelinquentUnits
+      .map((item) => ({
+        unitId: item.unitId,
+        unitLabel: item.unitLabel,
+        buildingName: item.buildingName,
+        outstanding: item.outstanding,
+      }))
       .sort((a, b) => b.outstanding - a.outstanding);
 
     if (rows.length === 0) {
@@ -216,7 +166,7 @@ export class AssistantReadOnlyQueryService {
         { key: 'open-units', label: 'Open Units' },
       ],
       metadata: {
-        itemCount: rows.length,
+        itemCount: summary.delinquentUnitsCount,
         top: rows.slice(0, 10),
       },
     };
@@ -225,36 +175,19 @@ export class AssistantReadOnlyQueryService {
   private async pendingPaymentsResolver(
     context: AssistantReadOnlyQueryContext,
   ): Promise<ResolverResult> {
-    const [count, pending] = await Promise.all([
-      this.prisma.payment.count({
-        where: {
-          tenantId: context.tenantId,
+    const [metrics, pending] = await Promise.all([
+      this.finanzasService.getPaymentMetrics(context.tenantId, {}),
+      this.finanzasService.listPendingPayments(
+        context.tenantId,
+        [context.role],
+        context.userId,
+        {
           status: PaymentStatus.SUBMITTED,
-          canceledAt: null,
+          limit: 10,
         },
-      }),
-      this.prisma.payment.findMany({
-        where: {
-          tenantId: context.tenantId,
-          status: PaymentStatus.SUBMITTED,
-          canceledAt: null,
-        },
-        include: {
-          unit: {
-            select: {
-              label: true,
-              building: {
-                select: {
-                  name: true,
-                },
-              },
-            },
-          },
-        },
-        orderBy: { createdAt: 'asc' },
-        take: 10,
-      }),
+      ),
     ]);
+    const count = metrics.backlogCount;
 
     if (count === 0) {
       return {
@@ -272,7 +205,7 @@ export class AssistantReadOnlyQueryService {
       .slice(0, 5)
       .map((payment) => {
         const unitLabel = payment.unit?.label || 'Sin unidad';
-        const buildingName = payment.unit?.building?.name || 'N/A';
+        const buildingName = payment.building?.name || 'N/A';
         return `${unitLabel} (${buildingName}): ${this.formatCurrency(payment.amount)}`;
       })
       .join(' | ');
@@ -413,63 +346,19 @@ export class AssistantReadOnlyQueryService {
   private async collectionsSummaryResolver(
     context: AssistantReadOnlyQueryContext,
   ): Promise<ResolverResult> {
-    const now = new Date();
-    const period = this.toPeriod(now);
-    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
-    const nextMonthStart = new Date(now.getFullYear(), now.getMonth() + 1, 1);
-
-    const charges = await this.prisma.charge.findMany({
-      where: {
-        tenantId: context.tenantId,
-        period,
-        canceledAt: null,
-      },
-      include: {
-        paymentAllocations: {
-          include: {
-            payment: {
-              select: {
-                status: true,
-              },
-            },
-          },
-        },
-      },
-      take: 10000,
-    });
-
-    const emitted = charges.reduce((sum, charge) => sum + charge.amount, 0);
-    const outstanding = this.debtCalculator.calculateOutstanding(charges);
-    const collectedApplied = Math.max(0, emitted - outstanding);
-
-    const [pendingApprovals, approvedInMonth] = await Promise.all([
-      this.prisma.payment.count({
-        where: {
-          tenantId: context.tenantId,
-          status: PaymentStatus.SUBMITTED,
-          canceledAt: null,
-        },
-      }),
-      this.prisma.payment.aggregate({
-        where: {
-          tenantId: context.tenantId,
-          status: { in: [PaymentStatus.APPROVED, PaymentStatus.RECONCILED] },
-          updatedAt: {
-            gte: monthStart,
-            lt: nextMonthStart,
-          },
-          canceledAt: null,
-        },
-        _sum: {
-          amount: true,
-        },
-      }),
+    const period = this.toPeriod(new Date());
+    const [summary, metrics] = await Promise.all([
+      this.finanzasService.getTenantFinancialSummary(context.tenantId, period),
+      this.finanzasService.getPaymentMetrics(context.tenantId, {}),
     ]);
 
-    const approvedTotal = approvedInMonth._sum.amount || 0;
+    const emitted = summary.totalCharges;
+    const outstanding = summary.totalOutstanding;
+    const collectedApplied = Math.max(0, emitted - outstanding);
+    const pendingApprovals = metrics.backlogCount;
     const collectionRate = emitted > 0 ? collectedApplied / emitted : 0;
 
-    if (emitted === 0 && approvedTotal === 0) {
+    if (emitted === 0 && summary.totalPaid === 0) {
       return {
         answer: `No hay movimientos de cobranzas para el período ${period}.`,
         responseType: 'no_data',
@@ -499,7 +388,7 @@ export class AssistantReadOnlyQueryService {
         collectedApplied,
         outstanding,
         pendingApprovals,
-        approvedTotal,
+        approvedTotal: summary.totalPaid,
       },
     };
   }
@@ -507,30 +396,31 @@ export class AssistantReadOnlyQueryService {
   private async tenantDebtResolver(
     context: AssistantReadOnlyQueryContext,
   ): Promise<ResolverResult> {
-    const summary = await this.tenantDebtService.resolveTenantDebtSummary(context.tenantId);
+    const summary = await this.finanzasService.getTenantFinancialSummary(context.tenantId);
+    const totalDebt = summary.totalOutstanding;
 
-    if (summary.totalDebt === 0) {
+    if (totalDebt === 0) {
       return {
         answer: 'La administración no tiene deuda pendiente.',
         responseType: 'no_data',
         actions: [{ key: 'open-charges', label: 'Open Charges' }],
         metadata: {
           noData: true,
-          totalDebt: summary.totalDebt,
+          totalDebt,
           currency: summary.currency,
-          chargeCount: summary.chargeCount,
+          chargeCount: summary.delinquentUnitsCount,
         },
       };
     }
 
     return {
-      answer: `Deuda total de la administración: ${this.formatCurrency(summary.totalDebt, summary.currency)}.`,
+      answer: `Deuda total de la administración: ${this.formatCurrency(totalDebt, summary.currency)}.`,
       responseType: 'summary',
       actions: [{ key: 'open-charges', label: 'Open Charges' }],
       metadata: {
-        totalDebt: summary.totalDebt,
+        totalDebt,
         currency: summary.currency,
-        chargeCount: summary.chargeCount,
+        chargeCount: summary.delinquentUnitsCount,
       },
     };
   }

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -25,6 +25,15 @@ import {
   MonthlyTrendDto,
 } from './finanzas.dto';
 
+export interface PendingPaymentListItem extends Payment {
+  building?: { id: string; name: string } | null;
+  unit?: { id: string; label: string } | null;
+  createdByUser?: { id: string; name: string; email: string } | null;
+  reviewedByMembership?: { id: string; user?: { name: string } | null } | null;
+  proofFile?: { id: string } | null;
+  proofDocumentId?: string | null;
+}
+
 @Injectable()
 export class FinanzasService {
   private readonly logger = new Logger(FinanzasService.name);
@@ -1788,7 +1797,7 @@ export class FinanzasService {
     userRoles: string[],
     userId: string,
     query: ListPendingPaymentsQueryDto,
-  ): Promise<Payment[]> {
+  ): Promise<PendingPaymentListItem[]> {
     // Build where clause
     const where: Prisma.PaymentWhereInput = {
       tenantId,
@@ -1880,7 +1889,7 @@ export class FinanzasService {
       }))
     );
 
-    return resolvedPayments as Payment[];
+    return resolvedPayments as PendingPaymentListItem[];
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -19709,13 +19709,19 @@
     "packages/contracts": {
       "name": "@buildingos/contracts",
       "version": "0.0.0",
+      "dependencies": {
+        "zod": "^4.3.6"
+      },
       "devDependencies": {
         "typescript": "^5.0.0"
       }
     },
     "packages/permissions": {
       "name": "@buildingos/permissions",
-      "version": "0.0.0"
+      "version": "0.0.0",
+      "dependencies": {
+        "@buildingos/contracts": "file:../contracts"
+      }
     }
   }
 }

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -11,6 +11,6 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@buildingos/contracts": "workspace:*"
+    "@buildingos/contracts": "file:../contracts"
   }
 }

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -5,10 +5,10 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "dev": "tsc --watch",
-    "lint": "tsc --noEmit",
-    "typecheck": "tsc --noEmit"
+    "lint": "tsc --noEmit -p tsconfig.lint.json",
+    "typecheck": "tsc --noEmit -p tsconfig.lint.json"
   },
   "dependencies": {
     "@buildingos/contracts": "file:../contracts"

--- a/packages/permissions/package.json
+++ b/packages/permissions/package.json
@@ -9,5 +9,8 @@
     "dev": "tsc --watch",
     "lint": "tsc --noEmit",
     "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@buildingos/contracts": "workspace:*"
   }
 }

--- a/packages/permissions/tsconfig.build.json
+++ b/packages/permissions/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@buildingos/contracts": ["../contracts/dist"]
+    }
+  }
+}

--- a/packages/permissions/tsconfig.json
+++ b/packages/permissions/tsconfig.json
@@ -3,6 +3,10 @@
     "target": "ES2020",
     "module": "commonjs",
     "lib": ["ES2020"],
+    "baseUrl": ".",
+    "paths": {
+      "@buildingos/contracts": ["../contracts/src"]
+    },
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist",

--- a/packages/permissions/tsconfig.lint.json
+++ b/packages/permissions/tsconfig.lint.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "..",
+    "baseUrl": ".",
+    "paths": {
+      "@buildingos/contracts": ["../contracts/src"]
+    }
+  }
+}


### PR DESCRIPTION
## Intent\nWire canonical finance read-only queries into the execution path and reuse finance services as source of truth.\n\n## Scope\n- Read-only execution only\n- tenant/building/unit finance reads\n- summaries, balances, delinquency, collections, pending payments\n\n## Out of scope\n- Any write operations\n\n## Verification\n- Focused assistant execution tests\n- TypeScript check