### PR TITLE
test(api): lock down finance read-only planner

### DIFF
--- a/apps/api/src/assistant/query-plan.service.spec.ts
+++ b/apps/api/src/assistant/query-plan.service.spec.ts
@@ -164,6 +164,14 @@ describe('AssistantQueryPlanService', () => {
     expect(plan?.intent).not.toBe('building_debt');
   });
 
+  it.each([
+    'crear pago de la unidad A-0101',
+    'actualizar deuda del edificio B',
+    'eliminar ticket del Edificio Norte',
+  ])('blocks write-intent finance phrases like "%s"', (phrase) => {
+    expect(service.createPlan(phrase)).toBeNull();
+  });
+
   it('detects building-level intent without explicit building token', () => {
     const plan = service.createPlan('Hay alguien que este tardando en pagar el mantenimiento');
 

--- a/apps/api/src/assistant/query-plan.service.ts
+++ b/apps/api/src/assistant/query-plan.service.ts
@@ -209,6 +209,13 @@ export class AssistantQueryPlanService {
       .trim();
   }
 
+  private hasWriteIntentSignal(normalized: string): boolean {
+    const writeVerbPattern = /\b(crear|agregar|anadir|editar|actualizar|modificar|eliminar|borrar|registrar|cargar|subir|cambiar|dar de baja)\b/;
+    const financeTargetPattern = /\b(pago|pagos|deuda|deudas|saldo|saldos|cobro|cobros|cobranza|cobranzas|ticket|tickets|reclamo|reclamos|documento|documentos|unidad|unidades|edificio|edificios|moroso|morosos|administracion|condominio)\b/;
+
+    return writeVerbPattern.test(normalized) && financeTargetPattern.test(normalized);
+  }
+
   private extractCommonFilters(normalized: string): AssistantQueryPlan['filters'] {
     const filters: AssistantQueryPlan['filters'] = {};
 

--- a/apps/api/src/assistant/query-plan.service.ts
+++ b/apps/api/src/assistant/query-plan.service.ts
@@ -179,8 +179,8 @@ export class AssistantQueryPlanService {
   }
 
   private hasWriteIntentSignal(normalized: string): boolean {
-    const writeVerbPattern = /\b(anular|cancelar|crear|editar|eliminar|borrar|registrar|cargar|subir|marcar)\b/;
-    const writeTargetPattern = /\b(pago|pagos|gasto|gastos|egreso|egresos|comprobante|comprobantes|recibo|recibos|pagado|pagada|pagados|pagadas)\b/;
+    const writeVerbPattern = /\b(anular|cancelar|crear|editar|eliminar|borrar|registrar|cargar|subir|marcar|actualizar|modificar|cambiar|dar de baja|agregar|anadir)\b/;
+    const writeTargetPattern = /\b(pago|pagos|gasto|gastos|egreso|egresos|comprobante|comprobantes|recibo|recibos|pagado|pagada|pagados|pagadas|deuda|deudas|saldo|saldos|cobro|cobros|cobranza|cobranzas|ticket|tickets|reclamo|reclamos|documento|documentos|unidad|unidades|edificio|edificios|moroso|morosos|administracion|condominio)\b/;
 
     if (writeVerbPattern.test(normalized) && writeTargetPattern.test(normalized)) {
       return true;
@@ -207,13 +207,6 @@ export class AssistantQueryPlanService {
       .replace(/[\u0300-\u036f]/g, '')
       .toLowerCase()
       .trim();
-  }
-
-  private hasWriteIntentSignal(normalized: string): boolean {
-    const writeVerbPattern = /\b(crear|agregar|anadir|editar|actualizar|modificar|eliminar|borrar|registrar|cargar|subir|cambiar|dar de baja)\b/;
-    const financeTargetPattern = /\b(pago|pagos|deuda|deudas|saldo|saldos|cobro|cobros|cobranza|cobranzas|ticket|tickets|reclamo|reclamos|documento|documentos|unidad|unidades|edificio|edificios|moroso|morosos|administracion|condominio)\b/;
-
-    return writeVerbPattern.test(normalized) && financeTargetPattern.test(normalized);
   }
 
   private extractCommonFilters(normalized: string): AssistantQueryPlan['filters'] {

--- a/apps/api/src/assistant/read-only-query.service.spec.ts
+++ b/apps/api/src/assistant/read-only-query.service.spec.ts
@@ -225,4 +225,48 @@ describe('AssistantReadOnlyQueryService', () => {
     expect(result.answer).toContain('Deuda total de la administración');
   });
 
+  it('uses finance source of truth for collections summary without touching write paths', async () => {
+    const { service, prisma, finanzasService } = makeService();
+
+    prisma.membership.findUnique.mockResolvedValue({
+      roles: [{ role: 'TENANT_ADMIN' }],
+    });
+    finanzasService.getTenantFinancialSummary.mockResolvedValue({
+      totalCharges: 150000,
+      totalPaid: 90000,
+      totalOutstanding: 60000,
+      delinquentUnitsCount: 2,
+      topDelinquentUnits: [],
+      currency: 'ARS',
+    });
+    finanzasService.getPaymentMetrics.mockResolvedValue({
+      backlogCount: 3,
+    });
+
+    const result = await service.execute(
+      {
+        intentCode: 'GET_COLLECTIONS_SUMMARY',
+        question: 'resumen de cobranzas del mes',
+        context: {
+          tenantId: 'tenant-1',
+          userId: 'user-1',
+          role: 'TENANT_ADMIN',
+        },
+      },
+      {
+        apiKey: 'test-readonly-key',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        role: 'TENANT_ADMIN',
+      },
+    );
+
+    expect(result.metadata.intentCode).toBe('GET_COLLECTIONS_SUMMARY');
+    expect(result.responseType).toBe('summary');
+    expect(finanzasService.getTenantFinancialSummary).toHaveBeenCalledWith('tenant-1', expect.any(String));
+    expect(finanzasService.getPaymentMetrics).toHaveBeenCalledWith('tenant-1', {});
+    expect(prisma.charge.findMany).not.toHaveBeenCalled();
+    expect(prisma.payment.findMany).not.toHaveBeenCalled();
+  });
+
 });


### PR DESCRIPTION
## Intent\nAdd regression coverage for the canonical finance read-only planner and read-only boundary.\n\n## Scope\n- Write-intent rejection\n- canonical finance read-only regression tests\n- fallback/read-only hardening\n\n## Out of scope\n- Any write operations\n- Broad refactors\n\n## Verification\n- Focused regression tests\n- TypeScript check