### PR TITLE
feat(web): show liquidation unit allocation details

### DIFF
--- a/apps/web/features/finance/components/LiquidationCard.tsx
+++ b/apps/web/features/finance/components/LiquidationCard.tsx
@@ -8,6 +8,7 @@ import { useToast } from '@/shared/components/ui/Toast';
 import Button from '@/shared/components/ui/Button';
 import { Liquidation, LiquidationDetail, LiquidationStatus } from '../services/expense-ledger.api';
 import {
+  useLiquidationDetail,
   useReviewLiquidation,
   useCancelLiquidation,
 } from '../hooks/useExpenseLedger';
@@ -46,8 +47,36 @@ export function LiquidationCard({
   const [expanded, setExpanded] = useState(false);
   const [showPublishModal, setShowPublishModal] = useState(false);
 
+  const detailQuery = useLiquidationDetail(tenantId, liquidation.id, expanded);
   const reviewMutation = useReviewLiquidation(tenantId);
   const cancelMutation = useCancelLiquidation(tenantId);
+  const resolvedDetail = detailQuery.data ?? (isDetail(liquidation) ? liquidation : null);
+  const detailSectionId = `liquidation-detail-${liquidation.id}`;
+  const detailIsLoading = expanded && !resolvedDetail && detailQuery.isLoading;
+  const detailIsError = expanded && !resolvedDetail && detailQuery.isError;
+  const detailErrorMessage =
+    detailQuery.error instanceof Error
+      ? detailQuery.error.message
+      : 'No pudimos cargar el detalle de la liquidación.';
+  const chargesPreview = resolvedDetail?.chargesPreview ?? [];
+  const expenses = resolvedDetail?.expenses ?? [];
+  const totalDistributedMinor = chargesPreview.reduce(
+    (sum, charge) => sum + charge.amountMinor,
+    0,
+  );
+  const hasDistributionMismatch =
+    resolvedDetail !== null &&
+    totalDistributedMinor !== liquidation.totalAmountMinor;
+  const detailTitle =
+    liquidation.status === 'PUBLISHED'
+      ? 'Cargos generados por unidad'
+      : 'Distribución estimada por unidad';
+  const terminalMessage =
+    liquidation.status === 'PUBLISHED'
+      ? 'Liquidación publicada — no hay acciones disponibles'
+      : liquidation.status === 'CANCELED'
+        ? 'Liquidación cancelada — no hay acciones disponibles'
+        : null;
 
   const handleReview = async () => {
     try {
@@ -71,18 +100,12 @@ export function LiquidationCard({
   };
 
   const totalsEntries = Object.entries(liquidation.totalsByCurrency);
-  const terminalMessage =
-    liquidation.status === 'PUBLISHED'
-      ? 'Liquidación publicada — no hay acciones disponibles'
-      : liquidation.status === 'CANCELED'
-        ? 'Liquidación cancelada — no hay acciones disponibles'
-        : null;
 
   return (
     <div className="rounded-lg border bg-background shadow-sm">
       {/* Header */}
       <div className="flex items-center justify-between p-4">
-        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-3">
           <div>
             <span className="font-semibold">Período {liquidation.period}</span>
             <span
@@ -111,7 +134,7 @@ export function LiquidationCard({
 
           {/* Acciones */}
           <div className="flex flex-col items-end gap-2">
-            <div className="flex gap-1">
+            <div className="flex flex-wrap justify-end gap-1">
               {liquidation.status === 'DRAFT' && (
                 <>
                   <Button
@@ -165,6 +188,22 @@ export function LiquidationCard({
                   </Button>
                 </>
               )}
+
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                onClick={() => setExpanded((value) => !value)}
+                aria-expanded={expanded}
+                aria-controls={detailSectionId}
+              >
+                {expanded ? 'Ocultar detalle' : 'Ver detalle'}
+                {expanded ? (
+                  <ChevronUp className="ml-1 h-4 w-4" />
+                ) : (
+                  <ChevronDown className="ml-1 h-4 w-4" />
+                )}
+              </Button>
             </div>
 
             {terminalMessage ? (
@@ -174,75 +213,122 @@ export function LiquidationCard({
             ) : null}
           </div>
 
-          {/* Expandir */}
-            {isDetail(liquidation) && (
-              <button
-                type="button"
-                aria-label={expanded ? 'Contraer detalles de la liquidación' : 'Expandir detalles de la liquidación'}
-                aria-expanded={expanded}
-                onClick={() => setExpanded((v) => !v)}
-                className="p-1 rounded hover:bg-muted"
-              >
-                {expanded ? (
-                <ChevronUp className="h-4 w-4" />
-              ) : (
-                <ChevronDown className="h-4 w-4" />
-              )}
-            </button>
-          )}
         </div>
       </div>
 
-      {/* Detail expandible */}
-      {expanded && isDetail(liquidation) && (
-        <div className="border-t px-4 py-3 space-y-4">
-          {/* Gastos */}
-          <div>
-            <h4 className="text-xs font-semibold uppercase text-muted-foreground mb-2">
-              Gastos incluidos
-            </h4>
-            <div className="space-y-1">
-              {liquidation.expenses.map((exp) => (
-                <div
-                  key={exp.id}
-                  className="flex justify-between text-sm text-muted-foreground"
-                >
-                  <span>
-                    {exp.categoryName}
-                    {exp.vendorName ? ` (${exp.vendorName})` : ''}
-                  </span>
-                  <span className="font-mono">
-                    {formatCurrency(exp.amountMinor, exp.currencyCode)}
-                  </span>
-                </div>
-              ))}
+      {expanded && (
+        <div
+          id={detailSectionId}
+          className="border-t px-4 py-3 space-y-4"
+          aria-live="polite"
+        >
+          {detailIsLoading ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground" role="status">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span>Cargando detalle de la liquidación…</span>
             </div>
-          </div>
-
-          {/* Preview por unidad */}
-          {liquidation.chargesPreview.length > 0 && (
-            <div>
-              <h4 className="text-xs font-semibold uppercase text-muted-foreground mb-2">
-                Distribución estimada por unidad
-              </h4>
-              <div className="grid grid-cols-2 gap-1 text-xs">
-                {liquidation.chargesPreview.map((c) => (
-                  <div
-                    key={c.unitId}
-                    className="flex justify-between text-muted-foreground"
-                  >
-                    <span>
-                      {c.unitCode}
-                      {c.unitLabel ? ` — ${c.unitLabel}` : ''}
-                    </span>
-                    <span className="font-mono">
-                      {formatCurrency(c.amountMinor, liquidation.baseCurrency)}
-                    </span>
-                  </div>
-                ))}
+          ) : detailIsError ? (
+            <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+              <p className="font-medium">No pudimos cargar el detalle de la liquidación.</p>
+              <p className="mt-1">{detailErrorMessage}</p>
+              <Button
+                type="button"
+                size="sm"
+                variant="secondary"
+                onClick={() => void detailQuery.refetch()}
+                className="mt-3"
+              >
+                Reintentar
+              </Button>
+            </div>
+          ) : resolvedDetail ? (
+            <>
+              <div className="space-y-2">
+                <h4 className="text-xs font-semibold uppercase text-muted-foreground">
+                  Gastos incluidos
+                </h4>
+                {expenses.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    No hay datos históricos disponibles.
+                  </p>
+                ) : (
+                  <ul className="space-y-2">
+                    {expenses.map((exp) => (
+                      <li
+                        key={exp.id}
+                        className="flex flex-col gap-1 rounded-md border bg-muted/20 p-3 sm:flex-row sm:items-center sm:justify-between"
+                      >
+                        <div className="min-w-0">
+                          <p className="text-sm font-medium text-foreground">
+                            {exp.categoryName}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            {exp.vendorName ? `${exp.vendorName} · ` : ''}
+                            {formatCurrency(exp.amountMinor, exp.currencyCode)}
+                          </p>
+                        </div>
+                        <div className="text-sm text-muted-foreground">
+                          {formatCurrency(exp.amountMinor, exp.currencyCode)}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </div>
-            </div>
-          )}
+
+              <div className="space-y-2">
+                <div className="flex flex-col gap-1">
+                  <h4 className="text-xs font-semibold uppercase text-muted-foreground">
+                    {detailTitle}
+                  </h4>
+                  {liquidation.status === 'PUBLISHED' ? (
+                    <p className="text-xs text-muted-foreground">
+                      Estos importes son cargos asignados a las unidades. No representan pagos recibidos.
+                    </p>
+                  ) : null}
+                </div>
+
+                {chargesPreview.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">
+                    No hay cargos asociados a esta liquidación.
+                  </p>
+                ) : (
+                  <ul className="space-y-2">
+                    {chargesPreview.map((charge) => (
+                      <li
+                        key={charge.unitId}
+                        className="flex flex-col gap-1 rounded-md border bg-muted/20 p-3 sm:flex-row sm:items-center sm:justify-between"
+                      >
+                        <div className="min-w-0">
+                          <p className="text-sm font-medium text-foreground">
+                            Unidad {charge.unitCode}
+                            {charge.unitLabel ? ` — ${charge.unitLabel}` : ''}
+                          </p>
+                        </div>
+                        <div className="text-sm font-mono text-foreground">
+                          {formatCurrency(charge.amountMinor, liquidation.baseCurrency)}
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                <div className="space-y-1 text-xs text-muted-foreground">
+                  <p>Unidades incluidas: {chargesPreview.length}</p>
+                  <p>
+                    Total distribuido:{' '}
+                    {formatCurrency(totalDistributedMinor, liquidation.baseCurrency)}
+                  </p>
+                </div>
+
+                {hasDistributionMismatch ? (
+                  <p className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-800">
+                    El total distribuido entre las unidades no coincide con el total de la liquidación.
+                  </p>
+                ) : null}
+              </div>
+            </>
+          ) : null}
         </div>
       )}
 

--- a/apps/web/features/finance/components/__tests__/LiquidationCard.test.tsx
+++ b/apps/web/features/finance/components/__tests__/LiquidationCard.test.tsx
@@ -1,10 +1,34 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { LiquidationCard } from '../LiquidationCard';
-import type { Liquidation } from '../../services/expense-ledger.api';
+import type {
+  Liquidation,
+  LiquidationDetail,
+  LiquidationExpenseItem,
+  LiquidationChargePreview,
+} from '../../services/expense-ledger.api';
 
 const reviewMutateAsync = jest.fn();
 const cancelMutateAsync = jest.fn();
 const toast = jest.fn();
+const detailRefetch = jest.fn();
+
+interface LiquidationDetailQueryState {
+  data?: LiquidationDetail;
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  refetch: typeof detailRefetch;
+}
+
+const useLiquidationDetailMock = jest.fn();
+
+let detailQueryState: LiquidationDetailQueryState = {
+  data: undefined,
+  isLoading: false,
+  isError: false,
+  error: null,
+  refetch: detailRefetch,
+};
 
 jest.mock('@/shared/components/ui/Toast', () => ({
   useToast: () => ({
@@ -21,6 +45,12 @@ jest.mock('../../hooks/useExpenseLedger', () => ({
     mutateAsync: cancelMutateAsync,
     isPending: false,
   }),
+  useLiquidationDetail: (
+    tenantId: string,
+    liquidationId: string,
+    enabled = true,
+  ): LiquidationDetailQueryState =>
+    useLiquidationDetailMock(tenantId, liquidationId, enabled),
 }));
 
 function buildLiquidation(status: Liquidation['status']): Liquidation {
@@ -31,17 +61,73 @@ function buildLiquidation(status: Liquidation['status']): Liquidation {
     period: '2026-05',
     status,
     baseCurrency: 'ARS',
-    totalAmountMinor: 12500,
-    totalsByCurrency: { ARS: 12500 },
-    unitCount: 3,
+    totalAmountMinor: 150000,
+    totalsByCurrency: { ARS: 150000 },
+    unitCount: 2,
     generatedAt: '2026-05-01T00:00:00.000Z',
-    reviewedAt: status === 'REVIEWED' || status === 'PUBLISHED' || status === 'CANCELED'
-      ? '2026-05-02T00:00:00.000Z'
-      : null,
+    reviewedAt:
+      status === 'REVIEWED' || status === 'PUBLISHED' || status === 'CANCELED'
+        ? '2026-05-02T00:00:00.000Z'
+        : null,
     publishedAt: status === 'PUBLISHED' ? '2026-05-03T00:00:00.000Z' : null,
     canceledAt: status === 'CANCELED' ? '2026-05-04T00:00:00.000Z' : null,
     createdAt: '2026-05-01T00:00:00.000Z',
   };
+}
+
+function buildDetail(
+  status: Liquidation['status'],
+  overrides: Partial<{
+    expenses: LiquidationExpenseItem[];
+    chargesPreview: LiquidationChargePreview[];
+    totalAmountMinor: number;
+  }> = {},
+): LiquidationDetail {
+  const liquidation = buildLiquidation(status);
+
+  return {
+    ...liquidation,
+    totalAmountMinor: overrides.totalAmountMinor ?? liquidation.totalAmountMinor,
+    expenses:
+      overrides.expenses ??
+      [
+        {
+          id: 'expense-1',
+          categoryName: 'Luz',
+          vendorName: 'Servicios SA',
+          amountMinor: 50000,
+          currencyCode: 'ARS',
+          invoiceDate: '2026-05-10T00:00:00.000Z',
+          description: 'Factura 123',
+        },
+      ],
+    chargesPreview:
+      overrides.chargesPreview ??
+      [
+        {
+          unitId: 'unit-1',
+          unitCode: 'A-01',
+          unitLabel: 'Apartamento 1',
+          amountMinor: 75000,
+        },
+        {
+          unitId: 'unit-2',
+          unitCode: 'A-02',
+          unitLabel: 'Apartamento 2',
+          amountMinor: 75000,
+        },
+      ],
+  };
+}
+
+function renderCard(status: Liquidation['status']) {
+  return render(
+    <LiquidationCard
+      tenantId="tenant-1"
+      liquidation={buildLiquidation(status)}
+      onRefresh={jest.fn()}
+    />,
+  );
 }
 
 describe('LiquidationCard', () => {
@@ -49,33 +135,44 @@ describe('LiquidationCard', () => {
     reviewMutateAsync.mockReset();
     cancelMutateAsync.mockReset();
     toast.mockReset();
+    detailRefetch.mockReset();
+    useLiquidationDetailMock.mockReset();
+    detailQueryState = {
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: detailRefetch,
+    };
+
+    useLiquidationDetailMock.mockImplementation(
+      (_tenantId: string, _liquidationId: string, enabled = true) => {
+        if (!enabled) {
+          return {
+            data: undefined,
+            isLoading: false,
+            isError: false,
+            error: null,
+            refetch: detailRefetch,
+          } satisfies LiquidationDetailQueryState;
+        }
+
+        return detailQueryState;
+      },
+    );
   });
 
   it('shows review and cancel for DRAFT, but not publish', () => {
-    render(
-      <LiquidationCard
-        tenantId="tenant-1"
-        liquidation={buildLiquidation('DRAFT')}
-        onRefresh={jest.fn()}
-      />,
-    );
+    renderCard('DRAFT');
 
     expect(screen.getByRole('button', { name: 'Revisar' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Cancelar' })).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Publicar' })).toBeNull();
-    expect(
-      screen.queryByText('Liquidación publicada — no hay acciones disponibles'),
-    ).toBeNull();
+    expect(screen.getByRole('button', { name: 'Ver detalle' })).toBeTruthy();
   });
 
   it('shows publish and cancel for REVIEWED, but not review', () => {
-    render(
-      <LiquidationCard
-        tenantId="tenant-1"
-        liquidation={buildLiquidation('REVIEWED')}
-        onRefresh={jest.fn()}
-      />,
-    );
+    renderCard('REVIEWED');
 
     expect(screen.getByRole('button', { name: 'Publicar' })).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Cancelar' })).toBeTruthy();
@@ -83,13 +180,7 @@ describe('LiquidationCard', () => {
   });
 
   it('shows terminal text and no mutating actions for PUBLISHED', () => {
-    render(
-      <LiquidationCard
-        tenantId="tenant-1"
-        liquidation={buildLiquidation('PUBLISHED')}
-        onRefresh={jest.fn()}
-      />,
-    );
+    renderCard('PUBLISHED');
 
     expect(
       screen.getByText('Liquidación publicada — no hay acciones disponibles'),
@@ -100,13 +191,7 @@ describe('LiquidationCard', () => {
   });
 
   it('shows terminal text and no mutating actions for CANCELED', () => {
-    render(
-      <LiquidationCard
-        tenantId="tenant-1"
-        liquidation={buildLiquidation('CANCELED')}
-        onRefresh={jest.fn()}
-      />,
-    );
+    renderCard('CANCELED');
 
     expect(
       screen.getByText('Liquidación cancelada — no hay acciones disponibles'),
@@ -116,17 +201,176 @@ describe('LiquidationCard', () => {
     expect(screen.queryByRole('button', { name: 'Cancelar' })).toBeNull();
   });
 
+  it('enables the detail query only when the user opens the card', () => {
+    renderCard('REVIEWED');
+
+    expect(useLiquidationDetailMock).toHaveBeenCalledWith(
+      'tenant-1',
+      'liq-1',
+      false,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ver detalle' }));
+
+    expect(useLiquidationDetailMock).toHaveBeenLastCalledWith(
+      'tenant-1',
+      'liq-1',
+      true,
+    );
+    expect(screen.getByRole('button', { name: 'Ocultar detalle' })).toBeTruthy();
+  });
+
+  it('shows loading state while the detail is being fetched', () => {
+    detailQueryState = {
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+      refetch: detailRefetch,
+    };
+
+    renderCard('REVIEWED');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ver detalle' }));
+
+    expect(screen.getByRole('status').textContent).toContain(
+      'Cargando detalle de la liquidación',
+    );
+  });
+
+  it('renders expenses and charges when the detail loads', () => {
+    detailQueryState = {
+      data: buildDetail('REVIEWED'),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: detailRefetch,
+    };
+
+    renderCard('REVIEWED');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ver detalle' }));
+
+    expect(screen.getByText('Gastos incluidos')).toBeTruthy();
+    expect(screen.getByText('Luz')).toBeTruthy();
+    expect(
+      screen.getByText((_, element) => element?.textContent === 'Servicios SA · $ 500,00'),
+    ).toBeTruthy();
+    expect(screen.getByText('Distribución estimada por unidad')).toBeTruthy();
+    expect(
+      screen.getAllByText(
+        (_, element) => element?.textContent === 'Unidad A-01 — Apartamento 1',
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText((_, element) => element?.textContent === '$ 750,00').length,
+    ).toBeGreaterThan(0);
+    expect(screen.getByText('Unidades incluidas: 2')).toBeTruthy();
+    expect(
+      screen.getByText((_, element) => element?.textContent === 'Total distribuido: $ 1.500,00'),
+    ).toBeTruthy();
+  });
+
+  it('shows the published copy when the liquidation is terminal and published', () => {
+    detailQueryState = {
+      data: buildDetail('PUBLISHED'),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: detailRefetch,
+    };
+
+    renderCard('PUBLISHED');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ver detalle' }));
+
+    expect(screen.getByText('Cargos generados por unidad')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'Estos importes son cargos asignados a las unidades. No representan pagos recibidos.',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('shows empty states when there are no expenses or charges', () => {
+    detailQueryState = {
+      data: buildDetail('REVIEWED', {
+        expenses: [],
+        chargesPreview: [],
+      }),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: detailRefetch,
+    };
+
+    renderCard('REVIEWED');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ver detalle' }));
+
+    expect(screen.getByText('No hay datos históricos disponibles.')).toBeTruthy();
+    expect(screen.getByText('No hay cargos asociados a esta liquidación.')).toBeTruthy();
+    expect(screen.getByText('Unidades incluidas: 0')).toBeTruthy();
+  });
+
+  it('shows a retry button when loading the detail fails', () => {
+    detailQueryState = {
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('boom'),
+      refetch: detailRefetch,
+    };
+
+    renderCard('REVIEWED');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ver detalle' }));
+
+    expect(
+      screen.getByText('No pudimos cargar el detalle de la liquidación.'),
+    ).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Reintentar' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reintentar' }));
+
+    expect(detailRefetch).toHaveBeenCalled();
+  });
+
+  it('warns when the distribution total does not match the liquidation total', () => {
+    detailQueryState = {
+      data: buildDetail('REVIEWED', {
+        chargesPreview: [
+          {
+            unitId: 'unit-1',
+            unitCode: 'A-01',
+            unitLabel: 'Apartamento 1',
+            amountMinor: 100000,
+          },
+        ],
+        totalAmountMinor: 150000,
+      }),
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: detailRefetch,
+    };
+
+    renderCard('REVIEWED');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ver detalle' }));
+
+    expect(
+      screen.getByText(
+        'El total distribuido entre las unidades no coincide con el total de la liquidación.',
+      ),
+    ).toBeTruthy();
+  });
+
   it('keeps review and cancel actions functional for DRAFT', async () => {
     reviewMutateAsync.mockResolvedValueOnce({});
     cancelMutateAsync.mockResolvedValueOnce({});
 
-    render(
-      <LiquidationCard
-        tenantId="tenant-1"
-        liquidation={buildLiquidation('DRAFT')}
-        onRefresh={jest.fn()}
-      />,
-    );
+    renderCard('DRAFT');
 
     fireEvent.click(screen.getByRole('button', { name: 'Revisar' }));
     fireEvent.click(screen.getByRole('button', { name: 'Cancelar' }));

--- a/apps/web/features/finance/hooks/useExpenseLedger.ts
+++ b/apps/web/features/finance/hooks/useExpenseLedger.ts
@@ -36,7 +36,6 @@ import {
   validateAdjustment,
   listAdjustments,
   ListAdjustmentsParams,
-  Adjustment,
 } from '../services/expense-ledger.api';
 
 // ── ExpenseLedgerCategories hooks ──────────────────────────────────────────
@@ -64,7 +63,7 @@ export function useCreateExpenseLedgerCategory(tenantId: string) {
       movementType?: 'EXPENSE' | 'INCOME';
       catalogScope?: 'BUILDING' | 'CONDOMINIUM_COMMON';
     }) => createExpenseLedgerCategory(tenantId, data),
-    onSuccess: (_, variables) => {
+    onSuccess: () => {
       // Invalidate both all categories and the specific movement type
       void queryClient.invalidateQueries({
         queryKey: ['expenseLedgerCategories', tenantId],
@@ -232,12 +231,16 @@ export function useLiquidations(
   });
 }
 
-export function useLiquidationDetail(tenantId: string, liquidationId: string) {
+export function useLiquidationDetail(
+  tenantId: string,
+  liquidationId: string,
+  enabled = true,
+) {
   return useQuery({
     queryKey: ['liquidation', tenantId, liquidationId],
     queryFn: () => getLiquidation(tenantId, liquidationId),
     staleTime: 2 * 60 * 1000,
-    enabled: !!tenantId && !!liquidationId,
+    enabled: !!tenantId && !!liquidationId && enabled,
   });
 }
 


### PR DESCRIPTION
## Resumen
Agrega el detalle expandible de las liquidaciones para mostrar las unidades incluidas y el importe asignado a cada una.

## Cambios
- Carga lazy del detalle de liquidación.
- Botones visibles `Ver detalle` y `Ocultar detalle`.
- Estados de carga, error y reintento.
- Gastos incluidos.
- Cargos generados por unidad.
- Diferencia visual entre cargos y pagos.
- Resumen de unidades y total distribuido.
- Advertencia cuando la distribución no coincide con el total.
- Mantiene intacta la máquina de estados de liquidaciones.

## Validaciones
- Jest focalizado: PASS
- TypeScript: PASS
- ESLint: PASS
- Next build: PASS
- git diff --check: PASS
- Sin any, casts inseguros, ignores ni skips

## Alcance
Solo frontend web.

No se modificaron:
- Backend
- Prisma
- Base de datos
- Docker
- Staging
- Producción