### PR TITLE
fix(assistant): preserve tenant relative debt periods

### DIFF
--- a/apps/api/src/assistant/ai.types.ts
+++ b/apps/api/src/assistant/ai.types.ts
@@ -32,6 +32,7 @@ export type AssistantConsensusPeriodKind =
   | 'relative_month'
   | 'relative_range'
   | 'month_range'
+  | 'year_to_date'
   | 'accumulated'
   | 'unknown';
 
@@ -83,6 +84,8 @@ export interface AssistantConsensusEvaluation {
   deterministicPlan: AssistantConsensusModelPlan | null;
   modelPlan: AssistantConsensusModelPlan | null;
   mismatchReason?: string;
+  modelValid?: boolean;
+  modelInvalidReason?: 'model_semantic_invalid' | 'model_intent_scope_conflict';
   clarificationMessage?: string;
   usedLocalModel: boolean;
   localProvider: 'ollama';

--- a/apps/api/src/assistant/ai.types.ts
+++ b/apps/api/src/assistant/ai.types.ts
@@ -21,6 +21,75 @@ export interface AiProviderChatOptions {
   maxTokens?: number;
 }
 
+export type AssistantConsensusIntent = 'tenant_debt' | 'building_debt' | 'unit_debt' | 'unknown';
+
+export type AssistantConsensusScope = 'tenant' | 'building' | 'unit' | 'unknown';
+
+export type AssistantConsensusPeriodKind =
+  | 'current_month'
+  | 'previous_month'
+  | 'named_month'
+  | 'relative_month'
+  | 'relative_range'
+  | 'month_range'
+  | 'accumulated'
+  | 'unknown';
+
+export interface AssistantConsensusEntity {
+  buildingAlias: string | null;
+  unitAlias: string | null;
+}
+
+export interface AssistantConsensusPeriod {
+  kind: AssistantConsensusPeriodKind;
+  month: number | null;
+  year: number | null;
+  offset: number | null;
+  amount: number | null;
+  unit: 'month' | null;
+  mode: 'including_current' | 'closed_months' | 'unknown' | null;
+}
+
+export interface AssistantConsensusModelPlan {
+  intent: AssistantConsensusIntent;
+  scope: AssistantConsensusScope;
+  entity: AssistantConsensusEntity;
+  period: AssistantConsensusPeriod;
+  confidence: number;
+  requiresClarification: boolean;
+  missingFields: string[];
+}
+
+export interface AssistantConsensusResult {
+  consensus: boolean;
+  deterministicIntent: AssistantConsensusIntent;
+  modelIntent: AssistantConsensusIntent;
+  mismatchReason?: string;
+  clarificationMessage?: string;
+}
+
+export interface AssistantConsensusModeConfig {
+  provider: 'none' | 'hybrid' | 'openai' | 'opencode' | 'ollama' | 'gemini';
+  localProvider: 'ollama';
+  alwaysCallLocalModel: boolean;
+  consensusMode: boolean;
+  geminiFallbackEnabled: boolean;
+  ollamaBaseUrl?: string;
+  ollamaModel?: string;
+}
+
+export interface AssistantConsensusEvaluation {
+  consensus: boolean;
+  deterministicPlan: AssistantConsensusModelPlan | null;
+  modelPlan: AssistantConsensusModelPlan | null;
+  mismatchReason?: string;
+  clarificationMessage?: string;
+  usedLocalModel: boolean;
+  localProvider: 'ollama';
+  localBaseUrl: string;
+  localModel: string;
+}
+
 export interface ChatResponse {
   answer: string;
   suggestedActions: SuggestedAction[];
@@ -119,7 +188,10 @@ export interface StructuredResponseDebug {
   llmProvider?: 'ollama' | 'opencode' | 'gemini' | 'none' | 'unknown';
   llmBaseUrl?: string;
   llmModel?: string;
-  llmReason?: 'no_intent' | 'missing_filters' | 'low_confidence' | 'multi_intent' | 'pending_clarification' | 'none';
+  llmReason?: 'no_intent' | 'missing_filters' | 'low_confidence' | 'multi_intent' | 'pending_clarification' | 'consensus_mismatch' | 'local_model_failed' | 'none';
+  consensusMode?: boolean;
+  consensusResult?: 'matched' | 'mismatch' | 'failed';
+  consensusReason?: string;
   semanticValidationStatus?: 'accepted' | 'needs_clarification' | 'override_suggested';
   semanticValidationReason?: string;
   zodValidationPassed?: boolean;

--- a/apps/api/src/assistant/assistant.module.ts
+++ b/apps/api/src/assistant/assistant.module.ts
@@ -41,6 +41,7 @@ const aiOptions = resolveAiProvider();
 // Intent Engine services
 import { IntentRegistry } from './intent-engine/intent-registry';
 import { IntentExtractorService } from './intent-engine/intent-extractor.service';
+import { AssistantLocalConsensusService } from './intent-engine/local-consensus.service';
 import { FilterCoverageValidator } from './intent-engine/filter-coverage.validator';
 import { EntityResolverService } from './resolver/entity-resolver.service';
 import { AmbiguityService } from './resolver/ambiguity.service';
@@ -157,6 +158,7 @@ import { AssistantTenantDebtService } from './tenant-debt.service';
     // Intent Engine services
     IntentRegistry,
     IntentExtractorService,
+    AssistantLocalConsensusService,
     FilterCoverageValidator,
     EntityResolverService,
     AmbiguityService,
@@ -189,6 +191,7 @@ import { AssistantTenantDebtService } from './tenant-debt.service';
     AssistantTenantDebtService,
     IntentRegistry,
     IntentExtractorService,
+    AssistantLocalConsensusService,
     FilterCoverageValidator,
     EntityResolverService,
     AmbiguityService,

--- a/apps/api/src/assistant/assistant.module.ts
+++ b/apps/api/src/assistant/assistant.module.ts
@@ -32,6 +32,7 @@ import { AssistantQueryPlanService } from './query-plan.service';
 import { AssistantPolicyEnforcerService } from './policy-enforcer.service';
 import { AssistantQueryExecutorsService } from './query-executors.service';
 import { AssistantDebtCalculatorService } from './assistant-debt-calculator.service';
+import { PeriodResolverService } from './period-resolver.service';
 import { CircuitBreaker } from './providers/circuit-breaker';
 import { AiProviderModule, AI_PROVIDER_TOKEN } from './providers/ai-provider.module';
 import { resolveAiProvider } from './providers/ai-provider.resolver';
@@ -154,6 +155,7 @@ import { AssistantTenantDebtService } from './tenant-debt.service';
     AssistantPolicyEnforcerService,
     AssistantQueryExecutorsService,
     AssistantDebtCalculatorService,
+    PeriodResolverService,
     AssistantTenantDebtService,
     // Intent Engine services
     IntentRegistry,
@@ -188,6 +190,7 @@ import { AssistantTenantDebtService } from './tenant-debt.service';
     AssistantPolicyEnforcerService,
     AssistantQueryExecutorsService,
     AssistantDebtCalculatorService,
+    PeriodResolverService,
     AssistantTenantDebtService,
     IntentRegistry,
     IntentExtractorService,

--- a/apps/api/src/assistant/assistant.service.spec.ts
+++ b/apps/api/src/assistant/assistant.service.spec.ts
@@ -295,6 +295,76 @@ describe('AssistantService - Strict Operational Questions', () => {
       );
     });
 
+    it('rehidrata la aclaración pendiente para "deuda de este mes" sin perder el edificio original', async () => {
+      const previousResolvedEntities = {
+        building: { id: 'demo-A', name: 'Edificio A', alias: 'A' },
+        alternatives: [],
+      };
+
+      mockConversationContext.getContext.mockResolvedValue([
+        {
+          role: 'user',
+          message: 'deuda del edificio A',
+          timestamp: new Date(),
+          resolvedEntities: previousResolvedEntities,
+        },
+      ]);
+      mockConversationContext.getLastResolved.mockResolvedValue({ buildingId: 'demo-A' });
+      mockConversationContext.getLastIntent.mockResolvedValue('building_debt');
+      mockConversationContext.getPendingClarification.mockResolvedValue({
+        intent: 'building_debt',
+        entity: { type: 'building', buildingAlias: 'A' },
+        filters: {},
+        missingFields: ['period'],
+        question: '¿Querés la deuda de este mes o la deuda acumulada?',
+        resolvedEntityIds: { buildingId: 'demo-A' },
+      });
+      mockIntentRegistry.has.mockReturnValue(true);
+      mockAmbiguityService.detectAmbiguity.mockReturnValue(false);
+      mockQueryPlannerService.buildPlan.mockImplementation((intent, resolved) => ({
+        intent: intent.intent,
+        entityIds: {
+          buildingId: resolved.building?.id,
+          unitId: resolved.unit?.id,
+          personId: resolved.person?.id,
+        },
+        filters: intent.filters,
+        pagination: { limit: 20 },
+      }));
+      mockQueryExecutorService.execute.mockResolvedValue({ totalDebt: 115801, currency: 'ARS' });
+      mockResponseFormatter.formatV2.mockReturnValue({
+        type: 'kpi',
+        title: 'Deuda',
+        summary: 'Deuda total: ARS 1.158,01',
+        meta: {},
+      });
+
+      await service.chatV2(
+        'tenant-1',
+        'user-1',
+        'membership-1',
+        { message: 'deuda de este mes', page: 'charges', conversationId: 'conv-1' },
+        ADMIN_ROLES,
+      );
+
+      expect(mockIntentExtractor.extractIntent).not.toHaveBeenCalled();
+      expect(mockQueryPlannerService.buildPlan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          intent: 'building_debt',
+          filters: expect.objectContaining({ period: new Date().toISOString().slice(0, 7) }),
+        }),
+        expect.objectContaining({
+          building: expect.objectContaining({ id: 'demo-A', alias: 'A' }),
+        }),
+      );
+      expect(mockQueryExecutorService.execute).toHaveBeenCalledWith(
+        expect.objectContaining({ entityIds: expect.objectContaining({ buildingId: 'demo-A' }) }),
+        'tenant-1',
+        'user-1',
+        ADMIN_ROLES,
+      );
+    });
+
     it('rehidrata aclaración pendiente para "acumulada" usando el edificio original', async () => {
       const previousResolvedEntities = {
         building: { id: 'demo-B', name: 'Edificio del Río', alias: 'B' },
@@ -621,6 +691,316 @@ describe('AssistantService - Strict Operational Questions', () => {
       expect(result.type).toBe('clarification');
     });
 
+    it('asks for period.mode on relative range debt queries and preserves the building context', async () => {
+      mockConversationContext.getContext.mockResolvedValue([]);
+      mockConversationContext.getLastResolved.mockResolvedValue({});
+      mockConversationContext.getLastIntent.mockResolvedValue(undefined);
+      mockQueryPlanService.createPlan.mockReturnValue({
+        intent: 'building_debt',
+        module: 'payments',
+        scope: 'building',
+        requiredPermission: 'payments.review',
+        executor: 'building_debt',
+        filters: {
+          buildingAlias: 'torre el parque',
+          buildingToken: 'torre el parque',
+          period: {
+            kind: 'relative_range',
+            amount: 5,
+            unit: 'month',
+            mode: 'unknown',
+            month: null,
+            year: null,
+            startMonth: null,
+            startYear: null,
+            endMonth: null,
+            endYear: null,
+          },
+        },
+        confidence: 0.9,
+        source: 'deterministic_rules',
+      });
+      mockIntentExtractor.extractIntent.mockResolvedValue({
+        intent: 'building_debt',
+        entity: { type: 'building', buildingAlias: 'torre el parque' },
+        filters: {},
+        confidence: 0.9,
+        source: 'deterministic',
+        llmProvider: 'none',
+        requiresClarification: false,
+        missingFields: [],
+      });
+      mockIntentRegistry.has.mockReturnValue(true);
+      mockIntentSemanticValidator.evaluate.mockResolvedValue({
+        status: 'needs_clarification',
+        reason: 'relative_range_mode_ambiguous',
+        question: '¿Querés incluir el mes actual o consultar solo los últimos 5 meses cerrados?',
+      });
+      mockResponseFormatter.formatV2.mockReturnValue({
+        type: 'clarification',
+        title: 'Aclaración',
+        summary: '¿Querés incluir el mes actual o consultar solo los últimos 5 meses cerrados?',
+        meta: {},
+      });
+
+      const result = await service.chatV2(
+        'tenant-1',
+        'user-1',
+        'membership-1',
+        {
+          message: 'deuda de los ultimos 5 meses de la torre el parque',
+          page: 'charges',
+          conversationId: 'conv-1',
+        },
+        ADMIN_ROLES,
+      );
+
+      expect(mockIntentSemanticValidator.evaluate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deterministicPlan: expect.objectContaining({
+            intent: 'building_debt',
+            filters: expect.objectContaining({
+              period: expect.objectContaining({
+                kind: 'relative_range',
+                amount: 5,
+                unit: 'month',
+                mode: 'unknown',
+              }),
+            }),
+          }),
+        }),
+      );
+      expect(mockConversationContext.setPendingClarification).toHaveBeenCalledWith(
+        'tenant-1',
+        'user-1',
+        'conv-1',
+        expect.objectContaining({
+          intent: 'building_debt',
+          entity: expect.objectContaining({ buildingAlias: 'torre el parque' }),
+          period: expect.objectContaining({
+            kind: 'relative_range',
+            amount: 5,
+            unit: 'month',
+            mode: 'unknown',
+          }),
+          missingFields: ['period.mode'],
+        }),
+      );
+      expect(mockQueryExecutorService.execute).not.toHaveBeenCalled();
+      expect(result.type).toBe('clarification');
+    });
+
+    it('updates the relative-range mode on follow-up without asking again for month vs accumulated', async () => {
+      mockConversationContext.getContext.mockResolvedValue([
+        {
+          role: 'user',
+          message: 'deuda de los ultimos 5 meses de la torre el parque',
+          timestamp: new Date(),
+          resolvedEntities: {
+            building: { id: 'demo-A', name: 'Torre El Parque', alias: 'torre el parque' },
+            alternatives: [],
+          },
+        },
+      ]);
+      mockConversationContext.getLastResolved.mockResolvedValue({ buildingId: 'demo-A' });
+      mockConversationContext.getLastIntent.mockResolvedValue('building_debt');
+      mockConversationContext.getPendingClarification.mockResolvedValue({
+        intent: 'building_debt',
+        entity: { type: 'building', buildingAlias: 'torre el parque' },
+        filters: {
+          period: {
+            kind: 'relative_range',
+            amount: 5,
+            unit: 'month',
+            mode: 'unknown',
+            month: null,
+            year: null,
+            startMonth: null,
+            startYear: null,
+            endMonth: null,
+            endYear: null,
+          },
+        },
+        period: {
+          kind: 'relative_range',
+          amount: 5,
+          unit: 'month',
+          mode: 'unknown',
+          month: null,
+          year: null,
+          startMonth: null,
+          startYear: null,
+          endMonth: null,
+          endYear: null,
+        },
+        missingFields: ['period.mode'],
+        question: '¿Querés incluir el mes actual o consultar solo los últimos 5 meses cerrados?',
+        resolvedEntityIds: { buildingId: 'demo-A' },
+      });
+      mockIntentRegistry.has.mockReturnValue(true);
+      mockIntentSemanticValidator.evaluate.mockResolvedValue({
+        status: 'accepted',
+        reason: 'period_present',
+      });
+
+      const result = await service.chatV2(
+        'tenant-1',
+        'user-1',
+        'membership-1',
+        {
+          message: 'incluyendo este mes',
+          page: 'charges',
+          conversationId: 'conv-1',
+        },
+        ADMIN_ROLES,
+      );
+
+      expect(mockIntentExtractor.extractIntent).not.toHaveBeenCalled();
+      expect(mockIntentSemanticValidator.evaluate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          extractedIntent: expect.objectContaining({
+            filters: expect.objectContaining({
+              period: expect.objectContaining({
+                kind: 'relative_range',
+                amount: 5,
+                unit: 'month',
+                mode: 'including_current',
+              }),
+            }),
+          }),
+        }),
+      );
+      expect(mockQueryExecutorService.execute).not.toHaveBeenCalled();
+      expect(mockConversationContext.clearPendingClarification).toHaveBeenCalledWith('tenant-1', 'user-1', 'conv-1');
+      expect(result.type).toBe('text');
+      expect(result.summary).toContain('últimos 5 meses incluyendo el mes actual');
+      expect(result.summary).not.toContain('este mes o la deuda acumulada');
+    });
+
+    it('updates the relative-range mode to closed_months on follow-up', async () => {
+      mockConversationContext.getContext.mockResolvedValue([]);
+      mockConversationContext.getLastResolved.mockResolvedValue({});
+      mockConversationContext.getLastIntent.mockResolvedValue('building_debt');
+      mockConversationContext.getPendingClarification.mockResolvedValue({
+        intent: 'building_debt',
+        entity: { type: 'building', buildingAlias: 'torre el parque' },
+        filters: {
+          period: {
+            kind: 'relative_range',
+            amount: 5,
+            unit: 'month',
+            mode: 'unknown',
+            month: null,
+            year: null,
+            startMonth: null,
+            startYear: null,
+            endMonth: null,
+            endYear: null,
+          },
+        },
+        period: {
+          kind: 'relative_range',
+          amount: 5,
+          unit: 'month',
+          mode: 'unknown',
+          month: null,
+          year: null,
+          startMonth: null,
+          startYear: null,
+          endMonth: null,
+          endYear: null,
+        },
+        missingFields: ['period.mode'],
+        question: '¿Querés incluir el mes actual o consultar solo los últimos 5 meses cerrados?',
+      });
+      mockIntentRegistry.has.mockReturnValue(true);
+      mockIntentSemanticValidator.evaluate.mockResolvedValue({
+        status: 'accepted',
+        reason: 'period_present',
+      });
+
+      const result = await service.chatV2(
+        'tenant-1',
+        'user-1',
+        'membership-1',
+        {
+          message: 'meses cerrados',
+          page: 'charges',
+          conversationId: 'conv-1',
+        },
+        ADMIN_ROLES,
+      );
+
+      expect(mockIntentSemanticValidator.evaluate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          extractedIntent: expect.objectContaining({
+            filters: expect.objectContaining({
+              period: expect.objectContaining({
+                kind: 'relative_range',
+                amount: 5,
+                unit: 'month',
+                mode: 'closed_months',
+              }),
+            }),
+          }),
+        }),
+      );
+      expect(mockQueryExecutorService.execute).not.toHaveBeenCalled();
+      expect(result.type).toBe('text');
+      expect(result.summary).toContain('últimos 5 meses cerrados');
+    });
+
+    it('asks for period.mode on tenant debt relative range queries', async () => {
+      mockConversationContext.getContext.mockResolvedValue([]);
+      mockConversationContext.getLastResolved.mockResolvedValue({});
+      mockConversationContext.getLastIntent.mockResolvedValue(undefined);
+      mockQueryPlanService.createPlan.mockReturnValue({
+        intent: 'tenant_debt',
+        module: 'payments',
+        scope: 'tenant',
+        requiredPermission: 'payments.review',
+        executor: 'tenant_debt',
+        filters: {
+          period: {
+            kind: 'relative_range',
+            amount: 5,
+            unit: 'month',
+            mode: 'unknown',
+            month: null,
+            year: null,
+            startMonth: null,
+            startYear: null,
+            endMonth: null,
+            endYear: null,
+          },
+        },
+        confidence: 0.9,
+        source: 'deterministic_rules',
+      });
+      mockIntentRegistry.has.mockReturnValue(true);
+      mockResponseFormatter.formatV2.mockReturnValue({
+        type: 'clarification',
+        title: 'Aclaración',
+        summary: '¿Querés incluir el mes actual o consultar solo los últimos 5 meses cerrados?',
+        meta: {},
+      });
+
+      const result = await service.chatV2(
+        'tenant-1',
+        'user-1',
+        'membership-1',
+        {
+          message: 'deuda de los ultimos 5 meses de la administracion',
+          page: 'charges',
+          conversationId: 'conv-1',
+        },
+        ADMIN_ROLES,
+      );
+
+      expect(result.summary).toContain('incluir el mes actual');
+      expect(result.summary).toContain('últimos 5 meses cerrados');
+    });
+
     it('falls back to deterministic debt plan when Gemini fails for condominio debt', async () => {
       mockConversationContext.getContext.mockResolvedValue([]);
       mockConversationContext.getLastResolved.mockResolvedValue({});
@@ -785,6 +1165,352 @@ describe('AssistantService - Strict Operational Questions', () => {
       expect(mockLocalConsensus.evaluate).toHaveBeenCalled();
       expect(mockIntentExtractor.extractIntent).not.toHaveBeenCalled();
       expect(mockQueryExecutorService.execute).toHaveBeenCalled();
+    });
+
+    it('executes deterministic building debt when the local model is semantically invalid', async () => {
+      mockConversationContext.getContext.mockResolvedValue([]);
+      mockConversationContext.getLastResolved.mockResolvedValue({});
+      mockConversationContext.getLastIntent.mockResolvedValue(undefined);
+      mockLocalConsensus.isEnabled.mockReturnValue(true);
+      mockLocalConsensus.evaluate.mockResolvedValue({
+        consensus: false,
+        deterministicPlan: {
+          intent: 'building_debt',
+          scope: 'building',
+          entity: {
+            buildingAlias: 'A',
+            unitAlias: null,
+          },
+          period: {
+            kind: 'current_month',
+            month: 6,
+            year: 2026,
+            offset: 0,
+            amount: null,
+            unit: 'month',
+            mode: 'including_current',
+          },
+          confidence: 0.9,
+          requiresClarification: false,
+          missingFields: [],
+        },
+        modelPlan: {
+          intent: 'tenant_debt',
+          scope: 'building',
+          entity: {
+            buildingAlias: 'A',
+            unitAlias: null,
+          },
+          period: {
+            kind: 'current_month',
+            month: 6,
+            year: 2026,
+            offset: 0,
+            amount: null,
+            unit: 'month',
+            mode: 'including_current',
+          },
+          confidence: 0.96,
+          requiresClarification: false,
+          missingFields: [],
+        },
+        mismatchReason: 'model_intent_scope_conflict',
+        modelValid: false,
+        modelInvalidReason: 'model_intent_scope_conflict',
+        usedLocalModel: true,
+        localProvider: 'ollama',
+        localBaseUrl: 'http://localhost:11434',
+        localModel: 'qwen2.5:7b',
+      });
+      mockQueryPlanService.createPlan.mockReturnValue({
+        intent: 'building_debt',
+        module: 'payments',
+        scope: 'building',
+        requiredPermission: 'payments.review',
+        executor: 'building_debt',
+        filters: { buildingAlias: 'A', buildingToken: 'A', period: '2026-06' },
+        confidence: 0.9,
+        source: 'deterministic_rules',
+      });
+      mockIntentRegistry.has.mockReturnValue(true);
+      mockIntentSemanticValidator.evaluate.mockResolvedValue({
+        status: 'accepted',
+        reason: 'default_accept',
+      });
+      mockPrisma.building.findFirst.mockResolvedValue({
+        id: 'demo-A',
+        tenantId: 'tenant-1',
+        deletedAt: null,
+      });
+      mockEntityResolver.resolveBuilding.mockResolvedValue({
+        building: { id: 'demo-A', name: 'Edificio A', alias: 'A' },
+        alternatives: [],
+      });
+      mockAmbiguityService.detectAmbiguity.mockReturnValue(false);
+      mockQueryPlannerService.buildPlan.mockImplementation((intent, resolved) => ({
+        intent: intent.intent,
+        entityIds: { buildingId: resolved.building?.id },
+        filters: intent.filters,
+        pagination: { limit: 20 },
+      }));
+      mockQueryExecutorService.execute.mockResolvedValue({ totalDebt: 115801, currency: 'ARS' });
+      mockResponseFormatter.formatV2.mockReturnValue({
+        type: 'kpi',
+        title: 'Deuda',
+        summary: 'Deuda total: ARS 1.158,01',
+        meta: {},
+      });
+
+      await service.chatV2(
+        'tenant-1',
+        'user-1',
+        'membership-1',
+        {
+          message: 'dame la deuda del mes que está corriendo del edificio A',
+          page: 'charges',
+          currentPage: '/tenant-1/buildings/demo-A/finance',
+          buildingId: 'demo-A',
+          conversationId: 'conv-1',
+        },
+        ADMIN_ROLES,
+      );
+
+      expect(mockQueryExecutorService.execute).toHaveBeenCalledWith(
+        expect.objectContaining({ entityIds: expect.objectContaining({ buildingId: 'demo-A' }) }),
+        'tenant-1',
+        'user-1',
+        ADMIN_ROLES,
+      );
+      expect(mockResponseFormatter.formatV2).not.toHaveBeenCalledWith(
+        expect.objectContaining({ clarificationMessage: expect.stringContaining('contexto') }),
+        expect.any(String),
+        expect.any(Number),
+      );
+    });
+
+    it('asks only for the missing period when the model is semantically invalid and the building is already known', async () => {
+      mockConversationContext.getContext.mockResolvedValue([]);
+      mockConversationContext.getLastResolved.mockResolvedValue({});
+      mockConversationContext.getLastIntent.mockResolvedValue(undefined);
+      mockLocalConsensus.isEnabled.mockReturnValue(true);
+      mockLocalConsensus.evaluate.mockResolvedValue({
+        consensus: false,
+        deterministicPlan: {
+          intent: 'building_debt',
+          scope: 'building',
+          entity: {
+            buildingAlias: 'A',
+            unitAlias: null,
+          },
+          period: {
+            kind: 'unknown',
+            month: null,
+            year: null,
+            offset: null,
+            amount: null,
+            unit: null,
+            mode: null,
+          },
+          confidence: 0.9,
+          requiresClarification: false,
+          missingFields: ['period'],
+        },
+        modelPlan: {
+          intent: 'tenant_debt',
+          scope: 'building',
+          entity: {
+            buildingAlias: 'A',
+            unitAlias: null,
+          },
+          period: {
+            kind: 'current_month',
+            month: 6,
+            year: 2026,
+            offset: 0,
+            amount: null,
+            unit: 'month',
+            mode: 'including_current',
+          },
+          confidence: 0.96,
+          requiresClarification: false,
+          missingFields: [],
+        },
+        mismatchReason: 'model_intent_scope_conflict',
+        modelValid: false,
+        modelInvalidReason: 'model_intent_scope_conflict',
+        usedLocalModel: true,
+        localProvider: 'ollama',
+        localBaseUrl: 'http://localhost:11434',
+        localModel: 'qwen2.5:7b',
+      });
+      mockQueryPlanService.createPlan.mockReturnValue({
+        intent: 'building_debt',
+        module: 'payments',
+        scope: 'building',
+        requiredPermission: 'payments.review',
+        executor: 'building_debt',
+        filters: { buildingAlias: 'A', buildingToken: 'A' },
+        confidence: 0.9,
+        source: 'deterministic_rules',
+      });
+      mockIntentRegistry.has.mockReturnValue(true);
+      mockIntentSemanticValidator.evaluate.mockResolvedValue({
+        status: 'needs_clarification',
+        reason: 'period_ambiguous',
+        question: '¿Querés la deuda de este mes o la deuda acumulada?',
+      });
+      mockEntityResolver.resolveBuilding.mockResolvedValue({
+        building: { id: 'demo-A', name: 'Edificio A', alias: 'A' },
+        alternatives: [],
+      });
+      mockResponseFormatter.formatV2.mockReturnValue({
+        type: 'clarification',
+        title: 'Aclaración',
+        summary: '¿Querés la deuda de este mes o la deuda acumulada?',
+        meta: {},
+      });
+
+      const result = await service.chatV2(
+        'tenant-1',
+        'user-1',
+        'membership-1',
+        {
+          message: 'deuda del edificio A',
+          page: 'charges',
+          buildingId: 'demo-A',
+          conversationId: 'conv-1',
+        },
+        ADMIN_ROLES,
+      );
+
+      expect(mockQueryExecutorService.execute).not.toHaveBeenCalled();
+      expect(result.type).toBe('clarification');
+      expect(result.summary).toContain('este mes o la deuda acumulada');
+      expect(result.summary).not.toContain('administración, un edificio o una unidad');
+    });
+
+    it('executes building debt when the local model enriches a missing current-month period', async () => {
+      mockConversationContext.getContext.mockResolvedValue([]);
+      mockConversationContext.getLastResolved.mockResolvedValue({});
+      mockConversationContext.getLastIntent.mockResolvedValue(undefined);
+      mockLocalConsensus.isEnabled.mockReturnValue(true);
+      mockLocalConsensus.evaluate.mockResolvedValue({
+        consensus: true,
+        deterministicPlan: {
+          intent: 'building_debt',
+          scope: 'building',
+          entity: {
+            buildingAlias: 'A',
+            unitAlias: null,
+          },
+          period: {
+            kind: 'unknown',
+            month: null,
+            year: null,
+            offset: null,
+            amount: null,
+            unit: null,
+            mode: null,
+          },
+          confidence: 0.85,
+          requiresClarification: false,
+          missingFields: [],
+        },
+        modelPlan: {
+          intent: 'building_debt',
+          scope: 'building',
+          entity: {
+            buildingAlias: 'A',
+            unitAlias: null,
+          },
+          period: {
+            kind: 'current_month',
+            month: 6,
+            year: 2026,
+            offset: 0,
+            amount: null,
+            unit: 'month',
+            mode: 'including_current',
+          },
+          confidence: 0.97,
+          requiresClarification: false,
+          missingFields: [],
+        },
+        usedLocalModel: true,
+        localProvider: 'ollama',
+        localBaseUrl: 'http://localhost:11434',
+        localModel: 'qwen2.5:7b',
+      });
+      mockQueryPlanService.createPlan.mockReturnValue({
+        intent: 'building_debt',
+        module: 'payments',
+        scope: 'building',
+        requiredPermission: 'payments.review',
+        executor: 'building_debt',
+        filters: { buildingAlias: 'A', buildingToken: 'A' },
+        confidence: 0.85,
+        source: 'deterministic_rules',
+      });
+      mockIntentRegistry.has.mockReturnValue(true);
+      mockIntentSemanticValidator.evaluate.mockResolvedValue({
+        status: 'accepted',
+        reason: 'default_accept',
+      });
+      mockPrisma.building.findFirst.mockResolvedValue({
+        id: 'demo-A',
+        tenantId: 'tenant-1',
+        deletedAt: null,
+      });
+      mockEntityResolver.resolveBuilding.mockResolvedValue({
+        building: { id: 'demo-A', name: 'Edificio A', alias: 'A' },
+        alternatives: [],
+      });
+      mockAmbiguityService.detectAmbiguity.mockReturnValue(false);
+      mockQueryPlannerService.buildPlan.mockImplementation((intent, resolved) => ({
+        intent: intent.intent,
+        entityIds: { buildingId: resolved.building?.id },
+        filters: intent.filters,
+        pagination: { limit: 20 },
+      }));
+      mockQueryExecutorService.execute.mockResolvedValue({ totalDebt: 115801, currency: 'ARS' });
+      mockResponseFormatter.formatV2.mockReturnValue({
+        type: 'kpi',
+        title: 'Deuda',
+        summary: 'Deuda total: ARS 1.158,01',
+        meta: {},
+      });
+
+      await service.chatV2(
+        'tenant-1',
+        'user-1',
+        'membership-1',
+        {
+          message: 'dame la deuda del mes que está corriendo del edificio A',
+          page: 'charges',
+          currentPage: '/tenant-1/buildings/demo-A/finance',
+          buildingId: 'demo-A',
+          conversationId: 'conv-1',
+        },
+        ADMIN_ROLES,
+      );
+
+      expect(mockLocalConsensus.evaluate).toHaveBeenCalled();
+      expect(mockIntentExtractor.extractIntent).not.toHaveBeenCalled();
+      expect(mockQueryPlannerService.buildPlan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          intent: 'building_debt',
+          filters: expect.objectContaining({ period: new Date().toISOString().slice(0, 7) }),
+        }),
+        expect.objectContaining({
+          building: expect.objectContaining({ id: 'demo-A', alias: 'A' }),
+        }),
+      );
+      expect(mockQueryExecutorService.execute).toHaveBeenCalledWith(
+        expect.objectContaining({ entityIds: expect.objectContaining({ buildingId: 'demo-A' }) }),
+        'tenant-1',
+        'user-1',
+        ADMIN_ROLES,
+      );
     });
 
     it('uses finance period context before executing building debt', async () => {

--- a/apps/api/src/assistant/assistant.service.spec.ts
+++ b/apps/api/src/assistant/assistant.service.spec.ts
@@ -14,6 +14,7 @@ import { AssistantQueryPlanService } from './query-plan.service';
 import { AssistantQueryExecutorsService } from './query-executors.service';
 import { AssistantDebtCalculatorService } from './assistant-debt-calculator.service';
 import { IntentExtractorService } from './intent-engine/intent-extractor.service';
+import { AssistantLocalConsensusService } from './intent-engine/local-consensus.service';
 import { EntityResolverService } from './resolver/entity-resolver.service';
 import { AmbiguityService } from './resolver/ambiguity.service';
 import { RedisConversationContextService } from './context/redis-conversation-context.service';
@@ -69,6 +70,12 @@ describe('AssistantService - Strict Operational Questions', () => {
   const mockQueryExecutors = { execute: jest.fn() };
   const mockDebtCalculator = new AssistantDebtCalculatorService();
   const mockIntentExtractor = { extractIntent: jest.fn() };
+  const mockLocalConsensus = {
+    isEnabled: jest.fn(),
+    evaluate: jest.fn(),
+    getBaseUrl: jest.fn(),
+    getModel: jest.fn(),
+  };
   const mockEntityResolver = { resolveBuilding: jest.fn(), resolveUnit: jest.fn(), resolvePerson: jest.fn() };
   const mockAmbiguityService = { detectAmbiguity: jest.fn(), generateClarification: jest.fn() };
   const mockConversationContext = {
@@ -106,6 +113,9 @@ describe('AssistantService - Strict Operational Questions', () => {
     mockAuthorize.authorize.mockResolvedValue(true);
     mockQueryPlanService.createPlan.mockReturnValue(null);
     mockQueryExecutors.execute.mockResolvedValue(null);
+    mockLocalConsensus.isEnabled.mockReturnValue(false);
+    mockLocalConsensus.getBaseUrl.mockReturnValue('http://localhost:11434');
+    mockLocalConsensus.getModel.mockReturnValue('qwen2.5:3b');
     mockConversationContext.getContext.mockResolvedValue([]);
     mockConversationContext.getLastResolved.mockResolvedValue({});
     mockConversationContext.getLastIntent.mockResolvedValue(undefined);
@@ -146,6 +156,7 @@ describe('AssistantService - Strict Operational Questions', () => {
         { provide: AssistantQueryExecutorsService, useValue: mockQueryExecutors },
         { provide: AssistantDebtCalculatorService, useValue: mockDebtCalculator },
         { provide: IntentExtractorService, useValue: mockIntentExtractor },
+        { provide: AssistantLocalConsensusService, useValue: mockLocalConsensus },
         { provide: EntityResolverService, useValue: mockEntityResolver },
         { provide: AmbiguityService, useValue: mockAmbiguityService },
         { provide: RedisConversationContextService, useValue: mockConversationContext },
@@ -663,6 +674,117 @@ describe('AssistantService - Strict Operational Questions', () => {
       expect(mockQueryPlannerService.buildPlan).not.toHaveBeenCalled();
       expect(mockQueryExecutorService.execute).not.toHaveBeenCalled();
       expect(result.type).toBe('clarification');
+    });
+
+    it('uses local consensus mode and bypasses the intent extractor when enabled', async () => {
+      mockConversationContext.getContext.mockResolvedValue([]);
+      mockConversationContext.getLastResolved.mockResolvedValue({});
+      mockConversationContext.getLastIntent.mockResolvedValue(undefined);
+      mockLocalConsensus.isEnabled.mockReturnValue(true);
+      mockLocalConsensus.evaluate.mockResolvedValue({
+        consensus: true,
+        deterministicPlan: {
+          intent: 'building_debt',
+          scope: 'building',
+          entity: {
+            buildingAlias: 'B',
+            unitAlias: null,
+          },
+          period: {
+            kind: 'current_month',
+            month: 6,
+            year: 2026,
+            offset: 0,
+            amount: null,
+            unit: 'month',
+            mode: 'including_current',
+          },
+          confidence: 0.9,
+          requiresClarification: false,
+          missingFields: [],
+        },
+        modelPlan: {
+          intent: 'building_debt',
+          scope: 'building',
+          entity: {
+            buildingAlias: 'B',
+            unitAlias: null,
+          },
+          period: {
+            kind: 'current_month',
+            month: 6,
+            year: 2026,
+            offset: 0,
+            amount: null,
+            unit: 'month',
+            mode: 'including_current',
+          },
+          confidence: 0.96,
+          requiresClarification: false,
+          missingFields: [],
+        },
+        usedLocalModel: true,
+        localProvider: 'ollama',
+        localBaseUrl: 'http://localhost:11434',
+        localModel: 'qwen2.5:3b',
+      });
+      mockQueryPlanService.createPlan.mockReturnValue({
+        intent: 'building_debt',
+        module: 'payments',
+        scope: 'building',
+        requiredPermission: 'payments.review',
+        executor: 'building_debt',
+        filters: { buildingAlias: 'B', buildingToken: 'B', period: '2026-06' },
+        confidence: 0.9,
+        source: 'deterministic_rules',
+      });
+      mockIntentRegistry.has.mockReturnValue(true);
+      mockIntentSemanticValidator.evaluate.mockResolvedValue({
+        status: 'accepted',
+        reason: 'default_accept',
+      });
+      mockPrisma.building.findFirst.mockResolvedValue({
+        id: 'demo-B',
+        tenantId: 'tenant-1',
+        deletedAt: null,
+      });
+      mockEntityResolver.resolveBuilding.mockResolvedValue({
+        building: { id: 'demo-B', name: 'Edificio del Río', alias: 'B' },
+        alternatives: [],
+      });
+      mockAmbiguityService.detectAmbiguity.mockReturnValue(false);
+      mockQueryPlannerService.buildPlan.mockImplementation((intent, resolved) => ({
+        intent: intent.intent,
+        entityIds: { buildingId: resolved.building?.id },
+        filters: intent.filters,
+        pagination: { limit: 20 },
+      }));
+      mockQueryExecutorService.execute.mockResolvedValue({ totalDebt: 115801, currency: 'ARS' });
+      mockResponseFormatter.formatV2.mockReturnValue({
+        type: 'kpi',
+        title: 'Deuda',
+        summary: 'Deuda total: ARS 1.158,01',
+        meta: {},
+      });
+
+      await service.chatV2(
+        'tenant-1',
+        'user-1',
+        'membership-1',
+        {
+          message: 'deuda de este mes del edificio B',
+          page: 'charges',
+          currentPage: '/tenant-1/buildings/demo-B/finance',
+          financePeriod: '2026-06',
+          buildingId: 'demo-B',
+          conversationId: 'conv-1',
+        },
+        ADMIN_ROLES,
+      );
+
+      expect(mockLocalConsensus.evaluate).toHaveBeenCalled();
+      expect(mockIntentExtractor.extractIntent).not.toHaveBeenCalled();
+      expect(mockQueryExecutorService.execute).toHaveBeenCalled();
     });
 
     it('uses finance period context before executing building debt', async () => {

--- a/apps/api/src/assistant/assistant.service.spec.ts
+++ b/apps/api/src/assistant/assistant.service.spec.ts
@@ -610,6 +610,61 @@ describe('AssistantService - Strict Operational Questions', () => {
       expect(result.type).toBe('clarification');
     });
 
+    it('falls back to deterministic debt plan when Gemini fails for condominio debt', async () => {
+      mockConversationContext.getContext.mockResolvedValue([]);
+      mockConversationContext.getLastResolved.mockResolvedValue({});
+      mockConversationContext.getLastIntent.mockResolvedValue(undefined);
+      mockQueryPlanService.createPlan.mockReturnValue({
+        intent: 'building_debt',
+        module: 'payments',
+        scope: 'building',
+        requiredPermission: 'payments.review',
+        executor: 'building_debt',
+        filters: {},
+        confidence: 0.85,
+        source: 'deterministic_rules',
+      });
+      mockIntentExtractor.extractIntent.mockRejectedValue(new Error('Gemini API error: 400 Bad Request'));
+      mockIntentRegistry.has.mockReturnValue(true);
+      mockIntentSemanticValidator.evaluate.mockResolvedValue({
+        status: 'needs_clarification',
+        reason: 'building_scope_missing_context',
+        question: '¿De cuál condominio/edificio quieres consultar la deuda?',
+      });
+      mockResponseFormatter.formatV2.mockReturnValue({
+        type: 'clarification',
+        title: 'Aclaración',
+        summary: '¿De cuál condominio/edificio quieres consultar la deuda?',
+        meta: {},
+      });
+
+      const result = await service.chatV2(
+        'tenant-1',
+        'user-1',
+        'membership-1',
+        { message: 'deuda del condominio', page: 'charges', conversationId: 'conv-1' },
+        ADMIN_ROLES,
+      );
+
+      expect(mockIntentSemanticValidator.evaluate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deterministicPlan: expect.objectContaining({
+            intent: 'building_debt',
+            confidence: 0.85,
+          }),
+          extractedIntent: expect.objectContaining({
+            intent: 'building_debt',
+            confidence: 0.85,
+            source: 'hybrid',
+            llmProvider: 'none',
+          }),
+        }),
+      );
+      expect(mockQueryPlannerService.buildPlan).not.toHaveBeenCalled();
+      expect(mockQueryExecutorService.execute).not.toHaveBeenCalled();
+      expect(result.type).toBe('clarification');
+    });
+
     it('uses finance period context before executing building debt', async () => {
       mockConversationContext.getContext.mockResolvedValue([]);
       mockConversationContext.getLastResolved.mockResolvedValue({});

--- a/apps/api/src/assistant/assistant.service.ts
+++ b/apps/api/src/assistant/assistant.service.ts
@@ -24,6 +24,7 @@ import {
   AiProviderContext,
   AiProviderStatus,
   StructuredResponse,
+  type AssistantConsensusPeriod,
 } from './ai.types';
 import type { AssistantConsensusEvaluation } from './ai.types';
 
@@ -65,6 +66,7 @@ import { buildingStatsIntent } from './intent-engine/allowed-intents/building-st
 import { tenantDebtIntent } from './intent-engine/allowed-intents/tenant-debt.intent';
 import { IntentSemanticValidatorService } from './intent-semantic-validator.service';
 import type { IntentSemanticValidationResult } from './intent-semantic-validator.service';
+import type { CanonicalFinancePeriod } from './finance-period.types';
 
 const TEMPORARILY_UNAVAILABLE_INTENTS = new Set([
   'expenses_summary',
@@ -711,7 +713,22 @@ export class AssistantService implements OnModuleInit {
             : 'consensus_mismatch';
 
         if (consensusResult.consensus && deterministicPlan) {
-          extractedIntent = this.buildExtractedIntentFromPlan(deterministicPlan);
+          extractedIntent = this.buildExtractedIntentFromPlan(
+            this.mergeConsensusPlanWithModel(deterministicPlan, consensusResult.modelPlan),
+          );
+        } else if (
+          (consensusResult.mismatchReason === 'model_semantic_invalid' ||
+            consensusResult.mismatchReason === 'model_intent_scope_conflict') &&
+          deterministicPlan
+        ) {
+          if (this.isDeterministicPlanExecutable(deterministicPlan)) {
+            extractedIntent = this.buildExtractedIntentFromPlan(deterministicPlan);
+          } else {
+            extractedIntent = this.buildClarificationIntentFromConsensus(
+              deterministicPlan,
+              consensusResult,
+            );
+          }
         } else {
           extractedIntent = this.buildClarificationIntentFromConsensus(
             deterministicPlan,
@@ -890,6 +907,7 @@ export class AssistantService implements OnModuleInit {
         buildingId: request.buildingId,
         unitId: request.unitId,
         financePeriod: request.financePeriod,
+        pendingClarification: shouldUsePendingClarification ? pendingClarification : undefined,
       },
     });
     debugInfo.semanticValidationStatus = semanticValidation.status;
@@ -911,6 +929,7 @@ export class AssistantService implements OnModuleInit {
           clarificationResolvedEntities,
           this.resolveClarificationMissingFields(semanticValidation, extractedIntent),
           semanticValidation.question,
+          this.extractCanonicalPeriod(deterministicPlan?.filters.period),
         ),
       );
       await this.storeConversationTurn(
@@ -963,6 +982,33 @@ export class AssistantService implements OnModuleInit {
       debugInfo.finalFilters = extractedIntent.filters as Record<string, unknown>;
     }
 
+    const canonicalRequestedPeriod = this.extractCanonicalPeriod(extractedIntent.filters.period);
+    if (
+      canonicalRequestedPeriod?.kind === 'relative_range' &&
+      semanticValidation.status === 'accepted' &&
+      extractedIntent.intent === 'building_debt'
+    ) {
+      const relativeRangeResponse = this.buildRelativeRangeAcknowledgementResponse(
+        extractedIntent,
+        canonicalRequestedPeriod,
+      );
+      if (debugEnabled) {
+        (relativeRangeResponse as StructuredResponse).debug = debugInfo;
+      }
+      await this.storeConversationTurn(
+        tenantId,
+        userId,
+        sessionId,
+        request.message,
+        contextResolvedEntities,
+        { intent: extractedIntent.intent, filters: extractedIntent.filters as Record<string, unknown> },
+      );
+      if (usedPendingClarification) {
+        await this.conversationContext.clearPendingClarification(tenantId, userId, sessionId);
+      }
+      return relativeRangeResponse;
+    }
+
     if (extractedIntent.requiresClarification) {
       const missing = extractedIntent.missingFields?.join(', ') || 'contexto adicional';
       const clarificationMessage =
@@ -983,6 +1029,8 @@ export class AssistantService implements OnModuleInit {
           clarificationResolvedEntities,
           this.resolveClarificationMissingFields(undefined, extractedIntent),
           clarificationMessage,
+          this.extractCanonicalPeriod(extractedIntent.filters.period) ??
+            this.extractCanonicalPeriod(deterministicPlan?.filters.period),
         ),
       );
       await this.storeConversationTurn(
@@ -1442,10 +1490,11 @@ export class AssistantService implements OnModuleInit {
       .trim();
 
     // Map follow-up keywords to intents
-    if (/\bmes(es)?\b.*\bdeuda\b|\bdeuda\b.*\bmes(es)?\b/.test(normalized)) {
-      return 'unit_debt';
+    if (this.isPeriodClarificationReply(normalized)) {
+      return null;
     }
-    if (/\bmes(es)?\b.*\bdebe\b|\bdebe\b.*\bmes(es)?\b/.test(normalized)) {
+
+    if (/\bunidad\b|\bapartamento\b|\bdepto\b|\bdepartamento\b/.test(normalized) && /\bdeuda\b|\bdebe\b/.test(normalized)) {
       return 'unit_debt';
     }
     if (/\bticket(s)?\b/.test(normalized)) {
@@ -1478,12 +1527,16 @@ export class AssistantService implements OnModuleInit {
       .trim();
 
     const expectsPeriod = pendingClarification.missingFields.includes('period');
+    const expectsPeriodMode = pendingClarification.missingFields.includes('period.mode');
     const expectsBuilding = pendingClarification.missingFields.includes('building');
+
+    if (expectsPeriodMode) {
+      return this.isRelativeRangeModeFollowUp(normalized);
+    }
 
     if (expectsPeriod) {
       return (
-        normalized.includes('este mes') ||
-        normalized.includes('mes actual') ||
+        this.isCurrentMonthFollowUpAlias(normalized) ||
         /^acumulad[ao]s?\b/.test(normalized) ||
         /^historic[ao]s?\b/.test(normalized) ||
         /^historica\b/.test(normalized) ||
@@ -1527,14 +1580,37 @@ export class AssistantService implements OnModuleInit {
     return {};
   }
 
-  private inferFiltersFromFollowUp(message: string): ExtractedIntent['filters'] {
+  private inferFiltersFromFollowUp(
+    message: string,
+    pendingClarification?: PendingClarificationContext,
+  ): ExtractedIntent['filters'] {
     const normalized = message
       .toLowerCase()
       .normalize('NFD')
       .replace(/[\u0300-\u036f]/g, '')
       .trim();
 
-    if (normalized.includes('este mes') || normalized.includes('mes actual')) {
+    if (pendingClarification?.period?.kind === 'relative_range') {
+      if (this.isIncludingCurrentRangeFollowUp(normalized)) {
+        return {
+          period: {
+            ...pendingClarification.period,
+            mode: 'including_current',
+          },
+        };
+      }
+
+      if (this.isClosedRangeFollowUp(normalized)) {
+        return {
+          period: {
+            ...pendingClarification.period,
+            mode: 'closed_months',
+          },
+        };
+      }
+    }
+
+    if (this.isCurrentMonthFollowUpAlias(normalized)) {
       return {
         period: new Date().toISOString().slice(0, 7),
       };
@@ -1583,7 +1659,7 @@ export class AssistantService implements OnModuleInit {
       },
       filters: {
         ...pendingClarification.filters,
-        ...this.inferFiltersFromFollowUp(message),
+        ...this.inferFiltersFromFollowUp(message, pendingClarification),
       },
       confidence: 0.85,
       source: 'hybrid',
@@ -1616,6 +1692,95 @@ export class AssistantService implements OnModuleInit {
       requiresClarification: false,
       missingFields: [],
     };
+  }
+
+  private mergeConsensusPlanWithModel(
+    deterministicPlan: AssistantQueryPlan,
+    modelPlan: AssistantConsensusEvaluation['modelPlan'],
+  ): AssistantQueryPlan {
+    if (!modelPlan) {
+      return deterministicPlan;
+    }
+
+    const mergedFilters: AssistantQueryPlan['filters'] = {
+      ...deterministicPlan.filters,
+    };
+
+    if (!mergedFilters.period) {
+      const mergedPeriod = this.resolveConsensusPeriod(modelPlan.period);
+      if (mergedPeriod) {
+        mergedFilters.period = mergedPeriod;
+      }
+    }
+
+    if (!mergedFilters.buildingAlias && modelPlan.entity.buildingAlias) {
+      mergedFilters.buildingAlias = modelPlan.entity.buildingAlias;
+    }
+
+    if (!mergedFilters.unitCode && modelPlan.entity.unitAlias) {
+      mergedFilters.unitCode = modelPlan.entity.unitAlias;
+    }
+
+    return {
+      ...deterministicPlan,
+      filters: mergedFilters,
+      confidence: Math.max(deterministicPlan.confidence, modelPlan.confidence ?? deterministicPlan.confidence),
+    };
+  }
+
+  private resolveConsensusPeriod(period: AssistantConsensusPeriod | null | undefined): string | undefined {
+    if (!period || period.kind === 'unknown') {
+      return undefined;
+    }
+
+    if (period.kind === 'accumulated') {
+      return 'accumulated';
+    }
+
+    if (period.kind === 'current_month') {
+      const current = new Date();
+      return current.toISOString().slice(0, 7);
+    }
+
+    if (period.kind === 'previous_month') {
+      const current = new Date();
+      const previous = new Date(current.getFullYear(), current.getMonth() - 1, 1);
+      return previous.toISOString().slice(0, 7);
+    }
+
+    if (period.kind === 'named_month' && period.year && period.month) {
+      return `${period.year}-${String(period.month).padStart(2, '0')}`;
+    }
+
+    return undefined;
+  }
+
+  private isCurrentMonthFollowUpAlias(normalized: string): boolean {
+    const isPastMonth = normalized.includes('mes pasado') || normalized.includes('ultimo mes') || normalized.includes('último mes');
+
+    return (
+      !isPastMonth &&
+      (
+        normalized.includes('este mes') ||
+        normalized.includes('mes actual') ||
+        normalized.includes('mes en curso') ||
+        normalized.includes('mes corriente') ||
+        normalized.includes('mes que esta corriendo') ||
+        normalized.includes('mes que corre') ||
+        normalized.includes('del mes actual') ||
+        normalized.includes('del mes en curso') ||
+        normalized.includes('deuda del mes') ||
+        /\bdel mes\b/.test(normalized)
+      )
+    );
+  }
+
+  private isPeriodClarificationReply(normalized: string): boolean {
+    return this.isCurrentMonthFollowUpAlias(normalized) ||
+      /^acumulad[ao]s?\b/.test(normalized) ||
+      /^historic[ao]s?\b/.test(normalized) ||
+      /^historica\b/.test(normalized) ||
+      /^toda\b/.test(normalized);
   }
 
   private buildClarificationIntentFromConsensus(
@@ -1656,6 +1821,17 @@ export class AssistantService implements OnModuleInit {
     consensusResult: AssistantConsensusEvaluation,
     deterministicPlan: AssistantQueryPlan | null,
   ): string[] {
+    if (consensusResult.modelPlan?.period.kind === 'relative_range') {
+      return ['period.mode'];
+    }
+
+    if (
+      consensusResult.mismatchReason === 'model_semantic_invalid' ||
+      consensusResult.mismatchReason === 'model_intent_scope_conflict'
+    ) {
+      return this.resolveDeterministicMissingFields(deterministicPlan);
+    }
+
     if (consensusResult.mismatchReason === 'period') {
       return ['period'];
     }
@@ -1690,6 +1866,59 @@ export class AssistantService implements OnModuleInit {
     }
 
     return [];
+  }
+
+  private resolveDeterministicMissingFields(deterministicPlan: AssistantQueryPlan | null): string[] {
+    if (!deterministicPlan) {
+      return ['scope'];
+    }
+
+    const missingFields: string[] = [];
+    const hasBuildingAlias = Boolean(deterministicPlan.filters.buildingAlias || deterministicPlan.filters.buildingToken);
+    const hasUnitCode = Boolean(deterministicPlan.filters.unitCode || deterministicPlan.filters.unitCodeRaw);
+    const hasPeriod = Boolean(deterministicPlan.filters.period);
+    const canonicalPeriod = this.extractCanonicalPeriod(deterministicPlan.filters.period);
+
+    if (deterministicPlan.scope === 'building') {
+      if (!hasBuildingAlias) {
+        missingFields.push('building');
+      }
+      if (!hasPeriod && deterministicPlan.intent === 'building_debt') {
+        missingFields.push('period');
+      }
+      if (canonicalPeriod?.kind === 'relative_range' && canonicalPeriod.mode === 'unknown') {
+        missingFields.push('period.mode');
+      }
+      return missingFields.length > 0 ? missingFields : [];
+    }
+
+    if (deterministicPlan.scope === 'unit') {
+      if (!hasUnitCode) {
+        missingFields.push('unit');
+      }
+      if (!hasPeriod && deterministicPlan.intent === 'unit_debt') {
+        missingFields.push('period');
+      }
+      if (canonicalPeriod?.kind === 'relative_range' && canonicalPeriod.mode === 'unknown') {
+        missingFields.push('period.mode');
+      }
+      return missingFields.length > 0 ? missingFields : [];
+    }
+
+    if (deterministicPlan.scope === 'tenant' && !hasPeriod && deterministicPlan.intent === 'tenant_debt') {
+      return ['period'];
+    }
+
+    if (canonicalPeriod?.kind === 'relative_range' && canonicalPeriod.mode === 'unknown') {
+      return ['period.mode'];
+    }
+
+    return missingFields;
+  }
+
+  private isDeterministicPlanExecutable(deterministicPlan: AssistantQueryPlan): boolean {
+    const missingFields = this.resolveDeterministicMissingFields(deterministicPlan);
+    return missingFields.length === 0;
   }
 
   private buildResolvedEntitiesFromPendingClarification(
@@ -1743,6 +1972,10 @@ export class AssistantService implements OnModuleInit {
     semanticValidation: IntentSemanticValidationResult | undefined,
     extractedIntent: ExtractedIntent,
   ): string[] {
+    if (semanticValidation?.reason === 'relative_range_mode_ambiguous') {
+      return ['period.mode'];
+    }
+
     if (semanticValidation?.reason === 'building_scope_missing_context') {
       return ['building'];
     }
@@ -1760,6 +1993,48 @@ export class AssistantService implements OnModuleInit {
     }
 
     return ['period'];
+  }
+
+  private buildRelativeRangeAcknowledgementResponse(
+    extractedIntent: ExtractedIntent,
+    period: CanonicalFinancePeriod,
+  ): StructuredResponse {
+    return {
+      type: 'text',
+      title: 'Periodo identificado',
+      summary: `Entendido. Tomé el período relativo como ${this.describeRelativeRangePeriod(period)}.`,
+      actions: [],
+      meta: {
+        confidence: extractedIntent.confidence,
+        periodKind: period.kind,
+      },
+    };
+  }
+
+  private describeRelativeRangePeriod(period: CanonicalFinancePeriod): string {
+    const amount = period.amount ?? 0;
+    if (period.mode === 'including_current') {
+      return `los últimos ${amount} meses incluyendo el mes actual`;
+    }
+    if (period.mode === 'closed_months') {
+      return `los últimos ${amount} meses cerrados`;
+    }
+    return `los últimos ${amount} meses`;
+  }
+
+  private isRelativeRangeModeFollowUp(normalized: string): boolean {
+    return this.isIncludingCurrentRangeFollowUp(normalized) || this.isClosedRangeFollowUp(normalized);
+  }
+
+  private isIncludingCurrentRangeFollowUp(normalized: string): boolean {
+    return (
+      /\b(incluyendo este mes|incluye este mes|con este mes|incluyendo el mes actual|sumando este mes|mas este mes|más este mes)\b/.test(normalized) ||
+      this.isCurrentMonthFollowUpAlias(normalized)
+    );
+  }
+
+  private isClosedRangeFollowUp(normalized: string): boolean {
+    return /\b(cerrados|solo meses cerrados|sin incluir este mes|sin contar este mes|solo los meses cerrados)\b/.test(normalized);
   }
 
   private async resolveClarificationContext(
@@ -1807,11 +2082,13 @@ export class AssistantService implements OnModuleInit {
     resolvedEntities: EntityResolution | undefined,
     missingFields: string[] | undefined,
     question?: string,
+    period?: CanonicalFinancePeriod | null,
   ): PendingClarificationContext {
     return {
       intent: extractedIntent.intent,
       entity: extractedIntent.entity,
       filters: extractedIntent.filters,
+      period: period ?? this.extractCanonicalPeriod(extractedIntent.filters.period),
       missingFields:
         missingFields && missingFields.length > 0
           ? missingFields
@@ -1825,6 +2102,14 @@ export class AssistantService implements OnModuleInit {
         personId: resolvedEntities?.person?.id,
       },
     };
+  }
+
+  private extractCanonicalPeriod(period: string | CanonicalFinancePeriod | undefined): CanonicalFinancePeriod | undefined {
+    if (!period || typeof period === 'string') {
+      return undefined;
+    }
+
+    return period;
   }
 
   private async storeConversationTurn(
@@ -1865,7 +2150,7 @@ export class AssistantService implements OnModuleInit {
     const debtInterpretation = this.debtIntentInterpreter.interpret(message);
 
     if (debtInterpretation.scope === 'tenant') {
-      const response = await this.tryResolveStrictTenantDebtQuestion(tenantId, userRoles, userId);
+      const response = await this.tryResolveStrictTenantDebtQuestion(tenantId, userRoles, userId, message);
       if (response) {
         return response;
       }
@@ -2623,9 +2908,19 @@ export class AssistantService implements OnModuleInit {
     tenantId: string,
     userRoles: string[],
     userId?: string,
+    message?: string,
   ): Promise<ChatResponse | null> {
     if (!this.canAccessOperationalData(userRoles)) {
       return null;
+    }
+
+    const plan = message ? this.queryPlanService.createPlan(message) : null;
+    const canonicalPeriod = this.extractCanonicalPeriod(plan?.filters.period);
+    if (plan?.intent === 'tenant_debt' && canonicalPeriod?.kind === 'relative_range' && canonicalPeriod.mode === 'unknown') {
+      return {
+        answer: `¿Querés incluir el mes actual o consultar solo los últimos ${canonicalPeriod.amount ?? 0} meses cerrados?`,
+        suggestedActions: [{ type: 'VIEW_PAYMENTS', payload: {} }],
+      };
     }
 
     const response = await this.queryExecutors.execute({
@@ -2638,7 +2933,7 @@ export class AssistantService implements OnModuleInit {
         scope: 'tenant',
         requiredPermission: 'payments.review',
         executor: 'tenant_debt',
-        filters: {},
+        filters: plan?.intent === 'tenant_debt' && plan.filters ? plan.filters : {},
         confidence: 0.9,
         source: 'deterministic_rules',
       },

--- a/apps/api/src/assistant/assistant.service.ts
+++ b/apps/api/src/assistant/assistant.service.ts
@@ -25,6 +25,7 @@ import {
   AiProviderStatus,
   StructuredResponse,
 } from './ai.types';
+import type { AssistantConsensusEvaluation } from './ai.types';
 
 // Re-export types for backward compatibility
 export type { SuggestedActionType, SuggestedAction, ChatResponse, AiProvider };
@@ -32,6 +33,7 @@ export type { SuggestedActionType, SuggestedAction, ChatResponse, AiProvider };
 // Intent Engine imports
 import { IntentRegistry } from './intent-engine/intent-registry';
 import { IntentExtractorService } from './intent-engine/intent-extractor.service';
+import { AssistantLocalConsensusService } from './intent-engine/local-consensus.service';
 import { EntityResolverService } from './resolver/entity-resolver.service';
 import { AmbiguityService } from './resolver/ambiguity.service';
 import { RedisConversationContextService } from './context/redis-conversation-context.service';
@@ -46,6 +48,7 @@ import {
 } from './intent-engine/intent.types';
 import { validateExtractedIntent } from './intent-engine/intent.schema';
 import { FilterCoverageValidator } from './intent-engine/filter-coverage.validator';
+import type { AssistantQueryPlan } from './query-plan.types';
 
 // Intent definitions
 import { unitDebtIntent } from './intent-engine/allowed-intents/unit-debt.intent';
@@ -222,6 +225,7 @@ export class AssistantService implements OnModuleInit {
     // Intent Engine services injected
     private readonly intentRegistry: IntentRegistry,
     private readonly intentExtractor: IntentExtractorService,
+    private readonly localConsensusService: AssistantLocalConsensusService,
     private readonly entityResolver: EntityResolverService,
     private readonly ambiguityService: AmbiguityService,
     private readonly conversationContext: RedisConversationContextService,
@@ -676,113 +680,135 @@ export class AssistantService implements OnModuleInit {
         `[chatV2] Rehydrated pending clarification for intent: ${pendingClarification.intent}`,
       );
     } else {
-      try {
-        extractedIntent = await this.intentExtractor.extractIntent(
+      const localConsensusEnabled = this.localConsensusService.isEnabled();
+      const localConsensusEligible = Boolean(
+        deterministicPlan &&
+        ['tenant_debt', 'building_debt', 'unit_debt'].includes(deterministicPlan.intent),
+      );
+
+      if (localConsensusEnabled && localConsensusEligible) {
+        const consensusResult = await this.localConsensusService.evaluate(
           request.message,
+          deterministicPlan,
           contextForExtraction,
         );
-        if (extractedIntent.source === 'llm' || extractedIntent.source === 'hybrid') {
-          debugInfo.usedLLM = true;
-          if (extractedIntent.llmProvider && extractedIntent.llmProvider !== 'none') {
-            debugInfo.llmProvider = extractedIntent.llmProvider;
-            if (extractedIntent.llmProvider === 'opencode') {
-              debugInfo.llmBaseUrl = 'https://api.opencode.ai/v1/chat/completions';
-              debugInfo.llmModel = 'qwen3.6-plus';
-            }
-          } else {
-            debugInfo.llmProvider = 'unknown';
-          }
-        }
-        this.logger.log(`[chatV2] Intent extracted: ${extractedIntent.intent} (confidence: ${extractedIntent.confidence})`);
-      } catch (error) {
-        this.logger.warn(`[chatV2] Intent extraction failed: ${error}`);
 
-        if (deterministicPlan) {
-          extractedIntent = {
-            intent: deterministicPlan.intent,
-            entity: {
-              type: deterministicPlan.scope === 'unit' ? 'unit' : 'building',
-              buildingAlias: deterministicPlan.filters.buildingAlias ?? deterministicPlan.filters.buildingToken,
-              unitCode: deterministicPlan.filters.unitCode,
-              personName: deterministicPlan.filters.personName,
-            },
-            filters: {
-              minAmount: deterministicPlan.filters.minAmount,
-              maxAmount: deterministicPlan.filters.maxAmount,
-              minDebt: deterministicPlan.filters.minDebt,
-              period: deterministicPlan.filters.period,
-              status: deterministicPlan.filters.status,
-              method: deterministicPlan.filters.method,
-              minAgeDays: deterministicPlan.filters.minAgeDays,
-            },
-            confidence: deterministicPlan.confidence,
-            source: 'hybrid',
-            llmProvider: 'none',
-            requiresClarification: false,
-            missingFields: [],
-          };
-          debugInfo.usedLLM = false;
-          debugInfo.llmReason = deterministicPlan.confidence >= 0.9 ? 'none' : 'low_confidence';
-          this.logger.warn(
-            `[chatV2] Falling back to deterministic plan after intent extraction failure: ${deterministicPlan.intent}`,
-          );
+        debugInfo.consensusMode = true;
+        debugInfo.usedLLM = consensusResult.usedLocalModel;
+        debugInfo.llmProvider = consensusResult.localProvider;
+        debugInfo.llmBaseUrl = consensusResult.localBaseUrl;
+        debugInfo.llmModel = consensusResult.localModel;
+        debugInfo.consensusResult = consensusResult.consensus
+          ? 'matched'
+          : consensusResult.mismatchReason === 'local_model_failed'
+            ? 'failed'
+            : 'mismatch';
+        debugInfo.consensusReason = consensusResult.mismatchReason;
+        debugInfo.llmReason = consensusResult.consensus
+          ? 'none'
+          : consensusResult.mismatchReason === 'local_model_failed'
+            ? 'local_model_failed'
+            : 'consensus_mismatch';
+
+        if (consensusResult.consensus && deterministicPlan) {
+          extractedIntent = this.buildExtractedIntentFromPlan(deterministicPlan);
         } else {
-        // Fallback: use conversation context for follow-up questions
-        const isFollowUp = await this.detectFollowUp(
-          request.message,
-          conversationContext,
-          tenantId,
-          userId,
-          sessionId,
+          extractedIntent = this.buildClarificationIntentFromConsensus(
+            deterministicPlan,
+            consensusResult,
+          );
+        }
+
+        this.logger.log(
+          `[chatV2] Local consensus ${consensusResult.consensus ? 'matched' : 'mismatch'} for "${request.message}"`,
         );
-
-        if (isFollowUp) {
-          const lastTurn = conversationContext.length > 0
-            ? conversationContext[conversationContext.length - 1]
-            : null;
-
-          if (lastTurn?.resolvedEntities) {
-            contextResolvedEntities = lastTurn.resolvedEntities;
-
-            // Try to infer intent from the follow-up message using last context
-            let inferredIntent = this.inferIntentFromFollowUp(request.message);
-            const inferredFilters = this.inferFiltersFromFollowUp(request.message);
-
-            // Fallback: if we can't infer a new intent, reuse the last one
-            if (!inferredIntent) {
-              const lastIntent = await this.conversationContext.getLastIntent(tenantId, userId, sessionId);
-              if (lastIntent) {
-                inferredIntent = lastIntent;
-                this.logger.log(`[chatV2] Reusing last intent: ${lastIntent}`);
+      } else {
+        try {
+          extractedIntent = await this.intentExtractor.extractIntent(
+            request.message,
+            contextForExtraction,
+          );
+          if (extractedIntent.source === 'llm' || extractedIntent.source === 'hybrid') {
+            debugInfo.usedLLM = true;
+            if (extractedIntent.llmProvider && extractedIntent.llmProvider !== 'none') {
+              debugInfo.llmProvider = extractedIntent.llmProvider;
+              if (extractedIntent.llmProvider === 'opencode') {
+                debugInfo.llmBaseUrl = 'https://api.opencode.ai/v1/chat/completions';
+                debugInfo.llmModel = 'qwen3.6-plus';
               }
+            } else {
+              debugInfo.llmProvider = 'unknown';
             }
+          }
+          this.logger.log(`[chatV2] Intent extracted: ${extractedIntent.intent} (confidence: ${extractedIntent.confidence})`);
+        } catch (error) {
+          this.logger.warn(`[chatV2] Intent extraction failed: ${error}`);
 
-            if (inferredIntent) {
-              extractedIntent = {
-                intent: inferredIntent,
-                entity: {
-                  type: lastTurn.resolvedEntities.unit?.id ? 'unit' : 'building',
-                  buildingAlias: undefined,
-                  unitCode: undefined,
-                },
-                filters: inferredFilters,
-                confidence: 0.6,
-                source: 'hybrid',
-                requiresClarification: false,
-                missingFields: [],
-              };
-              debugInfo.usedLLM = false;
-              debugInfo.llmReason = debugInfo.llmReason === 'none' ? 'low_confidence' : debugInfo.llmReason;
-              this.logger.log(`[chatV2] Follow-up detected, using intent: ${inferredIntent}`);
+          if (deterministicPlan) {
+            extractedIntent = this.buildExtractedIntentFromPlan(deterministicPlan);
+            debugInfo.usedLLM = false;
+            debugInfo.llmReason = deterministicPlan.confidence >= 0.9 ? 'none' : 'low_confidence';
+            this.logger.warn(
+              `[chatV2] Falling back to deterministic plan after intent extraction failure: ${deterministicPlan.intent}`,
+            );
+          } else {
+          // Fallback: use conversation context for follow-up questions
+          const isFollowUp = await this.detectFollowUp(
+            request.message,
+            conversationContext,
+            tenantId,
+            userId,
+            sessionId,
+          );
+
+          if (isFollowUp) {
+            const lastTurn = conversationContext.length > 0
+              ? conversationContext[conversationContext.length - 1]
+              : null;
+
+            if (lastTurn?.resolvedEntities) {
+              contextResolvedEntities = lastTurn.resolvedEntities;
+
+              // Try to infer intent from the follow-up message using last context
+              let inferredIntent = this.inferIntentFromFollowUp(request.message);
+              const inferredFilters = this.inferFiltersFromFollowUp(request.message);
+
+              // Fallback: if we can't infer a new intent, reuse the last one
+              if (!inferredIntent) {
+                const lastIntent = await this.conversationContext.getLastIntent(tenantId, userId, sessionId);
+                if (lastIntent) {
+                  inferredIntent = lastIntent;
+                  this.logger.log(`[chatV2] Reusing last intent: ${lastIntent}`);
+                }
+              }
+
+              if (inferredIntent) {
+                extractedIntent = {
+                  intent: inferredIntent,
+                  entity: {
+                    type: lastTurn.resolvedEntities.unit?.id ? 'unit' : 'building',
+                    buildingAlias: undefined,
+                    unitCode: undefined,
+                  },
+                  filters: inferredFilters,
+                  confidence: 0.6,
+                  source: 'hybrid',
+                  requiresClarification: false,
+                  missingFields: [],
+                };
+                debugInfo.usedLLM = false;
+                debugInfo.llmReason = debugInfo.llmReason === 'none' ? 'low_confidence' : debugInfo.llmReason;
+                this.logger.log(`[chatV2] Follow-up detected, using intent: ${inferredIntent}`);
+              } else {
+                throw new BadRequestException('Could not understand your message. Please rephrase.');
+              }
             } else {
               throw new BadRequestException('Could not understand your message. Please rephrase.');
             }
           } else {
             throw new BadRequestException('Could not understand your message. Please rephrase.');
           }
-        } else {
-          throw new BadRequestException('Could not understand your message. Please rephrase.');
-        }
+          }
         }
       }
     }
@@ -939,6 +965,9 @@ export class AssistantService implements OnModuleInit {
 
     if (extractedIntent.requiresClarification) {
       const missing = extractedIntent.missingFields?.join(', ') || 'contexto adicional';
+      const clarificationMessage =
+        extractedIntent.clarificationMessage ||
+        `Necesito más contexto para responder con precisión (${missing}).`;
       const clarificationResolvedEntities = await this.resolveClarificationContext(
         extractedIntent,
         contextResolvedEntities,
@@ -953,7 +982,7 @@ export class AssistantService implements OnModuleInit {
           extractedIntent,
           clarificationResolvedEntities,
           this.resolveClarificationMissingFields(undefined, extractedIntent),
-          `Necesito más contexto para responder con precisión (${missing}).`,
+          clarificationMessage,
         ),
       );
       await this.storeConversationTurn(
@@ -968,7 +997,7 @@ export class AssistantService implements OnModuleInit {
         {
           isAmbiguous: true,
           alternatives: [],
-          clarificationMessage: `Necesito más contexto para responder con precisión (${missing}).`,
+          clarificationMessage,
         },
         'ambiguous',
         extractedIntent.confidence,
@@ -1561,6 +1590,106 @@ export class AssistantService implements OnModuleInit {
       requiresClarification: false,
       missingFields: [],
     };
+  }
+
+  private buildExtractedIntentFromPlan(plan: AssistantQueryPlan): ExtractedIntent {
+    return {
+      intent: plan.intent,
+      entity: {
+        type: plan.scope === 'unit' ? 'unit' : 'building',
+        buildingAlias: plan.filters.buildingAlias ?? plan.filters.buildingToken,
+        unitCode: plan.filters.unitCode,
+        personName: plan.filters.personName,
+      },
+      filters: {
+        minAmount: plan.filters.minAmount,
+        maxAmount: plan.filters.maxAmount,
+        minDebt: plan.filters.minDebt,
+        period: plan.filters.period,
+        status: plan.filters.status,
+        method: plan.filters.method,
+        minAgeDays: plan.filters.minAgeDays,
+      },
+      confidence: plan.confidence,
+      source: 'hybrid',
+      llmProvider: 'none',
+      requiresClarification: false,
+      missingFields: [],
+    };
+  }
+
+  private buildClarificationIntentFromConsensus(
+    deterministicPlan: AssistantQueryPlan | null,
+    consensusResult: AssistantConsensusEvaluation,
+  ): ExtractedIntent {
+    const intent = deterministicPlan?.intent ?? 'unknown';
+    const entityType = deterministicPlan?.scope === 'unit' ? 'unit' : 'building';
+    const missingFields = this.resolveConsensusMissingFields(consensusResult, deterministicPlan);
+
+    return {
+      intent,
+      entity: {
+        type: entityType,
+        buildingAlias: deterministicPlan?.filters.buildingAlias ?? deterministicPlan?.filters.buildingToken,
+        unitCode: deterministicPlan?.filters.unitCode,
+        personName: deterministicPlan?.filters.personName,
+      },
+      filters: {
+        minAmount: deterministicPlan?.filters.minAmount,
+        maxAmount: deterministicPlan?.filters.maxAmount,
+        minDebt: deterministicPlan?.filters.minDebt,
+        period: deterministicPlan?.filters.period,
+        status: deterministicPlan?.filters.status,
+        method: deterministicPlan?.filters.method,
+        minAgeDays: deterministicPlan?.filters.minAgeDays,
+      },
+      confidence: deterministicPlan?.confidence ?? 0,
+      source: 'hybrid',
+      llmProvider: consensusResult.localProvider,
+      requiresClarification: true,
+      missingFields: missingFields.length > 0 ? missingFields : ['period'],
+      clarificationMessage: consensusResult.clarificationMessage,
+    };
+  }
+
+  private resolveConsensusMissingFields(
+    consensusResult: AssistantConsensusEvaluation,
+    deterministicPlan: AssistantQueryPlan | null,
+  ): string[] {
+    if (consensusResult.mismatchReason === 'period') {
+      return ['period'];
+    }
+
+    if (consensusResult.mismatchReason === 'clarification') {
+      if (consensusResult.modelPlan?.missingFields?.length) {
+        return consensusResult.modelPlan.missingFields;
+      }
+      return ['period'];
+    }
+
+    if (consensusResult.mismatchReason === 'unit_alias') {
+      return ['unit'];
+    }
+
+    if (consensusResult.mismatchReason === 'building_alias' || consensusResult.mismatchReason === 'entity') {
+      return ['building'];
+    }
+
+    if (consensusResult.mismatchReason === 'intent' || consensusResult.mismatchReason === 'scope') {
+      return ['scope'];
+    }
+
+    if (consensusResult.mismatchReason === 'local_model_failed' || consensusResult.mismatchReason === 'no_deterministic_plan') {
+      if (deterministicPlan?.scope === 'unit') {
+        return ['unit'];
+      }
+      if (deterministicPlan?.scope === 'building') {
+        return ['building', 'period'];
+      }
+      return ['scope'];
+    }
+
+    return [];
   }
 
   private buildResolvedEntitiesFromPendingClarification(

--- a/apps/api/src/assistant/assistant.service.ts
+++ b/apps/api/src/assistant/assistant.service.ts
@@ -697,6 +697,36 @@ export class AssistantService implements OnModuleInit {
       } catch (error) {
         this.logger.warn(`[chatV2] Intent extraction failed: ${error}`);
 
+        if (deterministicPlan) {
+          extractedIntent = {
+            intent: deterministicPlan.intent,
+            entity: {
+              type: deterministicPlan.scope === 'unit' ? 'unit' : 'building',
+              buildingAlias: deterministicPlan.filters.buildingAlias ?? deterministicPlan.filters.buildingToken,
+              unitCode: deterministicPlan.filters.unitCode,
+              personName: deterministicPlan.filters.personName,
+            },
+            filters: {
+              minAmount: deterministicPlan.filters.minAmount,
+              maxAmount: deterministicPlan.filters.maxAmount,
+              minDebt: deterministicPlan.filters.minDebt,
+              period: deterministicPlan.filters.period,
+              status: deterministicPlan.filters.status,
+              method: deterministicPlan.filters.method,
+              minAgeDays: deterministicPlan.filters.minAgeDays,
+            },
+            confidence: deterministicPlan.confidence,
+            source: 'hybrid',
+            llmProvider: 'none',
+            requiresClarification: false,
+            missingFields: [],
+          };
+          debugInfo.usedLLM = false;
+          debugInfo.llmReason = deterministicPlan.confidence >= 0.9 ? 'none' : 'low_confidence';
+          this.logger.warn(
+            `[chatV2] Falling back to deterministic plan after intent extraction failure: ${deterministicPlan.intent}`,
+          );
+        } else {
         // Fallback: use conversation context for follow-up questions
         const isFollowUp = await this.detectFollowUp(
           request.message,
@@ -752,6 +782,7 @@ export class AssistantService implements OnModuleInit {
           }
         } else {
           throw new BadRequestException('Could not understand your message. Please rephrase.');
+        }
         }
       }
     }

--- a/apps/api/src/assistant/finance-period.types.ts
+++ b/apps/api/src/assistant/finance-period.types.ts
@@ -1,0 +1,43 @@
+export type CanonicalFinancePeriodKind =
+  | 'current_month'
+  | 'previous_month'
+  | 'named_month'
+  | 'relative_range'
+  | 'month_range'
+  | 'year_to_date'
+  | 'accumulated'
+  | 'unknown';
+
+export type RelativeRangeMode = 'including_current' | 'closed_months' | 'unknown';
+
+export interface CanonicalFinancePeriod {
+  kind: CanonicalFinancePeriodKind;
+  amount: number | null;
+  unit: 'month' | null;
+  mode: RelativeRangeMode | null;
+  month: number | null;
+  year: number | null;
+  startMonth: number | null;
+  startYear: number | null;
+  endMonth: number | null;
+  endYear: number | null;
+}
+
+export interface ResolvedFinancePeriod {
+  kind: 'single_period' | 'period_range' | 'accumulated' | 'unknown';
+  periods: string[];
+  period: string | null;
+  startPeriod: string | null;
+  endPeriod: string | null;
+  startDate: Date | null;
+  endDate: Date | null;
+  label: string;
+}
+
+export interface PeriodValidationResult {
+  valid: boolean;
+  requiresClarification: boolean;
+  missingFields: string[];
+  clarificationMessage?: string;
+  normalizedPeriod: CanonicalFinancePeriod | null;
+}

--- a/apps/api/src/assistant/intent-engine/intent-extractor.service.spec.ts
+++ b/apps/api/src/assistant/intent-engine/intent-extractor.service.spec.ts
@@ -198,6 +198,7 @@ describe('IntentExtractorService', () => {
       const requestBody = JSON.parse(mockFetch.mock.calls[0]?.[1]?.body ?? '{}');
       expect(requestBody.generationConfig.responseMimeType).toBe('application/json');
       expect(requestBody.generationConfig.responseSchema).toBeDefined();
+      expect(JSON.stringify(requestBody.generationConfig.responseSchema)).not.toContain('additionalProperties');
     });
 
     it('uses Gemini structured output parser for valid structured responses', () => {

--- a/apps/api/src/assistant/intent-engine/intent-extractor.service.spec.ts
+++ b/apps/api/src/assistant/intent-engine/intent-extractor.service.spec.ts
@@ -32,8 +32,8 @@ describe('IntentExtractorService', () => {
     delete process.env.GEMINI_MODEL;
     delete process.env.AI_GEMINI_MODEL;
     delete process.env.OPENCODE_API_KEY;
+    process.env.GEMINI_API_KEY = 'test-key';
     service = new IntentExtractorService(
-      undefined as any, // ollamaProvider no longer used
       mockQueryPlanServiceInstance as any,
       mockFeedbackServiceInstance as any,
       mockFilterCoverageValidatorInstance as any,
@@ -52,16 +52,26 @@ describe('IntentExtractorService', () => {
   describe('extractIntent', () => {
     it('extracts intent from valid LLM response when deterministic fails', async () => {
       mockCreatePlan.mockReturnValue(null); // Force LLM path
+      process.env.GEMINI_API_KEY = 'test-key';
+      process.env.GEMINI_MODEL = 'gemini-2.5-flash-lite';
 
       const mockResponse = {
-        message: {
-          content: JSON.stringify({
-            intent: 'list_payments',
-            entity: { type: 'unit', buildingAlias: 'A', unitCode: '0101' },
-            filters: { status: 'pending' },
-            confidence: 0.85,
-          }),
-        },
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  text: JSON.stringify({
+                    intent: 'list_payments',
+                    entity: { type: 'unit', buildingAlias: 'A', unitCode: '0101' },
+                    filters: { status: 'pending' },
+                    confidence: 0.85,
+                  }),
+                },
+              ],
+            },
+          },
+        ],
       };
 
       mockFetch.mockResolvedValue({
@@ -77,7 +87,7 @@ describe('IntentExtractorService', () => {
       expect(result.entity.buildingAlias).toBe('A');
       expect(result.entity.unitCode).toBe('0101');
       expect(result.confidence).toBe(0.85);
-      expect(result.llmProvider).toBe('ollama');
+      expect(result.llmProvider).toBe('gemini');
     });
 
     it('falls back to deterministic keyword matching on timeout', async () => {
@@ -280,14 +290,22 @@ describe('IntentExtractorService', () => {
       });
 
       const mockResponse = {
-        message: {
-          content: JSON.stringify({
-            intent: 'building_payments',
-            entity: { type: 'building', buildingAlias: 'A' },
-            filters: { period: '2026-01', method: 'TRANSFER' },
-            confidence: 0.88,
-          }),
-        },
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  text: JSON.stringify({
+                    intent: 'building_payments',
+                    entity: { type: 'building', buildingAlias: 'A' },
+                    filters: { period: '2026-01', method: 'TRANSFER' },
+                    confidence: 0.88,
+                  }),
+                },
+              ],
+            },
+          },
+        ],
       };
 
       mockFetch.mockResolvedValue({
@@ -304,60 +322,36 @@ describe('IntentExtractorService', () => {
 
     it('rejects LLM response when confidence is below threshold', async () => {
       mockCreatePlan.mockReturnValue(null); // Force LLM path
-      const ollamaResponse = {
-        message: {
-          content: JSON.stringify({
-            intent: 'list_payments',
-            entity: { type: 'unit', buildingAlias: 'A', unitCode: '0101' },
-            filters: {},
-            confidence: 0.5, // Below 0.70 threshold
-          }),
-        },
+      process.env.GEMINI_API_KEY = 'test-key';
+      const geminiResponse = {
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  text: JSON.stringify({
+                    intent: 'list_payments',
+                    entity: { type: 'unit', buildingAlias: 'A', unitCode: '0101' },
+                    filters: {},
+                    confidence: 0.5, // Below 0.70 threshold
+                  }),
+                },
+              ],
+            },
+          },
+        ],
       };
 
-      mockFetch.mockImplementation(async (url: string) => {
-        return { ok: true, json: async () => ollamaResponse };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => geminiResponse,
       });
 
       await expect(service.extractIntent('¿Cuánto debe A-0101?')).rejects.toThrow(/Confidence 0.5 below threshold 0.7/);
     });
 
-    it('tracks opencode as provider when ollama fails and opencode succeeds', async () => {
+    it('uses Gemini fallback when deterministic fails', async () => {
       mockCreatePlan.mockReturnValue(null);
-      process.env.OPENCODE_API_KEY = 'test-key';
-
-      const opencodeResponse = {
-        choices: [{
-          message: {
-            content: JSON.stringify({
-              intent: 'building_tickets',
-              entity: { type: 'building', buildingAlias: 'A' },
-              filters: { status: 'OPEN' },
-              confidence: 0.88,
-            }),
-          },
-        }],
-      };
-
-      mockFetch.mockImplementation(async (url: string) => {
-        if (url.includes('/api/chat')) {
-          throw new Error('Ollama unavailable');
-        }
-        if (url.includes('opencode')) {
-          return { ok: true, json: async () => opencodeResponse };
-        }
-        throw new Error(`Unexpected URL ${url}`);
-      });
-
-      const result = await service.extractIntent('Tickets abiertos del edificio A');
-
-      expect(result.intent).toBe('building_tickets');
-      expect(result.llmProvider).toBe('opencode');
-    });
-
-    it('uses Gemini fallback when AI_PROVIDER=gemini without requiring Opencode', async () => {
-      mockCreatePlan.mockReturnValue(null);
-      process.env.AI_PROVIDER = 'gemini';
       process.env.GEMINI_API_KEY = 'test-key';
       process.env.GEMINI_MODEL = 'gemini-2.5-flash-lite';
 
@@ -386,7 +380,7 @@ describe('IntentExtractorService', () => {
           };
         }
 
-        throw new Error('Ollama unavailable');
+        throw new Error(`Unexpected URL ${url}`);
       });
 
       const result = await service.extractIntent('deuda del edificio B, del mes actual');
@@ -396,50 +390,8 @@ describe('IntentExtractorService', () => {
       expect(result.llmProvider).toBe('gemini');
     });
 
-    it('does not require Opencode when Gemini is configured and Ollama fails', async () => {
-      mockCreatePlan.mockReturnValue(null);
-      process.env.AI_PROVIDER = 'gemini';
-      process.env.GEMINI_API_KEY = 'test-key';
-
-      mockFetch.mockImplementation(async (url: string) => {
-        if (url.includes('/api/chat')) {
-          throw new Error('Ollama unavailable');
-        }
-        if (url.includes('generativelanguage.googleapis.com')) {
-          return {
-            ok: true,
-            json: async () => ({
-              candidates: [
-                {
-                  content: {
-                    parts: [
-                      {
-                        text: JSON.stringify({
-                          intent: 'building_tickets',
-                          entity: { type: 'building', buildingAlias: 'A' },
-                          filters: { status: 'OPEN' },
-                          confidence: 0.88,
-                        }),
-                      },
-                    ],
-                  },
-                },
-              ],
-            }),
-          };
-        }
-        throw new Error(`Unexpected URL ${url}`);
-      });
-
-      const result = await service.extractIntent('Tickets abiertos del edificio A');
-
-      expect(result.intent).toBe('building_tickets');
-      expect(result.llmProvider).toBe('gemini');
-    });
-
     it('does not map structured tenant cobro responses to missing data', async () => {
       mockCreatePlan.mockReturnValue(null);
-      process.env.AI_PROVIDER = 'gemini';
       process.env.GEMINI_API_KEY = 'test-key';
 
       mockFetch.mockImplementation(async (url: string) => {
@@ -467,7 +419,7 @@ describe('IntentExtractorService', () => {
           };
         }
 
-        throw new Error('Ollama unavailable');
+        throw new Error(`Unexpected URL ${url}`);
       });
 
       await expect(service.extractIntent('lo cobrado del mes en curso de la administracion')).resolves.toMatchObject({
@@ -480,14 +432,22 @@ describe('IntentExtractorService', () => {
       mockCreatePlan.mockReturnValue(null); // Force LLM path
 
       const mockResponse = {
-        message: {
-          content: JSON.stringify({
-            intent: 'list_payments',
-            entity: { type: 'unit', buildingAlias: 'A', unitCode: '0101' },
-            filters: {},
-            confidence: 0.85,
-          }),
-        },
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  text: JSON.stringify({
+                    intent: 'list_payments',
+                    entity: { type: 'unit', buildingAlias: 'A', unitCode: '0101' },
+                    filters: {},
+                    confidence: 0.85,
+                  }),
+                },
+              ],
+            },
+          },
+        ],
       };
 
       mockFetch.mockResolvedValue({
@@ -509,14 +469,22 @@ describe('IntentExtractorService', () => {
       mockCreatePlan.mockReturnValue(null); // Force LLM path
 
       const mockResponse = {
-        message: {
-          content: JSON.stringify({
-            intent: 'list_payments',
-            entity: { type: 'unit' },
-            filters: {},
-            confidence: 0.85,
-          }),
-        },
+        candidates: [
+          {
+            content: {
+              parts: [
+                {
+                  text: JSON.stringify({
+                    intent: 'list_payments',
+                    entity: { type: 'unit' },
+                    filters: {},
+                    confidence: 0.85,
+                  }),
+                },
+              ],
+            },
+          },
+        ],
       };
 
       let capturedUrl = '';

--- a/apps/api/src/assistant/intent-engine/intent-extractor.service.ts
+++ b/apps/api/src/assistant/intent-engine/intent-extractor.service.ts
@@ -28,23 +28,22 @@ export interface GeminiGenerateContentResponse {
 }
 
 const geminiExtractionResponseSchema = {
-  type: 'object',
-  properties: {
-    intent: { type: 'string' },
-    entity: {
       type: 'object',
+      properties: {
+        intent: { type: 'string' },
+        entity: {
+          type: 'object',
       properties: {
         type: { type: 'string', enum: ['unit', 'building', 'person'] },
         buildingAlias: { type: 'string' },
         unitCode: { type: 'string' },
         personName: { type: 'string' },
-      },
-      required: ['type'],
-      additionalProperties: false,
-    },
-    filters: {
-      type: 'object',
-      properties: {
+          },
+          required: ['type'],
+        },
+        filters: {
+          type: 'object',
+          properties: {
         minAmount: { type: 'number' },
         maxAmount: { type: 'number' },
         minDebt: { type: 'number' },
@@ -56,31 +55,28 @@ const geminiExtractionResponseSchema = {
         category: { type: 'string' },
         sortField: { type: 'string' },
         sortOrder: { type: 'string', enum: ['asc', 'desc'] },
+            limit: { type: 'number', maximum: 100 },
+          },
+        },
+        sort: {
+          type: 'object',
+          properties: {
+            field: { type: 'string' },
+            order: { type: 'string', enum: ['asc', 'desc'] },
+          },
+        },
         limit: { type: 'number', maximum: 100 },
-      },
-      additionalProperties: false,
-    },
-    sort: {
-      type: 'object',
-      properties: {
-        field: { type: 'string' },
-        order: { type: 'string', enum: ['asc', 'desc'] },
-      },
-      additionalProperties: false,
-    },
-    limit: { type: 'number', maximum: 100 },
-    confidence: { type: 'number', minimum: 0, maximum: 1 },
-    source: { type: 'string', enum: ['deterministic', 'llm', 'hybrid'] },
-    llmProvider: { type: 'string', enum: ['ollama', 'opencode', 'gemini', 'none'] },
+        confidence: { type: 'number', minimum: 0, maximum: 1 },
+        source: { type: 'string', enum: ['deterministic', 'llm', 'hybrid'] },
+        llmProvider: { type: 'string', enum: ['ollama', 'opencode', 'gemini', 'none'] },
     requiresClarification: { type: 'boolean' },
     missingFields: {
       type: 'array',
       items: { type: 'string' },
     },
-  },
-  required: ['intent', 'entity', 'filters', 'confidence'],
-  additionalProperties: false,
-} as const;
+      },
+      required: ['intent', 'entity', 'filters', 'confidence'],
+    } as const;
 
 export function parseGeminiStructuredIntentResponse(response: unknown): ExtractedIntent {
   const rawText = extractGeminiStructuredIntentText(response);

--- a/apps/api/src/assistant/intent-engine/intent-extractor.service.ts
+++ b/apps/api/src/assistant/intent-engine/intent-extractor.service.ts
@@ -1,21 +1,21 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { OllamaProvider } from '../ollama.provider';
 import { AssistantQueryPlanService } from '../query-plan.service';
 import { AssistantFeedbackService } from '../feedback/assistant-feedback.service';
 import { ExtractedIntent, ConversationContext, ConversationTurn } from './intent.types';
-import { extractedIntentSchema, validateExtractedIntent } from './intent.schema';
+import { validateExtractedIntent } from './intent.schema';
 import { FilterCoverageValidator } from './filter-coverage.validator';
 
 /**
  * Timeout configuration for LLM calls
  */
-const OLLAMA_TIMEOUT_MS = 15000;
 const GEMINI_TIMEOUT_MS = 5000;
-const OPENCODE_TIMEOUT_MS = 5000;
-const OPENCODE_BASE_URL = 'https://api.opencode.ai/v1/chat/completions';
-const OPENCODE_MODEL = 'qwen3.6-plus';
 const GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com/v1beta';
-const DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash-lite';
+const DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash';
+
+function normalizeGeminiModel(model: string): string {
+  const trimmed = model.trim();
+  return trimmed.startsWith('models/') ? trimmed.slice('models/'.length) : trimmed;
+}
 
 export interface GeminiGenerateContentResponse {
   candidates?: Array<{
@@ -133,20 +133,6 @@ export function extractGeminiStructuredIntentText(response: unknown): string {
   return text;
 }
 
-interface OllamaChatResponse {
-  message?: {
-    content?: string;
-  };
-}
-
-interface OpencodeChatCompletionResponse {
-  choices?: Array<{
-    message?: {
-      content?: string;
-    };
-  }>;
-}
-
 /**
  * Minimum confidence threshold for LLM extraction
  */
@@ -163,19 +149,15 @@ const BACKEND_CONFIDENCE_THRESHOLD = 0.9;
  *
  * Fallback chain:
  * 1. Deterministic keyword matching
- * 2. Configured semantic LLM fallback (Gemini when AI_PROVIDER=gemini, otherwise Ollama)
- * 3. Secondary fallback provider (Ollama or Opencode when configured)
+ * 2. Gemini structured fallback when confidence is below the backend threshold
  *
  * NEVER includes tenantId, roles, or permissions in LLM prompts.
  */
 @Injectable()
 export class IntentExtractorService {
   private readonly logger = new Logger(IntentExtractorService.name);
-  private readonly ollamaUrl = process.env.AI_OLLAMA_URL || 'http://localhost:11434';
-  private readonly ollamaModel = process.env.AI_OLLAMA_MODEL || 'llama3:latest';
 
   constructor(
-    private readonly ollamaProvider: OllamaProvider,
     private readonly queryPlanService: AssistantQueryPlanService,
     private readonly feedbackService: AssistantFeedbackService,
     private readonly filterCoverageValidator: FilterCoverageValidator,
@@ -196,9 +178,6 @@ export class IntentExtractorService {
     let backendBelowThreshold = false;
 
     this.logger.log(`[EXTRACTOR] Starting extraction for: "${message}"`);
-    const primaryFallback = this.getPrimaryFallbackProvider();
-    const secondaryFallback = this.getSecondaryFallbackProvider(primaryFallback);
-
     // Step 1: Try deterministic keyword matching first (fast, reliable, no hallucinations)
     try {
       this.logger.log(`[EXTRACTOR] Step 1: Trying deterministic...`);
@@ -220,23 +199,20 @@ export class IntentExtractorService {
       this.logger.warn(`[EXTRACTOR] Deterministic FAILED: ${lastError.message}`);
     }
 
-    const fallbackProviders = this.buildFallbackProviderOrder(primaryFallback, backendBelowThreshold);
-
-    // Step 2+: Fallback to the best available LLM providers
-    for (const [index, provider] of fallbackProviders.entries()) {
+    if ((backendBelowThreshold || lastError) && process.env.GEMINI_API_KEY) {
       try {
-        this.logger.log(`[EXTRACTOR] Step ${index + 2}: Trying ${provider}...`);
-        const result = await this.tryProvider(provider, message, context);
+        this.logger.log('[EXTRACTOR] Step 2: Trying Gemini...');
+        const result = await this.tryGemini(message, context);
         const durationMs = performance.now() - startTime;
-        this.logSuccess(result.intent, durationMs, provider);
-        if (backendResult && provider === 'gemini') {
+        this.logSuccess(result.intent, durationMs, 'gemini');
+        if (backendResult) {
           this.logBackendComparison(backendResult, result);
         }
-        this.logger.log(`[EXTRACTOR] ${this.formatProviderLabel(provider)} SUCCESS: intent=${result.intent} in ${durationMs.toFixed(0)}ms`);
+        this.logger.log(`[EXTRACTOR] Gemini SUCCESS: intent=${result.intent} in ${durationMs.toFixed(0)}ms`);
         return result;
       } catch (error) {
         lastError = error instanceof Error ? error : new Error(String(error));
-        this.logger.warn(`[EXTRACTOR] ${this.formatProviderLabel(provider)} FAILED: ${lastError.message}`);
+        this.logger.warn(`[EXTRACTOR] Gemini FAILED: ${lastError.message}`);
       }
     }
 
@@ -247,156 +223,63 @@ export class IntentExtractorService {
     throw new Error(`Failed to extract intent: ${lastError?.message ?? 'All extraction methods failed'}`);
   }
 
-  /**
-   * Try extraction via Ollama with timeout
-   *
-   * Calls Ollama directly instead of OllamaProvider.chat() to use the
-   * extractor's system prompt without the provider's general chat wrapper.
-   */
-  private async tryOllama(message: string, context?: ConversationContext): Promise<ExtractedIntent> {
-    const systemPrompt = this.buildPrompt(message, context);
-    this.logger.log(`[OLLAMA] Calling Ollama at ${this.ollamaUrl} with timeout ${OLLAMA_TIMEOUT_MS}ms`);
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => {
-      this.logger.error(`[OLLAMA] TIMEOUT after ${OLLAMA_TIMEOUT_MS}ms`);
-      controller.abort();
-    }, OLLAMA_TIMEOUT_MS);
-
-    const fetchStart = performance.now();
-
-    try {
-      const response = await fetch(`${this.ollamaUrl}/api/chat`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          model: this.ollamaModel,
-          messages: [
-            { role: 'system', content: systemPrompt },
-            { role: 'user', content: message },
-          ],
-          stream: false,
-          options: { num_predict: 120 },
-        }),
-        signal: controller.signal,
-      });
-
-      const fetchDuration = performance.now() - fetchStart;
-      this.logger.log(`[OLLAMA] HTTP response in ${fetchDuration.toFixed(0)}ms: status=${response.status}`);
-
-      if (!response.ok) {
-        throw new Error(`Ollama API error: ${response.status} ${response.statusText}`);
-      }
-
-      const raw: unknown = await response.json();
-      const data = raw as OllamaChatResponse;
-      const answer = data.message?.content ?? '';
-      this.logger.log(`[OLLAMA] Raw answer: ${answer.substring(0, 200)}`);
-
-      const parsed = this.parseAndValidate(answer);
-      return { ...parsed, llmProvider: 'ollama' };
-    } catch (error) {
-      const fetchDuration = performance.now() - fetchStart;
-      this.logger.error(`[OLLAMA] Error after ${fetchDuration.toFixed(0)}ms: ${error instanceof Error ? error.message : String(error)}`);
-      throw error;
-    } finally {
-      clearTimeout(timeoutId);
-    }
-  }
-
   private async tryGemini(message: string, context?: ConversationContext): Promise<ExtractedIntent> {
     const apiKey = process.env.GEMINI_API_KEY;
     if (!apiKey) {
       throw new Error('GEMINI_API_KEY not configured');
     }
 
-    const model = process.env.GEMINI_MODEL || process.env.AI_GEMINI_MODEL || DEFAULT_GEMINI_MODEL;
+    const model = normalizeGeminiModel(
+      process.env.GEMINI_MODEL || process.env.AI_GEMINI_MODEL || DEFAULT_GEMINI_MODEL,
+    );
     const prompt = this.buildPrompt(message, context);
+    const endpoint = `${GEMINI_BASE_URL}/models/${model}:generateContent`;
     const controller = new AbortController();
     const timeoutId = setTimeout(() => controller.abort(), GEMINI_TIMEOUT_MS);
+    const requestBody = {
+      systemInstruction: {
+        parts: [{ text: prompt }],
+      },
+      contents: [{ parts: [{ text: message }] }],
+      generationConfig: {
+        temperature: 0,
+        maxOutputTokens: 220,
+        responseMimeType: 'application/json',
+        responseSchema: geminiExtractionResponseSchema,
+      },
+    };
+
+    this.logger.debug(
+      `[GeminiExtractor] endpoint=${endpoint} model=${model} payload=${JSON.stringify({
+        systemInstruction: { parts: [{ textLength: prompt.length }] },
+        contents: [{ parts: [{ textLength: message.length }] }],
+        generationConfig: {
+          temperature: 0,
+          maxOutputTokens: 220,
+          responseMimeType: 'application/json',
+          responseSchemaKeys: Object.keys(geminiExtractionResponseSchema.properties ?? {}),
+        },
+      })}`,
+    );
 
     try {
-      const response = await fetch(
-        `${GEMINI_BASE_URL}/models/${model}:generateContent?key=${apiKey}`,
-        {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          signal: controller.signal,
-          body: JSON.stringify({
-            systemInstruction: {
-              parts: [{ text: prompt }],
-            },
-            contents: [{ parts: [{ text: message }] }],
-            generationConfig: {
-              temperature: 0,
-              maxOutputTokens: 220,
-              responseMimeType: 'application/json',
-              responseSchema: geminiExtractionResponseSchema,
-            },
-          }),
-        },
-      );
+      const response = await fetch(`${endpoint}?key=${apiKey}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        signal: controller.signal,
+        body: JSON.stringify(requestBody),
+      });
 
       if (!response.ok) {
-        throw new Error(`Gemini API error: ${response.status} ${response.statusText}`);
+        const errorBody = await response.text().catch(() => '');
+        throw new Error(
+          `Gemini API error: ${response.status} ${response.statusText}${errorBody ? ` | body=${errorBody}` : ''}`,
+        );
       }
 
       const payload: unknown = await response.json();
       const parsed = parseGeminiStructuredIntentResponse(payload);
       return { ...parsed, llmProvider: 'gemini' };
-    } finally {
-      clearTimeout(timeoutId);
-    }
-  }
-
-  /**
-   * Try extraction via Opencode Go API
-   */
-  private async tryOpencode(message: string, context?: ConversationContext): Promise<ExtractedIntent> {
-    const apiKey = process.env.OPENCODE_API_KEY;
-    if (!apiKey) {
-      throw new Error('OPENCODE_API_KEY not configured');
-    }
-
-    const prompt = this.buildPrompt(message, context);
-
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), OPENCODE_TIMEOUT_MS);
-
-    try {
-      const response = await fetch(OPENCODE_BASE_URL, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
-        body: JSON.stringify({
-          model: OPENCODE_MODEL,
-          messages: [
-            {
-              role: 'system',
-              content: prompt,
-            },
-            {
-              role: 'user',
-              content: message,
-            },
-          ],
-          max_tokens: 200,
-        }),
-        signal: controller.signal,
-      });
-
-      if (!response.ok) {
-        throw new Error(`Opencode API error: ${response.status} ${response.statusText}`);
-      }
-
-      const raw: unknown = await response.json();
-      const data = raw as OpencodeChatCompletionResponse;
-      const answer = data.choices?.[0]?.message?.content ?? '';
-
-      const parsed = this.parseAndValidate(answer);
-      return { ...parsed, llmProvider: 'opencode' };
     } finally {
       clearTimeout(timeoutId);
     }
@@ -450,77 +333,6 @@ export class IntentExtractorService {
     return this.parseAndValidate(JSON.stringify(extracted));
   }
 
-  private async tryProvider(
-    provider: 'ollama' | 'opencode' | 'gemini',
-    message: string,
-    context?: ConversationContext,
-  ): Promise<ExtractedIntent> {
-    switch (provider) {
-      case 'gemini':
-        return this.tryGemini(message, context);
-      case 'opencode':
-        return this.tryOpencode(message, context);
-      default:
-        return this.tryOllama(message, context);
-    }
-  }
-
-  private getPrimaryFallbackProvider(): 'ollama' | 'opencode' | 'gemini' {
-    const configured = (process.env.AI_PROVIDER || '').trim().toLowerCase();
-    if (configured === 'gemini') {
-      return 'gemini';
-    }
-    if (configured === 'opencode') {
-      return 'opencode';
-    }
-    return 'ollama';
-  }
-
-  private getSecondaryFallbackProvider(
-    primary: 'ollama' | 'opencode' | 'gemini',
-  ): 'ollama' | 'opencode' | 'gemini' | null {
-    if (primary === 'gemini') {
-      return process.env.OPENCODE_API_KEY ? 'opencode' : 'ollama';
-    }
-    if (primary === 'opencode') {
-      return 'ollama';
-    }
-    if (process.env.OPENCODE_API_KEY) {
-      return 'opencode';
-    }
-    return null;
-  }
-
-  private buildFallbackProviderOrder(
-    primary: 'ollama' | 'opencode' | 'gemini',
-    backendBelowThreshold: boolean,
-  ): Array<'ollama' | 'opencode' | 'gemini'> {
-    const providers: Array<'ollama' | 'opencode' | 'gemini'> = [];
-
-    if (backendBelowThreshold && process.env.GEMINI_API_KEY) {
-      providers.push('gemini');
-    }
-
-    providers.push(primary);
-
-    const secondary = this.getSecondaryFallbackProvider(primary);
-    if (secondary) {
-      providers.push(secondary);
-    }
-
-    return [...new Set(providers)];
-  }
-
-  private formatProviderLabel(provider: 'ollama' | 'opencode' | 'gemini'): string {
-    switch (provider) {
-      case 'gemini':
-        return 'Gemini';
-      case 'opencode':
-        return 'Opencode';
-      default:
-        return 'Ollama';
-    }
-  }
 
   /**
    * Build LLM prompt for intent extraction

--- a/apps/api/src/assistant/intent-engine/intent.schema.ts
+++ b/apps/api/src/assistant/intent-engine/intent.schema.ts
@@ -78,6 +78,7 @@ export const extractedIntentSchema = z.object({
   llmProvider: z.enum(['ollama', 'opencode', 'gemini', 'none']).optional(),
   requiresClarification: z.boolean().optional().default(false),
   missingFields: z.array(z.string()).optional().default([]),
+  clarificationMessage: z.string().optional(),
 }).strict();
 
 export const normalizedIntentSchema = extractedIntentSchema;

--- a/apps/api/src/assistant/intent-engine/intent.schema.ts
+++ b/apps/api/src/assistant/intent-engine/intent.schema.ts
@@ -5,6 +5,28 @@ import { z } from 'zod';
  * Strict validation - rejects unknown fields with detailed error messages
  */
 
+const canonicalFinancePeriodSchema = z.object({
+  kind: z.enum([
+    'current_month',
+    'previous_month',
+    'named_month',
+    'relative_range',
+    'month_range',
+    'year_to_date',
+    'accumulated',
+    'unknown',
+  ]),
+  amount: z.number().nullable(),
+  unit: z.enum(['month']).nullable(),
+  mode: z.enum(['including_current', 'closed_months', 'unknown']).nullable(),
+  month: z.number().nullable(),
+  year: z.number().nullable(),
+  startMonth: z.number().nullable(),
+  startYear: z.number().nullable(),
+  endMonth: z.number().nullable(),
+  endYear: z.number().nullable(),
+}).strict();
+
 // Entity reference schema - strict to reject unknown fields
 const entityReferenceSchema: z.ZodType<{
   type: 'unit' | 'building' | 'person';
@@ -25,7 +47,7 @@ const intentFiltersSchema: z.ZodType<{
   minAmount?: number;
   maxAmount?: number;
   minDebt?: number;
-  period?: string;
+  period?: string | z.infer<typeof canonicalFinancePeriodSchema>;
   status?: string;
   method?: string;
   minAgeDays?: number;
@@ -38,7 +60,7 @@ const intentFiltersSchema: z.ZodType<{
     minAmount: z.number().optional(),
     maxAmount: z.number().optional(),
     minDebt: z.number().optional(),
-    period: z.string().optional(),
+    period: z.union([z.string(), canonicalFinancePeriodSchema]).optional(),
     financePeriod: z.string().optional(),
     status: z.string().optional(),
     method: z.string().optional(),

--- a/apps/api/src/assistant/intent-engine/intent.types.ts
+++ b/apps/api/src/assistant/intent-engine/intent.types.ts
@@ -1,5 +1,6 @@
 import { Permission } from '../../rbac/permissions';
 import { PrismaService } from '../../prisma/prisma.service';
+import type { CanonicalFinancePeriod } from '../finance-period.types';
 
 /**
  * Supported response types for intent execution
@@ -29,7 +30,7 @@ export interface IntentFilters {
   minAmount?: number;
   maxAmount?: number;
   minDebt?: number;
-  period?: string;
+  period?: string | CanonicalFinancePeriod;
   financePeriod?: string;
   status?: string;
   method?: string;
@@ -273,6 +274,8 @@ export interface PendingClarificationContext {
   entity: EntityReference;
   /** Filters extracted before clarification */
   filters: IntentFilters;
+  /** Canonical period captured during clarification, when available */
+  period?: CanonicalFinancePeriod;
   /** Missing semantic fields that the follow-up must complete */
   missingFields: string[];
   /** Clarification question shown to the user */

--- a/apps/api/src/assistant/intent-engine/intent.types.ts
+++ b/apps/api/src/assistant/intent-engine/intent.types.ts
@@ -138,6 +138,8 @@ export interface ExtractedIntent {
   requiresClarification?: boolean;
   /** Missing semantic fields when extraction is incomplete */
   missingFields?: string[];
+  /** Suggested clarification message when the extractor needs a follow-up */
+  clarificationMessage?: string;
 }
 
 /**

--- a/apps/api/src/assistant/intent-engine/local-consensus.service.spec.ts
+++ b/apps/api/src/assistant/intent-engine/local-consensus.service.spec.ts
@@ -15,6 +15,8 @@ describe('AssistantLocalConsensusService', () => {
     process.env.AI_GEMINI_FALLBACK_ENABLED = 'false';
     process.env.OLLAMA_BASE_URL = 'http://localhost:11434';
     process.env.OLLAMA_MODEL = 'qwen2.5:3b';
+    delete process.env.AI_OLLAMA_TIMEOUT_MS;
+    delete process.env.ASSISTANT_TRACE;
     service = new AssistantLocalConsensusService();
   });
 
@@ -25,6 +27,8 @@ describe('AssistantLocalConsensusService', () => {
     delete process.env.AI_GEMINI_FALLBACK_ENABLED;
     delete process.env.OLLAMA_BASE_URL;
     delete process.env.OLLAMA_MODEL;
+    delete process.env.AI_OLLAMA_TIMEOUT_MS;
+    delete process.env.ASSISTANT_TRACE;
     mockFetch.mockReset();
   });
 
@@ -98,6 +102,23 @@ describe('AssistantLocalConsensusService', () => {
     expect(requestBody.format).toBeDefined();
   });
 
+  it('uses the configured Ollama timeout when provided', async () => {
+    process.env.AI_OLLAMA_TIMEOUT_MS = '30000';
+    service = new AssistantLocalConsensusService();
+
+    expect(service.getTimeoutMs()).toBe(30000);
+  });
+
+  it('falls back to 20000ms when the configured Ollama timeout is invalid', async () => {
+    process.env.AI_OLLAMA_TIMEOUT_MS = 'abc';
+    service = new AssistantLocalConsensusService();
+    expect(service.getTimeoutMs()).toBe(20000);
+
+    process.env.AI_OLLAMA_TIMEOUT_MS = '999';
+    service = new AssistantLocalConsensusService();
+    expect(service.getTimeoutMs()).toBe(20000);
+  });
+
   it('asks for clarification on period mismatch', async () => {
     const currentDate = new Date();
     mockFetch.mockResolvedValue({
@@ -140,6 +161,88 @@ describe('AssistantLocalConsensusService', () => {
     expect(result.mismatchReason).toBe('period');
     expect(result.clarificationMessage).toContain('este mes');
     expect(result.usedLocalModel).toBe(true);
+  });
+
+  it('accepts model-enriched current month when deterministic period is missing', async () => {
+    const currentDate = new Date();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        message: {
+          content: JSON.stringify({
+            intent: 'building_debt',
+            scope: 'building',
+            entity: {
+              buildingAlias: 'A',
+              unitAlias: null,
+            },
+            period: {
+              kind: 'current_month',
+              month: currentDate.getMonth() + 1,
+              year: currentDate.getFullYear(),
+              offset: 0,
+              amount: null,
+              unit: 'month',
+              mode: 'including_current',
+            },
+            confidence: 0.97,
+            requiresClarification: false,
+            missingFields: [],
+          }),
+        },
+      }),
+    });
+
+    const result = await service.evaluate(
+      'dame la deuda del mes que está corriendo del edificio A',
+      buildDeterministicPlan({ filters: { buildingAlias: 'A', buildingToken: 'A', period: undefined } }),
+      {},
+    );
+
+    expect(result.consensus).toBe(true);
+    expect(result.mismatchReason).toBeUndefined();
+    expect(result.modelPlan?.period.kind).toBe('current_month');
+  });
+
+  it('marks tenant_debt with building scope as semantically invalid', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        message: {
+          content: JSON.stringify({
+            intent: 'tenant_debt',
+            scope: 'building',
+            entity: {
+              buildingAlias: 'A',
+              unitAlias: null,
+            },
+            period: {
+              kind: 'current_month',
+              month: 6,
+              year: 2026,
+              offset: 0,
+              amount: null,
+              unit: 'month',
+              mode: 'including_current',
+            },
+            confidence: 0.92,
+            requiresClarification: false,
+            missingFields: [],
+          }),
+        },
+      }),
+    });
+
+    const result = await service.evaluate(
+      'dame la deuda del mes que está corriendo del edificio A',
+      buildDeterministicPlan(),
+      {},
+    );
+
+    expect(result.consensus).toBe(false);
+    expect(result.mismatchReason).toBe('model_intent_scope_conflict');
+    expect(result.modelValid).toBe(false);
+    expect(result.modelInvalidReason).toBe('model_intent_scope_conflict');
   });
 
   it('asks for clarification when the local model marks the query as incomplete', async () => {
@@ -193,6 +296,21 @@ describe('AssistantLocalConsensusService', () => {
 
     expect(result.consensus).toBe(false);
     expect(result.mismatchReason).toBe('local_model_failed');
-    expect(result.clarificationMessage).toContain('administración');
+    expect(result.clarificationMessage).toContain('administración, de un edificio o de una unidad');
+  });
+
+  it('asks only for the period when the local model fails but building context exists', async () => {
+    mockFetch.mockRejectedValue(new Error('AbortError'));
+
+    const result = await service.evaluate(
+      'dame la deuda del mes que está corriendo del edificio A',
+      buildDeterministicPlan({ filters: { buildingAlias: 'A', buildingToken: 'A', period: undefined } }),
+      {},
+    );
+
+    expect(result.consensus).toBe(false);
+    expect(result.mismatchReason).toBe('local_model_failed');
+    expect(result.clarificationMessage).toContain('este mes o la deuda acumulada');
+    expect(result.clarificationMessage).not.toContain('administración, de un edificio o de una unidad');
   });
 });

--- a/apps/api/src/assistant/intent-engine/local-consensus.service.spec.ts
+++ b/apps/api/src/assistant/intent-engine/local-consensus.service.spec.ts
@@ -1,0 +1,198 @@
+import { AssistantLocalConsensusService } from './local-consensus.service';
+import type { AssistantQueryPlan } from '../query-plan.types';
+
+const mockFetch = jest.fn();
+(global as any).fetch = mockFetch;
+
+describe('AssistantLocalConsensusService', () => {
+  let service: AssistantLocalConsensusService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.AI_PROVIDER = 'hybrid';
+    process.env.AI_CONSENSUS_MODE = 'true';
+    process.env.AI_ALWAYS_CALL_LOCAL_MODEL = 'true';
+    process.env.AI_GEMINI_FALLBACK_ENABLED = 'false';
+    process.env.OLLAMA_BASE_URL = 'http://localhost:11434';
+    process.env.OLLAMA_MODEL = 'qwen2.5:3b';
+    service = new AssistantLocalConsensusService();
+  });
+
+  afterEach(() => {
+    delete process.env.AI_PROVIDER;
+    delete process.env.AI_CONSENSUS_MODE;
+    delete process.env.AI_ALWAYS_CALL_LOCAL_MODEL;
+    delete process.env.AI_GEMINI_FALLBACK_ENABLED;
+    delete process.env.OLLAMA_BASE_URL;
+    delete process.env.OLLAMA_MODEL;
+    mockFetch.mockReset();
+  });
+
+  function buildDeterministicPlan(overrides: Partial<AssistantQueryPlan> = {}): AssistantQueryPlan {
+    const currentMonth = new Date().toISOString().slice(0, 7);
+    return {
+      intent: 'building_debt',
+      module: 'payments',
+      scope: 'building',
+      requiredPermission: 'payments.review',
+      executor: 'building_debt',
+      filters: {
+        buildingAlias: 'A',
+        buildingToken: 'A',
+        period: currentMonth,
+      },
+      confidence: 0.9,
+      source: 'deterministic_rules',
+      ...overrides,
+    };
+  }
+
+  it('returns consensus when deterministic and local plans match', async () => {
+    const currentDate = new Date();
+    const responsePayload = {
+      message: {
+        content: JSON.stringify({
+          intent: 'building_debt',
+          scope: 'building',
+          entity: {
+            buildingAlias: 'A',
+            unitAlias: null,
+          },
+          period: {
+            kind: 'current_month',
+            month: currentDate.getMonth() + 1,
+            year: currentDate.getFullYear(),
+            offset: 0,
+            amount: null,
+            unit: 'month',
+            mode: 'including_current',
+          },
+          confidence: 0.96,
+          requiresClarification: false,
+          missingFields: [],
+        }),
+      },
+    };
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => responsePayload,
+    });
+
+    const result = await service.evaluate(
+      'deuda de este mes del edificio A',
+      buildDeterministicPlan(),
+      {
+        buildingId: 'building-A',
+        currentPage: '/tenant/buildings/building-A/finance',
+        previousTurns: [],
+      },
+    );
+
+    expect(result.consensus).toBe(true);
+    expect(result.usedLocalModel).toBe(true);
+    expect(result.modelPlan?.intent).toBe('building_debt');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const requestBody = JSON.parse(mockFetch.mock.calls[0]?.[1]?.body ?? '{}');
+    expect(requestBody.model).toBe('qwen2.5:3b');
+    expect(requestBody.format).toBeDefined();
+  });
+
+  it('asks for clarification on period mismatch', async () => {
+    const currentDate = new Date();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        message: {
+          content: JSON.stringify({
+            intent: 'building_debt',
+            scope: 'building',
+            entity: {
+              buildingAlias: 'A',
+              unitAlias: null,
+            },
+            period: {
+              kind: 'accumulated',
+              month: null,
+              year: null,
+              offset: null,
+              amount: null,
+              unit: null,
+              mode: 'unknown',
+            },
+            confidence: 0.9,
+            requiresClarification: false,
+            missingFields: [],
+          }),
+        },
+      }),
+    });
+
+    const result = await service.evaluate(
+      'deuda de este mes del edificio A',
+      buildDeterministicPlan({
+        filters: { buildingAlias: 'A', buildingToken: 'A', period: currentDate.toISOString().slice(0, 7) },
+      }),
+      {},
+    );
+
+    expect(result.consensus).toBe(false);
+    expect(result.mismatchReason).toBe('period');
+    expect(result.clarificationMessage).toContain('este mes');
+    expect(result.usedLocalModel).toBe(true);
+  });
+
+  it('asks for clarification when the local model marks the query as incomplete', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        message: {
+          content: JSON.stringify({
+            intent: 'building_debt',
+            scope: 'building',
+            entity: {
+              buildingAlias: 'A',
+              unitAlias: null,
+            },
+            period: {
+              kind: 'unknown',
+              month: null,
+              year: null,
+              offset: null,
+              amount: null,
+              unit: null,
+              mode: null,
+            },
+            confidence: 0.6,
+            requiresClarification: true,
+            missingFields: ['period'],
+          }),
+        },
+      }),
+    });
+
+    const result = await service.evaluate(
+      'deuda del condominio',
+      buildDeterministicPlan({ filters: { buildingAlias: 'A', buildingToken: 'A', period: undefined } }),
+      {},
+    );
+
+    expect(result.consensus).toBe(false);
+    expect(result.mismatchReason).toBe('clarification');
+    expect(result.clarificationMessage).toContain('este mes');
+  });
+
+  it('returns clarification when the local model fails', async () => {
+    mockFetch.mockRejectedValue(new Error('Ollama down'));
+
+    const result = await service.evaluate(
+      'deuda del condominio',
+      buildDeterministicPlan({ filters: { buildingAlias: undefined, buildingToken: undefined, period: undefined } }),
+      {},
+    );
+
+    expect(result.consensus).toBe(false);
+    expect(result.mismatchReason).toBe('local_model_failed');
+    expect(result.clarificationMessage).toContain('administración');
+  });
+});

--- a/apps/api/src/assistant/intent-engine/local-consensus.service.ts
+++ b/apps/api/src/assistant/intent-engine/local-consensus.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { z } from 'zod';
 import { resolveAiConsensusModeConfig } from '../providers/ai-provider.resolver';
+import type { CanonicalFinancePeriod } from '../finance-period.types';
 import type {
   AssistantConsensusEvaluation,
   AssistantConsensusIntent,
@@ -9,8 +10,19 @@ import type {
 import type { ConversationTurn } from './intent.types';
 import type { AssistantQueryPlan } from '../query-plan.types';
 
-const OLLAMA_TIMEOUT_MS = 8000;
+const DEFAULT_OLLAMA_TIMEOUT_MS = 20000;
 const DEFAULT_OLLAMA_MODEL = 'qwen2.5:3b';
+
+function resolveOllamaTimeoutMs(): number {
+  const raw = process.env.AI_OLLAMA_TIMEOUT_MS;
+  const parsed = raw ? Number(raw) : DEFAULT_OLLAMA_TIMEOUT_MS;
+
+  if (!Number.isFinite(parsed) || parsed < 1000) {
+    return DEFAULT_OLLAMA_TIMEOUT_MS;
+  }
+
+  return parsed;
+}
 
 const assistantConsensusSchema = z.object({
   intent: z.enum(['tenant_debt', 'building_debt', 'unit_debt', 'unknown']),
@@ -24,12 +36,13 @@ const assistantConsensusSchema = z.object({
       'current_month',
       'previous_month',
       'named_month',
-      'relative_month',
-      'relative_range',
-      'month_range',
-      'accumulated',
-      'unknown',
-    ]),
+    'relative_month',
+    'relative_range',
+    'month_range',
+    'year_to_date',
+    'accumulated',
+    'unknown',
+  ]),
     month: z.number().int().nullable(),
     year: z.number().int().nullable(),
     offset: z.number().int().nullable(),
@@ -81,6 +94,8 @@ export class AssistantLocalConsensusService {
   private readonly config = resolveAiConsensusModeConfig();
   private readonly baseUrl = this.config.ollamaBaseUrl || process.env.OLLAMA_BASE_URL || process.env.AI_OLLAMA_URL || 'http://localhost:11434';
   private readonly model = this.config.ollamaModel || process.env.OLLAMA_MODEL || process.env.AI_OLLAMA_MODEL || DEFAULT_OLLAMA_MODEL;
+  private readonly timeoutMs = resolveOllamaTimeoutMs();
+  private readonly traceEnabled = process.env.ASSISTANT_TRACE === 'true';
 
   isEnabled(): boolean {
     return this.config.consensusMode || this.config.alwaysCallLocalModel;
@@ -92,6 +107,10 @@ export class AssistantLocalConsensusService {
 
   getModel(): string {
     return this.model;
+  }
+
+  getTimeoutMs(): number {
+    return this.timeoutMs;
   }
 
   async evaluate(
@@ -116,10 +135,30 @@ export class AssistantLocalConsensusService {
 
     try {
       const modelPlan = await this.callOllama(message, context);
-      const comparison = this.comparePlans(deterministicConsensusPlan, modelPlan);
+      const normalizedModelPlan = this.normalizeModelPlan(modelPlan);
+      const modelValidation = this.validateModelPlan(normalizedModelPlan);
+      if (!modelValidation.valid) {
+        const invalidReason = modelValidation.reason ?? 'model_semantic_invalid';
+        this.logger.warn(`[AssistantConsensus] model invalid=${invalidReason}${modelValidation.details ? ` details=${modelValidation.details.join('|')}` : ''}`);
+        return {
+          consensus: false,
+          deterministicPlan: deterministicConsensusPlan,
+          modelPlan: normalizedModelPlan,
+          mismatchReason: invalidReason,
+          modelValid: false,
+          modelInvalidReason: invalidReason,
+          clarificationMessage: this.buildClarificationMessage(invalidReason, deterministicConsensusPlan, normalizedModelPlan),
+          usedLocalModel: true,
+          localProvider: 'ollama',
+          localBaseUrl: this.baseUrl,
+          localModel: this.model,
+        };
+      }
+
+      const comparison = this.comparePlans(deterministicConsensusPlan, normalizedModelPlan);
 
       this.logger.log(
-        `[AssistantConsensus] deterministic=${this.summarizePlan(deterministicConsensusPlan)} model=${this.summarizePlan(modelPlan)} consensus=${comparison.consensus}`,
+        `[AssistantConsensus] deterministic=${this.summarizePlan(deterministicConsensusPlan)} model=${this.summarizePlan(normalizedModelPlan)} consensus=${comparison.consensus}`,
       );
 
       if (!comparison.consensus && comparison.mismatchReason) {
@@ -129,8 +168,9 @@ export class AssistantLocalConsensusService {
       return {
         consensus: comparison.consensus,
         deterministicPlan: deterministicConsensusPlan,
-        modelPlan,
+        modelPlan: normalizedModelPlan,
         mismatchReason: comparison.mismatchReason,
+        modelValid: true,
         clarificationMessage: comparison.clarificationMessage,
         usedLocalModel: true,
         localProvider: 'ollama',
@@ -145,6 +185,7 @@ export class AssistantLocalConsensusService {
         deterministicPlan: deterministicConsensusPlan,
         modelPlan: null,
         mismatchReason: 'local_model_failed',
+        modelValid: false,
         clarificationMessage: this.buildClarificationMessage('local_model_failed', deterministicConsensusPlan),
         usedLocalModel: true,
         localProvider: 'ollama',
@@ -156,7 +197,12 @@ export class AssistantLocalConsensusService {
 
   private async callOllama(message: string, context: LocalConsensusContext): Promise<AssistantConsensusModelPlan> {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), OLLAMA_TIMEOUT_MS);
+    const startedAt = Date.now();
+    let abortedByTimeout = false;
+    const timeoutId = setTimeout(() => {
+      abortedByTimeout = true;
+      controller.abort();
+    }, this.timeoutMs);
     const endpoint = `${this.baseUrl.replace(/\/$/, '')}/api/chat`;
     const requestBody = {
       model: this.model,
@@ -178,8 +224,8 @@ export class AssistantLocalConsensusService {
       format: this.buildSchema(),
     };
 
-    this.logger.debug(
-      `[AssistantConsensus] endpoint=${endpoint} model=${this.model} payload=${JSON.stringify({
+    this.trace(
+      `[AssistantConsensus] endpoint=${endpoint} model=${this.model} timeoutMs=${this.timeoutMs} payload=${JSON.stringify({
         messageLength: message.length,
         hasBuildingId: Boolean(context.buildingId),
         hasUnitId: Boolean(context.unitId),
@@ -195,6 +241,8 @@ export class AssistantLocalConsensusService {
         body: JSON.stringify(requestBody),
         signal: controller.signal,
       });
+      const durationMs = Date.now() - startedAt;
+      this.trace(`[AssistantConsensus] response.ok=${response.ok} durationMs=${durationMs} abortedByTimeout=${abortedByTimeout}`);
 
       if (!response.ok) {
         const errorBody = await response.text().catch(() => '');
@@ -204,6 +252,7 @@ export class AssistantLocalConsensusService {
       const raw: unknown = await response.json();
       const parsedResponse = ollamaChatSchema.parse(raw);
       const content = parsedResponse.message?.content?.trim();
+      this.trace(`[AssistantConsensus] receivedContent=${Boolean(content)} contentLength=${content?.length ?? 0}`);
       if (!content) {
         throw new Error('Invalid Ollama response format: missing message.content');
       }
@@ -214,13 +263,33 @@ export class AssistantLocalConsensusService {
         jsonStr = codeBlockMatch[1];
       }
 
-      const parsed = assistantConsensusSchema.safeParse(JSON.parse(jsonStr));
+      let parsedJson: unknown;
+      try {
+        parsedJson = JSON.parse(jsonStr);
+        this.trace('[AssistantConsensus] jsonParse=ok');
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        this.trace(`[AssistantConsensus] jsonParse=failed reason=${reason}`);
+        throw error;
+      }
+
+      const parsed = assistantConsensusSchema.safeParse(parsedJson);
       if (!parsed.success) {
         const issues = parsed.error.issues.map((issue) => issue.message).join(', ');
+        this.trace(`[AssistantConsensus] zod=failed issues=${issues}`);
         throw new Error(`Invalid consensus JSON: ${issues}`);
       }
 
+      this.trace(`[AssistantConsensus] zod=ok durationMs=${Date.now() - startedAt}`);
+
       return parsed.data;
+    } catch (error) {
+      const durationMs = Date.now() - startedAt;
+      const reason = error instanceof Error ? error.message : String(error);
+      this.trace(
+        `[AssistantConsensus] failed durationMs=${durationMs} abortedByTimeout=${abortedByTimeout} reason=${reason}`,
+      );
+      throw error;
     } finally {
       clearTimeout(timeoutId);
     }
@@ -240,7 +309,7 @@ export class AssistantLocalConsensusService {
       'Use building_debt for building/condominio/edificio debt questions.',
       'Use unit_debt for apartment/unit debt questions.',
       'Use scope tenant/building/unit to match the intent.',
-      'Use period.kind = current_month for "este mes", "mes actual", "mes en curso", or "del mes actual".',
+      'Use period.kind = current_month for "este mes", "mes actual", "mes en curso", "mes corriente", "mes que está corriendo", "del mes actual", "del mes en curso", or "deuda del mes".',
       'Use period.kind = accumulated for "acumulada", "histórica", "total", or "toda" when the user asks for total outstanding debt.',
       'If the query is unclear or missing a critical field, set requiresClarification=true and list the missing fields.',
       `Current date: ${new Date().toISOString().slice(0, 10)}`,
@@ -326,7 +395,7 @@ export class AssistantLocalConsensusService {
       };
     }
 
-    if (deterministic.period.kind !== model.period.kind) {
+    if (!this.periodsAreCompatible(deterministic.period, model.period)) {
       return {
         consensus: false,
         mismatchReason: 'period',
@@ -343,6 +412,60 @@ export class AssistantLocalConsensusService {
     }
 
     return { consensus: true };
+  }
+
+  private validateModelPlan(
+    model: AssistantConsensusModelPlan,
+  ): { valid: boolean; reason?: 'model_semantic_invalid' | 'model_intent_scope_conflict'; details?: string[] } {
+    const details: string[] = [];
+
+    if (model.intent === 'tenant_debt') {
+      if (model.scope !== 'tenant') {
+        details.push('tenant_debt_scope');
+      }
+      if (normalizeAlias(model.entity.buildingAlias) || normalizeAlias(model.entity.unitAlias)) {
+        details.push('tenant_debt_entity');
+      }
+    }
+
+    if (model.intent === 'building_debt') {
+      if (model.scope !== 'building') {
+        details.push('building_debt_scope');
+      }
+      if (!normalizeAlias(model.entity.buildingAlias)) {
+        details.push('building_debt_building_alias');
+      }
+      if (normalizeAlias(model.entity.unitAlias)) {
+        details.push('building_debt_unit_alias');
+      }
+    }
+
+    if (model.intent === 'unit_debt') {
+      if (model.scope !== 'unit') {
+        details.push('unit_debt_scope');
+      }
+      if (!normalizeAlias(model.entity.unitAlias)) {
+        details.push('unit_debt_unit_alias');
+      }
+    }
+
+    if (model.period.kind === 'month_range' && typeof model.period.amount === 'number' && model.period.amount <= 0) {
+      details.push('month_range_amount');
+    }
+
+    if (details.length === 0) {
+      return { valid: true };
+    }
+
+    const intentScopeConflict = details.some((detail) =>
+      detail.endsWith('_scope') || detail.endsWith('_entity'),
+    );
+
+    return {
+      valid: false,
+      reason: intentScopeConflict ? 'model_intent_scope_conflict' : 'model_semantic_invalid',
+      details,
+    };
   }
 
   private matchEntity(deterministic: AssistantConsensusModelPlan, model: AssistantConsensusModelPlan): boolean {
@@ -364,6 +487,38 @@ export class AssistantLocalConsensusService {
     return true;
   }
 
+  private periodsAreCompatible(
+    deterministic: AssistantConsensusModelPlan['period'],
+    model: AssistantConsensusModelPlan['period'],
+  ): boolean {
+    if (deterministic.kind === model.kind) {
+      return true;
+    }
+
+    if (deterministic.kind === 'unknown' || model.kind === 'unknown') {
+      return true;
+    }
+
+    if (this.isCurrentMonthPeriod(deterministic) && this.isCurrentMonthPeriod(model)) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private isCurrentMonthPeriod(period: AssistantConsensusModelPlan['period']): boolean {
+    if (period.kind === 'current_month') {
+      return true;
+    }
+
+    if (period.kind === 'named_month' && period.month && period.year) {
+      const current = new Date();
+      return period.year === current.getFullYear() && period.month === current.getMonth() + 1;
+    }
+
+    return false;
+  }
+
   private entityMismatchReason(deterministic: AssistantConsensusModelPlan, model: AssistantConsensusModelPlan): string {
     if (deterministic.scope === 'unit' && !isSameAlias(deterministic.entity.unitAlias, model.entity.unitAlias)) {
       return 'unit_alias';
@@ -382,7 +537,34 @@ export class AssistantLocalConsensusService {
     model?: AssistantConsensusModelPlan | null,
   ): string {
     if (mismatch === 'local_model_failed') {
+      if (deterministic?.scope === 'building') {
+        const buildingAlias = deterministic.entity.buildingAlias || model?.entity.buildingAlias;
+        if (buildingAlias) {
+          return `No pude validar esa consulta con el modelo local para el edificio ${buildingAlias}. ¿Querés la deuda de este mes o la deuda acumulada?`;
+        }
+        return 'No pude validar esa consulta con el modelo local. ¿Querés aclarar si se trata de una deuda de la administración, de un edificio o de una unidad?';
+      }
       return 'No pude validar esa consulta con el modelo local. ¿Querés aclarar si se trata de una deuda de la administración, de un edificio o de una unidad?';
+    }
+
+    if (mismatch === 'model_semantic_invalid' || mismatch === 'model_intent_scope_conflict') {
+      if (deterministic?.scope === 'building') {
+        const buildingAlias = deterministic.entity.buildingAlias || model?.entity.buildingAlias;
+        if (buildingAlias) {
+          return `El modelo local devolvió una combinación inválida para el edificio ${buildingAlias}. ¿Querés la deuda de este mes o la deuda acumulada?`;
+        }
+        return 'El modelo local devolvió una combinación inválida. ¿De cuál condominio o edificio querés consultar la deuda?';
+      }
+
+      if (deterministic?.scope === 'unit') {
+        return 'El modelo local devolvió una combinación inválida. ¿De qué unidad querés consultar la deuda?';
+      }
+
+      if (deterministic?.scope === 'tenant') {
+        return 'El modelo local devolvió una combinación inválida. ¿Querés la deuda de la administración o la deuda total?';
+      }
+
+      return 'El modelo local devolvió una combinación inválida. ¿Querés aclarar la consulta?';
     }
 
     if (mismatch === 'no_deterministic_plan') {
@@ -390,6 +572,10 @@ export class AssistantLocalConsensusService {
     }
 
     if (mismatch === 'period') {
+      if (deterministic?.period.kind === 'relative_range') {
+        const amount = deterministic.period.amount ?? model?.period.amount ?? 0;
+        return `¿Querés incluir el mes actual o consultar solo los últimos ${amount} meses cerrados?`;
+      }
       const buildingAlias = deterministic?.entity.buildingAlias || model?.entity.buildingAlias;
       if (buildingAlias) {
         return `Entiendo que quieres consultar la deuda del edificio ${buildingAlias}. ¿Te refieres a este mes o a la deuda acumulada?`;
@@ -399,6 +585,10 @@ export class AssistantLocalConsensusService {
 
     if (mismatch === 'clarification') {
       const missingFields = model?.missingFields ?? [];
+      if (deterministic?.period.kind === 'relative_range' || missingFields.includes('period.mode')) {
+        const amount = deterministic?.period.amount ?? model?.period.amount ?? 0;
+        return `¿Querés incluir el mes actual o consultar solo los últimos ${amount} meses cerrados?`;
+      }
       if (missingFields.includes('period')) {
         return '¿Te refieres a la deuda de este mes o a la deuda acumulada?';
       }
@@ -441,7 +631,7 @@ export class AssistantLocalConsensusService {
     };
   }
 
-  private mapDeterministicPeriod(period?: string): AssistantConsensusModelPlan['period'] {
+  private mapDeterministicPeriod(period?: string | CanonicalFinancePeriod): AssistantConsensusModelPlan['period'] {
     if (!period) {
       return {
         kind: 'unknown',
@@ -451,6 +641,18 @@ export class AssistantLocalConsensusService {
         amount: null,
         unit: null,
         mode: null,
+      };
+    }
+
+    if (typeof period !== 'string') {
+      return {
+        kind: period.kind,
+        month: period.month,
+        year: period.year,
+        offset: period.kind === 'relative_range' ? 0 : null,
+        amount: period.amount,
+        unit: period.unit,
+        mode: period.mode,
       };
     }
 
@@ -508,6 +710,39 @@ export class AssistantLocalConsensusService {
     };
   }
 
+  private normalizeModelPlan(model: AssistantConsensusModelPlan): AssistantConsensusModelPlan {
+    if (model.period.kind !== 'relative_range') {
+      return model;
+    }
+
+    const normalizedMissingFields = this.normalizeRelativeRangeMissingFields(model);
+    if (normalizedMissingFields.length === model.missingFields.length && normalizedMissingFields.every((item, index) => item === model.missingFields[index])) {
+      return model;
+    }
+
+    return {
+      ...model,
+      missingFields: normalizedMissingFields,
+    };
+  }
+
+  private normalizeRelativeRangeMissingFields(model: AssistantConsensusModelPlan): string[] {
+    const normalized = new Set<string>();
+    for (const field of model.missingFields) {
+      if (field === 'startMonth' || field === 'endMonth' || field === 'period.mode') {
+        normalized.add('period.mode');
+        continue;
+      }
+      normalized.add(field);
+    }
+
+    if (model.period.mode === 'unknown' && normalized.size === 0) {
+      normalized.add('period.mode');
+    }
+
+    return Array.from(normalized);
+  }
+
   private summarizePlan(plan: AssistantConsensusModelPlan | null): string {
     if (!plan) {
       return 'none';
@@ -516,5 +751,11 @@ export class AssistantLocalConsensusService {
     const building = plan.entity.buildingAlias ?? '-';
     const unit = plan.entity.unitAlias ?? '-';
     return `${plan.intent}/${plan.scope}/${plan.period.kind}/${building}/${unit}`;
+  }
+
+  private trace(message: string): void {
+    if (this.traceEnabled) {
+      this.logger.debug(message);
+    }
   }
 }

--- a/apps/api/src/assistant/intent-engine/local-consensus.service.ts
+++ b/apps/api/src/assistant/intent-engine/local-consensus.service.ts
@@ -1,0 +1,520 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { z } from 'zod';
+import { resolveAiConsensusModeConfig } from '../providers/ai-provider.resolver';
+import type {
+  AssistantConsensusEvaluation,
+  AssistantConsensusIntent,
+  AssistantConsensusModelPlan,
+} from '../ai.types';
+import type { ConversationTurn } from './intent.types';
+import type { AssistantQueryPlan } from '../query-plan.types';
+
+const OLLAMA_TIMEOUT_MS = 8000;
+const DEFAULT_OLLAMA_MODEL = 'qwen2.5:3b';
+
+const assistantConsensusSchema = z.object({
+  intent: z.enum(['tenant_debt', 'building_debt', 'unit_debt', 'unknown']),
+  scope: z.enum(['tenant', 'building', 'unit', 'unknown']),
+  entity: z.object({
+    buildingAlias: z.string().nullable(),
+    unitAlias: z.string().nullable(),
+  }).strict(),
+  period: z.object({
+    kind: z.enum([
+      'current_month',
+      'previous_month',
+      'named_month',
+      'relative_month',
+      'relative_range',
+      'month_range',
+      'accumulated',
+      'unknown',
+    ]),
+    month: z.number().int().nullable(),
+    year: z.number().int().nullable(),
+    offset: z.number().int().nullable(),
+    amount: z.number().nullable(),
+    unit: z.enum(['month']).nullable(),
+    mode: z.enum(['including_current', 'closed_months', 'unknown']).nullable(),
+  }).strict(),
+  confidence: z.number().min(0).max(1),
+  requiresClarification: z.boolean(),
+  missingFields: z.array(z.string()),
+}).strict();
+
+const ollamaChatSchema = z.object({
+  message: z.object({
+    content: z.string().optional(),
+  }).optional(),
+}).passthrough();
+
+interface LocalConsensusContext {
+  buildingId?: string;
+  unitId?: string;
+  currentPage?: string;
+  financePeriod?: string;
+  previousTurns?: ConversationTurn[];
+}
+
+interface ConsensusComparisonResult {
+  consensus: boolean;
+  mismatchReason?: string;
+  clarificationMessage?: string;
+}
+
+function normalizeAlias(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function isSameAlias(left: string | null, right: string | null): boolean {
+  return normalizeAlias(left) === normalizeAlias(right);
+}
+
+@Injectable()
+export class AssistantLocalConsensusService {
+  private readonly logger = new Logger(AssistantLocalConsensusService.name);
+  private readonly config = resolveAiConsensusModeConfig();
+  private readonly baseUrl = this.config.ollamaBaseUrl || process.env.OLLAMA_BASE_URL || process.env.AI_OLLAMA_URL || 'http://localhost:11434';
+  private readonly model = this.config.ollamaModel || process.env.OLLAMA_MODEL || process.env.AI_OLLAMA_MODEL || DEFAULT_OLLAMA_MODEL;
+
+  isEnabled(): boolean {
+    return this.config.consensusMode || this.config.alwaysCallLocalModel;
+  }
+
+  getBaseUrl(): string {
+    return this.baseUrl;
+  }
+
+  getModel(): string {
+    return this.model;
+  }
+
+  async evaluate(
+    message: string,
+    deterministicPlan: AssistantQueryPlan | null,
+    context: LocalConsensusContext,
+  ): Promise<AssistantConsensusEvaluation> {
+    const deterministicConsensusPlan = this.toConsensusPlan(deterministicPlan);
+    if (!deterministicConsensusPlan) {
+      return {
+        consensus: false,
+        deterministicPlan: null,
+        modelPlan: null,
+        mismatchReason: 'no_deterministic_plan',
+        clarificationMessage: this.buildClarificationMessage('no_deterministic_plan'),
+        usedLocalModel: false,
+        localProvider: 'ollama',
+        localBaseUrl: this.baseUrl,
+        localModel: this.model,
+      };
+    }
+
+    try {
+      const modelPlan = await this.callOllama(message, context);
+      const comparison = this.comparePlans(deterministicConsensusPlan, modelPlan);
+
+      this.logger.log(
+        `[AssistantConsensus] deterministic=${this.summarizePlan(deterministicConsensusPlan)} model=${this.summarizePlan(modelPlan)} consensus=${comparison.consensus}`,
+      );
+
+      if (!comparison.consensus && comparison.mismatchReason) {
+        this.logger.warn(`[AssistantConsensus] mismatch=${comparison.mismatchReason}`);
+      }
+
+      return {
+        consensus: comparison.consensus,
+        deterministicPlan: deterministicConsensusPlan,
+        modelPlan,
+        mismatchReason: comparison.mismatchReason,
+        clarificationMessage: comparison.clarificationMessage,
+        usedLocalModel: true,
+        localProvider: 'ollama',
+        localBaseUrl: this.baseUrl,
+        localModel: this.model,
+      };
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`[AssistantConsensus] local model failed: ${reason}`);
+      return {
+        consensus: false,
+        deterministicPlan: deterministicConsensusPlan,
+        modelPlan: null,
+        mismatchReason: 'local_model_failed',
+        clarificationMessage: this.buildClarificationMessage('local_model_failed', deterministicConsensusPlan),
+        usedLocalModel: true,
+        localProvider: 'ollama',
+        localBaseUrl: this.baseUrl,
+        localModel: this.model,
+      };
+    }
+  }
+
+  private async callOllama(message: string, context: LocalConsensusContext): Promise<AssistantConsensusModelPlan> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), OLLAMA_TIMEOUT_MS);
+    const endpoint = `${this.baseUrl.replace(/\/$/, '')}/api/chat`;
+    const requestBody = {
+      model: this.model,
+      messages: [
+        {
+          role: 'system',
+          content: this.buildPrompt(context),
+        },
+        {
+          role: 'user',
+          content: message,
+        },
+      ],
+      stream: false,
+      options: {
+        temperature: 0,
+        num_predict: 220,
+      },
+      format: this.buildSchema(),
+    };
+
+    this.logger.debug(
+      `[AssistantConsensus] endpoint=${endpoint} model=${this.model} payload=${JSON.stringify({
+        messageLength: message.length,
+        hasBuildingId: Boolean(context.buildingId),
+        hasUnitId: Boolean(context.unitId),
+        previousTurns: context.previousTurns?.length ?? 0,
+        formatKeys: Object.keys(this.buildSchema().properties ?? {}),
+      })}`,
+    );
+
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestBody),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text().catch(() => '');
+        throw new Error(`Ollama API error: ${response.status} ${response.statusText}${errorBody ? ` | body=${errorBody}` : ''}`);
+      }
+
+      const raw: unknown = await response.json();
+      const parsedResponse = ollamaChatSchema.parse(raw);
+      const content = parsedResponse.message?.content?.trim();
+      if (!content) {
+        throw new Error('Invalid Ollama response format: missing message.content');
+      }
+
+      let jsonStr = content;
+      const codeBlockMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+      if (codeBlockMatch?.[1]) {
+        jsonStr = codeBlockMatch[1];
+      }
+
+      const parsed = assistantConsensusSchema.safeParse(JSON.parse(jsonStr));
+      if (!parsed.success) {
+        const issues = parsed.error.issues.map((issue) => issue.message).join(', ');
+        throw new Error(`Invalid consensus JSON: ${issues}`);
+      }
+
+      return parsed.data;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private buildPrompt(context: LocalConsensusContext): string {
+    const turns = (context.previousTurns || []).slice(-3).map((turn) => ({
+      role: turn.role,
+      message: turn.message,
+    }));
+
+    return [
+      'You are a strict JSON-only intent planner for BuildingOS finance read-only assistant.',
+      'You NEVER answer the user, calculate debt, query databases, or invent business data.',
+      'Return only valid JSON matching the provided schema.',
+      'Use tenant_debt for administration/global debt questions.',
+      'Use building_debt for building/condominio/edificio debt questions.',
+      'Use unit_debt for apartment/unit debt questions.',
+      'Use scope tenant/building/unit to match the intent.',
+      'Use period.kind = current_month for "este mes", "mes actual", "mes en curso", or "del mes actual".',
+      'Use period.kind = accumulated for "acumulada", "histórica", "total", or "toda" when the user asks for total outstanding debt.',
+      'If the query is unclear or missing a critical field, set requiresClarification=true and list the missing fields.',
+      `Current date: ${new Date().toISOString().slice(0, 10)}`,
+      `Current context: ${JSON.stringify({
+        buildingId: context.buildingId ?? null,
+        unitId: context.unitId ?? null,
+        currentPage: context.currentPage ?? null,
+        financePeriod: context.financePeriod ?? null,
+        previousTurns: turns,
+      })}`,
+    ].join('\n');
+  }
+
+  private buildSchema() {
+    return {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        intent: { type: 'string', enum: ['tenant_debt', 'building_debt', 'unit_debt', 'unknown'] },
+        scope: { type: 'string', enum: ['tenant', 'building', 'unit', 'unknown'] },
+        entity: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            buildingAlias: { type: ['string', 'null'] },
+            unitAlias: { type: ['string', 'null'] },
+          },
+          required: ['buildingAlias', 'unitAlias'],
+        },
+        period: {
+          type: 'object',
+          additionalProperties: false,
+          properties: {
+            kind: {
+              type: 'string',
+              enum: ['current_month', 'previous_month', 'named_month', 'relative_month', 'relative_range', 'month_range', 'accumulated', 'unknown'],
+            },
+            month: { type: ['integer', 'null'] },
+            year: { type: ['integer', 'null'] },
+            offset: { type: ['integer', 'null'] },
+            amount: { type: ['number', 'null'] },
+            unit: { type: ['string', 'null'], enum: ['month', null] },
+            mode: { type: ['string', 'null'], enum: ['including_current', 'closed_months', 'unknown', null] },
+          },
+          required: ['kind', 'month', 'year', 'offset', 'amount', 'unit', 'mode'],
+        },
+        confidence: { type: 'number' },
+        requiresClarification: { type: 'boolean' },
+        missingFields: {
+          type: 'array',
+          items: { type: 'string' },
+        },
+      },
+      required: ['intent', 'scope', 'entity', 'period', 'confidence', 'requiresClarification', 'missingFields'],
+    } as const;
+  }
+
+  private comparePlans(
+    deterministic: AssistantConsensusModelPlan,
+    model: AssistantConsensusModelPlan,
+  ): ConsensusComparisonResult {
+    if (deterministic.intent !== model.intent) {
+      return {
+        consensus: false,
+        mismatchReason: 'intent',
+        clarificationMessage: this.buildClarificationMessage('intent', deterministic, model),
+      };
+    }
+
+    if (deterministic.scope !== model.scope) {
+      return {
+        consensus: false,
+        mismatchReason: 'scope',
+        clarificationMessage: this.buildClarificationMessage('scope', deterministic, model),
+      };
+    }
+
+    if (!this.matchEntity(deterministic, model)) {
+      return {
+        consensus: false,
+        mismatchReason: this.entityMismatchReason(deterministic, model),
+        clarificationMessage: this.buildClarificationMessage('entity', deterministic, model),
+      };
+    }
+
+    if (deterministic.period.kind !== model.period.kind) {
+      return {
+        consensus: false,
+        mismatchReason: 'period',
+        clarificationMessage: this.buildClarificationMessage('period', deterministic, model),
+      };
+    }
+
+    if (model.requiresClarification || model.missingFields.length > 0) {
+      return {
+        consensus: false,
+        mismatchReason: 'clarification',
+        clarificationMessage: this.buildClarificationMessage('clarification', deterministic, model),
+      };
+    }
+
+    return { consensus: true };
+  }
+
+  private matchEntity(deterministic: AssistantConsensusModelPlan, model: AssistantConsensusModelPlan): boolean {
+    if (deterministic.scope === 'tenant') {
+      return normalizeAlias(deterministic.entity.buildingAlias) === normalizeAlias(model.entity.buildingAlias)
+        && normalizeAlias(deterministic.entity.unitAlias) === normalizeAlias(model.entity.unitAlias);
+    }
+
+    if (deterministic.scope === 'building') {
+      return isSameAlias(deterministic.entity.buildingAlias, model.entity.buildingAlias)
+        && normalizeAlias(deterministic.entity.unitAlias) === normalizeAlias(model.entity.unitAlias);
+    }
+
+    if (deterministic.scope === 'unit') {
+      return isSameAlias(deterministic.entity.buildingAlias, model.entity.buildingAlias)
+        && isSameAlias(deterministic.entity.unitAlias, model.entity.unitAlias);
+    }
+
+    return true;
+  }
+
+  private entityMismatchReason(deterministic: AssistantConsensusModelPlan, model: AssistantConsensusModelPlan): string {
+    if (deterministic.scope === 'unit' && !isSameAlias(deterministic.entity.unitAlias, model.entity.unitAlias)) {
+      return 'unit_alias';
+    }
+
+    if (deterministic.scope !== 'tenant' && !isSameAlias(deterministic.entity.buildingAlias, model.entity.buildingAlias)) {
+      return 'building_alias';
+    }
+
+    return 'entity';
+  }
+
+  private buildClarificationMessage(
+    mismatch: string,
+    deterministic?: AssistantConsensusModelPlan | null,
+    model?: AssistantConsensusModelPlan | null,
+  ): string {
+    if (mismatch === 'local_model_failed') {
+      return 'No pude validar esa consulta con el modelo local. ¿Querés aclarar si se trata de una deuda de la administración, de un edificio o de una unidad?';
+    }
+
+    if (mismatch === 'no_deterministic_plan') {
+      return 'No pude identificar una consulta financiera clara. ¿Querés aclarar si se trata de una deuda de la administración, de un edificio o de una unidad?';
+    }
+
+    if (mismatch === 'period') {
+      const buildingAlias = deterministic?.entity.buildingAlias || model?.entity.buildingAlias;
+      if (buildingAlias) {
+        return `Entiendo que quieres consultar la deuda del edificio ${buildingAlias}. ¿Te refieres a este mes o a la deuda acumulada?`;
+      }
+      return '¿Te refieres a la deuda de este mes o a la deuda acumulada?';
+    }
+
+    if (mismatch === 'clarification') {
+      const missingFields = model?.missingFields ?? [];
+      if (missingFields.includes('period')) {
+        return '¿Te refieres a la deuda de este mes o a la deuda acumulada?';
+      }
+      if (missingFields.includes('building')) {
+        return '¿De cuál condominio o edificio querés consultar la deuda?';
+      }
+      if (missingFields.includes('unit')) {
+        return '¿De qué unidad querés consultar la deuda?';
+      }
+      return 'Necesito más contexto para responder con precisión.';
+    }
+
+    if (mismatch === 'building_alias' || mismatch === 'entity') {
+      return '¿De cuál condominio o edificio querés consultar la deuda?';
+    }
+
+    if (mismatch === 'unit_alias') {
+      return '¿De qué unidad querés consultar la deuda?';
+    }
+
+    return 'Necesito más contexto para responder con precisión.';
+  }
+
+  private toConsensusPlan(plan: AssistantQueryPlan | null): AssistantConsensusModelPlan | null {
+    if (!plan) {
+      return null;
+    }
+
+    return {
+      intent: plan.intent as AssistantConsensusIntent,
+      scope: plan.scope,
+      entity: {
+        buildingAlias: normalizeAlias(plan.filters.buildingAlias ?? plan.filters.buildingToken ?? null),
+        unitAlias: normalizeAlias(plan.filters.unitCode ?? plan.filters.unitCodeRaw ?? null),
+      },
+      period: this.mapDeterministicPeriod(plan.filters.period),
+      confidence: plan.confidence,
+      requiresClarification: false,
+      missingFields: [],
+    };
+  }
+
+  private mapDeterministicPeriod(period?: string): AssistantConsensusModelPlan['period'] {
+    if (!period) {
+      return {
+        kind: 'unknown',
+        month: null,
+        year: null,
+        offset: null,
+        amount: null,
+        unit: null,
+        mode: null,
+      };
+    }
+
+    if (period === 'accumulated') {
+      return {
+        kind: 'accumulated',
+        month: null,
+        year: null,
+        offset: null,
+        amount: null,
+        unit: null,
+        mode: 'unknown',
+      };
+    }
+
+    const current = new Date();
+    const currentMonth = `${current.getFullYear()}-${String(current.getMonth() + 1).padStart(2, '0')}`;
+
+    if (period === 'current_month' || period === currentMonth) {
+      return {
+        kind: 'current_month',
+        month: current.getMonth() + 1,
+        year: current.getFullYear(),
+        offset: 0,
+        amount: null,
+        unit: 'month',
+        mode: 'including_current',
+      };
+    }
+
+    const monthMatch = period.match(/^(\d{4})-(\d{2})$/);
+    if (monthMatch) {
+      const year = Number(monthMatch[1]);
+      const month = Number(monthMatch[2]);
+      const isCurrentMonth = year === current.getFullYear() && month === current.getMonth() + 1;
+      return {
+        kind: isCurrentMonth ? 'current_month' : 'named_month',
+        month,
+        year,
+        offset: null,
+        amount: null,
+        unit: 'month',
+        mode: isCurrentMonth ? 'including_current' : 'closed_months',
+      };
+    }
+
+    return {
+      kind: 'unknown',
+      month: null,
+      year: null,
+      offset: null,
+      amount: null,
+      unit: null,
+      mode: null,
+    };
+  }
+
+  private summarizePlan(plan: AssistantConsensusModelPlan | null): string {
+    if (!plan) {
+      return 'none';
+    }
+
+    const building = plan.entity.buildingAlias ?? '-';
+    const unit = plan.entity.unitAlias ?? '-';
+    return `${plan.intent}/${plan.scope}/${plan.period.kind}/${building}/${unit}`;
+  }
+}

--- a/apps/api/src/assistant/intent-semantic-validator.service.spec.ts
+++ b/apps/api/src/assistant/intent-semantic-validator.service.spec.ts
@@ -41,6 +41,22 @@ describe('IntentSemanticValidatorService', () => {
     };
   }
 
+  function buildRelativeRangePeriod(overrides: Record<string, unknown> = {}) {
+    return {
+      kind: 'relative_range',
+      amount: 5,
+      unit: 'month',
+      mode: 'unknown',
+      month: null,
+      year: null,
+      startMonth: null,
+      startYear: null,
+      endMonth: null,
+      endYear: null,
+      ...overrides,
+    } as const;
+  }
+
   it('accepts explicit accumulated debt without forcing a period', async () => {
     const result = await service.evaluate({
       userText: 'deuda acumulada edificio B',
@@ -156,6 +172,149 @@ describe('IntentSemanticValidatorService', () => {
     expect(result.status).toBe('needs_clarification');
     expect(result.reason).toBe('period_ambiguous');
     expect(result.question).toContain('este mes');
+  });
+
+  it('asks for period.mode when relative range period is incomplete', async () => {
+    const result = await service.evaluate({
+      userText: 'deuda de los ultimos 5 meses de la torre el parque',
+      deterministicPlan: buildPlan({
+        filters: {
+          buildingAlias: 'torre el parque',
+          buildingToken: 'torre el parque',
+          period: buildRelativeRangePeriod(),
+        },
+      }),
+      extractedIntent: buildExtractedIntent({
+        intent: 'building_debt',
+        entity: { type: 'building', buildingAlias: 'torre el parque' },
+        filters: {
+          period: buildRelativeRangePeriod(),
+        },
+        missingFields: ['startMonth', 'endMonth'],
+      }),
+      assistantContext: {},
+    });
+
+    expect(result).toEqual({
+      status: 'needs_clarification',
+      reason: 'relative_range_mode_ambiguous',
+      question: '¿Querés incluir el mes actual o consultar solo los últimos 5 meses cerrados?',
+    });
+  });
+
+  it('asks for period.mode when tenant debt relative range is incomplete', async () => {
+    const result = await service.evaluate({
+      userText: 'deuda de los ultimos 5 meses de la administracion',
+      deterministicPlan: buildPlan({
+        intent: 'tenant_debt',
+        scope: 'tenant',
+        filters: {
+          period: buildRelativeRangePeriod(),
+        },
+      }),
+      extractedIntent: buildExtractedIntent({
+        intent: 'tenant_debt',
+        entity: { type: 'building' },
+        filters: {
+          period: buildRelativeRangePeriod(),
+        },
+        missingFields: ['startMonth', 'endMonth'],
+      }),
+      assistantContext: {},
+    });
+
+    expect(result).toEqual({
+      status: 'needs_clarification',
+      reason: 'relative_range_mode_ambiguous',
+      question: '¿Querés incluir el mes actual o consultar solo los últimos 5 meses cerrados?',
+    });
+  });
+
+  it('accepts relative range with including_current mode', async () => {
+    const result = await service.evaluate({
+      userText: 'deuda de los ultimos 5 meses incluyendo este mes de la torre el parque',
+      deterministicPlan: buildPlan({
+        filters: {
+          buildingAlias: 'torre el parque',
+          buildingToken: 'torre el parque',
+          period: buildRelativeRangePeriod({ mode: 'including_current' }),
+        },
+      }),
+      extractedIntent: buildExtractedIntent({
+        intent: 'building_debt',
+        entity: { type: 'building', buildingAlias: 'torre el parque' },
+        filters: {
+          period: buildRelativeRangePeriod({ mode: 'including_current' }),
+        },
+      }),
+      assistantContext: {},
+    });
+
+    expect(result.status).toBe('accepted');
+  });
+
+  it('accepts relative range with closed_months mode', async () => {
+    const result = await service.evaluate({
+      userText: 'deuda de los ultimos 5 meses cerrados de la torre el parque',
+      deterministicPlan: buildPlan({
+        filters: {
+          buildingAlias: 'torre el parque',
+          buildingToken: 'torre el parque',
+          period: buildRelativeRangePeriod({ mode: 'closed_months' }),
+        },
+      }),
+      extractedIntent: buildExtractedIntent({
+        intent: 'building_debt',
+        entity: { type: 'building', buildingAlias: 'torre el parque' },
+        filters: {
+          period: buildRelativeRangePeriod({ mode: 'closed_months' }),
+        },
+      }),
+      assistantContext: {},
+    });
+
+    expect(result.status).toBe('accepted');
+  });
+
+  it('normalizes startMonth and endMonth errors to period.mode', async () => {
+    const result = await service.evaluate({
+      userText: 'deuda de los ultimos 5 meses de la torre el parque',
+      deterministicPlan: buildPlan({
+        filters: {
+          buildingAlias: 'torre el parque',
+          buildingToken: 'torre el parque',
+          period: buildRelativeRangePeriod(),
+        },
+      }),
+      extractedIntent: buildExtractedIntent({
+        intent: 'building_debt',
+        entity: { type: 'building', buildingAlias: 'torre el parque' },
+        filters: {
+          period: buildRelativeRangePeriod(),
+        },
+        missingFields: ['startMonth', 'endMonth'],
+      }),
+      assistantContext: {},
+    });
+
+    expect(result.reason).toBe('relative_range_mode_ambiguous');
+    expect(result.question).toContain('últimos 5 meses cerrados');
+  });
+
+  it('detects mes que esta corriendo as a temporal signal', async () => {
+    const result = await service.evaluate({
+      userText: 'dame la deuda del mes que está corriendo del edificio B',
+      deterministicPlan: buildPlan({ filters: { buildingAlias: 'B', buildingToken: 'B' } }),
+      extractedIntent: buildExtractedIntent({
+        intent: 'building_debt',
+        entity: { type: 'building', buildingAlias: 'B' },
+        filters: {},
+      }),
+      assistantContext: {},
+    });
+
+    expect(result.status).toBe('needs_clarification');
+    expect(result.reason).toBe('period_signal_missing');
   });
 
   it('uses finance context period instead of historical debt when available', async () => {

--- a/apps/api/src/assistant/intent-semantic-validator.service.ts
+++ b/apps/api/src/assistant/intent-semantic-validator.service.ts
@@ -1,7 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { z } from 'zod';
 import { AssistantDebtIntentInterpreter } from './debt-intent-interpreter';
+import { PeriodSemanticValidatorService } from './period-semantic-validator.service';
+import type { CanonicalFinancePeriod } from './finance-period.types';
 import type { ExtractedIntent } from './intent-engine/intent.types';
+import type { PendingClarificationContext } from './intent-engine/intent.types';
 import type { AssistantQueryIntent, AssistantQueryPlan } from './query-plan.types';
 
 export interface AssistantSemanticContext {
@@ -10,6 +13,7 @@ export interface AssistantSemanticContext {
   readonly buildingId?: string;
   readonly unitId?: string;
   readonly financePeriod?: string;
+  readonly pendingClarification?: PendingClarificationContext;
 }
 
 export interface IntentSemanticValidationInput {
@@ -66,6 +70,7 @@ export class IntentSemanticValidatorService {
   private readonly logger = new Logger(IntentSemanticValidatorService.name);
   private readonly geminiBaseUrl = 'https://generativelanguage.googleapis.com/v1beta';
   private readonly debtInterpreter = new AssistantDebtIntentInterpreter();
+  private readonly periodValidator = new PeriodSemanticValidatorService();
 
   async evaluate(input: IntentSemanticValidationInput): Promise<IntentSemanticValidationResult> {
     const normalized = this.normalize(input.userText);
@@ -77,6 +82,9 @@ export class IntentSemanticValidatorService {
     const period = input.extractedIntent.filters.period ?? input.deterministicPlan?.filters.period;
     const debtInterpretation = this.debtInterpreter.interpret(input.userText);
     const isBuildingDebt = input.extractedIntent.intent === 'building_debt';
+    const canonicalPeriod = this.getCanonicalPeriod(
+      input.extractedIntent.filters.period ?? input.deterministicPlan?.filters.period,
+    );
     const wantsAccumulatedDebt = /\b(acumulad[ao]s?|historic[ao]s?|hist[oó]rica|hist[oó]rico)\b/.test(normalized);
     const hasTemporalSignals = this.detectTemporalSignals(normalized);
     const isFinanceContext = this.isFinanceContext(assistantContext);
@@ -107,6 +115,23 @@ export class IntentSemanticValidatorService {
           intentOverride: 'tenant_debt',
           entityOverride: { type: 'building', buildingAlias: undefined, unitCode: undefined },
         };
+      }
+
+      if (canonicalPeriod?.kind === 'relative_range') {
+        const relativeRangeValidation = this.periodValidator.validate({
+          period: canonicalPeriod,
+          missingFields: input.extractedIntent.missingFields,
+        });
+
+        if (!relativeRangeValidation.valid) {
+          return {
+            status: 'needs_clarification',
+            reason: 'relative_range_mode_ambiguous',
+            question:
+              relativeRangeValidation.clarificationMessage ||
+              '¿Querés incluir el mes actual o consultar solo los últimos meses cerrados?',
+          };
+        }
       }
 
       return { status: 'accepted', reason: 'global_debt_scope' };
@@ -150,6 +175,23 @@ export class IntentSemanticValidatorService {
           },
           filterOverrides: period ? { period } : undefined,
         };
+      }
+
+      if (canonicalPeriod?.kind === 'relative_range') {
+        const relativeRangeValidation = this.periodValidator.validate({
+          period: canonicalPeriod,
+          missingFields: input.extractedIntent.missingFields,
+        });
+
+        if (!relativeRangeValidation.valid) {
+          return {
+            status: 'needs_clarification',
+            reason: 'relative_range_mode_ambiguous',
+            question:
+              relativeRangeValidation.clarificationMessage ||
+              '¿Querés incluir el mes actual o consultar solo los últimos meses cerrados?',
+          };
+        }
       }
     }
 
@@ -206,7 +248,7 @@ export class IntentSemanticValidatorService {
 
   private detectTemporalSignals(normalized: string): boolean {
     return (
-      /\b(este mes|mes actual|mes pasado|ultimo mes|último mes|hoy|ayer)\b/.test(normalized) ||
+      /\b(este mes|mes actual|mes en curso|mes corriente|mes que esta corriendo|del mes actual|del mes en curso|deuda del mes|del mes|mes pasado|ultimo mes|último mes|hoy|ayer)\b/.test(normalized) ||
       /\b\d{4}-\d{2}\b/.test(normalized) ||
       /\b(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|setiembre|octubre|noviembre|diciembre|january|february|march|april|may|june|july|august|september|october|november|december)(\s+\d{4})?\b/.test(normalized)
     );
@@ -220,7 +262,7 @@ export class IntentSemanticValidatorService {
   private detectYearAsUnitConflict(
     input: IntentSemanticValidationInput,
     explicitBuildingAlias: string | undefined,
-    period: string | undefined,
+    period: string | CanonicalFinancePeriod | undefined,
   ): boolean {
     const unitCode =
       input.extractedIntent.entity.unitCode ||
@@ -234,6 +276,14 @@ export class IntentSemanticValidatorService {
       /^\d{4}$/.test(unitCode) &&
       input.extractedIntent.entity.type === 'unit',
     );
+  }
+
+  private getCanonicalPeriod(period?: string | CanonicalFinancePeriod): CanonicalFinancePeriod | null {
+    if (!period || typeof period === 'string') {
+      return null;
+    }
+
+    return period;
   }
 
   private mapToBuildingIntent(intent: string): AssistantQueryIntent | undefined {

--- a/apps/api/src/assistant/intent-semantic-validator.service.ts
+++ b/apps/api/src/assistant/intent-semantic-validator.service.ts
@@ -30,7 +30,7 @@ export interface IntentSemanticValidationResult {
 }
 
 const GEMINI_TIMEOUT_MS = 4000;
-const DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash-lite';
+const DEFAULT_GEMINI_MODEL = 'gemini-2.5-flash';
 
 const semanticGeminiSchema = z.object({
   status: z.enum(['accepted', 'needs_clarification', 'override_suggested']),

--- a/apps/api/src/assistant/period-normalizer.service.spec.ts
+++ b/apps/api/src/assistant/period-normalizer.service.spec.ts
@@ -1,0 +1,96 @@
+import { PeriodNormalizerService } from './period-normalizer.service';
+
+describe('PeriodNormalizerService', () => {
+  let service: PeriodNormalizerService;
+
+  beforeEach(() => {
+    service = new PeriodNormalizerService();
+  });
+
+  it.each([
+    ['este mes', 'current_month'],
+    ['mes actual', 'current_month'],
+    ['mes en curso', 'current_month'],
+    ['mes corriente', 'current_month'],
+  ])('normalizes "%s" as %s', (phrase, kind) => {
+    expect(service.normalize(phrase)?.kind).toBe(kind);
+  });
+
+  it.each([
+    ['mes pasado', 'previous_month'],
+    ['último mes', 'previous_month'],
+  ])('normalizes "%s" as previous_month', (phrase) => {
+    expect(service.normalize(phrase)?.kind).toBe('previous_month');
+  });
+
+  it.each([
+    ['acumulada', 'accumulated'],
+    ['histórica', 'accumulated'],
+    ['historica', 'accumulated'],
+    ['toda', 'accumulated'],
+    ['todo', 'accumulated'],
+  ])('normalizes "%s" as accumulated', (phrase) => {
+    expect(service.normalize(phrase)?.kind).toBe('accumulated');
+  });
+
+  it('normalizes a named month with explicit year', () => {
+    const result = service.normalize('junio 2026');
+    expect(result).toMatchObject({
+      kind: 'named_month',
+      month: 6,
+      year: 2026,
+    });
+  });
+
+  it('normalizes an ISO month', () => {
+    const result = service.normalize('2026-06');
+    expect(result).toMatchObject({
+      kind: 'named_month',
+      month: 6,
+      year: 2026,
+    });
+  });
+
+  it.each([
+    'últimos 5 meses',
+    'ultimos 5 meses',
+    'los ultimos 5 meses',
+    'últimos cinco meses',
+  ])('normalizes "%s" as a relative range', (phrase) => {
+    expect(service.normalize(phrase)).toMatchObject({
+      kind: 'relative_range',
+      amount: 5,
+      unit: 'month',
+      mode: 'unknown',
+    });
+  });
+
+  it('detects relative range including the current month', () => {
+    expect(service.normalize('últimos 5 meses incluyendo este mes')).toMatchObject({
+      kind: 'relative_range',
+      amount: 5,
+      unit: 'month',
+      mode: 'including_current',
+    });
+  });
+
+  it('detects relative range closed months', () => {
+    expect(service.normalize('últimos 5 meses cerrados')).toMatchObject({
+      kind: 'relative_range',
+      amount: 5,
+      unit: 'month',
+      mode: 'closed_months',
+    });
+  });
+
+  it('clamps the relative range amount to a sane minimum and maximum', () => {
+    expect(service.normalize('últimos 0 meses')).toMatchObject({
+      kind: 'relative_range',
+      amount: 1,
+    });
+    expect(service.normalize('últimos 99 meses')).toMatchObject({
+      kind: 'relative_range',
+      amount: 12,
+    });
+  });
+});

--- a/apps/api/src/assistant/period-normalizer.service.ts
+++ b/apps/api/src/assistant/period-normalizer.service.ts
@@ -1,0 +1,346 @@
+import { Injectable } from '@nestjs/common';
+import type { CanonicalFinancePeriod, RelativeRangeMode } from './finance-period.types';
+
+const MONTH_NAMES = [
+  'enero',
+  'febrero',
+  'marzo',
+  'abril',
+  'mayo',
+  'junio',
+  'julio',
+  'agosto',
+  'septiembre',
+  'octubre',
+  'noviembre',
+  'diciembre',
+] as const;
+
+const NUMBER_WORDS: Record<string, number> = {
+  uno: 1,
+  una: 1,
+  un: 1,
+  dos: 2,
+  tres: 3,
+  cuatro: 4,
+  cinco: 5,
+  seis: 6,
+  siete: 7,
+  ocho: 8,
+  nueve: 9,
+  diez: 10,
+  once: 11,
+  doce: 12,
+};
+
+@Injectable()
+export class PeriodNormalizerService {
+  normalize(value: string): CanonicalFinancePeriod | null {
+    const normalized = this.normalizeText(value);
+
+    if (!normalized) {
+      return null;
+    }
+
+    const relativeRange = this.parseRelativeRange(normalized);
+    if (relativeRange) {
+      return relativeRange;
+    }
+
+    const currentMonth = this.parseCurrentMonth(normalized);
+    if (currentMonth) {
+      return currentMonth;
+    }
+
+    const previousMonth = this.parsePreviousMonth(normalized);
+    if (previousMonth) {
+      return previousMonth;
+    }
+
+    const accumulated = this.parseAccumulated(normalized);
+    if (accumulated) {
+      return accumulated;
+    }
+
+    const yearToDate = this.parseYearToDate(normalized);
+    if (yearToDate) {
+      return yearToDate;
+    }
+
+    const namedMonth = this.parseNamedMonth(normalized);
+    if (namedMonth) {
+      return namedMonth;
+    }
+
+    const monthRange = this.parseMonthRange(normalized);
+    if (monthRange) {
+      return monthRange;
+    }
+
+    return {
+      kind: 'unknown',
+      amount: null,
+      unit: null,
+      mode: null,
+      month: null,
+      year: null,
+      startMonth: null,
+      startYear: null,
+      endMonth: null,
+      endYear: null,
+    };
+  }
+
+  private parseCurrentMonth(normalized: string): CanonicalFinancePeriod | null {
+    if (
+      /\b(este mes|mes actual|mes en curso|mes corriente|del mes actual|del mes en curso|mes que esta corriendo)\b/.test(normalized) ||
+      /\bdeuda del mes\b/.test(normalized) ||
+      /\bdel mes\b/.test(normalized)
+    ) {
+      return {
+        kind: 'current_month',
+        amount: null,
+        unit: null,
+        mode: null,
+        month: null,
+        year: null,
+        startMonth: null,
+        startYear: null,
+        endMonth: null,
+        endYear: null,
+      };
+    }
+
+    return null;
+  }
+
+  private parsePreviousMonth(normalized: string): CanonicalFinancePeriod | null {
+    if (!/\b(mes pasado|ultimo mes|último mes)\b/.test(normalized)) {
+      return null;
+    }
+
+    return {
+      kind: 'previous_month',
+      amount: null,
+      unit: null,
+      mode: null,
+      month: null,
+      year: null,
+      startMonth: null,
+      startYear: null,
+      endMonth: null,
+      endYear: null,
+    };
+  }
+
+  private parseAccumulated(normalized: string): CanonicalFinancePeriod | null {
+    if (!/\b(acumulad[ao]s?|historica|historico|hist[oó]ric[ao]s?|toda|todo)\b/.test(normalized)) {
+      return null;
+    }
+
+    return {
+      kind: 'accumulated',
+      amount: null,
+      unit: null,
+      mode: null,
+      month: null,
+      year: null,
+      startMonth: null,
+      startYear: null,
+      endMonth: null,
+      endYear: null,
+    };
+  }
+
+  private parseYearToDate(normalized: string): CanonicalFinancePeriod | null {
+    if (!/\b(ano en curso|year to date|ytd)\b/.test(normalized)) {
+      return null;
+    }
+
+    return {
+      kind: 'year_to_date',
+      amount: null,
+      unit: null,
+      mode: null,
+      month: null,
+      year: null,
+      startMonth: null,
+      startYear: null,
+      endMonth: null,
+      endYear: null,
+    };
+  }
+
+  private parseNamedMonth(normalized: string): CanonicalFinancePeriod | null {
+    const direct = normalized.match(/\b(\d{4})-(\d{2})\b/);
+    if (direct?.[1] && direct?.[2]) {
+      const year = Number(direct[1]);
+      const month = Number(direct[2]);
+      if (this.isValidMonth(month)) {
+        return {
+          kind: 'named_month',
+          amount: null,
+          unit: null,
+          mode: null,
+          month,
+          year,
+          startMonth: null,
+          startYear: null,
+          endMonth: null,
+          endYear: null,
+        };
+      }
+    }
+
+    const match = normalized.match(
+      /\b(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|setiembre|octubre|noviembre|diciembre)\s+(\d{4})\b/,
+    );
+    if (!match?.[1] || !match[2]) {
+      return null;
+    }
+
+    const month = this.monthNameToNumber(match[1]);
+    if (!month) {
+      return null;
+    }
+
+    return {
+      kind: 'named_month',
+      amount: null,
+      unit: null,
+      mode: null,
+      month,
+      year: Number(match[2]),
+      startMonth: null,
+      startYear: null,
+      endMonth: null,
+      endYear: null,
+    };
+  }
+
+  private parseRelativeRange(normalized: string): CanonicalFinancePeriod | null {
+    const rangeMatch = normalized.match(
+      /\b(?:los?\s+)?(?:ultimos?|últimos?)\s+([a-z0-9]+)\s+meses?\b/,
+    );
+    if (!rangeMatch?.[1]) {
+      return null;
+    }
+
+    const amount = this.parseRangeAmount(rangeMatch[1]);
+    if (amount === null) {
+      return null;
+    }
+
+    const mode = this.parseRelativeRangeMode(normalized);
+    return {
+      kind: 'relative_range',
+      amount,
+      unit: 'month',
+      mode,
+      month: null,
+      year: null,
+      startMonth: null,
+      startYear: null,
+      endMonth: null,
+      endYear: null,
+    };
+  }
+
+  private parseMonthRange(normalized: string): CanonicalFinancePeriod | null {
+    const betweenMatch = normalized.match(
+      /\b(?:entre|de)\s+(.+?)\s+(?:y|a)\s+(.+?)\b/,
+    );
+
+    if (!betweenMatch?.[1] || !betweenMatch[2]) {
+      return null;
+    }
+
+    const start = this.parseMonthToken(betweenMatch[1]);
+    const end = this.parseMonthToken(betweenMatch[2]);
+
+    if (!start || !end) {
+      return null;
+    }
+
+    return {
+      kind: 'month_range',
+      amount: null,
+      unit: null,
+      mode: null,
+      month: null,
+      year: null,
+      startMonth: start.month,
+      startYear: start.year,
+      endMonth: end.month,
+      endYear: end.year,
+    };
+  }
+
+  private parseMonthToken(rawToken: string): { month: number; year: number } | null {
+    const token = this.normalizeText(rawToken);
+    const direct = token.match(/\b(\d{4})-(\d{2})\b/);
+    if (direct?.[1] && direct?.[2]) {
+      const year = Number(direct[1]);
+      const month = Number(direct[2]);
+      if (this.isValidMonth(month)) {
+        return { month, year };
+      }
+    }
+
+    const named = token.match(
+      /\b(enero|febrero|marzo|abril|mayo|junio|julio|agosto|septiembre|setiembre|octubre|noviembre|diciembre)\s+(\d{4})\b/,
+    );
+    if (named?.[1] && named[2]) {
+      const month = this.monthNameToNumber(named[1]);
+      if (month) {
+        return { month, year: Number(named[2]) };
+      }
+    }
+
+    return null;
+  }
+
+  private parseRangeAmount(rawAmount: string): number | null {
+    const numeric = Number(rawAmount);
+    const rawWord = rawAmount.toLowerCase();
+    const wordAmount = NUMBER_WORDS[rawWord];
+    const value = Number.isFinite(numeric) ? numeric : wordAmount;
+
+    if (value === undefined || value === null || Number.isNaN(value)) {
+      return null;
+    }
+
+    return Math.min(12, Math.max(1, Math.trunc(value)));
+  }
+
+  private parseRelativeRangeMode(normalized: string): RelativeRangeMode {
+    if (/\b(incluyendo este mes|incluye este mes|con este mes|incluyendo el mes actual|sumando este mes|mas este mes|más este mes)\b/.test(normalized)) {
+      return 'including_current';
+    }
+
+    if (/\b(cerrados|solo meses cerrados|sin incluir este mes|sin contar este mes|solo los meses cerrados)\b/.test(normalized)) {
+      return 'closed_months';
+    }
+
+    return 'unknown';
+  }
+
+  private monthNameToNumber(value: string): number | null {
+    const normalized = value.toLowerCase();
+    const index = MONTH_NAMES.findIndex((month) => month === normalized);
+    return index >= 0 ? index + 1 : null;
+  }
+
+  private normalizeText(value: string): string {
+    return value
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '')
+      .toLowerCase()
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
+  private isValidMonth(month: number): boolean {
+    return Number.isInteger(month) && month >= 1 && month <= 12;
+  }
+}

--- a/apps/api/src/assistant/period-resolver.service.spec.ts
+++ b/apps/api/src/assistant/period-resolver.service.spec.ts
@@ -1,0 +1,111 @@
+import { PeriodResolverService } from './period-resolver.service';
+import type { CanonicalFinancePeriod } from './finance-period.types';
+
+describe('PeriodResolverService', () => {
+  let service: PeriodResolverService;
+  const referenceDate = new Date(2026, 5, 24);
+
+  beforeEach(() => {
+    service = new PeriodResolverService();
+  });
+
+  function buildPeriod(overrides: Partial<CanonicalFinancePeriod> = {}): CanonicalFinancePeriod {
+    return {
+      kind: 'relative_range',
+      amount: 5,
+      unit: 'month',
+      mode: 'unknown',
+      month: null,
+      year: null,
+      startMonth: null,
+      startYear: null,
+      endMonth: null,
+      endYear: null,
+      ...overrides,
+    };
+  }
+
+  it('resolves last 5 months including the current month', () => {
+    const result = service.resolve(
+      buildPeriod({ mode: 'including_current' }),
+      referenceDate,
+    );
+
+    expect(result).toMatchObject({
+      kind: 'period_range',
+      periods: ['2026-02', '2026-03', '2026-04', '2026-05', '2026-06'],
+      startPeriod: '2026-02',
+      endPeriod: '2026-06',
+      label: 'febrero 2026 a junio 2026',
+    });
+  });
+
+  it('resolves last 5 closed months', () => {
+    const result = service.resolve(
+      buildPeriod({ mode: 'closed_months' }),
+      referenceDate,
+    );
+
+    expect(result).toMatchObject({
+      kind: 'period_range',
+      periods: ['2026-01', '2026-02', '2026-03', '2026-04', '2026-05'],
+      startPeriod: '2026-01',
+      endPeriod: '2026-05',
+      label: 'enero 2026 a mayo 2026',
+    });
+  });
+
+  it('resolves current month to a single period', () => {
+    const result = service.resolve(
+      {
+        kind: 'current_month',
+        amount: null,
+        unit: null,
+        mode: null,
+        month: null,
+        year: null,
+        startMonth: null,
+        startYear: null,
+        endMonth: null,
+        endYear: null,
+      },
+      referenceDate,
+    );
+
+    expect(result).toMatchObject({
+      kind: 'single_period',
+      periods: ['2026-06'],
+      period: '2026-06',
+      startPeriod: '2026-06',
+      endPeriod: '2026-06',
+      label: 'junio 2026',
+    });
+  });
+
+  it('resolves previous month to a single period', () => {
+    const result = service.resolve(
+      {
+        kind: 'previous_month',
+        amount: null,
+        unit: null,
+        mode: null,
+        month: null,
+        year: null,
+        startMonth: null,
+        startYear: null,
+        endMonth: null,
+        endYear: null,
+      },
+      referenceDate,
+    );
+
+    expect(result).toMatchObject({
+      kind: 'single_period',
+      periods: ['2026-05'],
+      period: '2026-05',
+      startPeriod: '2026-05',
+      endPeriod: '2026-05',
+      label: 'mayo 2026',
+    });
+  });
+});

--- a/apps/api/src/assistant/period-resolver.service.ts
+++ b/apps/api/src/assistant/period-resolver.service.ts
@@ -1,0 +1,245 @@
+import { Injectable } from '@nestjs/common';
+import type { CanonicalFinancePeriod, ResolvedFinancePeriod } from './finance-period.types';
+
+const MONTH_NAMES = [
+  'enero',
+  'febrero',
+  'marzo',
+  'abril',
+  'mayo',
+  'junio',
+  'julio',
+  'agosto',
+  'septiembre',
+  'octubre',
+  'noviembre',
+  'diciembre',
+] as const;
+
+@Injectable()
+export class PeriodResolverService {
+  resolve(period: CanonicalFinancePeriod, referenceDate: Date = new Date()): ResolvedFinancePeriod {
+    switch (period.kind) {
+      case 'current_month':
+        return this.resolveSingleMonth(this.currentMonth(referenceDate));
+      case 'previous_month':
+        return this.resolveSingleMonth(this.previousMonth(referenceDate));
+      case 'named_month':
+        return this.resolveNamedMonth(period.year, period.month);
+      case 'year_to_date':
+        return this.resolveYearToDate(referenceDate);
+      case 'relative_range':
+        return this.resolveRelativeRange(period, referenceDate);
+      case 'month_range':
+        return this.resolveExplicitRange(period);
+      case 'accumulated':
+        return {
+          kind: 'accumulated',
+          periods: [],
+          period: null,
+          startPeriod: null,
+          endPeriod: null,
+          startDate: null,
+          endDate: null,
+          label: 'acumulada',
+        };
+      default:
+        return {
+          kind: 'unknown',
+          periods: [],
+          period: null,
+          startPeriod: null,
+          endPeriod: null,
+          startDate: null,
+          endDate: null,
+          label: 'desconocido',
+        };
+    }
+  }
+
+  private resolveSingleMonth(periodKey: string): ResolvedFinancePeriod {
+    const [yearText, monthText] = periodKey.split('-');
+    const year = Number(yearText);
+    const month = Number(monthText);
+    const startDate = new Date(year, month - 1, 1);
+    const endDate = new Date(year, month, 0, 23, 59, 59, 999);
+
+    return {
+      kind: 'single_period',
+      periods: [periodKey],
+      period: periodKey,
+      startPeriod: periodKey,
+      endPeriod: periodKey,
+      startDate,
+      endDate,
+      label: `${MONTH_NAMES[month - 1]} ${year}`,
+    };
+  }
+
+  private resolveNamedMonth(year: number | null, month: number | null): ResolvedFinancePeriod {
+    if (!year || !month) {
+      return {
+        kind: 'unknown',
+        periods: [],
+        period: null,
+        startPeriod: null,
+        endPeriod: null,
+        startDate: null,
+        endDate: null,
+        label: 'desconocido',
+      };
+    }
+
+    return this.resolveSingleMonth(`${year}-${String(month).padStart(2, '0')}`);
+  }
+
+  private resolveYearToDate(referenceDate: Date): ResolvedFinancePeriod {
+    const currentYear = referenceDate.getFullYear();
+    const currentMonth = referenceDate.getMonth() + 1;
+    const periods = this.buildPeriods(currentYear, 1, currentYear, currentMonth);
+    return this.buildRangeResult(periods, 'año en curso', currentYear, 1, currentYear, currentMonth);
+  }
+
+  private resolveRelativeRange(
+    period: CanonicalFinancePeriod,
+    referenceDate: Date,
+  ): ResolvedFinancePeriod {
+    if (!period.amount || period.amount < 1 || !period.unit) {
+      return {
+        kind: 'unknown',
+        periods: [],
+        period: null,
+        startPeriod: null,
+        endPeriod: null,
+        startDate: null,
+        endDate: null,
+        label: 'desconocido',
+      };
+    }
+
+    const currentYear = referenceDate.getFullYear();
+    const currentMonth = referenceDate.getMonth() + 1;
+    const includeCurrent = period.mode === 'including_current';
+    const endIndex = includeCurrent ? this.toMonthIndex(currentYear, currentMonth) : this.toMonthIndex(currentYear, currentMonth) - 1;
+    const startIndex = endIndex - period.amount + 1;
+
+    const periods = this.buildPeriodsFromIndexes(startIndex, endIndex);
+    const startPeriod = periods[0] ?? null;
+    const endPeriod = periods[periods.length - 1] ?? null;
+    const startDate = startPeriod ? this.monthStartDate(startPeriod) : null;
+    const endDate = endPeriod ? this.monthEndDate(endPeriod) : null;
+    const label = startPeriod && endPeriod ? this.buildLabel(startPeriod, endPeriod) : 'desconocido';
+
+    return {
+      kind: 'period_range',
+      periods,
+      period: null,
+      startPeriod,
+      endPeriod,
+      startDate,
+      endDate,
+      label,
+    };
+  }
+
+  private resolveExplicitRange(period: CanonicalFinancePeriod): ResolvedFinancePeriod {
+    if (!period.startYear || !period.startMonth || !period.endYear || !period.endMonth) {
+      return {
+        kind: 'unknown',
+        periods: [],
+        period: null,
+        startPeriod: null,
+        endPeriod: null,
+        startDate: null,
+        endDate: null,
+        label: 'desconocido',
+      };
+    }
+
+    const periods = this.buildPeriods(period.startYear, period.startMonth, period.endYear, period.endMonth);
+    return this.buildRangeResult(periods, this.buildLabel(periods[0] ?? '', periods[periods.length - 1] ?? ''), period.startYear, period.startMonth, period.endYear, period.endMonth);
+  }
+
+  private buildRangeResult(
+    periods: string[],
+    label: string,
+    startYear: number,
+    startMonth: number,
+    endYear: number,
+    endMonth: number,
+  ): ResolvedFinancePeriod {
+    const startPeriod = periods[0] ?? null;
+    const endPeriod = periods[periods.length - 1] ?? null;
+    return {
+      kind: 'period_range',
+      periods,
+      period: null,
+      startPeriod,
+      endPeriod,
+      startDate: new Date(startYear, startMonth - 1, 1),
+      endDate: new Date(endYear, endMonth, 0, 23, 59, 59, 999),
+      label,
+    };
+  }
+
+  private buildPeriods(startYear: number, startMonth: number, endYear: number, endMonth: number): string[] {
+    const startIndex = this.toMonthIndex(startYear, startMonth);
+    const endIndex = this.toMonthIndex(endYear, endMonth);
+    return this.buildPeriodsFromIndexes(startIndex, endIndex);
+  }
+
+  private buildPeriodsFromIndexes(startIndex: number, endIndex: number): string[] {
+    const periods: string[] = [];
+    if (endIndex < startIndex) {
+      return periods;
+    }
+
+    for (let index = startIndex; index <= endIndex; index += 1) {
+      const { year, month } = this.fromMonthIndex(index);
+      periods.push(`${year}-${String(month).padStart(2, '0')}`);
+    }
+
+    return periods;
+  }
+
+  private currentMonth(referenceDate: Date): string {
+    return `${referenceDate.getFullYear()}-${String(referenceDate.getMonth() + 1).padStart(2, '0')}`;
+  }
+
+  private previousMonth(referenceDate: Date): string {
+    const index = this.toMonthIndex(referenceDate.getFullYear(), referenceDate.getMonth() + 1) - 1;
+    const { year, month } = this.fromMonthIndex(index);
+    return `${year}-${String(month).padStart(2, '0')}`;
+  }
+
+  private toMonthIndex(year: number, month: number): number {
+    return year * 12 + (month - 1);
+  }
+
+  private fromMonthIndex(index: number): { year: number; month: number } {
+    const year = Math.floor(index / 12);
+    const month = (index % 12) + 1;
+    return { year, month };
+  }
+
+  private monthStartDate(periodKey: string): Date {
+    const [yearText, monthText] = periodKey.split('-');
+    return new Date(Number(yearText), Number(monthText) - 1, 1);
+  }
+
+  private monthEndDate(periodKey: string): Date {
+    const [yearText, monthText] = periodKey.split('-');
+    return new Date(Number(yearText), Number(monthText), 0, 23, 59, 59, 999);
+  }
+
+  private buildLabel(startPeriod: string, endPeriod: string): string {
+    if (startPeriod === endPeriod) {
+      const [yearText, monthText] = startPeriod.split('-');
+      return `${MONTH_NAMES[Number(monthText) - 1]} ${yearText}`;
+    }
+
+    const [startYearText, startMonthText] = startPeriod.split('-');
+    const [endYearText, endMonthText] = endPeriod.split('-');
+    return `${MONTH_NAMES[Number(startMonthText) - 1]} ${startYearText} a ${MONTH_NAMES[Number(endMonthText) - 1]} ${endYearText}`;
+  }
+}

--- a/apps/api/src/assistant/period-semantic-validator.service.spec.ts
+++ b/apps/api/src/assistant/period-semantic-validator.service.spec.ts
@@ -1,0 +1,69 @@
+import { PeriodSemanticValidatorService } from './period-semantic-validator.service';
+import type { CanonicalFinancePeriod } from './finance-period.types';
+
+describe('PeriodSemanticValidatorService', () => {
+  let service: PeriodSemanticValidatorService;
+
+  beforeEach(() => {
+    service = new PeriodSemanticValidatorService();
+  });
+
+  function buildPeriod(overrides: Partial<CanonicalFinancePeriod> = {}): CanonicalFinancePeriod {
+    return {
+      kind: 'relative_range',
+      amount: 5,
+      unit: 'month',
+      mode: 'unknown',
+      month: null,
+      year: null,
+      startMonth: null,
+      startYear: null,
+      endMonth: null,
+      endYear: null,
+      ...overrides,
+    };
+  }
+
+  it('asks for period.mode when relative range mode is unknown', () => {
+    const result = service.validate({ period: buildPeriod() });
+
+    expect(result).toEqual({
+      valid: false,
+      requiresClarification: true,
+      missingFields: ['period.mode'],
+      clarificationMessage: '¿Querés incluir el mes actual o consultar solo los últimos 5 meses cerrados?',
+      normalizedPeriod: buildPeriod(),
+    });
+  });
+
+  it('accepts relative range including the current month', () => {
+    const result = service.validate({
+      period: buildPeriod({ mode: 'including_current' }),
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.requiresClarification).toBe(false);
+    expect(result.missingFields).toEqual([]);
+  });
+
+  it('accepts relative range closed months', () => {
+    const result = service.validate({
+      period: buildPeriod({ mode: 'closed_months' }),
+    });
+
+    expect(result.valid).toBe(true);
+    expect(result.requiresClarification).toBe(false);
+    expect(result.missingFields).toEqual([]);
+  });
+
+  it('normalizes startMonth and endMonth model errors to period.mode', () => {
+    const result = service.validate({
+      period: buildPeriod(),
+      missingFields: ['startMonth', 'endMonth'],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.requiresClarification).toBe(true);
+    expect(result.missingFields).toEqual(['period.mode']);
+  });
+});

--- a/apps/api/src/assistant/period-semantic-validator.service.ts
+++ b/apps/api/src/assistant/period-semantic-validator.service.ts
@@ -1,0 +1,158 @@
+import { Injectable } from '@nestjs/common';
+import type {
+  CanonicalFinancePeriod,
+  PeriodValidationResult,
+  RelativeRangeMode,
+} from './finance-period.types';
+
+export interface PeriodSemanticValidationInput {
+  period: CanonicalFinancePeriod | null;
+  missingFields?: string[];
+}
+
+@Injectable()
+export class PeriodSemanticValidatorService {
+  validate(input: PeriodSemanticValidationInput): PeriodValidationResult {
+    if (!input.period || input.period.kind === 'unknown') {
+      return {
+        valid: false,
+        requiresClarification: true,
+        missingFields: ['period'],
+        clarificationMessage: '¿Qué período financiero querés consultar?',
+        normalizedPeriod: input.period,
+      };
+    }
+
+    if (input.period.kind === 'relative_range') {
+      return this.validateRelativeRange(input.period, input.missingFields);
+    }
+
+    if (input.period.kind === 'month_range') {
+      return this.validateMonthRange(input.period, input.missingFields);
+    }
+
+    return {
+      valid: true,
+      requiresClarification: false,
+      missingFields: [],
+      normalizedPeriod: input.period,
+    };
+  }
+
+  private validateRelativeRange(
+    period: CanonicalFinancePeriod,
+    missingFields: string[] = [],
+  ): PeriodValidationResult {
+    const normalizedMissingFields = this.normalizeMissingFields(period, missingFields);
+    const hasMode = this.isFilledMode(period.mode);
+
+    if (!hasMode) {
+      return {
+        valid: false,
+        requiresClarification: true,
+        missingFields: normalizedMissingFields.length > 0 ? normalizedMissingFields : ['period.mode'],
+        clarificationMessage: this.buildRelativeRangeClarificationMessage(period.amount),
+        normalizedPeriod: period,
+      };
+    }
+
+    return {
+      valid: true,
+      requiresClarification: false,
+      missingFields: [],
+      normalizedPeriod: period,
+    };
+  }
+
+  private validateMonthRange(
+    period: CanonicalFinancePeriod,
+    missingFields: string[] = [],
+  ): PeriodValidationResult {
+    const normalizedMissingFields = this.normalizeMonthRangeMissingFields(period, missingFields);
+    const hasStart = this.isFilledMonth(period.startMonth) && this.isFilledYear(period.startYear);
+    const hasEnd = this.isFilledMonth(period.endMonth) && this.isFilledYear(period.endYear);
+
+    if (!hasStart || !hasEnd) {
+      return {
+        valid: false,
+        requiresClarification: true,
+        missingFields: normalizedMissingFields.length > 0 ? normalizedMissingFields : ['period.startMonth', 'period.endMonth'],
+        clarificationMessage: '¿Qué rango de meses querés consultar?',
+        normalizedPeriod: period,
+      };
+    }
+
+    return {
+      valid: true,
+      requiresClarification: false,
+      missingFields: [],
+      normalizedPeriod: period,
+    };
+  }
+
+  private normalizeMissingFields(
+    period: CanonicalFinancePeriod,
+    missingFields: string[],
+  ): string[] {
+    const normalized = new Set<string>();
+    for (const field of missingFields) {
+      if (field === 'startMonth' || field === 'endMonth' || field === 'period.mode') {
+        normalized.add('period.mode');
+        continue;
+      }
+      normalized.add(this.prefixField(field));
+    }
+
+    if (normalized.size === 0 && period.kind === 'relative_range' && !this.isFilledMode(period.mode)) {
+      normalized.add('period.mode');
+    }
+
+    return Array.from(normalized);
+  }
+
+  private normalizeMonthRangeMissingFields(
+    period: CanonicalFinancePeriod,
+    missingFields: string[],
+  ): string[] {
+    const normalized = new Set<string>();
+    for (const field of missingFields) {
+      if (field === 'period.mode') {
+        normalized.add('period.mode');
+        continue;
+      }
+      normalized.add(this.prefixField(field));
+    }
+
+    if (normalized.size === 0 && (!this.isFilledMonth(period.startMonth) || !this.isFilledMonth(period.endMonth))) {
+      normalized.add('period.startMonth');
+      normalized.add('period.endMonth');
+    }
+
+    return Array.from(normalized);
+  }
+
+  private buildRelativeRangeClarificationMessage(amount: number | null): string {
+    const amountText = amount ? `${amount}` : 'los últimos';
+    return `¿Querés incluir el mes actual o consultar solo los últimos ${amountText} meses cerrados?`;
+  }
+
+  private prefixField(field: string): string {
+    if (field.startsWith('period.')) {
+      return field;
+    }
+
+    return `period.${field}`;
+  }
+
+  private isFilledMode(mode: RelativeRangeMode | null): boolean {
+    return mode === 'including_current' || mode === 'closed_months';
+  }
+
+  private isFilledMonth(value: number | null): boolean {
+    return typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 12;
+  }
+
+  private isFilledYear(value: number | null): boolean {
+    return typeof value === 'number' && Number.isInteger(value) && value >= 1900;
+  }
+}

--- a/apps/api/src/assistant/planner/query-planner.service.ts
+++ b/apps/api/src/assistant/planner/query-planner.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { ExecutionPlan, ExtractedIntent, IntentFilters } from '../intent-engine/intent.types';
 import { EntityResolution } from '../intent-engine/intent.types';
+import type { CanonicalFinancePeriod } from '../finance-period.types';
 
 /**
  * Supported query shapes for the allowlist
@@ -159,9 +160,9 @@ export class QueryPlannerService {
     }
 
     if (filters.period !== undefined) {
-      // Validate period format YYYY-MM
-      if (/^\d{4}-\d{2}$/.test(filters.period)) {
-        applied.period = filters.period;
+      const normalizedPeriod = this.normalizePeriod(filters.period);
+      if (normalizedPeriod) {
+        applied.period = normalizedPeriod;
       }
     }
 
@@ -196,6 +197,34 @@ export class QueryPlannerService {
     }
 
     return applied;
+  }
+
+  private normalizePeriod(period: string | CanonicalFinancePeriod): string | CanonicalFinancePeriod | undefined {
+    if (typeof period === 'string') {
+      return /^\d{4}-\d{2}$/.test(period) ? period : undefined;
+    }
+
+    if (period.kind === 'relative_range') {
+      return period;
+    }
+
+    if (period.kind === 'current_month' && typeof period.year === 'number' && typeof period.month === 'number') {
+      return `${period.year}-${String(period.month).padStart(2, '0')}`;
+    }
+
+    if (period.kind === 'previous_month' && typeof period.year === 'number' && typeof period.month === 'number') {
+      return `${period.year}-${String(period.month).padStart(2, '0')}`;
+    }
+
+    if (period.kind === 'named_month' && typeof period.year === 'number' && typeof period.month === 'number') {
+      return `${period.year}-${String(period.month).padStart(2, '0')}`;
+    }
+
+    if (period.kind === 'year_to_date' && typeof period.year === 'number') {
+      return `${period.year}`;
+    }
+
+    return undefined;
   }
 
   /**

--- a/apps/api/src/assistant/providers/ai-provider.module.ts
+++ b/apps/api/src/assistant/providers/ai-provider.module.ts
@@ -20,7 +20,7 @@ import { AssistantLlmHealthController } from '../llm-health.controller';
 export const AI_PROVIDER_TOKEN = 'AI_PROVIDER';
 
 export interface AiProviderOptions {
-  provider: 'none' | 'openai' | 'opencode' | 'ollama' | 'gemini';
+  provider: 'none' | 'hybrid' | 'openai' | 'opencode' | 'ollama' | 'gemini';
   ollamaUrl?: string;
   openaiApiKey?: string;
   opencodeApiKey?: string;

--- a/apps/api/src/assistant/providers/ai-provider.resolver.spec.ts
+++ b/apps/api/src/assistant/providers/ai-provider.resolver.spec.ts
@@ -3,7 +3,7 @@
  * Verifies: default=none, reads env vars, missing creds fail with clear error
  */
 
-import { resolveAiProvider } from './ai-provider.resolver';
+import { resolveAiConsensusModeConfig, resolveAiProvider } from './ai-provider.resolver';
 
 describe('resolveAiProvider', () => {
   const originalEnv = process.env;
@@ -12,9 +12,14 @@ describe('resolveAiProvider', () => {
     jest.resetModules();
     process.env = { ...originalEnv };
     delete process.env.AI_PROVIDER;
+    delete process.env.AI_CONSENSUS_MODE;
+    delete process.env.AI_ALWAYS_CALL_LOCAL_MODEL;
+    delete process.env.AI_GEMINI_FALLBACK_ENABLED;
     delete process.env.OPENAI_API_KEY;
     delete process.env.GEMINI_API_KEY;
     delete process.env.AI_OLLAMA_URL;
+    delete process.env.OLLAMA_BASE_URL;
+    delete process.env.OLLAMA_MODEL;
     delete process.env.OPENCODE_API_KEY;
     delete process.env.OPENCODE_URL;
   });
@@ -71,6 +76,18 @@ describe('resolveAiProvider', () => {
     });
   });
 
+  describe('hybrid provider', () => {
+    it('reads OLLAMA_BASE_URL from env', () => {
+      const result = resolveAiProvider({
+        AI_PROVIDER: 'hybrid',
+        OLLAMA_BASE_URL: 'http://localhost:11434',
+      });
+
+      expect(result.provider).toBe('ollama');
+      expect(result.ollamaUrl).toBe('http://localhost:11434');
+    });
+  });
+
   describe('gemini provider', () => {
     it('reads GEMINI_API_KEY from env', () => {
       const result = resolveAiProvider({
@@ -106,6 +123,29 @@ describe('resolveAiProvider', () => {
       const result = resolveAiProvider({ AI_PROVIDER: 'opencode' });
       expect(result.provider).toBe('opencode');
       // opencode creds are optional — no throw
+    });
+  });
+
+  describe('consensus mode config', () => {
+    it('reads hybrid mode flags and local ollama settings', () => {
+      const result = resolveAiConsensusModeConfig({
+        AI_PROVIDER: 'hybrid',
+        AI_CONSENSUS_MODE: 'true',
+        AI_ALWAYS_CALL_LOCAL_MODEL: '1',
+        AI_GEMINI_FALLBACK_ENABLED: 'false',
+        OLLAMA_BASE_URL: 'http://localhost:11434',
+        OLLAMA_MODEL: 'qwen2.5:3b',
+      });
+
+      expect(result).toEqual(expect.objectContaining({
+        provider: 'hybrid',
+        localProvider: 'ollama',
+        consensusMode: true,
+        alwaysCallLocalModel: true,
+        geminiFallbackEnabled: false,
+        ollamaBaseUrl: 'http://localhost:11434',
+        ollamaModel: 'qwen2.5:3b',
+      }));
     });
   });
 });

--- a/apps/api/src/assistant/providers/ai-provider.resolver.ts
+++ b/apps/api/src/assistant/providers/ai-provider.resolver.ts
@@ -5,8 +5,42 @@
 
 import { AiProviderOptions } from './ai-provider.module';
 
+export interface AiConsensusModeConfig {
+  provider: 'none' | 'hybrid' | 'openai' | 'opencode' | 'ollama' | 'gemini';
+  localProvider: 'ollama';
+  alwaysCallLocalModel: boolean;
+  consensusMode: boolean;
+  geminiFallbackEnabled: boolean;
+  ollamaBaseUrl?: string;
+  ollamaModel?: string;
+}
+
+function parseBooleanEnv(value: string | undefined, defaultValue = false): boolean {
+  if (value === undefined || value === null || value.trim() === '') {
+    return defaultValue;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
+}
+
+export function resolveAiConsensusModeConfig(env: NodeJS.ProcessEnv = process.env): AiConsensusModeConfig {
+  const provider = ((env.AI_PROVIDER || 'none').trim() || 'none') as AiConsensusModeConfig['provider'];
+
+  return {
+    provider,
+    localProvider: 'ollama',
+    alwaysCallLocalModel: parseBooleanEnv(env.AI_ALWAYS_CALL_LOCAL_MODEL, false),
+    consensusMode: parseBooleanEnv(env.AI_CONSENSUS_MODE, false),
+    geminiFallbackEnabled: parseBooleanEnv(env.AI_GEMINI_FALLBACK_ENABLED, true),
+    ollamaBaseUrl: env.OLLAMA_BASE_URL || env.AI_OLLAMA_URL || undefined,
+    ollamaModel: env.OLLAMA_MODEL || env.AI_OLLAMA_MODEL || undefined,
+  };
+}
+
 export function resolveAiProvider(env: NodeJS.ProcessEnv = process.env): AiProviderOptions {
-  const provider = (env.AI_PROVIDER || 'none') as AiProviderOptions['provider'];
+  const rawProvider = (env.AI_PROVIDER || 'none').trim() || 'none';
+  const provider = (rawProvider === 'hybrid' ? 'ollama' : rawProvider) as AiProviderOptions['provider'];
   const options: AiProviderOptions = { provider };
 
   if (provider === 'none') {
@@ -32,13 +66,15 @@ export function resolveAiProvider(env: NodeJS.ProcessEnv = process.env): AiProvi
   }
 
   if (provider === 'ollama') {
-    if (!env.AI_OLLAMA_URL) {
+    const ollamaUrl = env.OLLAMA_BASE_URL || env.AI_OLLAMA_URL;
+    if (!ollamaUrl) {
       throw new Error(
         'AI_OLLAMA_URL is required when AI_PROVIDER=ollama. ' +
+        'AI_OLLAMA_URL (or OLLAMA_BASE_URL) is required when AI_PROVIDER=ollama or AI_PROVIDER=hybrid. ' +
         'Set the env var or switch to AI_PROVIDER=none.',
       );
     }
-    options.ollamaUrl = env.AI_OLLAMA_URL;
+    options.ollamaUrl = ollamaUrl;
     return options;
   }
 

--- a/apps/api/src/assistant/query-executors.service.spec.ts
+++ b/apps/api/src/assistant/query-executors.service.spec.ts
@@ -15,6 +15,7 @@ describe('AssistantQueryExecutorsService', () => {
   };
   const policy = { assertCanExecute: jest.fn() };
   const unitResolver = { resolve: jest.fn() };
+  const periodResolver = { resolve: jest.fn() };
   const finanzasService = {
     getUnitLedger: jest.fn(),
     getBuildingFinancialSummary: jest.fn(),
@@ -35,9 +36,20 @@ describe('AssistantQueryExecutorsService', () => {
       policy as never,
       unitResolver as never,
       finanzasService as never,
+      periodResolver as never,
     );
     unitResolver.resolve.mockResolvedValue({ resolved: resolvedUnit, errorResponse: null });
     policy.assertCanExecute.mockResolvedValue(undefined);
+    periodResolver.resolve.mockReturnValue({
+      kind: 'period_range',
+      periods: ['2026-02', '2026-03', '2026-04', '2026-05', '2026-06'],
+      period: null,
+      startPeriod: '2026-02',
+      endPeriod: '2026-06',
+      startDate: new Date('2026-02-01'),
+      endDate: new Date('2026-06-30T23:59:59.999Z'),
+      label: 'febrero 2026 a junio 2026',
+    });
   });
 
   it('executes unit_debt through allowlisted Prisma reads after policy enforcement', async () => {
@@ -169,6 +181,163 @@ describe('AssistantQueryExecutorsService', () => {
     expect(result?.answer).toContain('deuda pendiente total');
   });
 
+  it('executes building_debt with relative-range periods and a labeled range response', async () => {
+    const plan: AssistantQueryPlan = {
+      intent: 'building_debt',
+      module: 'payments',
+      scope: 'building',
+      requiredPermission: 'payments.review',
+      executor: 'building_debt',
+      filters: {
+        buildingToken: 'A',
+        buildingAlias: 'torre el parque',
+        period: {
+          kind: 'relative_range',
+          amount: 5,
+          unit: 'month',
+          mode: 'including_current',
+          month: null,
+          year: null,
+          startMonth: null,
+          startYear: null,
+          endMonth: null,
+          endYear: null,
+        },
+      },
+      confidence: 0.9,
+      source: 'deterministic_rules',
+    };
+    prisma.building.findMany.mockResolvedValue([{ id: 'building-1', name: 'Torre El Parque' }]);
+    prisma.tenant.findUniqueOrThrow.mockResolvedValue({ currency: 'ARS' });
+    finanzasService.getBuildingFinancialSummary.mockResolvedValue({
+      totalCharges: 150000,
+      totalPaid: 50000,
+      totalOutstanding: 100000,
+      delinquentUnitsCount: 1,
+      topDelinquentUnits: [],
+      currency: 'ARS',
+    });
+
+    const result = await service.execute({ tenantId: 'tenant-1', userId: 'operator-1', userRoles: ['OPERATOR'], plan });
+
+    expect(periodResolver.resolve).toHaveBeenCalledWith(expect.objectContaining({
+      kind: 'relative_range',
+      amount: 5,
+      unit: 'month',
+      mode: 'including_current',
+    }));
+    expect(finanzasService.getBuildingFinancialSummary).toHaveBeenCalledWith(
+      'tenant-1',
+      'building-1',
+      { periods: ['2026-02', '2026-03', '2026-04', '2026-05', '2026-06'] },
+    );
+    expect(result?.answer).toContain('febrero 2026 a junio 2026');
+  });
+
+  it('keeps accumulated building debt unfiltered while preserving the legacy flow', async () => {
+    const plan: AssistantQueryPlan = {
+      intent: 'building_debt',
+      module: 'payments',
+      scope: 'building',
+      requiredPermission: 'payments.review',
+      executor: 'building_debt',
+      filters: { buildingToken: 'A', period: 'accumulated' },
+      confidence: 0.9,
+      source: 'deterministic_rules',
+    };
+    prisma.building.findMany.mockResolvedValue([{ id: 'building-1', name: 'Edificio A' }]);
+    prisma.tenant.findUniqueOrThrow.mockResolvedValue({ currency: 'ARS' });
+    finanzasService.getBuildingFinancialSummary.mockResolvedValue({
+      totalCharges: 150000,
+      totalPaid: 50000,
+      totalOutstanding: 100000,
+      delinquentUnitsCount: 1,
+      topDelinquentUnits: [],
+      currency: 'ARS',
+    });
+
+    await service.execute({ tenantId: 'tenant-1', userId: 'operator-1', userRoles: ['OPERATOR'], plan });
+
+    expect(finanzasService.getBuildingFinancialSummary).toHaveBeenCalledWith('tenant-1', 'building-1', undefined);
+  });
+
+  it('keeps the YYYY-MM building debt path compatible', async () => {
+    const plan: AssistantQueryPlan = {
+      intent: 'building_debt',
+      module: 'payments',
+      scope: 'building',
+      requiredPermission: 'payments.review',
+      executor: 'building_debt',
+      filters: { buildingToken: 'A', period: '2026-06' },
+      confidence: 0.9,
+      source: 'deterministic_rules',
+    };
+    prisma.building.findMany.mockResolvedValue([{ id: 'building-1', name: 'Edificio A' }]);
+    prisma.tenant.findUniqueOrThrow.mockResolvedValue({ currency: 'ARS' });
+    finanzasService.getBuildingFinancialSummary.mockResolvedValue({
+      totalCharges: 150000,
+      totalPaid: 50000,
+      totalOutstanding: 100000,
+      delinquentUnitsCount: 1,
+      topDelinquentUnits: [],
+      currency: 'ARS',
+    });
+
+    await service.execute({ tenantId: 'tenant-1', userId: 'operator-1', userRoles: ['OPERATOR'], plan });
+
+    expect(finanzasService.getBuildingFinancialSummary).toHaveBeenCalledWith(
+      'tenant-1',
+      'building-1',
+      { period: '2026-06' },
+    );
+  });
+
+  it('executes building_debt with closed-month relative ranges', async () => {
+    const plan: AssistantQueryPlan = {
+      intent: 'building_debt',
+      module: 'payments',
+      scope: 'building',
+      requiredPermission: 'payments.review',
+      executor: 'building_debt',
+      filters: {
+        buildingToken: 'A',
+        buildingAlias: 'torre el parque',
+        period: {
+          kind: 'relative_range',
+          amount: 5,
+          unit: 'month',
+          mode: 'closed_months',
+          month: null,
+          year: null,
+          startMonth: null,
+          startYear: null,
+          endMonth: null,
+          endYear: null,
+        },
+      },
+      confidence: 0.9,
+      source: 'deterministic_rules',
+    };
+    prisma.building.findMany.mockResolvedValue([{ id: 'building-1', name: 'Torre El Parque' }]);
+    prisma.tenant.findUniqueOrThrow.mockResolvedValue({ currency: 'ARS' });
+    finanzasService.getBuildingFinancialSummary.mockResolvedValue({
+      totalCharges: 150000,
+      totalPaid: 50000,
+      totalOutstanding: 100000,
+      delinquentUnitsCount: 1,
+      topDelinquentUnits: [],
+      currency: 'ARS',
+    });
+
+    await service.execute({ tenantId: 'tenant-1', userId: 'operator-1', userRoles: ['OPERATOR'], plan });
+
+    expect(finanzasService.getBuildingFinancialSummary).toHaveBeenCalledWith(
+      'tenant-1',
+      'building-1',
+      { periods: ['2026-02', '2026-03', '2026-04', '2026-05', '2026-06'] },
+    );
+  });
+
   it('executes tenant_debt with a tenant-wide outstanding debt summary', async () => {
     const plan: AssistantQueryPlan = {
       intent: 'tenant_debt',
@@ -192,9 +361,85 @@ describe('AssistantQueryExecutorsService', () => {
     const result = await service.execute({ tenantId: 'tenant-1', userId: 'operator-1', userRoles: ['OPERATOR'], plan });
 
     expect(policy.assertCanExecute).toHaveBeenCalledWith(expect.objectContaining({ tenantId: 'tenant-1', plan }));
-    expect(finanzasService.getTenantFinancialSummary).toHaveBeenCalledWith('tenant-1');
+    expect(finanzasService.getTenantFinancialSummary).toHaveBeenCalledWith('tenant-1', undefined);
     expect(result?.answer).toContain('administración');
     expect(result?.suggestedActions[0].type).toBe('VIEW_PAYMENTS');
+  });
+
+  it('executes tenant_debt with relative-range periods and a labeled range response', async () => {
+    const plan: AssistantQueryPlan = {
+      intent: 'tenant_debt',
+      module: 'payments',
+      scope: 'tenant',
+      requiredPermission: 'payments.review',
+      executor: 'tenant_debt',
+      filters: {
+        period: {
+          kind: 'relative_range',
+          amount: 5,
+          unit: 'month',
+          mode: 'including_current',
+          month: null,
+          year: null,
+          offset: null,
+          startMonth: null,
+          startYear: null,
+          endMonth: null,
+          endYear: null,
+        },
+      },
+      confidence: 0.9,
+      source: 'deterministic_rules',
+    };
+    finanzasService.getTenantFinancialSummary.mockResolvedValue({
+      totalCharges: 200000,
+      totalPaid: 50000,
+      totalOutstanding: 150000,
+      delinquentUnitsCount: 2,
+      topDelinquentUnits: [],
+      currency: 'ARS',
+    });
+
+    const result = await service.execute({ tenantId: 'tenant-1', userId: 'operator-1', userRoles: ['OPERATOR'], plan });
+
+    expect(finanzasService.getTenantFinancialSummary).toHaveBeenCalledWith(
+      'tenant-1',
+      { periods: ['2026-02', '2026-03', '2026-04', '2026-05', '2026-06'] },
+    );
+    expect(result?.answer).toContain('Deuda global de la administración');
+    expect(result?.answer).toContain('febrero 2026 a junio 2026');
+  });
+
+  it('returns null for tenant_debt relative ranges when mode is still unknown', async () => {
+    const plan: AssistantQueryPlan = {
+      intent: 'tenant_debt',
+      module: 'payments',
+      scope: 'tenant',
+      requiredPermission: 'payments.review',
+      executor: 'tenant_debt',
+      filters: {
+        period: {
+          kind: 'relative_range',
+          amount: 5,
+          unit: 'month',
+          mode: 'unknown',
+          month: null,
+          year: null,
+          offset: null,
+          startMonth: null,
+          startYear: null,
+          endMonth: null,
+          endYear: null,
+        },
+      },
+      confidence: 0.9,
+      source: 'deterministic_rules',
+    };
+
+    const result = await service.execute({ tenantId: 'tenant-1', userId: 'operator-1', userRoles: ['OPERATOR'], plan });
+
+    expect(result).toBeNull();
+    expect(finanzasService.getTenantFinancialSummary).not.toHaveBeenCalled();
   });
 
   it('executes building_delinquents through finance summary source of truth', async () => {

--- a/apps/api/src/assistant/query-executors.service.ts
+++ b/apps/api/src/assistant/query-executors.service.ts
@@ -6,7 +6,10 @@ import { AssistantQueryParser, UnitToken } from './query-parser/assistant-query-
 import { AssistantPolicyEnforcerService } from './policy-enforcer.service';
 import { AssistantUnitResolverService, ResolvedUnit } from './unit-resolver/assistant-unit-resolver.service';
 import type { ChatResponse } from './ai.types';
+import type { CanonicalFinancePeriod, ResolvedFinancePeriod } from './finance-period.types';
+import { PeriodResolverService } from './period-resolver.service';
 import type { AssistantQueryExecutionContext } from './query-plan.types';
+import type { BuildingFinancialSummaryPeriodFilter } from '../finanzas/finanzas.service';
 
 @Injectable()
 export class AssistantQueryExecutorsService {
@@ -17,7 +20,106 @@ export class AssistantQueryExecutorsService {
     private readonly policy: AssistantPolicyEnforcerService,
     private readonly unitResolver: AssistantUnitResolverService,
     private readonly finanzasService: FinanzasService,
+    private readonly periodResolver: PeriodResolverService,
   ) {}
+
+  private normalizeExecutionPeriod(period: string | CanonicalFinancePeriod | undefined): string | undefined {
+    if (!period) {
+      return undefined;
+    }
+
+    if (typeof period === 'string') {
+      return period;
+    }
+
+    if (period.kind === 'current_month' && typeof period.year === 'number' && typeof period.month === 'number') {
+      return `${period.year}-${String(period.month).padStart(2, '0')}`;
+    }
+
+    if (period.kind === 'previous_month' && typeof period.year === 'number' && typeof period.month === 'number') {
+      return `${period.year}-${String(period.month).padStart(2, '0')}`;
+    }
+
+    if (period.kind === 'named_month' && typeof period.year === 'number' && typeof period.month === 'number') {
+      return `${period.year}-${String(period.month).padStart(2, '0')}`;
+    }
+
+    return undefined;
+  }
+
+  private resolveBuildingSummaryPeriod(
+    period: string | CanonicalFinancePeriod | undefined,
+  ): { filter?: BuildingFinancialSummaryPeriodFilter; resolved?: ResolvedFinancePeriod } {
+    if (!period) {
+      return {};
+    }
+
+    if (typeof period === 'string') {
+      if (period === 'accumulated') {
+        return {};
+      }
+
+      return {
+        filter: { period: this.normalizeExecutionPeriod(period) },
+      };
+    }
+
+    if (period.kind === 'relative_range') {
+      if (period.mode === 'unknown') {
+        return {};
+      }
+
+      const resolved = this.periodResolver.resolve(period);
+      if (resolved.kind !== 'period_range' || resolved.periods.length === 0) {
+        return {};
+      }
+
+      return {
+        filter: { periods: resolved.periods },
+        resolved,
+      };
+    }
+
+    const normalized = this.normalizeExecutionPeriod(period);
+    return normalized ? { filter: { period: normalized } } : {};
+  }
+
+  private resolveTenantSummaryPeriod(
+    period: string | CanonicalFinancePeriod | undefined,
+  ): { filter?: BuildingFinancialSummaryPeriodFilter; resolved?: ResolvedFinancePeriod; needsClarification?: boolean } {
+    if (!period) {
+      return {};
+    }
+
+    if (typeof period === 'string') {
+      if (period === 'accumulated') {
+        return {};
+      }
+
+      return {
+        filter: { period: this.normalizeExecutionPeriod(period) },
+      };
+    }
+
+    if (period.kind === 'relative_range') {
+      if (period.mode === 'unknown') {
+        return { needsClarification: true };
+      }
+
+      const resolved = this.periodResolver.resolve(period);
+      if (resolved.kind !== 'period_range' || resolved.periods.length === 0) {
+        return {};
+      }
+
+      return {
+        filter: { periods: resolved.periods },
+        resolved,
+      };
+    }
+
+    const normalized = this.normalizeExecutionPeriod(period);
+    return normalized ? { filter: { period: normalized } } : {};
+  }
 
   /**
    * Execute an allowlisted QueryPlan. This method never accepts SQL from the model.
@@ -273,6 +375,8 @@ export class AssistantQueryExecutorsService {
       return null;
     }
 
+    const periodResolution = this.resolveBuildingSummaryPeriod(context.plan.filters.period);
+
     await this.policy.assertCanExecute({
       tenantId: context.tenantId,
       userId: context.userId,
@@ -284,18 +388,29 @@ export class AssistantQueryExecutorsService {
     const summary = await this.finanzasService.getBuildingFinancialSummary(
       context.tenantId,
       building.id,
-      context.plan.filters.period,
+      periodResolution.filter,
     );
     const outstanding = summary.totalOutstanding;
+    const rangeLabel = periodResolution.resolved?.label;
     return {
       answer: outstanding > 0
-        ? `El edificio ${building.name} tiene una deuda pendiente total de ${this.formatMoney(outstanding, summary.currency)}.`
-        : `El edificio ${building.name} no tiene deuda pendiente. Saldo actual: ${this.formatMoney(outstanding, summary.currency)}.`,
+        ? rangeLabel
+          ? `Deuda de ${building.name}, ${rangeLabel}: ${this.formatMoney(outstanding, summary.currency)}.`
+          : `El edificio ${building.name} tiene una deuda pendiente total de ${this.formatMoney(outstanding, summary.currency)}.`
+        : rangeLabel
+          ? `Deuda de ${building.name}, ${rangeLabel}: ${this.formatMoney(outstanding, summary.currency)}.`
+          : `El edificio ${building.name} no tiene deuda pendiente. Saldo actual: ${this.formatMoney(outstanding, summary.currency)}.`,
       suggestedActions: [{ type: 'VIEW_PAYMENTS', payload: { buildingId: building.id } }],
     };
   }
 
   private async executeTenantDebt(context: AssistantQueryExecutionContext): Promise<ChatResponse | null> {
+    const periodResolution = this.resolveTenantSummaryPeriod(context.plan.filters.period);
+
+    if (periodResolution.needsClarification) {
+      return null;
+    }
+
     await this.policy.assertCanExecute({
       tenantId: context.tenantId,
       userId: context.userId,
@@ -303,12 +418,19 @@ export class AssistantQueryExecutorsService {
       plan: context.plan,
     });
 
-    const tenantDebt = await this.finanzasService.getTenantFinancialSummary(context.tenantId);
+    const tenantDebt = await this.finanzasService.getTenantFinancialSummary(
+      context.tenantId,
+      periodResolution.filter,
+    );
     const totalDebt = tenantDebt.totalOutstanding;
     return {
       answer: totalDebt > 0
-        ? `La administración tiene una deuda pendiente total de ${this.formatMoney(totalDebt, tenantDebt.currency)}.`
-        : `La administración no tiene deuda pendiente. Saldo actual: ${this.formatMoney(totalDebt, tenantDebt.currency)}.`,
+        ? periodResolution.resolved?.label
+          ? `Deuda global de la administración, ${periodResolution.resolved.label}: ${this.formatMoney(totalDebt, tenantDebt.currency)}.`
+          : `La administración tiene una deuda pendiente total de ${this.formatMoney(totalDebt, tenantDebt.currency)}.`
+        : periodResolution.resolved?.label
+          ? `Deuda global de la administración, ${periodResolution.resolved.label}: ${this.formatMoney(totalDebt, tenantDebt.currency)}.`
+          : `La administración no tiene deuda pendiente. Saldo actual: ${this.formatMoney(totalDebt, tenantDebt.currency)}.`,
       suggestedActions: [{ type: 'VIEW_PAYMENTS', payload: {} }],
     };
   }
@@ -319,6 +441,8 @@ export class AssistantQueryExecutorsService {
       return null;
     }
 
+    const periodResolution = this.resolveBuildingSummaryPeriod(context.plan.filters.period);
+
     await this.policy.assertCanExecute({
       tenantId: context.tenantId,
       userId: context.userId,
@@ -330,7 +454,7 @@ export class AssistantQueryExecutorsService {
     const summary = await this.finanzasService.getBuildingFinancialSummary(
       context.tenantId,
       building.id,
-      context.plan.filters.period,
+      periodResolution.filter,
     );
 
     if (summary.delinquentUnitsCount === 0) {
@@ -471,6 +595,8 @@ export class AssistantQueryExecutorsService {
       return null;
     }
 
+    const periodResolution = this.resolveBuildingSummaryPeriod(context.plan.filters.period);
+
     await this.policy.assertCanExecute({
       tenantId: context.tenantId,
       userId: context.userId,
@@ -484,7 +610,11 @@ export class AssistantQueryExecutorsService {
       this.prisma.unit.findMany({ where: { tenantId: context.tenantId, buildingId: building.id }, select: { id: true } }),
       this.prisma.ticket.count({ where: { tenantId: context.tenantId, buildingId: building.id, status: 'OPEN' } }),
       this.prisma.ticket.count({ where: { tenantId: context.tenantId, buildingId: building.id } }),
-      this.finanzasService.getBuildingFinancialSummary(context.tenantId, building.id, context.plan.filters.period),
+      this.finanzasService.getBuildingFinancialSummary(
+        context.tenantId,
+        building.id,
+        periodResolution.filter,
+      ),
     ]);
 
     const outstanding = summary.totalOutstanding;

--- a/apps/api/src/assistant/query-plan.service.spec.ts
+++ b/apps/api/src/assistant/query-plan.service.spec.ts
@@ -157,6 +157,36 @@ describe('AssistantQueryPlanService', () => {
     expect(plan?.filters.period).toBe(expectedPeriod);
   });
 
+  it('preserves relative-range tenant debt with unknown mode', () => {
+    const plan = service.createPlan('deuda de los ultimos 5 meses de la administracion');
+
+    expect(plan).toEqual(expect.objectContaining({
+      intent: 'tenant_debt',
+      scope: 'tenant',
+    }));
+    expect(plan?.filters.period).toEqual(expect.objectContaining({
+      kind: 'relative_range',
+      amount: 5,
+      unit: 'month',
+      mode: 'unknown',
+    }));
+  });
+
+  it('preserves relative-range tenant debt for including_current follow-up phrasing', () => {
+    const plan = service.createPlan('deuda de los ultimos 5 meses incluyendo este mes de la administracion');
+
+    expect(plan).toEqual(expect.objectContaining({
+      intent: 'tenant_debt',
+      scope: 'tenant',
+    }));
+    expect(plan?.filters.period).toEqual(expect.objectContaining({
+      kind: 'relative_range',
+      amount: 5,
+      unit: 'month',
+      mode: 'including_current',
+    }));
+  });
+
   it('preserves current month for building debt on a condominio phrase', () => {
     const plan = service.createPlan('deuda del mes actual del condominio');
 
@@ -174,6 +204,17 @@ describe('AssistantQueryPlanService', () => {
       intent: 'building_debt',
       scope: 'building',
     }));
+    expect(plan?.filters.period).toBe(new Date().toISOString().slice(0, 7));
+  });
+
+  it('preserves current month for building debt with mes que esta corriendo', () => {
+    const plan = service.createPlan('dame la deuda del mes que está corriendo del edificio A');
+
+    expect(plan).toEqual(expect.objectContaining({
+      intent: 'building_debt',
+      scope: 'building',
+    }));
+    expect(plan?.filters.buildingAlias).toBe('A');
     expect(plan?.filters.period).toBe(new Date().toISOString().slice(0, 7));
   });
 
@@ -273,6 +314,22 @@ describe('AssistantQueryPlanService', () => {
     expect(plan?.filters.period).toBe('2026-06');
     expect(plan?.filters.unitCode).toBeUndefined();
     expect(plan?.filters.unitCodeRaw).toBeUndefined();
+  });
+
+  it('preserves relative range debt queries for a named building', () => {
+    const plan = service.createPlan('deuda de los ultimos 5 meses de la torre el parque');
+
+    expect(plan).toEqual(expect.objectContaining({
+      intent: 'building_debt',
+      scope: 'building',
+    }));
+    expect(plan?.filters.buildingAlias).toEqual(expect.stringContaining('parque'));
+    expect(plan?.filters.period).toEqual(expect.objectContaining({
+      kind: 'relative_range',
+      amount: 5,
+      unit: 'month',
+      mode: 'unknown',
+    }));
   });
 
   it('keeps building-level payments queries with month and year out of unit parsing', () => {

--- a/apps/api/src/assistant/query-plan.service.spec.ts
+++ b/apps/api/src/assistant/query-plan.service.spec.ts
@@ -144,6 +144,7 @@ describe('AssistantQueryPlanService', () => {
 
   it.each([
     ['deuda de este mes de la administracion', 'current_month'],
+    ['deuda de mes en curso de la administracion', 'current_month'],
     ['deuda acumulada de la administracion', 'accumulated'],
     ['deuda total de este mes', 'current_month'],
   ])('preserves tenant debt period for "%s"', (phrase, expectedPeriod) => {
@@ -158,6 +159,16 @@ describe('AssistantQueryPlanService', () => {
 
   it('preserves current month for building debt on a condominio phrase', () => {
     const plan = service.createPlan('deuda del mes actual del condominio');
+
+    expect(plan).toEqual(expect.objectContaining({
+      intent: 'building_debt',
+      scope: 'building',
+    }));
+    expect(plan?.filters.period).toBe(new Date().toISOString().slice(0, 7));
+  });
+
+  it('preserves current month for building debt with mes en curso', () => {
+    const plan = service.createPlan('deuda del mes en curso del edificio A');
 
     expect(plan).toEqual(expect.objectContaining({
       intent: 'building_debt',
@@ -311,7 +322,7 @@ describe('AssistantQueryPlanService', () => {
       intent: 'building_debt',
     }));
     expect(plan?.filters.buildingAlias).toBe('B');
-    expect(plan?.filters.period).toBeUndefined();
+    expect(plan?.filters.period).toBe('accumulated');
   });
 
   it('extracts status and minAgeDays from ticket aging query', () => {

--- a/apps/api/src/assistant/query-plan.service.ts
+++ b/apps/api/src/assistant/query-plan.service.ts
@@ -1,5 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { AssistantDebtIntentInterpreter } from './debt-intent-interpreter';
+import { PeriodNormalizerService } from './period-normalizer.service';
+import type { CanonicalFinancePeriod } from './finance-period.types';
 import { AssistantQueryParser } from './query-parser/assistant-query-parser';
 import { AssistantSemanticLayerService } from './semantic-layer.service';
 import type { AssistantQueryIntent, AssistantQueryPlan } from './query-plan.types';
@@ -8,6 +10,7 @@ import type { AssistantQueryIntent, AssistantQueryPlan } from './query-plan.type
 export class AssistantQueryPlanService {
   private readonly parser = new AssistantQueryParser();
   private readonly debtInterpreter = new AssistantDebtIntentInterpreter();
+  private readonly periodNormalizer = new PeriodNormalizerService();
 
   constructor(private readonly semanticLayer: AssistantSemanticLayerService) {}
 
@@ -22,11 +25,13 @@ export class AssistantQueryPlanService {
 
     const parsedUnitToken = this.parser.parseUnitReference(message);
     const buildingToken = this.parser.extractBuildingToken(message);
+    const buildingReference = this.extractBuildingReference(message);
     const extractedFilters = this.extractCommonFilters(normalized);
     const personName = this.extractPersonName(message, normalized);
     const referencesSomeone = this.hasAny(normalized, ['alguien', 'persona', 'quien', 'quién']);
     const debtInterpretation = this.debtInterpreter.interpret(message);
     const tenantDebtPeriod = this.extractTenantDebtPeriod(normalized);
+    const canonicalPeriod = this.periodNormalizer.normalize(message);
 
     const hasExplicitUnitSyntax =
       /\b(unidad|apartamento|departamento|depto|apto|local|cochera|garage)\b/.test(normalized) ||
@@ -61,6 +66,7 @@ export class AssistantQueryPlanService {
           unitCodeRaw: unitToken.unitCodeRaw,
           buildingAlias: unitToken.buildingAlias,
           buildingName: unitToken.buildingName,
+          ...(buildingReference ? { buildingAlias: buildingReference.alias ?? buildingReference.name, buildingName: buildingReference.name } : {}),
           ...extractedFilters,
         },
         confidence: 0.92,
@@ -70,13 +76,16 @@ export class AssistantQueryPlanService {
 
     if (debtInterpretation.scope === 'tenant') {
       const definition = this.semanticLayer.getDefinition('tenant_debt');
+      const tenantPeriod = canonicalPeriod?.kind === 'relative_range'
+        ? this.mergeRelativeRangePeriod(extractedFilters, canonicalPeriod)
+        : {
+            ...extractedFilters,
+            ...(tenantDebtPeriod ? { period: tenantDebtPeriod } : {}),
+          };
       return {
         ...definition,
         executor: 'tenant_debt',
-        filters: {
-          ...extractedFilters,
-          ...(tenantDebtPeriod ? { period: tenantDebtPeriod } : {}),
-        },
+        filters: tenantPeriod,
         confidence: 0.9,
         source: 'deterministic_rules',
       };
@@ -111,7 +120,10 @@ export class AssistantQueryPlanService {
       return {
         ...definition,
         executor: buildingIntent,
-        filters: { ...extractedFilters },
+        filters: {
+          ...(buildingReference ? { buildingAlias: buildingReference.alias ?? buildingReference.name, buildingName: buildingReference.name } : {}),
+          ...this.mergeRelativeRangePeriod(extractedFilters, canonicalPeriod),
+        },
         confidence: 0.85,
         source: 'deterministic_rules',
       };
@@ -121,7 +133,12 @@ export class AssistantQueryPlanService {
     return {
       ...definition,
       executor: buildingIntent,
-      filters: { buildingToken, buildingAlias: buildingToken, ...extractedFilters },
+      filters: {
+        buildingToken,
+        buildingAlias: buildingReference?.alias ?? buildingToken,
+        ...(buildingReference?.name ? { buildingName: buildingReference.name } : {}),
+        ...this.mergeRelativeRangePeriod(extractedFilters, canonicalPeriod),
+      },
       confidence: 0.9,
       source: 'deterministic_rules',
     };
@@ -239,14 +256,22 @@ export class AssistantQueryPlanService {
     };
   }
 
+  private mergeRelativeRangePeriod(
+    filters: AssistantQueryPlan['filters'],
+    canonicalPeriod: CanonicalFinancePeriod | null,
+  ): AssistantQueryPlan['filters'] {
+    if (!canonicalPeriod || canonicalPeriod.kind !== 'relative_range') {
+      return filters;
+    }
+
+    return {
+      ...filters,
+      period: canonicalPeriod,
+    };
+  }
+
   private extractTenantDebtPeriod(normalized: string): string | undefined {
-    if (
-      normalized.includes('este mes') ||
-      normalized.includes('mes actual') ||
-      normalized.includes('mes en curso') ||
-      normalized.includes('del mes actual') ||
-      normalized.includes('del mes en curso')
-    ) {
+    if (this.isCurrentMonthAlias(normalized)) {
       return 'current_month';
     }
 
@@ -258,6 +283,11 @@ export class AssistantQueryPlanService {
   }
 
   private extractPeriod(normalized: string): string | undefined {
+    const canonical = this.periodNormalizer.normalize(normalized);
+    if (canonical?.kind === 'relative_range') {
+      return undefined;
+    }
+
     const direct = normalized.match(/\b(\d{4}-\d{2})\b/);
     if (direct?.[1]) {
       return direct[1];
@@ -312,11 +342,7 @@ export class AssistantQueryPlanService {
       }
     }
 
-    if (normalized.includes('este mes') || normalized.includes('mes actual')) {
-      return `${currentYear}-${String(now.getMonth() + 1).padStart(2, '0')}`;
-    }
-
-    if (normalized.includes('mes en curso') || normalized.includes('del mes en curso')) {
+    if (this.isCurrentMonthAlias(normalized)) {
       return `${currentYear}-${String(now.getMonth() + 1).padStart(2, '0')}`;
     }
 
@@ -330,6 +356,54 @@ export class AssistantQueryPlanService {
     }
 
     return undefined;
+  }
+
+  private extractBuildingReference(message: string): { alias?: string; name?: string } | null {
+    const normalized = this.normalize(message);
+    const buildingMatch = normalized.match(
+      /\b(?:torre|edificio|bloque|condominio|building)\s+([a-z0-9]+(?:\s+[a-z0-9]+)*)/,
+    );
+
+    if (!buildingMatch?.[1]) {
+      return null;
+    }
+
+    const raw = buildingMatch[1].trim();
+    if (!raw) {
+      return null;
+    }
+
+    const tokens = raw.split(/\s+/).filter(Boolean);
+    const trimmedTokens: string[] = [];
+    for (const token of tokens) {
+      if (this.isBuildingReferenceStopToken(token)) {
+        break;
+      }
+      trimmedTokens.push(token);
+    }
+
+    const normalizedReference = trimmedTokens.join(' ').trim();
+    if (!normalizedReference) {
+      return null;
+    }
+
+    if (/^[a-z0-9]{1,3}$/.test(normalizedReference)) {
+      return { alias: normalizedReference.toUpperCase() };
+    }
+
+    return {
+      alias: normalizedReference,
+      name: normalizedReference,
+    };
+  }
+
+  private isBuildingReferenceStopToken(token: string): boolean {
+    return (
+      /^(este|esta|estos|estas|actual|actuales|corriente|corrientes|en|curso|pasado|pasada|pasados|pasadas|ultimo|ultimos|último|últimos|acumulada|acumulado|historica|historico|histórica|histórico|total|toda|todo|deuda|deudas|saldo|pago|pagos|recaudacion|recaudación|ingreso|ingresos|documento|documentos|archivo|archivos|mes|meses|junio|julio|agosto|septiembre|setiembre|octubre|noviembre|diciembre|enero|febrero|marzo|abril|mayo)$/u.test(
+        token,
+      ) ||
+      /^\d{4}$/.test(token)
+    );
   }
 
   private extractMethod(normalized: string): string | undefined {
@@ -400,5 +474,27 @@ export class AssistantQueryPlanService {
       }
     }
     return undefined;
+  }
+
+  private isCurrentMonthAlias(normalized: string): boolean {
+    const isPastMonth =
+      normalized.includes('mes pasado') ||
+      normalized.includes('ultimo mes') ||
+      normalized.includes('último mes');
+
+    return (
+      !isPastMonth &&
+      (
+        normalized.includes('este mes') ||
+        normalized.includes('mes actual') ||
+        normalized.includes('mes en curso') ||
+        normalized.includes('mes corriente') ||
+        normalized.includes('mes que esta corriendo') ||
+        normalized.includes('del mes actual') ||
+        normalized.includes('del mes en curso') ||
+        normalized.includes('deuda del mes') ||
+        /\bdel mes\b/.test(normalized)
+      )
+    );
   }
 }

--- a/apps/api/src/assistant/query-plan.service.ts
+++ b/apps/api/src/assistant/query-plan.service.ts
@@ -240,7 +240,13 @@ export class AssistantQueryPlanService {
   }
 
   private extractTenantDebtPeriod(normalized: string): string | undefined {
-    if (normalized.includes('este mes') || normalized.includes('mes actual') || normalized.includes('del mes actual')) {
+    if (
+      normalized.includes('este mes') ||
+      normalized.includes('mes actual') ||
+      normalized.includes('mes en curso') ||
+      normalized.includes('del mes actual') ||
+      normalized.includes('del mes en curso')
+    ) {
       return 'current_month';
     }
 
@@ -310,9 +316,17 @@ export class AssistantQueryPlanService {
       return `${currentYear}-${String(now.getMonth() + 1).padStart(2, '0')}`;
     }
 
+    if (normalized.includes('mes en curso') || normalized.includes('del mes en curso')) {
+      return `${currentYear}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+    }
+
     if (normalized.includes('mes pasado') || normalized.includes('ultimo mes') || normalized.includes('último mes')) {
       const previous = new Date(currentYear, now.getMonth() - 1, 1);
       return `${previous.getFullYear()}-${String(previous.getMonth() + 1).padStart(2, '0')}`;
+    }
+
+    if (/acumulad[ao]s?/.test(normalized) || /hist[oó]ric[ao]s?/.test(normalized) || /\btoda\b/.test(normalized) || /\btodo\b/.test(normalized)) {
+      return 'accumulated';
     }
 
     return undefined;

--- a/apps/api/src/assistant/query-plan.types.ts
+++ b/apps/api/src/assistant/query-plan.types.ts
@@ -1,4 +1,5 @@
 import type { Permission } from '../rbac/permissions';
+import type { CanonicalFinancePeriod } from './finance-period.types';
 
 export type AssistantQueryModule = 'units' | 'payments' | 'tickets' | 'documents' | 'buildings';
 
@@ -25,7 +26,7 @@ export interface AssistantQueryPlanFilters {
   buildingAlias?: string;
   buildingName?: string;
   personName?: string;
-  period?: string;
+  period?: string | CanonicalFinancePeriod;
   status?: string;
   method?: string;
   minAmount?: number;

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -27,12 +27,19 @@ describe('FinanzasService', () => {
         {
           provide: PrismaService,
           useValue: {
+            tenant: {
+              findUniqueOrThrow: jest.fn(),
+            },
             charge: {
               create: jest.fn(),
               findFirst: jest.fn(),
               findUnique: jest.fn(),
               findMany: jest.fn(),
               update: jest.fn(),
+            },
+            unit: {
+              findMany: jest.fn(),
+              findFirst: jest.fn(),
             },
             payment: {
               create: jest.fn(),
@@ -579,6 +586,151 @@ describe('FinanzasService', () => {
       // These tests require complex mocks for FinanzasValidators
       // that are beyond unit test scope. Integration tests recommended.
       expect(true).toBe(true);
+    });
+  });
+
+  // ========== TESTS: BUILDING FINANCIAL SUMMARY ==========
+  describe('getBuildingFinancialSummary', () => {
+    it('uses Charge.period IN when periods are provided', async () => {
+      jest.spyOn(validators, 'validateBuildingBelongsToTenant').mockResolvedValue(undefined);
+      jest.spyOn(prismaService.tenant, 'findUniqueOrThrow').mockResolvedValue({ currency: 'ARS' } as never);
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([
+        {
+          id: 'charge-1',
+          tenantId: 'tenant-1',
+          buildingId: 'building-1',
+          unitId: 'unit-1',
+          amount: 1000,
+          paymentAllocations: [],
+        },
+      ] as never);
+      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue([
+        {
+          id: 'unit-1',
+          label: '0101',
+          buildingId: 'building-1',
+          building: { name: 'Edificio A' },
+        },
+      ] as never);
+
+      await service.getBuildingFinancialSummary('tenant-1', 'building-1', {
+        periods: ['2026-02', '2026-03', '2026-04', '2026-05', '2026-06'],
+      });
+
+      expect(prismaService.charge.findMany).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          tenantId: 'tenant-1',
+          buildingId: 'building-1',
+          canceledAt: null,
+          period: {
+            in: ['2026-02', '2026-03', '2026-04', '2026-05', '2026-06'],
+          },
+        }),
+      }));
+      expect(prismaService.charge.findMany).not.toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          createdAt: expect.anything(),
+        }),
+      }));
+    });
+
+    it('keeps the legacy period string path compatible', async () => {
+      jest.spyOn(validators, 'validateBuildingBelongsToTenant').mockResolvedValue(undefined);
+      jest.spyOn(prismaService.tenant, 'findUniqueOrThrow').mockResolvedValue({ currency: 'ARS' } as never);
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([
+        {
+          id: 'charge-1',
+          tenantId: 'tenant-1',
+          buildingId: 'building-1',
+          unitId: 'unit-1',
+          amount: 1000,
+          paymentAllocations: [],
+        },
+      ] as never);
+      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue([
+        {
+          id: 'unit-1',
+          label: '0101',
+          buildingId: 'building-1',
+          building: { name: 'Edificio A' },
+        },
+      ] as never);
+
+      await service.getBuildingFinancialSummary('tenant-1', 'building-1', '2026-06');
+
+      expect(prismaService.charge.findMany).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          period: '2026-06',
+        }),
+      }));
+    });
+  });
+
+  describe('getTenantFinancialSummary', () => {
+    it('uses Charge.period IN when tenant periods are provided', async () => {
+      jest.spyOn(prismaService.tenant, 'findUniqueOrThrow').mockResolvedValue({ currency: 'ARS' } as never);
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([
+        {
+          id: 'charge-1',
+          tenantId: 'tenant-1',
+          buildingId: 'building-1',
+          unitId: 'unit-1',
+          amount: 1000,
+          paymentAllocations: [],
+        },
+      ] as never);
+      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue([
+        {
+          id: 'unit-1',
+          label: '0101',
+          buildingId: 'building-1',
+          building: { name: 'Edificio A' },
+        },
+      ] as never);
+
+      await service.getTenantFinancialSummary('tenant-1', {
+        periods: ['2026-02', '2026-03', '2026-04', '2026-05', '2026-06'],
+      });
+
+      expect(prismaService.charge.findMany).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          tenantId: 'tenant-1',
+          canceledAt: null,
+          period: {
+            in: ['2026-02', '2026-03', '2026-04', '2026-05', '2026-06'],
+          },
+        }),
+      }));
+    });
+
+    it('keeps the legacy tenant period string path compatible', async () => {
+      jest.spyOn(prismaService.tenant, 'findUniqueOrThrow').mockResolvedValue({ currency: 'ARS' } as never);
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([
+        {
+          id: 'charge-1',
+          tenantId: 'tenant-1',
+          buildingId: 'building-1',
+          unitId: 'unit-1',
+          amount: 1000,
+          paymentAllocations: [],
+        },
+      ] as never);
+      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue([
+        {
+          id: 'unit-1',
+          label: '0101',
+          buildingId: 'building-1',
+          building: { name: 'Edificio A' },
+        },
+      ] as never);
+
+      await service.getTenantFinancialSummary('tenant-1', '2026-06');
+
+      expect(prismaService.charge.findMany).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          period: '2026-06',
+        }),
+      }));
     });
   });
 });

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -34,6 +34,11 @@ export interface PendingPaymentListItem extends Payment {
   proofDocumentId?: string | null;
 }
 
+export interface BuildingFinancialSummaryPeriodFilter {
+  period?: string;
+  periods?: string[];
+}
+
 @Injectable()
 export class FinanzasService {
   private readonly logger = new Logger(FinanzasService.name);
@@ -1084,7 +1089,7 @@ export class FinanzasService {
   async getBuildingFinancialSummary(
     tenantId: string,
     buildingId: string,
-    period?: string,
+    period?: string | BuildingFinancialSummaryPeriodFilter,
   ): Promise<FinancialSummaryDto> {
     // 1. Validate building
     await this.validators.validateBuildingBelongsToTenant(
@@ -1105,8 +1110,12 @@ export class FinanzasService {
       canceledAt: null,
     };
 
-    if (period) {
+    if (typeof period === 'string') {
       where.period = period;
+    } else if (period?.periods?.length) {
+      where.period = { in: period.periods };
+    } else if (period?.period) {
+      where.period = period.period;
     }
 
     // 2. Get all charges and allocations
@@ -1582,7 +1591,7 @@ export class FinanzasService {
    */
   async getTenantFinancialSummary(
     tenantId: string,
-    period?: string,
+    period?: string | BuildingFinancialSummaryPeriodFilter,
   ): Promise<FinancialSummaryDto> {
     // Load tenant to get currency
     const tenant = await this.prisma.tenant.findUniqueOrThrow({
@@ -1595,8 +1604,12 @@ export class FinanzasService {
       tenantId,
       canceledAt: null,
     };
-    if (period) {
+    if (typeof period === 'string') {
       chargeWhere.period = period;
+    } else if (period?.periods?.length) {
+      chargeWhere.period = { in: period.periods };
+    } else if (period?.period) {
+      chargeWhere.period = period.period;
     }
 
     // 2. Get all charges (aggregate by status, sum amounts)


### PR DESCRIPTION
## Summary

Implemented canonical relative period preservation for tenant-wide debt queries in Assistant Chat V2.

This extends the finance debt period handling flow after the `building_debt` implementation:

* Preserves `relative_range` for `tenant_debt`
* Resolves tenant debt periods through the canonical period flow
* Supports `including_current` and `closed_months` modes
* Keeps `accumulated` behavior compatible with legacy behavior
* Does not use `createdAt` as the primary debt period filter
* Does not touch writes, payments, expenses, income, `.env`, or secrets

## Validation

* `rtk tsc -p apps/api/tsconfig.json --noEmit`
* Focused assistant/finance test suite
* `rtk git diff --check`

## Risk

Low. Changes are limited to assistant finance debt period handling and preserve legacy behavior for accumulated and single-period debt queries.

## Commit

`11ab387` — `fix(assistant): preserve tenant relative debt periods`
