### PR TITLE
feat(finance): persist immutable liquidation snapshots

### DIFF
--- a/apps/api/prisma/migrations/20260711000000_add_liquidation_publication_snapshot/migration.sql
+++ b/apps/api/prisma/migrations/20260711000000_add_liquidation_publication_snapshot/migration.sql
@@ -1,0 +1,264 @@
+-- Add immutable publication snapshot for published liquidations
+ALTER TABLE "Liquidation"
+ADD COLUMN "publicationSnapshot" JSONB;
+
+CREATE OR REPLACE FUNCTION enforce_liquidation_publication_snapshot_immutable()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  has_review_metadata boolean;
+  has_publish_metadata boolean;
+  has_cancel_metadata boolean;
+BEGIN
+  has_review_metadata := NEW."reviewedAt" IS NOT NULL
+    OR NEW."reviewedByMembershipId" IS NOT NULL;
+  has_publish_metadata := NEW."publicationSnapshot" IS NOT NULL
+    OR NEW."publishedAt" IS NOT NULL
+    OR NEW."publishedByMembershipId" IS NOT NULL;
+  has_cancel_metadata := NEW."canceledAt" IS NOT NULL
+    OR NEW."canceledByMembershipId" IS NOT NULL;
+
+  IF NEW."generatedByMembershipId" IS NULL THEN
+    RAISE EXCEPTION 'liquidations require generatedByMembershipId';
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    CASE NEW."status"
+      WHEN 'DRAFT' THEN
+        IF has_review_metadata THEN
+          RAISE EXCEPTION 'draft liquidations cannot carry review metadata';
+        END IF;
+        IF has_publish_metadata THEN
+          RAISE EXCEPTION 'draft liquidations cannot carry publication metadata';
+        END IF;
+        IF has_cancel_metadata THEN
+          RAISE EXCEPTION 'draft liquidations cannot carry cancellation metadata';
+        END IF;
+        IF NEW."publicationSnapshot" IS NOT NULL THEN
+          RAISE EXCEPTION 'draft liquidations cannot carry publicationSnapshot';
+        END IF;
+      ELSE
+        RAISE EXCEPTION 'new liquidations must start in DRAFT';
+    END CASE;
+
+    RETURN NEW;
+  END IF;
+
+  IF OLD."status" = 'PUBLISHED' THEN
+    IF NEW."status" IS DISTINCT FROM OLD."status" THEN
+      RAISE EXCEPTION 'published liquidations cannot change status';
+    END IF;
+
+    IF NEW."tenantId" IS DISTINCT FROM OLD."tenantId"
+       OR NEW."id" IS DISTINCT FROM OLD."id"
+       OR NEW."buildingId" IS DISTINCT FROM OLD."buildingId"
+       OR NEW."period" IS DISTINCT FROM OLD."period"
+       OR NEW."chargePeriod" IS DISTINCT FROM OLD."chargePeriod"
+       OR NEW."baseCurrency" IS DISTINCT FROM OLD."baseCurrency"
+       OR NEW."totalAmountMinor" IS DISTINCT FROM OLD."totalAmountMinor"
+       OR NEW."totalsByCurrency" IS DISTINCT FROM OLD."totalsByCurrency"
+       OR NEW."expenseSnapshot" IS DISTINCT FROM OLD."expenseSnapshot"
+       OR NEW."unitCount" IS DISTINCT FROM OLD."unitCount"
+       OR NEW."generatedByMembershipId" IS DISTINCT FROM OLD."generatedByMembershipId"
+       OR NEW."generatedAt" IS DISTINCT FROM OLD."generatedAt"
+       OR NEW."reviewedByMembershipId" IS DISTINCT FROM OLD."reviewedByMembershipId"
+       OR NEW."reviewedAt" IS DISTINCT FROM OLD."reviewedAt"
+       OR NEW."publishedByMembershipId" IS DISTINCT FROM OLD."publishedByMembershipId"
+       OR NEW."publishedAt" IS DISTINCT FROM OLD."publishedAt"
+       OR NEW."canceledByMembershipId" IS DISTINCT FROM OLD."canceledByMembershipId"
+       OR NEW."canceledAt" IS DISTINCT FROM OLD."canceledAt"
+       OR NEW."createdAt" IS DISTINCT FROM OLD."createdAt"
+       OR NEW."publicationSnapshot" IS DISTINCT FROM OLD."publicationSnapshot"
+    THEN
+      RAISE EXCEPTION 'published liquidations are immutable';
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  IF OLD."status" = 'CANCELED' THEN
+    IF NEW."status" IS DISTINCT FROM OLD."status" THEN
+      RAISE EXCEPTION 'canceled liquidations cannot change status';
+    END IF;
+
+    IF NEW."tenantId" IS DISTINCT FROM OLD."tenantId"
+       OR NEW."id" IS DISTINCT FROM OLD."id"
+       OR NEW."buildingId" IS DISTINCT FROM OLD."buildingId"
+       OR NEW."period" IS DISTINCT FROM OLD."period"
+       OR NEW."chargePeriod" IS DISTINCT FROM OLD."chargePeriod"
+       OR NEW."baseCurrency" IS DISTINCT FROM OLD."baseCurrency"
+       OR NEW."totalAmountMinor" IS DISTINCT FROM OLD."totalAmountMinor"
+       OR NEW."totalsByCurrency" IS DISTINCT FROM OLD."totalsByCurrency"
+       OR NEW."expenseSnapshot" IS DISTINCT FROM OLD."expenseSnapshot"
+       OR NEW."unitCount" IS DISTINCT FROM OLD."unitCount"
+       OR NEW."generatedByMembershipId" IS DISTINCT FROM OLD."generatedByMembershipId"
+       OR NEW."generatedAt" IS DISTINCT FROM OLD."generatedAt"
+       OR NEW."reviewedByMembershipId" IS DISTINCT FROM OLD."reviewedByMembershipId"
+       OR NEW."reviewedAt" IS DISTINCT FROM OLD."reviewedAt"
+       OR NEW."publishedByMembershipId" IS DISTINCT FROM OLD."publishedByMembershipId"
+       OR NEW."publishedAt" IS DISTINCT FROM OLD."publishedAt"
+       OR NEW."canceledByMembershipId" IS DISTINCT FROM OLD."canceledByMembershipId"
+       OR NEW."canceledAt" IS DISTINCT FROM OLD."canceledAt"
+       OR NEW."createdAt" IS DISTINCT FROM OLD."createdAt"
+       OR NEW."publicationSnapshot" IS DISTINCT FROM OLD."publicationSnapshot"
+    THEN
+      RAISE EXCEPTION 'canceled liquidations are immutable';
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  CASE NEW."status"
+    WHEN 'DRAFT' THEN
+      IF OLD."status" IS DISTINCT FROM 'DRAFT' THEN
+        RAISE EXCEPTION 'invalid liquidation status transition from % to %', OLD."status", NEW."status";
+      END IF;
+      IF has_review_metadata THEN
+        RAISE EXCEPTION 'draft liquidations cannot carry review metadata';
+      END IF;
+      IF has_publish_metadata THEN
+        RAISE EXCEPTION 'draft liquidations cannot carry publication metadata';
+      END IF;
+      IF has_cancel_metadata THEN
+        RAISE EXCEPTION 'draft liquidations cannot carry cancellation metadata';
+      END IF;
+      IF NEW."publicationSnapshot" IS NOT NULL THEN
+        RAISE EXCEPTION 'draft liquidations cannot carry publicationSnapshot';
+      END IF;
+    WHEN 'REVIEWED' THEN
+      IF OLD."status" NOT IN ('DRAFT', 'REVIEWED') THEN
+        RAISE EXCEPTION 'invalid liquidation status transition from % to %', OLD."status", NEW."status";
+      END IF;
+      IF NEW."reviewedAt" IS NULL OR NEW."reviewedByMembershipId" IS NULL THEN
+        RAISE EXCEPTION 'reviewed liquidations require reviewedAt and reviewedByMembershipId';
+      END IF;
+      IF has_publish_metadata THEN
+        RAISE EXCEPTION 'reviewed liquidations cannot carry publication metadata';
+      END IF;
+      IF has_cancel_metadata THEN
+        RAISE EXCEPTION 'reviewed liquidations cannot carry cancellation metadata';
+      END IF;
+      IF NEW."publicationSnapshot" IS NOT NULL THEN
+        RAISE EXCEPTION 'reviewed liquidations cannot carry publicationSnapshot';
+      END IF;
+      IF NEW."status" = OLD."status" THEN
+        IF NEW."tenantId" IS DISTINCT FROM OLD."tenantId"
+           OR NEW."id" IS DISTINCT FROM OLD."id"
+           OR NEW."buildingId" IS DISTINCT FROM OLD."buildingId"
+           OR NEW."period" IS DISTINCT FROM OLD."period"
+           OR NEW."chargePeriod" IS DISTINCT FROM OLD."chargePeriod"
+           OR NEW."baseCurrency" IS DISTINCT FROM OLD."baseCurrency"
+           OR NEW."totalAmountMinor" IS DISTINCT FROM OLD."totalAmountMinor"
+           OR NEW."totalsByCurrency" IS DISTINCT FROM OLD."totalsByCurrency"
+           OR NEW."expenseSnapshot" IS DISTINCT FROM OLD."expenseSnapshot"
+           OR NEW."unitCount" IS DISTINCT FROM OLD."unitCount"
+           OR NEW."generatedByMembershipId" IS DISTINCT FROM OLD."generatedByMembershipId"
+           OR NEW."generatedAt" IS DISTINCT FROM OLD."generatedAt"
+           OR NEW."reviewedByMembershipId" IS DISTINCT FROM OLD."reviewedByMembershipId"
+           OR NEW."reviewedAt" IS DISTINCT FROM OLD."reviewedAt"
+           OR NEW."publicationSnapshot" IS DISTINCT FROM OLD."publicationSnapshot"
+           OR NEW."createdAt" IS DISTINCT FROM OLD."createdAt"
+        THEN
+          RAISE EXCEPTION 'reviewed liquidations are immutable';
+        END IF;
+      END IF;
+    WHEN 'PUBLISHED' THEN
+      IF OLD."status" IS DISTINCT FROM 'REVIEWED' THEN
+        RAISE EXCEPTION 'invalid liquidation status transition from % to %', OLD."status", NEW."status";
+      END IF;
+      IF NEW."publicationSnapshot" IS NULL
+         OR NEW."publishedAt" IS NULL
+         OR NEW."publishedByMembershipId" IS NULL
+      THEN
+        RAISE EXCEPTION 'publishing a liquidation requires publicationSnapshot, publishedAt and publishedByMembershipId';
+      END IF;
+      IF NEW."canceledAt" IS NOT NULL OR NEW."canceledByMembershipId" IS NOT NULL THEN
+        RAISE EXCEPTION 'published liquidations cannot carry cancellation metadata';
+      END IF;
+      IF NEW."tenantId" IS DISTINCT FROM OLD."tenantId"
+         OR NEW."id" IS DISTINCT FROM OLD."id"
+         OR NEW."buildingId" IS DISTINCT FROM OLD."buildingId"
+         OR NEW."period" IS DISTINCT FROM OLD."period"
+         OR NEW."chargePeriod" IS DISTINCT FROM OLD."chargePeriod"
+         OR NEW."baseCurrency" IS DISTINCT FROM OLD."baseCurrency"
+         OR NEW."totalAmountMinor" IS DISTINCT FROM OLD."totalAmountMinor"
+         OR NEW."totalsByCurrency" IS DISTINCT FROM OLD."totalsByCurrency"
+         OR NEW."expenseSnapshot" IS DISTINCT FROM OLD."expenseSnapshot"
+         OR NEW."unitCount" IS DISTINCT FROM OLD."unitCount"
+         OR NEW."generatedByMembershipId" IS DISTINCT FROM OLD."generatedByMembershipId"
+         OR NEW."generatedAt" IS DISTINCT FROM OLD."generatedAt"
+         OR NEW."reviewedByMembershipId" IS DISTINCT FROM OLD."reviewedByMembershipId"
+         OR NEW."reviewedAt" IS DISTINCT FROM OLD."reviewedAt"
+         OR NEW."canceledByMembershipId" IS DISTINCT FROM OLD."canceledByMembershipId"
+         OR NEW."canceledAt" IS DISTINCT FROM OLD."canceledAt"
+         OR NEW."createdAt" IS DISTINCT FROM OLD."createdAt"
+      THEN
+        RAISE EXCEPTION 'publishing a liquidation cannot change financial history';
+      END IF;
+    WHEN 'CANCELED' THEN
+      IF OLD."status" NOT IN ('DRAFT', 'REVIEWED') THEN
+        RAISE EXCEPTION 'invalid liquidation status transition from % to %', OLD."status", NEW."status";
+      END IF;
+      IF NEW."canceledAt" IS NULL OR NEW."canceledByMembershipId" IS NULL THEN
+        RAISE EXCEPTION 'canceled liquidations require canceledAt and canceledByMembershipId';
+      END IF;
+      IF has_publish_metadata THEN
+        RAISE EXCEPTION 'canceled liquidations cannot carry publication metadata';
+      END IF;
+      IF NEW."publicationSnapshot" IS NOT NULL THEN
+        RAISE EXCEPTION 'canceled liquidations cannot carry publicationSnapshot';
+      END IF;
+      IF NEW."tenantId" IS DISTINCT FROM OLD."tenantId"
+         OR NEW."id" IS DISTINCT FROM OLD."id"
+         OR NEW."buildingId" IS DISTINCT FROM OLD."buildingId"
+         OR NEW."period" IS DISTINCT FROM OLD."period"
+         OR NEW."chargePeriod" IS DISTINCT FROM OLD."chargePeriod"
+         OR NEW."baseCurrency" IS DISTINCT FROM OLD."baseCurrency"
+         OR NEW."totalAmountMinor" IS DISTINCT FROM OLD."totalAmountMinor"
+         OR NEW."totalsByCurrency" IS DISTINCT FROM OLD."totalsByCurrency"
+         OR NEW."expenseSnapshot" IS DISTINCT FROM OLD."expenseSnapshot"
+         OR NEW."unitCount" IS DISTINCT FROM OLD."unitCount"
+         OR NEW."generatedByMembershipId" IS DISTINCT FROM OLD."generatedByMembershipId"
+         OR NEW."generatedAt" IS DISTINCT FROM OLD."generatedAt"
+         OR NEW."reviewedByMembershipId" IS DISTINCT FROM OLD."reviewedByMembershipId"
+         OR NEW."reviewedAt" IS DISTINCT FROM OLD."reviewedAt"
+         OR NEW."publishedByMembershipId" IS DISTINCT FROM OLD."publishedByMembershipId"
+         OR NEW."publishedAt" IS DISTINCT FROM OLD."publishedAt"
+         OR NEW."createdAt" IS DISTINCT FROM OLD."createdAt"
+         OR NEW."publicationSnapshot" IS DISTINCT FROM OLD."publicationSnapshot"
+      THEN
+        RAISE EXCEPTION 'canceling a liquidation cannot change financial history';
+      END IF;
+    ELSE
+      RAISE EXCEPTION 'unknown liquidation status: %', NEW."status";
+  END CASE;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER "Liquidation_publicationSnapshot_immutable"
+BEFORE INSERT OR UPDATE ON "Liquidation"
+FOR EACH ROW
+EXECUTE FUNCTION enforce_liquidation_publication_snapshot_immutable();
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "Liquidation"
+    WHERE "status" = 'PUBLISHED'
+    GROUP BY "tenantId", "buildingId", "period"
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23505',
+      MESSAGE = 'cannot create published liquidation uniqueness constraint: duplicate published liquidations exist for tenant, building and period';
+  END IF;
+END;
+$$;
+
+CREATE UNIQUE INDEX "Liquidation_unique_published_tenant_building_period"
+ON "Liquidation" ("tenantId", "buildingId", "period")
+WHERE "status" = 'PUBLISHED';

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1778,6 +1778,7 @@ model Liquidation {
   totalAmountMinor         Int               // Total en centavos derivado de gastos VALIDATED
   totalsByCurrency         Json              // Snapshot: { "ARS": 150000, "USD": 5000 }
   expenseSnapshot          Json              // Array de { expenseId, amountMinor, currencyCode, type: "EXPENSE"|"ADJUSTMENT" }
+  publicationSnapshot      Json?             // Immutable snapshot persisted when published
   unitCount                Int               // Unidades billables al momento de draft
   generatedByMembershipId  String
   generatedAt              DateTime          @default(now())

--- a/apps/api/src/audit/audit.controller.spec.ts
+++ b/apps/api/src/audit/audit.controller.spec.ts
@@ -1,0 +1,206 @@
+import { ArgumentMetadata, BadRequestException, ForbiddenException, ValidationPipe } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { AuditAction } from '@prisma/client';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AuditController, type RequestWithUser } from './audit.controller';
+import { AuditService } from './audit.service';
+import { AuditLogQueryDto } from './dto/audit-log-query.dto';
+
+describe('AuditController', () => {
+  let controller: AuditController;
+  let auditService: {
+    queryLogs: jest.Mock;
+    queryTenantLogs: jest.Mock;
+    queryGlobalLogsForSuperAdmin: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    auditService = {
+      queryLogs: jest.fn().mockResolvedValue({ data: [], total: 0 }),
+      queryTenantLogs: jest.fn().mockResolvedValue({ data: [], total: 0 }),
+      queryGlobalLogsForSuperAdmin: jest.fn().mockResolvedValue({ data: [], total: 0 }),
+    };
+
+    const module = await Test.createTestingModule({
+      controllers: [AuditController],
+      providers: [
+        {
+          provide: AuditService,
+          useValue: auditService,
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: jest.fn().mockResolvedValue(true) })
+      .compile();
+
+    controller = module.get(AuditController);
+  });
+
+  it('uses the requested tenant membership without flattening roles across memberships', async () => {
+    const req = buildRequest([
+      { id: 'member-a', tenantId: 'tenant-a', roles: ['RESIDENT'] },
+      { id: 'member-b', tenantId: 'tenant-b', roles: ['TENANT_ADMIN'] },
+    ]);
+
+    const query = await validateQuery({
+      tenantId: ' tenant-b ',
+      actorUserId: 'user-2',
+      entityType: 'Liquidation',
+      action: AuditAction.LIQUIDATION_PUBLISH,
+      dateFrom: '2026-07-01T00:00:00.000Z',
+      dateTo: '2026-07-02T00:00:00.000Z',
+      page: 2,
+      limit: 25,
+    });
+
+    await expect(controller.getLogs(req, query)).resolves.toEqual({
+      data: [],
+      total: 0,
+      pagination: {
+        page: 2,
+        limit: 25,
+        skip: 25,
+        take: 25,
+        total: 0,
+      },
+    });
+
+    expect(auditService.queryTenantLogs).toHaveBeenCalledWith('tenant-b', 'member-b', {
+      actorUserId: 'user-2',
+      action: AuditAction.LIQUIDATION_PUBLISH,
+      entityType: 'Liquidation',
+      dateFrom: new Date('2026-07-01T00:00:00.000Z'),
+      dateTo: new Date('2026-07-02T00:00:00.000Z'),
+      skip: 25,
+      take: 25,
+    });
+  });
+
+  it('rejects a tenantId that is not backed by an audit-eligible membership', async () => {
+    const req = buildRequest([
+      { id: 'member-a', tenantId: 'tenant-a', roles: ['TENANT_ADMIN'] },
+    ]);
+    const query = await validateQuery({ tenantId: 'tenant-b' });
+
+    await expect(controller.getLogs(req, query)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(auditService.queryTenantLogs).not.toHaveBeenCalled();
+  });
+
+  it('uses the only eligible tenant when tenantId is omitted', async () => {
+    const req = buildRequest([
+      { id: 'member-a', tenantId: 'tenant-a', roles: ['RESIDENT'] },
+      { id: 'member-b', tenantId: 'tenant-b', roles: ['TENANT_OWNER'] },
+    ]);
+    const query = await validateQuery({ page: 1, limit: 10 });
+
+    await controller.getLogs(req, query);
+
+    expect(auditService.queryTenantLogs).toHaveBeenCalledWith('tenant-b', 'member-b', {
+      actorUserId: undefined,
+      action: undefined,
+      entityType: undefined,
+      dateFrom: undefined,
+      dateTo: undefined,
+      skip: 0,
+      take: 10,
+    });
+  });
+
+  it('uses the request tenant context when it is already defined', async () => {
+    const req = buildRequest(
+      [
+        { id: 'member-a', tenantId: 'tenant-a', roles: ['TENANT_ADMIN'] },
+        { id: 'member-b', tenantId: 'tenant-b', roles: ['TENANT_OWNER'] },
+      ],
+      'tenant-b',
+    );
+    const query = await validateQuery({ limit: 15 });
+
+    await controller.getLogs(req, query);
+
+    expect(auditService.queryTenantLogs).toHaveBeenCalledWith('tenant-b', 'member-b', {
+      actorUserId: undefined,
+      action: undefined,
+      entityType: undefined,
+      dateFrom: undefined,
+      dateTo: undefined,
+      skip: 0,
+      take: 15,
+    });
+  });
+
+  it('rejects ambiguous tenant scope when tenantId is omitted', async () => {
+    const req = buildRequest([
+      { id: 'member-a', tenantId: 'tenant-a', roles: ['TENANT_ADMIN'] },
+      { id: 'member-b', tenantId: 'tenant-b', roles: ['TENANT_OWNER'] },
+    ]);
+    const query = await validateQuery({ limit: 20 });
+
+    await expect(controller.getLogs(req, query)).rejects.toThrow(
+      BadRequestException,
+    );
+    expect(auditService.queryTenantLogs).not.toHaveBeenCalled();
+  });
+
+  it('rejects resident-only memberships from tenant-scoped audit access', async () => {
+    const req = buildRequest([
+      { id: 'member-a', tenantId: 'tenant-a', roles: ['RESIDENT'] },
+    ]);
+    const query = await validateQuery({ tenantId: 'tenant-a' });
+
+    await expect(controller.getLogs(req, query)).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(auditService.queryTenantLogs).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { body: { tenantId: 'tenant-a', page: 'abc' } },
+    { body: { tenantId: 'tenant-a', limit: -1 } },
+    { body: { tenantId: 'tenant-a', limit: 101 } },
+    { body: { tenantId: 'tenant-a', action: 'NOT_REAL' } },
+    { body: { tenantId: 'tenant-a', dateFrom: 'not-a-date' } },
+  ])('rejects invalid audit query parameters', async ({ body }) => {
+    await expect(validateQuery(body)).rejects.toMatchObject({
+      status: 400,
+    });
+  });
+
+  async function validateQuery(body: unknown): Promise<AuditLogQueryDto> {
+    const pipe = new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: false,
+      transform: true,
+      transformOptions: {
+        enableImplicitConversion: true,
+      },
+    });
+
+    const metadata: ArgumentMetadata = {
+      type: 'query',
+      metatype: AuditLogQueryDto,
+      data: undefined,
+    };
+
+    return pipe.transform(body, metadata) as Promise<AuditLogQueryDto>;
+  }
+
+  function buildRequest(
+    memberships: RequestWithUser['user']['memberships'],
+    tenantId?: string,
+  ): RequestWithUser {
+    return {
+      user: {
+        id: 'user-1',
+        email: 'user@example.com',
+        name: 'User',
+        tenantId,
+        membershipId: memberships[0]?.id,
+        memberships,
+      },
+    } as RequestWithUser;
+  }
+});

--- a/apps/api/src/audit/audit.controller.ts
+++ b/apps/api/src/audit/audit.controller.ts
@@ -1,115 +1,181 @@
-import { Controller, Get, Query, UseGuards, Request, ForbiddenException } from '@nestjs/common';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
-import { AuditService, AuditLogQueryFilters } from './audit.service';
+import {
+  BadRequestException,
+  Controller,
+  ForbiddenException,
+  Get,
+  Query,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
 import { AuditAction } from '@prisma/client';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AuditLogQueryDto } from './dto/audit-log-query.dto';
+import { AuditService } from './audit.service';
 
 export interface RequestWithUser extends Request {
+  tenantId?: string;
   user: {
     id: string;
     email: string;
     name: string;
+    tenantId?: string;
+    membershipId?: string;
+    roles?: string[];
+    effectiveMembership?: {
+      id: string;
+      tenantId: string;
+      roles: string[];
+    };
     memberships: Array<{
+      id: string;
       tenantId: string;
       roles: string[];
     }>;
   };
 }
 
-/**
- * AuditController: Query audit logs
- *
- * ACCESS CONTROL:
- * - SUPER_ADMIN: Can query all tenants or filter by specific tenantId
- * - TENANT_ADMIN/OWNER/OPERATOR: Forced to their own primary tenantId
- * - RESIDENT: 403 Forbidden (no audit access)
- *
- * ENDPOINT: GET /audit/logs
- * QUERY PARAMS:
- *   - tenantId (optional, forced if not SUPER_ADMIN)
- *   - actorUserId (optional)
- *   - action (optional, any AuditAction enum value)
- *   - entityType (optional, e.g., "Ticket", "Building")
- *   - dateFrom (optional, ISO date string)
- *   - dateTo (optional, ISO date string)
- *   - skip (optional, default 0)
- *   - take (optional, default 50, max 100)
- */
 @Controller('audit')
 @UseGuards(JwtAuthGuard)
 export class AuditController {
-  constructor(private auditService: AuditService) {}
+  constructor(private readonly auditService: AuditService) {}
 
   @Get('logs')
   async getLogs(
     @Request() req: RequestWithUser,
-    @Query('tenantId') queryTenantId?: string,
-    @Query('actorUserId') actorUserId?: string,
-    @Query('action') action?: string,
-    @Query('entityType') entityType?: string,
-    @Query('dateFrom') dateFrom?: string,
-    @Query('dateTo') dateTo?: string,
-    @Query('skip') skip?: string,
-    @Query('take') take?: string,
+    @Query() query: AuditLogQueryDto,
   ) {
-    // Check role: RESIDENT cannot access audit logs
-    const userRoles = req.user.memberships.flatMap((m) => m.roles);
-    const isSuperAdmin = userRoles.includes('SUPER_ADMIN');
-    const isResident = userRoles.includes('RESIDENT') && !isSuperAdmin;
+    const memberships = req.user?.memberships ?? [];
+    const isSuperAdmin = memberships.some((membership) =>
+      membership.roles.includes('SUPER_ADMIN'),
+    );
 
-    if (isResident) {
+    if (!isSuperAdmin && memberships.every((membership) => membership.roles.includes('RESIDENT'))) {
       throw new ForbiddenException('Residents cannot access audit logs');
     }
 
-    // Determine effective tenantId based on role
-    let effectiveTenantId: string | undefined;
-
-    if (isSuperAdmin) {
-      // SUPER_ADMIN: use provided tenantId or undefined (no filter)
-      effectiveTenantId = queryTenantId;
-    } else {
-      // TENANT_ADMIN/OWNER/OPERATOR: must use their tenantId
-      const firstTenantId = req.user.memberships[0]?.tenantId;
-      if (!firstTenantId) {
-        return {
-          data: [],
-          total: 0,
-          message: 'No active tenant',
-        };
-      }
-      effectiveTenantId = firstTenantId;
-      // Ignore queryTenantId if provided (security: force own tenant)
-    }
-
-    // Parse date filters
-    const dateFromObj = dateFrom ? new Date(dateFrom) : undefined;
-    const dateToObj = dateTo ? new Date(dateTo) : undefined;
-
-    // Parse pagination
-    const skipNum = skip ? Math.max(0, parseInt(skip, 10)) : 0;
-    let takeNum = take ? Math.max(1, parseInt(take, 10)) : 50;
-    takeNum = Math.min(takeNum, 100); // Max 100 per request
-
-    // Build query filters
-    const filters: AuditLogQueryFilters = {
-      tenantId: effectiveTenantId,
-      actorUserId,
-      action: action ? (action as AuditAction) : undefined,
-      entityType,
-      dateFrom: dateFromObj,
-      dateTo: dateToObj,
-      skip: skipNum,
-      take: takeNum,
+    const context = this.resolveAuditContext(req, query.tenantId, isSuperAdmin);
+    const page = query.page ?? 1;
+    const limit = query.limit ?? 50;
+    const skip = (page - 1) * limit;
+    const filters = {
+      actorUserId: query.actorUserId,
+      action: query.action,
+      entityType: query.entityType,
+      dateFrom: query.dateFrom ? new Date(query.dateFrom) : undefined,
+      dateTo: query.dateTo ? new Date(query.dateTo) : undefined,
+      skip,
+      take: limit,
     };
 
-    const result = await this.auditService.queryLogs(filters);
+    const result = isSuperAdmin
+      ? await this.auditService.queryGlobalLogsForSuperAdmin(context.tenantId, filters)
+      : await this.auditService.queryTenantLogs(context.tenantId, context.membershipId, filters);
 
     return {
       ...result,
       pagination: {
-        skip: skipNum,
-        take: takeNum,
+        page,
+        limit,
+        skip,
+        take: limit,
         total: result.total,
       },
     };
+  }
+
+  private resolveAuditContext(
+    req: RequestWithUser,
+    requestedTenantId: string | undefined,
+    isSuperAdmin: boolean,
+  ): { tenantId: string; membershipId: string } {
+    const normalizedRequestedTenantId = requestedTenantId?.trim();
+    const memberships = req.user?.memberships ?? [];
+    const effectiveMembership = req.user?.effectiveMembership;
+    const directTenantId = req.tenantId?.trim() ?? req.user?.tenantId?.trim();
+
+    if (isSuperAdmin) {
+      if (!normalizedRequestedTenantId) {
+        throw new BadRequestException('tenantId is required for super-admin audit queries');
+      }
+
+      return { tenantId: normalizedRequestedTenantId, membershipId: '' };
+    }
+
+    if (normalizedRequestedTenantId) {
+      const requestedMembership = this.findMembershipForTenant(
+        memberships,
+        effectiveMembership,
+        normalizedRequestedTenantId,
+      );
+
+      if (!requestedMembership) {
+        throw new ForbiddenException('Residents cannot access audit logs');
+      }
+
+      return requestedMembership;
+    }
+
+    if (directTenantId) {
+      const directMembership = this.findMembershipForTenant(
+        memberships,
+        effectiveMembership,
+        directTenantId,
+      );
+
+      if (!directMembership) {
+        throw new ForbiddenException('Residents cannot access audit logs');
+      }
+
+      return directMembership;
+    }
+
+    const eligibleMemberships = memberships.filter((membership) =>
+      membership.roles.some((role) => role !== 'RESIDENT'),
+    );
+
+    if (eligibleMemberships.length === 0) {
+      throw new ForbiddenException('Residents cannot access audit logs');
+    }
+
+    if (eligibleMemberships.length > 1) {
+      throw new BadRequestException('Ambiguous tenant scope');
+    }
+
+    const [onlyMembership] = eligibleMemberships;
+    if (!onlyMembership) {
+      throw new ForbiddenException('Residents cannot access audit logs');
+    }
+
+    return { tenantId: onlyMembership.tenantId.trim(), membershipId: onlyMembership.id.trim() };
+  }
+
+  private findMembershipForTenant(
+    memberships: RequestWithUser['user']['memberships'],
+    effectiveMembership: RequestWithUser['user']['effectiveMembership'],
+    tenantId: string,
+  ): { tenantId: string; membershipId: string } | null {
+    const effectiveMatchesTenant = effectiveMembership?.tenantId === tenantId;
+    const membership = effectiveMatchesTenant
+      ? {
+          id: effectiveMembership.id,
+          tenantId: effectiveMembership.tenantId,
+          roles: effectiveMembership.roles,
+        }
+      : memberships.find((candidate) => candidate.tenantId === tenantId);
+
+    if (!membership) {
+      return null;
+    }
+
+    if (membership.roles.every((role) => role === 'RESIDENT')) {
+      return null;
+    }
+
+    const membershipId = membership.id?.trim();
+    if (!membershipId) {
+      return null;
+    }
+
+    return { tenantId: membership.tenantId.trim(), membershipId };
   }
 }

--- a/apps/api/src/audit/audit.service.spec.ts
+++ b/apps/api/src/audit/audit.service.spec.ts
@@ -1,0 +1,338 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException } from '@nestjs/common';
+import { AuditAction } from '@prisma/client';
+import { AuditService } from './audit.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('AuditService', () => {
+  let service: AuditService;
+  let prisma: {
+    auditLog: {
+      create: jest.Mock;
+      findMany: jest.Mock;
+      count: jest.Mock;
+    };
+  };
+
+  beforeEach(async () => {
+    prisma = {
+      auditLog: {
+        create: jest.fn().mockResolvedValue(undefined),
+        findMany: jest.fn().mockResolvedValue([]),
+        count: jest.fn().mockResolvedValue(0),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuditService,
+        {
+          provide: PrismaService,
+          useValue: prisma,
+        },
+      ],
+    }).compile();
+
+    service = module.get(AuditService);
+  });
+
+  it('requires a tenantId for tenant-scoped queries', async () => {
+    await expect(service.queryLogs('')).rejects.toThrow(BadRequestException);
+  });
+
+  it('trims the tenantId before querying audit logs', async () => {
+    await service.queryLogs('  tenant-a  ');
+
+    expect(prisma.auditLog.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { tenantId: 'tenant-a' },
+      }),
+    );
+    expect(prisma.auditLog.count).toHaveBeenCalledWith({
+      where: { tenantId: 'tenant-a' },
+    });
+  });
+
+  it('always scopes audit queries to the requested tenant', async () => {
+    await service.queryLogs('tenant-a', {
+      actorUserId: 'user-1',
+      action: AuditAction.LIQUIDATION_PUBLISH,
+      entityType: 'Liquidation',
+      skip: 5,
+      take: 10,
+    });
+
+    expect(prisma.auditLog.findMany).toHaveBeenCalledWith({
+      where: {
+        tenantId: 'tenant-a',
+        actorUserId: 'user-1',
+        action: AuditAction.LIQUIDATION_PUBLISH,
+        entity: 'Liquidation',
+      },
+      orderBy: { createdAt: 'desc' },
+      skip: 5,
+      take: 10,
+      include: {
+        tenant: { select: { id: true, name: true } },
+        actor: { select: { id: true, email: true, name: true } },
+      },
+    });
+    expect(prisma.auditLog.count).toHaveBeenCalledWith({
+      where: {
+        tenantId: 'tenant-a',
+        actorUserId: 'user-1',
+        action: AuditAction.LIQUIDATION_PUBLISH,
+        entity: 'Liquidation',
+      },
+    });
+  });
+
+  it('keeps tenant isolation even when filters are empty', async () => {
+    await service.queryLogs('tenant-b');
+
+    expect(prisma.auditLog.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { tenantId: 'tenant-b' },
+      }),
+    );
+    expect(prisma.auditLog.count).toHaveBeenCalledWith({
+      where: { tenantId: 'tenant-b' },
+    });
+  });
+
+  it('rejects invalid query dates before querying audit logs', async () => {
+    await expect(
+      service.queryLogs('tenant-a', {
+        dateFrom: new Date('invalid'),
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(prisma.auditLog.findMany).not.toHaveBeenCalled();
+    expect(prisma.auditLog.count).not.toHaveBeenCalled();
+  });
+
+  it('writes transactional audit logs with the provided transaction client', async () => {
+    const tx = {
+      auditLog: {
+        create: jest.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    await service.createLogRequired(
+      {
+        tenantId: 'tenant-a',
+        actorMembershipId: 'member-1',
+        action: 'LIQUIDATION_REVIEW',
+        entityType: 'Liquidation',
+        entityId: 'liq-1',
+      },
+      tx as never,
+    );
+
+    expect(tx.auditLog.create).toHaveBeenCalledWith({
+      data: {
+        tenantId: 'tenant-a',
+        actorUserId: null,
+        actorMembershipId: 'member-1',
+        action: 'LIQUIDATION_REVIEW',
+        entity: 'Liquidation',
+        entityId: 'liq-1',
+        metadata: {},
+      },
+    });
+  });
+
+  it('persists JSON metadata values without unsafe casts', async () => {
+    const tx = {
+      auditLog: {
+        create: jest.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    await service.createLogRequired(
+      {
+        tenantId: 'tenant-a',
+        actorMembershipId: 'member-1',
+        action: 'LIQUIDATION_PUBLISH',
+        entityType: 'Liquidation',
+        entityId: 'liq-1',
+        metadata: {
+          count: 2,
+          flags: ['a', 'b'],
+          nested: {
+            ok: true,
+            note: 'ok',
+          },
+        },
+      },
+      tx as never,
+    );
+
+    expect(tx.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        tenantId: 'tenant-a',
+        actorMembershipId: 'member-1',
+        entityId: 'liq-1',
+        metadata: expect.objectContaining({
+          count: 2,
+          flags: ['a', 'b'],
+          nested: expect.objectContaining({
+            ok: true,
+            note: 'ok',
+          }),
+        }),
+      }),
+    });
+  });
+
+  it.each([
+    ['primitive metadata', 'hello'],
+    ['array metadata', ['one', 2, true, false]],
+  ])('accepts %s when metadata is JSON compatible', async (_label, metadata) => {
+    const tx = {
+      auditLog: {
+        create: jest.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    await service.createLogRequired(
+      {
+        tenantId: 'tenant-a',
+        actorMembershipId: 'member-1',
+        action: 'LIQUIDATION_PUBLISH',
+        entityType: 'Liquidation',
+        entityId: 'liq-1',
+        metadata,
+      },
+      tx as never,
+    );
+
+    expect(tx.auditLog.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        metadata,
+      }),
+    });
+  });
+
+  it('rejects null metadata values', async () => {
+    const tx = {
+      auditLog: {
+        create: jest.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    await expect(
+      service.createLogRequired(
+        {
+          tenantId: 'tenant-a',
+          actorMembershipId: 'member-1',
+          action: 'LIQUIDATION_PUBLISH',
+          entityType: 'Liquidation',
+          entityId: 'liq-1',
+          metadata: null,
+        },
+        tx as never,
+      ),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(tx.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-finite numeric metadata values', async () => {
+    const tx = {
+      auditLog: {
+        create: jest.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    await expect(
+      service.createLogRequired(
+        {
+          tenantId: 'tenant-a',
+          actorMembershipId: 'member-1',
+          action: 'LIQUIDATION_PUBLISH',
+          entityType: 'Liquidation',
+          entityId: 'liq-1',
+          metadata: Number.NaN,
+        },
+        tx as never,
+      ),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(tx.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['undefined property', { foo: undefined }],
+    ['date value', new Date('2026-05-01T00:00:00.000Z')],
+    ['bigint value', BigInt(1)],
+    ['symbol value', Symbol('audit')],
+    ['function value', () => undefined],
+    ['class instance', new (class AuditPayload {
+      value = 'x';
+    })()],
+  ])('rejects %s in audit metadata', async (_label, metadata) => {
+    const tx = {
+      auditLog: {
+        create: jest.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    await expect(
+      service.createLogRequired(
+        {
+          tenantId: 'tenant-a',
+          actorMembershipId: 'member-1',
+          action: 'LIQUIDATION_PUBLISH',
+          entityType: 'Liquidation',
+          entityId: 'liq-1',
+          metadata,
+        },
+        tx as never,
+      ),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(tx.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects circular audit metadata before writing', async () => {
+    const metadata: Record<string, unknown> = { self: null };
+    metadata.self = metadata;
+    const tx = {
+      auditLog: {
+        create: jest.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    await expect(
+      service.createLogRequired(
+        {
+          tenantId: 'tenant-a',
+          actorMembershipId: 'member-1',
+          action: 'LIQUIDATION_PUBLISH',
+          entityType: 'Liquidation',
+          entityId: 'liq-1',
+          metadata,
+        },
+        tx as never,
+      ),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(tx.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it('keeps createLog fire-and-forget when metadata is invalid', async () => {
+    await expect(
+      service.createLog({
+        tenantId: 'tenant-a',
+        actorMembershipId: 'member-1',
+        action: 'LIQUIDATION_PUBLISH',
+        entityType: 'Liquidation',
+        entityId: 'liq-1',
+        metadata: new Date('2026-05-01T00:00:00.000Z'),
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(prisma.auditLog.create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/audit/audit.service.ts
+++ b/apps/api/src/audit/audit.service.ts
@@ -1,6 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { PrismaService } from '../prisma/prisma.service';
+import { BadRequestException, ForbiddenException, Injectable, Logger } from '@nestjs/common';
 import { AuditAction, AuditLog, Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
 
 export interface AuditLogInput {
   tenantId?: string;
@@ -13,7 +13,6 @@ export interface AuditLogInput {
 }
 
 export interface AuditLogQueryFilters {
-  tenantId?: string;
   actorUserId?: string;
   action?: AuditAction;
   entityType?: string;
@@ -28,14 +27,32 @@ export interface AuditLogQueryResponse {
   total: number;
 }
 
-/**
- * AuditService: Global service for audit logging
- *
- * PATTERN:
- * - createLog() is fire-and-forget: async but never throws
- * - Never fails the main operation even if audit write fails
- * - Logs errors to console for debugging
- */
+interface AuditWriteClient {
+  auditLog: {
+    create: (args: { data: Prisma.AuditLogUncheckedCreateInput }) => Promise<unknown>;
+  };
+}
+
+interface MembershipQueryClient {
+  membership: {
+    findFirst: (args: {
+      where: { id: string; tenantId: string };
+      select: {
+        id: boolean;
+        tenantId: boolean;
+        roles: { select: { role: boolean; scopeType: boolean } };
+      };
+    }) => Promise<{
+      id: string;
+      tenantId: string;
+      roles: Array<{
+        role: string;
+        scopeType: 'TENANT' | 'BUILDING' | 'UNIT';
+      }>;
+    } | null>;
+  };
+}
+
 @Injectable()
 export class AuditService {
   private readonly logger = new Logger(AuditService.name);
@@ -43,29 +60,15 @@ export class AuditService {
   constructor(private readonly prisma: PrismaService) {}
 
   /**
-   * Write audit log entry (fire-and-forget pattern)
-   *
-   * RULE: This method must NEVER throw or fail the calling operation.
-   * If DB write fails, log to console and continue.
-   *
-   * @param input Audit log input with context
+   * Writes a best-effort audit record. Failures are logged and intentionally
+   * do not change the caller's outcome; financial mutations must use
+   * createLogRequired instead.
    */
   async createLog(input: AuditLogInput): Promise<void> {
     try {
-      await this.prisma.auditLog.create({
-        data: {
-          tenantId: input.tenantId ?? null,
-          actorUserId: input.actorUserId ?? null,
-          actorMembershipId: input.actorMembershipId ?? null,
-          action: input.action,
-          entity: input.entityType,
-          entityId: input.entityId,
-          metadata: (input.metadata ?? {}) as Prisma.InputJsonValue,
-        },
-      });
-    } catch (err) {
-      // RULE: Never fail main operation on audit write failure
-      const message = err instanceof Error ? err.message : String(err);
+      await this.createLogRequired(input, this.prisma);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
       this.logger.error('[AuditService] Failed to write audit log', {
         message,
         input,
@@ -74,33 +77,55 @@ export class AuditService {
     }
   }
 
-  /**
-   * Query audit logs with filters
-   *
-   * RULE: Only return logs from within the scope of the requesting actor.
-   * This is enforced by the controller/guard, not here.
-   *
-   * @param filters Query filters (all optional)
-   * @returns Paginated audit logs
-   */
-  async queryLogs(filters: AuditLogQueryFilters): Promise<AuditLogQueryResponse> {
-    const {
-      tenantId,
-      actorUserId,
-      action,
-      entityType,
-      dateFrom,
-      dateTo,
-      skip = 0,
-      take = 50,
-    } = filters;
+  async createLogRequired(input: AuditLogInput, tx: AuditWriteClient): Promise<void> {
+    const tenantId = this.normalizeTenantId(input.tenantId);
+    const metadata = this.normalizeMetadata(
+      input.metadata === undefined ? {} : input.metadata,
+    );
 
-    // Build dynamic where clause
-    const where: Prisma.AuditLogWhereInput = {};
+    await tx.auditLog.create({
+      data: {
+        tenantId,
+        actorUserId: input.actorUserId ?? null,
+        actorMembershipId: input.actorMembershipId ?? null,
+        action: input.action,
+        entity: input.entityType,
+        entityId: input.entityId,
+        metadata,
+      },
+    });
+  }
 
-    if (tenantId) {
-      where.tenantId = tenantId;
-    }
+  async queryTenantLogs(
+    tenantId: string,
+    membershipId: string,
+    filters: AuditLogQueryFilters = {},
+  ): Promise<AuditLogQueryResponse> {
+    await this.resolveTenantAuditMembership(tenantId, membershipId);
+    return this.queryLogs(tenantId, filters);
+  }
+
+  async queryGlobalLogsForSuperAdmin(
+    tenantId: string,
+    filters: AuditLogQueryFilters = {},
+  ): Promise<AuditLogQueryResponse> {
+    return this.queryLogs(tenantId, filters);
+  }
+
+  async queryLogs(
+    tenantId: string,
+    filters: AuditLogQueryFilters = {},
+  ): Promise<AuditLogQueryResponse> {
+    const normalizedTenantId = this.normalizeTenantId(tenantId);
+    const { actorUserId, action, entityType, dateFrom, dateTo, skip = 0, take = 50 } = filters;
+
+    this.assertValidDate(dateFrom, 'dateFrom');
+    this.assertValidDate(dateTo, 'dateTo');
+
+    const where: Prisma.AuditLogWhereInput = {
+      tenantId: normalizedTenantId,
+    };
+
     if (actorUserId) {
       where.actorUserId = actorUserId;
     }
@@ -111,7 +136,6 @@ export class AuditService {
       where.entity = entityType;
     }
 
-    // Date range filter
     if (dateFrom || dateTo) {
       where.createdAt = {};
       if (dateFrom) {
@@ -122,7 +146,6 @@ export class AuditService {
       }
     }
 
-    // Execute parallel queries for consistency
     const [data, total] = await Promise.all([
       this.prisma.auditLog.findMany({
         where,
@@ -138,5 +161,134 @@ export class AuditService {
     ]);
 
     return { data, total };
+  }
+
+  private async resolveTenantAuditMembership(
+    tenantId: string,
+    membershipId: string,
+  ): Promise<void> {
+    const membership = await (this.prisma as PrismaService & MembershipQueryClient).membership.findFirst({
+      where: { id: membershipId, tenantId },
+      select: {
+        id: true,
+        tenantId: true,
+        roles: { select: { role: true, scopeType: true } },
+      },
+    });
+
+    if (!membership) {
+      throw new ForbiddenException('No tiene acceso al tenant solicitado');
+    }
+
+    const tenantRoles = membership.roles
+      .filter((role) => role.scopeType === 'TENANT')
+      .map((role) => role.role);
+
+    if (tenantRoles.length === 0 || tenantRoles.every((role) => role === 'RESIDENT')) {
+      throw new ForbiddenException('Residents cannot access audit logs');
+    }
+  }
+
+  private normalizeTenantId(tenantId?: string): string {
+    const normalized = tenantId?.trim();
+
+    if (!normalized) {
+      throw new BadRequestException('tenantId is required');
+    }
+
+    return normalized;
+  }
+
+  private assertValidDate(value: Date | undefined, field: 'dateFrom' | 'dateTo'): void {
+    if (!value) {
+      return;
+    }
+
+    if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+      throw new BadRequestException(`${field} must be a valid date`);
+    }
+  }
+
+  private normalizeMetadata(metadata: unknown): Prisma.InputJsonValue {
+    if (metadata === null || metadata === undefined) {
+      throw new BadRequestException('metadata must not be null');
+    }
+
+    return this.normalizeJsonValue(metadata, 'metadata');
+  }
+
+  private normalizeJsonValue(
+    value: unknown,
+    path: string,
+    seen: WeakSet<object> = new WeakSet<object>(),
+  ): Prisma.InputJsonValue {
+    if (value === null || value === undefined) {
+      throw new BadRequestException(`${path} must not be null or undefined`);
+    }
+
+    const valueType = typeof value;
+
+    if (valueType === 'string' || valueType === 'boolean') {
+      return value;
+    }
+
+    if (valueType === 'number') {
+      if (!Number.isFinite(value)) {
+        throw new BadRequestException(`${path} must be a finite number`);
+      }
+
+      return value;
+    }
+
+    if (Array.isArray(value)) {
+      if (seen.has(value)) {
+        throw new BadRequestException(`${path} contains a circular reference`);
+      }
+
+      seen.add(value);
+
+      const normalizedArray: unknown[] = [];
+
+      for (const [index, item] of value.entries()) {
+        normalizedArray.push(this.normalizeJsonValue(item, `${path}[${index}]`, seen));
+      }
+
+      return normalizedArray as Prisma.InputJsonValue;
+    }
+
+    if (valueType === 'object') {
+      if (!this.isPlainObject(value)) {
+        throw new BadRequestException(`${path} must be a plain JSON object`);
+      }
+
+      if (seen.has(value)) {
+        throw new BadRequestException(`${path} contains a circular reference`);
+      }
+
+      seen.add(value);
+
+      const normalizedObject: Record<string, unknown> = {};
+
+      for (const [key, nestedValue] of Object.entries(value)) {
+        if (nestedValue === undefined) {
+          throw new BadRequestException(`${path}.${key} must not be undefined`);
+        }
+
+        normalizedObject[key] = this.normalizeJsonValue(
+          nestedValue,
+          `${path}.${key}`,
+          seen,
+        );
+      }
+
+      return normalizedObject as Prisma.InputJsonValue;
+    }
+
+    throw new BadRequestException(`${path} must be JSON-compatible`);
+  }
+
+  private isPlainObject(value: object): boolean {
+    const prototype = Object.getPrototypeOf(value);
+    return prototype === Object.prototype || prototype === null;
   }
 }

--- a/apps/api/src/audit/dto/audit-log-query.dto.ts
+++ b/apps/api/src/audit/dto/audit-log-query.dto.ts
@@ -1,0 +1,67 @@
+import { AuditAction } from '@prisma/client';
+import { Type, Transform } from 'class-transformer';
+import {
+  IsDateString,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+
+const trimString = ({ value }: { value: unknown }): unknown =>
+  typeof value === 'string' ? value.trim() : value;
+
+export class AuditLogQueryDto {
+  @IsOptional()
+  @Transform(trimString)
+  @IsString()
+  @MinLength(1)
+  @MaxLength(64)
+  tenantId?: string;
+
+  @IsOptional()
+  @Transform(trimString)
+  @IsString()
+  @MinLength(1)
+  @MaxLength(64)
+  actorUserId?: string;
+
+  @IsOptional()
+  @Transform(trimString)
+  @IsString()
+  @MinLength(1)
+  @MaxLength(120)
+  entityType?: string;
+
+  @IsOptional()
+  @Transform(trimString)
+  @IsEnum(AuditAction)
+  action?: AuditAction;
+
+  @IsOptional()
+  @Transform(trimString)
+  @IsDateString()
+  dateFrom?: string;
+
+  @IsOptional()
+  @Transform(trimString)
+  @IsDateString()
+  dateTo?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit?: number = 50;
+}

--- a/apps/api/src/common/request-context.spec.ts
+++ b/apps/api/src/common/request-context.spec.ts
@@ -1,0 +1,111 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { resolveTenantMembershipContext } from './request-context';
+import type { AuthenticatedRequest } from './types/request.types';
+
+function buildRequest(overrides: Partial<AuthenticatedRequest> = {}): AuthenticatedRequest {
+  return {
+    tenantId: 'tenant-legacy',
+    user: {
+      id: 'user-1',
+      email: 'user@example.com',
+      tenantId: 'tenant-legacy',
+      membershipId: 'member-legacy',
+      roles: ['TENANT_ADMIN'],
+      effectiveMembership: {
+        id: 'member-effective',
+        tenantId: 'tenant-legacy',
+        roles: ['TENANT_ADMIN'],
+      },
+      memberships: [],
+    },
+    ...overrides,
+  } as AuthenticatedRequest;
+}
+
+describe('resolveTenantMembershipContext', () => {
+  it('uses effectiveMembership when tenant matches', () => {
+    const context = resolveTenantMembershipContext(buildRequest());
+
+    expect(context).toEqual({
+      tenantId: 'tenant-legacy',
+      membershipId: 'member-effective',
+      roles: ['TENANT_ADMIN'],
+    });
+  });
+
+  it('rejects mismatched effectiveMembership tenantId', () => {
+    expect(() =>
+      resolveTenantMembershipContext(
+        buildRequest({
+          tenantId: 'tenant-a',
+          user: {
+            id: 'user-1',
+            email: 'user@example.com',
+            tenantId: 'tenant-a',
+            membershipId: 'member-legacy',
+            roles: ['TENANT_ADMIN'],
+            effectiveMembership: {
+              id: 'member-effective',
+              tenantId: 'tenant-b',
+              roles: ['TENANT_ADMIN'],
+            },
+            memberships: [],
+          },
+        }),
+      ),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('falls back to the legacy membership context when effectiveMembership is absent', () => {
+    const context = resolveTenantMembershipContext(
+      buildRequest({
+        user: {
+          id: 'user-1',
+          email: 'user@example.com',
+          tenantId: 'tenant-legacy',
+          membershipId: 'member-legacy',
+          roles: ['TENANT_ADMIN'],
+          memberships: [],
+        },
+      }),
+    );
+
+    expect(context).toEqual({
+      tenantId: 'tenant-legacy',
+      membershipId: 'member-legacy',
+      roles: ['TENANT_ADMIN'],
+    });
+  });
+
+  it('rejects missing tenantId', () => {
+    expect(() =>
+      resolveTenantMembershipContext(
+        buildRequest({
+          tenantId: undefined,
+          user: {
+            id: 'user-1',
+            email: 'user@example.com',
+            roles: ['TENANT_ADMIN'],
+            memberships: [],
+          },
+        }),
+      ),
+    ).toThrow(BadRequestException);
+  });
+
+  it('rejects missing membershipId when no effectiveMembership is available', () => {
+    expect(() =>
+      resolveTenantMembershipContext(
+        buildRequest({
+          user: {
+            id: 'user-1',
+            email: 'user@example.com',
+            tenantId: 'tenant-legacy',
+            roles: ['TENANT_ADMIN'],
+            memberships: [],
+          },
+        }),
+      ),
+    ).toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/common/request-context.spec.ts
+++ b/apps/api/src/common/request-context.spec.ts
@@ -29,7 +29,6 @@ describe('resolveTenantMembershipContext', () => {
     expect(context).toEqual({
       tenantId: 'tenant-legacy',
       membershipId: 'member-effective',
-      roles: ['TENANT_ADMIN'],
     });
   });
 
@@ -73,7 +72,6 @@ describe('resolveTenantMembershipContext', () => {
     expect(context).toEqual({
       tenantId: 'tenant-legacy',
       membershipId: 'member-legacy',
-      roles: ['TENANT_ADMIN'],
     });
   });
 

--- a/apps/api/src/common/request-context.ts
+++ b/apps/api/src/common/request-context.ts
@@ -1,0 +1,46 @@
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import type { AuthenticatedRequest } from './types/request.types';
+
+export interface TenantMembershipContext {
+  tenantId: string;
+  membershipId: string;
+  roles: string[];
+}
+
+export function resolveTenantMembershipContext(
+  req: AuthenticatedRequest,
+): TenantMembershipContext {
+  const tenantId = req.tenantId?.trim() ?? req.user?.tenantId?.trim();
+  if (!tenantId) {
+    throw new BadRequestException('tenantId is required');
+  }
+
+  const effectiveMembership = req.user?.effectiveMembership;
+  if (effectiveMembership) {
+    if (effectiveMembership.tenantId.trim() !== tenantId) {
+      throw new ForbiddenException('effectiveMembership tenant mismatch');
+    }
+
+    const effectiveMembershipId = effectiveMembership.id?.trim();
+    if (!effectiveMembershipId) {
+      throw new BadRequestException('membershipId is required');
+    }
+
+    return {
+      tenantId,
+      membershipId: effectiveMembershipId,
+      roles: effectiveMembership.roles.slice(),
+    };
+  }
+
+  const membershipId = req.user?.membershipId?.trim();
+  if (!membershipId) {
+    throw new BadRequestException('membershipId is required');
+  }
+
+  return {
+    tenantId,
+    membershipId,
+    roles: req.user?.roles?.slice() ?? [],
+  };
+}

--- a/apps/api/src/common/request-context.ts
+++ b/apps/api/src/common/request-context.ts
@@ -4,7 +4,6 @@ import type { AuthenticatedRequest } from './types/request.types';
 export interface TenantMembershipContext {
   tenantId: string;
   membershipId: string;
-  roles: string[];
 }
 
 export function resolveTenantMembershipContext(
@@ -29,7 +28,6 @@ export function resolveTenantMembershipContext(
     return {
       tenantId,
       membershipId: effectiveMembershipId,
-      roles: effectiveMembership.roles.slice(),
     };
   }
 
@@ -41,6 +39,5 @@ export function resolveTenantMembershipContext(
   return {
     tenantId,
     membershipId,
-    roles: req.user?.roles?.slice() ?? [],
   };
 }

--- a/apps/api/src/finanzas/expense-ledger-categories.controller.spec.ts
+++ b/apps/api/src/finanzas/expense-ledger-categories.controller.spec.ts
@@ -1,0 +1,151 @@
+import { Test } from '@nestjs/testing';
+import { ExpenseLedgerCategoriesController } from './expense-ledger-categories.controller';
+import { ExpenseLedgerCategoriesService } from './expense-ledger-categories.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import type { AuthenticatedRequest } from '../common/types/request.types';
+import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
+import type {
+  CreateExpenseLedgerCategoryDto,
+  ExpenseLedgerCategoryQueryDto,
+  ExpenseLedgerCategoryParamDto,
+  ExpenseLedgerCategoryResponseDto,
+  UpdateExpenseLedgerCategoryDto,
+} from './expense-ledger.dto';
+
+const stubReq = (
+  overrides: Record<string, unknown> = {},
+): AuthenticatedRequest =>
+  ({
+    tenantId: 'tenant-1',
+    user: {
+      id: 'user-1',
+      email: 'admin@test.com',
+      membershipId: 'member-legacy',
+      tenantId: 'tenant-1',
+      effectiveMembership: {
+        id: 'member-effective',
+        tenantId: 'tenant-1',
+        roles: ['TENANT_ADMIN'],
+      },
+      roles: ['TENANT_ADMIN'],
+    },
+    ...overrides,
+  }) as AuthenticatedRequest;
+
+describe('ExpenseLedgerCategoriesController', () => {
+  let controller: ExpenseLedgerCategoriesController;
+  let service: {
+    listCategories: jest.Mock;
+    getCategory: jest.Mock;
+    createCategory: jest.Mock;
+    updateCategory: jest.Mock;
+    deleteCategory: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    service = {
+      listCategories: jest.fn(),
+      getCategory: jest.fn(),
+      createCategory: jest.fn(),
+      updateCategory: jest.fn(),
+      deleteCategory: jest.fn(),
+    };
+
+    const module = await Test.createTestingModule({
+      controllers: [ExpenseLedgerCategoriesController],
+      providers: [
+        {
+          provide: ExpenseLedgerCategoriesService,
+          useValue: service,
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: jest.fn().mockResolvedValue(true) })
+      .overrideGuard(TenantAccessGuard)
+      .useValue({ canActivate: jest.fn().mockResolvedValue(true) })
+      .compile();
+
+    controller = module.get(ExpenseLedgerCategoriesController);
+  });
+
+  it('uses the effective membership for read operations', async () => {
+    service.listCategories.mockResolvedValue([]);
+
+    const query: ExpenseLedgerCategoryQueryDto = {
+      movementType: 'EXPENSE',
+      catalogScope: 'BUILDING',
+    };
+    const params: ExpenseLedgerCategoryParamDto = {
+      categoryId: 'c123456789012345678901234',
+    };
+
+    await controller.listCategories(query, stubReq());
+    await controller.getCategory(params, stubReq());
+
+    expect(service.listCategories).toHaveBeenCalledWith(
+      'tenant-1',
+      'member-effective',
+      'EXPENSE',
+      'BUILDING',
+    );
+    expect(service.getCategory).toHaveBeenCalledWith(
+      'tenant-1',
+      'c123456789012345678901234',
+      'member-effective',
+    );
+  });
+
+  it('uses the effective membership for write operations', async () => {
+    const expected: ExpenseLedgerCategoryResponseDto = {
+      id: 'cat-1',
+      tenantId: 'tenant-1',
+      code: 'EXP_ELECTRICIDAD_1234',
+      name: 'Electricidad',
+      description: null,
+      movementType: 'EXPENSE',
+      catalogScope: 'BUILDING',
+      sortOrder: 0,
+      isActive: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    service.createCategory.mockResolvedValue(expected);
+    service.getCategory.mockResolvedValue(expected);
+    service.updateCategory.mockResolvedValue(expected);
+    service.deleteCategory.mockResolvedValue(undefined);
+
+    const createDto: CreateExpenseLedgerCategoryDto = { name: 'Electricidad' };
+    const updateDto: UpdateExpenseLedgerCategoryDto = { isActive: false };
+    const params: ExpenseLedgerCategoryParamDto = {
+      categoryId: 'c123456789012345678901234',
+    };
+
+    await controller.createCategory(createDto, stubReq());
+    await controller.getCategory(params, stubReq());
+    await controller.updateCategory(params, updateDto, stubReq());
+    await controller.deleteCategory(params, stubReq());
+
+    expect(service.createCategory).toHaveBeenCalledWith(
+      'tenant-1',
+      'member-effective',
+      createDto,
+    );
+    expect(service.getCategory).toHaveBeenCalledWith(
+      'tenant-1',
+      'c123456789012345678901234',
+      'member-effective',
+    );
+    expect(service.updateCategory).toHaveBeenCalledWith(
+      'tenant-1',
+      'c123456789012345678901234',
+      'member-effective',
+      updateDto,
+    );
+    expect(service.deleteCategory).toHaveBeenCalledWith(
+      'tenant-1',
+      'c123456789012345678901234',
+      'member-effective',
+    );
+  });
+});

--- a/apps/api/src/finanzas/expense-ledger-categories.controller.ts
+++ b/apps/api/src/finanzas/expense-ledger-categories.controller.ts
@@ -15,9 +15,12 @@ import {
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
 import { AuthenticatedRequest } from '../common/types/request.types';
+import { resolveTenantMembershipContext } from '../common/request-context';
 import { ExpenseLedgerCategoriesService } from './expense-ledger-categories.service';
 import {
   CreateExpenseLedgerCategoryDto,
+  ExpenseLedgerCategoryParamDto,
+  ExpenseLedgerCategoryQueryDto,
   UpdateExpenseLedgerCategoryDto,
   ExpenseLedgerCategoryResponseDto,
 } from './expense-ledger.dto';
@@ -35,27 +38,30 @@ export class ExpenseLedgerCategoriesController {
 
   @Get()
   async listCategories(
-    @Query('movementType') movementType?: 'EXPENSE' | 'INCOME',
-    @Query('catalogScope') catalogScope?: 'BUILDING' | 'CONDOMINIUM_COMMON',
-    @Request() req?: AuthenticatedRequest,
+    @Query() query: ExpenseLedgerCategoryQueryDto,
+    @Request() req: AuthenticatedRequest,
   ): Promise<ExpenseLedgerCategoryResponseDto[]> {
+    const context = this.resolveRequestContext(req);
+
     return this.categoriesService.listCategories(
-      req!.tenantId!,
-      req!.user.roles ?? [],
-      movementType,
-      catalogScope,
+      context.tenantId,
+      context.membershipId,
+      query.movementType,
+      query.catalogScope,
     );
   }
 
   @Get(':categoryId')
   async getCategory(
-    @Param('categoryId') categoryId: string,
+    @Param() params: ExpenseLedgerCategoryParamDto,
     @Request() req: AuthenticatedRequest,
   ): Promise<ExpenseLedgerCategoryResponseDto> {
+    const context = this.resolveRequestContext(req);
+
     return this.categoriesService.getCategory(
-      req.tenantId!,
-      categoryId,
-      req.user.roles ?? [],
+      context.tenantId,
+      params.categoryId,
+      context.membershipId,
     );
   }
 
@@ -64,25 +70,27 @@ export class ExpenseLedgerCategoriesController {
     @Body() dto: CreateExpenseLedgerCategoryDto,
     @Request() req: AuthenticatedRequest,
   ): Promise<ExpenseLedgerCategoryResponseDto> {
+    const context = this.resolveRequestContext(req);
+
     return this.categoriesService.createCategory(
-      req.tenantId!,
-      req.user.membershipId ?? '',
-      req.user.roles ?? [],
+      context.tenantId,
+      context.membershipId,
       dto,
     );
   }
 
   @Patch(':categoryId')
   async updateCategory(
-    @Param('categoryId') categoryId: string,
+    @Param() params: ExpenseLedgerCategoryParamDto,
     @Body() dto: UpdateExpenseLedgerCategoryDto,
     @Request() req: AuthenticatedRequest,
   ): Promise<ExpenseLedgerCategoryResponseDto> {
+    const context = this.resolveRequestContext(req);
+
     return this.categoriesService.updateCategory(
-      req.tenantId!,
-      categoryId,
-      req.user.membershipId ?? '',
-      req.user.roles ?? [],
+      context.tenantId,
+      params.categoryId,
+      context.membershipId,
       dto,
     );
   }
@@ -90,14 +98,23 @@ export class ExpenseLedgerCategoriesController {
   @Delete(':categoryId')
   @HttpCode(HttpStatus.NO_CONTENT)
   async deleteCategory(
-    @Param('categoryId') categoryId: string,
+    @Param() params: ExpenseLedgerCategoryParamDto,
     @Request() req: AuthenticatedRequest,
   ): Promise<void> {
+    const context = this.resolveRequestContext(req);
+
     return this.categoriesService.deleteCategory(
-      req.tenantId!,
-      categoryId,
-      req.user.membershipId ?? '',
-      req.user.roles ?? [],
+      context.tenantId,
+      params.categoryId,
+      context.membershipId,
     );
+  }
+
+  private resolveRequestContext(req: AuthenticatedRequest): {
+    tenantId: string;
+    membershipId: string;
+  } {
+    const { tenantId, membershipId } = resolveTenantMembershipContext(req);
+    return { tenantId, membershipId };
   }
 }

--- a/apps/api/src/finanzas/expense-ledger-categories.query.dto.spec.ts
+++ b/apps/api/src/finanzas/expense-ledger-categories.query.dto.spec.ts
@@ -1,0 +1,83 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+import {
+  ExpenseLedgerCategoryParamDto,
+  ExpenseLedgerCategoryQueryDto,
+} from './expense-ledger.dto';
+
+describe('ExpenseLedgerCategoryQueryDto', () => {
+  const validate = (input: Record<string, unknown>) =>
+    validateSync(plainToInstance(ExpenseLedgerCategoryQueryDto, input), {
+      whitelist: true,
+      forbidUnknownValues: true,
+    });
+
+  it('accepts a valid movementType', () => {
+    expect(validate({ movementType: 'EXPENSE' })).toHaveLength(0);
+  });
+
+  it('rejects an invalid movementType', () => {
+    const errors = validate({ movementType: 'OTHER' });
+
+    expect(errors.map((error) => error.property)).toContain('movementType');
+  });
+
+  it('accepts a valid catalogScope', () => {
+    expect(validate({ catalogScope: 'BUILDING' })).toHaveLength(0);
+  });
+
+  it('rejects an invalid catalogScope', () => {
+    const errors = validate({ catalogScope: 'ANYWHERE' });
+
+    expect(errors.map((error) => error.property)).toContain('catalogScope');
+  });
+
+  it('accepts both filters together when valid', () => {
+    expect(
+      validate({ movementType: 'INCOME', catalogScope: 'CONDOMINIUM_COMMON' }),
+    ).toHaveLength(0);
+  });
+
+  it('accepts both filters omitted', () => {
+    expect(validate({})).toHaveLength(0);
+  });
+
+  it('rejects arbitrary strings before they reach the service', () => {
+    const errors = validate({
+      movementType: 'foo',
+      catalogScope: 'bar',
+      extra: 'baz',
+    });
+
+    expect(errors.map((error) => error.property).sort()).toEqual(['catalogScope', 'movementType']);
+  });
+
+  it('accepts a valid categoryId', () => {
+    expect(
+      validateSync(
+        plainToInstance(ExpenseLedgerCategoryParamDto, {
+          categoryId: 'c123456789012345678901234',
+        }),
+        {
+          whitelist: true,
+          forbidUnknownValues: true,
+        },
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('rejects an invalid categoryId', () => {
+    const errors = validateSync(
+      plainToInstance(ExpenseLedgerCategoryParamDto, {
+        categoryId: 'cat-1',
+      }),
+      {
+        whitelist: true,
+        forbidUnknownValues: true,
+      },
+    );
+
+    expect(errors.map((error) => error.property)).toContain('categoryId');
+  });
+});

--- a/apps/api/src/finanzas/expense-ledger-categories.service.spec.ts
+++ b/apps/api/src/finanzas/expense-ledger-categories.service.spec.ts
@@ -1,0 +1,672 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { ExpenseLedgerCategoriesService } from './expense-ledger-categories.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { ExpenseLedgerCategoryMovementType } from './expense-ledger.dto';
+
+const baseCategory = {
+  id: 'cat-1',
+  tenantId: 'tenant-1',
+  code: 'EXP_ELECTRICIDAD_0001',
+  name: 'Electricidad',
+  description: 'Energy',
+  movementType: 'EXPENSE' as ExpenseLedgerCategoryMovementType,
+  catalogScope: 'BUILDING' as const,
+  sortOrder: 0,
+  isActive: true,
+  createdAt: new Date('2026-05-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-05-01T00:00:00.000Z'),
+};
+
+describe('ExpenseLedgerCategoriesService', () => {
+  let service: ExpenseLedgerCategoriesService;
+  let prisma: {
+    membership: {
+      findFirst: jest.Mock;
+    };
+    expenseLedgerCategory: {
+      findMany: jest.Mock;
+      findFirst: jest.Mock;
+      create: jest.Mock;
+      updateMany: jest.Mock;
+      update: jest.Mock;
+      deleteMany: jest.Mock;
+      delete: jest.Mock;
+    };
+    expense: {
+      count: jest.Mock;
+    };
+    $transaction: jest.Mock;
+  };
+  let tx: {
+    membership: {
+      findFirst: jest.Mock;
+    };
+    expenseLedgerCategory: {
+      findMany: jest.Mock;
+      create: jest.Mock;
+      updateMany: jest.Mock;
+      update: jest.Mock;
+      deleteMany: jest.Mock;
+      delete: jest.Mock;
+      findFirst: jest.Mock;
+    };
+    expense: {
+      count: jest.Mock;
+    };
+  };
+  let auditService: {
+    createLog: jest.Mock;
+    createLogRequired: jest.Mock;
+  };
+  let validators: { isAdminOrOperator: jest.Mock };
+  let currentMembershipRoles: Array<{
+    role: string;
+    scopeType: 'TENANT' | 'BUILDING' | 'UNIT';
+  }>;
+  let membershipFindFirst: jest.Mock;
+
+  beforeEach(async () => {
+    currentMembershipRoles = [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }];
+    membershipFindFirst = jest.fn().mockImplementation(async ({ where }: { where?: { id?: string; tenantId?: string } }) => {
+      if (where?.id === 'member-missing' || where?.tenantId === 'tenant-other') {
+        return null;
+      }
+
+      if (where?.id === 'member-tenant-b') {
+        return where?.tenantId === 'tenant-2'
+          ? {
+              id: 'member-tenant-b',
+              userId: 'user-2',
+              roles: [{ role: 'TENANT_OWNER', scopeType: 'TENANT' }],
+            }
+          : null;
+      }
+
+      return {
+        id: 'member-1',
+        userId: 'user-1',
+        tenantId: 'tenant-1',
+        roles: currentMembershipRoles,
+      };
+    });
+
+    tx = {
+      membership: {
+        findFirst: membershipFindFirst,
+      },
+      expenseLedgerCategory: {
+        findMany: jest.fn().mockResolvedValue([]),
+        create: jest.fn().mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+          ...baseCategory,
+          ...data,
+          id: 'cat-created',
+        })),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+        update: jest.fn().mockImplementation(async ({ data }: { data: Record<string, unknown> }) => ({
+          ...baseCategory,
+          ...data,
+          id: 'cat-1',
+        })),
+        deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
+        delete: jest.fn().mockResolvedValue(undefined),
+        findFirst: jest.fn().mockResolvedValue(null),
+      },
+      auditLog: { create: jest.fn().mockResolvedValue(undefined) },
+      expense: { count: jest.fn().mockResolvedValue(0) },
+    };
+
+    prisma = {
+      membership: {
+        findFirst: membershipFindFirst,
+      },
+      expenseLedgerCategory: {
+        findMany: jest.fn().mockResolvedValue([]),
+        findFirst: jest.fn().mockResolvedValue(null),
+        create: jest.fn(),
+        updateMany: jest.fn(),
+        update: jest.fn(),
+        deleteMany: jest.fn(),
+        delete: jest.fn(),
+      },
+      expense: { count: jest.fn().mockResolvedValue(0) },
+      $transaction: jest.fn(async (callback: (transaction: typeof tx) => Promise<unknown>) => callback(tx)),
+    };
+
+    auditService = {
+      createLog: jest.fn(),
+      createLogRequired: jest.fn().mockResolvedValue(undefined),
+    };
+    validators = {
+      isAdminOrOperator: jest.fn().mockImplementation((roles: string[]) =>
+        roles.some((role) => role !== 'RESIDENT'),
+      ),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExpenseLedgerCategoriesService,
+        {
+          provide: PrismaService,
+          useValue: prisma,
+        },
+        {
+          provide: AuditService,
+          useValue: auditService,
+        },
+        {
+          provide: FinanzasValidators,
+          useValue: validators,
+        },
+      ],
+    }).compile();
+
+    service = module.get(ExpenseLedgerCategoriesService);
+  });
+
+  it('lists categories using the validated membership from the same tenant', async () => {
+    prisma.expenseLedgerCategory.findMany.mockResolvedValueOnce([baseCategory]);
+
+    const result = await service.listCategories(
+      'tenant-1',
+      'member-1',
+      'EXPENSE',
+      'BUILDING',
+    );
+
+    expect(result).toEqual([expect.objectContaining({ id: 'cat-1', tenantId: 'tenant-1' })]);
+    expect(prisma.expenseLedgerCategory.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          tenantId: 'tenant-1',
+          movementType: 'EXPENSE',
+          catalogScope: 'BUILDING',
+        }),
+      }),
+    );
+  });
+
+  it('rejects a membership from another tenant before listing categories', async () => {
+    await expect(
+      service.listCategories('tenant-1', 'member-tenant-b'),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(prisma.expenseLedgerCategory.findMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing membership before listing categories', async () => {
+    await expect(
+      service.listCategories('tenant-1', 'member-missing'),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(prisma.expenseLedgerCategory.findMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects a resident membership even if caller roles claim admin when listing categories', async () => {
+    currentMembershipRoles = [{ role: 'RESIDENT', scopeType: 'TENANT' }];
+
+    await expect(
+      service.listCategories('tenant-1', 'member-1'),
+    ).rejects.toThrow(ForbiddenException);
+
+    expect(prisma.expenseLedgerCategory.findMany).not.toHaveBeenCalled();
+  });
+
+  it.each(['BUILDING', 'UNIT'] as const)(
+    'rejects an admin role limited to %s scope',
+    async (scopeType) => {
+      currentMembershipRoles = [{ role: 'TENANT_ADMIN', scopeType }];
+
+      await expect(service.listCategories('tenant-1', 'member-1')).rejects.toThrow(
+        ForbiddenException,
+      );
+
+      expect(prisma.expenseLedgerCategory.findMany).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does not reveal a missing category before authorizing the actor', async () => {
+    await expect(
+      service.getCategory('tenant-1', 'cat-missing', 'member-tenant-b'),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(prisma.expenseLedgerCategory.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('returns a category for an authorized membership in the same tenant', async () => {
+    prisma.expenseLedgerCategory.findFirst.mockResolvedValueOnce(baseCategory);
+
+    const result = await service.getCategory('tenant-1', 'cat-1', 'member-1');
+
+    expect(result).toEqual(expect.objectContaining({ id: 'cat-1', tenantId: 'tenant-1' }));
+    expect(prisma.expenseLedgerCategory.findFirst).toHaveBeenCalledWith({
+      where: { id: 'cat-1', tenantId: 'tenant-1' },
+    });
+  });
+
+  it('checks for duplicate category names only after authorizing the actor', async () => {
+    membershipFindFirst.mockImplementationOnce(async ({ where }: { where?: { id?: string; tenantId?: string } }) => {
+      expect(where).toEqual({ id: 'member-1', tenantId: 'tenant-1' });
+      expect(tx.expenseLedgerCategory.findFirst).not.toHaveBeenCalled();
+      return {
+        id: 'member-1',
+        userId: 'user-1',
+        roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+      };
+    });
+    tx.expenseLedgerCategory.findFirst.mockResolvedValueOnce(null);
+
+    await service.createCategory('tenant-1', 'member-1', {
+      name: 'Agua',
+    });
+
+    expect(prisma.$transaction).toHaveBeenCalled();
+    expect(tx.expenseLedgerCategory.findFirst).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks for the current category only after authorizing the actor on update', async () => {
+    membershipFindFirst.mockImplementationOnce(async ({ where }: { where?: { id?: string; tenantId?: string } }) => {
+      expect(where).toEqual({ id: 'member-1', tenantId: 'tenant-1' });
+      expect(tx.expenseLedgerCategory.findFirst).not.toHaveBeenCalled();
+      return {
+        id: 'member-1',
+        userId: 'user-1',
+        roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+      };
+    });
+    tx.expenseLedgerCategory.findFirst
+      .mockResolvedValueOnce(baseCategory)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        ...baseCategory,
+        name: 'Electricidad general',
+      });
+
+    await service.updateCategory('tenant-1', 'cat-1', 'member-1', {
+      name: 'Electricidad general',
+    });
+
+    expect(prisma.$transaction).toHaveBeenCalled();
+    expect(tx.expenseLedgerCategory.findFirst).toHaveBeenCalledTimes(3);
+    expect(tx.expenseLedgerCategory.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'cat-1', tenantId: 'tenant-1' },
+      }),
+    );
+    expect(tx.expenseLedgerCategory.findFirst).toHaveBeenLastCalledWith({
+      where: { id: 'cat-1', tenantId: 'tenant-1' },
+    });
+  });
+
+  it('rejects a resident membership before loading the current category on update', async () => {
+    currentMembershipRoles = [{ role: 'RESIDENT', scopeType: 'TENANT' }];
+
+    await expect(
+      service.updateCategory('tenant-1', 'cat-1', 'member-1', {
+        name: 'Electricidad general',
+      }),
+    ).rejects.toThrow(ForbiddenException);
+
+    expect(prisma.$transaction).toHaveBeenCalled();
+    expect(tx.expenseLedgerCategory.findFirst).not.toHaveBeenCalled();
+    expect(auditService.createLogRequired).not.toHaveBeenCalled();
+  });
+
+  it('persists BUILDING explicitly when catalogScope is omitted on create', async () => {
+    const result = await service.createCategory('tenant-1', 'member-1', {
+      name: 'Electricidad',
+      description: 'Energy',
+    });
+
+    expect(result.catalogScope).toBe('BUILDING');
+    expect(prisma.$transaction).toHaveBeenCalled();
+    expect(auditService.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          catalogScope: 'BUILDING',
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('persists CONDOMINIUM_COMMON explicitly when catalogScope is provided on create', async () => {
+    const result = await service.createCategory('tenant-1', 'member-1', {
+      name: 'Amenities',
+      description: 'Common services',
+      catalogScope: 'CONDOMINIUM_COMMON',
+    });
+
+    expect(result.catalogScope).toBe('CONDOMINIUM_COMMON');
+    expect(prisma.$transaction).toHaveBeenCalled();
+    expect(auditService.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          catalogScope: 'CONDOMINIUM_COMMON',
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('updates catalogScope when changing from BUILDING to CONDOMINIUM_COMMON', async () => {
+    tx.expenseLedgerCategory.findFirst
+      .mockResolvedValueOnce(baseCategory)
+      .mockResolvedValueOnce({
+        ...baseCategory,
+        catalogScope: 'CONDOMINIUM_COMMON',
+      });
+
+    const result = await service.updateCategory('tenant-1', 'cat-1', 'member-1', {
+      catalogScope: 'CONDOMINIUM_COMMON',
+    });
+
+    expect(result.catalogScope).toBe('CONDOMINIUM_COMMON');
+    expect(prisma.$transaction).toHaveBeenCalled();
+    expect(auditService.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          catalogScope: 'CONDOMINIUM_COMMON',
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('preserves catalogScope when update omits the field', async () => {
+    tx.expenseLedgerCategory.findFirst
+      .mockResolvedValueOnce({
+        ...baseCategory,
+        catalogScope: 'CONDOMINIUM_COMMON',
+      })
+      .mockResolvedValueOnce({
+        ...baseCategory,
+        catalogScope: 'CONDOMINIUM_COMMON',
+      });
+
+    const result = await service.updateCategory('tenant-1', 'cat-1', 'member-1', {
+      description: 'Updated description',
+    });
+
+    expect(result.catalogScope).toBe('CONDOMINIUM_COMMON');
+    expect(auditService.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          catalogScope: 'CONDOMINIUM_COMMON',
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('rolls back category creation when required audit logging fails', async () => {
+    auditService.createLogRequired.mockRejectedValueOnce(new Error('audit failed'));
+
+    await expect(
+      service.createCategory('tenant-1', 'member-1', {
+        name: 'Emergencia',
+        catalogScope: 'CONDOMINIUM_COMMON',
+      }),
+    ).rejects.toThrow('audit failed');
+
+    expect(prisma.$transaction).toHaveBeenCalled();
+  });
+
+  it('soft-deletes categories and audits the deletion in the same transaction', async () => {
+    tx.expenseLedgerCategory.findFirst.mockResolvedValueOnce(baseCategory);
+    tx.expense.count.mockResolvedValueOnce(2);
+
+    await service.deleteCategory('tenant-1', 'cat-1', 'member-1');
+
+    expect(prisma.$transaction).toHaveBeenCalled();
+    expect(tx.expenseLedgerCategory.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'cat-1', tenantId: 'tenant-1', isActive: true },
+      }),
+    );
+    expect(auditService.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          hadExpenses: true,
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('hard-deletes tenant-scoped categories when there are no expenses', async () => {
+    tx.expenseLedgerCategory.findFirst.mockResolvedValueOnce(baseCategory);
+    tx.expense.count.mockResolvedValueOnce(0);
+
+    await service.deleteCategory('tenant-1', 'cat-1', 'member-1');
+
+    expect(tx.expenseLedgerCategory.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'cat-1', tenantId: 'tenant-1' },
+      }),
+    );
+    expect(auditService.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          hadExpenses: false,
+        }),
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('rejects missing categories on update', async () => {
+    tx.expenseLedgerCategory.findFirst.mockResolvedValueOnce(null);
+
+    await expect(
+      service.updateCategory('tenant-1', 'cat-missing', 'member-1', {
+        catalogScope: 'BUILDING',
+      }),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('rejects duplicate names on create', async () => {
+    tx.expenseLedgerCategory.findFirst.mockResolvedValueOnce(baseCategory);
+
+    await expect(
+      service.createCategory('tenant-1', 'member-1', {
+        name: 'Electricidad',
+      }),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('rejects a membership from another tenant before mutating a category', async () => {
+    await expect(
+      service.createCategory('tenant-1', 'member-tenant-b', {
+        name: 'Mantenimiento',
+      }),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(prisma.$transaction).toHaveBeenCalled();
+    expect(tx.expenseLedgerCategory.findFirst).not.toHaveBeenCalled();
+    expect(auditService.createLogRequired).not.toHaveBeenCalled();
+  });
+
+  it('rejects updates when the tenant-scoped write does not affect a row', async () => {
+    tx.expenseLedgerCategory.findFirst.mockResolvedValueOnce(baseCategory);
+    tx.expenseLedgerCategory.updateMany.mockResolvedValueOnce({ count: 0 });
+
+    await expect(
+      service.updateCategory('tenant-1', 'cat-1', 'member-1', {
+        name: 'Electricidad general',
+      }),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(auditService.createLogRequired).not.toHaveBeenCalled();
+  });
+
+  it('rejects soft deletes when the tenant-scoped write does not affect a row', async () => {
+    tx.expenseLedgerCategory.findFirst.mockResolvedValueOnce(baseCategory);
+    tx.expense.count.mockResolvedValueOnce(3);
+    tx.expenseLedgerCategory.updateMany.mockResolvedValueOnce({ count: 0 });
+
+    await expect(
+      service.deleteCategory('tenant-1', 'cat-1', 'member-1'),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(auditService.createLogRequired).not.toHaveBeenCalled();
+  });
+
+  it('rejects hard deletes when the tenant-scoped write does not affect a row', async () => {
+    tx.expenseLedgerCategory.findFirst.mockResolvedValueOnce(baseCategory);
+    tx.expense.count.mockResolvedValueOnce(0);
+    tx.expenseLedgerCategory.deleteMany.mockResolvedValueOnce({ count: 0 });
+
+    await expect(
+      service.deleteCategory('tenant-1', 'cat-1', 'member-1'),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(auditService.createLogRequired).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing membership before mutating a category', async () => {
+    await expect(
+      service.createCategory('tenant-1', 'member-missing', {
+        name: 'Mantenimiento',
+      }),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(prisma.$transaction).toHaveBeenCalled();
+    expect(tx.expenseLedgerCategory.findFirst).not.toHaveBeenCalled();
+    expect(auditService.createLogRequired).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unauthorized role derived from the real membership even if caller roles claim admin', async () => {
+    currentMembershipRoles = [{ role: 'RESIDENT', scopeType: 'TENANT' }];
+
+    await expect(
+      service.createCategory('tenant-1', 'member-1', {
+        name: 'Mantenimiento',
+      }),
+    ).rejects.toThrow(ForbiddenException);
+
+    expect(prisma.$transaction).toHaveBeenCalled();
+    expect(tx.expenseLedgerCategory.findFirst).not.toHaveBeenCalled();
+    expect(auditService.createLogRequired).not.toHaveBeenCalled();
+  });
+
+  it('uses the validated membership for audit logging', async () => {
+    tx.expenseLedgerCategory.findFirst.mockResolvedValueOnce(null);
+
+    await service.createCategory('tenant-1', 'member-1', {
+      name: 'Conserjería',
+    });
+
+    expect(auditService.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorMembershipId: 'member-1',
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('translates P2002 on create into a domain conflict', async () => {
+    tx.expenseLedgerCategory.findFirst.mockResolvedValueOnce(null);
+    const uniqueError = new Error('Unique constraint failed');
+    Object.assign(uniqueError, { code: 'P2002', meta: { target: ['tenantId', 'name'] } });
+    Object.setPrototypeOf(uniqueError, Prisma.PrismaClientKnownRequestError.prototype);
+    tx.expenseLedgerCategory.create.mockRejectedValueOnce(uniqueError);
+
+    await expect(
+      service.createCategory('tenant-1', 'member-1', {
+        name: 'Duplicado',
+      }),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('retries code collisions on create and only retries the code field', async () => {
+    tx.expenseLedgerCategory.findFirst.mockResolvedValue(null);
+    const uniqueError = new Error('Unique constraint failed');
+    Object.assign(uniqueError, { code: 'P2002', meta: { target: ['tenantId', 'code'] } });
+    Object.setPrototypeOf(uniqueError, Prisma.PrismaClientKnownRequestError.prototype);
+    tx.expenseLedgerCategory.create
+      .mockRejectedValueOnce(uniqueError)
+      .mockResolvedValueOnce({
+        ...baseCategory,
+        id: 'cat-retried',
+        code: 'EXP_DUPLICATED_2',
+      });
+    {
+      const result = await service.createCategory('tenant-1', 'member-1', {
+        name: 'Duplicado',
+        movementType: 'EXPENSE',
+      });
+
+      expect(result.id).toBe('cat-retried');
+      expect(tx.expenseLedgerCategory.create).toHaveBeenCalledTimes(2);
+      const firstCode = tx.expenseLedgerCategory.create.mock.calls[0]?.[0]?.data?.code as string | undefined;
+      const secondCode = tx.expenseLedgerCategory.create.mock.calls[1]?.[0]?.data?.code as string | undefined;
+
+      expect(firstCode).toMatch(/^EXP_DUPLICADO_[A-F0-9]{8}$/);
+      expect(secondCode).toMatch(/^EXP_DUPLICADO_[A-F0-9]{8}$/);
+      expect(secondCode).not.toBe(firstCode);
+      expect(tx.expenseLedgerCategory.create).toHaveBeenNthCalledWith(1, {
+        data: expect.objectContaining({
+          tenantId: 'tenant-1',
+          code: expect.stringMatching(/^EXP_DUPLICADO_[A-F0-9]{8}$/),
+          name: 'Duplicado',
+          description: null,
+          movementType: 'EXPENSE',
+          catalogScope: 'BUILDING',
+        }),
+      });
+      expect(tx.expenseLedgerCategory.create).toHaveBeenNthCalledWith(2, {
+        data: expect.objectContaining({
+          tenantId: 'tenant-1',
+          code: expect.stringMatching(/^EXP_DUPLICADO_[A-F0-9]{8}$/),
+          name: 'Duplicado',
+          description: null,
+          movementType: 'EXPENSE',
+          catalogScope: 'BUILDING',
+        }),
+      });
+    }
+  });
+
+  it('translates P2002 on update into a domain conflict', async () => {
+    tx.expenseLedgerCategory.findFirst.mockResolvedValueOnce(baseCategory);
+    const uniqueError = new Error('Unique constraint failed');
+    Object.assign(uniqueError, { code: 'P2002', meta: { target: ['tenantId', 'name'] } });
+    Object.setPrototypeOf(uniqueError, Prisma.PrismaClientKnownRequestError.prototype);
+    tx.expenseLedgerCategory.updateMany.mockRejectedValueOnce(uniqueError);
+
+    await expect(
+      service.updateCategory('tenant-1', 'cat-1', 'member-1', {
+        name: 'Duplicado',
+      }),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('distinguishes code conflicts from name conflicts on update', async () => {
+    tx.expenseLedgerCategory.findFirst.mockResolvedValueOnce(baseCategory);
+    const uniqueError = new Error('Unique constraint failed');
+    Object.assign(uniqueError, { code: 'P2002', meta: { target: ['tenantId', 'code'] } });
+    Object.setPrototypeOf(uniqueError, Prisma.PrismaClientKnownRequestError.prototype);
+    tx.expenseLedgerCategory.updateMany.mockRejectedValueOnce(uniqueError);
+
+    await expect(
+      service.updateCategory('tenant-1', 'cat-1', 'member-1', {
+        catalogScope: 'CONDOMINIUM_COMMON',
+      }),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('propagates non-P2002 errors from update', async () => {
+    tx.expenseLedgerCategory.findFirst.mockResolvedValueOnce(baseCategory);
+    tx.expenseLedgerCategory.updateMany.mockRejectedValueOnce(new Error('boom'));
+
+    await expect(
+      service.updateCategory('tenant-1', 'cat-1', 'member-1', {
+        name: 'Nuevo nombre',
+      }),
+    ).rejects.toThrow('boom');
+  });
+});

--- a/apps/api/src/finanzas/expense-ledger-categories.service.ts
+++ b/apps/api/src/finanzas/expense-ledger-categories.service.ts
@@ -1,17 +1,77 @@
 import {
-  Injectable,
-  NotFoundException,
   ConflictException,
   ForbiddenException,
+  Injectable,
+  NotFoundException,
 } from '@nestjs/common';
-import { PrismaService } from '../prisma/prisma.service';
+import { Prisma } from '@prisma/client';
+import { randomUUID } from 'node:crypto';
 import { AuditService } from '../audit/audit.service';
+import { PrismaService } from '../prisma/prisma.service';
 import {
   CreateExpenseLedgerCategoryDto,
-  UpdateExpenseLedgerCategoryDto,
+  ExpenseLedgerCategoryCatalogScope,
   ExpenseLedgerCategoryResponseDto,
+  UpdateExpenseLedgerCategoryDto,
 } from './expense-ledger.dto';
 import { FinanzasValidators } from './finanzas.validators';
+
+type ExpenseLedgerCategoryMovementType = 'EXPENSE' | 'INCOME';
+
+interface MembershipRecord {
+  id: string;
+  tenantId: string;
+  roles: Array<{
+    role: string;
+    scopeType: 'TENANT' | 'BUILDING' | 'UNIT';
+  }>;
+}
+
+interface ExpenseLedgerCategoryRecord {
+  id: string;
+  tenantId: string;
+  code: string | null;
+  name: string;
+  description: string | null;
+  movementType: ExpenseLedgerCategoryMovementType;
+  catalogScope: 'BUILDING' | 'CONDOMINIUM_COMMON';
+  sortOrder: number;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+interface CategoryMutationTx {
+  membership: {
+    findFirst: (args: {
+      where: { id: string; tenantId: string };
+      select?: { id: boolean; tenantId?: boolean; roles?: boolean };
+    }) => Promise<MembershipRecord | null>;
+  };
+  expenseLedgerCategory: {
+    findMany: (args: {
+      where: Record<string, unknown>;
+      orderBy?: Array<Record<string, unknown>>;
+    }) => Promise<ExpenseLedgerCategoryRecord[]>;
+    findFirst: (args: { where: Record<string, unknown> }) => Promise<ExpenseLedgerCategoryRecord | null>;
+    create: (args: {
+      data: Record<string, unknown>;
+    }) => Promise<ExpenseLedgerCategoryRecord>;
+    updateMany: (args: {
+      where: Record<string, unknown>;
+      data: Record<string, unknown>;
+    }) => Promise<{ count: number }>;
+    deleteMany: (args: {
+      where: Record<string, unknown>;
+    }) => Promise<{ count: number }>;
+  };
+  expense: {
+    count: (args: { where: Record<string, unknown> }) => Promise<number>;
+  };
+  auditLog?: {
+    create: (args: { data: Record<string, unknown> }) => Promise<unknown>;
+  };
+}
 
 @Injectable()
 export class ExpenseLedgerCategoriesService {
@@ -23,15 +83,11 @@ export class ExpenseLedgerCategoriesService {
 
   async listCategories(
     tenantId: string,
-    userRoles: string[],
+    membershipId: string,
     movementType?: 'EXPENSE' | 'INCOME',
     catalogScope?: 'BUILDING' | 'CONDOMINIUM_COMMON',
   ): Promise<ExpenseLedgerCategoryResponseDto[]> {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
-      throw new ForbiddenException(
-        'Solo administradores pueden gestionar rubros',
-      );
-    }
+    await this.resolveAuthorizedMembership(this.prisma, tenantId, membershipId);
 
     const categories = await this.prisma.expenseLedgerCategory.findMany({
       where: {
@@ -41,33 +97,27 @@ export class ExpenseLedgerCategoriesService {
       },
       orderBy: [
         { isActive: 'desc' },
-        { sortOrder: 'asc' }, // nulls last (PostgreSQL default)
+        { sortOrder: 'asc' },
         { name: 'asc' },
       ],
     });
 
-    return categories.map(this.toDto);
+    return categories.map((category) => this.toDto(category));
   }
 
   async getCategory(
     tenantId: string,
     categoryId: string,
-    userRoles: string[],
+    membershipId: string,
   ): Promise<ExpenseLedgerCategoryResponseDto> {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
-      throw new ForbiddenException(
-        'Solo administradores pueden gestionar rubros de gastos',
-      );
-    }
+    await this.resolveAuthorizedMembership(this.prisma, tenantId, membershipId);
 
     const category = await this.prisma.expenseLedgerCategory.findFirst({
       where: { id: categoryId, tenantId },
     });
 
     if (!category) {
-      throw new NotFoundException(
-        `Rubro de gasto no encontrado: ${categoryId}`,
-      );
+      throw new NotFoundException(`Rubro de gasto no encontrado: ${categoryId}`);
     }
 
     return this.toDto(category);
@@ -76,189 +126,292 @@ export class ExpenseLedgerCategoriesService {
   async createCategory(
     tenantId: string,
     membershipId: string,
-    userRoles: string[],
     dto: CreateExpenseLedgerCategoryDto,
   ): Promise<ExpenseLedgerCategoryResponseDto> {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
-      throw new ForbiddenException(
-        'Solo administradores pueden gestionar rubros',
+    return this.prisma.$transaction(async (tx) => {
+      const membership = await this.resolveAuthorizedMembership(tx, tenantId, membershipId);
+
+      const existing = await tx.expenseLedgerCategory.findFirst({
+        where: { tenantId, name: dto.name },
+      });
+
+      if (existing) {
+        throw new ConflictException(`Ya existe un rubro con el nombre "${dto.name}"`);
+      }
+
+      const movementType = dto.movementType ?? 'EXPENSE';
+      const catalogScope = dto.catalogScope ?? 'BUILDING';
+      let code = this.generateCode(dto.name, movementType);
+      let category: ExpenseLedgerCategoryRecord | null = null;
+
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        try {
+          category = await tx.expenseLedgerCategory.create({
+            data: {
+              tenantId,
+              code,
+              name: dto.name,
+              description: dto.description ?? null,
+              movementType,
+              catalogScope,
+            },
+          });
+          break;
+        } catch (error: unknown) {
+          if (!this.isP2002Error(error)) {
+            throw error;
+          }
+
+          const target = this.getUniqueTarget(error);
+          if (this.isUniqueField(target, 'code') && attempt === 0) {
+            code = this.generateCode(dto.name, movementType);
+            continue;
+          }
+
+          this.handleCategoryMutationError(error, dto);
+        }
+      }
+
+      if (!category) {
+        throw new ConflictException('No se pudo crear el rubro de gasto');
+      }
+
+      await this.auditService.createLogRequired(
+        {
+          tenantId,
+          actorMembershipId: membership.id,
+          action: 'EXPENSE_LEDGER_CATEGORY_CREATE',
+          entityType: 'ExpenseLedgerCategory',
+          entityId: category.id,
+          metadata: { name: dto.name, movementType, catalogScope, code },
+        },
+        tx,
       );
-    }
 
-    const existing = await this.prisma.expenseLedgerCategory.findFirst({
-      where: { tenantId, name: dto.name },
+      return this.toDto(category);
     });
-
-    if (existing) {
-      throw new ConflictException(
-        `Ya existe un rubro con el nombre "${dto.name}"`,
-      );
-    }
-
-    const movementType = (dto.movementType ?? 'EXPENSE') as 'EXPENSE' | 'INCOME';
-    const code = this.generateCode(dto.name, movementType);
-
-    const category = await this.prisma.expenseLedgerCategory.create({
-      data: {
-        tenantId,
-        code,
-        name: dto.name,
-        description: dto.description ?? null,
-        movementType,
-      },
-    });
-
-    void this.auditService.createLog({
-      tenantId,
-      actorMembershipId: membershipId,
-      action: 'EXPENSE_LEDGER_CATEGORY_CREATE',
-      entityType: 'ExpenseLedgerCategory',
-      entityId: category.id,
-      metadata: { name: dto.name, movementType, code },
-    });
-
-    return this.toDto(category);
   }
 
   async updateCategory(
     tenantId: string,
     categoryId: string,
     membershipId: string,
-    userRoles: string[],
     dto: UpdateExpenseLedgerCategoryDto,
   ): Promise<ExpenseLedgerCategoryResponseDto> {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
-      throw new ForbiddenException(
-        'Solo administradores pueden gestionar rubros de gastos',
-      );
-    }
+    return this.prisma.$transaction(async (tx) => {
+      const membership = await this.resolveAuthorizedMembership(tx, tenantId, membershipId);
 
-    const category = await this.prisma.expenseLedgerCategory.findFirst({
-      where: { id: categoryId, tenantId },
-    });
-
-    if (!category) {
-      throw new NotFoundException(
-        `Rubro de gasto no encontrado: ${categoryId}`,
-      );
-    }
-
-    if (dto.name && dto.name !== category.name) {
-      const conflict = await this.prisma.expenseLedgerCategory.findFirst({
-        where: { tenantId, name: dto.name, id: { not: categoryId } },
+      const current = await tx.expenseLedgerCategory.findFirst({
+        where: { id: categoryId, tenantId },
       });
-      if (conflict) {
-        throw new ConflictException(
-          `Ya existe un rubro con el nombre "${dto.name}"`,
-        );
+
+      if (!current) {
+        throw new NotFoundException(`Rubro de gasto no encontrado: ${categoryId}`);
       }
-    }
 
-    const updated = await this.prisma.expenseLedgerCategory.update({
-      where: { id: categoryId },
-      data: {
-        name: dto.name ?? category.name,
-        description: dto.description !== undefined ? dto.description : category.description,
-        isActive: dto.isActive !== undefined ? dto.isActive : category.isActive,
-      },
-    });
+      if (dto.name && dto.name !== current.name) {
+        const conflict = await tx.expenseLedgerCategory.findFirst({
+          where: { tenantId, name: dto.name, id: { not: categoryId } },
+        });
+        if (conflict) {
+          throw new ConflictException(`Ya existe un rubro con el nombre "${dto.name}"`);
+        }
+      }
 
-    void this.auditService.createLog({
-      tenantId,
-      actorMembershipId: membershipId,
-      action: 'EXPENSE_LEDGER_CATEGORY_UPDATE',
-      entityType: 'ExpenseLedgerCategory',
-      entityId: categoryId,
-      metadata: dto,
-    });
+      const mutationResult = await tx.expenseLedgerCategory.updateMany({
+        where: { id: categoryId, tenantId },
+        data: {
+          name: dto.name ?? current.name,
+          description: dto.description !== undefined ? dto.description : current.description,
+          isActive: dto.isActive !== undefined ? dto.isActive : current.isActive,
+          catalogScope: dto.catalogScope ?? current.catalogScope,
+        },
+      });
 
-    return this.toDto(updated);
+      if (mutationResult.count === 0) {
+        throw new NotFoundException(`Rubro de gasto no encontrado: ${categoryId}`);
+      }
+
+      if (mutationResult.count > 1) {
+        throw new ConflictException('Mutación ambigua al actualizar el rubro');
+      }
+
+      const updated = await tx.expenseLedgerCategory.findFirst({
+        where: { id: categoryId, tenantId },
+      });
+
+      if (!updated) {
+        throw new NotFoundException(`Rubro de gasto no encontrado: ${categoryId}`);
+      }
+
+      await this.auditService.createLogRequired(
+        {
+          tenantId,
+          actorMembershipId: membership.id,
+          action: 'EXPENSE_LEDGER_CATEGORY_UPDATE',
+          entityType: 'ExpenseLedgerCategory',
+          entityId: categoryId,
+          metadata: {
+            ...dto,
+            catalogScope: dto.catalogScope ?? current.catalogScope,
+          },
+        },
+        tx,
+      );
+
+      return this.toDto(updated);
+    }).catch((error: unknown) => this.handleCategoryMutationError(error, dto));
   }
 
   async deleteCategory(
     tenantId: string,
     categoryId: string,
     membershipId: string,
-    userRoles: string[],
   ): Promise<void> {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
-      throw new ForbiddenException(
-        'Solo administradores pueden gestionar rubros de gastos',
-      );
-    }
+    await this.prisma.$transaction(async (tx) => {
+      const membership = await this.resolveAuthorizedMembership(tx, tenantId, membershipId);
 
-    const category = await this.prisma.expenseLedgerCategory.findFirst({
-      where: { id: categoryId, tenantId },
-    });
-
-    if (!category) {
-      throw new NotFoundException(
-        `Rubro de gasto no encontrado: ${categoryId}`,
-      );
-    }
-
-    const usageCount = await this.prisma.expense.count({
-      where: { categoryId, tenantId },
-    });
-
-    if (usageCount > 0) {
-      // Soft delete: marcar inactivo en vez de borrar (hay gastos usando este rubro)
-      await this.prisma.expenseLedgerCategory.update({
-        where: { id: categoryId },
-        data: { isActive: false },
+      const current = await tx.expenseLedgerCategory.findFirst({
+        where: { id: categoryId, tenantId },
       });
-    } else {
-      await this.prisma.expenseLedgerCategory.delete({
-        where: { id: categoryId },
-      });
-    }
 
-    void this.auditService.createLog({
-      tenantId,
-      actorMembershipId: membershipId,
-      action: 'EXPENSE_LEDGER_CATEGORY_DELETE',
-      entityType: 'ExpenseLedgerCategory',
-      entityId: categoryId,
-      metadata: { name: category.name, hadExpenses: usageCount > 0 },
+      if (!current) {
+        throw new NotFoundException(`Rubro de gasto no encontrado: ${categoryId}`);
+      }
+
+      const usageCount = await tx.expense.count({
+        where: { categoryId, tenantId },
+      });
+
+      if (usageCount > 0) {
+        const mutationResult = await tx.expenseLedgerCategory.updateMany({
+          where: { id: categoryId, tenantId, isActive: true },
+          data: { isActive: false },
+        });
+
+        if (mutationResult.count === 0) {
+          throw new NotFoundException(`Rubro de gasto no encontrado: ${categoryId}`);
+        }
+
+        if (mutationResult.count > 1) {
+          throw new ConflictException('Mutación ambigua al eliminar el rubro');
+        }
+      } else {
+        const mutationResult = await tx.expenseLedgerCategory.deleteMany({
+          where: { id: categoryId, tenantId },
+        });
+
+        if (mutationResult.count === 0) {
+          throw new NotFoundException(`Rubro de gasto no encontrado: ${categoryId}`);
+        }
+
+        if (mutationResult.count > 1) {
+          throw new ConflictException('Mutación ambigua al eliminar el rubro');
+        }
+      }
+
+      await this.auditService.createLogRequired(
+        {
+          tenantId,
+          actorMembershipId: membership.id,
+          action: 'EXPENSE_LEDGER_CATEGORY_DELETE',
+          entityType: 'ExpenseLedgerCategory',
+          entityId: categoryId,
+          metadata: { name: current.name, hadExpenses: usageCount > 0 },
+        },
+        tx,
+      );
     });
   }
 
-  private toDto(category: {
-    id: string;
-    tenantId: string;
-    code?: string | null;
-    name: string;
-    description: string | null;
-    movementType: 'EXPENSE' | 'INCOME';
-    catalogScope: 'BUILDING' | 'CONDOMINIUM_COMMON';
-    sortOrder?: number;
-    isActive: boolean;
-    createdAt: Date;
-    updatedAt: Date;
-  }): ExpenseLedgerCategoryResponseDto {
+  private async resolveAuthorizedMembership(
+    tx: CategoryMutationTx | PrismaService | Prisma.TransactionClient,
+    tenantId: string,
+    membershipId: string,
+  ): Promise<{ id: string; tenantId: string; roles: string[] }> {
+    const membership = await tx.membership.findFirst({
+      where: { id: membershipId, tenantId },
+      select: { id: true, tenantId: true, roles: true },
+    });
+
+    if (!membership) {
+      throw new NotFoundException('No se encontró una membresía válida para el tenant');
+    }
+
+    const membershipRoles = membership.roles
+      .filter((role) => role.scopeType === 'TENANT')
+      .map((role) => role.role);
+
+    if (!this.validators.isAdminOrOperator(membershipRoles)) {
+      throw new ForbiddenException('Solo administradores pueden gestionar rubros');
+    }
+
+    return { id: membership.id, tenantId: membership.tenantId, roles: membershipRoles };
+  }
+
+  private handleCategoryMutationError<T>(
+    error: unknown,
+    dto: T,
+  ): never {
+    if (this.isP2002Error(error)) {
+      const target = this.getUniqueTarget(error);
+
+      if (this.isUniqueField(target, 'name')) {
+        const name = (dto as { name?: string }).name;
+        throw new ConflictException(
+          name ? `Ya existe un rubro con el nombre "${name}"` : 'Ya existe un rubro con ese nombre',
+        );
+      }
+
+      throw new ConflictException('Conflicto de unicidad al actualizar el rubro');
+    }
+
+    throw error as never;
+  }
+
+  private isP2002Error(error: unknown): error is Prisma.PrismaClientKnownRequestError {
+    return (
+      error instanceof Prisma.PrismaClientKnownRequestError &&
+      error.code === 'P2002'
+    );
+  }
+
+  private getUniqueTarget(error: Prisma.PrismaClientKnownRequestError): string[] {
+    const meta = error.meta as { target?: unknown } | undefined;
+    if (!Array.isArray(meta?.target)) {
+      return [];
+    }
+
+    return meta.target.filter((value): value is string => typeof value === 'string');
+  }
+
+  private isUniqueField(target: string[], field: string): boolean {
+    return target.includes(field);
+  }
+
+  private toDto(category: ExpenseLedgerCategoryRecord): ExpenseLedgerCategoryResponseDto {
     return {
       id: category.id,
       tenantId: category.tenantId,
-      code: category.code ?? null,
+      code: category.code,
       name: category.name,
       description: category.description,
       movementType: category.movementType,
       catalogScope: category.catalogScope,
-      sortOrder: category.sortOrder ?? 0,
+      sortOrder: category.sortOrder,
       isActive: category.isActive,
       createdAt: category.createdAt,
       updatedAt: category.updatedAt,
     };
   }
 
-  private generateCode(name: string, movementType: 'EXPENSE' | 'INCOME'): string {
+  private generateCode(name: string, movementType: ExpenseLedgerCategoryMovementType): string {
     const prefix = movementType === 'EXPENSE' ? 'EXP' : 'INC';
-    // Convert name to slug: "Electricidad" → "ELECTRICIDAD"
     const slug = name
       .toUpperCase()
       .replace(/\s+/g, '_')
       .replace(/[^A-Z0-9_]/g, '');
-    const timestamp = Date.now().toString().slice(-4); // last 4 digits of timestamp
-    return `${prefix}_${slug}_${timestamp}`;
+
+    return `${prefix}_${slug}_${randomUUID().slice(0, 8).toUpperCase()}`;
   }
 }

--- a/apps/api/src/finanzas/expense-ledger.dto.ts
+++ b/apps/api/src/finanzas/expense-ledger.dto.ts
@@ -2,7 +2,6 @@ import {
   IsString,
   IsOptional,
   IsInt,
-  IsNumber,
   IsISO8601,
   IsBoolean,
   IsEnum,
@@ -10,11 +9,18 @@ import {
   ValidateNested,
   MinLength,
   Min,
-  Max,
   Length,
   Matches,
+  ValidateIf,
+  registerDecorator,
+  ValidationOptions,
+  ValidationArguments,
 } from 'class-validator';
-import { Type } from 'class-transformer';
+import { Transform, Type } from 'class-transformer';
+import { MovementType } from '@prisma/client';
+
+export type ExpenseLedgerCategoryMovementType = 'EXPENSE' | 'INCOME';
+export type ExpenseLedgerCategoryCatalogScope = 'BUILDING' | 'CONDOMINIUM_COMMON';
 
 // ── Movement Allocation ────────────────────────────────────────────────────
 
@@ -22,10 +28,9 @@ export class AllocationInputDto {
   @IsString()
   buildingId!: string;
 
-  @IsNumber({ maxDecimalPlaces: 4 })
+  @IsInt()
   @IsOptional()
   @Min(0)
-  @Max(100)
   percentage?: number; // 0-100
 
   @IsInt()
@@ -52,11 +57,12 @@ export class CreateExpenseLedgerCategoryDto {
 
   @IsString()
   @IsOptional()
-  movementType?: 'EXPENSE' | 'INCOME'; // default EXPENSE if not provided
+  @IsEnum(MovementType)
+  movementType?: ExpenseLedgerCategoryMovementType; // default EXPENSE if not provided
 
   @IsEnum(['BUILDING', 'CONDOMINIUM_COMMON'])
   @IsOptional()
-  catalogScope?: 'BUILDING' | 'CONDOMINIUM_COMMON'; // default BUILDING if not provided
+  catalogScope?: ExpenseLedgerCategoryCatalogScope; // default BUILDING if not provided
 }
 
 export class UpdateExpenseLedgerCategoryDto {
@@ -75,7 +81,25 @@ export class UpdateExpenseLedgerCategoryDto {
 
   @IsEnum(['BUILDING', 'CONDOMINIUM_COMMON'])
   @IsOptional()
-  catalogScope?: 'BUILDING' | 'CONDOMINIUM_COMMON';
+  catalogScope?: ExpenseLedgerCategoryCatalogScope;
+}
+
+export class ExpenseLedgerCategoryQueryDto {
+  @IsOptional()
+  @IsEnum(MovementType, { message: 'movementType must be EXPENSE or INCOME' })
+  movementType?: ExpenseLedgerCategoryMovementType;
+
+  @IsOptional()
+  @Matches(/^(BUILDING|CONDOMINIUM_COMMON)$/, {
+    message: 'catalogScope must be BUILDING or CONDOMINIUM_COMMON',
+  })
+  catalogScope?: ExpenseLedgerCategoryCatalogScope;
+}
+
+export class ExpenseLedgerCategoryParamDto {
+  @IsString()
+  @Matches(/^c[0-9a-z]{24}$/)
+  categoryId!: string;
 }
 
 export interface ExpenseLedgerCategoryResponseDto {
@@ -100,9 +124,8 @@ export class CreateExpenseDto {
   buildingId?: string; // Optional for TENANT_SHARED scope
 
   @IsString()
-  @IsOptional()
   @Matches(/^\d{4}-\d{2}$/, { message: 'period must be in YYYY-MM format' })
-  period?: string; // Informational only — liquidationPeriod is derived from invoiceDate
+  period!: string;
 
   @IsString()
   categoryId!: string;
@@ -206,7 +229,9 @@ export class CreateLiquidationDraftDto {
   buildingId!: string;
 
   @IsString()
-  @Matches(/^\d{4}-\d{2}$/, { message: 'period must be in YYYY-MM format' })
+  @Matches(/^\d{4}-(0[1-9]|1[0-2])$/, {
+    message: 'period must be in YYYY-MM format',
+  })
   period!: string;
 
   @IsString()
@@ -215,8 +240,64 @@ export class CreateLiquidationDraftDto {
 }
 
 export class PublishLiquidationDto {
-  @IsISO8601()
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @IsString()
+  @IsStrictDateString({ message: 'dueDate must be a valid YYYY-MM-DD date' })
   dueDate!: string;
+}
+
+export class CancelLiquidationDto {
+  @Transform(({ value }) => (typeof value === 'string' ? value.trim() : value))
+  @ValidateIf((_, value) => value !== undefined)
+  @IsString()
+  @MinLength(1)
+  reason?: string;
+}
+
+export class ListLiquidationsQueryDto {
+  @IsOptional()
+  @Matches(/^\d{4}-(0[1-9]|1[0-2])$/, {
+    message: 'period must be in YYYY-MM format',
+  })
+  period?: string;
+
+  @IsOptional()
+  @IsString()
+  buildingId?: string;
+}
+
+export class LiquidationParamDto {
+  @IsString()
+  @Matches(/^c[0-9a-z]{24}$/)
+  liquidationId!: string;
+}
+
+function IsStrictDateString(validationOptions?: ValidationOptions) {
+  return (object: object, propertyName: string): void => {
+    registerDecorator({
+      name: 'IsStrictDateString',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown, args: ValidationArguments): boolean {
+          if (typeof value !== 'string') {
+            return false;
+          }
+
+          if (value.trim() !== value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+            return false;
+          }
+
+          const date = new Date(`${value}T00:00:00.000Z`);
+          return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+        },
+        defaultMessage(validationArguments?: ValidationArguments): string {
+          return `${validationArguments?.property ?? 'value'} must be a valid YYYY-MM-DD date`;
+        },
+      },
+    });
+  };
 }
 
 export interface LiquidationResponseDto {
@@ -238,6 +319,7 @@ export interface LiquidationResponseDto {
 }
 
 export interface LiquidationDetailDto extends LiquidationResponseDto {
+  publicationSnapshotStatus: 'AVAILABLE' | 'LEGACY';
   expenses: Array<{
     id: string;
     categoryName: string;

--- a/apps/api/src/finanzas/liquidation-engine.controller.spec.ts
+++ b/apps/api/src/finanzas/liquidation-engine.controller.spec.ts
@@ -1,0 +1,152 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { LiquidationEngineController } from './liquidation-engine.controller';
+import { LiquidationEngineService } from './liquidation-engine.service';
+import type { AuthenticatedRequest } from '../common/types/request.types';
+
+describe('LiquidationEngineController', () => {
+  let controller: LiquidationEngineController;
+  let service: {
+    createLiquidationDraft: jest.Mock;
+    getLiquidationDetail: jest.Mock;
+    reviewLiquidation: jest.Mock;
+    publishLiquidation: jest.Mock;
+    cancelLiquidation: jest.Mock;
+  };
+
+  const tenantId = 'tenant-1';
+  const membershipId = 'member-1';
+
+  const stubReq = (
+    overrides: Partial<AuthenticatedRequest> = {},
+  ): AuthenticatedRequest =>
+    ({
+      tenantId,
+      user: {
+        id: 'user-1',
+        email: 'admin@test.com',
+        membershipId,
+        tenantId,
+        roles: ['TENANT_ADMIN'],
+      },
+      ...overrides,
+    }) as AuthenticatedRequest;
+
+  beforeEach(async () => {
+    service = {
+      createLiquidationDraft: jest.fn(),
+      getLiquidationDetail: jest.fn(),
+      reviewLiquidation: jest.fn(),
+      publishLiquidation: jest.fn(),
+      cancelLiquidation: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [LiquidationEngineController],
+      providers: [
+        {
+          provide: LiquidationEngineService,
+          useValue: service,
+        },
+      ],
+    }).compile();
+
+    controller = module.get(LiquidationEngineController);
+  });
+
+  it('creates drafts without forwarding JWT roles and uses persisted membership', async () => {
+    const dto = {
+      buildingId: 'building-1',
+      period: '2026-05',
+      baseCurrency: 'ARS',
+    };
+
+    service.createLiquidationDraft.mockResolvedValue({
+      liquidation: { id: 'liq-1' },
+      expenses: [],
+      chargesPreview: [],
+    });
+
+    await controller.createDraft(stubReq(), dto);
+
+    expect(service.createLiquidationDraft).toHaveBeenCalledWith(
+      tenantId,
+      dto.buildingId,
+      dto.period,
+      dto.baseCurrency,
+      membershipId,
+    );
+  });
+
+  it('requires membershipId for detail reads', async () => {
+    await expect(
+      controller.getDetail(
+        {
+          tenantId,
+          user: {
+            id: 'user-1',
+            email: 'admin@test.com',
+            tenantId,
+            roles: ['TENANT_ADMIN'],
+          },
+        } as AuthenticatedRequest,
+        'liq-1',
+      ),
+    ).rejects.toThrow(UnauthorizedException);
+  });
+
+  it('reads details using the persisted membership only', async () => {
+    const req = stubReq();
+
+    service.getLiquidationDetail.mockResolvedValue({
+      id: 'liq-1',
+      status: 'DRAFT',
+      expenses: [],
+      chargesPreview: [],
+    });
+
+    await controller.getDetail(req, 'liq-1');
+
+    expect(service.getLiquidationDetail).toHaveBeenCalledWith(
+      tenantId,
+      'liq-1',
+      membershipId,
+    );
+  });
+
+  it('reviews, publishes and cancels without forwarding JWT roles', async () => {
+    const params = 'liq-1';
+    const publishDto = { dueDate: '2026-06-10' };
+
+    service.reviewLiquidation.mockResolvedValue({ id: params });
+    service.publishLiquidation.mockResolvedValue({ id: params });
+    service.cancelLiquidation.mockResolvedValue({ id: params });
+
+    await controller.review(stubReq(), params);
+    await controller.publish(stubReq(), params, publishDto);
+    await controller.cancel(stubReq(), params);
+
+    expect(service.reviewLiquidation).toHaveBeenCalledWith(
+      tenantId,
+      params,
+      membershipId,
+    );
+    expect(service.publishLiquidation).toHaveBeenCalledWith(
+      tenantId,
+      params,
+      expect.any(Date),
+      membershipId,
+    );
+    expect(service.cancelLiquidation).toHaveBeenCalledWith(
+      tenantId,
+      params,
+      membershipId,
+    );
+  });
+
+  it('rejects invalid due dates before reaching the service', async () => {
+    await expect(
+      controller.publish(stubReq(), 'liq-1', { dueDate: 'not-a-date' }),
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/finanzas/liquidation-engine.controller.ts
+++ b/apps/api/src/finanzas/liquidation-engine.controller.ts
@@ -50,7 +50,6 @@ export class LiquidationEngineController {
   ) {
     const tenantId = req.tenantId || req.user?.tenantId;
     const membershipId = req.user?.membershipId;
-    const roles = req.user?.roles ?? [];
 
     if (!tenantId || !membershipId) {
       throw new UnauthorizedException(
@@ -64,7 +63,6 @@ export class LiquidationEngineController {
       dto.period,
       dto.baseCurrency,
       membershipId,
-      roles,
     );
   }
 
@@ -80,16 +78,18 @@ export class LiquidationEngineController {
     @Param('liquidationId') liquidationId: string,
   ) {
     const tenantId = req.tenantId || req.user?.tenantId;
-    const roles = req.user?.roles ?? [];
+    const membershipId = req.user?.membershipId;
 
-    if (!tenantId) {
-      throw new UnauthorizedException('Missing tenantId in request');
+    if (!tenantId || !membershipId) {
+      throw new UnauthorizedException(
+        'Missing tenantId or membershipId in request',
+      );
     }
 
     return this.liquidationEngine.getLiquidationDetail(
       tenantId,
       liquidationId,
-      roles,
+      membershipId,
     );
   }
 
@@ -107,7 +107,6 @@ export class LiquidationEngineController {
   ) {
     const tenantId = req.tenantId || req.user?.tenantId;
     const membershipId = req.user?.membershipId;
-    const roles = req.user?.roles ?? [];
 
     if (!tenantId || !membershipId) {
       throw new UnauthorizedException(
@@ -119,7 +118,6 @@ export class LiquidationEngineController {
       tenantId,
       liquidationId,
       membershipId,
-      roles,
     );
   }
 
@@ -139,7 +137,6 @@ export class LiquidationEngineController {
   ) {
     const tenantId = req.tenantId || req.user?.tenantId;
     const membershipId = req.user?.membershipId;
-    const roles = req.user?.roles ?? [];
 
     if (!tenantId || !membershipId) {
       throw new UnauthorizedException(
@@ -157,13 +154,12 @@ export class LiquidationEngineController {
       liquidationId,
       dueDate,
       membershipId,
-      roles,
     );
   }
 
   /**
    * Cancel a liquidation
-   * If PUBLISHED, removes all associated charges
+   * PUBLISHED liquidations are terminal and cannot be canceled directly
    * @param req Authenticated request with tenantId and membershipId
    * @param liquidationId ID of liquidation to cancel
    * @returns Updated liquidation
@@ -175,7 +171,6 @@ export class LiquidationEngineController {
   ) {
     const tenantId = req.tenantId || req.user?.tenantId;
     const membershipId = req.user?.membershipId;
-    const roles = req.user?.roles ?? [];
 
     if (!tenantId || !membershipId) {
       throw new UnauthorizedException(
@@ -187,7 +182,6 @@ export class LiquidationEngineController {
       tenantId,
       liquidationId,
       membershipId,
-      roles,
     );
   }
 }

--- a/apps/api/src/finanzas/liquidation-engine.service.spec.ts
+++ b/apps/api/src/finanzas/liquidation-engine.service.spec.ts
@@ -14,7 +14,6 @@ describe('LiquidationEngineService', () => {
   const tenantId = 'tenant-123';
   const buildingId = 'building-456';
   const membershipId = 'member-789';
-  const adminRoles = ['TENANT_ADMIN'];
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -29,6 +28,7 @@ describe('LiquidationEngineService', () => {
               findFirst: jest.fn(),
               create: jest.fn(),
               update: jest.fn(),
+              updateMany: jest.fn(),
               delete: jest.fn(),
               deleteMany: jest.fn(),
             },
@@ -36,6 +36,9 @@ describe('LiquidationEngineService', () => {
               createMany: jest.fn(),
               findMany: jest.fn(),
               deleteMany: jest.fn(),
+            },
+            membership: {
+              findFirst: jest.fn(),
             },
             $transaction: jest.fn(),
           },
@@ -61,6 +64,11 @@ describe('LiquidationEngineService', () => {
     jest.spyOn(prisma, '$transaction').mockImplementation(
       async (callback) => callback(prisma),
     );
+    jest.spyOn(prisma.membership, 'findFirst').mockResolvedValue({
+      id: membershipId,
+      tenantId,
+      roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+    } as never);
   });
 
   describe('createLiquidationDraft', () => {
@@ -89,12 +97,18 @@ describe('LiquidationEngineService', () => {
         { id: 'unit-2', code: 'A-102', label: '102', m2: 150 },
       ];
 
+      const persistedMembershipId = 'member-persisted-create';
+      jest.spyOn(prisma.membership, 'findFirst').mockResolvedValueOnce({
+        id: persistedMembershipId,
+        tenantId,
+        roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+      } as never);
       jest
         .spyOn(prisma.expense, 'findMany')
-        .mockResolvedValueOnce(expenses as any)
-        .mockResolvedValueOnce([]);
-      jest.spyOn(prisma.unit, 'findMany').mockResolvedValue(units as any);
-      jest.spyOn(prisma.liquidation, 'create').mockResolvedValue({
+        .mockResolvedValueOnce(expenses as never)
+        .mockResolvedValueOnce([] as never);
+      jest.spyOn(prisma.unit, 'findMany').mockResolvedValue(units as never);
+      const createSpy = jest.spyOn(prisma.liquidation, 'create').mockResolvedValue({
         id: 'liq-1',
         tenantId,
         buildingId,
@@ -104,7 +118,7 @@ describe('LiquidationEngineService', () => {
         totalAmountMinor: 150000,
         totalsByCurrency: { ARS: 150000 },
         unitCount: 2,
-      } as any);
+      } as never);
 
       const result = await service.createLiquidationDraft(
         tenantId,
@@ -112,15 +126,22 @@ describe('LiquidationEngineService', () => {
         '2026-04',
         'ARS',
         membershipId,
-        adminRoles,
       );
 
       expect(result.liquidation.id).toBe('liq-1');
       expect(result.liquidation.status).toBe('DRAFT');
       expect(result.chargesPreview.length).toBe(2);
+      expect(createSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            generatedByMembershipId: persistedMembershipId,
+          }),
+        }),
+      );
       expect(auditService.createLogRequired).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'LIQUIDATION_DRAFT',
+          actorMembershipId: persistedMembershipId,
         }),
         prisma,
       );
@@ -139,7 +160,6 @@ describe('LiquidationEngineService', () => {
           '2026-04',
           'ARS',
           membershipId,
-          adminRoles,
         ),
       ).rejects.toThrow(BadRequestException);
     });
@@ -159,7 +179,7 @@ describe('LiquidationEngineService', () => {
 
       jest
         .spyOn(prisma.expense, 'findMany')
-        .mockResolvedValueOnce(expenses as any)
+        .mockResolvedValueOnce(expenses as never)
         .mockResolvedValueOnce([]);
       jest.spyOn(prisma.unit, 'findMany').mockResolvedValue([]);
 
@@ -170,15 +190,12 @@ describe('LiquidationEngineService', () => {
           '2026-04',
           'ARS',
           membershipId,
-          adminRoles,
         ),
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('debería prevenir acceso no-admin', async () => {
-      jest
-        .spyOn(validators, 'isAdminOrOperator')
-        .mockReturnValue(false);
+    it('debería rechazar una membresía inexistente aunque el JWT tenga rol ADMIN', async () => {
+      jest.spyOn(prisma.membership, 'findFirst').mockResolvedValueOnce(null);
 
       await expect(
         service.createLiquidationDraft(
@@ -187,52 +204,107 @@ describe('LiquidationEngineService', () => {
           '2026-04',
           'ARS',
           membershipId,
-          ['RESIDENT'],
         ),
-      ).rejects.toThrow('Solo administradores pueden crear liquidaciones');
+      ).rejects.toThrow('No se encontró una membresía válida para el tenant');
+    });
+
+    it('debería rechazar una membresía de otro tenant', async () => {
+      jest.spyOn(prisma.membership, 'findFirst').mockResolvedValueOnce(null);
+
+      await expect(
+        service.createLiquidationDraft(
+          'tenant-other',
+          buildingId,
+          '2026-04',
+          'ARS',
+          membershipId,
+        ),
+      ).rejects.toThrow('No se encontró una membresía válida para el tenant');
+    });
+
+    it('debería rechazar una membresía sin rol TENANT autorizado', async () => {
+      jest.spyOn(validators, 'isAdminOrOperator').mockReturnValueOnce(false);
+      jest.spyOn(prisma.membership, 'findFirst').mockResolvedValueOnce({
+        id: membershipId,
+        tenantId,
+        roles: [{ role: 'TENANT_ADMIN', scopeType: 'BUILDING' }],
+      } as never);
+
+      await expect(
+        service.createLiquidationDraft(
+          tenantId,
+          buildingId,
+          '2026-04',
+          'ARS',
+          membershipId,
+        ),
+      ).rejects.toThrow('Solo administradores pueden gestionar liquidaciones');
     });
   });
 
   describe('reviewLiquidation', () => {
-    it('debería cambiar estado DRAFT → REVIEWED', async () => {
+    it('debería cambiar estado DRAFT → REVIEWED y persistir reviewedByMembershipId', async () => {
       const liquidation = {
         id: 'liq-1',
         status: 'DRAFT',
         period: '2026-04',
       };
+      const reviewedLiquidation = {
+        ...liquidation,
+        status: 'REVIEWED',
+        reviewedByMembershipId: membershipId,
+      };
 
-      jest
-        .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValue(liquidation as any);
-      jest
-        .spyOn(prisma.liquidation, 'update')
-        .mockResolvedValue({ ...liquidation, status: 'REVIEWED' } as any);
+      jest.spyOn(prisma.liquidation, 'findFirst')
+        .mockResolvedValueOnce(liquidation as never)
+        .mockResolvedValueOnce(reviewedLiquidation as never);
+      const updateManySpy = jest
+        .spyOn(prisma.liquidation, 'updateMany')
+        .mockResolvedValue({ count: 1 });
 
       const result = await service.reviewLiquidation(
         tenantId,
         'liq-1',
-        membershipId,
-        adminRoles,
+        membershipId
       );
 
       expect(result.status).toBe('REVIEWED');
+      expect(result.reviewedByMembershipId).toBe(membershipId);
+      expect(updateManySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            id: 'liq-1',
+            tenantId,
+            status: 'DRAFT',
+          },
+        }),
+      );
+
+      const updateArgs = updateManySpy.mock.calls[0][0];
+      expect(updateArgs.data.reviewedAt).toBeInstanceOf(Date);
+      expect(updateArgs.data.updatedAt).toBe(updateArgs.data.reviewedAt);
+      expect(updateArgs.data.reviewedByMembershipId).toBe(membershipId);
       expect(auditService.createLogRequired).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'LIQUIDATION_REVIEW',
+          actorMembershipId: membershipId,
+          metadata: expect.objectContaining({
+            period: '2026-04',
+            previousStatus: 'DRAFT',
+          }),
         }),
         prisma,
       );
     });
 
     it('debería lanzar error si liquidación no existe', async () => {
-      jest.spyOn(prisma.liquidation, 'findFirst').mockResolvedValue(null);
+      jest.spyOn(prisma.liquidation, 'findFirst').mockResolvedValueOnce(null);
 
       await expect(
         service.reviewLiquidation(
           tenantId,
           'liq-not-found',
-          membershipId,
-          adminRoles,
+          membershipId
         ),
       ).rejects.toThrow(NotFoundException);
     });
@@ -240,16 +312,80 @@ describe('LiquidationEngineService', () => {
     it('debería lanzar error si status no es DRAFT', async () => {
       jest
         .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValue({ id: 'liq-1', status: 'PUBLISHED' } as any);
+        .mockResolvedValueOnce({ id: 'liq-1', status: 'PUBLISHED', period: '2026-04' } as never);
 
       await expect(
         service.reviewLiquidation(
           tenantId,
           'liq-1',
-          membershipId,
-          adminRoles,
+          membershipId
         ),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('debería lanzar error si la carrera deja la liquidación sin actualizar', async () => {
+      jest
+        .spyOn(prisma.liquidation, 'findFirst')
+        .mockResolvedValueOnce({ id: 'liq-1', status: 'DRAFT', period: '2026-04' } as never);
+      jest.spyOn(prisma.liquidation, 'updateMany').mockResolvedValue({ count: 0 });
+
+      await expect(
+        service.reviewLiquidation(
+          tenantId,
+          'liq-1',
+          membershipId
+        ),
+      ).rejects.toThrow('No fue posible revisar la liquidación porque cambió de estado');
+    });
+
+    it('debería revertir la revisión si falla la auditoría obligatoria', async () => {
+      const liquidation = {
+        id: 'liq-1',
+        status: 'DRAFT',
+        period: '2026-04',
+      };
+      let persistedStatus = 'DRAFT';
+      const transactionClient = {
+        ...prisma,
+        liquidation: {
+          ...prisma.liquidation,
+          findFirst: jest.fn().mockImplementation(async () => (
+            persistedStatus === 'REVIEWED'
+              ? {
+                ...liquidation,
+                status: 'REVIEWED',
+                reviewedByMembershipId: membershipId,
+              }
+              : liquidation
+          )),
+          updateMany: jest.fn().mockImplementation(async ({ data }) => {
+            persistedStatus = data.status;
+            return { count: 1 };
+          }),
+        },
+      };
+
+      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback) => {
+        const snapshot = persistedStatus;
+        try {
+          return await callback(transactionClient);
+        } catch (error) {
+          persistedStatus = snapshot;
+          throw error;
+        }
+      });
+      jest.spyOn(auditService, 'createLogRequired').mockRejectedValueOnce(new Error('audit failed'));
+      jest.spyOn(prisma.liquidation, 'findFirst').mockResolvedValueOnce(liquidation as never);
+
+      await expect(
+        service.reviewLiquidation(
+          tenantId,
+          'liq-1',
+          membershipId
+        ),
+      ).rejects.toThrow('audit failed');
+
+      expect(persistedStatus).toBe('DRAFT');
     });
   });
 
@@ -282,14 +418,20 @@ describe('LiquidationEngineService', () => {
         { id: 'unit-2', code: 'A-102', label: '102', m2: 200 },
       ];
 
+      const persistedMembershipId = 'member-persisted-publish';
+      jest.spyOn(prisma.membership, 'findFirst').mockResolvedValueOnce({
+        id: persistedMembershipId,
+        tenantId,
+        roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+      } as never);
       jest
         .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValue(liquidation as any);
+        .mockResolvedValue(liquidation as never);
       jest
         .spyOn(prisma.expense, 'findMany')
-        .mockResolvedValueOnce(expenses as any)
-        .mockResolvedValueOnce([]);
-      jest.spyOn(prisma.unit, 'findMany').mockResolvedValue(units as any);
+        .mockResolvedValueOnce(expenses as never)
+        .mockResolvedValueOnce([] as never);
+      jest.spyOn(prisma.unit, 'findMany').mockResolvedValue(units as never);
       jest
         .spyOn(prisma.charge, 'createMany')
         .mockResolvedValue({ count: 2 });
@@ -298,7 +440,7 @@ describe('LiquidationEngineService', () => {
         .mockResolvedValue({
           ...liquidation,
           status: 'PUBLISHED',
-        } as any);
+        } as never);
 
       const dueDate = new Date('2026-05-30');
       const result = await service.publishLiquidation(
@@ -306,7 +448,6 @@ describe('LiquidationEngineService', () => {
         'liq-1',
         dueDate,
         membershipId,
-        adminRoles,
       );
 
       expect(result.status).toBe('PUBLISHED');
@@ -324,16 +465,96 @@ describe('LiquidationEngineService', () => {
               ]),
             }),
             publishedAt: expect.any(Date),
-            publishedByMembershipId: membershipId,
+            publishedByMembershipId: persistedMembershipId,
           }),
         }),
       );
       expect(auditService.createLogRequired).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'LIQUIDATION_PUBLISH',
+          actorMembershipId: persistedMembershipId,
         }),
         prisma,
       );
+    });
+
+    it('debería distribuir centavos exactos con Largest Remainder y reflejarlos en la snapshot', async () => {
+      const liquidation = {
+        id: 'liq-1',
+        status: 'REVIEWED',
+        buildingId,
+        period: '2026-04',
+        baseCurrency: 'ARS',
+      };
+
+      const expenses = [
+        {
+          id: 'exp-1',
+          amountMinor: 100,
+          currencyCode: 'ARS',
+          category: { name: 'Electricidad' },
+          vendor: { name: 'EDENOR' },
+          invoiceDate: new Date('2026-04-10'),
+          description: 'Servicio eléctrico',
+          allocations: [],
+          scopeType: 'BUILDING',
+        },
+      ];
+
+      const units = [
+        { id: 'unit-c', code: 'C-103', label: '103', m2: 1 },
+        { id: 'unit-a', code: 'A-101', label: '101', m2: 1 },
+        { id: 'unit-b', code: 'B-102', label: '102', m2: 1 },
+      ];
+
+      jest.spyOn(prisma.membership, 'findFirst').mockResolvedValueOnce({
+        id: 'member-persisted-publish',
+        tenantId,
+        roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+      } as never);
+      jest
+        .spyOn(prisma.liquidation, 'findFirst')
+        .mockResolvedValueOnce(liquidation as never);
+      jest
+        .spyOn(prisma.expense, 'findMany')
+        .mockResolvedValueOnce(expenses as never)
+        .mockResolvedValueOnce([] as never);
+      jest.spyOn(prisma.unit, 'findMany').mockResolvedValue(units as never);
+      const createManySpy = jest
+        .spyOn(prisma.charge, 'createMany')
+        .mockResolvedValue({ count: 3 });
+      jest.spyOn(prisma.liquidation, 'update').mockImplementation(async ({ data }) => ({
+        ...liquidation,
+        status: 'PUBLISHED',
+        publicationSnapshot: data.publicationSnapshot,
+        publishedAt: data.publishedAt,
+        publishedByMembershipId: data.publishedByMembershipId,
+      }) as never);
+
+      const result = await service.publishLiquidation(
+        tenantId,
+        'liq-1',
+        new Date('2026-05-30'),
+        membershipId,
+      );
+
+      expect(result.status).toBe('PUBLISHED');
+
+      const chargeAmounts = createManySpy.mock.calls[0][0].data.map(
+        (charge) => charge.amount,
+      );
+      expect(chargeAmounts).toEqual([34, 33, 33]);
+
+      expect(
+        (result.publicationSnapshot as {
+          allocations: Array<{ unitId: string; amountMinor: number }>;
+        }).allocations.map((allocation) => allocation.amountMinor),
+      ).toEqual([34, 33, 33]);
+      expect(
+        (result.publicationSnapshot as {
+          allocations: Array<{ unitId: string; amountMinor: number }>;
+        }).allocations.reduce((sum, allocation) => sum + allocation.amountMinor, 0),
+      ).toBe(100);
     });
 
     it('rolls back publication when required audit logging fails', async () => {
@@ -397,7 +618,6 @@ describe('LiquidationEngineService', () => {
           liquidation.id,
           new Date('2026-05-30'),
           membershipId,
-          adminRoles,
         ),
       ).rejects.toThrow('audit failed');
 
@@ -413,7 +633,7 @@ describe('LiquidationEngineService', () => {
     it('debería lanzar error si status no es REVIEWED', async () => {
       jest
         .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValue({ id: 'liq-1', status: 'DRAFT' } as any);
+        .mockResolvedValue({ id: 'liq-1', status: 'DRAFT' } as never);
 
       await expect(
         service.publishLiquidation(
@@ -421,75 +641,179 @@ describe('LiquidationEngineService', () => {
           'liq-1',
           new Date(),
           membershipId,
-          adminRoles,
         ),
       ).rejects.toThrow(BadRequestException);
     });
   });
 
   describe('cancelLiquidation', () => {
-    it('debería cambiar estado a CANCELED sin eliminar charges si DRAFT', async () => {
-      jest
-        .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValue({ id: 'liq-1', status: 'DRAFT' } as any);
-      jest.spyOn(prisma.liquidation, 'delete').mockResolvedValue({
+    it('debería cambiar estado DRAFT → CANCELED sin borrar la liquidación ni los cargos', async () => {
+      const liquidation = {
         id: 'liq-1',
         status: 'DRAFT',
-      } as any);
+        period: '2026-04',
+      };
+      const canceledLiquidation = {
+        ...liquidation,
+        status: 'CANCELED',
+        canceledByMembershipId: membershipId,
+      };
 
-      await service.cancelLiquidation(
+      jest
+        .spyOn(prisma.liquidation, 'findFirst')
+        .mockResolvedValueOnce(liquidation as never)
+        .mockResolvedValueOnce(canceledLiquidation as never);
+      const updateManySpy = jest
+        .spyOn(prisma.liquidation, 'updateMany')
+        .mockResolvedValue({ count: 1 });
+
+      const result = await service.cancelLiquidation(
         tenantId,
         'liq-1',
-        membershipId,
-        adminRoles,
+        membershipId
       );
 
+      expect(result.status).toBe('CANCELED');
+      expect(result.canceledByMembershipId).toBe(membershipId);
       expect(prisma.charge.deleteMany).not.toHaveBeenCalled();
-      expect(prisma.liquidation.delete).toHaveBeenCalledWith({
-        where: { id: 'liq-1' },
-      });
+      expect(prisma.liquidation.delete).not.toHaveBeenCalled();
+      expect(updateManySpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            id: 'liq-1',
+            tenantId,
+            status: { in: ['DRAFT', 'REVIEWED'] },
+          },
+        }),
+      );
+      const updateArgs = updateManySpy.mock.calls[0][0];
+      expect(updateArgs.data.canceledAt).toBeInstanceOf(Date);
+      expect(updateArgs.data.updatedAt).toBe(updateArgs.data.canceledAt);
+      expect(updateArgs.data.canceledByMembershipId).toBe(membershipId);
       expect(auditService.createLogRequired).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'LIQUIDATION_CANCEL' }),
+        expect.objectContaining({
+          action: 'LIQUIDATION_CANCEL',
+          actorMembershipId: membershipId,
+          metadata: expect.objectContaining({
+            period: '2026-04',
+            previousStatus: 'DRAFT',
+          }),
+        }),
         prisma,
       );
     });
 
-    it('debería eliminar charges si status es PUBLISHED', async () => {
+    it('debería permitir cancelar una liquidación REVIEWED', async () => {
       jest
         .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValue({ id: 'liq-1', status: 'PUBLISHED' } as any);
-      jest.spyOn(prisma.liquidation, 'delete').mockResolvedValue({
-        id: 'liq-1',
-        status: 'PUBLISHED',
-      } as any);
+        .mockResolvedValueOnce({ id: 'liq-1', status: 'REVIEWED', period: '2026-04' } as never)
+        .mockResolvedValueOnce({
+          id: 'liq-1',
+          status: 'CANCELED',
+          period: '2026-04',
+        } as never);
+      jest.spyOn(prisma.liquidation, 'updateMany').mockResolvedValue({ count: 1 });
 
-      await service.cancelLiquidation(
+      const result = await service.cancelLiquidation(
         tenantId,
         'liq-1',
-        membershipId,
-        adminRoles,
+        membershipId
       );
 
-      expect(prisma.charge.deleteMany).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: { tenantId, liquidationId: 'liq-1' },
-        }),
-      );
+      expect(result.status).toBe('CANCELED');
     });
 
-    it('debería lanzar error si ya está CANCELED', async () => {
+    it('debería rechazar cancelación directa de liquidaciones PUBLISHED', async () => {
       jest
         .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValue({ id: 'liq-1', status: 'CANCELED' } as any);
+        .mockResolvedValueOnce({ id: 'liq-1', status: 'PUBLISHED', period: '2026-04' } as never);
 
       await expect(
         service.cancelLiquidation(
           tenantId,
           'liq-1',
-          membershipId,
-          adminRoles,
+          membershipId
+        ),
+      ).rejects.toThrow('La liquidación publicada no se puede cancelar directamente');
+    });
+
+    it('debería rechazar una liquidación ya CANCELED', async () => {
+      jest
+        .spyOn(prisma.liquidation, 'findFirst')
+        .mockResolvedValueOnce({ id: 'liq-1', status: 'CANCELED', period: '2026-04' } as never);
+
+      await expect(
+        service.cancelLiquidation(
+          tenantId,
+          'liq-1',
+          membershipId
         ),
       ).rejects.toThrow(BadRequestException);
+    });
+
+    it('debería lanzar error si la carrera deja la liquidación sin actualizar', async () => {
+      jest
+        .spyOn(prisma.liquidation, 'findFirst')
+        .mockResolvedValueOnce({ id: 'liq-1', status: 'DRAFT', period: '2026-04' } as never);
+      jest.spyOn(prisma.liquidation, 'updateMany').mockResolvedValue({ count: 0 });
+
+      await expect(
+        service.cancelLiquidation(
+          tenantId,
+          'liq-1',
+          membershipId
+        ),
+      ).rejects.toThrow('No fue posible cancelar la liquidación porque cambió de estado');
+    });
+
+    it('debería revertir la cancelación si falla la auditoría obligatoria', async () => {
+      const liquidation = {
+        id: 'liq-1',
+        status: 'DRAFT',
+        period: '2026-04',
+      };
+      let persistedStatus = 'DRAFT';
+      const transactionClient = {
+        ...prisma,
+        liquidation: {
+          ...prisma.liquidation,
+          findFirst: jest.fn().mockImplementation(async () => (
+            persistedStatus === 'CANCELED'
+              ? {
+                ...liquidation,
+                status: 'CANCELED',
+                canceledByMembershipId: membershipId,
+              }
+              : liquidation
+          )),
+          updateMany: jest.fn().mockImplementation(async ({ data }) => {
+            persistedStatus = data.status;
+            return { count: 1 };
+          }),
+        },
+      };
+
+      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback) => {
+        const snapshot = persistedStatus;
+        try {
+          return await callback(transactionClient);
+        } catch (error) {
+          persistedStatus = snapshot;
+          throw error;
+        }
+      });
+      jest.spyOn(auditService, 'createLogRequired').mockRejectedValueOnce(new Error('audit failed'));
+      jest.spyOn(prisma.liquidation, 'findFirst').mockResolvedValueOnce(liquidation as never);
+
+      await expect(
+        service.cancelLiquidation(
+          tenantId,
+          'liq-1',
+          membershipId
+        ),
+      ).rejects.toThrow('audit failed');
+
+      expect(persistedStatus).toBe('DRAFT');
     });
   });
 
@@ -527,14 +851,14 @@ describe('LiquidationEngineService', () => {
 
       jest
         .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValue(liquidation as any);
-      jest.spyOn(prisma.expense, 'findMany').mockResolvedValue(expenses as any);
-      jest.spyOn(prisma.charge, 'findMany').mockResolvedValue(charges as any);
+        .mockResolvedValue(liquidation as never);
+      jest.spyOn(prisma.expense, 'findMany').mockResolvedValue(expenses as never);
+      jest.spyOn(prisma.charge, 'findMany').mockResolvedValue(charges as never);
 
       const result = await service.getLiquidationDetail(
         tenantId,
         'liq-1',
-        adminRoles,
+        membershipId,
       );
 
       expect(result.id).toBe('liq-1');
@@ -550,16 +874,28 @@ describe('LiquidationEngineService', () => {
           status: 'DRAFT',
           buildingId,
           period: '2026-04',
-        } as any);
+        } as never);
       jest.spyOn(prisma.expense, 'findMany').mockResolvedValue([]);
 
       const result = await service.getLiquidationDetail(
         tenantId,
         'liq-1',
-        adminRoles,
+        membershipId,
       );
 
       expect(result.chargesPreview).toEqual([]);
+    });
+
+    it('debería rechazar detail si la membresía no existe o no pertenece al tenant', async () => {
+      jest.spyOn(prisma.membership, 'findFirst').mockResolvedValueOnce(null);
+
+      await expect(
+        service.getLiquidationDetail(
+          tenantId,
+          'liq-1',
+          'member-missing',
+        ),
+      ).rejects.toThrow('No se encontró una membresía válida para el tenant');
     });
   });
 });

--- a/apps/api/src/finanzas/liquidation-engine.service.spec.ts
+++ b/apps/api/src/finanzas/liquidation-engine.service.spec.ts
@@ -37,11 +37,12 @@ describe('LiquidationEngineService', () => {
               findMany: jest.fn(),
               deleteMany: jest.fn(),
             },
+            $transaction: jest.fn(),
           },
         },
         {
           provide: AuditService,
-          useValue: { createLog: jest.fn() },
+          useValue: { createLog: jest.fn(), createLogRequired: jest.fn().mockResolvedValue(undefined) },
         },
         {
           provide: FinanzasValidators,
@@ -57,6 +58,9 @@ describe('LiquidationEngineService', () => {
     prisma = module.get<PrismaService>(PrismaService);
     auditService = module.get<AuditService>(AuditService);
     validators = module.get<FinanzasValidators>(FinanzasValidators);
+    jest.spyOn(prisma, '$transaction').mockImplementation(
+      async (callback) => callback(prisma),
+    );
   });
 
   describe('createLiquidationDraft', () => {
@@ -114,10 +118,11 @@ describe('LiquidationEngineService', () => {
       expect(result.liquidation.id).toBe('liq-1');
       expect(result.liquidation.status).toBe('DRAFT');
       expect(result.chargesPreview.length).toBe(2);
-      expect(auditService.createLog).toHaveBeenCalledWith(
+      expect(auditService.createLogRequired).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'LIQUIDATION_DRAFT',
         }),
+        prisma,
       );
     });
 
@@ -211,10 +216,11 @@ describe('LiquidationEngineService', () => {
       );
 
       expect(result.status).toBe('REVIEWED');
-      expect(auditService.createLog).toHaveBeenCalledWith(
+      expect(auditService.createLogRequired).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'LIQUIDATION_REVIEW',
         }),
+        prisma,
       );
     });
 
@@ -254,6 +260,7 @@ describe('LiquidationEngineService', () => {
         status: 'REVIEWED',
         buildingId,
         period: '2026-04',
+        baseCurrency: 'ARS',
       };
 
       const expenses = [
@@ -261,6 +268,10 @@ describe('LiquidationEngineService', () => {
           id: 'exp-1',
           amountMinor: 120000,
           currencyCode: 'ARS',
+          category: { name: 'Electricidad' },
+          vendor: { name: 'EDENOR' },
+          invoiceDate: new Date('2026-04-10'),
+          description: 'Servicio eléctrico',
           allocations: [],
           scopeType: 'BUILDING',
         },
@@ -300,10 +311,102 @@ describe('LiquidationEngineService', () => {
 
       expect(result.status).toBe('PUBLISHED');
       expect(prisma.charge.createMany).toHaveBeenCalled();
-      expect(auditService.createLog).toHaveBeenCalledWith(
+      expect(prisma.liquidation.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            publicationSnapshot: expect.objectContaining({
+              version: 1,
+              liquidationId: 'liq-1',
+              totalAmountMinor: 120000,
+              publishedAt: expect.any(String),
+              allocations: expect.arrayContaining([
+                expect.objectContaining({ unitId: 'unit-1' }),
+              ]),
+            }),
+            publishedAt: expect.any(Date),
+            publishedByMembershipId: membershipId,
+          }),
+        }),
+      );
+      expect(auditService.createLogRequired).toHaveBeenCalledWith(
         expect.objectContaining({
           action: 'LIQUIDATION_PUBLISH',
         }),
+        prisma,
+      );
+    });
+
+    it('rolls back publication when required audit logging fails', async () => {
+      const liquidation = {
+        id: 'liq-1',
+        status: 'REVIEWED',
+        buildingId,
+        period: '2026-04',
+        baseCurrency: 'ARS',
+      };
+      const expenses = [{
+        id: 'exp-1',
+        amountMinor: 120000,
+        currencyCode: 'ARS',
+        category: { name: 'Electricidad' },
+        vendor: { name: 'EDENOR' },
+        invoiceDate: new Date('2026-04-10'),
+        description: 'Servicio eléctrico',
+        allocations: [],
+        scopeType: 'BUILDING',
+      }];
+      const units = [
+        { id: 'unit-1', code: 'A-101', label: '101', m2: 100 },
+        { id: 'unit-2', code: 'A-102', label: '102', m2: 200 },
+      ];
+      let persistedStatus = 'REVIEWED';
+      const transactionClient = {
+        ...prisma,
+        charge: {
+          ...prisma.charge,
+          createMany: jest.fn().mockResolvedValue({ count: 2 }),
+        },
+        liquidation: {
+          ...prisma.liquidation,
+          update: jest.fn().mockImplementation(async () => ({
+            ...liquidation,
+            status: 'PUBLISHED',
+          })),
+        },
+      };
+
+      jest.spyOn(prisma.liquidation, 'findFirst').mockResolvedValue(liquidation as never);
+      jest.spyOn(prisma.expense, 'findMany')
+        .mockResolvedValueOnce(expenses as never)
+        .mockResolvedValueOnce([] as never);
+      jest.spyOn(prisma.unit, 'findMany').mockResolvedValue(units as never);
+      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback) => {
+        try {
+          const result = await callback(transactionClient);
+          persistedStatus = 'PUBLISHED';
+          return result;
+        } catch (error) {
+          throw error;
+        }
+      });
+      jest.spyOn(auditService, 'createLogRequired').mockRejectedValueOnce(new Error('audit failed'));
+
+      await expect(
+        service.publishLiquidation(
+          tenantId,
+          liquidation.id,
+          new Date('2026-05-30'),
+          membershipId,
+          adminRoles,
+        ),
+      ).rejects.toThrow('audit failed');
+
+      expect(persistedStatus).toBe('REVIEWED');
+      expect(transactionClient.charge.createMany).toHaveBeenCalledTimes(1);
+      expect(transactionClient.liquidation.update).toHaveBeenCalledTimes(1);
+      expect(auditService.createLogRequired).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'LIQUIDATION_PUBLISH' }),
+        transactionClient,
       );
     });
 
@@ -345,6 +448,10 @@ describe('LiquidationEngineService', () => {
       expect(prisma.liquidation.delete).toHaveBeenCalledWith({
         where: { id: 'liq-1' },
       });
+      expect(auditService.createLogRequired).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'LIQUIDATION_CANCEL' }),
+        prisma,
+      );
     });
 
     it('debería eliminar charges si status es PUBLISHED', async () => {

--- a/apps/api/src/finanzas/liquidation-engine.service.ts
+++ b/apps/api/src/finanzas/liquidation-engine.service.ts
@@ -8,6 +8,7 @@ import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { FinanzasValidators } from './finanzas.validators';
+import { buildLiquidationPublicationSnapshot } from './liquidation-publication-snapshot';
 
 export interface LiquidationCalculationInput {
   buildingId: string;
@@ -168,8 +169,9 @@ export class LiquidationEngineService {
     );
 
     // Crear liquidación en DRAFT
-    const liquidation = await this.prisma.liquidation.create({
-      data: {
+    const liquidation = await this.prisma.$transaction(async (tx) => {
+      const created = await tx.liquidation.create({
+        data: {
         tenantId,
         buildingId,
         period,
@@ -192,23 +194,26 @@ export class LiquidationEngineService {
         }),
         unitCount: units.length,
         generatedByMembershipId: membershipId,
-      },
-    });
+        },
+      });
 
-    void this.auditService.createLog({
-      tenantId,
-      actorMembershipId: membershipId,
-      action: 'LIQUIDATION_DRAFT',
-      entityType: 'Liquidation',
-      entityId: liquidation.id,
-      metadata: {
-        period,
-        buildingId,
-        expenseCount: allExpenses.length,
-        buildingExpenseCount: buildingExpenses.length,
-        sharedExpenseCount: sharedExpenses.length,
-        totalAmountMinor,
-      },
+      await this.auditService.createLogRequired({
+        tenantId,
+        actorMembershipId: membershipId,
+        action: 'LIQUIDATION_DRAFT',
+        entityType: 'Liquidation',
+        entityId: created.id,
+        metadata: {
+          period,
+          buildingId,
+          expenseCount: allExpenses.length,
+          buildingExpenseCount: buildingExpenses.length,
+          sharedExpenseCount: sharedExpenses.length,
+          totalAmountMinor,
+        },
+      }, tx);
+
+      return created;
     });
 
     return {
@@ -299,24 +304,26 @@ export class LiquidationEngineService {
       );
     }
 
-    const updated = await this.prisma.liquidation.update({
-      where: { id: liquidationId },
-      data: {
-        status: 'REVIEWED',
-        reviewedAt: new Date(),
-      },
-    });
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.liquidation.update({
+        where: { id: liquidationId },
+        data: {
+          status: 'REVIEWED',
+          reviewedAt: new Date(),
+        },
+      });
 
-    void this.auditService.createLog({
-      tenantId,
-      actorMembershipId: membershipId,
-      action: 'LIQUIDATION_REVIEW',
-      entityType: 'Liquidation',
-      entityId: liquidationId,
-      metadata: { period: liquidation.period, previousStatus: 'DRAFT' },
-    });
+      await this.auditService.createLogRequired({
+        tenantId,
+        actorMembershipId: membershipId,
+        action: 'LIQUIDATION_REVIEW',
+        entityType: 'Liquidation',
+        entityId: liquidationId,
+        metadata: { period: liquidation.period, previousStatus: 'DRAFT' },
+      }, tx);
 
-    return updated;
+      return updated;
+    });
   }
 
   /**
@@ -334,61 +341,121 @@ export class LiquidationEngineService {
       throw new ForbiddenException('Solo administradores pueden publicar liquidaciones');
     }
 
-    const liquidation = await this.prisma.liquidation.findFirst({
-      where: { id: liquidationId, tenantId },
-      include: { building: { select: { id: true } } },
-    });
+    return this.prisma.$transaction(async (tx) => {
+      const liquidation = await tx.liquidation.findFirst({
+        where: { id: liquidationId, tenantId },
+      });
 
-    if (!liquidation) {
-      throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-    }
+      if (!liquidation) {
+        throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
+      }
 
-    if (liquidation.status !== 'REVIEWED') {
-      throw new BadRequestException(
-        `La liquidación debe estar en REVIEWED. Estado actual: ${liquidation.status}`,
+      if (liquidation.status !== 'REVIEWED') {
+        throw new BadRequestException(
+          `La liquidación debe estar en REVIEWED. Estado actual: ${liquidation.status}`,
+        );
+      }
+
+      const buildingExpenses = await tx.expense.findMany({
+        where: {
+          tenantId,
+          buildingId: liquidation.buildingId,
+          period: liquidation.period,
+          status: 'VALIDATED',
+        },
+        include: {
+          category: { select: { name: true } },
+          vendor: { select: { name: true } },
+          allocations: true,
+        },
+      });
+
+      const sharedExpenses = await tx.expense.findMany({
+        where: {
+          tenantId,
+          period: liquidation.period,
+          status: 'VALIDATED',
+          scopeType: 'TENANT_SHARED',
+          allocations: { some: { buildingId: liquidation.buildingId } },
+        },
+        include: {
+          category: { select: { name: true } },
+          vendor: { select: { name: true } },
+          allocations: { where: { buildingId: liquidation.buildingId } },
+        },
+      });
+
+      const units = await tx.unit.findMany({
+        where: { tenantId, buildingId: liquidation.buildingId, isBillable: true },
+        select: { id: true, code: true, label: true, m2: true },
+      });
+
+      const buildingTotal = buildingExpenses.reduce(
+        (sum, expense) => sum + expense.amountMinor,
+        0,
       );
-    }
+      const sharedTotal = sharedExpenses.reduce((sum, expense) => {
+        const allocation = expense.allocations[0];
+        if (!allocation) {
+          return sum;
+        }
 
-    // Recalcular charges para crear registros de Charge
-    const buildingExpenses = await this.prisma.expense.findMany({
-      where: {
+        return sum + (
+          allocation.amountMinor
+          ?? Math.floor(expense.amountMinor * (allocation.percentage ?? 0) / 100)
+        );
+      }, 0);
+      const totalAmountMinor = buildingTotal + sharedTotal;
+      const allExpenses = [...buildingExpenses, ...sharedExpenses];
+      const charges = this.calculateCharges(allExpenses, units, totalAmountMinor);
+      const totalsByCurrency: Record<string, number> = {};
+      const publicationExpenses = allExpenses.map((expense) => {
+        const allocation = expense.scopeType === 'TENANT_SHARED'
+          ? expense.allocations[0]
+          : undefined;
+        const amountMinor = allocation
+          ? (
+            allocation.amountMinor
+            ?? Math.floor(expense.amountMinor * (allocation.percentage ?? 0) / 100)
+          )
+          : expense.amountMinor;
+
+        totalsByCurrency[expense.currencyCode] =
+          (totalsByCurrency[expense.currencyCode] ?? 0) + amountMinor;
+
+        return {
+          expenseId: expense.id,
+          categoryName: expense.category.name,
+          vendorName: expense.vendor?.name ?? null,
+          amountMinor,
+          currencyCode: expense.currencyCode,
+          invoiceDate: expense.invoiceDate.toISOString(),
+          description: expense.description,
+          type: 'EXPENSE' as const,
+        };
+      });
+      const publishedAt = new Date();
+      const publicationSnapshot = buildLiquidationPublicationSnapshot({
+        liquidationId: liquidation.id,
         tenantId,
         buildingId: liquidation.buildingId,
         period: liquidation.period,
-        status: 'VALIDATED',
-      },
-    });
+        baseCurrency: liquidation.baseCurrency,
+        totalAmountMinor,
+        totalsByCurrency,
+        expenses: publicationExpenses,
+        allocations: charges.map((charge) => ({
+          unitId: charge.unitId,
+          unitCode: charge.unitCode,
+          unitLabel: charge.unitLabel,
+          amountMinor: charge.amountMinor,
+        })),
+        dueDate,
+        publishedAt,
+      });
 
-    const sharedExpenses = await this.prisma.expense.findMany({
-      where: {
-        tenantId,
-        period: liquidation.period,
-        status: 'VALIDATED',
-        scopeType: 'TENANT_SHARED',
-        allocations: { some: { buildingId: liquidation.buildingId } },
-      },
-      include: { allocations: { where: { buildingId: liquidation.buildingId } } },
-    });
-
-    const units = await this.prisma.unit.findMany({
-      where: { tenantId, buildingId: liquidation.buildingId, isBillable: true },
-      select: { id: true, code: true, label: true, m2: true },
-    });
-
-    const buildingTotal = buildingExpenses.reduce((s, e) => s + e.amountMinor, 0);
-    const sharedTotal = sharedExpenses.reduce((s, e) => {
-      const alloc = e.allocations[0];
-      if (!alloc) return s;
-      return s + (alloc.amountMinor ?? Math.floor(e.amountMinor * (alloc.percentage ?? 0) / 100));
-    }, 0);
-    const totalAmountMinor = buildingTotal + sharedTotal;
-
-    const allExpenses = [...buildingExpenses, ...sharedExpenses];
-    const charges = this.calculateCharges(allExpenses, units, totalAmountMinor);
-
-    // Crear charges para cada unidad
-    const chargeRecords = await this.prisma.charge.createMany({
-      data: charges.map((charge) => ({
+      const chargeRecords = await tx.charge.createMany({
+        data: charges.map((charge) => ({
         tenantId,
         buildingId: liquidation.buildingId,
         unitId: charge.unitId,
@@ -399,34 +466,35 @@ export class LiquidationEngineService {
         dueDate,
         status: 'PENDING',
         liquidationId: liquidation.id,
-      })),
-    });
+        })),
+      });
 
-    // Actualizar liquidación a PUBLISHED
-    const updated = await this.prisma.liquidation.update({
-      where: { id: liquidationId },
-      data: {
-        status: 'PUBLISHED',
-        publishedByMembershipId: membershipId,
-        publishedAt: new Date(),
-      },
-    });
+      const updated = await tx.liquidation.update({
+        where: { id: liquidationId },
+        data: {
+          status: 'PUBLISHED',
+          publicationSnapshot,
+          publishedByMembershipId: membershipId,
+          publishedAt,
+        },
+      });
 
-    void this.auditService.createLog({
-      tenantId,
-      actorMembershipId: membershipId,
-      action: 'LIQUIDATION_PUBLISH',
-      entityType: 'Liquidation',
-      entityId: liquidationId,
-      metadata: {
-        period: liquidation.period,
-        chargeCount: chargeRecords.count,
-        totalAmountMinor,
-        dueDate: dueDate.toISOString(),
-      },
-    });
+      await this.auditService.createLogRequired({
+        tenantId,
+        actorMembershipId: membershipId,
+        action: 'LIQUIDATION_PUBLISH',
+        entityType: 'Liquidation',
+        entityId: liquidationId,
+        metadata: {
+          period: liquidation.period,
+          chargeCount: chargeRecords.count,
+          totalAmountMinor,
+          dueDate: dueDate.toISOString(),
+        },
+      }, tx);
 
-    return updated;
+      return updated;
+    });
   }
 
   /**
@@ -455,27 +523,27 @@ export class LiquidationEngineService {
       throw new BadRequestException('La liquidación ya está cancelada');
     }
 
-    // Si PUBLISHED, eliminar charges asociadas
-    if (liquidation.status === 'PUBLISHED') {
-      await this.prisma.charge.deleteMany({ where: { tenantId, liquidationId } });
-    }
+    return this.prisma.$transaction(async (tx) => {
+      if (liquidation.status === 'PUBLISHED') {
+        await tx.charge.deleteMany({ where: { tenantId, liquidationId } });
+      }
 
-    // Hard delete: el historial queda en AuditLog
-    await this.prisma.liquidation.delete({ where: { id: liquidationId } });
+      await tx.liquidation.delete({ where: { id: liquidationId } });
 
-    void this.auditService.createLog({
-      tenantId,
-      actorMembershipId: membershipId,
-      action: 'LIQUIDATION_CANCEL',
-      entityType: 'Liquidation',
-      entityId: liquidationId,
-      metadata: {
-        period: liquidation.period,
-        previousStatus: liquidation.status,
-      },
+      await this.auditService.createLogRequired({
+        tenantId,
+        actorMembershipId: membershipId,
+        action: 'LIQUIDATION_CANCEL',
+        entityType: 'Liquidation',
+        entityId: liquidationId,
+        metadata: {
+          period: liquidation.period,
+          previousStatus: liquidation.status,
+        },
+      }, tx);
+
+      return liquidation;
     });
-
-    return liquidation;
   }
 
   /**

--- a/apps/api/src/finanzas/liquidation-engine.service.ts
+++ b/apps/api/src/finanzas/liquidation-engine.service.ts
@@ -8,7 +8,10 @@ import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { FinanzasValidators } from './finanzas.validators';
-import { buildLiquidationPublicationSnapshot } from './liquidation-publication-snapshot';
+import {
+  buildLiquidationPublicationSnapshot,
+  distributeLiquidationAmountByLargestRemainder,
+} from './liquidation-publication-snapshot';
 
 export interface LiquidationCalculationInput {
   buildingId: string;
@@ -67,13 +70,12 @@ export class LiquidationEngineService {
     period: string,
     baseCurrency: string,
     membershipId: string,
-    userRoles: string[],
   ) {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
-      throw new ForbiddenException(
-        'Solo administradores pueden crear liquidaciones',
-      );
-    }
+    const membership = await this.requireFinanceMembership(
+      this.prisma,
+      tenantId,
+      membershipId,
+    );
 
     await this.validators.validateBuildingBelongsToTenant(tenantId, buildingId);
 
@@ -193,13 +195,13 @@ export class LiquidationEngineService {
           };
         }),
         unitCount: units.length,
-        generatedByMembershipId: membershipId,
+        generatedByMembershipId: membership.id,
         },
       });
 
       await this.auditService.createLogRequired({
         tenantId,
-        actorMembershipId: membershipId,
+        actorMembershipId: membership.id,
         action: 'LIQUIDATION_DRAFT',
         entityType: 'Liquidation',
         entityId: created.id,
@@ -254,26 +256,15 @@ export class LiquidationEngineService {
     // Por ahora: prorrateo simple por m2 para BUILDING scope
     // TODO: soporte para TENANT_SHARED y UNIT_GROUP scopes
 
-    const totalM2 = units.reduce((sum, u) => sum + (u.m2 ?? 0), 0);
-    if (totalM2 === 0) {
-      throw new BadRequestException(
-        'Las unidades no tienen área m2 registrada para prorrateo',
-      );
-    }
-
-    return units.map((unit) => {
-      const unitAreaM2 = unit.m2 ?? 0;
-      const unitPercentage = unitAreaM2 / totalM2;
-      const unitAmountMinor = Math.round(totalAmountMinor * unitPercentage);
-
-      return {
-        unitId: unit.id,
-        unitCode: unit.code,
-        unitLabel: unit.label,
-        areaM2: unitAreaM2,
-        amountMinor: unitAmountMinor,
-      };
-    });
+    return distributeLiquidationAmountByLargestRemainder(
+      units.map((unit) => ({
+        id: unit.id,
+        code: unit.code,
+        label: unit.label,
+        areaM2: unit.m2 ?? 0,
+      })),
+      totalAmountMinor,
+    );
   }
 
   /**
@@ -284,38 +275,56 @@ export class LiquidationEngineService {
     tenantId: string,
     liquidationId: string,
     membershipId: string,
-    userRoles: string[],
   ) {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
-      throw new ForbiddenException('Solo administradores pueden revisar liquidaciones');
-    }
-
-    const liquidation = await this.prisma.liquidation.findFirst({
-      where: { id: liquidationId, tenantId },
-    });
-
-    if (!liquidation) {
-      throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-    }
-
-    if (liquidation.status !== 'DRAFT') {
-      throw new BadRequestException(
-        `La liquidación debe estar en DRAFT. Estado actual: ${liquidation.status}`,
-      );
-    }
-
     return this.prisma.$transaction(async (tx) => {
-      const updated = await tx.liquidation.update({
-        where: { id: liquidationId },
-        data: {
-          status: 'REVIEWED',
-          reviewedAt: new Date(),
+      const membership = await this.requireFinanceMembership(tx, tenantId, membershipId);
+      const liquidation = await tx.liquidation.findFirst({
+        where: { id: liquidationId, tenantId },
+        select: {
+          id: true,
+          status: true,
+          period: true,
         },
       });
 
+      if (!liquidation) {
+        throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
+      }
+
+      if (liquidation.status !== 'DRAFT') {
+        throw new BadRequestException(
+          `La liquidación debe estar en DRAFT. Estado actual: ${liquidation.status}`,
+        );
+      }
+
+      const reviewedAt = new Date();
+      const updateResult = await tx.liquidation.updateMany({
+        where: { id: liquidationId, tenantId, status: 'DRAFT' },
+        data: {
+          status: 'REVIEWED',
+          reviewedAt,
+          reviewedByMembershipId: membership.id,
+          updatedAt: reviewedAt,
+        },
+      });
+
+      if (updateResult.count !== 1) {
+        throw new BadRequestException(
+          'No fue posible revisar la liquidación porque cambió de estado',
+        );
+      }
+
+      const updated = await tx.liquidation.findFirst({
+        where: { id: liquidationId, tenantId },
+      });
+
+      if (!updated) {
+        throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
+      }
+
       await this.auditService.createLogRequired({
         tenantId,
-        actorMembershipId: membershipId,
+        actorMembershipId: membership.id,
         action: 'LIQUIDATION_REVIEW',
         entityType: 'Liquidation',
         entityId: liquidationId,
@@ -335,13 +344,9 @@ export class LiquidationEngineService {
     liquidationId: string,
     dueDate: Date,
     membershipId: string,
-    userRoles: string[],
   ) {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
-      throw new ForbiddenException('Solo administradores pueden publicar liquidaciones');
-    }
-
     return this.prisma.$transaction(async (tx) => {
+      const membership = await this.requireFinanceMembership(tx, tenantId, membershipId);
       const liquidation = await tx.liquidation.findFirst({
         where: { id: liquidationId, tenantId },
       });
@@ -474,14 +479,14 @@ export class LiquidationEngineService {
         data: {
           status: 'PUBLISHED',
           publicationSnapshot,
-          publishedByMembershipId: membershipId,
+          publishedByMembershipId: membership.id,
           publishedAt,
         },
       });
 
       await this.auditService.createLogRequired({
         tenantId,
-        actorMembershipId: membershipId,
+        actorMembershipId: membership.id,
         action: 'LIQUIDATION_PUBLISH',
         entityType: 'Liquidation',
         entityId: liquidationId,
@@ -498,51 +503,80 @@ export class LiquidationEngineService {
   }
 
   /**
-   * Cancel a liquidation (DRAFT, REVIEWED, or PUBLISHED)
-   * Deletes associated charges if PUBLISHED
+   * Cancel a liquidation (DRAFT or REVIEWED)
+   * Publishes a terminal CANCELED state without deleting financial history
    */
   async cancelLiquidation(
     tenantId: string,
     liquidationId: string,
     membershipId: string,
-    userRoles: string[],
   ) {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
-      throw new ForbiddenException('Solo administradores pueden cancelar liquidaciones');
-    }
-
-    const liquidation = await this.prisma.liquidation.findFirst({
-      where: { id: liquidationId, tenantId },
-    });
-
-    if (!liquidation) {
-      throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-    }
-
-    if (liquidation.status === 'CANCELED') {
-      throw new BadRequestException('La liquidación ya está cancelada');
-    }
-
     return this.prisma.$transaction(async (tx) => {
-      if (liquidation.status === 'PUBLISHED') {
-        await tx.charge.deleteMany({ where: { tenantId, liquidationId } });
+      const membership = await this.requireFinanceMembership(tx, tenantId, membershipId);
+      const liquidation = await tx.liquidation.findFirst({
+        where: { id: liquidationId, tenantId },
+        select: {
+          id: true,
+          status: true,
+          period: true,
+        },
+      });
+
+      if (!liquidation) {
+        throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
       }
 
-      await tx.liquidation.delete({ where: { id: liquidationId } });
+      if (liquidation.status === 'PUBLISHED') {
+        throw new BadRequestException('La liquidación publicada no se puede cancelar directamente');
+      }
+
+      if (liquidation.status === 'CANCELED') {
+        throw new BadRequestException('La liquidación ya está cancelada');
+      }
+
+      const canceledAt = new Date();
+      const updateResult = await tx.liquidation.updateMany({
+        where: {
+          id: liquidationId,
+          tenantId,
+          status: { in: ['DRAFT', 'REVIEWED'] },
+        },
+        data: {
+          status: 'CANCELED',
+          canceledAt,
+          canceledByMembershipId: membership.id,
+          updatedAt: canceledAt,
+        },
+      });
+
+      if (updateResult.count !== 1) {
+        throw new BadRequestException(
+          'No fue posible cancelar la liquidación porque cambió de estado',
+        );
+      }
+
+      const canceled = await tx.liquidation.findFirst({
+        where: { id: liquidationId, tenantId },
+      });
+
+      if (!canceled) {
+        throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
+      }
 
       await this.auditService.createLogRequired({
         tenantId,
-        actorMembershipId: membershipId,
+        actorMembershipId: membership.id,
         action: 'LIQUIDATION_CANCEL',
         entityType: 'Liquidation',
         entityId: liquidationId,
         metadata: {
           period: liquidation.period,
           previousStatus: liquidation.status,
+          canceledAt: canceledAt.toISOString(),
         },
       }, tx);
 
-      return liquidation;
+      return canceled;
     });
   }
 
@@ -552,11 +586,9 @@ export class LiquidationEngineService {
   async getLiquidationDetail(
     tenantId: string,
     liquidationId: string,
-    userRoles: string[],
+    membershipId: string,
   ) {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
-      throw new ForbiddenException('Solo administradores pueden ver liquidaciones');
-    }
+    await this.requireFinanceMembership(this.prisma, tenantId, membershipId);
 
     const liquidation = await this.prisma.liquidation.findFirst({
       where: { id: liquidationId, tenantId },
@@ -611,6 +643,44 @@ export class LiquidationEngineService {
         areaM2: c.unit.m2,
         amountMinor: c.amount,
       })),
+    };
+  }
+
+  private async requireFinanceMembership(
+    client: PrismaService | Prisma.TransactionClient,
+    tenantId: string,
+    membershipId: string,
+  ): Promise<{ id: string; tenantId: string; roles: string[] }> {
+    const membership = await client.membership.findFirst({
+      where: { id: membershipId, tenantId },
+      select: {
+        id: true,
+        tenantId: true,
+        roles: {
+          select: {
+            role: true,
+            scopeType: true,
+          },
+        },
+      },
+    });
+
+    if (!membership) {
+      throw new ForbiddenException('No se encontró una membresía válida para el tenant');
+    }
+
+    const tenantRoles = membership.roles
+      .filter((role) => role.scopeType === 'TENANT')
+      .map((role) => role.role);
+
+    if (!this.validators.isAdminOrOperator(tenantRoles)) {
+      throw new ForbiddenException('Solo administradores pueden gestionar liquidaciones');
+    }
+
+    return {
+      id: membership.id,
+      tenantId: membership.tenantId,
+      roles: tenantRoles,
     };
   }
 }

--- a/apps/api/src/finanzas/liquidation-publication-snapshot.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication-snapshot.spec.ts
@@ -1,0 +1,173 @@
+import { BadRequestException } from '@nestjs/common';
+import {
+  buildLiquidationPublicationSnapshot,
+  parseLiquidationPublicationSnapshot,
+} from './liquidation-publication-snapshot';
+
+describe('liquidation publication snapshot', () => {
+  const baseInput = {
+    liquidationId: 'liq-1',
+    tenantId: 'tenant-1',
+    buildingId: 'building-1',
+    period: '2026-05',
+    baseCurrency: 'ARS',
+    totalAmountMinor: 100,
+    totalsByCurrency: { ARS: 100 },
+    expenses: [
+      {
+        expenseId: 'exp-1',
+        categoryName: 'Water',
+        vendorName: 'Vendor',
+        amountMinor: 100,
+        currencyCode: 'ARS',
+        invoiceDate: '2026-05-01T00:00:00.000Z',
+        description: null,
+        type: 'EXPENSE' as const,
+      },
+    ],
+    allocations: [
+      {
+        unitId: 'unit-1',
+        unitCode: '1A',
+        unitLabel: '1A',
+        amountMinor: 100,
+      },
+    ],
+    dueDate: new Date('2026-06-10T00:00:00.000Z'),
+    publishedAt: new Date('2026-07-12T00:00:00.000Z'),
+  };
+
+  it('builds and parses a valid snapshot', () => {
+    const snapshot = buildLiquidationPublicationSnapshot(baseInput);
+    const parsed = parseLiquidationPublicationSnapshot(snapshot);
+
+    expect(parsed).toMatchObject({
+      version: 1,
+      liquidationId: 'liq-1',
+      baseCurrency: 'ARS',
+      totalAmountMinor: 100,
+      totalsByCurrency: { ARS: 100 },
+    });
+  });
+
+  it.each([
+    {
+      name: 'baseCurrency absent',
+      input: { ...baseInput, baseCurrency: 'USD', totalsByCurrency: { ARS: 100 } },
+    },
+    {
+      name: 'baseCurrency total mismatch',
+      input: { ...baseInput, totalAmountMinor: 101 },
+    },
+    {
+      name: 'allocations below total',
+      input: { ...baseInput, allocations: [{ ...baseInput.allocations[0], amountMinor: 99 }] },
+    },
+    {
+      name: 'allocations above total',
+      input: { ...baseInput, allocations: [{ ...baseInput.allocations[0], amountMinor: 101 }] },
+    },
+    {
+      name: 'decimal amount',
+      input: { ...baseInput, totalAmountMinor: 100.5 },
+    },
+    {
+      name: 'negative amount',
+      input: { ...baseInput, totalAmountMinor: -1 },
+    },
+    {
+      name: 'overflow amount',
+      input: { ...baseInput, totalAmountMinor: Number.MAX_SAFE_INTEGER + 1 },
+    },
+    {
+      name: 'financially inconsistent snapshot',
+      input: {
+        ...baseInput,
+        expenses: [
+          {
+            ...baseInput.expenses[0],
+            amountMinor: 50,
+          },
+        ],
+      },
+    },
+  ])('rejects $name', ({ input }) => {
+    expect(() => buildLiquidationPublicationSnapshot(input)).toThrow(BadRequestException);
+  });
+
+  it('rejects a structurally valid but financially inconsistent parsed snapshot', () => {
+    expect(() =>
+      parseLiquidationPublicationSnapshot({
+        version: 1,
+        liquidationId: 'liq-1',
+        tenantId: 'tenant-1',
+        buildingId: 'building-1',
+        period: '2026-05',
+        baseCurrency: 'ARS',
+        totalAmountMinor: 100,
+        totalsByCurrency: { ARS: 100 },
+        expenses: [
+          {
+            expenseId: 'exp-1',
+            categoryName: 'Water',
+            vendorName: 'Vendor',
+            amountMinor: 40,
+            currencyCode: 'ARS',
+            invoiceDate: '2026-05-01T00:00:00.000Z',
+            description: null,
+            type: 'EXPENSE',
+          },
+        ],
+        allocations: [
+          {
+            unitId: 'unit-1',
+            unitCode: '1A',
+            unitLabel: '1A',
+            amountMinor: 100,
+          },
+        ],
+        dueDate: '2026-06-10T00:00:00.000Z',
+        publishedAt: '2026-07-12T00:00:00.000Z',
+      }),
+    ).toThrow(BadRequestException);
+  });
+
+  it('rejects aggregate overflow in expense totals', () => {
+    expect(() =>
+      buildLiquidationPublicationSnapshot({
+        ...baseInput,
+        expenses: [
+          {
+            ...baseInput.expenses[0],
+            amountMinor: Number.MAX_SAFE_INTEGER,
+          },
+          {
+            ...baseInput.expenses[0],
+            expenseId: 'exp-2',
+            amountMinor: 1,
+          },
+        ],
+      }),
+    ).toThrow(BadRequestException);
+  });
+
+  it('rejects aggregate overflow in allocation totals', () => {
+    expect(() =>
+      buildLiquidationPublicationSnapshot({
+        ...baseInput,
+        allocations: [
+          {
+            ...baseInput.allocations[0],
+            amountMinor: Number.MAX_SAFE_INTEGER,
+          },
+          {
+            ...baseInput.allocations[0],
+            unitId: 'unit-2',
+            unitCode: '1B',
+            amountMinor: 1,
+          },
+        ],
+      }),
+    ).toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/finanzas/liquidation-publication-snapshot.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication-snapshot.spec.ts
@@ -1,6 +1,7 @@
 import { BadRequestException } from '@nestjs/common';
 import {
   buildLiquidationPublicationSnapshot,
+  distributeLiquidationAmountByLargestRemainder,
   parseLiquidationPublicationSnapshot,
 } from './liquidation-publication-snapshot';
 
@@ -50,6 +51,39 @@ describe('liquidation publication snapshot', () => {
     });
   });
 
+  it('builds a snapshot from an exact Largest Remainder repartition', () => {
+    const distributed = distributeLiquidationAmountByLargestRemainder(
+      [
+        { id: 'unit-b', code: 'B-201', label: '201', areaM2: 1 },
+        { id: 'unit-a', code: 'A-101', label: '101', areaM2: 1 },
+        { id: 'unit-c', code: 'C-301', label: '301', areaM2: 1 },
+      ],
+      100,
+    );
+
+    expect(distributed.map((allocation) => allocation.amountMinor)).toEqual([34, 33, 33]);
+    expect(distributed.every((allocation) => Number.isInteger(allocation.amountMinor) && allocation.amountMinor >= 0)).toBe(true);
+    expect(distributed.reduce((sum, allocation) => sum + allocation.amountMinor, 0)).toBe(100);
+
+    const snapshot = buildLiquidationPublicationSnapshot({
+      ...baseInput,
+      allocations: distributed.map(({ unitId, unitCode, unitLabel, amountMinor }) => ({
+        unitId,
+        unitCode,
+        unitLabel,
+        amountMinor,
+      })),
+    });
+
+    expect(snapshot.allocations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ unitId: 'unit-a', amountMinor: 34 }),
+        expect.objectContaining({ unitId: 'unit-b', amountMinor: 33 }),
+        expect.objectContaining({ unitId: 'unit-c', amountMinor: 33 }),
+      ]),
+    );
+  });
+
   it.each([
     {
       name: 'baseCurrency absent',
@@ -93,6 +127,64 @@ describe('liquidation publication snapshot', () => {
     },
   ])('rejects $name', ({ input }) => {
     expect(() => buildLiquidationPublicationSnapshot(input)).toThrow(BadRequestException);
+  });
+
+  it.each([
+    {
+      name: '100 distributed across 3 equal units',
+      totalAmountMinor: 100,
+      units: [
+        { id: 'unit-c', code: 'C', label: 'C', areaM2: 1 },
+        { id: 'unit-a', code: 'A', label: 'A', areaM2: 1 },
+        { id: 'unit-b', code: 'B', label: 'B', areaM2: 1 },
+      ],
+      amounts: [34, 33, 33],
+    },
+    {
+      name: '1 distributed across 3 equal units',
+      totalAmountMinor: 1,
+      units: [
+        { id: 'unit-c', code: 'C', label: 'C', areaM2: 1 },
+        { id: 'unit-a', code: 'A', label: 'A', areaM2: 1 },
+        { id: 'unit-b', code: 'B', label: 'B', areaM2: 1 },
+      ],
+      amounts: [1, 0, 0],
+    },
+    {
+      name: 'different areas stay proportional',
+      totalAmountMinor: 100,
+      units: [
+        { id: 'unit-a', code: 'A', label: 'A', areaM2: 1 },
+        { id: 'unit-b', code: 'B', label: 'B', areaM2: 2 },
+        { id: 'unit-c', code: 'C', label: 'C', areaM2: 3 },
+      ],
+      amounts: [17, 33, 50],
+    },
+    {
+      name: 'all zero total stays zero',
+      totalAmountMinor: 0,
+      units: [
+        { id: 'unit-a', code: 'A', label: 'A', areaM2: 1 },
+        { id: 'unit-b', code: 'B', label: 'B', areaM2: 1 },
+      ],
+      amounts: [0, 0],
+    },
+    {
+      name: 'one unit gets all when others have zero area',
+      totalAmountMinor: 9,
+      units: [
+        { id: 'unit-a', code: 'A', label: 'A', areaM2: 3 },
+        { id: 'unit-b', code: 'B', label: 'B', areaM2: 0 },
+        { id: 'unit-c', code: 'C', label: 'C', areaM2: 0 },
+      ],
+      amounts: [9, 0, 0],
+    },
+  ])('distributes exact cents for $name', ({ totalAmountMinor, units, amounts }) => {
+    const allocations = distributeLiquidationAmountByLargestRemainder(units, totalAmountMinor);
+
+    expect(allocations.map((allocation) => allocation.amountMinor)).toEqual(amounts);
+    expect(allocations.every((allocation) => Number.isInteger(allocation.amountMinor) && allocation.amountMinor >= 0)).toBe(true);
+    expect(allocations.reduce((sum, allocation) => sum + allocation.amountMinor, 0)).toBe(totalAmountMinor);
   });
 
   it('rejects a structurally valid but financially inconsistent parsed snapshot', () => {

--- a/apps/api/src/finanzas/liquidation-publication-snapshot.ts
+++ b/apps/api/src/finanzas/liquidation-publication-snapshot.ts
@@ -1,0 +1,472 @@
+import { BadRequestException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+
+export interface PublishedExpenseSnapshot {
+  expenseId: string;
+  categoryName: string;
+  vendorName: string | null;
+  amountMinor: number;
+  currencyCode: string;
+  invoiceDate: string;
+  description: string | null;
+  type: 'EXPENSE' | 'ADJUSTMENT';
+  sourcePeriod?: string;
+}
+
+export interface PublishedAllocationSnapshot {
+  unitId: string;
+  unitCode: string;
+  unitLabel: string | null;
+  amountMinor: number;
+}
+
+export interface LiquidationPublicationSnapshotV1 {
+  version: 1;
+  liquidationId: string;
+  tenantId: string;
+  buildingId: string;
+  period: string;
+  baseCurrency: string;
+  totalAmountMinor: number;
+  totalsByCurrency: Record<string, number>;
+  expenses: readonly PublishedExpenseSnapshot[];
+  allocations: readonly PublishedAllocationSnapshot[];
+  dueDate: string;
+  publishedAt: string;
+}
+
+export interface BuildLiquidationPublicationSnapshotInput {
+  liquidationId: string;
+  tenantId: string;
+  buildingId: string;
+  period: string;
+  baseCurrency: string;
+  totalAmountMinor: number;
+  totalsByCurrency: Record<string, number>;
+  expenses: readonly PublishedExpenseSnapshot[];
+  allocations: readonly PublishedAllocationSnapshot[];
+  dueDate: Date;
+  publishedAt: Date;
+}
+
+export function buildLiquidationPublicationSnapshot(
+  input: BuildLiquidationPublicationSnapshotInput,
+): Prisma.InputJsonObject {
+  assertSafeIntegerNonNegative(input.totalAmountMinor, 'totalAmountMinor');
+  assertNonEmpty(input.liquidationId, 'liquidationId');
+  assertNonEmpty(input.tenantId, 'tenantId');
+  assertNonEmpty(input.buildingId, 'buildingId');
+  assertNonEmpty(input.period, 'period');
+  assertNonEmpty(input.baseCurrency, 'baseCurrency');
+  assertIsoDate(input.dueDate, 'dueDate');
+  assertIsoDate(input.publishedAt, 'publishedAt');
+
+  const totalsByCurrency = normalizeTotalsByCurrency(input.totalsByCurrency);
+  const expenses = input.expenses.map(normalizeExpenseSnapshot);
+  const allocations = input.allocations.map(normalizeAllocationSnapshot);
+  const expenseTotalsByCurrency = sumByCurrency(expenses);
+  const allocationTotal = allocations.reduce(
+    (sum, allocation) =>
+      safeAddMinor(sum, allocation.amountMinor, 'allocations.totalAmountMinor'),
+    0,
+  );
+  const baseCurrencyTotal = totalsByCurrency[input.baseCurrency];
+
+  if (baseCurrencyTotal === undefined) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot must include the base currency total',
+    );
+  }
+
+  if (baseCurrencyTotal !== input.totalAmountMinor) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot totals must match the liquidation total',
+    );
+  }
+
+  if (allocationTotal !== input.totalAmountMinor) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot allocations must match the liquidation total',
+    );
+  }
+
+  assertCurrencyTotalsMatch(totalsByCurrency, expenseTotalsByCurrency);
+
+  return createJsonObject({
+    version: 1,
+    liquidationId: input.liquidationId,
+    tenantId: input.tenantId,
+    buildingId: input.buildingId,
+    period: input.period,
+    baseCurrency: input.baseCurrency,
+    totalAmountMinor: input.totalAmountMinor,
+    totalsByCurrency,
+    expenses: createJsonArray(expenses.map(toExpenseJsonObject)),
+    allocations: createJsonArray(allocations.map(toAllocationJsonObject)),
+    dueDate: input.dueDate.toISOString(),
+    publishedAt: input.publishedAt.toISOString(),
+  });
+}
+
+export function parseLiquidationPublicationSnapshot(
+  value: unknown,
+): LiquidationPublicationSnapshotV1 | null {
+  if (value === null) {
+    return null;
+  }
+
+  if (!isPlainObject(value)) {
+    throw new BadRequestException('Liquidation publication snapshot is invalid');
+  }
+
+  if (value.version !== 1) {
+    throw new BadRequestException('Liquidation publication snapshot version is invalid');
+  }
+
+  const liquidationId = parseNonEmptyString(value.liquidationId, 'liquidationId');
+  const tenantId = parseNonEmptyString(value.tenantId, 'tenantId');
+  const buildingId = parseNonEmptyString(value.buildingId, 'buildingId');
+  const period = parseNonEmptyString(value.period, 'period');
+  const baseCurrency = parseNonEmptyString(value.baseCurrency, 'baseCurrency');
+  const totalAmountMinor = parseSafeIntegerNonNegative(value.totalAmountMinor, 'totalAmountMinor');
+  const totalsByCurrency = parseTotalsByCurrency(value.totalsByCurrency);
+  const dueDate = parseIsoDateString(value.dueDate, 'dueDate');
+  const publishedAt = parseIsoDateString(value.publishedAt, 'publishedAt');
+
+  if (!Array.isArray(value.expenses)) {
+    throw new BadRequestException('Liquidation publication snapshot expenses are invalid');
+  }
+
+  if (!Array.isArray(value.allocations)) {
+    throw new BadRequestException('Liquidation publication snapshot allocations are invalid');
+  }
+
+  const expenses = value.expenses.map(parseExpenseSnapshot);
+  const allocations = value.allocations.map(parseAllocationSnapshot);
+  const expenseTotalsByCurrency = sumByCurrency(expenses);
+  const allocationTotal = allocations.reduce(
+    (sum, allocation) =>
+      safeAddMinor(sum, allocation.amountMinor, 'allocations.totalAmountMinor'),
+    0,
+  );
+
+  if (totalsByCurrency[baseCurrency] === undefined) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot must include the base currency total',
+    );
+  }
+
+  if (totalsByCurrency[baseCurrency] !== totalAmountMinor) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot totals must match the liquidation total',
+    );
+  }
+
+  if (allocationTotal !== totalAmountMinor) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot allocations must match the liquidation total',
+    );
+  }
+
+  assertCurrencyTotalsMatch(totalsByCurrency, expenseTotalsByCurrency);
+
+  return {
+    version: 1,
+    liquidationId,
+    tenantId,
+    buildingId,
+    period,
+    baseCurrency,
+    totalAmountMinor,
+    totalsByCurrency,
+    expenses,
+    allocations,
+    dueDate,
+    publishedAt,
+  };
+}
+
+function normalizeExpenseSnapshot(value: PublishedExpenseSnapshot): PublishedExpenseSnapshot {
+  assertNonEmpty(value.expenseId, 'expenseId');
+  assertNonEmpty(value.categoryName, 'categoryName');
+  assertNonEmpty(value.currencyCode, 'currencyCode');
+  parseIsoDateString(value.invoiceDate, 'invoiceDate');
+  assertSafeIntegerNonNegative(value.amountMinor, 'amountMinor');
+
+  if (value.vendorName !== null) {
+    assertNonEmpty(value.vendorName, 'vendorName');
+  }
+
+  if (value.description !== null) {
+    assertNonEmpty(value.description, 'description');
+  }
+
+  const sourcePeriod = value.sourcePeriod;
+  if (sourcePeriod !== undefined && sourcePeriod !== null) {
+    assertNonEmpty(sourcePeriod, 'sourcePeriod');
+  }
+
+  if (value.type !== 'EXPENSE' && value.type !== 'ADJUSTMENT') {
+    throw new BadRequestException('Liquidation publication snapshot expense type is invalid');
+  }
+
+  return {
+    expenseId: value.expenseId,
+    categoryName: value.categoryName,
+    vendorName: value.vendorName,
+    amountMinor: value.amountMinor,
+    currencyCode: value.currencyCode,
+    invoiceDate: value.invoiceDate,
+    description: value.description,
+    type: value.type,
+    ...(sourcePeriod ? { sourcePeriod } : {}),
+  };
+}
+
+function normalizeAllocationSnapshot(value: PublishedAllocationSnapshot): PublishedAllocationSnapshot {
+  assertNonEmpty(value.unitId, 'unitId');
+  assertNonEmpty(value.unitCode, 'unitCode');
+  assertSafeIntegerNonNegative(value.amountMinor, 'amountMinor');
+  if (value.unitLabel !== null) {
+    assertNonEmpty(value.unitLabel, 'unitLabel');
+  }
+
+  return {
+    unitId: value.unitId,
+    unitCode: value.unitCode,
+    unitLabel: value.unitLabel,
+    amountMinor: value.amountMinor,
+  };
+}
+
+function toExpenseJsonObject(value: PublishedExpenseSnapshot): Prisma.InputJsonObject {
+  return createJsonObject({
+    expenseId: value.expenseId,
+    categoryName: value.categoryName,
+    vendorName: value.vendorName,
+    amountMinor: value.amountMinor,
+    currencyCode: value.currencyCode,
+    invoiceDate: value.invoiceDate,
+    description: value.description,
+    type: value.type,
+    ...(value.sourcePeriod ? { sourcePeriod: value.sourcePeriod } : {}),
+  });
+}
+
+function toAllocationJsonObject(value: PublishedAllocationSnapshot): Prisma.InputJsonObject {
+  return createJsonObject({
+    unitId: value.unitId,
+    unitCode: value.unitCode,
+    unitLabel: value.unitLabel,
+    amountMinor: value.amountMinor,
+  });
+}
+
+function parseExpenseSnapshot(value: unknown): PublishedExpenseSnapshot {
+  if (!isPlainObject(value)) {
+    throw new BadRequestException('Liquidation publication snapshot expense is invalid');
+  }
+
+  const expenseId = parseNonEmptyString(value.expenseId, 'expenseId');
+  const categoryName = parseNonEmptyString(value.categoryName, 'categoryName');
+  const vendorName = parseNullableString(value.vendorName, 'vendorName');
+  const amountMinor = parseSafeIntegerNonNegative(value.amountMinor, 'amountMinor');
+  const currencyCode = parseNonEmptyString(value.currencyCode, 'currencyCode');
+  const invoiceDate = parseIsoDateString(value.invoiceDate, 'invoiceDate');
+  const description = parseNullableString(value.description, 'description');
+  const type = parseNonEmptyString(value.type, 'type');
+
+  if (type !== 'EXPENSE' && type !== 'ADJUSTMENT') {
+    throw new BadRequestException('Liquidation publication snapshot expense type is invalid');
+  }
+
+  const sourcePeriod =
+    value.sourcePeriod === undefined || value.sourcePeriod === null
+      ? undefined
+      : parseNonEmptyString(value.sourcePeriod, 'sourcePeriod');
+
+  return {
+    expenseId,
+    categoryName,
+    vendorName,
+    amountMinor,
+    currencyCode,
+    invoiceDate,
+    description,
+    type,
+    ...(sourcePeriod ? { sourcePeriod } : {}),
+  };
+}
+
+function parseAllocationSnapshot(value: unknown): PublishedAllocationSnapshot {
+  if (!isPlainObject(value)) {
+    throw new BadRequestException('Liquidation publication snapshot allocation is invalid');
+  }
+
+  const unitId = parseNonEmptyString(value.unitId, 'unitId');
+  const unitCode = parseNonEmptyString(value.unitCode, 'unitCode');
+  const unitLabel = parseNullableString(value.unitLabel, 'unitLabel');
+  const amountMinor = parseSafeIntegerNonNegative(value.amountMinor, 'amountMinor');
+
+  return {
+    unitId,
+    unitCode,
+    unitLabel,
+    amountMinor,
+  };
+}
+
+function normalizeTotalsByCurrency(value: Record<string, number>): Record<string, number> {
+  if (!isPlainObject(value)) {
+    throw new BadRequestException('Liquidation publication snapshot totalsByCurrency is invalid');
+  }
+
+  const totals: Record<string, number> = {};
+
+  for (const [currencyCode, amount] of Object.entries(value)) {
+    assertNonEmpty(currencyCode, `totalsByCurrency.${currencyCode}`);
+    totals[currencyCode] = parseSafeIntegerNonNegative(amount, `totalsByCurrency.${currencyCode}`);
+  }
+
+  return totals;
+}
+
+function parseTotalsByCurrency(value: unknown): Record<string, number> {
+  if (!isPlainObject(value)) {
+    throw new BadRequestException('Liquidation publication snapshot totalsByCurrency is invalid');
+  }
+
+  const totals: Record<string, number> = {};
+
+  for (const [currencyCode, amount] of Object.entries(value)) {
+    if (!currencyCode.trim()) {
+      throw new BadRequestException('Liquidation publication snapshot currency code is invalid');
+    }
+
+    totals[currencyCode] = parseSafeIntegerNonNegative(amount, `totalsByCurrency.${currencyCode}`);
+  }
+
+  return totals;
+}
+
+function sumByCurrency(
+  items: ReadonlyArray<{
+    currencyCode: string;
+    amountMinor: number;
+  }>,
+): Record<string, number> {
+  return items.reduce<Record<string, number>>((acc, item) => {
+    assertNonEmpty(item.currencyCode, 'currencyCode');
+    assertSafeIntegerNonNegative(item.amountMinor, `amountMinor:${item.currencyCode}`);
+    acc[item.currencyCode] = safeAddMinor(
+      acc[item.currencyCode] ?? 0,
+      item.amountMinor,
+      `totalsByCurrency.${item.currencyCode}`,
+    );
+    return acc;
+  }, {});
+}
+
+function safeAddMinor(left: number, right: number, field: string): number {
+  const total = left + right;
+
+  if (!Number.isSafeInteger(total) || total < 0) {
+    throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
+  }
+
+  return total;
+}
+
+function assertCurrencyTotalsMatch(
+  declaredTotals: Record<string, number>,
+  actualTotals: Record<string, number>,
+): void {
+  const declaredCurrencies = Object.keys(declaredTotals);
+  const actualCurrencies = Object.keys(actualTotals);
+
+  for (const currencyCode of declaredCurrencies) {
+    const declaredAmount = declaredTotals[currencyCode];
+    const actualAmount = actualTotals[currencyCode] ?? 0;
+
+    if (declaredAmount !== actualAmount) {
+      throw new BadRequestException(
+        'Liquidation publication snapshot currency totals are inconsistent',
+      );
+    }
+  }
+
+  for (const currencyCode of actualCurrencies) {
+    if (!(currencyCode in declaredTotals)) {
+      throw new BadRequestException(
+        'Liquidation publication snapshot currency totals are inconsistent',
+      );
+    }
+  }
+}
+
+function parseNonEmptyString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
+  }
+
+  return value;
+}
+
+function parseNullableString(value: unknown, field: string): string | null {
+  if (value === null) {
+    return null;
+  }
+
+  return parseNonEmptyString(value, field);
+}
+
+function parseSafeIntegerNonNegative(value: unknown, field: string): number {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
+  }
+
+  return value;
+}
+
+function parseIsoDateString(value: unknown, field: string): string {
+  if (typeof value !== 'string') {
+    throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
+  }
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
+  }
+
+  return parsed.toISOString();
+}
+
+function assertIsoDate(value: Date, field: string): void {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) {
+    throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
+  }
+}
+
+function assertNonEmpty(value: string | null | undefined, field: string): void {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
+  }
+}
+
+function assertSafeIntegerNonNegative(value: number, field: string): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function createJsonObject<T extends Prisma.InputJsonObject>(value: T): T {
+  return value;
+}
+
+function createJsonArray<T extends Prisma.InputJsonArray>(value: T): T {
+  return value;
+}

--- a/apps/api/src/finanzas/liquidation-publication-snapshot.ts
+++ b/apps/api/src/finanzas/liquidation-publication-snapshot.ts
@@ -49,6 +49,21 @@ export interface BuildLiquidationPublicationSnapshotInput {
   publishedAt: Date;
 }
 
+export interface LiquidationDistributionUnit {
+  id: string;
+  code: string;
+  label: string | null;
+  areaM2: number;
+}
+
+export interface LiquidationDistributionAllocation {
+  unitId: string;
+  unitCode: string;
+  unitLabel: string | null;
+  areaM2: number;
+  amountMinor: number;
+}
+
 export function buildLiquidationPublicationSnapshot(
   input: BuildLiquidationPublicationSnapshotInput,
 ): Prisma.InputJsonObject {
@@ -106,6 +121,117 @@ export function buildLiquidationPublicationSnapshot(
     dueDate: input.dueDate.toISOString(),
     publishedAt: input.publishedAt.toISOString(),
   });
+}
+
+export function distributeLiquidationAmountByLargestRemainder(
+  units: readonly LiquidationDistributionUnit[],
+  totalAmountMinor: number,
+): LiquidationDistributionAllocation[] {
+  assertSafeIntegerNonNegative(totalAmountMinor, 'totalAmountMinor');
+
+  if (units.length === 0) {
+    if (totalAmountMinor === 0) {
+      return [];
+    }
+
+    throw new BadRequestException(
+      'Liquidation publication snapshot requires billable units to allocate a positive amount',
+    );
+  }
+
+  const normalizedUnits = units.map(normalizeDistributionUnit);
+  const totalAreaM2 = normalizedUnits.reduce(
+    (sum, unit) => safeAddFinite(sum, unit.areaM2, 'units.totalAreaM2'),
+    0,
+  );
+
+  if (totalAreaM2 === 0) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot units must have a positive allocation area',
+    );
+  }
+
+  const rankedAllocations = normalizedUnits.map((unit, index) => {
+    const exactShare = (totalAmountMinor * unit.areaM2) / totalAreaM2;
+    const amountMinor = Math.floor(exactShare);
+
+    return {
+      unit,
+      originalIndex: index,
+      amountMinor,
+      fraction: exactShare - amountMinor,
+    };
+  });
+
+  let allocatedMinor = rankedAllocations.reduce(
+    (sum, allocation) => safeAddMinor(sum, allocation.amountMinor, 'allocations.totalAmountMinor'),
+    0,
+  );
+  const remainder = totalAmountMinor - allocatedMinor;
+
+  if (!Number.isSafeInteger(remainder) || remainder < 0) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot allocations must match the liquidation total',
+    );
+  }
+
+  const winners = [...rankedAllocations]
+    .sort((left, right) => {
+      if (right.fraction !== left.fraction) {
+        return right.fraction - left.fraction;
+      }
+
+      const unitIdComparison = left.unit.id.localeCompare(right.unit.id);
+      if (unitIdComparison !== 0) {
+        return unitIdComparison;
+      }
+
+      const unitCodeComparison = left.unit.code.localeCompare(right.unit.code);
+      if (unitCodeComparison !== 0) {
+        return unitCodeComparison;
+      }
+
+      return left.originalIndex - right.originalIndex;
+    })
+    .slice(0, remainder);
+
+  for (const winner of winners) {
+    winner.amountMinor += 1;
+  }
+
+  const finalTotal = rankedAllocations.reduce(
+    (sum, allocation) => safeAddMinor(sum, allocation.amountMinor, 'allocations.totalAmountMinor'),
+    0,
+  );
+
+  if (finalTotal !== totalAmountMinor) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot allocations must match the liquidation total',
+    );
+  }
+
+  return rankedAllocations
+    .slice()
+    .sort((left, right) => {
+      const unitIdComparison = left.unit.id.localeCompare(right.unit.id);
+      if (unitIdComparison !== 0) {
+        return unitIdComparison;
+      }
+
+      const unitCodeComparison = left.unit.code.localeCompare(right.unit.code);
+      if (unitCodeComparison !== 0) {
+        return unitCodeComparison;
+      }
+
+      return left.originalIndex - right.originalIndex;
+    })
+    .map((allocation) => ({
+      unitId: allocation.unit.id,
+      unitCode: allocation.unit.code,
+      unitLabel: allocation.unit.label,
+      areaM2: allocation.unit.areaM2,
+      amountMinor: allocation.amountMinor,
+    }));
 }
 
 export function parseLiquidationPublicationSnapshot(
@@ -236,6 +362,26 @@ function normalizeAllocationSnapshot(value: PublishedAllocationSnapshot): Publis
     unitCode: value.unitCode,
     unitLabel: value.unitLabel,
     amountMinor: value.amountMinor,
+  };
+}
+
+function normalizeDistributionUnit(
+  value: LiquidationDistributionUnit,
+): LiquidationDistributionUnit {
+  assertNonEmpty(value.id, 'unit.id');
+  assertNonEmpty(value.code, 'unit.code');
+  if (value.label !== null) {
+    assertNonEmpty(value.label, 'unit.label');
+  }
+  if (typeof value.areaM2 !== 'number' || !Number.isFinite(value.areaM2) || value.areaM2 < 0) {
+    throw new BadRequestException('Liquidation publication snapshot unit areaM2 is invalid');
+  }
+
+  return {
+    id: value.id,
+    code: value.code,
+    label: value.label,
+    areaM2: value.areaM2,
   };
 }
 
@@ -371,6 +517,16 @@ function safeAddMinor(left: number, right: number, field: string): number {
   const total = left + right;
 
   if (!Number.isSafeInteger(total) || total < 0) {
+    throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
+  }
+
+  return total;
+}
+
+function safeAddFinite(left: number, right: number, field: string): number {
+  const total = left + right;
+
+  if (!Number.isFinite(total) || total < 0) {
     throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
   }
 

--- a/apps/api/src/finanzas/liquidation-snapshot-migration.spec.ts
+++ b/apps/api/src/finanzas/liquidation-snapshot-migration.spec.ts
@@ -1,0 +1,271 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('liquidation snapshot migration preflight', () => {
+  const migrationPath = join(
+    __dirname,
+    '../../prisma/migrations/20260711000000_add_liquidation_publication_snapshot/migration.sql',
+  );
+
+  it('adds a duplicate preflight before the unique index', () => {
+    const migration = readFileSync(migrationPath, 'utf8');
+    const preflightIndex = migration.indexOf('DO $$');
+    const uniqueIndex = migration.indexOf('CREATE UNIQUE INDEX "Liquidation_unique_published_tenant_building_period"');
+
+    expect(preflightIndex).toBeGreaterThanOrEqual(0);
+    expect(uniqueIndex).toBeGreaterThan(preflightIndex);
+    expect(migration).toContain('WHERE "status" = \'PUBLISHED\'');
+    expect(migration).toContain('GROUP BY "tenantId", "buildingId", "period"');
+    expect(migration).toContain('HAVING COUNT(*) > 1');
+    expect(migration).toContain('END;');
+    expect(migration).toContain('NEW."createdAt" IS DISTINCT FROM OLD."createdAt"');
+    expect(migration).toContain(
+      'cannot create published liquidation uniqueness constraint: duplicate published liquidations exist for tenant, building and period',
+    );
+  });
+});
+
+const migrationSql = readFileSync(
+  join(
+    __dirname,
+    '../../prisma/migrations/20260711000000_add_liquidation_publication_snapshot/migration.sql',
+  ),
+  'utf8',
+);
+
+const migrationFunctionStart = migrationSql.indexOf('CREATE OR REPLACE FUNCTION enforce_liquidation_publication_snapshot_immutable()');
+const migrationTriggerStart = migrationSql.indexOf('CREATE TRIGGER "Liquidation_publicationSnapshot_immutable"');
+const migrationFunctionSql =
+  migrationFunctionStart >= 0 && migrationTriggerStart > migrationFunctionStart
+    ? migrationSql.slice(migrationFunctionStart, migrationTriggerStart).trim()
+    : '';
+
+const shouldRunDatabaseBehaviorTests = Boolean(process.env.DATABASE_URL);
+const describeDatabaseBehavior = shouldRunDatabaseBehaviorTests ? describe : describe.skip;
+
+describeDatabaseBehavior('liquidation snapshot migration database behavior', () => {
+  let prisma: import('@prisma/client').PrismaClient;
+
+  const createTempLiquidationTableSql = `
+    CREATE TEMP TABLE "Liquidation" (
+      "id" TEXT PRIMARY KEY,
+      "tenantId" TEXT NOT NULL,
+      "buildingId" TEXT NOT NULL,
+      "period" TEXT NOT NULL,
+      "chargePeriod" TEXT,
+      "status" TEXT NOT NULL,
+      "baseCurrency" TEXT NOT NULL,
+      "totalAmountMinor" BIGINT NOT NULL,
+      "totalsByCurrency" JSONB NOT NULL,
+      "expenseSnapshot" JSONB NOT NULL,
+      "unitCount" INTEGER NOT NULL,
+      "generatedByMembershipId" TEXT NOT NULL,
+      "generatedAt" TIMESTAMPTZ NOT NULL,
+      "reviewedByMembershipId" TEXT,
+      "reviewedAt" TIMESTAMPTZ,
+      "publishedByMembershipId" TEXT,
+      "publishedAt" TIMESTAMPTZ,
+      "canceledByMembershipId" TEXT,
+      "canceledAt" TIMESTAMPTZ,
+      "publicationSnapshot" JSONB,
+      "createdAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+      "updatedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    ) ON COMMIT DROP;
+  `;
+
+  const createTempTriggerSql = `
+    CREATE TRIGGER "Liquidation_publicationSnapshot_immutable"
+    BEFORE INSERT OR UPDATE ON "Liquidation"
+    FOR EACH ROW
+    EXECUTE FUNCTION enforce_liquidation_publication_snapshot_immutable();
+  `;
+
+  const createTempUniqueIndexSql = `
+    CREATE UNIQUE INDEX "Liquidation_unique_published_tenant_building_period"
+    ON "Liquidation" ("tenantId", "buildingId", "period")
+    WHERE "status" = 'PUBLISHED';
+  `;
+
+  beforeAll(async () => {
+    const prismaModule = await import('@prisma/client');
+    prisma = new prismaModule.PrismaClient();
+  });
+
+  afterAll(async () => {
+    await prisma.$disconnect();
+  });
+
+  async function withSandbox<T>(action: (tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0]) => Promise<T>): Promise<T> {
+    return prisma.$transaction(async (tx) => {
+      await tx.$executeRawUnsafe(createTempLiquidationTableSql);
+      if (!migrationFunctionSql) {
+        throw new Error('Could not extract liquidation snapshot trigger function SQL');
+      }
+      await tx.$executeRawUnsafe(migrationFunctionSql);
+      await tx.$executeRawUnsafe(createTempTriggerSql);
+      await tx.$executeRawUnsafe(createTempUniqueIndexSql);
+      return action(tx);
+    });
+  }
+
+  async function publishLiquidationInSandbox(
+    tx: Parameters<Parameters<typeof prisma.$transaction>[0]>[0],
+    liquidationId: string,
+    period: string,
+    publishedAt: string,
+  ): Promise<void> {
+    await tx.$executeRawUnsafe(`
+      INSERT INTO "Liquidation" (
+        "id", "tenantId", "buildingId", "period", "chargePeriod", "status",
+        "baseCurrency", "totalAmountMinor", "totalsByCurrency", "expenseSnapshot",
+        "unitCount", "generatedByMembershipId", "generatedAt", "createdAt", "updatedAt"
+      ) VALUES (
+        '${liquidationId}', 'tenant-1', 'building-1', '${period}', '2026-06', 'DRAFT',
+        'ARS', 100, '{"ARS":100}', '[]',
+        2, 'member-1', '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z'
+      );
+    `);
+
+    await tx.$executeRawUnsafe(`
+      UPDATE "Liquidation"
+      SET "status" = 'REVIEWED',
+          "reviewedAt" = '2026-05-02T00:00:00.000Z',
+          "reviewedByMembershipId" = 'member-1',
+          "updatedAt" = '2026-05-02T00:00:00.000Z'
+      WHERE "id" = '${liquidationId}';
+    `);
+
+    await tx.$executeRawUnsafe(`
+      UPDATE "Liquidation"
+      SET "status" = 'PUBLISHED',
+          "publicationSnapshot" = '{"version":1,"liquidationId":"${liquidationId}","tenantId":"tenant-1","buildingId":"building-1","period":"${period}","baseCurrency":"ARS","totalAmountMinor":100,"totalsByCurrency":{"ARS":100},"expenses":[],"allocations":[],"dueDate":"2026-06-10T00:00:00.000Z","publishedAt":"${publishedAt}"}',
+          "publishedAt" = '${publishedAt}',
+          "publishedByMembershipId" = 'member-1',
+          "updatedAt" = '${publishedAt}'
+      WHERE "id" = '${liquidationId}';
+    `);
+  }
+
+  it('allows the expected draft, review and publication lifecycle in PostgreSQL', async () => {
+    await withSandbox(async (tx) => {
+      await tx.$executeRawUnsafe(`
+        INSERT INTO "Liquidation" (
+          "id", "tenantId", "buildingId", "period", "chargePeriod", "status",
+          "baseCurrency", "totalAmountMinor", "totalsByCurrency", "expenseSnapshot",
+          "unitCount", "generatedByMembershipId", "generatedAt", "createdAt", "updatedAt"
+        ) VALUES (
+          'liq-1', 'tenant-1', 'building-1', '2026-05', '2026-06', 'DRAFT',
+          'ARS', 100, '{"ARS":100}', '[]',
+          2, 'member-1', '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z'
+        );
+      `);
+
+      await tx.$executeRawUnsafe(`
+        UPDATE "Liquidation"
+        SET "status" = 'REVIEWED',
+            "reviewedAt" = '2026-05-02T00:00:00.000Z',
+            "reviewedByMembershipId" = 'member-1',
+            "updatedAt" = '2026-05-02T00:00:00.000Z'
+        WHERE "id" = 'liq-1';
+      `);
+
+      await tx.$executeRawUnsafe(`
+        UPDATE "Liquidation"
+        SET "status" = 'PUBLISHED',
+            "publicationSnapshot" = '{"version":1,"liquidationId":"liq-1","tenantId":"tenant-1","buildingId":"building-1","period":"2026-05","baseCurrency":"ARS","totalAmountMinor":100,"totalsByCurrency":{"ARS":100},"expenses":[],"allocations":[],"dueDate":"2026-06-10T00:00:00.000Z","publishedAt":"2026-05-03T00:00:00.000Z"}',
+            "publishedAt" = '2026-05-03T00:00:00.000Z',
+            "publishedByMembershipId" = 'member-1',
+            "updatedAt" = '2026-05-03T00:00:00.000Z'
+        WHERE "id" = 'liq-1';
+      `);
+
+      const rows = await tx.$queryRawUnsafe<Array<{ status: string; publicationSnapshot: unknown }>>(
+        `SELECT "status", "publicationSnapshot" FROM "Liquidation" WHERE "id" = 'liq-1';`,
+      );
+
+      expect(rows[0]?.status).toBe('PUBLISHED');
+      expect(rows[0]?.publicationSnapshot).not.toBeNull();
+    });
+  });
+
+  it('rejects a direct draft to published transition in PostgreSQL', async () => {
+    await expect(
+      withSandbox(async (tx) => {
+        await tx.$executeRawUnsafe(`
+          INSERT INTO "Liquidation" (
+            "id", "tenantId", "buildingId", "period", "chargePeriod", "status",
+            "baseCurrency", "totalAmountMinor", "totalsByCurrency", "expenseSnapshot",
+            "unitCount", "generatedByMembershipId", "generatedAt", "createdAt", "updatedAt"
+          ) VALUES (
+            'liq-2', 'tenant-1', 'building-1', '2026-05', '2026-06', 'DRAFT',
+            'ARS', 100, '{"ARS":100}', '[]',
+            2, 'member-1', '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z'
+          );
+        `);
+
+        await tx.$executeRawUnsafe(`
+          UPDATE "Liquidation"
+          SET "status" = 'PUBLISHED',
+              "publicationSnapshot" = '{"version":1,"liquidationId":"liq-2","tenantId":"tenant-1","buildingId":"building-1","period":"2026-05","baseCurrency":"ARS","totalAmountMinor":100,"totalsByCurrency":{"ARS":100},"expenses":[],"allocations":[],"dueDate":"2026-06-10T00:00:00.000Z","publishedAt":"2026-05-03T00:00:00.000Z"}',
+              "publishedAt" = '2026-05-03T00:00:00.000Z',
+              "publishedByMembershipId" = 'member-1',
+              "updatedAt" = '2026-05-03T00:00:00.000Z'
+          WHERE "id" = 'liq-2';
+        `);
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects immutable createdAt changes on published liquidations in PostgreSQL', async () => {
+    await expect(
+      withSandbox(async (tx) => {
+        await publishLiquidationInSandbox(tx, 'liq-3', '2026-05', '2026-05-03T00:00:00.000Z');
+
+        await tx.$executeRawUnsafe(`
+          UPDATE "Liquidation"
+          SET "createdAt" = '2026-05-04T00:00:00.000Z'
+          WHERE "id" = 'liq-3';
+        `);
+      }),
+    ).rejects.toThrow();
+  });
+
+  it('rejects duplicate published liquidations in PostgreSQL', async () => {
+    await expect(
+      withSandbox(async (tx) => {
+        await publishLiquidationInSandbox(tx, 'liq-4', '2026-05', '2026-05-03T00:00:00.000Z');
+
+        await tx.$executeRawUnsafe(`
+          INSERT INTO "Liquidation" (
+            "id", "tenantId", "buildingId", "period", "chargePeriod", "status",
+            "baseCurrency", "totalAmountMinor", "totalsByCurrency", "expenseSnapshot",
+            "unitCount", "generatedByMembershipId", "generatedAt", "createdAt", "updatedAt"
+          ) VALUES (
+            'liq-5', 'tenant-1', 'building-1', '2026-05', '2026-06', 'DRAFT',
+            'ARS', 100, '{"ARS":100}', '[]',
+            2, 'member-1', '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z', '2026-05-01T00:00:00.000Z'
+          );
+        `);
+
+        await tx.$executeRawUnsafe(`
+          UPDATE "Liquidation"
+          SET "status" = 'REVIEWED',
+              "reviewedAt" = '2026-05-02T00:00:00.000Z',
+              "reviewedByMembershipId" = 'member-1',
+              "updatedAt" = '2026-05-02T00:00:00.000Z'
+          WHERE "id" = 'liq-5';
+        `);
+
+        await tx.$executeRawUnsafe(`
+          UPDATE "Liquidation"
+          SET "status" = 'PUBLISHED',
+              "publicationSnapshot" = '{"version":1,"liquidationId":"liq-5","tenantId":"tenant-1","buildingId":"building-1","period":"2026-05","baseCurrency":"ARS","totalAmountMinor":100,"totalsByCurrency":{"ARS":100},"expenses":[],"allocations":[],"dueDate":"2026-06-10T00:00:00.000Z","publishedAt":"2026-05-03T00:00:00.000Z"}',
+              "publishedAt" = '2026-05-03T00:00:00.000Z',
+              "publishedByMembershipId" = 'member-1',
+              "updatedAt" = '2026-05-03T00:00:00.000Z'
+          WHERE "id" = 'liq-5';
+        `);
+      }),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/api/src/finanzas/liquidations.controller.spec.ts
+++ b/apps/api/src/finanzas/liquidations.controller.spec.ts
@@ -1,0 +1,212 @@
+import { Test } from '@nestjs/testing';
+import { LiquidationsController } from './liquidations.controller';
+import { LiquidationsService } from './liquidations.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import type { AuthenticatedRequest } from '../common/types/request.types';
+import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
+import type {
+  CreateLiquidationDraftDto,
+  CancelLiquidationDto,
+  ListLiquidationsQueryDto,
+  LiquidationParamDto,
+  LiquidationDetailDto,
+  LiquidationResponseDto,
+  PublishLiquidationDto,
+} from './expense-ledger.dto';
+
+const stubReq = (
+  overrides: Record<string, unknown> = {},
+): AuthenticatedRequest =>
+  ({
+    tenantId: 'tenant-1',
+    user: {
+      id: 'user-1',
+      email: 'admin@test.com',
+      membershipId: 'member-legacy',
+      tenantId: 'tenant-1',
+      effectiveMembership: {
+        id: 'member-effective',
+        tenantId: 'tenant-1',
+        roles: ['TENANT_ADMIN'],
+      },
+      roles: ['TENANT_ADMIN'],
+    },
+    ...overrides,
+  }) as AuthenticatedRequest;
+
+describe('LiquidationsController', () => {
+  let controller: LiquidationsController;
+  let service: {
+    listLiquidations: jest.Mock;
+    getLiquidation: jest.Mock;
+    createDraft: jest.Mock;
+    reviewLiquidation: jest.Mock;
+    publishLiquidation: jest.Mock;
+    cancelLiquidation: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    service = {
+      listLiquidations: jest.fn(),
+      getLiquidation: jest.fn(),
+      createDraft: jest.fn(),
+      reviewLiquidation: jest.fn(),
+      publishLiquidation: jest.fn(),
+      cancelLiquidation: jest.fn(),
+    };
+
+    const module = await Test.createTestingModule({
+      controllers: [LiquidationsController],
+      providers: [
+        {
+          provide: LiquidationsService,
+          useValue: service,
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: jest.fn().mockResolvedValue(true) })
+      .overrideGuard(TenantAccessGuard)
+      .useValue({ canActivate: jest.fn().mockResolvedValue(true) })
+      .compile();
+
+    controller = module.get(LiquidationsController);
+  });
+
+  it('uses the effective membership for liquidation reads', async () => {
+    const expected: LiquidationResponseDto = {
+      id: 'liq-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      period: '2026-05',
+      chargePeriod: null,
+      status: 'REVIEWED',
+      totalAmountMinor: 100,
+      totalsByCurrency: { ARS: 100 },
+      baseCurrency: 'ARS',
+      unitCount: 2,
+      generatedAt: new Date(),
+      reviewedAt: null,
+      publishedAt: null,
+      canceledAt: null,
+      createdAt: new Date(),
+    };
+    const readDetail: LiquidationDetailDto = {
+      ...expected,
+      publicationSnapshotStatus: 'LEGACY',
+      expenses: [],
+      chargesPreview: [],
+    };
+    service.listLiquidations.mockResolvedValue([expected]);
+    service.getLiquidation.mockResolvedValue(readDetail);
+    const query: ListLiquidationsQueryDto = {
+      buildingId: 'building-1',
+      period: '2026-05',
+    };
+    const params: LiquidationParamDto = {
+      liquidationId: 'c123456789012345678901234',
+    };
+
+    await controller.listLiquidations(query, stubReq());
+    await controller.getLiquidation(params, stubReq());
+
+    expect(service.listLiquidations).toHaveBeenCalledWith(
+      'tenant-1',
+      'member-effective',
+      ['TENANT_ADMIN'],
+      { buildingId: 'building-1', period: '2026-05' },
+    );
+    expect(service.getLiquidation).toHaveBeenCalledWith(
+      'tenant-1',
+      'c123456789012345678901234',
+      'member-effective',
+      ['TENANT_ADMIN'],
+    );
+  });
+
+  it('uses the effective membership for liquidation writes', async () => {
+    const detail: LiquidationDetailDto = {
+      id: 'liq-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      period: '2026-05',
+      chargePeriod: null,
+      status: 'DRAFT',
+      baseCurrency: 'ARS',
+      totalAmountMinor: 100,
+      unitCount: 2,
+      totalsByCurrency: { ARS: 100 },
+      generatedAt: new Date(),
+      reviewedAt: null,
+      publishedAt: null,
+      canceledAt: null,
+      createdAt: new Date(),
+      publicationSnapshotStatus: 'LEGACY',
+      expenses: [],
+      chargesPreview: [],
+    };
+    const draftDto: CreateLiquidationDraftDto = {
+      buildingId: 'building-1',
+      baseCurrency: 'ARS',
+      period: '2026-05',
+    };
+    const publishDto: PublishLiquidationDto = { dueDate: '2026-06-10' };
+    const cancelDto: CancelLiquidationDto = { reason: 'Board decision' };
+    const params: LiquidationParamDto = {
+      liquidationId: 'c123456789012345678901234',
+    };
+    const published: LiquidationResponseDto = {
+      id: 'liq-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      period: '2026-05',
+      chargePeriod: null,
+      status: 'PUBLISHED',
+      totalAmountMinor: 100,
+      totalsByCurrency: { ARS: 100 },
+      baseCurrency: 'ARS',
+      unitCount: 2,
+      generatedAt: new Date(),
+      reviewedAt: null,
+      publishedAt: null,
+      canceledAt: null,
+      createdAt: new Date(),
+    };
+    service.createDraft.mockResolvedValue(detail);
+    service.reviewLiquidation.mockResolvedValue(published);
+    service.publishLiquidation.mockResolvedValue(published);
+    service.cancelLiquidation.mockResolvedValue(published);
+
+    await controller.createDraft(draftDto, stubReq());
+    await controller.reviewLiquidation(params, stubReq());
+    await controller.publishLiquidation(params, publishDto, stubReq());
+    await controller.cancelLiquidation(params, cancelDto, stubReq());
+
+    expect(service.createDraft).toHaveBeenCalledWith(
+      'tenant-1',
+      'member-effective',
+      ['TENANT_ADMIN'],
+      draftDto,
+    );
+    expect(service.reviewLiquidation).toHaveBeenCalledWith(
+      'tenant-1',
+      'c123456789012345678901234',
+      'member-effective',
+      ['TENANT_ADMIN'],
+    );
+    expect(service.publishLiquidation).toHaveBeenCalledWith(
+      'tenant-1',
+      'c123456789012345678901234',
+      'member-effective',
+      ['TENANT_ADMIN'],
+      publishDto,
+    );
+    expect(service.cancelLiquidation).toHaveBeenCalledWith(
+      'tenant-1',
+      'c123456789012345678901234',
+      'member-effective',
+      ['TENANT_ADMIN'],
+      { reason: 'Board decision' },
+    );
+  });
+});

--- a/apps/api/src/finanzas/liquidations.controller.spec.ts
+++ b/apps/api/src/finanzas/liquidations.controller.spec.ts
@@ -113,14 +113,12 @@ describe('LiquidationsController', () => {
     expect(service.listLiquidations).toHaveBeenCalledWith(
       'tenant-1',
       'member-effective',
-      ['TENANT_ADMIN'],
       { buildingId: 'building-1', period: '2026-05' },
     );
     expect(service.getLiquidation).toHaveBeenCalledWith(
       'tenant-1',
       'c123456789012345678901234',
       'member-effective',
-      ['TENANT_ADMIN'],
     );
   });
 
@@ -185,27 +183,23 @@ describe('LiquidationsController', () => {
     expect(service.createDraft).toHaveBeenCalledWith(
       'tenant-1',
       'member-effective',
-      ['TENANT_ADMIN'],
       draftDto,
     );
     expect(service.reviewLiquidation).toHaveBeenCalledWith(
       'tenant-1',
       'c123456789012345678901234',
       'member-effective',
-      ['TENANT_ADMIN'],
     );
     expect(service.publishLiquidation).toHaveBeenCalledWith(
       'tenant-1',
       'c123456789012345678901234',
       'member-effective',
-      ['TENANT_ADMIN'],
       publishDto,
     );
     expect(service.cancelLiquidation).toHaveBeenCalledWith(
       'tenant-1',
       'c123456789012345678901234',
       'member-effective',
-      ['TENANT_ADMIN'],
       { reason: 'Board decision' },
     );
   });

--- a/apps/api/src/finanzas/liquidations.controller.ts
+++ b/apps/api/src/finanzas/liquidations.controller.ts
@@ -1,41 +1,30 @@
 import {
+  Body,
   Controller,
   Get,
-  Post,
-  Param,
-  Body,
-  Query,
-  UseGuards,
-  Request,
   HttpCode,
   HttpStatus,
+  Param,
+  Post,
+  Query,
+  Request,
+  UseGuards,
 } from '@nestjs/common';
-import { IsOptional, IsString } from 'class-validator';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
-import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
 import { AuthenticatedRequest } from '../common/types/request.types';
-import { LiquidationsService } from './liquidations.service';
+import { resolveTenantMembershipContext } from '../common/request-context';
+import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
 import {
+  CancelLiquidationDto,
   CreateLiquidationDraftDto,
-  PublishLiquidationDto,
-  LiquidationResponseDto,
+  ListLiquidationsQueryDto,
   LiquidationDetailDto,
+  LiquidationParamDto,
+  LiquidationResponseDto,
+  PublishLiquidationDto,
 } from './expense-ledger.dto';
+import { LiquidationsService } from './liquidations.service';
 
-class ListLiquidationsQuery {
-  @IsOptional()
-  @IsString()
-  buildingId?: string;
-
-  @IsOptional()
-  @IsString()
-  period?: string;
-}
-
-/**
- * Liquidaciones de expensas
- * Routes: /tenants/:tenantId/finance/liquidations
- */
 @Controller('tenants/:tenantId/finance/liquidations')
 @UseGuards(JwtAuthGuard, TenantAccessGuard)
 export class LiquidationsController {
@@ -43,25 +32,31 @@ export class LiquidationsController {
 
   @Get()
   async listLiquidations(
-    @Query() query: ListLiquidationsQuery,
+    @Query() query: ListLiquidationsQueryDto,
     @Request() req: AuthenticatedRequest,
   ): Promise<LiquidationResponseDto[]> {
+    const context = this.resolveRequestContext(req);
+
     return this.liquidationsService.listLiquidations(
-      req.tenantId!,
-      req.user.roles ?? [],
+      context.tenantId,
+      context.membershipId,
+      context.roles,
       { buildingId: query.buildingId, period: query.period },
     );
   }
 
   @Get(':liquidationId')
   async getLiquidation(
-    @Param('liquidationId') liquidationId: string,
+    @Param() params: LiquidationParamDto,
     @Request() req: AuthenticatedRequest,
   ): Promise<LiquidationDetailDto> {
+    const context = this.resolveRequestContext(req);
+
     return this.liquidationsService.getLiquidation(
-      req.tenantId!,
-      liquidationId,
-      req.user.roles ?? [],
+      context.tenantId,
+      params.liquidationId,
+      context.membershipId,
+      context.roles,
     );
   }
 
@@ -70,10 +65,12 @@ export class LiquidationsController {
     @Body() dto: CreateLiquidationDraftDto,
     @Request() req: AuthenticatedRequest,
   ): Promise<LiquidationDetailDto> {
+    const context = this.resolveRequestContext(req);
+
     return this.liquidationsService.createDraft(
-      req.tenantId!,
-      req.user.membershipId ?? '',
-      req.user.roles ?? [],
+      context.tenantId,
+      context.membershipId,
+      context.roles,
       dto,
     );
   }
@@ -81,29 +78,33 @@ export class LiquidationsController {
   @Post(':liquidationId/review')
   @HttpCode(HttpStatus.OK)
   async reviewLiquidation(
-    @Param('liquidationId') liquidationId: string,
+    @Param() params: LiquidationParamDto,
     @Request() req: AuthenticatedRequest,
   ): Promise<LiquidationResponseDto> {
+    const context = this.resolveRequestContext(req);
+
     return this.liquidationsService.reviewLiquidation(
-      req.tenantId!,
-      liquidationId,
-      req.user.membershipId ?? '',
-      req.user.roles ?? [],
+      context.tenantId,
+      params.liquidationId,
+      context.membershipId,
+      context.roles,
     );
   }
 
   @Post(':liquidationId/publish')
   @HttpCode(HttpStatus.OK)
   async publishLiquidation(
-    @Param('liquidationId') liquidationId: string,
+    @Param() params: LiquidationParamDto,
     @Body() dto: PublishLiquidationDto,
     @Request() req: AuthenticatedRequest,
   ): Promise<LiquidationResponseDto> {
+    const context = this.resolveRequestContext(req);
+
     return this.liquidationsService.publishLiquidation(
-      req.tenantId!,
-      liquidationId,
-      req.user.membershipId ?? '',
-      req.user.roles ?? [],
+      context.tenantId,
+      params.liquidationId,
+      context.membershipId,
+      context.roles,
       dto,
     );
   }
@@ -111,14 +112,26 @@ export class LiquidationsController {
   @Post(':liquidationId/cancel')
   @HttpCode(HttpStatus.OK)
   async cancelLiquidation(
-    @Param('liquidationId') liquidationId: string,
+    @Param() params: LiquidationParamDto,
+    @Body() dto: CancelLiquidationDto,
     @Request() req: AuthenticatedRequest,
   ): Promise<LiquidationResponseDto> {
+    const context = this.resolveRequestContext(req);
+
     return this.liquidationsService.cancelLiquidation(
-      req.tenantId!,
-      liquidationId,
-      req.user.membershipId ?? '',
-      req.user.roles ?? [],
+      context.tenantId,
+      params.liquidationId,
+      context.membershipId,
+      context.roles,
+      { reason: dto.reason },
     );
+  }
+
+  private resolveRequestContext(req: AuthenticatedRequest): {
+    tenantId: string;
+    membershipId: string;
+    roles: string[];
+  } {
+    return resolveTenantMembershipContext(req);
   }
 }

--- a/apps/api/src/finanzas/liquidations.controller.ts
+++ b/apps/api/src/finanzas/liquidations.controller.ts
@@ -40,7 +40,6 @@ export class LiquidationsController {
     return this.liquidationsService.listLiquidations(
       context.tenantId,
       context.membershipId,
-      context.roles,
       { buildingId: query.buildingId, period: query.period },
     );
   }
@@ -56,7 +55,6 @@ export class LiquidationsController {
       context.tenantId,
       params.liquidationId,
       context.membershipId,
-      context.roles,
     );
   }
 
@@ -70,7 +68,6 @@ export class LiquidationsController {
     return this.liquidationsService.createDraft(
       context.tenantId,
       context.membershipId,
-      context.roles,
       dto,
     );
   }
@@ -87,7 +84,6 @@ export class LiquidationsController {
       context.tenantId,
       params.liquidationId,
       context.membershipId,
-      context.roles,
     );
   }
 
@@ -104,7 +100,6 @@ export class LiquidationsController {
       context.tenantId,
       params.liquidationId,
       context.membershipId,
-      context.roles,
       dto,
     );
   }
@@ -122,7 +117,6 @@ export class LiquidationsController {
       context.tenantId,
       params.liquidationId,
       context.membershipId,
-      context.roles,
       { reason: dto.reason },
     );
   }
@@ -130,7 +124,6 @@ export class LiquidationsController {
   private resolveRequestContext(req: AuthenticatedRequest): {
     tenantId: string;
     membershipId: string;
-    roles: string[];
   } {
     return resolveTenantMembershipContext(req);
   }

--- a/apps/api/src/finanzas/liquidations.request.dto.spec.ts
+++ b/apps/api/src/finanzas/liquidations.request.dto.spec.ts
@@ -1,0 +1,101 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+import {
+  CancelLiquidationDto,
+  ListLiquidationsQueryDto,
+  LiquidationParamDto,
+  PublishLiquidationDto,
+  CreateLiquidationDraftDto,
+} from './expense-ledger.dto';
+
+const validate = <T extends object>(cls: new () => T, input: Record<string, unknown>) =>
+  validateSync(plainToInstance(cls, input), {
+    whitelist: true,
+    forbidUnknownValues: true,
+  });
+
+describe('Liquidation request DTOs', () => {
+  describe('ListLiquidationsQueryDto.period', () => {
+    it.each(['2026-01', '2026-12'])('accepts %s', (period) => {
+      expect(validate(ListLiquidationsQueryDto, { period })).toHaveLength(0);
+    });
+
+    it.each(['2026-00', '2026-13', '2026-1', 'foo', ' 2026-01 '])('rejects %s', (period) => {
+      expect(validate(ListLiquidationsQueryDto, { period }).map((error) => error.property)).toContain('period');
+    });
+  });
+
+  describe('LiquidationParamDto.liquidationId', () => {
+    it('accepts a valid CUID', () => {
+      expect(
+        validate(LiquidationParamDto, { liquidationId: 'c123456789012345678901234' }),
+      ).toHaveLength(0);
+    });
+
+    it.each(['', '   ', 'liq-1', 'c123', 'c1234567890123456789012345'])(
+      'rejects %s',
+      (liquidationId) => {
+        expect(
+          validate(LiquidationParamDto, { liquidationId }).map((error) => error.property),
+        ).toContain('liquidationId');
+      },
+    );
+  });
+
+  describe('CancelLiquidationDto.reason', () => {
+    it('accepts a trimmed reason', () => {
+      const dto = plainToInstance(CancelLiquidationDto, { reason: '  Board decision  ' });
+
+      expect(dto.reason).toBe('Board decision');
+      expect(validate(CancelLiquidationDto, { reason: '  Board decision  ' })).toHaveLength(0);
+    });
+
+    it('allows omission of reason', () => {
+      expect(validate(CancelLiquidationDto, {})).toHaveLength(0);
+    });
+
+    it.each([0, '', '   ', null, ['x'], { text: 'x' }, true])('rejects %p', (reason) => {
+      expect(
+        validate(CancelLiquidationDto, { reason }).map((error) => error.property),
+      ).toContain('reason');
+    });
+  });
+
+  describe('PublishLiquidationDto.dueDate', () => {
+    it('accepts a strict ISO date', () => {
+      expect(validate(PublishLiquidationDto, { dueDate: '2026-06-10' })).toHaveLength(0);
+    });
+
+    it.each(['01/02/2026', 'January 2 2026', '2026-1-2', '2026-13-01', '2026-06-31', '2026-06-10T00:00:00.000Z'])(
+      'rejects ambiguous or invalid dueDate %s',
+      (dueDate) => {
+        expect(
+          validate(PublishLiquidationDto, { dueDate }).map((error) => error.property),
+        ).toContain('dueDate');
+      },
+    );
+  });
+
+  describe('CreateLiquidationDraftDto.period', () => {
+    it('accepts a valid month period', () => {
+      expect(
+        validate(CreateLiquidationDraftDto, {
+          buildingId: 'building-1',
+          period: '2026-01',
+          baseCurrency: 'ARS',
+        }),
+      ).toHaveLength(0);
+    });
+
+    it('rejects malformed periods', () => {
+      expect(
+        validate(CreateLiquidationDraftDto, {
+          buildingId: 'building-1',
+          period: '2026-13',
+          baseCurrency: 'ARS',
+        }).map((error) => error.property),
+      ).toContain('period');
+    });
+  });
+});

--- a/apps/api/src/finanzas/liquidations.service.spec.ts
+++ b/apps/api/src/finanzas/liquidations.service.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import {
+  BadRequestException,
   ConflictException,
   ForbiddenException,
   NotFoundException,
@@ -16,11 +17,23 @@ const baseLiquidation = {
   tenantId: 'tenant-1',
   buildingId: 'building-1',
   period: '2026-05',
+  chargePeriod: '2026-06',
   status: 'REVIEWED',
   baseCurrency: 'ARS',
   totalAmountMinor: 101,
   totalsByCurrency: { ARS: 101 },
-  expenseSnapshot: [],
+  expenseSnapshot: [
+    {
+      expenseId: 'exp-1',
+      categoryName: 'Water',
+      vendorName: 'Vendor',
+      amountMinor: 101,
+      currencyCode: 'ARS',
+      invoiceDate: '2026-05-01T00:00:00.000Z',
+      description: null,
+      type: 'EXPENSE',
+    },
+  ],
   unitCount: 2,
   generatedAt: new Date('2026-05-01T00:00:00.000Z'),
   reviewedAt: null,
@@ -32,10 +45,26 @@ const baseLiquidation = {
 describe('LiquidationsService', () => {
   let service: LiquidationsService;
   let prisma: PrismaService;
-  let auditService: { createLog: jest.Mock };
+  let auditService: { createLog: jest.Mock; createLogRequired: jest.Mock };
   let validators: { isAdminOrOperator: jest.Mock };
   let notificationsService: { createNotification: jest.Mock };
   let tx: {
+    membership: {
+      findFirst: jest.Mock;
+    };
+    building: {
+      findFirst: jest.Mock;
+    };
+    expense: {
+      count: jest.Mock;
+      findMany: jest.Mock;
+    };
+    adjustment: {
+      findMany: jest.Mock;
+    };
+    unit: {
+      findMany: jest.Mock;
+    };
     liquidation: {
       findFirst: jest.Mock;
       updateMany: jest.Mock;
@@ -43,6 +72,7 @@ describe('LiquidationsService', () => {
     };
     charge: {
       count: jest.Mock;
+      findMany: jest.Mock;
       createMany: jest.Mock;
       updateMany: jest.Mock;
       deleteMany: jest.Mock;
@@ -53,6 +83,29 @@ describe('LiquidationsService', () => {
 
   beforeEach(async () => {
     tx = {
+      membership: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'member-1',
+          tenantId: 'tenant-1',
+          roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+        }),
+      },
+      building: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'building-1' }),
+      },
+      expense: {
+        count: jest.fn().mockResolvedValue(0),
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      adjustment: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      unit: {
+        findMany: jest.fn().mockResolvedValue([
+          { id: 'unit-1', code: '1A', label: '1A', unitCategory: null },
+          { id: 'unit-2', code: '1B', label: '1B', unitCategory: null },
+        ]),
+      },
       liquidation: {
         findFirst: jest.fn().mockImplementation(({ where }: { where?: { status?: string } }) => {
           if (where?.status === 'PUBLISHED') {
@@ -66,6 +119,7 @@ describe('LiquidationsService', () => {
       },
       charge: {
         count: jest.fn().mockResolvedValue(0),
+        findMany: jest.fn().mockResolvedValue([]),
         createMany: jest.fn().mockResolvedValue({ count: 2 }),
         updateMany: jest.fn().mockResolvedValue({ count: 2 }),
         deleteMany: jest.fn(),
@@ -81,6 +135,13 @@ describe('LiquidationsService', () => {
         {
           provide: PrismaService,
           useValue: {
+            membership: {
+              findFirst: jest.fn().mockResolvedValue({
+                id: 'member-1',
+                tenantId: 'tenant-1',
+                roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+              }),
+            },
             unit: {
               findMany: jest.fn().mockResolvedValue([
                 { id: 'unit-1', code: '1A', label: '1A', unitCategory: null },
@@ -92,12 +153,23 @@ describe('LiquidationsService', () => {
                 unitOccupants: [],
               }),
             },
-            charge: {
+            expense: {
+              count: jest.fn().mockResolvedValue(0),
               findMany: jest.fn().mockResolvedValue([]),
-              deleteMany: jest.fn(),
             },
+            adjustment: {
+              findMany: jest.fn().mockResolvedValue([]),
+            },
+            building: {
+              findFirst: jest.fn().mockResolvedValue({ id: 'building-1' }),
+            },
+          charge: {
+            findMany: jest.fn().mockResolvedValue([]),
+            deleteMany: jest.fn(),
+          },
             paymentAllocation: { count: jest.fn().mockResolvedValue(0) },
             liquidation: {
+              findMany: jest.fn().mockResolvedValue([baseLiquidation]),
               findFirst: jest.fn().mockImplementation(({ where }: { where?: { status?: string; id?: { not?: string } } }) => {
                 if (where?.status === 'PUBLISHED' && where?.id?.not === 'liq-1') {
                   return Promise.resolve(null);
@@ -118,7 +190,10 @@ describe('LiquidationsService', () => {
         },
         {
           provide: AuditService,
-          useValue: (auditService = { createLog: jest.fn() }),
+          useValue: (auditService = {
+            createLog: jest.fn(),
+            createLogRequired: jest.fn().mockResolvedValue(undefined),
+          }),
         },
         {
           provide: FinanzasValidators,
@@ -133,6 +208,19 @@ describe('LiquidationsService', () => {
 
     service = module.get<LiquidationsService>(LiquidationsService);
     prisma = module.get<PrismaService>(PrismaService);
+  });
+
+  it('includes chargePeriod when mapping a liquidation response', async () => {
+    const liquidations = await service.listLiquidations(
+      'tenant-1',
+      'member-1',
+      ['TENANT_ADMIN'],
+      {},
+    );
+
+    expect(liquidations).toEqual([
+      expect.objectContaining({ chargePeriod: '2026-06' }),
+    ]);
   });
 
   it('creates one charge per billable unit when publishing', async () => {
@@ -157,14 +245,19 @@ describe('LiquidationsService', () => {
     });
     expect(tx.liquidation.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: 'liq-1', tenantId: 'tenant-1' },
+        where: {
+          id: 'liq-1',
+          tenantId: 'tenant-1',
+          status: 'REVIEWED',
+          publicationSnapshot: { equals: Prisma.DbNull },
+        },
         data: expect.objectContaining({ status: 'PUBLISHED' }),
       }),
     );
   });
 
   it('returns an already published liquidation without creating duplicate charges', async () => {
-    prisma.liquidation.findFirst.mockResolvedValue({
+    tx.liquidation.findFirst.mockResolvedValueOnce({
       ...baseLiquidation,
       status: 'PUBLISHED',
       publishedAt: new Date('2026-05-02T00:00:00.000Z'),
@@ -175,11 +268,68 @@ describe('LiquidationsService', () => {
     });
 
     expect(result.status).toBe('PUBLISHED');
-    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(tx.charge.createMany).not.toHaveBeenCalled();
+    expect(prisma.$transaction).toHaveBeenCalled();
+  });
+
+  it('rejects draft creation when the base currency is missing from totalsByCurrency', async () => {
+    tx.liquidation.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null);
+    tx.expense.count.mockResolvedValueOnce(0);
+    tx.expense.findMany
+      .mockResolvedValueOnce([
+        {
+          id: 'exp-1',
+          amountMinor: 100,
+          currencyCode: 'ARS',
+          invoiceDate: new Date('2026-05-01T00:00:00.000Z'),
+          description: null,
+          category: { name: 'Water' },
+          vendor: { name: 'Vendor' },
+          allocations: [],
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    tx.adjustment.findMany.mockResolvedValueOnce([]);
+    tx.unit.findMany.mockResolvedValueOnce([
+      { id: 'unit-1', code: '1A', label: '1A', unitCategory: null },
+    ]);
+
+    await expect(
+      service.createDraft('tenant-1', 'member-1', ['TENANT_ADMIN'], {
+        buildingId: 'building-1',
+        period: '2026-05',
+        baseCurrency: 'USD',
+      }),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(auditService.createLogRequired).not.toHaveBeenCalled();
   });
 
   it('finishes publication without creating charges when all charges already exist', async () => {
-    tx.charge.count.mockResolvedValueOnce(2);
+    tx.charge.findMany.mockResolvedValueOnce([
+      {
+        unitId: 'unit-1',
+        amount: 51,
+        currency: 'ARS',
+        dueDate: new Date('2026-06-10T00:00:00.000Z'),
+        buildingId: 'building-1',
+        period: '2026-05',
+        liquidationId: 'liq-1',
+        concept: 'Expensas comunes 2026-05',
+      },
+      {
+        unitId: 'unit-2',
+        amount: 50,
+        currency: 'ARS',
+        dueDate: new Date('2026-06-10T00:00:00.000Z'),
+        buildingId: 'building-1',
+        period: '2026-05',
+        liquidationId: 'liq-1',
+        concept: 'Expensas comunes 2026-05',
+      },
+    ]);
     tx.liquidation.findFirst
       .mockResolvedValueOnce({ ...baseLiquidation, status: 'REVIEWED' })
       .mockResolvedValueOnce(null)
@@ -194,16 +344,74 @@ describe('LiquidationsService', () => {
     });
 
     expect(tx.charge.createMany).not.toHaveBeenCalled();
+    expect(tx.charge.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          tenantId: 'tenant-1',
+          liquidationId: 'liq-1',
+          buildingId: 'building-1',
+          period: '2026-05',
+        },
+      }),
+    );
     expect(tx.liquidation.updateMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { id: 'liq-1', tenantId: 'tenant-1' },
+        where: {
+          id: 'liq-1',
+          tenantId: 'tenant-1',
+          status: 'REVIEWED',
+          publicationSnapshot: { equals: Prisma.DbNull },
+        },
         data: expect.objectContaining({ status: 'PUBLISHED' }),
       }),
     );
   });
 
   it('rejects publish when only some charges already exist', async () => {
-    tx.charge.count.mockResolvedValueOnce(1);
+    tx.charge.findMany.mockResolvedValueOnce([
+      {
+        unitId: 'unit-1',
+        amount: 51,
+        currency: 'ARS',
+        dueDate: new Date('2026-06-10T00:00:00.000Z'),
+        buildingId: 'building-1',
+        period: '2026-05',
+        liquidationId: 'liq-1',
+        concept: 'Expensas comunes 2026-05',
+      },
+    ]);
+
+    await expect(
+      service.publishLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN'], {
+        dueDate: '2026-06-10',
+      }),
+    ).rejects.toThrow(ConflictException);
+    expect(tx.charge.createMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects publish when existing charges do not match the publication snapshot', async () => {
+    tx.charge.findMany.mockResolvedValueOnce([
+      {
+        unitId: 'unit-1',
+        amount: 999,
+        currency: 'ARS',
+        dueDate: new Date('2026-06-10T00:00:00.000Z'),
+        buildingId: 'building-1',
+        period: '2026-05',
+        liquidationId: 'liq-1',
+        concept: 'Expensas comunes 2026-05',
+      },
+      {
+        unitId: 'unit-2',
+        amount: 50,
+        currency: 'ARS',
+        dueDate: new Date('2026-06-10T00:00:00.000Z'),
+        buildingId: 'building-1',
+        period: '2026-05',
+        liquidationId: 'liq-1',
+        concept: 'Expensas comunes 2026-05',
+      },
+    ]);
 
     await expect(
       service.publishLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN'], {
@@ -268,6 +476,29 @@ describe('LiquidationsService', () => {
     );
   });
 
+  it('returns the published liquidation after a serializable conflict when the row is already published', async () => {
+    const serializationError = new Error('Transaction conflict');
+    Object.assign(serializationError, { code: 'P2034' });
+    Object.setPrototypeOf(serializationError, Prisma.PrismaClientKnownRequestError.prototype);
+
+    const publishedLiquidation = {
+      ...baseLiquidation,
+      status: 'PUBLISHED',
+      publishedAt: new Date('2026-05-02T00:00:00.000Z'),
+    };
+
+    prisma.$transaction.mockRejectedValueOnce(serializationError);
+    prisma.liquidation.findFirst.mockResolvedValueOnce(publishedLiquidation);
+
+    const result = await service.publishLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN'], {
+      dueDate: '2026-06-10',
+    });
+
+    expect(result.status).toBe('PUBLISHED');
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(tx.charge.createMany).not.toHaveBeenCalled();
+  });
+
   it.each([
     ['DRAFT', 'draft'],
     ['REVIEWED', 'approved'],
@@ -300,12 +531,12 @@ describe('LiquidationsService', () => {
     expect(result.status).toBe('CANCELED');
     expect(tx.charge.updateMany).not.toHaveBeenCalled();
     expect(tx.liquidation.delete).not.toHaveBeenCalled();
-    expect(tx.auditLog.create).toHaveBeenCalledWith({
-      data: expect.objectContaining({
+    expect(auditService.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
         tenantId: 'tenant-1',
         actorMembershipId: 'member-1',
         action: 'LIQUIDATION_CANCEL',
-        entity: 'Liquidation',
+        entityType: 'Liquidation',
         entityId: 'liq-1',
         metadata: expect.objectContaining({
           period: '2026-05',
@@ -314,7 +545,8 @@ describe('LiquidationsService', () => {
           reason: 'Board decision',
         }),
       }),
-    });
+      tx,
+    );
   });
 
   it('rejects cancellation of a published liquidation', async () => {
@@ -338,7 +570,7 @@ describe('LiquidationsService', () => {
 
     expect(tx.liquidation.updateMany).not.toHaveBeenCalled();
     expect(tx.charge.updateMany).not.toHaveBeenCalled();
-    expect(tx.auditLog.create).not.toHaveBeenCalled();
+    expect(auditService.createLogRequired).not.toHaveBeenCalled();
   });
 
   it('uses a fallback reason when none is provided', async () => {
@@ -359,13 +591,14 @@ describe('LiquidationsService', () => {
 
     await service.cancelLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN']);
 
-    expect(tx.auditLog.create).toHaveBeenCalledWith({
-      data: expect.objectContaining({
+    expect(auditService.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
         metadata: expect.objectContaining({
           reason: 'No reason provided',
         }),
       }),
-    });
+      tx,
+    );
   });
 
   it('rejects cancellation when the requested buildingId does not match', async () => {
@@ -385,7 +618,7 @@ describe('LiquidationsService', () => {
 
     expect(tx.charge.updateMany).not.toHaveBeenCalled();
     expect(tx.liquidation.updateMany).not.toHaveBeenCalled();
-    expect(tx.auditLog.create).not.toHaveBeenCalled();
+    expect(auditService.createLogRequired).not.toHaveBeenCalled();
   });
 
   it('rejects cancellation for resident roles', async () => {
@@ -539,20 +772,22 @@ describe('LiquidationsService', () => {
       service.publishLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN'], {
         dueDate: '2026-06-10',
       }),
-    ).rejects.toThrow(ConflictException);
+    ).resolves.toMatchObject({ status: 'PUBLISHED' });
     expect(notifications).toHaveBeenCalledTimes(2);
-    expect(auditService.createLog).toHaveBeenCalledWith({
-      tenantId: 'tenant-1',
-      actorMembershipId: 'member-1',
-      action: 'LIQUIDATION_PUBLISH',
-      entityType: 'Liquidation',
-      entityId: 'liq-1',
-      metadata: expect.objectContaining({
-        notificationFailure: true,
-        sentCount: 1,
-        failedCount: 1,
+    expect(auditService.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant-1',
+        actorMembershipId: 'member-1',
+        action: 'LIQUIDATION_PUBLISH',
+        entityType: 'Liquidation',
+        entityId: 'liq-1',
+        metadata: expect.objectContaining({
+          snapshotVersion: 1,
+          dueDate: '2026-06-10',
+        }),
       }),
-    });
+      tx,
+    );
     expect(prisma.unit.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
         where: {
@@ -602,7 +837,7 @@ describe('LiquidationsService', () => {
         canceledByMembershipId: 'member-1',
       },
     });
-    expect(tx.auditLog.create).toHaveBeenCalledTimes(1);
+    expect(auditService.createLogRequired).toHaveBeenCalledTimes(1);
     expect(prisma.$transaction).toHaveBeenCalledWith(
       expect.any(Function),
       expect.objectContaining({
@@ -641,6 +876,6 @@ describe('LiquidationsService', () => {
         canceledByMembershipId: 'member-1',
       },
     });
-    expect(tx.auditLog.create).not.toHaveBeenCalled();
+    expect(auditService.createLogRequired).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/finanzas/liquidations.service.spec.ts
+++ b/apps/api/src/finanzas/liquidations.service.spec.ts
@@ -214,7 +214,6 @@ describe('LiquidationsService', () => {
     const liquidations = await service.listLiquidations(
       'tenant-1',
       'member-1',
-      ['TENANT_ADMIN'],
       {},
     );
 
@@ -233,7 +232,7 @@ describe('LiquidationsService', () => {
         publishedAt: new Date('2026-05-02T00:00:00.000Z'),
       });
 
-    await service.publishLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN'], {
+    await service.publishLiquidation('tenant-1', 'liq-1', 'member-1', {
       dueDate: '2026-06-10',
     });
 
@@ -263,7 +262,7 @@ describe('LiquidationsService', () => {
       publishedAt: new Date('2026-05-02T00:00:00.000Z'),
     });
 
-    const result = await service.publishLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN'], {
+    const result = await service.publishLiquidation('tenant-1', 'liq-1', 'member-1', {
       dueDate: '2026-06-10',
     });
 
@@ -297,7 +296,7 @@ describe('LiquidationsService', () => {
     ]);
 
     await expect(
-      service.createDraft('tenant-1', 'member-1', ['TENANT_ADMIN'], {
+      service.createDraft('tenant-1', 'member-1', {
         buildingId: 'building-1',
         period: '2026-05',
         baseCurrency: 'USD',
@@ -339,7 +338,7 @@ describe('LiquidationsService', () => {
         publishedAt: new Date('2026-05-02T00:00:00.000Z'),
       });
 
-    await service.publishLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN'], {
+    await service.publishLiquidation('tenant-1', 'liq-1', 'member-1', {
       dueDate: '2026-06-10',
     });
 
@@ -382,7 +381,7 @@ describe('LiquidationsService', () => {
     ]);
 
     await expect(
-      service.publishLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN'], {
+      service.publishLiquidation('tenant-1', 'liq-1', 'member-1', {
         dueDate: '2026-06-10',
       }),
     ).rejects.toThrow(ConflictException);
@@ -414,7 +413,7 @@ describe('LiquidationsService', () => {
     ]);
 
     await expect(
-      service.publishLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN'], {
+      service.publishLiquidation('tenant-1', 'liq-1', 'member-1', {
         dueDate: '2026-06-10',
       }),
     ).rejects.toThrow(ConflictException);
@@ -435,7 +434,7 @@ describe('LiquidationsService', () => {
       .mockResolvedValueOnce(publishedOtherLiquidation);
 
     await expect(
-      service.publishLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN'], {
+      service.publishLiquidation('tenant-1', 'liq-1', 'member-1', {
         dueDate: '2026-06-10',
       }),
     ).rejects.toThrow(ConflictException);
@@ -461,7 +460,7 @@ describe('LiquidationsService', () => {
       .mockResolvedValueOnce({ ...baseLiquidation, status: 'PUBLISHED' })
       .mockResolvedValueOnce(publishedLiquidation);
 
-    const result = await service.publishLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN'], {
+    const result = await service.publishLiquidation('tenant-1', 'liq-1', 'member-1', {
       dueDate: '2026-06-10',
     });
 
@@ -490,7 +489,7 @@ describe('LiquidationsService', () => {
     prisma.$transaction.mockRejectedValueOnce(serializationError);
     prisma.liquidation.findFirst.mockResolvedValueOnce(publishedLiquidation);
 
-    const result = await service.publishLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN'], {
+    const result = await service.publishLiquidation('tenant-1', 'liq-1', 'member-1', {
       dueDate: '2026-06-10',
     });
 
@@ -524,7 +523,6 @@ describe('LiquidationsService', () => {
       'tenant-1',
       'liq-1',
       'member-1',
-      ['TENANT_ADMIN'],
       { reason: 'Board decision' },
     );
 
@@ -563,7 +561,6 @@ describe('LiquidationsService', () => {
         'tenant-1',
         'liq-1',
         'member-1',
-        ['TENANT_ADMIN'],
         { reason: 'Board decision' },
       ),
     ).rejects.toThrow(ConflictException);
@@ -589,7 +586,7 @@ describe('LiquidationsService', () => {
       });
     tx.liquidation.updateMany.mockResolvedValue({ count: 1 });
 
-    await service.cancelLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN']);
+    await service.cancelLiquidation('tenant-1', 'liq-1', 'member-1');
 
     expect(auditService.createLogRequired).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -611,7 +608,7 @@ describe('LiquidationsService', () => {
     tx.liquidation.findFirst.mockResolvedValue(publishedLiquidation);
 
     await expect(
-      service.cancelLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN'], {
+      service.cancelLiquidation('tenant-1', 'liq-1', 'member-1', {
         buildingId: 'building-2',
       }),
     ).rejects.toThrow(NotFoundException);
@@ -625,7 +622,7 @@ describe('LiquidationsService', () => {
     validators.isAdminOrOperator.mockReturnValue(false);
 
     await expect(
-      service.cancelLiquidation('tenant-1', 'liq-1', 'member-1', ['RESIDENT']),
+      service.cancelLiquidation('tenant-1', 'liq-1', 'member-1'),
     ).rejects.toThrow(ForbiddenException);
 
     expect(prisma.liquidation.findFirst).not.toHaveBeenCalled();
@@ -635,7 +632,7 @@ describe('LiquidationsService', () => {
     prisma.liquidation.findFirst.mockResolvedValue(null);
 
     await expect(
-      service.cancelLiquidation('tenant-2', 'liq-1', 'member-1', ['TENANT_ADMIN']),
+      service.cancelLiquidation('tenant-2', 'liq-1', 'member-1'),
     ).rejects.toThrow(NotFoundException);
   });
 
@@ -651,7 +648,6 @@ describe('LiquidationsService', () => {
       'tenant-1',
       'liq-1',
       'member-1',
-      ['TENANT_ADMIN'],
     );
 
     expect(result.status).toBe('CANCELED');
@@ -677,7 +673,7 @@ describe('LiquidationsService', () => {
       });
     tx.liquidation.updateMany.mockResolvedValue({ count: 1 });
 
-    await service.cancelLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN']);
+    await service.cancelLiquidation('tenant-1', 'liq-1', 'member-1');
 
     expect(prisma.liquidation.delete).not.toHaveBeenCalled();
     expect(tx.liquidation.delete).not.toHaveBeenCalled();
@@ -712,7 +708,7 @@ describe('LiquidationsService', () => {
       },
     ]);
 
-    await service.publishLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN'], {
+    await service.publishLiquidation('tenant-1', 'liq-1', 'member-1', {
       dueDate: '2026-06-10',
     });
 
@@ -769,7 +765,7 @@ describe('LiquidationsService', () => {
       .mockResolvedValueOnce(undefined);
 
     await expect(
-      service.publishLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN'], {
+      service.publishLiquidation('tenant-1', 'liq-1', 'member-1', {
         dueDate: '2026-06-10',
       }),
     ).resolves.toMatchObject({ status: 'PUBLISHED' });
@@ -823,8 +819,8 @@ describe('LiquidationsService', () => {
       });
     tx.liquidation.updateMany.mockResolvedValue({ count: 1 });
 
-    await service.cancelLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN']);
-    const secondResult = await service.cancelLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN']);
+    await service.cancelLiquidation('tenant-1', 'liq-1', 'member-1');
+    const secondResult = await service.cancelLiquidation('tenant-1', 'liq-1', 'member-1');
 
     expect(secondResult.status).toBe('CANCELED');
     expect(prisma.$transaction).toHaveBeenCalledTimes(1);
@@ -865,7 +861,7 @@ describe('LiquidationsService', () => {
       .mockResolvedValueOnce(canceledLiquidation);
     tx.liquidation.updateMany.mockResolvedValueOnce({ count: 0 });
 
-    const result = await service.cancelLiquidation('tenant-1', 'liq-1', 'member-1', ['TENANT_ADMIN']);
+    const result = await service.cancelLiquidation('tenant-1', 'liq-1', 'member-1');
 
     expect(result.status).toBe('CANCELED');
     expect(tx.liquidation.updateMany).toHaveBeenCalledWith({

--- a/apps/api/src/finanzas/liquidations.service.ts
+++ b/apps/api/src/finanzas/liquidations.service.ts
@@ -17,6 +17,11 @@ import {
   LiquidationDetailDto,
 } from './expense-ledger.dto';
 import { FinanzasValidators } from './finanzas.validators';
+import {
+  buildLiquidationPublicationSnapshot,
+  parseLiquidationPublicationSnapshot,
+  type PublishedExpenseSnapshot,
+} from './liquidation-publication-snapshot';
 
 interface LiquidationExpenseSnapshotItem extends Prisma.InputJsonObject {
   expenseId: string;
@@ -45,6 +50,34 @@ interface LiquidationExpenseSnapshotRow {
 interface CancelLiquidationOptions {
   readonly buildingId?: string;
   readonly reason?: string;
+}
+
+interface FinanceMembershipRecord {
+  id: string;
+  tenantId: string;
+  roles: Array<{
+    role: string;
+    scopeType: 'TENANT' | 'BUILDING' | 'UNIT';
+  }>;
+}
+
+interface FinanceMembershipContext {
+  id: string;
+  tenantId: string;
+  roles: string[];
+}
+
+interface FinanceMembershipClient {
+  membership: {
+    findFirst: (args: {
+      where: { id: string; tenantId: string };
+      select: {
+        id: boolean;
+        tenantId: boolean;
+        roles: { select: { role: boolean; scopeType: boolean } };
+      };
+    }) => Promise<FinanceMembershipRecord | null>;
+  };
 }
 
 interface NotificationDispatchResult {
@@ -77,10 +110,12 @@ export class LiquidationsService {
 
   async listLiquidations(
     tenantId: string,
-    userRoles: string[],
+    _membershipId: string,
+    _userRoles: string[],
     query: { buildingId?: string; period?: string },
   ): Promise<LiquidationResponseDto[]> {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
+    const membership = await this.requireFinanceMembership(this.prisma, tenantId, _membershipId);
+    if (!this.validators.isAdminOrOperator(membership.roles)) {
       throw new ForbiddenException('Solo administradores pueden ver liquidaciones');
     }
 
@@ -94,15 +129,17 @@ export class LiquidationsService {
       orderBy: [{ period: 'desc' }, { createdAt: 'desc' }],
     });
 
-    return liquidations.map(this.toDto);
+    return liquidations.map((liquidation) => this.toDto(liquidation));
   }
 
   async getLiquidation(
     tenantId: string,
     liquidationId: string,
-    userRoles: string[],
+    _membershipId: string,
+    _userRoles: string[],
   ): Promise<LiquidationDetailDto> {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
+    const membership = await this.requireFinanceMembership(this.prisma, tenantId, _membershipId);
+    if (!this.validators.isAdminOrOperator(membership.roles)) {
       throw new ForbiddenException('Acceso denegado');
     }
 
@@ -121,430 +158,554 @@ export class LiquidationsService {
       throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
     }
 
-    // Rebuild expense list from snapshot
-    const expenseSnapshot = this.parseExpenseSnapshot(liq.expenseSnapshot);
-
-    return {
-      ...this.toDto(liq),
-      expenses: expenseSnapshot.map((e) => ({
-        id: e.expenseId,
-        categoryName: e.categoryName,
-        vendorName: e.vendorName,
-        amountMinor: e.amountMinor,
-        currencyCode: e.currencyCode,
-        invoiceDate: new Date(e.invoiceDate),
-        description: e.description,
-      })),
-      chargesPreview: liq.charges.map((c) => ({
+    return this.toDetailDto(liq, {
+      charges: liq.charges.map((c) => ({
         unitId: c.unit.id,
         unitCode: c.unit.code,
         unitLabel: c.unit.label,
         amountMinor: c.amount,
       })),
-    };
+    });
   }
 
   async createDraft(
     tenantId: string,
     membershipId: string,
-    userRoles: string[],
+    _userRoles: string[],
     dto: CreateLiquidationDraftDto,
   ): Promise<LiquidationDetailDto> {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
-      throw new ForbiddenException('Solo administradores pueden generar liquidaciones');
-    }
-
-    await this.validators.validateBuildingBelongsToTenant(tenantId, dto.buildingId);
-
-    // Anti-duplicado: no puede haber otra PUBLISHED para este (building, period)
-    const existingPublished = await this.prisma.liquidation.findFirst({
-      where: {
-        tenantId,
-        buildingId: dto.buildingId,
-        period: dto.period,
-        status: 'PUBLISHED',
-      },
-    });
-
-    if (existingPublished) {
-      throw new ConflictException(
-        `Ya existe una liquidación publicada para el período ${dto.period} en este edificio`,
-      );
-    }
-
-    // Prerequisito: no puede haber gastos de áreas comunes (TENANT_SHARED) sin validar para este período.
-    // Si los hay, el admin debe validarlos primero antes de liquidar cualquier edificio,
-    // para garantizar que el reparto esté completo y correcto.
-    const pendingSharedExpenses = await this.prisma.expense.count({
-      where: {
-        tenantId,
-        ...this.expenseAccountingPeriodWhere(dto.period),
-        scopeType: 'TENANT_SHARED',
-        status: 'DRAFT',
-      },
-    });
-
-    if (pendingSharedExpenses > 0) {
-      throw new BadRequestException(
-        `Hay ${pendingSharedExpenses} gasto(s) de áreas comunes pendientes de validar para ${dto.period}. ` +
-        `Validalos desde Finanzas → Gastos comunes antes de generar la liquidación del edificio.`,
-      );
-    }
-
-    // Cargar gastos VALIDATED del (building, period) - solo BUILDING scope
-    const buildingExpenses = await this.prisma.expense.findMany({
-      where: {
-        tenantId,
-        buildingId: dto.buildingId,
-        ...this.expenseAccountingPeriodWhere(dto.period),
-        status: 'VALIDATED',
-        scopeType: 'BUILDING',
-      },
-      include: {
-        category: { select: { name: true } },
-        vendor: { select: { name: true } },
-      },
-    });
-
-    // Cargar gastos VALIDATED TENANT_SHARED que tienen allocation a este edificio
-    const sharedExpenses = await this.prisma.expense.findMany({
-      where: {
-        tenantId,
-        ...this.expenseAccountingPeriodWhere(dto.period),
-        status: 'VALIDATED',
-        scopeType: 'TENANT_SHARED',
-      },
-      include: {
-        category: { select: { name: true } },
-        vendor: { select: { name: true } },
-        allocations: {
-          where: { buildingId: dto.buildingId },
-        },
-      },
-    });
-
-    // Filtrar solo los que tienen allocation a este edificio
-    const allocatedSharedExpenses = sharedExpenses.filter(e => e.allocations.length > 0);
-
-    // Combinar: buildingExpenses (monto completo) + allocatedSharedExpenses (solo monto asignado)
-    const allExpenses: LiquidationExpenseSnapshotRow[] = buildingExpenses.map((expense) => ({
-      expenseId: expense.id,
-      categoryName: expense.category.name,
-      vendorName: expense.vendor?.name ?? null,
-      amountMinor: expense.amountMinor,
-      currencyCode: expense.currencyCode,
-      invoiceDate: expense.invoiceDate,
-      description: expense.description,
-      type: 'EXPENSE',
-    }));
-    for (const exp of allocatedSharedExpenses) {
-      const allocation = exp.allocations[0];
-      if (allocation && allocation.amountMinor !== null) {
-        allExpenses.push({
-          expenseId: exp.id,
-          categoryName: exp.category.name,
-          vendorName: exp.vendor?.name ?? null,
-          amountMinor: allocation.amountMinor,
-          currencyCode: exp.currencyCode,
-          invoiceDate: exp.invoiceDate,
-          description: exp.description,
-          type: 'EXPENSE',
-        });
+    return this.prisma.$transaction(async (tx) => {
+      const membership = await this.requireFinanceMembership(tx, tenantId, membershipId);
+      if (!this.validators.isAdminOrOperator(membership.roles)) {
+        throw new ForbiddenException('Solo administradores pueden generar liquidaciones');
       }
-    }
 
-    // Calcular totales por moneda - inicializar antes de usar
-    const totalsByCurrency: Record<string, number> = {};
-    for (const expense of allExpenses) {
-      const expCurrency = expense.currencyCode;
-      const expAmount = expense.amountMinor;
-      totalsByCurrency[expCurrency] =
-        (totalsByCurrency[expCurrency] ?? 0) + expAmount;
-    }
-
-    // NUEVO: Cargar ajustes VALIDATED para este edificio y período target
-    const adjustments = await this.prisma.adjustment.findMany({
-      where: {
-        tenantId,
-        buildingId: dto.buildingId,
-        targetPeriod: dto.period,
-        status: 'VALIDATED',
-      },
-      include: {
-        category: { select: { name: true } },
-      },
-    });
-
-    // Si hay ajustes, agregarlos al snapshot y a los totales
-    const expenseSnapshotItems: LiquidationExpenseSnapshotItem[] = allExpenses.map((e) => ({
-      expenseId: e.expenseId,
-      categoryName: e.categoryName,
-      vendorName: e.vendorName,
-      amountMinor: e.amountMinor,
-      currencyCode: e.currencyCode,
-      invoiceDate: e.invoiceDate.toISOString(),
-      description: e.description,
-      type: e.type,
-    }));
-
-    for (const adj of adjustments) {
-      expenseSnapshotItems.push({
-        expenseId: `ADJ-${adj.id}`,
-        categoryName: adj.category.name,
-        vendorName: null,
-        amountMinor: adj.amountMinor,
-        currencyCode: adj.currencyCode,
-        invoiceDate: adj.sourceInvoiceDate.toISOString(),
-        description: `Ajuste retroactivo: ${adj.reason}`,
-        type: 'ADJUSTMENT',
-        sourcePeriod: adj.sourcePeriod,
+      const building = await tx.building.findFirst({
+        where: { id: dto.buildingId, tenantId, deletedAt: null },
+        select: { id: true },
       });
-      const adjCurrency = adj.currencyCode;
-      totalsByCurrency[adjCurrency] = (totalsByCurrency[adjCurrency] ?? 0) + adj.amountMinor;
-    }
 
-    const expenseSnapshot: ReadonlyArray<LiquidationExpenseSnapshotItem> = expenseSnapshotItems;
+      if (!building) {
+        throw new NotFoundException(`Building not found or does not belong to this tenant`);
+      }
 
-    if (allExpenses.length === 0 && adjustments.length === 0) {
-      throw new BadRequestException(
-        `No hay gastos VALIDADOS ni ajustes para el período ${dto.period} en este edificio. ` +
-        `Registrá gastos propios del edificio o verificá que los gastos comunes tengan asignación a este edificio.`,
+      const existingPublished = await tx.liquidation.findFirst({
+        where: {
+          tenantId,
+          buildingId: dto.buildingId,
+          period: dto.period,
+          status: 'PUBLISHED',
+        },
+        select: { id: true },
+      });
+
+      if (existingPublished) {
+        throw new ConflictException(
+          `Ya existe una liquidación publicada para el período ${dto.period} en este edificio`,
+        );
+      }
+
+      const pendingSharedExpenses = await tx.expense.count({
+        where: {
+          tenantId,
+          ...this.expenseAccountingPeriodWhere(dto.period),
+          scopeType: 'TENANT_SHARED',
+          status: 'DRAFT',
+        },
+      });
+
+      if (pendingSharedExpenses > 0) {
+        throw new BadRequestException(
+          `Hay ${pendingSharedExpenses} gasto(s) de áreas comunes pendientes de validar para ${dto.period}. ` +
+            `Validalos desde Finanzas → Gastos comunes antes de generar la liquidación del edificio.`,
+        );
+      }
+
+      const buildingExpenses = await tx.expense.findMany({
+        where: {
+          tenantId,
+          buildingId: dto.buildingId,
+          ...this.expenseAccountingPeriodWhere(dto.period),
+          status: 'VALIDATED',
+          scopeType: 'BUILDING',
+        },
+        include: {
+          category: { select: { name: true } },
+          vendor: { select: { name: true } },
+        },
+      });
+
+          const sharedExpenses = await tx.expense.findMany({
+            where: {
+              tenantId,
+              ...this.expenseAccountingPeriodWhere(dto.period),
+              status: 'VALIDATED',
+              scopeType: 'TENANT_SHARED',
+            },
+            include: {
+              category: { select: { name: true } },
+              vendor: { select: { name: true } },
+              allocations: {
+                where: { tenantId, buildingId: dto.buildingId },
+              },
+            },
+          });
+
+      const allocatedSharedExpenses = sharedExpenses.filter((expense) => expense.allocations.length > 0);
+
+      const adjustments = await tx.adjustment.findMany({
+        where: {
+          tenantId,
+          buildingId: dto.buildingId,
+          targetPeriod: dto.period,
+          status: 'VALIDATED',
+        },
+        include: {
+          category: { select: { name: true } },
+        },
+      });
+
+      const billableUnits = await tx.unit.findMany({
+        where: { tenantId, buildingId: dto.buildingId, isBillable: true },
+        include: { unitCategory: { select: { coefficient: true, id: true } } },
+        orderBy: { code: 'asc' },
+      });
+
+      const allExpenses: LiquidationExpenseSnapshotRow[] = buildingExpenses.map((expense) => ({
+        expenseId: expense.id,
+        categoryName: expense.category.name,
+        vendorName: expense.vendor?.name ?? null,
+        amountMinor: expense.amountMinor,
+        currencyCode: expense.currencyCode,
+        invoiceDate: expense.invoiceDate,
+        description: expense.description,
+        type: 'EXPENSE',
+      }));
+
+      for (const expense of allocatedSharedExpenses) {
+        const allocation = expense.allocations[0];
+        if (allocation && allocation.amountMinor !== null) {
+          allExpenses.push({
+            expenseId: expense.id,
+            categoryName: expense.category.name,
+            vendorName: expense.vendor?.name ?? null,
+            amountMinor: allocation.amountMinor,
+            currencyCode: expense.currencyCode,
+            invoiceDate: expense.invoiceDate,
+            description: expense.description,
+            type: 'EXPENSE',
+          });
+        }
+      }
+
+      const expenseSnapshotItems: LiquidationExpenseSnapshotItem[] = allExpenses.map((expense) => ({
+        expenseId: expense.expenseId,
+        categoryName: expense.categoryName,
+        vendorName: expense.vendorName,
+        amountMinor: expense.amountMinor,
+        currencyCode: expense.currencyCode,
+        invoiceDate: expense.invoiceDate.toISOString(),
+        description: expense.description,
+        type: expense.type,
+      }));
+
+      const totalsByCurrency: Record<string, number> = {};
+      for (const expense of allExpenses) {
+        totalsByCurrency[expense.currencyCode] = this.safeAddAmountMinor(
+          totalsByCurrency[expense.currencyCode] ?? 0,
+          expense.amountMinor,
+          `totalsByCurrency.${expense.currencyCode}`,
+        );
+      }
+
+      for (const adjustment of adjustments) {
+        expenseSnapshotItems.push({
+          expenseId: `ADJ-${adjustment.id}`,
+          categoryName: adjustment.category.name,
+          vendorName: null,
+          amountMinor: adjustment.amountMinor,
+          currencyCode: adjustment.currencyCode,
+          invoiceDate: adjustment.sourceInvoiceDate.toISOString(),
+          description: `Ajuste retroactivo: ${adjustment.reason}`,
+          type: 'ADJUSTMENT',
+          sourcePeriod: adjustment.sourcePeriod,
+        });
+
+        totalsByCurrency[adjustment.currencyCode] = this.safeAddAmountMinor(
+          totalsByCurrency[adjustment.currencyCode] ?? 0,
+          adjustment.amountMinor,
+          `totalsByCurrency.${adjustment.currencyCode}`,
+        );
+      }
+
+      if (allExpenses.length === 0 && adjustments.length === 0) {
+        throw new BadRequestException(
+          `No hay gastos VALIDADOS ni ajustes para el período ${dto.period} en este edificio. ` +
+            `Registrá gastos propios del edificio o verificá que los gastos comunes tengan asignación a este edificio.`,
+        );
+      }
+
+      const totalAmountMinor = this.requireCurrencyTotal(totalsByCurrency, dto.baseCurrency);
+      const chargesPreview = this.calculateDistribution(
+        billableUnits,
+        totalAmountMinor,
+        dto.buildingId,
       );
-    }
 
-    // Total en baseCurrency
-    const totalAmountMinor = totalsByCurrency[dto.baseCurrency] ?? 0;
+      const liquidation = await tx.liquidation.create({
+        data: {
+          tenantId,
+          buildingId: dto.buildingId,
+          period: dto.period,
+          baseCurrency: dto.baseCurrency,
+          totalAmountMinor,
+          totalsByCurrency,
+          expenseSnapshot: expenseSnapshotItems,
+          unitCount: billableUnits.length,
+          generatedByMembershipId: membership.id,
+        },
+      });
 
-    // Contar unidades billables
-    const billableUnits = await this.prisma.unit.findMany({
-      where: { tenantId, buildingId: dto.buildingId, isBillable: true },
-      include: { unitCategory: { select: { coefficient: true, id: true } } },
-      orderBy: { code: 'asc' },
+      await this.auditService.createLogRequired(
+        {
+          tenantId,
+          actorMembershipId: membership.id,
+          action: 'LIQUIDATION_DRAFT',
+          entityType: 'Liquidation',
+          entityId: liquidation.id,
+          metadata: {
+            period: dto.period,
+            buildingId: dto.buildingId,
+            totalAmountMinor,
+            baseCurrency: dto.baseCurrency,
+            expenseCount: allExpenses.length,
+            adjustmentCount: adjustments.length,
+          },
+        },
+        tx,
+      );
+
+      const created = await tx.liquidation.findFirst({
+        where: { id: liquidation.id, tenantId },
+      });
+
+      if (!created) {
+        throw new NotFoundException(`Liquidación no encontrada: ${liquidation.id}`);
+      }
+
+      return this.toDetailDto(created, {
+        charges: chargesPreview,
+      });
     });
-
-    // Snapshot ya calculado arriba con tipo EXPENSE/ADJUSTMENT
-
-    const liq = await this.prisma.liquidation.create({
-      data: {
-        tenantId,
-        buildingId: dto.buildingId,
-        period: dto.period,
-        baseCurrency: dto.baseCurrency,
-        totalAmountMinor,
-        totalsByCurrency,
-        expenseSnapshot,
-        unitCount: billableUnits.length,
-        generatedByMembershipId: membershipId,
-      },
-    });
-
-    await this.auditService.createLog({
-      tenantId,
-      actorMembershipId: membershipId,
-      action: 'LIQUIDATION_DRAFT',
-      entityType: 'Liquidation',
-      entityId: liq.id,
-      metadata: {
-        period: dto.period,
-        buildingId: dto.buildingId,
-        totalAmountMinor,
-        baseCurrency: dto.baseCurrency,
-        expenseCount: allExpenses.length,
-        adjustmentCount: adjustments.length,
-      },
-    });
-
-    // Calcular preview de distribución para el detail
-    const chargesPreview = this.calculateDistribution(
-      billableUnits,
-      totalAmountMinor,
-      dto.buildingId,
-    );
-
-    return {
-      ...this.toDto(liq),
-      expenses: expenseSnapshot.map((e) => ({
-        id: e.expenseId,
-        categoryName: e.categoryName,
-        vendorName: e.vendorName,
-        amountMinor: e.amountMinor,
-        currencyCode: e.currencyCode,
-        invoiceDate: new Date(e.invoiceDate),
-        description: e.description,
-      })),
-      chargesPreview,
-    };
   }
 
   async reviewLiquidation(
     tenantId: string,
     liquidationId: string,
     membershipId: string,
-    userRoles: string[],
+    _userRoles: string[],
   ): Promise<LiquidationResponseDto> {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
-      throw new ForbiddenException('Acceso denegado');
-    }
+    return this.prisma.$transaction(async (tx) => {
+      const membership = await this.requireFinanceMembership(tx, tenantId, membershipId);
+      if (!this.validators.isAdminOrOperator(membership.roles)) {
+        throw new ForbiddenException('Acceso denegado');
+      }
 
-    const liq = await this.prisma.liquidation.findFirst({
-      where: { id: liquidationId, tenantId },
-    });
+      const current = await tx.liquidation.findFirst({
+        where: { id: liquidationId, tenantId },
+      });
 
-    if (!liq) {
-      throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-    }
+      if (!current) {
+        throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
+      }
 
-    if (liq.status !== 'DRAFT') {
-      throw new BadRequestException(
-        `Solo se puede revisar una liquidación en DRAFT. Estado actual: ${liq.status}`,
+      const now = new Date();
+      const updateResult = await tx.liquidation.updateMany({
+        where: { id: liquidationId, tenantId, status: 'DRAFT' },
+        data: {
+          status: 'REVIEWED',
+          reviewedByMembershipId: membership.id,
+          reviewedAt: now,
+          updatedAt: now,
+        },
+      });
+
+      if (updateResult.count !== 1) {
+        const latest = await tx.liquidation.findFirst({
+          where: { id: liquidationId, tenantId },
+        });
+
+        if (!latest) {
+          throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
+        }
+
+        if (latest.status === 'DRAFT') {
+          throw new ConflictException(`La liquidación ${liquidationId} cambió durante la revisión`);
+        }
+
+        throw new ConflictException(
+          `Solo se puede revisar una liquidación en DRAFT. Estado actual: ${latest.status}`,
+        );
+      }
+
+      await this.auditService.createLogRequired(
+        {
+          tenantId,
+          actorMembershipId: membership.id,
+          action: 'LIQUIDATION_REVIEW',
+          entityType: 'Liquidation',
+          entityId: liquidationId,
+          metadata: {
+            period: current.period,
+            buildingId: current.buildingId,
+            reviewedAt: now.toISOString(),
+          },
+        },
+        tx,
       );
-    }
 
-    await this.prisma.liquidation.updateMany({
-      where: { id: liquidationId, tenantId },
-      data: {
-        status: 'REVIEWED',
-        reviewedByMembershipId: membershipId,
-        reviewedAt: new Date(),
-      },
+      const updated = await tx.liquidation.findFirst({
+        where: { id: liquidationId, tenantId },
+      });
+
+      if (!updated) {
+        throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
+      }
+
+      return this.toDto(updated);
     });
-
-    const updated = await this.prisma.liquidation.findFirst({
-      where: { id: liquidationId, tenantId },
-    });
-
-    if (!updated) {
-      throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-    }
-
-    await this.auditService.createLog({
-      tenantId,
-      actorMembershipId: membershipId,
-      action: 'LIQUIDATION_REVIEW',
-      entityType: 'Liquidation',
-      entityId: liquidationId,
-      metadata: { period: liq.period, buildingId: liq.buildingId },
-    });
-
-    return this.toDto(updated);
   }
 
+  /**
+   * Publishes a reviewed liquidation transactionally.
+   *
+   * The update is idempotent, persists the publication snapshot and audit log
+   * inside the same transaction, and only emits charge-notification side
+   * effects after the database commit succeeds.
+   */
   async publishLiquidation(
     tenantId: string,
     liquidationId: string,
     membershipId: string,
-    userRoles: string[],
+    _userRoles: string[],
     dto: PublishLiquidationDto,
   ): Promise<LiquidationResponseDto> {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
-      throw new ForbiddenException('Acceso denegado');
-    }
-
-    const liq = await this.prisma.liquidation.findFirst({
-      where: { id: liquidationId, tenantId },
-    });
-
-    if (!liq) {
-      throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-    }
-
-    if (liq.status === 'PUBLISHED') {
-      return this.toDto(liq);
-    }
-
-    if (liq.status !== 'DRAFT' && liq.status !== 'REVIEWED') {
-      throw new BadRequestException(
-        `Solo se puede publicar una liquidación en DRAFT o REVIEWED. Estado actual: ${liq.status}`,
-      );
-    }
-
-    // Cargar unidades billables con categorías para distribución
-    const billableUnits = await this.prisma.unit.findMany({
-      where: { tenantId, buildingId: liq.buildingId, isBillable: true },
-      include: { unitCategory: { select: { coefficient: true, id: true } } },
-      orderBy: { code: 'asc' },
-    });
-
-    if (billableUnits.length === 0) {
-      throw new BadRequestException('No hay unidades facturables en este edificio');
-    }
-
-    const dueDate = new Date(dto.dueDate);
-    const concept = `Expensas comunes ${liq.period}`;
-    const distribution = this.calculateDistribution(
-      billableUnits,
-      liq.totalAmountMinor,
-      liq.buildingId,
-    );
-
-    let shouldSendPublishedNotifications = false;
-    let publishResult: { publishedNow: boolean; liquidation?: LiquidationResponseDto } | null = null;
+    let publishResult: { liquidation: LiquidationResponseDto; publishedNow: boolean } | null = null;
 
     try {
       publishResult = await this.prisma.$transaction(
         async (tx) => {
-        const current = await tx.liquidation.findFirst({
-          where: { id: liquidationId, tenantId },
-          select: { status: true },
-        });
+          const membership = await this.requireFinanceMembership(tx, tenantId, membershipId);
+          if (!this.validators.isAdminOrOperator(membership.roles)) {
+            throw new ForbiddenException('Acceso denegado');
+          }
 
-        if (!current) {
-          throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-        }
-
-        if (current.status === 'PUBLISHED') {
-          const published = await tx.liquidation.findFirst({
+          const current = await tx.liquidation.findFirst({
             where: { id: liquidationId, tenantId },
           });
 
-          if (!published) {
+          if (!current) {
             throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
           }
 
-          return { publishedNow: false, liquidation: this.toDto(published) };
-        }
+          if (current.status === 'PUBLISHED') {
+            return { liquidation: this.toPublishedLiquidationDto(current), publishedNow: false };
+          }
 
-        if (current.status !== 'DRAFT' && current.status !== 'REVIEWED') {
-          throw new BadRequestException(
-            `Solo se puede publicar una liquidación en DRAFT o REVIEWED. Estado actual: ${current.status}`,
+          if (current.status !== 'REVIEWED') {
+            throw new BadRequestException(
+              `Solo se puede publicar una liquidación revisada. Estado actual: ${current.status}`,
+            );
+          }
+
+          const billableUnits = await tx.unit.findMany({
+            where: { tenantId, buildingId: current.buildingId, isBillable: true },
+            include: { unitCategory: { select: { coefficient: true, id: true } } },
+            orderBy: { code: 'asc' },
+          });
+
+          if (billableUnits.length === 0) {
+            throw new BadRequestException('No hay unidades facturables en este edificio');
+          }
+
+          const now = new Date();
+          const dueDate = new Date(dto.dueDate);
+          if (Number.isNaN(dueDate.getTime())) {
+            throw new BadRequestException('dueDate must be a valid date');
+          }
+
+          const distribution = this.calculateDistribution(
+            billableUnits,
+            current.totalAmountMinor,
+            current.buildingId,
           );
-        }
 
-        const duplicatePublished = await tx.liquidation.findFirst({
-          where: {
+          const publicationSnapshot = buildLiquidationPublicationSnapshot({
+            liquidationId: current.id,
             tenantId,
-            buildingId: liq.buildingId,
-            period: liq.period,
-            status: 'PUBLISHED',
-            id: { not: liquidationId },
-          },
-          select: { id: true },
-        });
+            buildingId: current.buildingId,
+            period: current.period,
+            baseCurrency: current.baseCurrency,
+            totalAmountMinor: current.totalAmountMinor,
+            totalsByCurrency: this.parseTotalsByCurrency(current.totalsByCurrency),
+            expenses: this.getPublicationSnapshotExpenses(current.expenseSnapshot),
+            allocations: distribution.map((item) => ({
+              unitId: item.unitId,
+              unitCode: item.unitCode,
+              unitLabel: item.unitLabel,
+              amountMinor: item.amountMinor,
+            })),
+            dueDate,
+            publishedAt: now,
+          });
 
-        if (duplicatePublished) {
-          throw new ConflictException(
-            `Ya existe una liquidación publicada para el período ${liq.period}`,
-          );
-        }
+          const duplicatePublished = await tx.liquidation.findFirst({
+            where: {
+              tenantId,
+              buildingId: current.buildingId,
+              period: current.period,
+              status: 'PUBLISHED',
+              id: { not: liquidationId },
+            },
+            select: { id: true },
+          });
 
-        const duplicateCharges = await tx.charge.count({
-          where: {
+          if (duplicatePublished) {
+            throw new ConflictException(
+              `Ya existe una liquidación publicada para el período ${current.period}`,
+            );
+          }
+
+          const concept = `Expensas comunes ${current.period}`;
+          const expectedCharges = distribution.map((distributionItem) => ({
             tenantId,
+            buildingId: current.buildingId,
+            unitId: distributionItem.unitId,
+            period: current.period,
+            type: 'COMMON_EXPENSE' as const,
+            concept,
+            amount: distributionItem.amountMinor,
+            currency: current.baseCurrency,
+            dueDate,
             liquidationId,
-            period: liq.period,
-            unitId: { in: distribution.map((d) => d.unitId) },
-          },
-        });
+          }));
 
-        if (duplicateCharges === distribution.length) {
-          await tx.liquidation.updateMany({
-            where: { id: liquidationId, tenantId },
+          const existingCharges = await tx.charge.findMany({
+            where: {
+              tenantId,
+              liquidationId,
+              buildingId: current.buildingId,
+              period: current.period,
+            },
+            select: {
+              unitId: true,
+              amount: true,
+              currency: true,
+              dueDate: true,
+              buildingId: true,
+              period: true,
+              liquidationId: true,
+              concept: true,
+            },
+            orderBy: { unitId: 'asc' },
+          });
+
+          if (existingCharges.length > 0) {
+            if (existingCharges.length !== expectedCharges.length) {
+              throw new ConflictException(
+                `La liquidación ${liquidationId} tiene cargos parciales generados para ${current.period}`,
+              );
+            }
+
+            const expectedChargesByUnit = new Map(
+              expectedCharges.map((charge) => [charge.unitId, charge]),
+            );
+
+            for (const existingCharge of existingCharges) {
+              const expectedCharge = expectedChargesByUnit.get(existingCharge.unitId);
+
+              if (
+                !expectedCharge ||
+                existingCharge.amount !== expectedCharge.amount ||
+                existingCharge.currency !== expectedCharge.currency ||
+                existingCharge.buildingId !== expectedCharge.buildingId ||
+                existingCharge.period !== expectedCharge.period ||
+                existingCharge.liquidationId !== expectedCharge.liquidationId ||
+                existingCharge.concept !== expectedCharge.concept ||
+                existingCharge.dueDate.getTime() !== expectedCharge.dueDate.getTime()
+              ) {
+                throw new ConflictException(
+                  `La liquidación ${liquidationId} tiene cargos existentes que no coinciden con la publicación esperada`,
+                );
+              }
+            }
+          } else {
+            await tx.charge.createMany({
+              data: expectedCharges.map((charge) => ({
+                ...charge,
+                status: ChargeStatus.PENDING,
+                createdByMembershipId: membership.id,
+              })),
+            });
+          }
+
+          const updateResult = await tx.liquidation.updateMany({
+            where: {
+              id: liquidationId,
+              tenantId,
+              status: 'REVIEWED',
+              publicationSnapshot: { equals: Prisma.DbNull },
+            },
             data: {
               status: 'PUBLISHED',
-              publishedByMembershipId: membershipId,
-              publishedAt: new Date(),
+              publicationSnapshot,
+              publishedByMembershipId: membership.id,
+              publishedAt: now,
+              updatedAt: now,
             },
           });
+
+          if (updateResult.count === 0) {
+            const currentPublication = await tx.liquidation.findFirst({
+              where: { id: liquidationId, tenantId },
+            });
+
+            if (!currentPublication) {
+              throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
+            }
+
+            if (currentPublication.status === 'PUBLISHED') {
+              return {
+                liquidation: this.toPublishedLiquidationDto(currentPublication),
+                publishedNow: false,
+              };
+            }
+
+            throw new ConflictException(
+              `La liquidación ${liquidationId} cambió durante la operación`,
+            );
+          }
+
+          await this.auditService.createLogRequired(
+            {
+              tenantId,
+              actorMembershipId: membership.id,
+              action: 'LIQUIDATION_PUBLISH',
+              entityType: 'Liquidation',
+              entityId: liquidationId,
+              metadata: {
+                period: current.period,
+                buildingId: current.buildingId,
+                chargesCount: distribution.length,
+                totalAmountMinor: current.totalAmountMinor,
+                baseCurrency: current.baseCurrency,
+                snapshotVersion: 1,
+                dueDate: dueDate.toISOString().slice(0, 10),
+                publishedAt: now.toISOString(),
+              },
+            },
+            tx,
+          );
 
           const liquidation = await tx.liquidation.findFirst({
             where: { id: liquidationId, tenantId },
@@ -554,64 +715,12 @@ export class LiquidationsService {
             throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
           }
 
-          return { publishedNow: true, liquidation: this.toDto(liquidation) };
-        }
-
-        if (duplicateCharges > 0) {
-          throw new ConflictException(
-            `La liquidación ${liquidationId} tiene cargos parciales generados para ${liq.period}`,
-          );
-        }
-
-        const chargeData = distribution.map((d) => ({
-          tenantId,
-          buildingId: liq.buildingId,
-          unitId: d.unitId,
-          period: liq.period,
-          type: 'COMMON_EXPENSE' as const,
-          concept,
-          amount: d.amountMinor,
-          currency: liq.baseCurrency,
-          dueDate,
-          status: ChargeStatus.PENDING,
-          liquidationId,
-          createdByMembershipId: membershipId,
-        }));
-
-        await tx.charge.createMany({ data: chargeData });
-
-        await tx.liquidation.updateMany({
-          where: { id: liquidationId, tenantId },
-          data: {
-            status: 'PUBLISHED',
-            publishedByMembershipId: membershipId,
-            publishedAt: new Date(),
-          },
-        });
-
-        const liquidation = await tx.liquidation.findFirst({
-          where: { id: liquidationId, tenantId },
-        });
-
-        if (!liquidation) {
-          throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-        }
-
-        return { publishedNow: true, liquidation: this.toDto(liquidation) };
+          return { liquidation: this.toPublishedLiquidationDto(liquidation), publishedNow: true };
         },
         { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
       );
-
-      if (!publishResult) {
-        throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-      }
-
-      shouldSendPublishedNotifications = publishResult.publishedNow;
     } catch (error) {
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.code === 'P2002'
-      ) {
+      if (this.isSerializationConflict(error)) {
         const current = await this.prisma.liquidation.findFirst({
           where: { id: liquidationId, tenantId },
         });
@@ -621,76 +730,64 @@ export class LiquidationsService {
         }
 
         throw new ConflictException(
-          `La liquidación ${liquidationId} ya tiene cargos generados para ${liq.period}`,
+          `La liquidación ${liquidationId} cambió durante la operación`,
+        );
+      }
+
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        const current = await this.prisma.liquidation.findFirst({
+          where: { id: liquidationId, tenantId },
+        });
+
+        if (current?.status === 'PUBLISHED') {
+          return this.toDto(current);
+        }
+
+        throw new ConflictException(
+          `La liquidación ${liquidationId} ya tiene cargos generados para ${current?.period ?? 'este período'}`,
         );
       }
 
       throw error;
     }
 
-    if (shouldSendPublishedNotifications) {
-      await this.auditService.createLog({
-        tenantId,
-        actorMembershipId: membershipId,
-        action: 'LIQUIDATION_PUBLISH',
-        entityType: 'Liquidation',
-        entityId: liquidationId,
-        metadata: {
-          period: liq.period,
-          buildingId: liq.buildingId,
-          chargesCount: distribution.length,
-          totalAmountMinor: liq.totalAmountMinor,
-          baseCurrency: liq.baseCurrency,
-        },
-      });
+    if (!publishResult) {
+      throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
+    }
 
-      // [PHASE 2 QUICK #2] Send CHARGE_PUBLISHED notifications to all residents
+    if (publishResult.publishedNow) {
       const notificationResult = await this.sendChargePublishedNotifications(tenantId, liquidationId, {
-        period: liq.period,
-        buildingId: liq.buildingId,
-        baseCurrency: liq.baseCurrency,
+        period: publishResult.liquidation.period,
+        buildingId: publishResult.liquidation.buildingId,
+        baseCurrency: publishResult.liquidation.baseCurrency,
       });
 
       if (notificationResult.failedCount > 0) {
-        await this.auditService.createLog({
-          tenantId,
-          actorMembershipId: membershipId,
-          action: 'LIQUIDATION_PUBLISH',
-          entityType: 'Liquidation',
-          entityId: liquidationId,
-          metadata: {
-            period: liq.period,
-            buildingId: liq.buildingId,
-            notificationFailure: true,
-            sentCount: notificationResult.sentCount,
-            failedCount: notificationResult.failedCount,
-            errorMessages: notificationResult.errorMessages,
-          },
-        });
         this.logger.warn(
           `Charge notifications for liquidation ${liquidationId} completed with ${notificationResult.failedCount} failure(s)`,
-        );
-        throw new ConflictException(
-          `Charge notifications completed with ${notificationResult.failedCount} failure(s)`,
         );
       }
     }
 
-    if (!publishResult?.liquidation) {
-      throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-    }
-
-    return this.toDto(publishResult.liquidation);
+    return publishResult.liquidation;
   }
 
+  /**
+   * Cancels a draft or reviewed liquidation transactionally.
+   *
+   * The cancellation keeps the liquidation record and audit trail intact,
+   * rejects attempts to cancel published liquidations, and preserves the
+   * irreversible financial history for already persisted states.
+   */
   async cancelLiquidation(
     tenantId: string,
     liquidationId: string,
     membershipId: string,
-    userRoles: string[],
+    _userRoles: string[],
     options: CancelLiquidationOptions = {},
   ): Promise<LiquidationResponseDto> {
-    if (!this.validators.isAdminOrOperator(userRoles)) {
+    const membership = await this.requireFinanceMembership(this.prisma, tenantId, membershipId);
+    if (!this.validators.isAdminOrOperator(membership.roles)) {
       throw new ForbiddenException('Acceso denegado');
     }
 
@@ -737,7 +834,7 @@ export class LiquidationsService {
         data: {
           status: 'CANCELED',
           canceledAt,
-          canceledByMembershipId: membershipId,
+          canceledByMembershipId: membership.id,
         },
       });
 
@@ -756,12 +853,12 @@ export class LiquidationsService {
       }
 
       if (cancelResult.count > 0) {
-        await tx.auditLog.create({
-          data: {
+        await this.auditService.createLogRequired(
+          {
             tenantId,
-            actorMembershipId: membershipId,
+            actorMembershipId: membership.id,
             action: 'LIQUIDATION_CANCEL',
-            entity: 'Liquidation',
+            entityType: 'Liquidation',
             entityId: liquidationId,
             metadata: {
               period: current.period,
@@ -771,7 +868,8 @@ export class LiquidationsService {
               reason: cancellationReason,
             },
           },
-        });
+          tx,
+        );
       }
 
       return { liquidation, canceled: true };
@@ -875,6 +973,7 @@ export class LiquidationsService {
     tenantId: string;
     buildingId: string;
     period: string;
+    chargePeriod: string | null;
     status: 'DRAFT' | 'REVIEWED' | 'PUBLISHED' | 'CANCELED';
     baseCurrency: string;
     totalAmountMinor: number;
@@ -893,6 +992,7 @@ export class LiquidationsService {
       tenantId: liq.tenantId,
       buildingId: liq.buildingId,
       period: liq.period,
+      chargePeriod: liq.chargePeriod,
       status: liq.status,
       baseCurrency: liq.baseCurrency,
       totalAmountMinor: liq.totalAmountMinor,
@@ -906,6 +1006,134 @@ export class LiquidationsService {
     };
   }
 
+  private toDetailDto(
+    liq: {
+      id: string;
+      tenantId: string;
+      buildingId: string;
+      period: string;
+      chargePeriod: string | null;
+      status: 'DRAFT' | 'REVIEWED' | 'PUBLISHED' | 'CANCELED';
+      baseCurrency: string;
+      totalAmountMinor: number;
+      totalsByCurrency: unknown;
+      expenseSnapshot: unknown;
+      publicationSnapshot: unknown;
+      unitCount: number;
+      generatedAt: Date;
+      reviewedAt: Date | null;
+      publishedAt: Date | null;
+      canceledAt: Date | null;
+      createdAt: Date;
+    },
+    options: {
+      expenses?: ReadonlyArray<PublishedExpenseSnapshot>;
+      charges: Array<{
+        unitId: string;
+        unitCode: string;
+        unitLabel: string | null;
+        amountMinor: number;
+      }>;
+    },
+  ): LiquidationDetailDto {
+    const publicationSnapshot =
+      liq.status === 'PUBLISHED'
+        ? parseLiquidationPublicationSnapshot(liq.publicationSnapshot)
+        : null;
+
+    if (publicationSnapshot) {
+      return {
+        ...this.toDto(liq),
+        publicationSnapshotStatus: 'AVAILABLE',
+        expenses: publicationSnapshot.expenses.map((expense) => ({
+          id: expense.expenseId,
+          categoryName: expense.categoryName,
+          vendorName: expense.vendorName,
+          amountMinor: expense.amountMinor,
+          currencyCode: expense.currencyCode,
+          invoiceDate: new Date(expense.invoiceDate),
+          description: expense.description,
+        })),
+        chargesPreview: publicationSnapshot.allocations.map((allocation) => ({
+          unitId: allocation.unitId,
+          unitCode: allocation.unitCode,
+          unitLabel: allocation.unitLabel,
+          amountMinor: allocation.amountMinor,
+        })),
+      };
+    }
+
+    const expenseSnapshot = this.parseExpenseSnapshot(liq.expenseSnapshot);
+
+    return {
+      ...this.toDto(liq),
+      publicationSnapshotStatus: 'LEGACY',
+      expenses: expenseSnapshot.map((expense) => ({
+        id: expense.expenseId,
+        categoryName: expense.categoryName,
+        vendorName: expense.vendorName,
+        amountMinor: expense.amountMinor,
+        currencyCode: expense.currencyCode,
+        invoiceDate: new Date(expense.invoiceDate),
+        description: expense.description,
+      })),
+      chargesPreview: options.charges,
+    };
+  }
+
+  private toPublishedLiquidationDto(liq: {
+    id: string;
+    tenantId: string;
+    buildingId: string;
+    period: string;
+    chargePeriod: string | null;
+    status: 'DRAFT' | 'REVIEWED' | 'PUBLISHED' | 'CANCELED';
+    baseCurrency: string;
+    totalAmountMinor: number;
+    totalsByCurrency: unknown;
+    unitCount: number;
+    generatedAt: Date;
+    reviewedAt: Date | null;
+    publishedAt: Date | null;
+    canceledAt: Date | null;
+    createdAt: Date;
+  }): LiquidationResponseDto {
+    return this.toDto(liq);
+  }
+
+  private async requireFinanceMembership(
+    client: PrismaService | Prisma.TransactionClient | FinanceMembershipClient,
+    tenantId: string,
+    membershipId: string,
+  ): Promise<FinanceMembershipContext> {
+    const membership = await client.membership.findFirst({
+      where: { id: membershipId, tenantId },
+      select: {
+        id: true,
+        tenantId: true,
+        roles: { select: { role: true, scopeType: true } },
+      },
+    });
+
+    if (!membership) {
+      throw new ForbiddenException('No se encontró una membresía válida para el tenant');
+    }
+
+    const tenantRoles = membership.roles
+      .filter((role) => role.scopeType === 'TENANT')
+      .map((role) => role.role);
+
+    if (!this.validators.isAdminOrOperator(tenantRoles)) {
+      throw new ForbiddenException('Solo administradores pueden gestionar liquidaciones');
+    }
+
+    return {
+      id: membership.id,
+      tenantId: membership.tenantId,
+      roles: tenantRoles,
+    };
+  }
+
   private parseTotalsByCurrency(value: unknown): Record<string, number> {
     if (value === null || typeof value !== 'object' || Array.isArray(value)) {
       throw new BadRequestException('Liquidation totalsByCurrency snapshot is invalid');
@@ -914,7 +1142,7 @@ export class LiquidationsService {
     const result: Record<string, number> = {};
 
     for (const [currency, amount] of Object.entries(value as Record<string, unknown>)) {
-      if (typeof amount !== 'number' || !Number.isFinite(amount)) {
+      if (typeof amount !== 'number' || !Number.isSafeInteger(amount) || amount < 0) {
         throw new BadRequestException(
           `Liquidation totalsByCurrency snapshot has invalid amount for ${currency}`,
         );
@@ -924,6 +1152,37 @@ export class LiquidationsService {
     }
 
     return result;
+  }
+
+  private safeAddAmountMinor(left: number, right: number, field: string): number {
+    const total = left + right;
+
+    if (!Number.isSafeInteger(total) || total < 0) {
+      throw new BadRequestException(`Liquidation ${field} is invalid`);
+    }
+
+    return total;
+  }
+
+  private requireCurrencyTotal(
+    totalsByCurrency: Record<string, number>,
+    baseCurrency: string,
+  ): number {
+    const total = totalsByCurrency[baseCurrency];
+
+    if (total === undefined) {
+      throw new BadRequestException(
+        `No se puede generar la liquidación porque no hay totales para la moneda base ${baseCurrency}`,
+      );
+    }
+
+    return total;
+  }
+
+  private isSerializationConflict(
+    error: unknown,
+  ): error is Prisma.PrismaClientKnownRequestError {
+    return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2034';
   }
 
   private parseExpenseSnapshot(value: unknown): LiquidationExpenseSnapshotItem[] {
@@ -956,7 +1215,7 @@ export class LiquidationsService {
       if (vendorName !== null && typeof vendorName !== 'string') {
         throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid vendorName`);
       }
-      if (typeof amountMinor !== 'number' || !Number.isFinite(amountMinor)) {
+      if (typeof amountMinor !== 'number' || !Number.isSafeInteger(amountMinor) || amountMinor < 0) {
         throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid amountMinor`);
       }
       if (typeof currencyCode !== 'string') {
@@ -975,18 +1234,39 @@ export class LiquidationsService {
         throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid sourcePeriod`);
       }
 
+      const parsedInvoiceDate = new Date(invoiceDate);
+      if (Number.isNaN(parsedInvoiceDate.getTime())) {
+        throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid invoiceDate`);
+      }
+
       return {
         expenseId,
         categoryName,
         vendorName,
         amountMinor,
         currencyCode,
-        invoiceDate,
+        invoiceDate: parsedInvoiceDate.toISOString(),
         description,
         type,
         sourcePeriod: sourcePeriod ?? undefined,
       };
     });
+  }
+
+  private getPublicationSnapshotExpenses(
+    value: unknown,
+  ): ReadonlyArray<PublishedExpenseSnapshot> {
+    return this.parseExpenseSnapshot(value).map((expense) => ({
+      expenseId: expense.expenseId,
+      categoryName: expense.categoryName,
+      vendorName: expense.vendorName,
+      amountMinor: expense.amountMinor,
+      currencyCode: expense.currencyCode,
+      invoiceDate: expense.invoiceDate,
+      description: expense.description,
+      type: expense.type,
+      ...(expense.sourcePeriod ? { sourcePeriod: expense.sourcePeriod } : {}),
+    }));
   }
 
   /**
@@ -1022,9 +1302,11 @@ export class LiquidationsService {
           },
           include: {
             unitOccupants: {
-              where: { endDate: null }, // Active occupants only
+              where: { tenantId, endDate: null }, // Active occupants only
               include: {
-                member: { select: { id: true, user: { select: { id: true } } } },
+                member: {
+                  select: { id: true, tenantId: true, user: { select: { id: true } } },
+                },
               },
             },
           },

--- a/apps/api/src/finanzas/liquidations.service.ts
+++ b/apps/api/src/finanzas/liquidations.service.ts
@@ -110,11 +110,10 @@ export class LiquidationsService {
 
   async listLiquidations(
     tenantId: string,
-    _membershipId: string,
-    _userRoles: string[],
+    membershipId: string,
     query: { buildingId?: string; period?: string },
   ): Promise<LiquidationResponseDto[]> {
-    const membership = await this.requireFinanceMembership(this.prisma, tenantId, _membershipId);
+    const membership = await this.requireFinanceMembership(this.prisma, tenantId, membershipId);
     if (!this.validators.isAdminOrOperator(membership.roles)) {
       throw new ForbiddenException('Solo administradores pueden ver liquidaciones');
     }
@@ -135,10 +134,9 @@ export class LiquidationsService {
   async getLiquidation(
     tenantId: string,
     liquidationId: string,
-    _membershipId: string,
-    _userRoles: string[],
+    membershipId: string,
   ): Promise<LiquidationDetailDto> {
-    const membership = await this.requireFinanceMembership(this.prisma, tenantId, _membershipId);
+    const membership = await this.requireFinanceMembership(this.prisma, tenantId, membershipId);
     if (!this.validators.isAdminOrOperator(membership.roles)) {
       throw new ForbiddenException('Acceso denegado');
     }
@@ -171,7 +169,6 @@ export class LiquidationsService {
   async createDraft(
     tenantId: string,
     membershipId: string,
-    _userRoles: string[],
     dto: CreateLiquidationDraftDto,
   ): Promise<LiquidationDetailDto> {
     return this.prisma.$transaction(async (tx) => {
@@ -403,7 +400,6 @@ export class LiquidationsService {
     tenantId: string,
     liquidationId: string,
     membershipId: string,
-    _userRoles: string[],
   ): Promise<LiquidationResponseDto> {
     return this.prisma.$transaction(async (tx) => {
       const membership = await this.requireFinanceMembership(tx, tenantId, membershipId);
@@ -487,7 +483,6 @@ export class LiquidationsService {
     tenantId: string,
     liquidationId: string,
     membershipId: string,
-    _userRoles: string[],
     dto: PublishLiquidationDto,
   ): Promise<LiquidationResponseDto> {
     let publishResult: { liquidation: LiquidationResponseDto; publishedNow: boolean } | null = null;
@@ -783,7 +778,6 @@ export class LiquidationsService {
     tenantId: string,
     liquidationId: string,
     membershipId: string,
-    _userRoles: string[],
     options: CancelLiquidationOptions = {},
   ): Promise<LiquidationResponseDto> {
     const membership = await this.requireFinanceMembership(this.prisma, tenantId, membershipId);

--- a/docs/hardening/LIQUIDATION_SNAPSHOT.md
+++ b/docs/hardening/LIQUIDATION_SNAPSHOT.md
@@ -1,0 +1,152 @@
+# Liquidation Publication Snapshot Hardening
+
+## Purpose
+
+Published liquidations now persist an immutable publication snapshot so later reads do not depend on mutable draft-time data.
+
+## What changed
+
+- Added `publicationSnapshot` to the `Liquidation` model and a matching Prisma migration.
+- Persisted the snapshot at publish time inside the same transaction that creates charges and audit records.
+- Made liquidation reads for `PUBLISHED` records source their expense and charge preview data from the stored snapshot when available.
+- Added an explicit legacy read path for historical published liquidations that do not yet have `publicationSnapshot`.
+- Kept post-commit notifications best effort so a notification failure does not turn a successful publication into an HTTP error.
+- Hardened the database trigger so snapshots can only be created on valid `INSERT`/`UPDATE` transitions to `PUBLISHED`, and never mutated afterward.
+- Added an internal migration preflight that fails fast when duplicate `PUBLISHED` rows already exist for the same tenant, building, and period.
+- Added a partial unique index that guarantees only one published liquidation per tenant, building, and financial period.
+
+## Snapshot contents
+
+The snapshot stores:
+
+- liquidation identity and tenant/building scope
+- publication timestamp (`publishedAt`); the parent `Liquidation` retains the publisher identity (`publishedByMembershipId`)
+- summary totals and rounding data
+- the exact expense list used for publication
+- the exact unit allocation plan used to create charges
+
+## Liquidation fields protected after publish
+
+Once a liquidation is already `PUBLISHED`, the database trigger treats these fields as immutable:
+
+- `tenantId`
+- `buildingId`
+- `period`
+- `chargePeriod`
+- `status`
+- `baseCurrency`
+- `totalAmountMinor`
+- `totalsByCurrency`
+- `expenseSnapshot`
+- `publicationSnapshot`
+- `unitCount`
+- `generatedByMembershipId`
+- `generatedAt`
+- `reviewedByMembershipId`
+- `reviewedAt`
+- `publishedByMembershipId`
+- `publishedAt`
+- `canceledByMembershipId`
+- `canceledAt`
+
+`updatedAt` remains operational and is not part of the immutable financial document boundary.
+
+Canceled liquidations are also terminal: after a liquidation reaches `CANCELED`, the trigger rejects any further changes to the financial history or cancellation metadata, preserving the canceled record as an audit trail.
+
+## Historical compatibility strategy
+
+The existing historical rows are not rich enough to rebuild a version-1 snapshot exactly in every case.
+
+Why:
+
+- `Liquidation` keeps the draft expense snapshot and the final charges.
+- `Charge` keeps the published amount and unit reference.
+- The schema does not preserve every publication-time derived value as an immutable version-1 snapshot did not exist yet.
+
+So the implementation uses two modes:
+
+- `publicationSnapshotStatus: "AVAILABLE"` for modern liquidations with a persisted snapshot.
+- `publicationSnapshotStatus: "LEGACY"` for older published liquidations without the new snapshot column populated.
+
+Legacy reads are still tenant/building scoped and they do not recalculate data from current tables. They read the persisted liquidation expense snapshot and the persisted charge rows already stored on the liquidation record. The only mutable legacy dependency that remains is unit metadata used for display (`unit.code` and `unit.label`), so renaming a unit can still change how an older liquidation is rendered.
+
+## Trigger rules
+
+The PostgreSQL trigger enforces these rules:
+
+1. New liquidations must always be inserted with `status = DRAFT`.
+2. A `DRAFT` liquidation cannot contain review, publication, cancellation, or publication snapshot metadata.
+3. A `DRAFT` liquidation may transition only to `REVIEWED` or `CANCELED`.
+4. A `REVIEWED` liquidation must include `reviewedAt` and `reviewedByMembershipId`.
+5. A `REVIEWED` liquidation may transition only to `PUBLISHED` or `CANCELED`.
+6. A liquidation may transition to `PUBLISHED` only from `REVIEWED`.
+7. Publishing requires `publicationSnapshot`, `publishedAt`, and `publishedByMembershipId` in the same update.
+8. A liquidation cannot transition directly from `DRAFT` to `PUBLISHED`.
+9. During `REVIEWED → PUBLISHED`, the trigger allows the publication fields (`publicationSnapshot`, `publishedAt`, `publishedByMembershipId`) to change atomically while protecting the financial history.
+10. A `PUBLISHED` liquidation is terminal and its protected financial, historical, and snapshot fields are immutable after publication.
+11. A `CANCELED` liquidation requires `canceledAt` and `canceledByMembershipId` and is terminal and immutable.
+12. `PUBLISHED` liquidations cannot be canceled directly; reversal or compensation requires a separate domain flow.
+13. Legacy `PUBLISHED` liquidations with `publicationSnapshot = null` remain explicitly legacy and the snapshot must remain null.
+14. Non-published liquidations cannot create or carry publication metadata or `publicationSnapshot`.
+15. The `DRAFT → CANCELED` and `REVIEWED → CANCELED` transition may only set the cancellation metadata, `status`, and `updatedAt`; all financial and historical fields must remain unchanged.
+
+## Timestamp consistency
+
+Publication now uses one shared `publishedAt` value for:
+
+- `publicationSnapshot.publishedAt`
+- `Liquidation.publishedAt`
+
+The snapshot stores `publishedAt` only. The parent `Liquidation` row stores
+`publishedByMembershipId`, which identifies the membership that performed the
+publication; that identity is not duplicated into the snapshot.
+
+That prevents drift between the snapshot and the row that represents the publication event.
+
+## Verification checklist
+
+Run these checks before merging or promoting the slice:
+
+- targeted liquidation service tests
+- full API test suite
+- TypeScript typecheck for `apps/api`
+- Prisma schema validation
+- API build
+- lint
+
+## Legacy compatibility
+
+Historical published liquidations without a snapshot remain readable through `publicationSnapshotStatus: "LEGACY"`.
+That compatibility path is read-only: the database trigger does not allow retroactive snapshot insertion into those rows, and the service keeps consuming the persisted legacy data as-is.
+
+## Uniqueness rule for published liquidations
+
+The database now enforces one published liquidation per:
+
+- `tenantId`
+- `buildingId`
+- `period`
+
+with a partial unique index that only applies when `status = 'PUBLISHED'`.
+
+The migration now runs a preflight check immediately before creating that index. If duplicate published rows already exist for the same tenant/building/period, the migration aborts with an explicit uniqueness error instead of trying to deduplicate data silently.
+
+Prisma does not model this partial index directly in `schema.prisma`, so the migration owns the invariant.
+
+### Preflight before applying the migration to a populated database
+
+Run this read-only query to detect duplicates before deployment:
+
+```sql
+SELECT "tenantId", "buildingId", "period", COUNT(*)
+FROM "Liquidation"
+WHERE "status" = 'PUBLISHED'
+GROUP BY "tenantId", "buildingId", "period"
+HAVING COUNT(*) > 1;
+```
+
+The migration is expected to fail if that query returns rows. Do not deduplicate silently.
+
+## Remaining operational note
+
+This hardening does not authorize production deployment or remote migration execution. Those remain separate approval steps.


### PR DESCRIPTION
## Resumen

Persiste snapshots inmutables al publicar liquidaciones y endurece el flujo financiero relacionado.

## Alcance

- agrega `publicationSnapshot` a `Liquidation`;
- aplica máquina de estados DRAFT → REVIEWED → PUBLISHED/CANCELED;
- protege liquidaciones publicadas y canceladas mediante trigger PostgreSQL;
- exige snapshot, metadata de publicación y unicidad por tenant/edificio/período;
- mantiene liquidaciones históricas sin snapshot como `LEGACY`;
- mueve lecturas, efectos financieros y auditoría obligatoria dentro de la transacción;
- valida autorización multi-tenant mediante membership persistida;
- exige scope `TENANT` para categorías globales;
- alinea el camino legacy de publicación con el snapshot transaccional;
- agrega pruebas de servicios, controllers, DTO, migración y snapshot.

## Validaciones realizadas

- TypeScript API: PASS
- Prisma validate: PASS
- Nest build: PASS
- tests focalizados: PASS
- Jest completo: PASS
- PostgreSQL 16 migration test: PASS
- trigger/manual SQL validation: PASS
- diff check: PASS
- scan de escapes de tipos: PASS

## Estado

Draft pendiente de:

- revisión 4R obligatoria;
- checks de CI;
- revisión final antes de merge.

## Exclusiones

Este PR no incluye:

- HITL;
- scripts QA del asistente;
- documentación general de arquitectura;
- scripts de reparación;
- Ops;
- despliegue a staging, VPS o producción.