### PR TITLE
fix: close local auth, audit and liquidation baseline

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,6 +19,8 @@
     "migrate:deploy": "prisma migrate deploy",
     "migrate:status": "prisma migrate status",
     "seed": "ts-node prisma/seed.ts",
+    "reset:local-password": "ts-node scripts/reset-local-user-password.ts",
+    "seed:local:manual": "ts-node prisma/seed-local-manual.ts",
     "seed:test": "ts-node prisma/seed.test.ts",
     "seed:staging": "NODE_ENV=staging ts-node prisma/seed.ts",
     "seed:pilot": "ts-node prisma/seed-pilot.ts",

--- a/apps/api/prisma/lib/local-seed/local-manual-seed.ts
+++ b/apps/api/prisma/lib/local-seed/local-manual-seed.ts
@@ -1,0 +1,623 @@
+import * as bcrypt from 'bcrypt';
+import {
+  BillingPlanId,
+  MemberStatus,
+  Prisma,
+  PrismaClient,
+  Role,
+  ScopeType,
+  SubscriptionStatus,
+  TenantType,
+  UnitOccupantRole,
+} from '@prisma/client';
+
+export const LOCAL_MANUAL_SEED = {
+  database: 'buildingos',
+  tenantName: 'Administración Autogestionada Local',
+  buildingName: 'Torre Local A',
+  buildingAlias: 'torre-local-a',
+  plan: {
+    planId: BillingPlanId.FREE,
+    name: 'Free',
+    description: 'Local manual testing tier',
+    monthlyPrice: 0,
+    maxBuildings: 1,
+    maxUnits: 10,
+    maxUsers: 3,
+    maxOccupants: 20,
+    canExportReports: false,
+    canBulkOperations: false,
+    canUseAI: false,
+    aiBudgetCents: 0,
+    aiCallsMonthlyLimit: 0,
+    aiAllowBigModel: false,
+    aiConsultationsLimit: 0,
+    supportLevel: 'COMMUNITY',
+  },
+  units: [
+    { code: 'A-01-01', label: 'Torre Local A - Piso 01 - Unidad 01', occupancyStatus: 'OCCUPIED' },
+    { code: 'A-01-02', label: 'Torre Local A - Piso 01 - Unidad 02', occupancyStatus: 'OCCUPIED' },
+    { code: 'A-02-01', label: 'Torre Local A - Piso 02 - Unidad 01', occupancyStatus: 'VACANT' },
+  ],
+} as const;
+
+interface SeedEnvironment {
+  readonly [key: string]: string | undefined;
+  readonly NODE_ENV?: string;
+  readonly DATABASE_URL?: string;
+  readonly LOCAL_SEED_ADMIN_EMAIL?: string;
+  readonly LOCAL_SEED_ADMIN_PASSWORD?: string;
+  readonly LOCAL_SEED_RESIDENT_1_EMAIL?: string;
+  readonly LOCAL_SEED_RESIDENT_1_PASSWORD?: string;
+  readonly LOCAL_SEED_RESIDENT_2_EMAIL?: string;
+  readonly LOCAL_SEED_RESIDENT_2_PASSWORD?: string;
+}
+
+export interface LocalSeedTarget {
+  readonly database: string;
+  readonly host: string;
+}
+
+export interface LocalSeedEmails {
+  readonly admin: string;
+  readonly resident1: string;
+  readonly resident2: string;
+}
+
+export interface LocalSeedCredentials extends LocalSeedEmails {
+  readonly adminPassword: string;
+  readonly resident1Password: string;
+  readonly resident2Password: string;
+}
+
+interface ConnectionInfo {
+  readonly database: string;
+  readonly user: string;
+  readonly address: string | null;
+  readonly port: number | null;
+}
+
+export interface SeedRecordResult {
+  readonly id: string;
+  readonly created: boolean;
+}
+
+export interface LocalManualSeedResult {
+  readonly target: LocalSeedTarget;
+  readonly tenant: SeedRecordResult;
+  readonly building: SeedRecordResult;
+  readonly subscription: SeedRecordResult;
+  readonly units: readonly SeedRecordResult[];
+  readonly users: readonly SeedRecordResult[];
+  readonly memberships: readonly SeedRecordResult[];
+  readonly tenantMembers: readonly SeedRecordResult[];
+  readonly occupancies: readonly SeedRecordResult[];
+  readonly financialCounts: Readonly<Record<'expenses' | 'liquidations' | 'charges' | 'payments', number>>;
+}
+
+export interface SeedUserSpec {
+  readonly name: string;
+  readonly email: string;
+  readonly password: string;
+  readonly passwordHash: string;
+  readonly role: Role;
+  readonly unitCode?: string;
+}
+
+interface FinancialCounts {
+  readonly expenses: number;
+  readonly liquidations: number;
+  readonly charges: number;
+  readonly payments: number;
+}
+
+const LOCAL_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
+const LOCAL_ALLOWED_NODE_ENVS = new Set(['', 'development', 'test']);
+const LOCAL_EMAIL_SUFFIX = '@buildingos.test';
+
+function required(environment: SeedEnvironment, name: keyof SeedEnvironment): string {
+  const value = environment[name]?.trim();
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+function normalizeEmail(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized.endsWith(LOCAL_EMAIL_SUFFIX)) {
+    throw new Error(`Local seed emails must end with ${LOCAL_EMAIL_SUFFIX}`);
+  }
+  return normalized;
+}
+
+function assertAllowedLocalNodeEnv(nodeEnv: string | undefined, scope: string): void {
+  const normalized = nodeEnv?.trim().toLowerCase() ?? '';
+
+  if (normalized === 'production' || normalized === 'staging') {
+    throw new Error(`${scope} refuses to run when NODE_ENV=${normalized}`);
+  }
+
+  if (!LOCAL_ALLOWED_NODE_ENVS.has(normalized)) {
+    throw new Error(`${scope} only allows NODE_ENV=development, test, or empty. Received: ${normalized || 'empty'}`);
+  }
+}
+
+/** Validates only the configured target, before creating a Prisma client. */
+export function assertSafeLocalSeedEnvironment(environment: SeedEnvironment): LocalSeedTarget {
+  assertAllowedLocalNodeEnv(environment.NODE_ENV, 'Local manual seed');
+
+  const databaseUrl = required(environment, 'DATABASE_URL');
+  let parsed: URL;
+  try {
+    parsed = new URL(databaseUrl);
+  } catch {
+    throw new Error('DATABASE_URL must be a valid PostgreSQL URL');
+  }
+
+  if (parsed.protocol !== 'postgresql:' && parsed.protocol !== 'postgres:') {
+    throw new Error('Local manual seed requires a PostgreSQL DATABASE_URL');
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  if (!LOCAL_HOSTS.has(host)) {
+    throw new Error(`Local manual seed refuses non-local host: ${host}`);
+  }
+
+  const database = decodeURIComponent(parsed.pathname.replace(/^\//, '')).split('/')[0] ?? '';
+  if (!database || /(staging|production|prod)/i.test(database)) {
+    throw new Error('Local manual seed refuses staging, production, or prod database names');
+  }
+  if (database !== LOCAL_MANUAL_SEED.database) {
+    throw new Error(`Local manual seed requires database ${LOCAL_MANUAL_SEED.database}, received ${database}`);
+  }
+
+  return { database, host };
+}
+
+export function readSeedEmails(environment: SeedEnvironment): LocalSeedEmails {
+  return {
+    admin: normalizeEmail(required(environment, 'LOCAL_SEED_ADMIN_EMAIL')),
+    resident1: normalizeEmail(required(environment, 'LOCAL_SEED_RESIDENT_1_EMAIL')),
+    resident2: normalizeEmail(required(environment, 'LOCAL_SEED_RESIDENT_2_EMAIL')),
+  };
+}
+
+export function readApplyCredentials(environment: SeedEnvironment): LocalSeedCredentials {
+  return {
+    ...readSeedEmails(environment),
+    adminPassword: required(environment, 'LOCAL_SEED_ADMIN_PASSWORD'),
+    resident1Password: required(environment, 'LOCAL_SEED_RESIDENT_1_PASSWORD'),
+    resident2Password: required(environment, 'LOCAL_SEED_RESIDENT_2_PASSWORD'),
+  };
+}
+
+async function readConnectionInfo(prisma: PrismaClient): Promise<ConnectionInfo> {
+  const rows = await prisma.$queryRaw<ConnectionInfo[]>(Prisma.sql`
+    SELECT
+      current_database() AS "database",
+      current_user AS "user",
+      inet_server_addr()::text AS "address",
+      inet_server_port() AS "port"
+  `);
+  const connection = rows[0];
+  if (!connection) {
+    throw new Error('Could not determine the current PostgreSQL database');
+  }
+  return connection;
+}
+
+async function assertConnectedDatabase(prisma: PrismaClient, target: LocalSeedTarget): Promise<ConnectionInfo> {
+  const connection = await readConnectionInfo(prisma);
+  if (connection.database !== target.database) {
+    throw new Error(`Local manual seed connected to ${connection.database}, expected ${target.database}`);
+  }
+  return connection;
+}
+
+async function financialCounts(client: Prisma.TransactionClient): Promise<FinancialCounts> {
+  const [expenses, liquidations, charges, payments] = await Promise.all([
+    client.expense.count(),
+    client.liquidation.count(),
+    client.charge.count(),
+    client.payment.count(),
+  ]);
+  return { expenses, liquidations, charges, payments };
+}
+
+function sameFinancialCounts(left: FinancialCounts, right: FinancialCounts): boolean {
+  return left.expenses === right.expenses
+    && left.liquidations === right.liquidations
+    && left.charges === right.charges
+    && left.payments === right.payments;
+}
+
+export function assertFreePlanCompatibility(plan: {
+  readonly name: string;
+  readonly monthlyPrice: number;
+  readonly maxBuildings: number;
+  readonly maxUnits: number;
+  readonly maxUsers: number;
+  readonly maxOccupants: number;
+  readonly canExportReports: boolean;
+  readonly canBulkOperations: boolean;
+  readonly canUseAI: boolean;
+  readonly aiBudgetCents: number;
+  readonly aiCallsMonthlyLimit: number;
+  readonly aiAllowBigModel: boolean;
+  readonly aiConsultationsLimit: number;
+  readonly supportLevel: string;
+}): void {
+  const expected = LOCAL_MANUAL_SEED.plan;
+  const compatible = plan.name === expected.name
+    && plan.monthlyPrice === expected.monthlyPrice
+    && plan.maxBuildings >= expected.maxBuildings
+    && plan.maxUnits >= expected.maxUnits
+    && plan.maxUsers >= expected.maxUsers
+    && plan.maxOccupants >= expected.maxOccupants
+    && plan.canExportReports === expected.canExportReports
+    && plan.canBulkOperations === expected.canBulkOperations
+    && plan.canUseAI === expected.canUseAI
+    && plan.aiBudgetCents === expected.aiBudgetCents
+    && plan.aiCallsMonthlyLimit === expected.aiCallsMonthlyLimit
+    && plan.aiAllowBigModel === expected.aiAllowBigModel
+    && plan.aiConsultationsLimit === expected.aiConsultationsLimit
+    && plan.supportLevel === expected.supportLevel;
+
+  if (!compatible) {
+    throw new Error('Existing FREE billing plan is incompatible with the local manual seed contract');
+  }
+}
+
+export function assertLocalManualTenantCompatibility(tenant: { readonly type: TenantType; readonly isDemo: boolean }): void {
+  if (tenant.type !== TenantType.ADMINISTRADORA || tenant.isDemo) {
+    throw new Error('Existing local manual tenant is incompatible with ADMINISTRADORA local setup');
+  }
+}
+
+export function assertLocalManualUserCompatibility(user: { readonly name: string }, spec: SeedUserSpec): void {
+  if (user.name !== spec.name) {
+    throw new Error(`Existing user ${spec.email} has an incompatible name`);
+  }
+}
+
+export function assertLocalManualBuildingCompatibility(building: {
+  readonly name: string;
+  readonly deletedAt: Date | null;
+}): void {
+  if (building.name !== LOCAL_MANUAL_SEED.buildingName || building.deletedAt !== null) {
+    throw new Error('Existing local manual building is incompatible or deleted');
+  }
+}
+
+export function assertLocalManualUnitCompatibility(unit: {
+  readonly tenantId: string;
+  readonly label: string | null;
+  readonly occupancyStatus: string;
+  readonly isBillable: boolean;
+}, tenantId: string, unitSpec: (typeof LOCAL_MANUAL_SEED.units)[number]): void {
+  if (unit.tenantId !== tenantId || unit.label !== unitSpec.label || unit.occupancyStatus !== unitSpec.occupancyStatus || !unit.isBillable) {
+    throw new Error(`Existing unit ${unitSpec.code} is incompatible with the local manual seed`);
+  }
+}
+
+export function assertLocalManualTenantMemberCompatibility(member: {
+  readonly userId: string | null;
+  readonly name: string;
+  readonly role: Role;
+  readonly status: MemberStatus;
+  readonly disabledAt: Date | null;
+}, userId: string, spec: SeedUserSpec): void {
+  if (member.userId !== userId || member.name !== spec.name || member.role !== spec.role || member.status !== MemberStatus.ACTIVE || member.disabledAt !== null) {
+    throw new Error(`Existing tenant member ${spec.email} is incompatible with the local manual seed`);
+  }
+}
+
+export function assertLocalManualOccupancyCompatibility(occupancy: {
+  readonly tenantId: string;
+  readonly role: UnitOccupantRole;
+  readonly isPrimary: boolean;
+  readonly endDate: Date | null;
+}, tenantId: string, email: string): void {
+  if (occupancy.tenantId !== tenantId || occupancy.role !== UnitOccupantRole.RESIDENT || !occupancy.isPrimary || occupancy.endDate !== null) {
+    throw new Error(`Existing occupancy for ${email} is incompatible with the local manual seed`);
+  }
+}
+
+async function ensureUser(
+  tx: Prisma.TransactionClient,
+  spec: SeedUserSpec,
+): Promise<SeedRecordResult> {
+  const existing = await tx.user.findUnique({
+    where: { email: spec.email },
+  });
+
+  if (existing) {
+    assertLocalManualUserCompatibility(existing, spec);
+    if (!(await bcrypt.compare(spec.password, existing.passwordHash))) {
+      throw new Error(`Existing user ${spec.email} does not match the supplied local seed password`);
+    }
+    return { id: existing.id, created: false };
+  }
+
+  const created = await tx.user.create({
+    data: { email: spec.email, name: spec.name, passwordHash: spec.passwordHash },
+  });
+  return { id: created.id, created: true };
+}
+
+async function assertUserHasNoOtherTenantMembership(
+  tx: Prisma.TransactionClient,
+  userId: string,
+  tenantId: string,
+  email: string,
+): Promise<void> {
+  const otherMembership = await tx.membership.findFirst({
+    where: { userId, tenantId: { not: tenantId } },
+    select: { id: true },
+  });
+  if (otherMembership) {
+    throw new Error(`Existing user ${email} belongs to a different tenant`);
+  }
+}
+
+async function ensureMembership(
+  tx: Prisma.TransactionClient,
+  userId: string,
+  tenantId: string,
+): Promise<SeedRecordResult> {
+  const existing = await tx.membership.findUnique({ where: { userId_tenantId: { userId, tenantId } } });
+  if (existing) {
+    return { id: existing.id, created: false };
+  }
+  const created = await tx.membership.create({ data: { userId, tenantId } });
+  return { id: created.id, created: true };
+}
+
+async function ensureTenantRole(
+  tx: Prisma.TransactionClient,
+  tenantId: string,
+  membershipId: string,
+  role: Role,
+): Promise<void> {
+  const existing = await tx.membershipRole.findMany({
+    where: { tenantId, membershipId, role, scopeType: ScopeType.TENANT },
+    select: { id: true, scopeBuildingId: true, scopeUnitId: true },
+  });
+  if (existing.length > 1) {
+    throw new Error(`Membership ${membershipId} has duplicate ${role} tenant roles`);
+  }
+  if (existing.length === 1) {
+    const current = existing[0];
+    if (current?.scopeBuildingId !== null || current.scopeUnitId !== null) {
+      throw new Error(`Membership ${membershipId} has an incompatible ${role} role scope`);
+    }
+    return;
+  }
+  await tx.membershipRole.create({ data: { tenantId, membershipId, role, scopeType: ScopeType.TENANT } });
+}
+
+async function ensureTenantMember(
+  tx: Prisma.TransactionClient,
+  tenantId: string,
+  userId: string,
+  spec: SeedUserSpec,
+): Promise<SeedRecordResult> {
+  const existing = await tx.tenantMember.findUnique({ where: { tenantId_email: { tenantId, email: spec.email } } });
+  if (existing) {
+    assertLocalManualTenantMemberCompatibility(existing, userId, spec);
+    return { id: existing.id, created: false };
+  }
+  const created = await tx.tenantMember.create({
+    data: {
+      tenantId,
+      userId,
+      name: spec.name,
+      email: spec.email,
+      role: spec.role,
+      status: MemberStatus.ACTIVE,
+    },
+  });
+  return { id: created.id, created: true };
+}
+
+async function ensureResidentOccupancy(
+  tx: Prisma.TransactionClient,
+  tenantId: string,
+  unitId: string,
+  memberId: string,
+  email: string,
+): Promise<SeedRecordResult> {
+  const activeElsewhere = await tx.unitOccupant.findFirst({
+    where: { tenantId, memberId, endDate: null, unitId: { not: unitId } },
+    select: { id: true },
+  });
+  if (activeElsewhere) {
+    throw new Error(`Resident ${email} already has an active occupancy in another unit`);
+  }
+
+  const activeUnitOccupant = await tx.unitOccupant.findFirst({
+    where: { tenantId, unitId, endDate: null },
+    select: { id: true, memberId: true },
+  });
+  if (activeUnitOccupant && activeUnitOccupant.memberId !== memberId) {
+    throw new Error(`Target unit for ${email} already has an incompatible active occupant`);
+  }
+
+  const existing = await tx.unitOccupant.findUnique({ where: { unitId_memberId: { unitId, memberId } } });
+  if (existing) {
+    assertLocalManualOccupancyCompatibility(existing, tenantId, email);
+    return { id: existing.id, created: false };
+  }
+
+  const created = await tx.unitOccupant.create({
+    data: { tenantId, unitId, memberId, role: UnitOccupantRole.RESIDENT, isPrimary: true, endDate: null },
+  });
+  return { id: created.id, created: true };
+}
+
+export async function inspectLocalManualSeed(prisma: PrismaClient, target: LocalSeedTarget, emails: LocalSeedEmails): Promise<{
+  readonly connection: ConnectionInfo;
+  readonly existing: Readonly<Record<'plan' | 'tenant' | 'building' | 'units' | 'users', number>>;
+  readonly missingPasswords: readonly string[];
+}> {
+  const connection = await assertConnectedDatabase(prisma, target);
+  const [plan, tenant, users] = await Promise.all([
+    prisma.billingPlan.findUnique({ where: { planId: BillingPlanId.FREE } }),
+    prisma.tenant.findUnique({ where: { name: LOCAL_MANUAL_SEED.tenantName } }),
+    prisma.user.count({ where: { email: { in: [emails.admin, emails.resident1, emails.resident2] } } }),
+  ]);
+  const building = tenant
+    ? await prisma.building.findUnique({ where: { tenantId_alias: { tenantId: tenant.id, alias: LOCAL_MANUAL_SEED.buildingAlias } } })
+    : null;
+  const units = building && tenant
+    ? await prisma.unit.count({ where: { tenantId: tenant.id, buildingId: building.id, code: { in: LOCAL_MANUAL_SEED.units.map((unit) => unit.code) } } })
+    : 0;
+
+  return {
+    connection,
+    existing: { plan: plan ? 1 : 0, tenant: tenant ? 1 : 0, building: building ? 1 : 0, units, users },
+    missingPasswords: [],
+  };
+}
+
+/** Creates or reuses the local manual dataset in one serializable transaction. */
+export async function applyLocalManualSeed(
+  prisma: PrismaClient,
+  target: LocalSeedTarget,
+  credentials: LocalSeedCredentials,
+): Promise<LocalManualSeedResult> {
+  await assertConnectedDatabase(prisma, target);
+  const [adminPasswordHash, resident1PasswordHash, resident2PasswordHash] = await Promise.all([
+    bcrypt.hash(credentials.adminPassword, 10),
+    bcrypt.hash(credentials.resident1Password, 10),
+    bcrypt.hash(credentials.resident2Password, 10),
+  ]);
+
+  return prisma.$transaction(async (tx) => {
+    const beforeFinancial = await financialCounts(tx);
+    const planExisting = await tx.billingPlan.findUnique({ where: { planId: BillingPlanId.FREE } });
+    if (planExisting) {
+      assertFreePlanCompatibility(planExisting);
+    }
+    const plan = planExisting ?? await tx.billingPlan.create({ data: LOCAL_MANUAL_SEED.plan });
+    const planResult = { id: plan.id, created: !planExisting };
+
+    const existingTenant = await tx.tenant.findUnique({ where: { name: LOCAL_MANUAL_SEED.tenantName } });
+    if (existingTenant) {
+      assertLocalManualTenantCompatibility(existingTenant);
+    }
+    const tenant = existingTenant ?? await tx.tenant.create({
+      data: { name: LOCAL_MANUAL_SEED.tenantName, type: TenantType.ADMINISTRADORA, isDemo: false },
+    });
+    const tenantResult = { id: tenant.id, created: !existingTenant };
+
+    const existingSubscription = await tx.subscription.findUnique({ where: { tenantId: tenant.id } });
+    if (existingSubscription && (existingSubscription.planId !== plan.id || existingSubscription.status !== SubscriptionStatus.ACTIVE || existingSubscription.currentPeriodEnd !== null)) {
+      throw new Error('Existing local manual tenant subscription is incompatible with the FREE active subscription');
+    }
+    const subscription = existingSubscription ?? await tx.subscription.create({
+      data: { tenantId: tenant.id, planId: plan.id, status: SubscriptionStatus.ACTIVE, currentPeriodEnd: null },
+    });
+    const subscriptionResult = { id: subscription.id, created: !existingSubscription };
+
+    const aliasElsewhere = await tx.building.findFirst({
+      where: { alias: LOCAL_MANUAL_SEED.buildingAlias, tenantId: { not: tenant.id } },
+      select: { id: true },
+    });
+    if (aliasElsewhere) {
+      throw new Error(`Building alias ${LOCAL_MANUAL_SEED.buildingAlias} already belongs to another tenant`);
+    }
+    const existingBuilding = await tx.building.findUnique({
+      where: { tenantId_alias: { tenantId: tenant.id, alias: LOCAL_MANUAL_SEED.buildingAlias } },
+    });
+    if (existingBuilding) {
+      assertLocalManualBuildingCompatibility(existingBuilding);
+    }
+    const building = existingBuilding ?? await tx.building.create({
+      data: { tenantId: tenant.id, name: LOCAL_MANUAL_SEED.buildingName, alias: LOCAL_MANUAL_SEED.buildingAlias, deletedAt: null },
+    });
+    const buildingResult = { id: building.id, created: !existingBuilding };
+
+    const unitResults: SeedRecordResult[] = [];
+    const unitsByCode = new Map<string, { id: string }>();
+    for (const unitSpec of LOCAL_MANUAL_SEED.units) {
+      const existingUnit = await tx.unit.findUnique({ where: { buildingId_code: { buildingId: building.id, code: unitSpec.code } } });
+      if (existingUnit) {
+        assertLocalManualUnitCompatibility(existingUnit, tenant.id, unitSpec);
+      }
+      const unit = existingUnit ?? await tx.unit.create({
+        data: {
+          tenantId: tenant.id,
+          buildingId: building.id,
+          code: unitSpec.code,
+          label: unitSpec.label,
+          unitType: 'APARTAMENTO',
+          occupancyStatus: unitSpec.occupancyStatus,
+          isBillable: true,
+        },
+      });
+      unitResults.push({ id: unit.id, created: !existingUnit });
+      unitsByCode.set(unitSpec.code, unit);
+    }
+
+    const userSpecs: readonly SeedUserSpec[] = [
+      { name: 'Administrador Local', email: credentials.admin, password: credentials.adminPassword, passwordHash: adminPasswordHash, role: Role.TENANT_OWNER },
+      { name: 'Residente Local 1', email: credentials.resident1, password: credentials.resident1Password, passwordHash: resident1PasswordHash, role: Role.RESIDENT, unitCode: 'A-01-01' },
+      { name: 'Residente Local 2', email: credentials.resident2, password: credentials.resident2Password, passwordHash: resident2PasswordHash, role: Role.RESIDENT, unitCode: 'A-01-02' },
+    ];
+
+    const users: SeedRecordResult[] = [];
+    const memberships: SeedRecordResult[] = [];
+    const tenantMembers: SeedRecordResult[] = [];
+    const occupancies: SeedRecordResult[] = [];
+    for (const userSpec of userSpecs) {
+      const user = await ensureUser(tx, userSpec);
+      await assertUserHasNoOtherTenantMembership(tx, user.id, tenant.id, userSpec.email);
+      const membership = await ensureMembership(tx, user.id, tenant.id);
+      await ensureTenantRole(tx, tenant.id, membership.id, userSpec.role);
+      const tenantMember = await ensureTenantMember(tx, tenant.id, user.id, userSpec);
+      users.push(user);
+      memberships.push(membership);
+      tenantMembers.push(tenantMember);
+
+      if (userSpec.unitCode) {
+        const unit = unitsByCode.get(userSpec.unitCode);
+        if (!unit) {
+          throw new Error(`Missing expected unit ${userSpec.unitCode}`);
+        }
+        occupancies.push(await ensureResidentOccupancy(tx, tenant.id, unit.id, tenantMember.id, userSpec.email));
+      }
+    }
+
+    const vacantUnit = unitsByCode.get('A-02-01');
+    if (!vacantUnit) {
+      throw new Error('Missing expected vacant unit A-02-01');
+    }
+    const unexpectedVacantOccupant = await tx.unitOccupant.findFirst({
+      where: { tenantId: tenant.id, unitId: vacantUnit.id, endDate: null },
+      select: { id: true },
+    });
+    if (unexpectedVacantOccupant) {
+      throw new Error('Unit A-02-01 must remain vacant for the local manual seed');
+    }
+
+    const afterFinancial = await financialCounts(tx);
+    if (!sameFinancialCounts(beforeFinancial, afterFinancial)) {
+      throw new Error('Local manual seed must not create financial records');
+    }
+
+    return {
+      target,
+      tenant: tenantResult,
+      building: buildingResult,
+      subscription: subscriptionResult,
+      units: unitResults,
+      users,
+      memberships,
+      tenantMembers,
+      occupancies,
+      financialCounts: afterFinancial,
+    };
+  }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+}

--- a/apps/api/prisma/lib/seed-liquidation-workflow.ts
+++ b/apps/api/prisma/lib/seed-liquidation-workflow.ts
@@ -1,0 +1,370 @@
+import { Prisma, PrismaClient } from '@prisma/client';
+import { AuditService } from '../../src/audit/audit.service';
+import { FinanzasValidators } from '../../src/finanzas/finanzas.validators';
+import {
+  createLiquidationDraftRecord,
+  LiquidationPublicationUseCase,
+  requireFinanceMembership,
+  reviewLiquidationRecord,
+  type LiquidationExpenseSnapshotItem,
+  type NotificationPolicy,
+} from '../../src/finanzas/liquidation-publication.use-case';
+
+interface WorkflowUnitRecord {
+  readonly id: string;
+  readonly code: string;
+  readonly label: string | null;
+}
+
+interface SeedLiquidationWorkflowInput {
+  readonly prisma: PrismaClient;
+  readonly tenantId: string;
+  readonly buildingId: string;
+  readonly membershipId: string;
+  readonly period: string;
+  readonly chargePeriod?: string | null;
+  readonly baseCurrency: string;
+  readonly totalAmountMinor: number;
+  readonly totalsByCurrency: Prisma.InputJsonObject;
+  readonly expenseSnapshot: Prisma.InputJsonArray;
+  readonly units: ReadonlyArray<WorkflowUnitRecord>;
+  readonly dueDate: Date;
+  readonly notificationPolicy?: NotificationPolicy;
+}
+
+interface SeedWorkflowResult {
+  readonly id: string;
+  readonly created: boolean;
+  readonly status: 'PUBLISHED';
+}
+
+interface ActiveLiquidationRecord {
+  id: string;
+  tenantId: string;
+  buildingId: string;
+  period: string;
+  chargePeriod: string | null;
+  status: 'DRAFT' | 'REVIEWED' | 'PUBLISHED' | 'CANCELED';
+  baseCurrency: string;
+  totalAmountMinor: number;
+  totalsByCurrency: unknown;
+  expenseSnapshot: unknown;
+  publicationSnapshot: unknown;
+  unitCount: number;
+  generatedByMembershipId: string;
+  generatedAt: Date;
+  reviewedAt: Date | null;
+  publishedAt: Date | null;
+  canceledAt: Date | null;
+  createdAt: Date;
+}
+
+function normalizeJson(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeJson(item));
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((accumulator, key) => {
+        accumulator[key] = normalizeJson((value as Record<string, unknown>)[key]);
+        return accumulator;
+      }, {});
+  }
+
+  return value;
+}
+
+function sameJson(left: unknown, right: unknown): boolean {
+  return JSON.stringify(normalizeJson(left)) === JSON.stringify(normalizeJson(right));
+}
+
+function isP2002(error: unknown): error is Prisma.PrismaClientKnownRequestError {
+  return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002';
+}
+
+function normalizeSnapshotForComparison(snapshot: unknown): Record<string, unknown> | null {
+  if (snapshot === null || typeof snapshot !== 'object' || Array.isArray(snapshot)) {
+    return null;
+  }
+
+  const cloned = JSON.parse(JSON.stringify(snapshot)) as Record<string, unknown>;
+  delete cloned.publishedAt;
+  return cloned;
+}
+
+export async function ensureSeedPublishedLiquidation(
+  input: SeedLiquidationWorkflowInput,
+): Promise<SeedWorkflowResult> {
+  const validators = new FinanzasValidators(input.prisma as never);
+  const auditService = new AuditService(input.prisma as never);
+  const publicationUseCase = new LiquidationPublicationUseCase({
+    prisma: input.prisma as never,
+    isAdminOrOperator: (roles) => validators.isAdminOrOperator(roles),
+    createAuditLogRequired: (payload, tx) => auditService.createLogRequired(payload, tx),
+    createAuditLog: (payload) => auditService.createLog(payload),
+    toPublishedLiquidationDto: (liquidation) => ({
+      id: liquidation.id,
+      tenantId: liquidation.tenantId,
+      buildingId: liquidation.buildingId,
+      period: liquidation.period,
+      chargePeriod: liquidation.chargePeriod,
+      status: liquidation.status,
+      baseCurrency: liquidation.baseCurrency,
+      totalAmountMinor: liquidation.totalAmountMinor,
+      totalsByCurrency: liquidation.totalsByCurrency as Record<string, number>,
+      unitCount: liquidation.unitCount,
+      generatedAt: liquidation.generatedAt,
+      reviewedAt: liquidation.reviewedAt,
+      publishedAt: liquidation.publishedAt,
+      canceledAt: liquidation.canceledAt,
+      createdAt: liquidation.createdAt,
+    }),
+    sendChargePublishedNotifications: async () => ({
+      sentCount: 0,
+      failedCount: 0,
+      errorMessages: [],
+    }),
+  });
+
+  const membership = await requireFinanceMembership(
+    input.prisma as never,
+    input.tenantId,
+    input.membershipId,
+    (roles) => validators.isAdminOrOperator(roles),
+  );
+
+  const findActive = async (): Promise<ActiveLiquidationRecord | null> =>
+    input.prisma.liquidation.findFirst({
+      where: {
+        tenantId: input.tenantId,
+        buildingId: input.buildingId,
+        period: input.period,
+        status: { not: 'CANCELED' },
+      },
+    }) as Promise<ActiveLiquidationRecord | null>;
+
+  const expectedDraftExpenseSnapshot = input.expenseSnapshot;
+  const expectedPublishedSnapshotBase = {
+    version: 1,
+    liquidationId: '',
+    tenantId: input.tenantId,
+    buildingId: input.buildingId,
+    period: input.period,
+    baseCurrency: input.baseCurrency,
+    totalAmountMinor: input.totalAmountMinor,
+    totalsByCurrency: input.totalsByCurrency,
+    expenses: expectedDraftExpenseSnapshot,
+    allocations: undefined,
+    dueDate: input.dueDate.toISOString(),
+  };
+
+  const validateCompatible = async (liquidation: ActiveLiquidationRecord): Promise<void> => {
+    if (
+      liquidation.baseCurrency !== input.baseCurrency ||
+      liquidation.totalAmountMinor !== input.totalAmountMinor ||
+      liquidation.unitCount !== input.units.length ||
+      liquidation.chargePeriod !== (input.chargePeriod ?? null) ||
+      !sameJson(liquidation.totalsByCurrency, input.totalsByCurrency) ||
+      !sameJson(liquidation.expenseSnapshot, expectedDraftExpenseSnapshot)
+    ) {
+      throw new Error(
+        `Seed liquidation ${liquidation.id} exists but does not match expected invariants`,
+      );
+    }
+
+    if (liquidation.status !== 'PUBLISHED') {
+      return;
+    }
+
+    const charges = await input.prisma.charge.findMany({
+      where: {
+        tenantId: input.tenantId,
+        liquidationId: liquidation.id,
+        buildingId: input.buildingId,
+        period: input.period,
+      },
+      orderBy: { unitId: 'asc' },
+      select: {
+        unitId: true,
+        amount: true,
+        currency: true,
+        concept: true,
+        dueDate: true,
+        period: true,
+        buildingId: true,
+        liquidationId: true,
+      },
+    });
+
+    if (charges.length !== input.units.length) {
+      throw new Error(
+        `Seed liquidation ${liquidation.id} has ${charges.length} charges but ${input.units.length} were expected`,
+      );
+    }
+
+    const publicationSnapshot = normalizeSnapshotForComparison(liquidation.publicationSnapshot);
+    if (!publicationSnapshot) {
+      throw new Error(`Seed liquidation ${liquidation.id} is missing publicationSnapshot`);
+    }
+
+    if (
+      publicationSnapshot.tenantId !== expectedPublishedSnapshotBase.tenantId ||
+      publicationSnapshot.buildingId !== expectedPublishedSnapshotBase.buildingId ||
+      publicationSnapshot.period !== expectedPublishedSnapshotBase.period ||
+      publicationSnapshot.baseCurrency !== expectedPublishedSnapshotBase.baseCurrency ||
+      publicationSnapshot.totalAmountMinor !== expectedPublishedSnapshotBase.totalAmountMinor ||
+      !sameJson(publicationSnapshot.totalsByCurrency, expectedPublishedSnapshotBase.totalsByCurrency) ||
+      !sameJson(publicationSnapshot.expenses, expectedPublishedSnapshotBase.expenses) ||
+      publicationSnapshot.dueDate !== expectedPublishedSnapshotBase.dueDate
+    ) {
+      throw new Error(
+        `Seed liquidation ${liquidation.id} publication snapshot does not match expected invariants`,
+      );
+    }
+
+    const allocations = Array.isArray(publicationSnapshot.allocations)
+      ? publicationSnapshot.allocations
+      : null;
+
+    if (!allocations || allocations.length !== charges.length) {
+      throw new Error(
+        `Seed liquidation ${liquidation.id} publication snapshot allocations do not match expected charges`,
+      );
+    }
+
+    const expectedByUnit = new Map(
+      allocations.map((allocation) => {
+        const row = allocation as {
+          unitId?: string;
+          amountMinor?: number;
+        };
+        return [row.unitId, row.amountMinor];
+      }),
+    );
+
+    for (const charge of charges) {
+      if (
+        charge.currency !== input.baseCurrency ||
+        charge.buildingId !== input.buildingId ||
+        charge.period !== input.period ||
+        charge.liquidationId !== liquidation.id ||
+        charge.concept !== `Expensas comunes ${input.period}` ||
+        charge.dueDate.toISOString() !== input.dueDate.toISOString() ||
+        expectedByUnit.get(charge.unitId) !== charge.amount
+      ) {
+        throw new Error(
+          `Seed liquidation ${liquidation.id} has charges that do not match the published snapshot`,
+        );
+      }
+    }
+  };
+
+  let liquidation = await findActive();
+  let created = false;
+
+  if (!liquidation) {
+    try {
+      liquidation = await input.prisma.$transaction((tx) =>
+        createLiquidationDraftRecord(tx, {
+          createAuditLogRequired: (payload, client) => auditService.createLogRequired(payload, client),
+        }, {
+          tenantId: input.tenantId,
+          buildingId: input.buildingId,
+          period: input.period,
+          chargePeriod: input.chargePeriod ?? null,
+          baseCurrency: input.baseCurrency,
+          totalAmountMinor: input.totalAmountMinor,
+          totalsByCurrency: input.totalsByCurrency,
+          expenseSnapshot: expectedDraftExpenseSnapshot,
+          unitCount: input.units.length,
+          generatedByMembershipId: membership.id,
+        }),
+      ) as unknown as ActiveLiquidationRecord;
+      created = true;
+    } catch (error) {
+      if (!isP2002(error)) {
+        throw error;
+      }
+
+      liquidation = await findActive();
+      if (!liquidation) {
+        throw error;
+      }
+    }
+  }
+
+  if (!liquidation) {
+    throw new Error(
+      `Seed liquidation ${input.tenantId}/${input.buildingId}/${input.period} could not be loaded`,
+    );
+  }
+
+  let currentLiquidation = liquidation;
+  await validateCompatible(currentLiquidation);
+
+  if (currentLiquidation.status === 'DRAFT') {
+    currentLiquidation = await input.prisma.$transaction((tx) =>
+      reviewLiquidationRecord(tx, {
+        createAuditLogRequired: (payload, client) => auditService.createLogRequired(payload, client),
+      }, {
+        tenantId: input.tenantId,
+        liquidationId: currentLiquidation.id,
+        membershipId: membership.id,
+      }),
+    ) as unknown as ActiveLiquidationRecord;
+    liquidation = currentLiquidation;
+  }
+
+  if (currentLiquidation.status === 'REVIEWED') {
+    await publicationUseCase.execute(
+      input.tenantId,
+      currentLiquidation.id,
+      membership.id,
+      { dueDate: input.dueDate.toISOString() },
+      input.notificationPolicy ?? 'disabled',
+    );
+    liquidation = await findActive();
+    if (!liquidation) {
+      throw new Error(`Seed liquidation ${input.tenantId}/${input.buildingId}/${input.period} disappeared after publish`);
+    }
+    currentLiquidation = liquidation;
+  }
+
+  await validateCompatible(currentLiquidation);
+
+  if (currentLiquidation.status !== 'PUBLISHED') {
+    throw new Error(`Seed liquidation ${currentLiquidation.id} has unsupported status ${currentLiquidation.status}`);
+  }
+
+  return {
+    id: currentLiquidation.id,
+    created,
+    status: 'PUBLISHED',
+  };
+}
+
+export function buildSeedExpenseSnapshotItem(input: {
+  readonly expenseId: string;
+  readonly categoryName: string;
+  readonly vendorName?: string | null;
+  readonly amountMinor: number;
+  readonly currencyCode: string;
+  readonly invoiceDate: Date;
+  readonly description?: string | null;
+  readonly type?: 'EXPENSE' | 'ADJUSTMENT';
+  readonly sourcePeriod?: string;
+}): LiquidationExpenseSnapshotItem {
+  return {
+    expenseId: input.expenseId,
+    categoryName: input.categoryName,
+    vendorName: input.vendorName ?? null,
+    amountMinor: input.amountMinor,
+    currencyCode: input.currencyCode,
+    invoiceDate: input.invoiceDate.toISOString(),
+    description: input.description ?? null,
+    type: input.type ?? 'EXPENSE',
+    ...(input.sourcePeriod ? { sourcePeriod: input.sourcePeriod } : {}),
+  };
+}

--- a/apps/api/prisma/seed-local-manual.ts
+++ b/apps/api/prisma/seed-local-manual.ts
@@ -1,0 +1,78 @@
+import 'dotenv/config';
+
+import { PrismaClient } from '@prisma/client';
+import {
+  applyLocalManualSeed,
+  assertSafeLocalSeedEnvironment,
+  inspectLocalManualSeed,
+  LOCAL_MANUAL_SEED,
+  readApplyCredentials,
+  readSeedEmails,
+} from './lib/local-seed/local-manual-seed';
+
+function hasApplyFlag(args: readonly string[]): boolean {
+  return args.includes('--apply');
+}
+
+function countByMode(records: readonly { readonly created: boolean }[]): { created: number; reused: number } {
+  const created = records.filter((record) => record.created).length;
+  return { created, reused: records.length - created };
+}
+
+async function main(): Promise<void> {
+  const apply = hasApplyFlag(process.argv.slice(2));
+  const target = assertSafeLocalSeedEnvironment(process.env);
+  const emails = readSeedEmails(process.env);
+  const credentials = apply ? readApplyCredentials(process.env) : undefined;
+
+  const prisma = new PrismaClient();
+
+  try {
+    if (!apply) {
+      const inspection = await inspectLocalManualSeed(prisma, target, emails);
+      console.log('Local manual seed diagnostic');
+      console.log(`Target database: ${inspection.connection.database}`);
+      console.log(`Target host: ${target.host}`);
+      console.log(`Tenant type: ADMINISTRADORA`);
+      console.log('Management mode: not supported by the current Tenant model');
+      console.log(`Existing plan/tenant/building/units/users: ${inspection.existing.plan}/${inspection.existing.tenant}/${inspection.existing.building}/${inspection.existing.units}/${inspection.existing.users}`);
+      console.log(`Will prepare: ${LOCAL_MANUAL_SEED.tenantName}, ${LOCAL_MANUAL_SEED.buildingName}, ${LOCAL_MANUAL_SEED.units.length} units, 1 administrator, 2 residents`);
+      console.log('No data was written. Re-run with --apply after providing all LOCAL_SEED_* email and password variables.');
+      return;
+    }
+
+    if (!credentials) {
+      throw new Error('Apply credentials are required before connecting to PostgreSQL');
+    }
+    const result = await applyLocalManualSeed(prisma, target, credentials);
+    const units = countByMode(result.units);
+    const users = countByMode(result.users);
+    const memberships = countByMode(result.memberships);
+    const tenantMembers = countByMode(result.tenantMembers);
+    const occupancies = countByMode(result.occupancies);
+
+    console.log('Local manual seed applied');
+    console.log(`Target database: ${result.target.database}`);
+    console.log('Tenant type: ADMINISTRADORA');
+    console.log('Management mode: not supported by the current Tenant model');
+    console.log(`Tenant: ${result.tenant.created ? 'created' : 'reused'}`);
+    console.log(`Building: ${result.building.created ? 'created' : 'reused'}`);
+    console.log(`Units: created=${units.created}, reused=${units.reused}`);
+    console.log(`Users: created=${users.created}, reused=${users.reused}`);
+    console.log(`Memberships: created=${memberships.created}, reused=${memberships.reused}`);
+    console.log(`TenantMembers: created=${tenantMembers.created}, reused=${tenantMembers.reused}`);
+    console.log(`UnitOccupants: created=${occupancies.created}, reused=${occupancies.reused}`);
+    console.log(`Administrator: ${emails.admin} (TENANT_OWNER)`);
+    console.log(`Residents: ${emails.resident1} → A-01-01; ${emails.resident2} → A-01-02`);
+    console.log('Vacant unit: A-02-01');
+    console.log(`Financial records unchanged: expenses=${result.financialCounts.expenses}, liquidations=${result.financialCounts.liquidations}, charges=${result.financialCounts.charges}, payments=${result.financialCounts.payments}`);
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+void main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Local manual seed failed: ${message}`);
+  process.exitCode = 1;
+});

--- a/apps/api/prisma/seed-pilot-data-pack.ts
+++ b/apps/api/prisma/seed-pilot-data-pack.ts
@@ -10,10 +10,14 @@
  *   NODE_ENV=staging npm run seed:pilot:data-pack:staging -- --tenantId <TENANT_ID> --buildingId <BUILDING_ID>
  */
 
-import { Prisma, PrismaClient, Role, ScopeType, MemberStatus, MovementScope, MovementType, CatalogScope, ExpensePeriodStatus, ExpenseStatus, LiquidationStatus, ChargeStatus, PaymentStatus, PaymentMethod, ReceiptStatus, TicketCategory, TicketPriority, TicketStatus, CommunicationChannel, CommunicationStatus, CommunicationPriority, CommunicationTargetType, DocumentCategory, DocumentVisibility, UnitOccupantRole } from '@prisma/client';
+import { Prisma, PrismaClient, Role, ScopeType, MemberStatus, MovementScope, MovementType, CatalogScope, ExpensePeriodStatus, ExpenseStatus, PaymentStatus, PaymentMethod, ReceiptStatus, TicketCategory, TicketPriority, TicketStatus, CommunicationChannel, CommunicationStatus, CommunicationPriority, CommunicationTargetType, DocumentCategory, DocumentVisibility, UnitOccupantRole } from '@prisma/client';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import * as Minio from 'minio';
+import {
+  buildSeedExpenseSnapshotItem,
+  ensureSeedPublishedLiquidation,
+} from './lib/seed-liquidation-workflow';
 
 interface CliOptions {
   tenantId: string;
@@ -143,13 +147,6 @@ interface ExpenseCategorySeedSpec {
 interface ExpenseDataSeedSpec extends ExpenseCategorySeedSpec {
   amountMinor: number;
   invoiceOffsetDays: number;
-}
-
-interface ExpenseSnapshotEntry extends Prisma.InputJsonObject {
-  expenseId: string;
-  amountMinor: number;
-  currencyCode: string;
-  type: 'EXPENSE';
 }
 
 interface DocumentSeedSpec {
@@ -401,12 +398,6 @@ function addDaysUtc(date: Date, days: number): Date {
   const next = new Date(date.getTime());
   next.setUTCDate(next.getUTCDate() + days);
   return next;
-}
-
-function computeEvenAllocations(totalMinor: number, parts: number): number[] {
-  const baseAmount = Math.floor(totalMinor / parts);
-  const remainder = totalMinor % parts;
-  return Array.from({ length: parts }, (_, index) => baseAmount + (index < remainder ? 1 : 0));
 }
 
 async function ensureBucket(client: Minio.Client, bucket: string, region: string): Promise<void> {
@@ -721,7 +712,7 @@ async function ensureExpense(
 }
 
 async function ensureLiquidation(
-  db: DbClient,
+  db: PrismaClient,
   tenantId: string,
   buildingId: string,
   period: string,
@@ -729,106 +720,25 @@ async function ensureLiquidation(
   ownerMembershipId: string,
   totalAmountMinor: number,
   expenseSnapshot: Prisma.InputJsonArray,
-  unitCount: number,
+  unitRecords: Array<{ id: string; code: string; label: string | null }>,
 ): Promise<{ id: string; created: boolean }> {
-  const id = buildSeedId('pilot-liquidation', tenantId, buildingId, period, chargePeriod ?? 'open');
-  const snapshot: Prisma.InputJsonArray = expenseSnapshot;
-  const totalsByCurrency: Prisma.InputJsonObject = { ARS: totalAmountMinor };
+  const result = await ensureSeedPublishedLiquidation({
+    prisma: db,
+    tenantId,
+    buildingId,
+    membershipId: ownerMembershipId,
+    period,
+    chargePeriod,
+    baseCurrency: 'ARS',
+    totalAmountMinor,
+    totalsByCurrency: { ARS: totalAmountMinor },
+    expenseSnapshot,
+    units: unitRecords,
+    dueDate: new Date(`${chargePeriod}-15T00:00:00.000Z`),
+    notificationPolicy: 'disabled',
+  });
 
-  try {
-    const created = await db.liquidation.create({
-      data: {
-        id,
-        tenantId,
-        buildingId,
-        period,
-        chargePeriod,
-        status: LiquidationStatus.PUBLISHED,
-        baseCurrency: 'ARS',
-        totalAmountMinor,
-        totalsByCurrency,
-        expenseSnapshot: snapshot,
-        unitCount,
-        generatedByMembershipId: ownerMembershipId,
-        generatedAt: new Date(),
-        reviewedByMembershipId: ownerMembershipId,
-        reviewedAt: new Date(),
-        publishedByMembershipId: ownerMembershipId,
-        publishedAt: new Date(),
-      },
-    });
-
-    return { id: created.id, created: true };
-  } catch (error: unknown) {
-    if (!isUniqueConstraintError(error)) {
-      throw error;
-    }
-
-    const existing = await db.liquidation.findFirst({
-      where: { id, tenantId },
-    });
-
-    if (!existing) {
-      throw new Error(`Pilot data pack failed during liquidation reuse. Likely cause: ${describeSeedError(error)}`);
-    }
-
-    return { id: existing.id, created: false };
-  }
-}
-
-async function ensureCharge(
-  db: DbClient,
-  params: {
-    tenantId: string;
-    buildingId: string;
-    unitId: string;
-    period: string;
-    liquidationId: string;
-    amount: number;
-    dueDate: Date;
-    concept: string;
-    periodId?: string;
-    status: ChargeStatus;
-    ownerMembershipId: string;
-  },
-): Promise<{ id: string; created: boolean }> {
-  const id = buildSeedId('pilot-charge', params.tenantId, params.liquidationId, params.unitId, params.period);
-
-  try {
-    const created = await db.charge.create({
-      data: {
-        id,
-        tenantId: params.tenantId,
-        buildingId: params.buildingId,
-        unitId: params.unitId,
-        period: params.period,
-        liquidationId: params.liquidationId,
-        amount: params.amount,
-        dueDate: params.dueDate,
-        concept: params.concept,
-        status: params.status,
-        createdByMembershipId: params.ownerMembershipId,
-        periodId: params.periodId,
-        currency: 'ARS',
-      },
-    });
-
-    return { id: created.id, created: true };
-  } catch (error: unknown) {
-    if (!isUniqueConstraintError(error)) {
-      throw error;
-    }
-
-    const existing = await db.charge.findFirst({
-      where: { id, tenantId: params.tenantId },
-    });
-
-    if (!existing) {
-      throw new Error(`Pilot data pack failed during charge reuse. Likely cause: ${describeSeedError(error)}`);
-    }
-
-    return { id: existing.id, created: false };
-  }
+  return { id: result.id, created: result.created };
 }
 
 async function ensurePayment(
@@ -1374,9 +1284,9 @@ async function loadPilotDataPack() {
     },
   ];
 
-  const financeResult = await runSeedStep('finance seeding', async () => prisma.$transaction(async (tx) => {
+  const financeResult = await runSeedStep('finance seeding', async () => {
     const expensePeriodResult = await ensureExpensePeriod(
-      tx,
+      prisma,
       options.tenantId,
       options.buildingId,
       currentYear,
@@ -1396,7 +1306,7 @@ async function loadPilotDataPack() {
       }
       const invoiceDate = addDaysUtc(startOfUtcMonth(now), spec.invoiceOffsetDays);
       const result = await ensureExpense(
-        tx,
+        prisma,
         options.tenantId,
         options.buildingId,
         currentPeriod,
@@ -1412,15 +1322,23 @@ async function loadPilotDataPack() {
     }
 
     const totalAmountMinor = expenseSpecs.reduce((sum, spec) => sum + spec.amountMinor, 0);
-    const expenseSnapshot: ExpenseSnapshotEntry[] = expenseResults.map((expenseResult, index) => ({
-      expenseId: expenseResult.id,
-      amountMinor: expenseSpecs[index]!.amountMinor,
-      currencyCode: 'ARS',
-      type: 'EXPENSE',
-    }));
+    const expenseSnapshot = expenseResults.map((expenseResult, index) => {
+      const spec = expenseSpecs[index]!;
+      const invoiceDate = addDaysUtc(startOfUtcMonth(now), spec.invoiceOffsetDays);
+
+      return buildSeedExpenseSnapshotItem({
+        expenseId: expenseResult.id,
+        categoryName: spec.name,
+        vendorName: 'Servicios Integrales Piloto',
+        amountMinor: spec.amountMinor,
+        currencyCode: 'ARS',
+        invoiceDate,
+        description: spec.description,
+      });
+    });
 
     const liquidationResult = await ensureLiquidation(
-      tx,
+      prisma,
       options.tenantId,
       options.buildingId,
       currentPeriod,
@@ -1428,38 +1346,32 @@ async function loadPilotDataPack() {
       ownerMembership.id,
       totalAmountMinor,
       expenseSnapshot,
-      unitRecords.length,
+      unitRecords,
     );
     counts.liquidations[liquidationResult.created ? 'created' : 'reused'] += 1;
-
-    const chargeAmounts = computeEvenAllocations(totalAmountMinor, unitRecords.length);
-    const chargeResults: Array<{ id: string; created: boolean; amount: number; unitId: string; period: string }> = [];
-
-    for (let index = 0; index < unitRecords.length; index += 1) {
-      const unit = unitRecords[index]!;
-      const amount = chargeAmounts[index]!;
-      const dueDateForCharge = addDaysUtc(startOfUtcMonth(nextMonthDate), 9);
-      const chargeResult = await ensureCharge(tx, {
+    const publishedCharges = await prisma.charge.findMany({
+      where: {
         tenantId: options.tenantId,
         buildingId: options.buildingId,
-        unitId: unit.id,
-        period: chargePeriod,
         liquidationId: liquidationResult.id,
-        amount,
-        dueDate: dueDateForCharge,
-        concept: `Expensas piloto ${chargePeriod} - Unidad ${unit.code}`,
-        periodId: expensePeriodResult.id,
-        status: ChargeStatus.PENDING,
-        ownerMembershipId: ownerMembership.id,
-      });
-      counts.charges[chargeResult.created ? 'created' : 'reused'] += 1;
-      chargeResults.push({
-        ...chargeResult,
-        amount,
-        unitId: unit.id,
-        period: chargePeriod,
-      });
-    }
+        period: currentPeriod,
+      },
+      orderBy: { unitId: 'asc' },
+      select: {
+        id: true,
+        unitId: true,
+        amount: true,
+        period: true,
+      },
+    });
+    counts.charges[liquidationResult.created ? 'created' : 'reused'] += publishedCharges.length;
+    const chargeResults = publishedCharges.map((charge) => ({
+      id: charge.id,
+      created: liquidationResult.created,
+      amount: charge.amount,
+      unitId: charge.unitId,
+      period: charge.period,
+    }));
 
     const paymentSpecs: Array<{
       reference: string;
@@ -1470,20 +1382,20 @@ async function loadPilotDataPack() {
       {
         reference: 'PILOT-PAGO-001',
         unitId: unitRecords[0]!.id,
-        amount: chargeAmounts[0]!,
+        amount: chargeResults[0]!.amount,
         chargeId: chargeResults[0]!.id,
       },
       {
         reference: 'PILOT-PAGO-002',
         unitId: unitRecords[1]!.id,
-        amount: chargeAmounts[1]!,
+        amount: chargeResults[1]!.amount,
         chargeId: chargeResults[1]!.id,
       },
     ];
 
     const paymentResults: Array<{ id: string; created: boolean; chargeId: string; amount: number }> = [];
     for (const paymentSpec of paymentSpecs) {
-      const payment = await ensurePayment(tx, {
+      const payment = await ensurePayment(prisma, {
         tenantId: options.tenantId,
         buildingId: options.buildingId,
         unitId: paymentSpec.unitId,
@@ -1513,7 +1425,7 @@ async function loadPilotDataPack() {
 
     for (const paymentResult of paymentResults) {
       const allocation = await ensurePaymentAllocation(
-        tx,
+        prisma,
         options.tenantId,
         paymentResult.id,
         paymentResult.chargeId,
@@ -1529,7 +1441,7 @@ async function loadPilotDataPack() {
       chargeResults,
       paymentResults,
     };
-  }));
+  });
 
   const documentSpecs: DocumentSeedSpec[] = [
     {

--- a/apps/api/prisma/seed.test.ts
+++ b/apps/api/prisma/seed.test.ts
@@ -1,5 +1,6 @@
-import { PrismaClient, Role, TenantType, BillingPlanId, ChargeStatus, PaymentStatus, PaymentMethod, ChargeType, LiquidationStatus } from "@prisma/client";
+import { PrismaClient, Role, TenantType, BillingPlanId, ChargeStatus, PaymentStatus, PaymentMethod } from "@prisma/client";
 import * as bcrypt from "bcrypt";
+import { buildSeedExpenseSnapshotItem, ensureSeedPublishedLiquidation } from "./lib/seed-liquidation-workflow";
 
 const prisma = new PrismaClient();
 
@@ -265,7 +266,7 @@ async function main() {
     return membership;
   }
 
-  await upsertMembership({ tenantId: tenantA.id, userId: testUsers.tenantAdminA.id, role: Role.TENANT_ADMIN });
+  const adminMembershipA = await upsertMembership({ tenantId: tenantA.id, userId: testUsers.tenantAdminA.id, role: Role.TENANT_ADMIN });
   await upsertMembership({ tenantId: tenantA.id, userId: testUsers.operator.id, role: Role.OPERATOR });
   await upsertMembership({ tenantId: tenantA.id, userId: testUsers.resident.id, role: Role.RESIDENT });
   await upsertMembership({ tenantId: tenantB.id, userId: testUsers.tenantAdminB.id, role: Role.TENANT_ADMIN });
@@ -420,52 +421,75 @@ async function main() {
   // ============================================================================
   const currentPeriod = "2026-04";
   const currency = "ARS";
+  const expenseSnapshot = [
+    buildSeedExpenseSnapshotItem({
+      expenseId: `seed-expense-${currentPeriod}`,
+      categoryName: "Test Expense",
+      vendorName: "Seed Vendor",
+      amountMinor: 500000,
+      currencyCode: currency,
+      invoiceDate: new Date(`${currentPeriod}-01T00:00:00.000Z`),
+      description: "Test liquidation expense snapshot",
+      type: "EXPENSE",
+    }),
+  ];
 
   // Create a published liquidation for Tenant A, Building A1
-  const liquidationA1 = await prisma.liquidation.upsert({
-    where: { id: "liq-test-a1-apr-2026" },
-    update: {},
-    create: {
-      id: "liq-test-a1-apr-2026",
-      tenantId: tenantA.id,
-      buildingId: buildingA1.id,
-      period: currentPeriod,
-      status: LiquidationStatus.PUBLISHED,
-      totalAmountMinor: 500000, // $5,000.00 ARS
-      baseCurrency: currency,
-      totalsByCurrency: { "ARS": 500000 },
-      expenseSnapshot: [],
-      unitCount: unitsA1.length,
-      generatedByMembershipId: adminMemberA.id,
-      publishedAt: new Date(),
-    },
+  const liquidationWorkflowResult = await ensureSeedPublishedLiquidation({
+    prisma,
+    tenantId: tenantA.id,
+    buildingId: buildingA1.id,
+    membershipId: adminMembershipA.id,
+    period: currentPeriod,
+    chargePeriod: currentPeriod,
+    baseCurrency: currency,
+    totalAmountMinor: 500000,
+    totalsByCurrency: { ARS: 500000 },
+    expenseSnapshot,
+    units: unitsA1.map((unitId, index) => ({
+      id: unitId,
+      code: `A1-10${index + 1}`,
+      label: `Unidad A1-10${index + 1}`,
+    })),
+    dueDate: new Date(`${currentPeriod}-15T00:00:00.000Z`),
+    notificationPolicy: 'disabled',
   });
 
-  // Create charges for each unit in Building A1.
-  // The first charge is marked PAID so the test dataset exercises collection-rate
-  // logic without creating duplicate charges for the same liquidation/unit/period.
-  for (let i = 0; i < unitsA1.length; i++) {
-    const amount = 100000 + i * 10000; // $1,000.00 - $1,400.00
-    const status = i === 0 ? ChargeStatus.PAID : ChargeStatus.PENDING;
-    await prisma.charge.upsert({
-      where: { id: `charge-test-a1-${i}-apr-2026` },
-      update: {},
-      create: {
-        id: `charge-test-a1-${i}-apr-2026`,
-        tenantId: tenantA.id,
-        buildingId: buildingA1.id,
-        unitId: unitsA1[i]!,
-        liquidationId: liquidationA1.id,
-        period: currentPeriod,
-        type: ChargeType.COMMON_EXPENSE,
-        concept: i === 0 ? `Expensas Comunes Abril 2026 (Pagada)` : `Expensas Comunes Abril 2026`,
-        amount,
-        currency,
-        dueDate: new Date(2026, 3, 15), // April 15, 2026
-        status,
-      },
-    });
+  let liquidationA1 = await prisma.liquidation.findUniqueOrThrow({
+    where: { id: liquidationWorkflowResult.id },
+  });
+
+  const expectedTotals = { ARS: 500000 };
+  if (liquidationA1.baseCurrency !== currency || liquidationA1.totalAmountMinor !== 500000 ||
+      liquidationA1.unitCount !== unitsA1.length || liquidationA1.chargePeriod !== null && liquidationA1.chargePeriod !== currentPeriod ||
+      JSON.stringify(liquidationA1.totalsByCurrency) !== JSON.stringify(expectedTotals) ||
+      !Array.isArray(liquidationA1.expenseSnapshot) ||
+      liquidationA1.expenseSnapshot.length !== 1) {
+    throw new Error(`Test liquidation ${liquidationA1.id} does not match the expected fixture`);
   }
+  const [snapshotExpense] = liquidationA1.expenseSnapshot as Array<{ amountMinor?: number; currencyCode?: string }>;
+  if (!snapshotExpense || snapshotExpense.amountMinor !== 500000 || snapshotExpense.currencyCode !== currency) {
+    throw new Error(`Test liquidation ${liquidationA1.id} snapshot expense does not match the expected fixture`);
+  }
+  const chargesA1 = await prisma.charge.findMany({
+    where: {
+      tenantId: tenantA.id,
+      buildingId: buildingA1.id,
+      liquidationId: liquidationA1.id,
+      period: currentPeriod,
+    },
+    orderBy: { unitId: "asc" },
+  });
+  if (chargesA1.length !== unitsA1.length) {
+    throw new Error(`Expected ${unitsA1.length} generated charges but got ${chargesA1.length}`);
+  }
+
+  await prisma.charge.update({
+    where: { id: chargesA1[0]!.id },
+    data: {
+      status: ChargeStatus.PAID,
+    },
+  });
 
   // Create one SUBMITTED payment
   await prisma.payment.upsert({
@@ -476,7 +500,7 @@ async function main() {
       tenantId: tenantA.id,
       buildingId: buildingA1.id,
       unitId: unitsA1[1],
-      amount: 110000,
+      amount: chargesA1[1]!.amount,
       currency,
       method: PaymentMethod.TRANSFER,
       status: PaymentStatus.SUBMITTED,

--- a/apps/api/scripts/reset-local-user-password.ts
+++ b/apps/api/scripts/reset-local-user-password.ts
@@ -1,0 +1,7 @@
+import { main } from '../src/local-seed/reset-local-user-password';
+
+main().catch((error: unknown) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`Local password reset failed: ${message}`);
+  process.exit(1);
+});

--- a/apps/api/src/audit/audit.service.spec.ts
+++ b/apps/api/src/audit/audit.service.spec.ts
@@ -142,6 +142,43 @@ describe('AuditService', () => {
     });
   });
 
+  it('writes global audit logs with a null tenantId when the domain is global', async () => {
+    const tx = {
+      auditLog: {
+        create: jest.fn().mockResolvedValue(undefined),
+      },
+    };
+
+    await service.createGlobalLogRequired(
+      {
+        actorMembershipId: 'member-1',
+        action: 'AUTH_LOGIN',
+        entityType: 'User',
+        entityId: 'user-1',
+        metadata: {
+          email: 'user@example.com',
+          isSuperAdmin: true,
+        },
+      },
+      tx as never,
+    );
+
+    expect(tx.auditLog.create).toHaveBeenCalledWith({
+      data: {
+        tenantId: null,
+        actorUserId: null,
+        actorMembershipId: 'member-1',
+        action: 'AUTH_LOGIN',
+        entity: 'User',
+        entityId: 'user-1',
+        metadata: {
+          email: 'user@example.com',
+          isSuperAdmin: true,
+        },
+      },
+    });
+  });
+
   it('persists JSON metadata values without unsafe casts', async () => {
     const tx = {
       auditLog: {
@@ -334,5 +371,24 @@ describe('AuditService', () => {
     ).resolves.toBeUndefined();
 
     expect(prisma.auditLog.create).not.toHaveBeenCalled();
+  });
+
+  it('keeps createLog fire-and-forget when persistence fails', async () => {
+    prisma.auditLog.create.mockRejectedValueOnce(new Error('database down'));
+
+    await expect(
+      service.createLog({
+        tenantId: 'tenant-a',
+        actorMembershipId: 'member-1',
+        action: 'AUTH_LOGIN',
+        entityType: 'User',
+        entityId: 'user-1',
+        metadata: {
+          email: 'user@example.com',
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(prisma.auditLog.create).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/audit/audit.service.ts
+++ b/apps/api/src/audit/audit.service.ts
@@ -33,6 +33,15 @@ interface AuditWriteClient {
   };
 }
 
+interface GlobalAuditLogInput {
+  actorUserId?: string;
+  actorMembershipId?: string;
+  action: AuditAction;
+  entityType: string;
+  entityId: string;
+  metadata?: unknown;
+}
+
 interface MembershipQueryClient {
   membership: {
     findFirst: (args: {
@@ -77,23 +86,51 @@ export class AuditService {
     }
   }
 
+  async createGlobalLog(input: GlobalAuditLogInput): Promise<void> {
+    try {
+      await this.createGlobalLogRequired(input, this.prisma);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error('[AuditService] Failed to write global audit log', {
+        message,
+        input,
+        timestamp: new Date().toISOString(),
+      });
+    }
+  }
+
   async createLogRequired(input: AuditLogInput, tx: AuditWriteClient): Promise<void> {
     const tenantId = this.normalizeTenantId(input.tenantId);
-    const metadata = this.normalizeMetadata(
-      input.metadata === undefined ? {} : input.metadata,
-    );
-
-    await tx.auditLog.create({
-      data: {
+    await this.writeLog(
+      {
         tenantId,
-        actorUserId: input.actorUserId ?? null,
-        actorMembershipId: input.actorMembershipId ?? null,
+        actorUserId: input.actorUserId,
+        actorMembershipId: input.actorMembershipId,
         action: input.action,
-        entity: input.entityType,
+        entityType: input.entityType,
         entityId: input.entityId,
-        metadata,
+        metadata: input.metadata,
       },
-    });
+      tx,
+    );
+  }
+
+  async createGlobalLogRequired(
+    input: GlobalAuditLogInput,
+    tx: AuditWriteClient,
+  ): Promise<void> {
+    await this.writeLog(
+      {
+        tenantId: null,
+        actorUserId: input.actorUserId,
+        actorMembershipId: input.actorMembershipId,
+        action: input.action,
+        entityType: input.entityType,
+        entityId: input.entityId,
+        metadata: input.metadata,
+      },
+      tx,
+    );
   }
 
   async queryTenantLogs(
@@ -197,6 +234,35 @@ export class AuditService {
     }
 
     return normalized;
+  }
+
+  private async writeLog(
+    input: {
+      tenantId: string | null;
+      actorUserId?: string;
+      actorMembershipId?: string;
+      action: AuditAction;
+      entityType: string;
+      entityId: string;
+      metadata?: unknown;
+    },
+    tx: AuditWriteClient,
+  ): Promise<void> {
+    const metadata = this.normalizeMetadata(
+      input.metadata === undefined ? {} : input.metadata,
+    );
+
+    await tx.auditLog.create({
+      data: {
+        tenantId: input.tenantId,
+        actorUserId: input.actorUserId ?? null,
+        actorMembershipId: input.actorMembershipId ?? null,
+        action: input.action,
+        entity: input.entityType,
+        entityId: input.entityId,
+        metadata,
+      },
+    });
   }
 
   private assertValidDate(value: Date | undefined, field: 'dateFrom' | 'dateTo'): void {

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -5,6 +5,7 @@ import {
   Get,
   UseGuards,
   Request,
+  Headers,
   UnauthorizedException,
   Res,
 } from '@nestjs/common';
@@ -81,6 +82,7 @@ export class AuthController {
   @Post('login')
   async login(
     @Body() loginDto: LoginDto,
+    @Headers('x-tenant-id') selectedTenantId: string | undefined,
     @Res({ passthrough: true }) res: Response,
   ): Promise<PublicAuthResponse> {
     const user = await this.authService.validateUser(
@@ -92,7 +94,7 @@ export class AuthController {
       await this.authService.logFailedLogin(loginDto.email);
       throw new UnauthorizedException('Credenciales inválidas');
     }
-    const response = await this.authService.login(user);
+    const response = await this.authService.login(user, selectedTenantId ?? null);
     setAuthCookies(res, response.accessToken, response.refreshToken);
 
     // Set user context in Sentry for error tracking

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -69,6 +69,7 @@ describe('AuthService', () => {
           provide: AuditService,
           useValue: {
             createLog: jest.fn(),
+            createGlobalLog: jest.fn(),
           },
         },
       ],
@@ -562,6 +563,7 @@ describe('AuthService', () => {
 
       // ASSERT
       expect(auditService.createLog).toHaveBeenCalledWith({
+        tenantId: 'tenant-123',
         actorUserId: 'user-123',
         action: AuditAction.AUTH_LOGIN,
         entityType: 'User',
@@ -569,9 +571,176 @@ describe('AuthService', () => {
         metadata: {
           email: 'user@example.com',
           isSuperAdmin: false,
+          membershipCount: 1,
+          tenantIds: ['tenant-123'],
+          selectedTenantId: 'tenant-123',
         },
       });
     });
+
+    it('should write a global audit log for superadmin logins', async () => {
+      const user = {
+        id: 'admin-123',
+        email: 'admin@example.com',
+        name: 'Admin User',
+        memberships: [
+          {
+            tenantId: 'tenant-123',
+            roles: [{ role: 'SUPER_ADMIN' }],
+          },
+          {
+            tenantId: 'tenant-456',
+            roles: [{ role: 'TENANT_OWNER' }],
+          },
+        ],
+      };
+
+      jest.spyOn(tenancyService, 'getMembershipsForUser').mockResolvedValue([
+        { tenantId: 'tenant-123', roles: ['SUPER_ADMIN'] },
+        { tenantId: 'tenant-456', roles: ['TENANT_OWNER'] },
+      ] as any);
+      jest.spyOn(prismaService.authSession, 'create').mockResolvedValue({
+        id: 'session-admin-global',
+        userId: 'admin-123',
+        refreshTokenHash: 'refresh-hash',
+        expiresAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        lastUsedAt: null,
+        revokedAt: null,
+        userAgent: null,
+        ipAddress: null,
+      } as any);
+      jest.spyOn(jwtService, 'sign').mockReturnValue('jwt_token_global');
+      jest.spyOn(auditService, 'createGlobalLog').mockResolvedValue(undefined);
+
+      await service.login(user as any);
+
+      expect(auditService.createGlobalLog).toHaveBeenCalledWith({
+        actorUserId: 'admin-123',
+        action: AuditAction.AUTH_LOGIN,
+        entityType: 'User',
+        entityId: 'admin-123',
+        metadata: {
+          email: 'admin@example.com',
+          isSuperAdmin: true,
+          membershipCount: 2,
+          tenantIds: ['tenant-123', 'tenant-456'],
+          selectedTenantId: null,
+        },
+      });
+      expect(auditService.createLog).not.toHaveBeenCalled();
+    });
+
+    it('should write a global audit log for multi-tenant logins without a selected tenant', async () => {
+      const user = {
+        id: 'user-multi',
+        email: 'multi@example.com',
+        name: 'Multi User',
+        memberships: [
+          {
+            tenantId: 'tenant-123',
+            roles: [{ role: 'TENANT_OWNER' }],
+          },
+          {
+            tenantId: 'tenant-456',
+            roles: [{ role: 'OPERATOR' }],
+          },
+        ],
+      };
+
+      jest.spyOn(tenancyService, 'getMembershipsForUser').mockResolvedValue([
+        { tenantId: 'tenant-123', roles: ['TENANT_OWNER'] },
+        { tenantId: 'tenant-456', roles: ['OPERATOR'] },
+      ] as any);
+      jest.spyOn(prismaService.authSession, 'create').mockResolvedValue({
+        id: 'session-multi-global',
+        userId: 'user-multi',
+        refreshTokenHash: 'refresh-hash',
+        expiresAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        lastUsedAt: null,
+        revokedAt: null,
+        userAgent: null,
+        ipAddress: null,
+      } as any);
+      jest.spyOn(jwtService, 'sign').mockReturnValue('jwt_token_multi');
+      jest.spyOn(auditService, 'createGlobalLog').mockResolvedValue(undefined);
+
+      await service.login(user as any);
+
+      expect(auditService.createGlobalLog).toHaveBeenCalledWith({
+        actorUserId: 'user-multi',
+        action: AuditAction.AUTH_LOGIN,
+        entityType: 'User',
+        entityId: 'user-multi',
+        metadata: {
+          email: 'multi@example.com',
+          isSuperAdmin: false,
+          membershipCount: 2,
+          tenantIds: ['tenant-123', 'tenant-456'],
+          selectedTenantId: null,
+        },
+      });
+      expect(auditService.createLog).not.toHaveBeenCalled();
+    });
+
+    it('should audit the selected tenant when login receives one', async () => {
+      const user = {
+        id: 'user-selected',
+        email: 'selected@example.com',
+        name: 'Selected User',
+        memberships: [
+          {
+            tenantId: 'tenant-123',
+            roles: [{ role: 'TENANT_OWNER' }],
+          },
+          {
+            tenantId: 'tenant-456',
+            roles: [{ role: 'OPERATOR' }],
+          },
+        ],
+      };
+
+      jest.spyOn(tenancyService, 'getMembershipsForUser').mockResolvedValue([
+        { tenantId: 'tenant-123', roles: ['TENANT_OWNER'] },
+        { tenantId: 'tenant-456', roles: ['OPERATOR'] },
+      ] as any);
+      jest.spyOn(prismaService.authSession, 'create').mockResolvedValue({
+        id: 'session-selected',
+        userId: 'user-selected',
+        refreshTokenHash: 'refresh-hash',
+        expiresAt: new Date(),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        lastUsedAt: null,
+        revokedAt: null,
+        userAgent: null,
+        ipAddress: null,
+      } as any);
+      jest.spyOn(jwtService, 'sign').mockReturnValue('jwt_token_selected');
+      jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
+
+      await service.login(user as any, 'tenant-456');
+
+      expect(auditService.createLog).toHaveBeenCalledWith({
+        tenantId: 'tenant-456',
+        actorUserId: 'user-selected',
+        action: AuditAction.AUTH_LOGIN,
+        entityType: 'User',
+        entityId: 'user-selected',
+        metadata: {
+          email: 'selected@example.com',
+          isSuperAdmin: false,
+          membershipCount: 2,
+          tenantIds: ['tenant-123', 'tenant-456'],
+          selectedTenantId: 'tenant-456',
+        },
+      });
+      expect(auditService.createGlobalLog).not.toHaveBeenCalled();
+    });
+
   });
 
   // ========== TESTS: REFRESH SESSION ==========

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -23,6 +23,11 @@ interface UserWithMemberships {
   }>;
 }
 
+interface TenantMembershipForLogin {
+  tenantId: string;
+  roles: string[];
+}
+
 export interface AuthResponse {
   accessToken: string;
   refreshToken: string;
@@ -157,22 +162,45 @@ export class AuthService {
     return null;
   }
 
-  async login(user: UserWithMemberships): Promise<AuthResponse> {
-    const memberships = await this.tenancyService.getMembershipsForUser(user.id);
+  async login(
+    user: UserWithMemberships,
+    selectedTenantId?: string | null,
+  ): Promise<AuthResponse> {
+    const memberships = (await this.tenancyService.getMembershipsForUser(user.id)) as TenantMembershipForLogin[];
     const isSuperAdmin = memberships.some((m) =>
       m.roles.includes('SUPER_ADMIN'),
     );
+    const loginAuditTenantId = this.resolveLoginAuditTenantId(
+      memberships,
+      isSuperAdmin,
+      selectedTenantId,
+    );
+    const auditMetadata = {
+      email: user.email,
+      isSuperAdmin,
+      membershipCount: memberships.length,
+      tenantIds: memberships.map((membership) => membership.tenantId),
+      selectedTenantId: loginAuditTenantId,
+    };
 
-    void this.auditService.createLog({
-      actorUserId: user.id,
-      action: AuditAction.AUTH_LOGIN,
-      entityType: 'User',
-      entityId: user.id,
-      metadata: {
-        email: user.email,
-        isSuperAdmin,
-      },
-    });
+    if (loginAuditTenantId) {
+      void this.auditService.createLog({
+        tenantId: loginAuditTenantId,
+        actorUserId: user.id,
+        action: AuditAction.AUTH_LOGIN,
+        entityType: 'User',
+        entityId: user.id,
+        metadata: auditMetadata,
+      });
+    } else {
+      void this.auditService.createGlobalLog({
+        actorUserId: user.id,
+        action: AuditAction.AUTH_LOGIN,
+        entityType: 'User',
+        entityId: user.id,
+        metadata: auditMetadata,
+      });
+    }
 
     return this.createAuthResponse({
       user: {
@@ -343,6 +371,30 @@ export class AuthService {
 
   private hashToken(token: string): string {
     return crypto.createHash('sha256').update(token).digest('hex');
+  }
+
+  private resolveLoginAuditTenantId(
+    memberships: TenantMembershipForLogin[],
+    isSuperAdmin: boolean,
+    selectedTenantId?: string | null,
+  ): string | null {
+    if (selectedTenantId != null) {
+      const matchingMembership = memberships.find(
+        (membership) => membership.tenantId === selectedTenantId,
+      );
+
+      return matchingMembership?.tenantId ?? null;
+    }
+
+    if (isSuperAdmin) {
+      return null;
+    }
+
+    if (memberships.length === 1) {
+      return memberships[0]?.tenantId ?? null;
+    }
+
+    return null;
   }
 
   private getSessionExpiresAt(): Date {

--- a/apps/api/src/finanzas/finanzas.module.ts
+++ b/apps/api/src/finanzas/finanzas.module.ts
@@ -8,6 +8,10 @@ import { ExpenseLedgerCategoriesController } from './expense-ledger-categories.c
 import { ExpensesController } from './expenses.controller';
 import { IncomesController } from './incomes.controller';
 import { LiquidationsController } from './liquidations.controller';
+import {
+  createLiquidationWorkflowDependencies,
+  LiquidationPublicationUseCase,
+} from './liquidation-publication.use-case';
 import { UnitGroupController } from './unit-group.controller';
 import { MovementAllocationController } from './movement-allocation.controller';
 import { AdjustmentsController } from './adjustments.controller';
@@ -24,8 +28,11 @@ import { UnitGroupService } from './unit-group.service';
 import { LiquidationEngineService } from './liquidation-engine.service';
 import { AdjustmentsService } from './adjustments.service';
 import { PrismaModule } from '../prisma/prisma.module';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
 import { EmailModule } from '../email/email.module';
 import { NotificationsModule } from '../notifications/notifications.module';
+import { NotificationsService } from '../notifications/notifications.service';
 import { StorageModule } from '../storage/storage.module';
 import { PaymentGatewayModule } from './payment-gateway/payment-gateway.module';
 import { ConfigService } from '../config/config.service';
@@ -81,6 +88,24 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     ExpenseLedgerCategoriesService,
     ExpensesService,
     IncomesService,
+    {
+      provide: LiquidationPublicationUseCase,
+      inject: [PrismaService, AuditService, FinanzasValidators, NotificationsService],
+      useFactory: (
+        prisma: PrismaService,
+        auditService: AuditService,
+        validators: FinanzasValidators,
+        notificationsService: NotificationsService,
+      ) =>
+        new LiquidationPublicationUseCase(
+          createLiquidationWorkflowDependencies({
+            prisma,
+            auditService,
+            validators,
+            notificationsService,
+          }),
+        ),
+    },
     LiquidationsService,
     MovementAllocationService,
     UnitGroupService,

--- a/apps/api/src/finanzas/liquidation-publication.postgres.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication.postgres.spec.ts
@@ -1,0 +1,813 @@
+import { ConflictException } from '@nestjs/common';
+import {
+  Prisma,
+  PrismaClient,
+  Role,
+  ScopeType,
+  TenantType,
+} from '@prisma/client';
+import { AuditService } from '../audit/audit.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { LiquidationsService } from './liquidations.service';
+import {
+  createLiquidationWorkflowDependencies,
+  createLiquidationDraftRecord,
+  LiquidationPublicationUseCase,
+  reviewLiquidationRecord,
+  type LiquidationWorkflowDependencies,
+} from './liquidation-publication.use-case';
+import { ensureSeedPublishedLiquidation } from '../../prisma/lib/seed-liquidation-workflow';
+
+const describePostgresIntegration =
+  process.env.RUN_POSTGRES_INTEGRATION === '1' ? describe : describe.skip;
+
+describePostgresIntegration('Liquidation publication PostgreSQL integration', () => {
+  const expectedDatabaseName = process.env.POSTGRES_TEST_DB_NAME;
+  let prisma: PrismaClient;
+  let auditService: AuditService;
+  let validators: FinanzasValidators;
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) {
+      throw new Error('DATABASE_URL is required for PostgreSQL integration tests');
+    }
+
+    prisma = new PrismaClient();
+    await prisma.$connect();
+    auditService = new AuditService(prisma as unknown as PrismaService);
+    validators = new FinanzasValidators(prisma as unknown as PrismaService);
+  });
+
+  afterAll(async () => {
+    await prisma?.$disconnect();
+  });
+
+  beforeEach(async () => {
+    const [row] = await prisma.$queryRaw<Array<{ current_database: string }>>`
+      SELECT current_database()
+    `;
+
+    if (!row?.current_database) {
+      throw new Error('Could not determine current_database()');
+    }
+
+    if (row.current_database === 'buildingos') {
+      throw new Error('Refusing to run destructive integration tests against buildingos');
+    }
+
+    if (expectedDatabaseName && row.current_database !== expectedDatabaseName) {
+      throw new Error(
+        `Refusing to run against unexpected database ${row.current_database}; expected ${expectedDatabaseName}`,
+      );
+    }
+  });
+
+  const suffix = () =>
+    `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+
+  const toResponseDto: LiquidationWorkflowDependencies['toPublishedLiquidationDto'] = (liquidation) => ({
+    id: liquidation.id,
+    tenantId: liquidation.tenantId,
+    buildingId: liquidation.buildingId,
+    period: liquidation.period,
+    chargePeriod: liquidation.chargePeriod,
+    status: liquidation.status,
+    baseCurrency: liquidation.baseCurrency,
+    totalAmountMinor: liquidation.totalAmountMinor,
+    totalsByCurrency: liquidation.totalsByCurrency as Record<string, number>,
+    unitCount: liquidation.unitCount,
+    generatedAt: liquidation.generatedAt,
+    reviewedAt: liquidation.reviewedAt,
+    publishedAt: liquidation.publishedAt,
+    canceledAt: liquidation.canceledAt,
+    createdAt: liquidation.createdAt,
+  });
+
+  const createDeps = (options?: {
+    prismaOverride?: LiquidationWorkflowDependencies['prisma'];
+    sendChargePublishedNotifications?: LiquidationWorkflowDependencies['sendChargePublishedNotifications'];
+  }): LiquidationWorkflowDependencies => ({
+    prisma: options?.prismaOverride ?? (prisma as unknown as LiquidationWorkflowDependencies['prisma']),
+    isAdminOrOperator: (roles) => validators.isAdminOrOperator(roles),
+    createAuditLogRequired: (input, tx) => auditService.createLogRequired(input, tx),
+    createAuditLog: (input) => auditService.createLog(input),
+    toPublishedLiquidationDto: toResponseDto,
+    sendChargePublishedNotifications:
+      options?.sendChargePublishedNotifications ??
+      (async () => ({ sentCount: 0, failedCount: 0, errorMessages: [] })),
+  });
+
+  const createUseCase = (options?: Parameters<typeof createDeps>[0]) =>
+    new LiquidationPublicationUseCase(createDeps(options));
+
+  const buildExpenseSnapshot = (
+    period: string,
+    totalAmountMinor: number,
+  ): Prisma.InputJsonArray => [
+    {
+      expenseId: `exp-${period}`,
+      categoryName: 'Integration Expense',
+      vendorName: null,
+      amountMinor: totalAmountMinor,
+      currencyCode: 'ARS',
+      invoiceDate: `${period}-01T00:00:00.000Z`,
+      description: 'Integration expense snapshot',
+      type: 'EXPENSE',
+    },
+  ];
+
+  async function createFinanceContext(label: string, unitCount: number = 2) {
+    const idSuffix = suffix();
+    const tenant = await prisma.tenant.create({
+      data: {
+        name: `ITEST ${label} ${idSuffix}`,
+        type: TenantType.ADMINISTRADORA,
+      },
+    });
+
+    const user = await prisma.user.create({
+      data: {
+        email: `itest-${label}-${idSuffix}@buildingos.local`,
+        name: `ITest ${label}`,
+        passwordHash: 'integration-test-hash',
+      },
+    });
+
+    const membership = await prisma.membership.create({
+      data: {
+        tenantId: tenant.id,
+        userId: user.id,
+      },
+    });
+
+    await prisma.membershipRole.create({
+      data: {
+        tenantId: tenant.id,
+        membershipId: membership.id,
+        role: Role.TENANT_ADMIN,
+        scopeType: ScopeType.TENANT,
+      },
+    });
+
+    const building = await prisma.building.create({
+      data: {
+        tenantId: tenant.id,
+        name: `ITEST Building ${label} ${idSuffix}`,
+        alias: `IT-${idSuffix.slice(0, 8)}`,
+        address: 'Integration Street 123',
+      },
+    });
+
+    const units = await Promise.all(
+      Array.from({ length: unitCount }, async (_, index) =>
+        prisma.unit.create({
+          data: {
+            tenantId: tenant.id,
+            buildingId: building.id,
+            code: `U-${index + 1}`,
+            label: `Unit ${index + 1}`,
+            unitType: 'APARTAMENTO',
+            occupancyStatus: 'OCCUPIED',
+            isBillable: true,
+          },
+        }),
+      ),
+    );
+
+    return { tenant, user, membership, building, units };
+  }
+
+  async function createDraftAndReview(params: {
+    tenantId: string;
+    buildingId: string;
+    membershipId: string;
+    period: string;
+    chargePeriod?: string | null;
+    totalAmountMinor?: number;
+    expenseSnapshot?: Prisma.InputJsonArray;
+  }) {
+    const totalAmountMinor = params.totalAmountMinor ?? 200;
+    const expenseSnapshot = params.expenseSnapshot ?? buildExpenseSnapshot(params.period, totalAmountMinor);
+
+    const draft = await prisma.$transaction((tx) =>
+      createLiquidationDraftRecord(
+        tx,
+        {
+          createAuditLogRequired: (input, client) =>
+            auditService.createLogRequired(input, client),
+        },
+        {
+          tenantId: params.tenantId,
+          buildingId: params.buildingId,
+          period: params.period,
+          chargePeriod: params.chargePeriod ?? null,
+          baseCurrency: 'ARS',
+          totalAmountMinor,
+          totalsByCurrency: { ARS: totalAmountMinor },
+          expenseSnapshot,
+          unitCount: 2,
+          generatedByMembershipId: params.membershipId,
+        },
+      ),
+    );
+
+    const reviewed = await prisma.$transaction((tx) =>
+      reviewLiquidationRecord(
+        tx,
+        {
+          createAuditLogRequired: (input, client) =>
+            auditService.createLogRequired(input, client),
+        },
+        {
+          tenantId: params.tenantId,
+          liquidationId: draft.id,
+          membershipId: params.membershipId,
+        },
+      ),
+    );
+
+    return reviewed;
+  }
+
+  async function createCancelService() {
+    const notificationsService = {
+      createNotification: jest.fn(),
+    } as unknown as NotificationsService;
+
+    return new LiquidationsService(
+      prisma as unknown as PrismaService,
+      auditService,
+      validators,
+      notificationsService,
+      new LiquidationPublicationUseCase(
+        createLiquidationWorkflowDependencies({
+          prisma: prisma as unknown as PrismaService,
+          auditService,
+          validators,
+          notificationsService,
+        }),
+      ),
+    );
+  }
+
+  it('enforces the partial unique index and allows a new active liquidation after canceling the previous one', async () => {
+    const ctx = await createFinanceContext('partial-index');
+
+    const first = await prisma.$transaction((tx) =>
+      createLiquidationDraftRecord(
+        tx,
+        {
+          createAuditLogRequired: (input, client) =>
+            auditService.createLogRequired(input, client),
+        },
+        {
+          tenantId: ctx.tenant.id,
+          buildingId: ctx.building.id,
+          period: '2026-07',
+          chargePeriod: '2026-08',
+          baseCurrency: 'ARS',
+          totalAmountMinor: 200,
+          totalsByCurrency: { ARS: 200 },
+          expenseSnapshot: [],
+          unitCount: ctx.units.length,
+          generatedByMembershipId: ctx.membership.id,
+        },
+      ),
+    );
+
+    await expect(
+      prisma.$transaction((tx) =>
+        createLiquidationDraftRecord(
+          tx,
+          {
+            createAuditLogRequired: (input, client) =>
+              auditService.createLogRequired(input, client),
+          },
+          {
+            tenantId: ctx.tenant.id,
+            buildingId: ctx.building.id,
+            period: '2026-07',
+            chargePeriod: '2026-08',
+            baseCurrency: 'ARS',
+            totalAmountMinor: 200,
+            totalsByCurrency: { ARS: 200 },
+            expenseSnapshot: [],
+            unitCount: ctx.units.length,
+            generatedByMembershipId: ctx.membership.id,
+          },
+        ),
+      ),
+    ).rejects.toMatchObject({ code: 'P2002' });
+
+    const cancelService = await createCancelService();
+    const canceled = await cancelService.cancelLiquidation(
+      ctx.tenant.id,
+      first.id,
+      ctx.membership.id,
+      { reason: 'Partial index integration test' },
+    );
+
+    expect(canceled.status).toBe('CANCELED');
+
+    const second = await prisma.$transaction((tx) =>
+      createLiquidationDraftRecord(
+        tx,
+        {
+          createAuditLogRequired: (input, client) =>
+            auditService.createLogRequired(input, client),
+        },
+        {
+          tenantId: ctx.tenant.id,
+          buildingId: ctx.building.id,
+          period: '2026-07',
+          chargePeriod: '2026-08',
+          baseCurrency: 'ARS',
+          totalAmountMinor: 200,
+          totalsByCurrency: { ARS: 200 },
+          expenseSnapshot: [],
+          unitCount: ctx.units.length,
+          generatedByMembershipId: ctx.membership.id,
+        },
+      ),
+    );
+
+    expect(second.id).not.toBe(first.id);
+  });
+
+  it('publishes through the real PostgreSQL transaction, writes snapshot V1, audit, and charges', async () => {
+    const ctx = await createFinanceContext('publish');
+    const reviewed = await createDraftAndReview({
+      tenantId: ctx.tenant.id,
+      buildingId: ctx.building.id,
+      membershipId: ctx.membership.id,
+      period: '2026-09',
+      chargePeriod: '2026-10',
+    });
+
+    const result = await createUseCase().execute(
+      ctx.tenant.id,
+      reviewed.id,
+      ctx.membership.id,
+      { dueDate: '2026-10-10' },
+      'disabled',
+    );
+
+    expect(result.status).toBe('PUBLISHED');
+
+    const persisted = await prisma.liquidation.findUniqueOrThrow({
+      where: { id: reviewed.id },
+    });
+    expect(persisted.status).toBe('PUBLISHED');
+    expect(persisted.publicationSnapshot).toEqual(
+      expect.objectContaining({
+        version: 1,
+        liquidationId: reviewed.id,
+        dueDate: '2026-10-10T00:00:00.000Z',
+      }),
+    );
+
+    const charges = await prisma.charge.findMany({
+      where: { liquidationId: reviewed.id },
+      orderBy: { unitId: 'asc' },
+    });
+    expect(charges).toHaveLength(ctx.units.length);
+    expect(charges.every((charge) => charge.liquidationId === reviewed.id)).toBe(true);
+
+    const publishAuditCount = await prisma.auditLog.count({
+      where: {
+        tenantId: ctx.tenant.id,
+        entity: 'Liquidation',
+        entityId: reviewed.id,
+        action: 'LIQUIDATION_PUBLISH',
+      },
+    });
+    expect(publishAuditCount).toBe(1);
+  });
+
+  it('keeps the workflow idempotent across repeated executions', async () => {
+    const ctx = await createFinanceContext('idempotency');
+
+    const first = await ensureSeedPublishedLiquidation({
+      prisma,
+      tenantId: ctx.tenant.id,
+      buildingId: ctx.building.id,
+      membershipId: ctx.membership.id,
+      period: '2026-11',
+      chargePeriod: '2026-12',
+      baseCurrency: 'ARS',
+      totalAmountMinor: 200,
+      totalsByCurrency: { ARS: 200 },
+      expenseSnapshot: buildExpenseSnapshot('2026-11', 200),
+      units: ctx.units.map((unit) => ({
+        id: unit.id,
+        code: unit.code,
+        label: unit.label,
+      })),
+      dueDate: new Date('2026-12-10T00:00:00.000Z'),
+      notificationPolicy: 'disabled',
+    });
+
+    const countsAfterFirst = {
+      liquidations: await prisma.liquidation.count({ where: { tenantId: ctx.tenant.id } }),
+      charges: await prisma.charge.count({ where: { tenantId: ctx.tenant.id } }),
+      audits: await prisma.auditLog.count({
+        where: { tenantId: ctx.tenant.id, entityId: first.id, entity: 'Liquidation' },
+      }),
+    };
+
+    const second = await ensureSeedPublishedLiquidation({
+      prisma,
+      tenantId: ctx.tenant.id,
+      buildingId: ctx.building.id,
+      membershipId: ctx.membership.id,
+      period: '2026-11',
+      chargePeriod: '2026-12',
+      baseCurrency: 'ARS',
+      totalAmountMinor: 200,
+      totalsByCurrency: { ARS: 200 },
+      expenseSnapshot: buildExpenseSnapshot('2026-11', 200),
+      units: ctx.units.map((unit) => ({
+        id: unit.id,
+        code: unit.code,
+        label: unit.label,
+      })),
+      dueDate: new Date('2026-12-10T00:00:00.000Z'),
+      notificationPolicy: 'disabled',
+    });
+
+    const countsAfterSecond = {
+      liquidations: await prisma.liquidation.count({ where: { tenantId: ctx.tenant.id } }),
+      charges: await prisma.charge.count({ where: { tenantId: ctx.tenant.id } }),
+      audits: await prisma.auditLog.count({
+        where: { tenantId: ctx.tenant.id, entityId: first.id, entity: 'Liquidation' },
+      }),
+    };
+
+    expect(second.id).toBe(first.id);
+    expect(countsAfterSecond).toEqual(countsAfterFirst);
+  });
+
+  it('handles concurrent publication safely without duplicating liquidations, charges, or publish audits', async () => {
+    const ctx = await createFinanceContext('concurrency');
+    const reviewed = await createDraftAndReview({
+      tenantId: ctx.tenant.id,
+      buildingId: ctx.building.id,
+      membershipId: ctx.membership.id,
+      period: '2027-01',
+      chargePeriod: '2027-02',
+    });
+
+    const useCase = createUseCase();
+    const results = await Promise.allSettled([
+      useCase.execute(ctx.tenant.id, reviewed.id, ctx.membership.id, { dueDate: '2027-02-10' }, 'disabled'),
+      useCase.execute(ctx.tenant.id, reviewed.id, ctx.membership.id, { dueDate: '2027-02-10' }, 'disabled'),
+    ]);
+
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        throw result.reason;
+      }
+
+      expect(result.value.status).toBe('PUBLISHED');
+    }
+
+    const liquidations = await prisma.liquidation.findMany({
+      where: {
+        tenantId: ctx.tenant.id,
+        buildingId: ctx.building.id,
+        period: '2027-01',
+        status: 'PUBLISHED',
+      },
+    });
+    expect(liquidations).toHaveLength(1);
+
+    const charges = await prisma.charge.findMany({
+      where: { tenantId: ctx.tenant.id, liquidationId: reviewed.id },
+    });
+    expect(charges).toHaveLength(ctx.units.length);
+
+    const publishAuditCount = await prisma.auditLog.count({
+      where: {
+        tenantId: ctx.tenant.id,
+        entity: 'Liquidation',
+        entityId: reviewed.id,
+        action: 'LIQUIDATION_PUBLISH',
+      },
+    });
+    expect(publishAuditCount).toBe(1);
+  });
+
+  it('rolls back the publication transaction when charge creation fails', async () => {
+    const ctx = await createFinanceContext('rollback');
+    const reviewed = await createDraftAndReview({
+      tenantId: ctx.tenant.id,
+      buildingId: ctx.building.id,
+      membershipId: ctx.membership.id,
+      period: '2027-03',
+      chargePeriod: '2027-04',
+    });
+
+    const failingPrisma = {
+      ...(prisma as unknown as LiquidationWorkflowDependencies['prisma']),
+      $transaction: async <T>(
+        callback: (tx: Prisma.TransactionClient) => Promise<T>,
+        options?: { isolationLevel?: Prisma.TransactionIsolationLevel },
+      ) =>
+        prisma.$transaction(async (tx) => {
+          const proxiedTx = new Proxy(tx, {
+            get(target, prop, receiver) {
+              if (prop === 'charge') {
+                return {
+                  ...target.charge,
+                  createMany: async () => {
+                    throw new Error('forced charge failure');
+                  },
+                };
+              }
+
+              return Reflect.get(target, prop, receiver);
+            },
+          });
+
+          return callback(proxiedTx as Prisma.TransactionClient);
+        }, options),
+    };
+
+    const useCase = createUseCase({ prismaOverride: failingPrisma });
+
+    await expect(
+      useCase.execute(
+        ctx.tenant.id,
+        reviewed.id,
+        ctx.membership.id,
+        { dueDate: '2027-04-10' },
+        'disabled',
+      ),
+    ).rejects.toThrow('forced charge failure');
+
+    const persisted = await prisma.liquidation.findUniqueOrThrow({
+      where: { id: reviewed.id },
+    });
+    expect(persisted.status).toBe('REVIEWED');
+    expect(await prisma.charge.count({ where: { liquidationId: reviewed.id } })).toBe(0);
+    expect(
+      await prisma.auditLog.count({
+        where: {
+          tenantId: ctx.tenant.id,
+          entityId: reviewed.id,
+          entity: 'Liquidation',
+          action: 'LIQUIDATION_PUBLISH',
+        },
+      }),
+    ).toBe(0);
+  });
+
+  it('keeps notifications disabled when requested and sends post-commit notifications only after commit', async () => {
+    const disabledCtx = await createFinanceContext('notifications-disabled');
+    const disabledReviewed = await createDraftAndReview({
+      tenantId: disabledCtx.tenant.id,
+      buildingId: disabledCtx.building.id,
+      membershipId: disabledCtx.membership.id,
+      period: '2027-05',
+      chargePeriod: '2027-06',
+    });
+
+    const disabledNotifications = jest.fn().mockResolvedValue({
+      sentCount: 0,
+      failedCount: 0,
+      errorMessages: [],
+    });
+
+    await createUseCase({
+      sendChargePublishedNotifications: disabledNotifications,
+    }).execute(
+      disabledCtx.tenant.id,
+      disabledReviewed.id,
+      disabledCtx.membership.id,
+      { dueDate: '2027-06-10' },
+      'disabled',
+    );
+
+    expect(disabledNotifications).not.toHaveBeenCalled();
+
+    const postCommitCtx = await createFinanceContext('notifications-post-commit');
+    const postCommitReviewed = await createDraftAndReview({
+      tenantId: postCommitCtx.tenant.id,
+      buildingId: postCommitCtx.building.id,
+      membershipId: postCommitCtx.membership.id,
+      period: '2027-07',
+      chargePeriod: '2027-08',
+    });
+
+    const postCommitNotifications = jest.fn().mockImplementation(async () => {
+      const liquidation = await prisma.liquidation.findUniqueOrThrow({
+        where: { id: postCommitReviewed.id },
+      });
+      const chargeCount = await prisma.charge.count({
+        where: { liquidationId: postCommitReviewed.id },
+      });
+
+      expect(liquidation.status).toBe('PUBLISHED');
+      expect(chargeCount).toBe(postCommitCtx.units.length);
+
+      return {
+        sentCount: 0,
+        failedCount: 1,
+        errorMessages: ['simulated notification failure'],
+      };
+    });
+
+    const postCommitResult = await createUseCase({
+      sendChargePublishedNotifications: postCommitNotifications,
+    }).execute(
+      postCommitCtx.tenant.id,
+      postCommitReviewed.id,
+      postCommitCtx.membership.id,
+      { dueDate: '2027-08-10' },
+      'post-commit',
+    );
+
+    expect(postCommitResult.status).toBe('PUBLISHED');
+    expect(postCommitNotifications).toHaveBeenCalledTimes(1);
+
+    const publishAuditCount = await prisma.auditLog.count({
+      where: {
+        tenantId: postCommitCtx.tenant.id,
+        entity: 'Liquidation',
+        entityId: postCommitReviewed.id,
+        action: 'LIQUIDATION_PUBLISH',
+      },
+    });
+    expect(publishAuditCount).toBe(2);
+  });
+
+  it('recovers safely after a partial seed failure without duplicating tenant, building, units, liquidation, charges, or audit logs', async () => {
+    const seedKey = suffix();
+    const period = '2027-09';
+    const chargePeriod = '2027-10';
+    const dueDate = new Date('2027-10-10T00:00:00.000Z');
+
+    const runResumableSeedPass = async (failAfterWorkflow: boolean) => {
+      const tenant = await prisma.tenant.upsert({
+        where: { name: `ITEST Seed Tenant ${seedKey}` },
+        update: {},
+        create: {
+          name: `ITEST Seed Tenant ${seedKey}`,
+          type: TenantType.ADMINISTRADORA,
+        },
+      });
+
+      const user = await prisma.user.upsert({
+        where: { email: `itest-seed-${seedKey}@buildingos.local` },
+        update: {},
+        create: {
+          email: `itest-seed-${seedKey}@buildingos.local`,
+          name: 'ITest Seed User',
+          passwordHash: 'integration-test-hash',
+        },
+      });
+
+      const membership = await prisma.membership.upsert({
+        where: { userId_tenantId: { userId: user.id, tenantId: tenant.id } },
+        update: {},
+        create: {
+          tenantId: tenant.id,
+          userId: user.id,
+        },
+      });
+
+      await prisma.membershipRole.upsert({
+        where: {
+          id: `${membership.id}-tenant-admin`,
+        },
+        update: {},
+        create: {
+          id: `${membership.id}-tenant-admin`,
+          tenantId: tenant.id,
+          membershipId: membership.id,
+          role: Role.TENANT_ADMIN,
+          scopeType: ScopeType.TENANT,
+        },
+      });
+
+      const building = await prisma.building.upsert({
+        where: { tenantId_name: { tenantId: tenant.id, name: `ITEST Seed Building ${seedKey}` } },
+        update: {},
+        create: {
+          tenantId: tenant.id,
+          name: `ITEST Seed Building ${seedKey}`,
+          alias: `IS-${seedKey.slice(0, 8)}`,
+          address: 'Resume Avenue 123',
+        },
+      });
+
+      const units = await Promise.all(
+        ['A', 'B'].map((code) =>
+          prisma.unit.upsert({
+            where: {
+              buildingId_code: {
+                buildingId: building.id,
+                code: `U-${code}`,
+              },
+            },
+            update: {},
+            create: {
+              tenantId: tenant.id,
+              buildingId: building.id,
+              code: `U-${code}`,
+              label: `Unit ${code}`,
+              unitType: 'APARTAMENTO',
+              occupancyStatus: 'OCCUPIED',
+              isBillable: true,
+            },
+          }),
+        ),
+      );
+
+      await ensureSeedPublishedLiquidation({
+        prisma,
+        tenantId: tenant.id,
+        buildingId: building.id,
+        membershipId: membership.id,
+        period,
+        chargePeriod,
+        baseCurrency: 'ARS',
+        totalAmountMinor: 200,
+        totalsByCurrency: { ARS: 200 },
+        expenseSnapshot: buildExpenseSnapshot(period, 200),
+        units: units.map((unit) => ({
+          id: unit.id,
+          code: unit.code,
+          label: unit.label,
+        })),
+        dueDate,
+        notificationPolicy: 'disabled',
+      });
+
+      if (failAfterWorkflow) {
+        throw new Error('intentional post-workflow failure');
+      }
+
+      return { tenant, building, units };
+    };
+
+    await expect(runResumableSeedPass(true)).rejects.toThrow(
+      'intentional post-workflow failure',
+    );
+
+    const tenantAfterFirst = await prisma.tenant.findFirstOrThrow({
+      where: { name: `ITEST Seed Tenant ${seedKey}` },
+    });
+    const buildingAfterFirst = await prisma.building.findFirstOrThrow({
+      where: { tenantId: tenantAfterFirst.id, name: `ITEST Seed Building ${seedKey}` },
+    });
+
+    const countsAfterFirst = {
+      tenants: await prisma.tenant.count({
+        where: { name: `ITEST Seed Tenant ${seedKey}` },
+      }),
+      buildings: await prisma.building.count({
+        where: { tenantId: tenantAfterFirst.id, name: `ITEST Seed Building ${seedKey}` },
+      }),
+      units: await prisma.unit.count({
+        where: { tenantId: tenantAfterFirst.id, buildingId: buildingAfterFirst.id },
+      }),
+      liquidations: await prisma.liquidation.count({
+        where: { tenantId: tenantAfterFirst.id, buildingId: buildingAfterFirst.id, period },
+      }),
+      charges: await prisma.charge.count({
+        where: { tenantId: tenantAfterFirst.id, buildingId: buildingAfterFirst.id },
+      }),
+      audits: await prisma.auditLog.count({
+        where: { tenantId: tenantAfterFirst.id, entity: 'Liquidation' },
+      }),
+    };
+
+    await runResumableSeedPass(false);
+
+    const countsAfterSecond = {
+      tenants: await prisma.tenant.count({
+        where: { name: `ITEST Seed Tenant ${seedKey}` },
+      }),
+      buildings: await prisma.building.count({
+        where: { tenantId: tenantAfterFirst.id, name: `ITEST Seed Building ${seedKey}` },
+      }),
+      units: await prisma.unit.count({
+        where: { tenantId: tenantAfterFirst.id, buildingId: buildingAfterFirst.id },
+      }),
+      liquidations: await prisma.liquidation.count({
+        where: { tenantId: tenantAfterFirst.id, buildingId: buildingAfterFirst.id, period },
+      }),
+      charges: await prisma.charge.count({
+        where: { tenantId: tenantAfterFirst.id, buildingId: buildingAfterFirst.id },
+      }),
+      audits: await prisma.auditLog.count({
+        where: { tenantId: tenantAfterFirst.id, entity: 'Liquidation' },
+      }),
+    };
+
+    expect(countsAfterSecond).toEqual(countsAfterFirst);
+  });
+});

--- a/apps/api/src/finanzas/liquidation-publication.use-case.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.spec.ts
@@ -1,0 +1,298 @@
+import {
+  BadRequestException,
+  ConflictException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import {
+  LiquidationPublicationUseCase,
+  type LiquidationWorkflowDependencies,
+} from './liquidation-publication.use-case';
+
+const baseLiquidation = {
+  id: 'liq-1',
+  tenantId: 'tenant-1',
+  buildingId: 'building-1',
+  period: '2026-05',
+  chargePeriod: '2026-06',
+  status: 'REVIEWED' as const,
+  baseCurrency: 'ARS',
+  totalAmountMinor: 101,
+  totalsByCurrency: { ARS: 101 },
+  expenseSnapshot: [
+    {
+      expenseId: 'exp-1',
+      categoryName: 'Water',
+      vendorName: 'Vendor',
+      amountMinor: 101,
+      currencyCode: 'ARS',
+      invoiceDate: '2026-05-01T00:00:00.000Z',
+      description: null,
+      type: 'EXPENSE',
+    },
+  ],
+  unitCount: 2,
+  generatedAt: new Date('2026-05-01T00:00:00.000Z'),
+  reviewedAt: new Date('2026-05-02T00:00:00.000Z'),
+  publishedAt: null,
+  canceledAt: null,
+  createdAt: new Date('2026-05-01T00:00:00.000Z'),
+};
+
+describe('LiquidationPublicationUseCase', () => {
+  const createKnownError = (code: 'P2002' | 'P2034', message: string) => {
+    const error = new Error(message);
+    Object.assign(error, { code });
+    Object.setPrototypeOf(error, Prisma.PrismaClientKnownRequestError.prototype);
+    return error;
+  };
+
+  let tx: {
+    membership: { findFirst: jest.Mock };
+    liquidation: { findFirst: jest.Mock; updateMany: jest.Mock };
+    unit: { findMany: jest.Mock };
+    charge: { findMany: jest.Mock; createMany: jest.Mock };
+    auditLog: { create: jest.Mock };
+  };
+  let deps: LiquidationWorkflowDependencies;
+  let useCase: LiquidationPublicationUseCase;
+
+  beforeEach(() => {
+    tx = {
+      membership: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'member-1',
+          tenantId: 'tenant-1',
+          roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+        }),
+      },
+      liquidation: {
+        findFirst: jest
+          .fn()
+          .mockResolvedValueOnce(baseLiquidation)
+          .mockResolvedValueOnce(null)
+          .mockResolvedValueOnce({
+            ...baseLiquidation,
+            status: 'PUBLISHED',
+            publishedAt: new Date('2026-05-03T00:00:00.000Z'),
+          }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      unit: {
+        findMany: jest.fn().mockResolvedValue([
+          { id: 'unit-1', code: '1A', label: '1A', unitCategory: null },
+          { id: 'unit-2', code: '1B', label: '1B', unitCategory: null },
+        ]),
+      },
+      charge: {
+        findMany: jest.fn().mockResolvedValue([]),
+        createMany: jest.fn().mockResolvedValue({ count: 2 }),
+      },
+      auditLog: { create: jest.fn().mockResolvedValue(undefined) },
+    };
+
+    deps = {
+      prisma: {
+        $transaction: jest.fn(async (callback) =>
+          callback(tx as unknown as Prisma.TransactionClient),
+        ),
+        membership: tx.membership,
+        liquidation: {
+          findFirst: jest.fn(),
+          create: jest.fn(),
+        },
+      } as unknown as LiquidationWorkflowDependencies['prisma'],
+      isAdminOrOperator: jest.fn().mockReturnValue(true),
+      createAuditLogRequired: jest.fn().mockResolvedValue(undefined),
+      createAuditLog: jest.fn().mockResolvedValue(undefined),
+      toPublishedLiquidationDto: jest.fn((liquidation) => ({
+        id: liquidation.id,
+        tenantId: liquidation.tenantId,
+        buildingId: liquidation.buildingId,
+        period: liquidation.period,
+        chargePeriod: liquidation.chargePeriod,
+        status: liquidation.status,
+        baseCurrency: liquidation.baseCurrency,
+        totalAmountMinor: liquidation.totalAmountMinor,
+        totalsByCurrency: liquidation.totalsByCurrency as Record<string, number>,
+        unitCount: liquidation.unitCount,
+        generatedAt: liquidation.generatedAt,
+        reviewedAt: liquidation.reviewedAt,
+        publishedAt: liquidation.publishedAt,
+        canceledAt: liquidation.canceledAt,
+        createdAt: liquidation.createdAt,
+      })),
+      sendChargePublishedNotifications: jest.fn().mockResolvedValue({
+        sentCount: 0,
+        failedCount: 0,
+        errorMessages: [],
+      }),
+    };
+
+    useCase = new LiquidationPublicationUseCase(deps);
+  });
+
+  it('publishes a reviewed liquidation and creates charges exactly once', async () => {
+    const result = await useCase.execute('tenant-1', 'liq-1', 'member-1', {
+      dueDate: '2026-06-10',
+    });
+
+    expect(result.status).toBe('PUBLISHED');
+    expect(tx.charge.createMany).toHaveBeenCalledTimes(1);
+    expect(deps.createAuditLogRequired).toHaveBeenCalledTimes(1);
+    expect(tx.liquidation.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          status: 'PUBLISHED',
+          publicationSnapshot: expect.objectContaining({
+            version: 1,
+            totalAmountMinor: 101,
+            dueDate: '2026-06-10T00:00:00.000Z',
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('rejects publication when status is not REVIEWED', async () => {
+    tx.liquidation.findFirst.mockReset().mockResolvedValue({
+      ...baseLiquidation,
+      status: 'DRAFT',
+    });
+
+    await expect(
+      useCase.execute('tenant-1', 'liq-1', 'member-1', {
+        dueDate: '2026-06-10',
+      }),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('reuses compatible existing charges instead of creating duplicates', async () => {
+    tx.charge.findMany.mockResolvedValue([
+      {
+        unitId: 'unit-1',
+        amount: 51,
+        currency: 'ARS',
+        dueDate: new Date('2026-06-10T00:00:00.000Z'),
+        buildingId: 'building-1',
+        period: '2026-05',
+        liquidationId: 'liq-1',
+        concept: 'Expensas comunes 2026-05',
+      },
+      {
+        unitId: 'unit-2',
+        amount: 50,
+        currency: 'ARS',
+        dueDate: new Date('2026-06-10T00:00:00.000Z'),
+        buildingId: 'building-1',
+        period: '2026-05',
+        liquidationId: 'liq-1',
+        concept: 'Expensas comunes 2026-05',
+      },
+    ]);
+
+    await useCase.execute('tenant-1', 'liq-1', 'member-1', {
+      dueDate: '2026-06-10',
+    });
+
+    expect(tx.charge.createMany).not.toHaveBeenCalled();
+  });
+
+  it('fails when existing charges are incompatible', async () => {
+    tx.charge.findMany.mockResolvedValue([
+      {
+        unitId: 'unit-1',
+        amount: 999,
+        currency: 'ARS',
+        dueDate: new Date('2026-06-10T00:00:00.000Z'),
+        buildingId: 'building-1',
+        period: '2026-05',
+        liquidationId: 'liq-1',
+        concept: 'Expensas comunes 2026-05',
+      },
+      {
+        unitId: 'unit-2',
+        amount: 50,
+        currency: 'ARS',
+        dueDate: new Date('2026-06-10T00:00:00.000Z'),
+        buildingId: 'building-1',
+        period: '2026-05',
+        liquidationId: 'liq-1',
+        concept: 'Expensas comunes 2026-05',
+      },
+    ]);
+
+    await expect(
+      useCase.execute('tenant-1', 'liq-1', 'member-1', {
+        dueDate: '2026-06-10',
+      }),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('returns the published liquidation after P2002 when a concurrent publish already won', async () => {
+    (deps.prisma.$transaction as jest.Mock).mockRejectedValueOnce(
+      createKnownError('P2002', 'Unique violation'),
+    );
+    (deps.prisma.liquidation.findFirst as jest.Mock).mockResolvedValueOnce({
+      ...baseLiquidation,
+      status: 'PUBLISHED',
+      publishedAt: new Date('2026-05-03T00:00:00.000Z'),
+    });
+
+    const result = await useCase.execute('tenant-1', 'liq-1', 'member-1', {
+      dueDate: '2026-06-10',
+    });
+
+    expect(result.status).toBe('PUBLISHED');
+  });
+
+  it('returns the published liquidation after P2034 when a concurrent publish already won', async () => {
+    (deps.prisma.$transaction as jest.Mock).mockRejectedValueOnce(
+      createKnownError('P2034', 'Serialization conflict'),
+    );
+    (deps.prisma.liquidation.findFirst as jest.Mock).mockResolvedValueOnce({
+      ...baseLiquidation,
+      status: 'PUBLISHED',
+      publishedAt: new Date('2026-05-03T00:00:00.000Z'),
+    });
+
+    const result = await useCase.execute('tenant-1', 'liq-1', 'member-1', {
+      dueDate: '2026-06-10',
+    });
+
+    expect(result.status).toBe('PUBLISHED');
+  });
+
+  it('skips external notifications when policy is disabled', async () => {
+    await useCase.execute(
+      'tenant-1',
+      'liq-1',
+      'member-1',
+      { dueDate: '2026-06-10' },
+      'disabled',
+    );
+
+    expect(deps.sendChargePublishedNotifications).not.toHaveBeenCalled();
+  });
+
+  it('does not roll back publication when post-commit notifications report failures', async () => {
+    (deps.sendChargePublishedNotifications as jest.Mock).mockResolvedValueOnce({
+      sentCount: 0,
+      failedCount: 1,
+      errorMessages: ['mail failed'],
+    });
+
+    const result = await useCase.execute('tenant-1', 'liq-1', 'member-1', {
+      dueDate: '2026-06-10',
+    });
+
+    expect(result.status).toBe('PUBLISHED');
+    expect(deps.createAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          notificationFailure: true,
+          errors: ['mail failed'],
+        }),
+      }),
+    );
+  });
+});

--- a/apps/api/src/finanzas/liquidation-publication.use-case.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.ts
@@ -1,0 +1,951 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  Logger,
+  NotFoundException,
+} from '@nestjs/common';
+import { ChargeStatus, Prisma } from '@prisma/client';
+import { AuditService } from '../audit/audit.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { FinanzasValidators } from './finanzas.validators';
+import {
+  buildLiquidationPublicationSnapshot,
+  type PublishedExpenseSnapshot,
+} from './liquidation-publication-snapshot';
+import {
+  type LiquidationResponseDto,
+  type PublishLiquidationDto,
+} from './expense-ledger.dto';
+
+export type NotificationPolicy = 'post-commit' | 'disabled';
+
+interface FinanceMembershipRecord {
+  id: string;
+  tenantId: string;
+  roles: Array<{
+    role: string;
+    scopeType: 'TENANT' | 'BUILDING' | 'UNIT';
+  }>;
+}
+
+export interface FinanceMembershipContext {
+  readonly id: string;
+  readonly tenantId: string;
+  readonly roles: string[];
+}
+
+interface FinanceMembershipClient {
+  membership: {
+    findFirst: (args: {
+      where: { id: string; tenantId: string };
+      select: {
+        id: boolean;
+        tenantId: boolean;
+        roles: { select: { role: boolean; scopeType: boolean } };
+      };
+    }) => Promise<FinanceMembershipRecord | null>;
+  };
+}
+
+export interface LiquidationExpenseSnapshotItem extends Prisma.InputJsonObject {
+  expenseId: string;
+  categoryName: string;
+  vendorName: string | null;
+  amountMinor: number;
+  currencyCode: string;
+  invoiceDate: string;
+  description: string | null;
+  type: 'EXPENSE' | 'ADJUSTMENT';
+  sourcePeriod?: string;
+}
+
+export interface NotificationDispatchResult {
+  readonly sentCount: number;
+  readonly failedCount: number;
+  readonly errorMessages: ReadonlyArray<string>;
+}
+
+interface AuditWriteClient {
+  auditLog: {
+    create: (args: { data: Prisma.AuditLogUncheckedCreateInput }) => Promise<unknown>;
+  };
+}
+
+interface NotificationServicePort {
+  createNotification: NotificationsService['createNotification'];
+}
+
+export interface LiquidationWorkflowPrismaClient extends FinanceMembershipClient {
+  $transaction: <T>(
+    fn: (tx: Prisma.TransactionClient) => Promise<T>,
+    options?: { isolationLevel?: Prisma.TransactionIsolationLevel },
+  ) => Promise<T>;
+  liquidation: {
+    findFirst: (args: Prisma.LiquidationFindFirstArgs) => Promise<Prisma.LiquidationGetPayload<Prisma.LiquidationFindFirstArgs> | null>;
+    create: (args: Prisma.LiquidationCreateArgs) => Promise<Prisma.LiquidationGetPayload<Prisma.LiquidationCreateArgs>>;
+  };
+}
+
+export interface LiquidationWorkflowDependencies {
+  readonly prisma: LiquidationWorkflowPrismaClient;
+  readonly isAdminOrOperator: (roles: string[]) => boolean;
+  readonly createAuditLogRequired: (
+    input: {
+      tenantId: string;
+      actorMembershipId?: string;
+      action: 'LIQUIDATION_DRAFT' | 'LIQUIDATION_REVIEW' | 'LIQUIDATION_PUBLISH';
+      entityType: 'Liquidation';
+      entityId: string;
+      metadata?: Record<string, unknown>;
+    },
+    tx: AuditWriteClient,
+  ) => Promise<void>;
+  readonly createAuditLog: (
+    input: {
+      tenantId?: string;
+      action: 'LIQUIDATION_PUBLISH';
+      entityType: 'Liquidation';
+      entityId: string;
+      metadata?: Record<string, unknown>;
+    },
+  ) => Promise<void>;
+  readonly toPublishedLiquidationDto: (
+    liquidation: LiquidationRecord,
+  ) => LiquidationResponseDto;
+  readonly sendChargePublishedNotifications: (
+    tenantId: string,
+    liquidationId: string,
+    liquidation: {
+      period: string;
+      buildingId: string;
+      baseCurrency: string;
+    },
+  ) => Promise<NotificationDispatchResult>;
+}
+
+type LiquidationRecord = {
+  id: string;
+  tenantId: string;
+  buildingId: string;
+  period: string;
+  chargePeriod: string | null;
+  status: 'DRAFT' | 'REVIEWED' | 'PUBLISHED' | 'CANCELED';
+  baseCurrency: string;
+  totalAmountMinor: number;
+  totalsByCurrency: unknown;
+  expenseSnapshot: unknown;
+  publicationSnapshot: unknown;
+  unitCount: number;
+  generatedAt: Date;
+  reviewedAt: Date | null;
+  publishedAt: Date | null;
+  canceledAt: Date | null;
+  createdAt: Date;
+};
+
+type LiquidationResponseRecord = Omit<LiquidationRecord, 'expenseSnapshot' | 'publicationSnapshot'>;
+
+export interface DraftLiquidationInput {
+  readonly tenantId: string;
+  readonly buildingId: string;
+  readonly period: string;
+  readonly chargePeriod?: string | null;
+  readonly baseCurrency: string;
+  readonly totalAmountMinor: number;
+  readonly totalsByCurrency: Prisma.InputJsonObject;
+  readonly expenseSnapshot: Prisma.InputJsonArray;
+  readonly unitCount: number;
+  readonly generatedByMembershipId: string;
+}
+
+export async function requireFinanceMembership(
+  client: FinanceMembershipClient,
+  tenantId: string,
+  membershipId: string,
+  isAdminOrOperator: (roles: string[]) => boolean,
+): Promise<FinanceMembershipContext> {
+  const membership = await client.membership.findFirst({
+    where: { id: membershipId, tenantId },
+    select: {
+      id: true,
+      tenantId: true,
+      roles: { select: { role: true, scopeType: true } },
+    },
+  });
+
+  if (!membership) {
+    throw new ForbiddenException('No se encontró una membresía válida para el tenant');
+  }
+
+  const tenantRoles = membership.roles
+    .filter((role) => role.scopeType === 'TENANT')
+    .map((role) => role.role);
+
+  if (!isAdminOrOperator(tenantRoles)) {
+    throw new ForbiddenException('Solo administradores pueden gestionar liquidaciones');
+  }
+
+  return {
+    id: membership.id,
+    tenantId: membership.tenantId,
+    roles: tenantRoles,
+  };
+}
+
+export function toLiquidationResponseDto(
+  liquidation: LiquidationResponseRecord,
+): LiquidationResponseDto {
+  return {
+    id: liquidation.id,
+    tenantId: liquidation.tenantId,
+    buildingId: liquidation.buildingId,
+    period: liquidation.period,
+    chargePeriod: liquidation.chargePeriod,
+    status: liquidation.status,
+    baseCurrency: liquidation.baseCurrency,
+    totalAmountMinor: liquidation.totalAmountMinor,
+    totalsByCurrency: parseTotalsByCurrency(liquidation.totalsByCurrency),
+    unitCount: liquidation.unitCount,
+    generatedAt: liquidation.generatedAt,
+    reviewedAt: liquidation.reviewedAt,
+    publishedAt: liquidation.publishedAt,
+    canceledAt: liquidation.canceledAt,
+    createdAt: liquidation.createdAt,
+  };
+}
+
+export async function sendChargePublishedNotifications(
+  prisma: Pick<PrismaService, 'charge' | 'unit'>,
+  notificationsService: NotificationServicePort,
+  tenantId: string,
+  liquidationId: string,
+  liquidation: {
+    period: string;
+    buildingId: string;
+    baseCurrency: string;
+  },
+): Promise<NotificationDispatchResult> {
+  const logger = new Logger(LiquidationPublicationUseCase.name);
+  let sentCount = 0;
+  let failedCount = 0;
+  const errorMessages: string[] = [];
+
+  const charges = await prisma.charge.findMany({
+    where: { tenantId, liquidationId },
+  });
+
+  for (const charge of charges) {
+    const unit = await prisma.unit.findFirst({
+      where: {
+        tenantId,
+        buildingId: liquidation.buildingId,
+        id: charge.unitId,
+      },
+      include: {
+        unitOccupants: {
+          where: { tenantId, endDate: null },
+          include: {
+            member: {
+              select: { id: true, tenantId: true, user: { select: { id: true } } },
+            },
+          },
+        },
+      },
+    });
+
+    if (!unit) {
+      continue;
+    }
+
+    for (const occupant of unit.unitOccupants) {
+      if (!occupant.member?.user?.id) {
+        continue;
+      }
+
+      const dueDateStr = charge.dueDate
+        ? new Date(charge.dueDate).toLocaleDateString('es-AR')
+        : 'N/A';
+
+      try {
+        await notificationsService.createNotification({
+          tenantId,
+          userId: occupant.member.user.id,
+          type: 'CHARGE_PUBLISHED',
+          title: `${liquidation.buildingId} - Nuevo cargo por ${liquidation.period}`,
+          body: `Se ha registrado un cargo de ${(charge.amount / 100).toFixed(2)} ${liquidation.baseCurrency} en la unidad ${unit.label}. Vencimiento: ${dueDateStr}`,
+          data: {
+            chargeId: charge.id,
+            unitLabel: unit.label,
+            amountMinor: charge.amount,
+            currency: liquidation.baseCurrency,
+            period: liquidation.period,
+            dueDate: charge.dueDate?.toISOString() ?? null,
+            liquidationId,
+          },
+        });
+        sentCount += 1;
+      } catch (error) {
+        failedCount += 1;
+        const message = error instanceof Error ? error.message : String(error);
+        errorMessages.push(
+          `charge=${charge.id} user=${occupant.member.user.id} message=${message}`,
+        );
+        logger.error(
+          `Failed to create notification for charge ${charge.id} in liquidation ${liquidationId}`,
+          error instanceof Error ? error.stack : undefined,
+        );
+      }
+    }
+  }
+
+  return {
+    sentCount,
+    failedCount,
+    errorMessages,
+  };
+}
+
+export function createLiquidationWorkflowDependencies(params: {
+  prisma: PrismaService;
+  auditService: AuditService;
+  validators: FinanzasValidators;
+  notificationsService: NotificationServicePort;
+}): LiquidationWorkflowDependencies {
+  return {
+    prisma: params.prisma,
+    isAdminOrOperator: (roles) => params.validators.isAdminOrOperator(roles),
+    createAuditLogRequired: (input, tx) => params.auditService.createLogRequired(input, tx),
+    createAuditLog: (input) => params.auditService.createLog(input),
+    toPublishedLiquidationDto: (liquidation) => toLiquidationResponseDto(liquidation),
+    sendChargePublishedNotifications: (tenantId, liquidationId, liquidation) =>
+      sendChargePublishedNotifications(
+        params.prisma,
+        params.notificationsService,
+        tenantId,
+        liquidationId,
+        liquidation,
+      ),
+  };
+}
+
+export async function createLiquidationDraftRecord(
+  tx: Prisma.TransactionClient,
+  deps: Pick<LiquidationWorkflowDependencies, 'createAuditLogRequired'>,
+  input: DraftLiquidationInput,
+): Promise<LiquidationRecord> {
+  const liquidation = await tx.liquidation.create({
+    data: {
+      tenantId: input.tenantId,
+      buildingId: input.buildingId,
+      period: input.period,
+      chargePeriod: input.chargePeriod ?? null,
+      baseCurrency: input.baseCurrency,
+      totalAmountMinor: input.totalAmountMinor,
+      totalsByCurrency: input.totalsByCurrency,
+      expenseSnapshot: input.expenseSnapshot,
+      unitCount: input.unitCount,
+      generatedByMembershipId: input.generatedByMembershipId,
+    },
+  });
+
+  await deps.createAuditLogRequired(
+    {
+      tenantId: input.tenantId,
+      actorMembershipId: input.generatedByMembershipId,
+      action: 'LIQUIDATION_DRAFT',
+      entityType: 'Liquidation',
+      entityId: liquidation.id,
+      metadata: {
+        period: input.period,
+        buildingId: input.buildingId,
+        totalAmountMinor: input.totalAmountMinor,
+        baseCurrency: input.baseCurrency,
+        expenseCount: input.expenseSnapshot.length,
+      },
+    },
+    tx,
+  );
+
+  const created = await tx.liquidation.findFirst({
+    where: { id: liquidation.id, tenantId: input.tenantId },
+  });
+
+  if (!created) {
+    throw new NotFoundException(`Liquidación no encontrada: ${liquidation.id}`);
+  }
+
+  return created as LiquidationRecord;
+}
+
+export async function reviewLiquidationRecord(
+  tx: Prisma.TransactionClient,
+  deps: Pick<LiquidationWorkflowDependencies, 'createAuditLogRequired'>,
+  input: {
+    readonly tenantId: string;
+    readonly liquidationId: string;
+    readonly membershipId: string;
+  },
+): Promise<LiquidationRecord> {
+  const current = await tx.liquidation.findFirst({
+    where: { id: input.liquidationId, tenantId: input.tenantId },
+  });
+
+  if (!current) {
+    throw new NotFoundException(`Liquidación no encontrada: ${input.liquidationId}`);
+  }
+
+  const now = new Date();
+  const updateResult = await tx.liquidation.updateMany({
+    where: { id: input.liquidationId, tenantId: input.tenantId, status: 'DRAFT' },
+    data: {
+      status: 'REVIEWED',
+      reviewedByMembershipId: input.membershipId,
+      reviewedAt: now,
+      updatedAt: now,
+    },
+  });
+
+  if (updateResult.count !== 1) {
+    const latest = await tx.liquidation.findFirst({
+      where: { id: input.liquidationId, tenantId: input.tenantId },
+    });
+
+    if (!latest) {
+      throw new NotFoundException(`Liquidación no encontrada: ${input.liquidationId}`);
+    }
+
+    if (latest.status === 'DRAFT') {
+      throw new ConflictException(`La liquidación ${input.liquidationId} cambió durante la revisión`);
+    }
+
+    throw new ConflictException(
+      `Solo se puede revisar una liquidación en DRAFT. Estado actual: ${latest.status}`,
+    );
+  }
+
+  await deps.createAuditLogRequired(
+    {
+      tenantId: input.tenantId,
+      actorMembershipId: input.membershipId,
+      action: 'LIQUIDATION_REVIEW',
+      entityType: 'Liquidation',
+      entityId: input.liquidationId,
+      metadata: {
+        period: current.period,
+        buildingId: current.buildingId,
+        reviewedAt: now.toISOString(),
+      },
+    },
+    tx,
+  );
+
+  const updated = await tx.liquidation.findFirst({
+    where: { id: input.liquidationId, tenantId: input.tenantId },
+  });
+
+  if (!updated) {
+    throw new NotFoundException(`Liquidación no encontrada: ${input.liquidationId}`);
+  }
+
+  return updated as LiquidationRecord;
+}
+
+@Injectable()
+export class LiquidationPublicationUseCase {
+  constructor(private readonly deps: LiquidationWorkflowDependencies) {}
+
+  async execute(
+    tenantId: string,
+    liquidationId: string,
+    membershipId: string,
+    dto: PublishLiquidationDto,
+    notificationPolicy: NotificationPolicy = 'post-commit',
+  ): Promise<LiquidationResponseDto> {
+    let publishResult: { liquidation: LiquidationResponseDto; publishedNow: boolean } | null = null;
+
+    try {
+      publishResult = await this.deps.prisma.$transaction(
+        async (tx) => {
+          const membership = await requireFinanceMembership(
+            tx as unknown as FinanceMembershipClient,
+            tenantId,
+            membershipId,
+            this.deps.isAdminOrOperator,
+          );
+
+          const current = await tx.liquidation.findFirst({
+            where: { id: liquidationId, tenantId },
+          });
+
+          if (!current) {
+            throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
+          }
+
+          if (current.status === 'PUBLISHED') {
+            return {
+              liquidation: this.deps.toPublishedLiquidationDto(current as LiquidationRecord),
+              publishedNow: false,
+            };
+          }
+
+          if (current.status !== 'REVIEWED') {
+            throw new BadRequestException(
+              `Solo se puede publicar una liquidación revisada. Estado actual: ${current.status}`,
+            );
+          }
+
+          const billableUnits = await tx.unit.findMany({
+            where: { tenantId, buildingId: current.buildingId, isBillable: true },
+            include: { unitCategory: { select: { coefficient: true, id: true } } },
+            orderBy: { code: 'asc' },
+          });
+
+          if (billableUnits.length === 0) {
+            throw new BadRequestException('No hay unidades facturables en este edificio');
+          }
+
+          const now = new Date();
+          const dueDate = new Date(dto.dueDate);
+          if (Number.isNaN(dueDate.getTime())) {
+            throw new BadRequestException('dueDate must be a valid date');
+          }
+
+          const distribution = calculateDistribution(
+            billableUnits,
+            current.totalAmountMinor,
+            current.buildingId,
+          );
+
+          const publicationSnapshot = buildLiquidationPublicationSnapshot({
+            liquidationId: current.id,
+            tenantId,
+            buildingId: current.buildingId,
+            period: current.period,
+            baseCurrency: current.baseCurrency,
+            totalAmountMinor: current.totalAmountMinor,
+            totalsByCurrency: parseTotalsByCurrency(current.totalsByCurrency),
+            expenses: getPublicationSnapshotExpenses(current.expenseSnapshot),
+            allocations: distribution.map((item) => ({
+              unitId: item.unitId,
+              unitCode: item.unitCode,
+              unitLabel: item.unitLabel,
+              amountMinor: item.amountMinor,
+            })),
+            dueDate,
+            publishedAt: now,
+          });
+
+          const duplicatePublished = await tx.liquidation.findFirst({
+            where: {
+              tenantId,
+              buildingId: current.buildingId,
+              period: current.period,
+              status: 'PUBLISHED',
+              id: { not: liquidationId },
+            },
+            select: { id: true },
+          });
+
+          if (duplicatePublished) {
+            throw new ConflictException(
+              `Ya existe una liquidación publicada para el período ${current.period}`,
+            );
+          }
+
+          const concept = `Expensas comunes ${current.period}`;
+          const expectedCharges = distribution.map((distributionItem) => ({
+            tenantId,
+            buildingId: current.buildingId,
+            unitId: distributionItem.unitId,
+            period: current.period,
+            type: 'COMMON_EXPENSE' as const,
+            concept,
+            amount: distributionItem.amountMinor,
+            currency: current.baseCurrency,
+            dueDate,
+            liquidationId,
+          }));
+
+          const existingCharges = await tx.charge.findMany({
+            where: {
+              tenantId,
+              liquidationId,
+              buildingId: current.buildingId,
+              period: current.period,
+            },
+            select: {
+              unitId: true,
+              amount: true,
+              currency: true,
+              dueDate: true,
+              buildingId: true,
+              period: true,
+              liquidationId: true,
+              concept: true,
+            },
+            orderBy: { unitId: 'asc' },
+          });
+
+          if (existingCharges.length > 0) {
+            if (existingCharges.length !== expectedCharges.length) {
+              throw new ConflictException(
+                `La liquidación ${liquidationId} tiene cargos parciales generados para ${current.period}`,
+              );
+            }
+
+            const expectedChargesByUnit = new Map(
+              expectedCharges.map((charge) => [charge.unitId, charge]),
+            );
+
+            for (const existingCharge of existingCharges) {
+              const expectedCharge = expectedChargesByUnit.get(existingCharge.unitId);
+
+              if (
+                !expectedCharge ||
+                existingCharge.amount !== expectedCharge.amount ||
+                existingCharge.currency !== expectedCharge.currency ||
+                existingCharge.buildingId !== expectedCharge.buildingId ||
+                existingCharge.period !== expectedCharge.period ||
+                existingCharge.liquidationId !== expectedCharge.liquidationId ||
+                existingCharge.concept !== expectedCharge.concept ||
+                existingCharge.dueDate.getTime() !== expectedCharge.dueDate.getTime()
+              ) {
+                throw new ConflictException(
+                  `La liquidación ${liquidationId} tiene cargos existentes que no coinciden con la publicación esperada`,
+                );
+              }
+            }
+          } else {
+            await tx.charge.createMany({
+              data: expectedCharges.map((charge) => ({
+                ...charge,
+                status: ChargeStatus.PENDING,
+                createdByMembershipId: membership.id,
+              })),
+            });
+          }
+
+          const updateResult = await tx.liquidation.updateMany({
+            where: {
+              id: liquidationId,
+              tenantId,
+              status: 'REVIEWED',
+              publicationSnapshot: { equals: Prisma.DbNull },
+            },
+            data: {
+              status: 'PUBLISHED',
+              publicationSnapshot,
+              publishedByMembershipId: membership.id,
+              publishedAt: now,
+              updatedAt: now,
+            },
+          });
+
+          if (updateResult.count === 0) {
+            const currentPublication = await tx.liquidation.findFirst({
+              where: { id: liquidationId, tenantId },
+            });
+
+            if (!currentPublication) {
+              throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
+            }
+
+            if (currentPublication.status === 'PUBLISHED') {
+              return {
+                liquidation: this.deps.toPublishedLiquidationDto(currentPublication as LiquidationRecord),
+                publishedNow: false,
+              };
+            }
+
+            throw new ConflictException(
+              `La liquidación ${liquidationId} cambió durante la operación`,
+            );
+          }
+
+          await this.deps.createAuditLogRequired(
+            {
+              tenantId,
+              actorMembershipId: membership.id,
+              action: 'LIQUIDATION_PUBLISH',
+              entityType: 'Liquidation',
+              entityId: liquidationId,
+              metadata: {
+                period: current.period,
+                buildingId: current.buildingId,
+                chargesCount: distribution.length,
+                totalAmountMinor: current.totalAmountMinor,
+                baseCurrency: current.baseCurrency,
+                snapshotVersion: 1,
+                dueDate: dueDate.toISOString().slice(0, 10),
+                publishedAt: now.toISOString(),
+              },
+            },
+            tx,
+          );
+
+          const liquidation = await tx.liquidation.findFirst({
+            where: { id: liquidationId, tenantId },
+          });
+
+          if (!liquidation) {
+            throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
+          }
+
+          return {
+            liquidation: this.deps.toPublishedLiquidationDto(liquidation as LiquidationRecord),
+            publishedNow: true,
+          };
+        },
+        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
+      );
+    } catch (error) {
+      if (isSerializationConflict(error)) {
+        const current = await this.deps.prisma.liquidation.findFirst({
+          where: { id: liquidationId, tenantId },
+        });
+
+        if (current?.status === 'PUBLISHED') {
+          return this.deps.toPublishedLiquidationDto(current as LiquidationRecord);
+        }
+
+        throw new ConflictException(
+          `La liquidación ${liquidationId} cambió durante la operación`,
+        );
+      }
+
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        const current = await this.deps.prisma.liquidation.findFirst({
+          where: { id: liquidationId, tenantId },
+        });
+
+        if (current?.status === 'PUBLISHED') {
+          return this.deps.toPublishedLiquidationDto(current as LiquidationRecord);
+        }
+
+        throw new ConflictException(
+          `La liquidación ${liquidationId} ya tiene cargos generados para ${current?.period ?? 'este período'}`,
+        );
+      }
+
+      throw error;
+    }
+
+    if (!publishResult) {
+      throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
+    }
+
+    if (publishResult.publishedNow && notificationPolicy === 'post-commit') {
+      const notificationResult = await this.deps.sendChargePublishedNotifications(
+        tenantId,
+        liquidationId,
+        {
+          period: publishResult.liquidation.period,
+          buildingId: publishResult.liquidation.buildingId,
+          baseCurrency: publishResult.liquidation.baseCurrency,
+        },
+      );
+
+      if (notificationResult.failedCount > 0) {
+        await this.deps.createAuditLog({
+          tenantId,
+          action: 'LIQUIDATION_PUBLISH',
+          entityType: 'Liquidation',
+          entityId: liquidationId,
+          metadata: {
+            period: publishResult.liquidation.period,
+            buildingId: publishResult.liquidation.buildingId,
+            notificationFailure: true,
+            errors: notificationResult.errorMessages,
+          },
+        });
+      }
+    }
+
+    return publishResult.liquidation;
+  }
+}
+
+export function parseTotalsByCurrency(value: unknown): Record<string, number> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw new BadRequestException('Liquidation totalsByCurrency snapshot is invalid');
+  }
+
+  const result: Record<string, number> = {};
+
+  for (const [currency, amount] of Object.entries(value as Record<string, unknown>)) {
+    if (typeof amount !== 'number' || !Number.isSafeInteger(amount) || amount < 0) {
+      throw new BadRequestException(
+        `Liquidation totalsByCurrency snapshot has invalid amount for ${currency}`,
+      );
+    }
+
+    result[currency] = amount;
+  }
+
+  return result;
+}
+
+function isSerializationConflict(
+  error: unknown,
+): error is Prisma.PrismaClientKnownRequestError {
+  return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2034';
+}
+
+function parseExpenseSnapshot(value: unknown): LiquidationExpenseSnapshotItem[] {
+  if (!Array.isArray(value)) {
+    throw new BadRequestException('Liquidation expense snapshot is invalid');
+  }
+
+  return value.map((item, index) => {
+    if (item === null || typeof item !== 'object' || Array.isArray(item)) {
+      throw new BadRequestException(`Liquidation expense snapshot item ${index} is invalid`);
+    }
+
+    const snapshot = item as Record<string, unknown>;
+    const expenseId = snapshot.expenseId;
+    const categoryName = snapshot.categoryName;
+    const vendorName = snapshot.vendorName;
+    const amountMinor = snapshot.amountMinor;
+    const currencyCode = snapshot.currencyCode;
+    const invoiceDate = snapshot.invoiceDate;
+    const description = snapshot.description;
+    const type = snapshot.type;
+    const sourcePeriod = snapshot.sourcePeriod;
+
+    if (typeof expenseId !== 'string') {
+      throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid expenseId`);
+    }
+    if (typeof categoryName !== 'string') {
+      throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid categoryName`);
+    }
+    if (vendorName !== null && typeof vendorName !== 'string') {
+      throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid vendorName`);
+    }
+    if (typeof amountMinor !== 'number' || !Number.isSafeInteger(amountMinor) || amountMinor < 0) {
+      throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid amountMinor`);
+    }
+    if (typeof currencyCode !== 'string') {
+      throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid currencyCode`);
+    }
+    if (typeof invoiceDate !== 'string') {
+      throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid invoiceDate`);
+    }
+    if (description !== null && typeof description !== 'string') {
+      throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid description`);
+    }
+    if (type !== 'EXPENSE' && type !== 'ADJUSTMENT') {
+      throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid type`);
+    }
+    if (sourcePeriod !== undefined && sourcePeriod !== null && typeof sourcePeriod !== 'string') {
+      throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid sourcePeriod`);
+    }
+
+    const parsedInvoiceDate = new Date(invoiceDate);
+    if (Number.isNaN(parsedInvoiceDate.getTime())) {
+      throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid invoiceDate`);
+    }
+
+    return {
+      expenseId,
+      categoryName,
+      vendorName,
+      amountMinor,
+      currencyCode,
+      invoiceDate: parsedInvoiceDate.toISOString(),
+      description,
+      type,
+      sourcePeriod: sourcePeriod ?? undefined,
+    };
+  });
+}
+
+function getPublicationSnapshotExpenses(
+  value: unknown,
+): ReadonlyArray<PublishedExpenseSnapshot> {
+  return parseExpenseSnapshot(value).map((expense) => ({
+    expenseId: expense.expenseId,
+    categoryName: expense.categoryName,
+    vendorName: expense.vendorName,
+    amountMinor: expense.amountMinor,
+    currencyCode: expense.currencyCode,
+    invoiceDate: expense.invoiceDate,
+    description: expense.description,
+    type: expense.type,
+    ...(expense.sourcePeriod ? { sourcePeriod: expense.sourcePeriod } : {}),
+  }));
+}
+
+function calculateDistribution(
+  units: Array<{
+    id: string;
+    code: string;
+    label: string | null;
+    unitCategory: { id: string; coefficient: number } | null;
+  }>,
+  totalAmountMinor: number,
+  buildingId: string,
+): Array<{ unitId: string; unitCode: string; unitLabel: string | null; amountMinor: number }> {
+  if (units.length === 0) {
+    throw new BadRequestException(`No billable units found for building ${buildingId}`);
+  }
+
+  const unitsWithWeight = units.map((unit) => ({
+    unitId: unit.id,
+    unitCode: unit.code,
+    unitLabel: unit.label,
+    weight: unit.unitCategory?.coefficient && unit.unitCategory.coefficient > 0
+      ? unit.unitCategory.coefficient
+      : 1,
+  }));
+
+  const totalWeight = unitsWithWeight.reduce((sum, unit) => sum + unit.weight, 0);
+
+  if (totalWeight <= 0) {
+    throw new BadRequestException(`Invalid unit coefficients for building ${buildingId}`);
+  }
+
+  const allocations = unitsWithWeight.map((unit) => ({
+    ...unit,
+    rawAmount: (totalAmountMinor * unit.weight) / totalWeight,
+  }));
+
+  const roundedAllocations = allocations.map((unit) => ({
+    unitId: unit.unitId,
+    unitCode: unit.unitCode,
+    unitLabel: unit.unitLabel,
+    amountMinor: Math.floor(unit.rawAmount),
+    fractionalRemainder: unit.rawAmount - Math.floor(unit.rawAmount),
+  }));
+
+  let allocatedTotal = roundedAllocations.reduce((sum, item) => sum + item.amountMinor, 0);
+  let remainder = totalAmountMinor - allocatedTotal;
+
+  roundedAllocations
+    .sort((left, right) => right.fractionalRemainder - left.fractionalRemainder)
+    .forEach((item) => {
+      if (remainder > 0) {
+        item.amountMinor += 1;
+        remainder -= 1;
+      }
+    });
+
+  allocatedTotal = roundedAllocations.reduce((sum, item) => sum + item.amountMinor, 0);
+
+  if (allocatedTotal !== totalAmountMinor) {
+    throw new BadRequestException(
+      `Distribution total ${allocatedTotal} does not match liquidation total ${totalAmountMinor}`,
+    );
+  }
+
+  return roundedAllocations
+    .map(({ unitId, unitCode, unitLabel, amountMinor }) => ({
+      unitId,
+      unitCode,
+      unitLabel,
+      amountMinor,
+    }))
+    .sort((left, right) => left.unitCode.localeCompare(right.unitCode));
+}

--- a/apps/api/src/finanzas/liquidations.service.spec.ts
+++ b/apps/api/src/finanzas/liquidations.service.spec.ts
@@ -11,6 +11,10 @@ import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { FinanzasValidators } from './finanzas.validators';
 import { NotificationsService } from '../notifications/notifications.service';
+import {
+  createLiquidationWorkflowDependencies,
+  LiquidationPublicationUseCase,
+} from './liquidation-publication.use-case';
 
 const baseLiquidation = {
   id: 'liq-1',
@@ -48,6 +52,7 @@ describe('LiquidationsService', () => {
   let auditService: { createLog: jest.Mock; createLogRequired: jest.Mock };
   let validators: { isAdminOrOperator: jest.Mock };
   let notificationsService: { createNotification: jest.Mock };
+  let publicationUseCase: LiquidationPublicationUseCase;
   let tx: {
     membership: {
       findFirst: jest.Mock;
@@ -133,6 +138,24 @@ describe('LiquidationsService', () => {
       providers: [
         LiquidationsService,
         {
+          provide: LiquidationPublicationUseCase,
+          inject: [PrismaService, AuditService, FinanzasValidators, NotificationsService],
+          useFactory: (
+            prisma: PrismaService,
+            auditService: AuditService,
+            validators: FinanzasValidators,
+            notificationsService: NotificationsService,
+          ) =>
+            new LiquidationPublicationUseCase(
+              createLiquidationWorkflowDependencies({
+                prisma,
+                auditService,
+                validators,
+                notificationsService,
+              }),
+            ),
+        },
+        {
           provide: PrismaService,
           useValue: {
             membership: {
@@ -207,6 +230,7 @@ describe('LiquidationsService', () => {
     }).compile();
 
     service = module.get<LiquidationsService>(LiquidationsService);
+    publicationUseCase = module.get<LiquidationPublicationUseCase>(LiquidationPublicationUseCase);
     prisma = module.get<PrismaService>(PrismaService);
   });
 
@@ -873,5 +897,24 @@ describe('LiquidationsService', () => {
       },
     });
     expect(auditService.createLogRequired).not.toHaveBeenCalled();
+  });
+
+  it('applies the same finance membership validation in the service path and the publication use case', async () => {
+    (prisma.membership.findFirst as jest.Mock).mockResolvedValueOnce(null);
+    tx.membership.findFirst.mockResolvedValueOnce(null);
+
+    await expect(
+      service.listLiquidations('tenant-1', 'member-1', {}),
+    ).rejects.toThrow('No se encontró una membresía válida para el tenant');
+
+    await expect(
+      publicationUseCase.execute(
+        'tenant-1',
+        'liq-1',
+        'member-1',
+        { dueDate: '2026-06-10' },
+        'disabled',
+      ),
+    ).rejects.toThrow('No se encontró una membresía válida para el tenant');
   });
 });

--- a/apps/api/src/finanzas/liquidations.service.ts
+++ b/apps/api/src/finanzas/liquidations.service.ts
@@ -4,12 +4,10 @@ import {
   BadRequestException,
   ConflictException,
   ForbiddenException,
-  Logger,
 } from '@nestjs/common';
 import { ChargeStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
-import { NotificationsService } from '../notifications/notifications.service';
 import {
   CreateLiquidationDraftDto,
   PublishLiquidationDto,
@@ -18,10 +16,16 @@ import {
 } from './expense-ledger.dto';
 import { FinanzasValidators } from './finanzas.validators';
 import {
-  buildLiquidationPublicationSnapshot,
   parseLiquidationPublicationSnapshot,
   type PublishedExpenseSnapshot,
 } from './liquidation-publication-snapshot';
+import {
+  createLiquidationDraftRecord,
+  LiquidationPublicationUseCase,
+  parseTotalsByCurrency,
+  requireFinanceMembership,
+  reviewLiquidationRecord,
+} from './liquidation-publication.use-case';
 
 interface LiquidationExpenseSnapshotItem extends Prisma.InputJsonObject {
   expenseId: string;
@@ -52,49 +56,13 @@ interface CancelLiquidationOptions {
   readonly reason?: string;
 }
 
-interface FinanceMembershipRecord {
-  id: string;
-  tenantId: string;
-  roles: Array<{
-    role: string;
-    scopeType: 'TENANT' | 'BUILDING' | 'UNIT';
-  }>;
-}
-
-interface FinanceMembershipContext {
-  id: string;
-  tenantId: string;
-  roles: string[];
-}
-
-interface FinanceMembershipClient {
-  membership: {
-    findFirst: (args: {
-      where: { id: string; tenantId: string };
-      select: {
-        id: boolean;
-        tenantId: boolean;
-        roles: { select: { role: boolean; scopeType: boolean } };
-      };
-    }) => Promise<FinanceMembershipRecord | null>;
-  };
-}
-
-interface NotificationDispatchResult {
-  readonly sentCount: number;
-  readonly failedCount: number;
-  readonly errorMessages: ReadonlyArray<string>;
-}
-
 @Injectable()
 export class LiquidationsService {
-  private readonly logger = new Logger(LiquidationsService.name);
-
   constructor(
     private readonly prisma: PrismaService,
     private readonly auditService: AuditService,
     private readonly validators: FinanzasValidators,
-    private readonly notificationsService: NotificationsService,
+    private readonly publicationUseCase: LiquidationPublicationUseCase,
   ) {}
 
   private expenseAccountingPeriodWhere(period: string): {
@@ -113,7 +81,12 @@ export class LiquidationsService {
     membershipId: string,
     query: { buildingId?: string; period?: string },
   ): Promise<LiquidationResponseDto[]> {
-    const membership = await this.requireFinanceMembership(this.prisma, tenantId, membershipId);
+    const membership = await requireFinanceMembership(
+      this.prisma,
+      tenantId,
+      membershipId,
+      (roles) => this.validators.isAdminOrOperator(roles),
+    );
     if (!this.validators.isAdminOrOperator(membership.roles)) {
       throw new ForbiddenException('Solo administradores pueden ver liquidaciones');
     }
@@ -136,7 +109,12 @@ export class LiquidationsService {
     liquidationId: string,
     membershipId: string,
   ): Promise<LiquidationDetailDto> {
-    const membership = await this.requireFinanceMembership(this.prisma, tenantId, membershipId);
+    const membership = await requireFinanceMembership(
+      this.prisma,
+      tenantId,
+      membershipId,
+      (roles) => this.validators.isAdminOrOperator(roles),
+    );
     if (!this.validators.isAdminOrOperator(membership.roles)) {
       throw new ForbiddenException('Acceso denegado');
     }
@@ -172,7 +150,12 @@ export class LiquidationsService {
     dto: CreateLiquidationDraftDto,
   ): Promise<LiquidationDetailDto> {
     return this.prisma.$transaction(async (tx) => {
-      const membership = await this.requireFinanceMembership(tx, tenantId, membershipId);
+      const membership = await requireFinanceMembership(
+        tx,
+        tenantId,
+        membershipId,
+        (roles) => this.validators.isAdminOrOperator(roles),
+      );
       if (!this.validators.isAdminOrOperator(membership.roles)) {
         throw new ForbiddenException('Solo administradores pueden generar liquidaciones');
       }
@@ -349,46 +332,19 @@ export class LiquidationsService {
         dto.buildingId,
       );
 
-      const liquidation = await tx.liquidation.create({
-        data: {
-          tenantId,
-          buildingId: dto.buildingId,
-          period: dto.period,
-          baseCurrency: dto.baseCurrency,
-          totalAmountMinor,
-          totalsByCurrency,
-          expenseSnapshot: expenseSnapshotItems,
-          unitCount: billableUnits.length,
-          generatedByMembershipId: membership.id,
-        },
+      const created = await createLiquidationDraftRecord(tx, {
+        createAuditLogRequired: (input, client) => this.auditService.createLogRequired(input, client),
+      }, {
+        tenantId,
+        buildingId: dto.buildingId,
+        period: dto.period,
+        baseCurrency: dto.baseCurrency,
+        totalAmountMinor,
+        totalsByCurrency,
+        expenseSnapshot: expenseSnapshotItems,
+        unitCount: billableUnits.length,
+        generatedByMembershipId: membership.id,
       });
-
-      await this.auditService.createLogRequired(
-        {
-          tenantId,
-          actorMembershipId: membership.id,
-          action: 'LIQUIDATION_DRAFT',
-          entityType: 'Liquidation',
-          entityId: liquidation.id,
-          metadata: {
-            period: dto.period,
-            buildingId: dto.buildingId,
-            totalAmountMinor,
-            baseCurrency: dto.baseCurrency,
-            expenseCount: allExpenses.length,
-            adjustmentCount: adjustments.length,
-          },
-        },
-        tx,
-      );
-
-      const created = await tx.liquidation.findFirst({
-        where: { id: liquidation.id, tenantId },
-      });
-
-      if (!created) {
-        throw new NotFoundException(`Liquidación no encontrada: ${liquidation.id}`);
-      }
 
       return this.toDetailDto(created, {
         charges: chargesPreview,
@@ -402,71 +358,23 @@ export class LiquidationsService {
     membershipId: string,
   ): Promise<LiquidationResponseDto> {
     return this.prisma.$transaction(async (tx) => {
-      const membership = await this.requireFinanceMembership(tx, tenantId, membershipId);
+      const membership = await requireFinanceMembership(
+        tx,
+        tenantId,
+        membershipId,
+        (roles) => this.validators.isAdminOrOperator(roles),
+      );
       if (!this.validators.isAdminOrOperator(membership.roles)) {
         throw new ForbiddenException('Acceso denegado');
       }
 
-      const current = await tx.liquidation.findFirst({
-        where: { id: liquidationId, tenantId },
+      const updated = await reviewLiquidationRecord(tx, {
+        createAuditLogRequired: (input, client) => this.auditService.createLogRequired(input, client),
+      }, {
+        tenantId,
+        liquidationId,
+        membershipId: membership.id,
       });
-
-      if (!current) {
-        throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-      }
-
-      const now = new Date();
-      const updateResult = await tx.liquidation.updateMany({
-        where: { id: liquidationId, tenantId, status: 'DRAFT' },
-        data: {
-          status: 'REVIEWED',
-          reviewedByMembershipId: membership.id,
-          reviewedAt: now,
-          updatedAt: now,
-        },
-      });
-
-      if (updateResult.count !== 1) {
-        const latest = await tx.liquidation.findFirst({
-          where: { id: liquidationId, tenantId },
-        });
-
-        if (!latest) {
-          throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-        }
-
-        if (latest.status === 'DRAFT') {
-          throw new ConflictException(`La liquidación ${liquidationId} cambió durante la revisión`);
-        }
-
-        throw new ConflictException(
-          `Solo se puede revisar una liquidación en DRAFT. Estado actual: ${latest.status}`,
-        );
-      }
-
-      await this.auditService.createLogRequired(
-        {
-          tenantId,
-          actorMembershipId: membership.id,
-          action: 'LIQUIDATION_REVIEW',
-          entityType: 'Liquidation',
-          entityId: liquidationId,
-          metadata: {
-            period: current.period,
-            buildingId: current.buildingId,
-            reviewedAt: now.toISOString(),
-          },
-        },
-        tx,
-      );
-
-      const updated = await tx.liquidation.findFirst({
-        where: { id: liquidationId, tenantId },
-      });
-
-      if (!updated) {
-        throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-      }
 
       return this.toDto(updated);
     });
@@ -485,286 +393,15 @@ export class LiquidationsService {
     membershipId: string,
     dto: PublishLiquidationDto,
   ): Promise<LiquidationResponseDto> {
-    let publishResult: { liquidation: LiquidationResponseDto; publishedNow: boolean } | null = null;
+    const result = await this.publicationUseCase.execute(
+      tenantId,
+      liquidationId,
+      membershipId,
+      dto,
+      'post-commit',
+    );
 
-    try {
-      publishResult = await this.prisma.$transaction(
-        async (tx) => {
-          const membership = await this.requireFinanceMembership(tx, tenantId, membershipId);
-          if (!this.validators.isAdminOrOperator(membership.roles)) {
-            throw new ForbiddenException('Acceso denegado');
-          }
-
-          const current = await tx.liquidation.findFirst({
-            where: { id: liquidationId, tenantId },
-          });
-
-          if (!current) {
-            throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-          }
-
-          if (current.status === 'PUBLISHED') {
-            return { liquidation: this.toPublishedLiquidationDto(current), publishedNow: false };
-          }
-
-          if (current.status !== 'REVIEWED') {
-            throw new BadRequestException(
-              `Solo se puede publicar una liquidación revisada. Estado actual: ${current.status}`,
-            );
-          }
-
-          const billableUnits = await tx.unit.findMany({
-            where: { tenantId, buildingId: current.buildingId, isBillable: true },
-            include: { unitCategory: { select: { coefficient: true, id: true } } },
-            orderBy: { code: 'asc' },
-          });
-
-          if (billableUnits.length === 0) {
-            throw new BadRequestException('No hay unidades facturables en este edificio');
-          }
-
-          const now = new Date();
-          const dueDate = new Date(dto.dueDate);
-          if (Number.isNaN(dueDate.getTime())) {
-            throw new BadRequestException('dueDate must be a valid date');
-          }
-
-          const distribution = this.calculateDistribution(
-            billableUnits,
-            current.totalAmountMinor,
-            current.buildingId,
-          );
-
-          const publicationSnapshot = buildLiquidationPublicationSnapshot({
-            liquidationId: current.id,
-            tenantId,
-            buildingId: current.buildingId,
-            period: current.period,
-            baseCurrency: current.baseCurrency,
-            totalAmountMinor: current.totalAmountMinor,
-            totalsByCurrency: this.parseTotalsByCurrency(current.totalsByCurrency),
-            expenses: this.getPublicationSnapshotExpenses(current.expenseSnapshot),
-            allocations: distribution.map((item) => ({
-              unitId: item.unitId,
-              unitCode: item.unitCode,
-              unitLabel: item.unitLabel,
-              amountMinor: item.amountMinor,
-            })),
-            dueDate,
-            publishedAt: now,
-          });
-
-          const duplicatePublished = await tx.liquidation.findFirst({
-            where: {
-              tenantId,
-              buildingId: current.buildingId,
-              period: current.period,
-              status: 'PUBLISHED',
-              id: { not: liquidationId },
-            },
-            select: { id: true },
-          });
-
-          if (duplicatePublished) {
-            throw new ConflictException(
-              `Ya existe una liquidación publicada para el período ${current.period}`,
-            );
-          }
-
-          const concept = `Expensas comunes ${current.period}`;
-          const expectedCharges = distribution.map((distributionItem) => ({
-            tenantId,
-            buildingId: current.buildingId,
-            unitId: distributionItem.unitId,
-            period: current.period,
-            type: 'COMMON_EXPENSE' as const,
-            concept,
-            amount: distributionItem.amountMinor,
-            currency: current.baseCurrency,
-            dueDate,
-            liquidationId,
-          }));
-
-          const existingCharges = await tx.charge.findMany({
-            where: {
-              tenantId,
-              liquidationId,
-              buildingId: current.buildingId,
-              period: current.period,
-            },
-            select: {
-              unitId: true,
-              amount: true,
-              currency: true,
-              dueDate: true,
-              buildingId: true,
-              period: true,
-              liquidationId: true,
-              concept: true,
-            },
-            orderBy: { unitId: 'asc' },
-          });
-
-          if (existingCharges.length > 0) {
-            if (existingCharges.length !== expectedCharges.length) {
-              throw new ConflictException(
-                `La liquidación ${liquidationId} tiene cargos parciales generados para ${current.period}`,
-              );
-            }
-
-            const expectedChargesByUnit = new Map(
-              expectedCharges.map((charge) => [charge.unitId, charge]),
-            );
-
-            for (const existingCharge of existingCharges) {
-              const expectedCharge = expectedChargesByUnit.get(existingCharge.unitId);
-
-              if (
-                !expectedCharge ||
-                existingCharge.amount !== expectedCharge.amount ||
-                existingCharge.currency !== expectedCharge.currency ||
-                existingCharge.buildingId !== expectedCharge.buildingId ||
-                existingCharge.period !== expectedCharge.period ||
-                existingCharge.liquidationId !== expectedCharge.liquidationId ||
-                existingCharge.concept !== expectedCharge.concept ||
-                existingCharge.dueDate.getTime() !== expectedCharge.dueDate.getTime()
-              ) {
-                throw new ConflictException(
-                  `La liquidación ${liquidationId} tiene cargos existentes que no coinciden con la publicación esperada`,
-                );
-              }
-            }
-          } else {
-            await tx.charge.createMany({
-              data: expectedCharges.map((charge) => ({
-                ...charge,
-                status: ChargeStatus.PENDING,
-                createdByMembershipId: membership.id,
-              })),
-            });
-          }
-
-          const updateResult = await tx.liquidation.updateMany({
-            where: {
-              id: liquidationId,
-              tenantId,
-              status: 'REVIEWED',
-              publicationSnapshot: { equals: Prisma.DbNull },
-            },
-            data: {
-              status: 'PUBLISHED',
-              publicationSnapshot,
-              publishedByMembershipId: membership.id,
-              publishedAt: now,
-              updatedAt: now,
-            },
-          });
-
-          if (updateResult.count === 0) {
-            const currentPublication = await tx.liquidation.findFirst({
-              where: { id: liquidationId, tenantId },
-            });
-
-            if (!currentPublication) {
-              throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-            }
-
-            if (currentPublication.status === 'PUBLISHED') {
-              return {
-                liquidation: this.toPublishedLiquidationDto(currentPublication),
-                publishedNow: false,
-              };
-            }
-
-            throw new ConflictException(
-              `La liquidación ${liquidationId} cambió durante la operación`,
-            );
-          }
-
-          await this.auditService.createLogRequired(
-            {
-              tenantId,
-              actorMembershipId: membership.id,
-              action: 'LIQUIDATION_PUBLISH',
-              entityType: 'Liquidation',
-              entityId: liquidationId,
-              metadata: {
-                period: current.period,
-                buildingId: current.buildingId,
-                chargesCount: distribution.length,
-                totalAmountMinor: current.totalAmountMinor,
-                baseCurrency: current.baseCurrency,
-                snapshotVersion: 1,
-                dueDate: dueDate.toISOString().slice(0, 10),
-                publishedAt: now.toISOString(),
-              },
-            },
-            tx,
-          );
-
-          const liquidation = await tx.liquidation.findFirst({
-            where: { id: liquidationId, tenantId },
-          });
-
-          if (!liquidation) {
-            throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-          }
-
-          return { liquidation: this.toPublishedLiquidationDto(liquidation), publishedNow: true };
-        },
-        { isolationLevel: Prisma.TransactionIsolationLevel.Serializable },
-      );
-    } catch (error) {
-      if (this.isSerializationConflict(error)) {
-        const current = await this.prisma.liquidation.findFirst({
-          where: { id: liquidationId, tenantId },
-        });
-
-        if (current?.status === 'PUBLISHED') {
-          return this.toDto(current);
-        }
-
-        throw new ConflictException(
-          `La liquidación ${liquidationId} cambió durante la operación`,
-        );
-      }
-
-      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
-        const current = await this.prisma.liquidation.findFirst({
-          where: { id: liquidationId, tenantId },
-        });
-
-        if (current?.status === 'PUBLISHED') {
-          return this.toDto(current);
-        }
-
-        throw new ConflictException(
-          `La liquidación ${liquidationId} ya tiene cargos generados para ${current?.period ?? 'este período'}`,
-        );
-      }
-
-      throw error;
-    }
-
-    if (!publishResult) {
-      throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-    }
-
-    if (publishResult.publishedNow) {
-      const notificationResult = await this.sendChargePublishedNotifications(tenantId, liquidationId, {
-        period: publishResult.liquidation.period,
-        buildingId: publishResult.liquidation.buildingId,
-        baseCurrency: publishResult.liquidation.baseCurrency,
-      });
-
-      if (notificationResult.failedCount > 0) {
-        this.logger.warn(
-          `Charge notifications for liquidation ${liquidationId} completed with ${notificationResult.failedCount} failure(s)`,
-        );
-      }
-    }
-
-    return publishResult.liquidation;
+    return result;
   }
 
   /**
@@ -780,7 +417,12 @@ export class LiquidationsService {
     membershipId: string,
     options: CancelLiquidationOptions = {},
   ): Promise<LiquidationResponseDto> {
-    const membership = await this.requireFinanceMembership(this.prisma, tenantId, membershipId);
+    const membership = await requireFinanceMembership(
+      this.prisma,
+      tenantId,
+      membershipId,
+      (roles) => this.validators.isAdminOrOperator(roles),
+    );
     if (!this.validators.isAdminOrOperator(membership.roles)) {
       throw new ForbiddenException('Acceso denegado');
     }
@@ -979,7 +621,7 @@ export class LiquidationsService {
     canceledAt: Date | null;
     createdAt: Date;
   }): LiquidationResponseDto {
-    const totalsByCurrency = this.parseTotalsByCurrency(liq.totalsByCurrency);
+    const totalsByCurrency = parseTotalsByCurrency(liq.totalsByCurrency);
 
     return {
       id: liq.id,
@@ -1073,79 +715,6 @@ export class LiquidationsService {
       })),
       chargesPreview: options.charges,
     };
-  }
-
-  private toPublishedLiquidationDto(liq: {
-    id: string;
-    tenantId: string;
-    buildingId: string;
-    period: string;
-    chargePeriod: string | null;
-    status: 'DRAFT' | 'REVIEWED' | 'PUBLISHED' | 'CANCELED';
-    baseCurrency: string;
-    totalAmountMinor: number;
-    totalsByCurrency: unknown;
-    unitCount: number;
-    generatedAt: Date;
-    reviewedAt: Date | null;
-    publishedAt: Date | null;
-    canceledAt: Date | null;
-    createdAt: Date;
-  }): LiquidationResponseDto {
-    return this.toDto(liq);
-  }
-
-  private async requireFinanceMembership(
-    client: PrismaService | Prisma.TransactionClient | FinanceMembershipClient,
-    tenantId: string,
-    membershipId: string,
-  ): Promise<FinanceMembershipContext> {
-    const membership = await client.membership.findFirst({
-      where: { id: membershipId, tenantId },
-      select: {
-        id: true,
-        tenantId: true,
-        roles: { select: { role: true, scopeType: true } },
-      },
-    });
-
-    if (!membership) {
-      throw new ForbiddenException('No se encontró una membresía válida para el tenant');
-    }
-
-    const tenantRoles = membership.roles
-      .filter((role) => role.scopeType === 'TENANT')
-      .map((role) => role.role);
-
-    if (!this.validators.isAdminOrOperator(tenantRoles)) {
-      throw new ForbiddenException('Solo administradores pueden gestionar liquidaciones');
-    }
-
-    return {
-      id: membership.id,
-      tenantId: membership.tenantId,
-      roles: tenantRoles,
-    };
-  }
-
-  private parseTotalsByCurrency(value: unknown): Record<string, number> {
-    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-      throw new BadRequestException('Liquidation totalsByCurrency snapshot is invalid');
-    }
-
-    const result: Record<string, number> = {};
-
-    for (const [currency, amount] of Object.entries(value as Record<string, unknown>)) {
-      if (typeof amount !== 'number' || !Number.isSafeInteger(amount) || amount < 0) {
-        throw new BadRequestException(
-          `Liquidation totalsByCurrency snapshot has invalid amount for ${currency}`,
-        );
-      }
-
-      result[currency] = amount;
-    }
-
-    return result;
   }
 
   private safeAddAmountMinor(left: number, right: number, field: string): number {
@@ -1263,127 +832,4 @@ export class LiquidationsService {
     }));
   }
 
-  /**
-   * [PHASE 2 QUICK #2] Send CHARGE_PUBLISHED notifications to residents
-   * Best-effort notification dispatch with observable result.
-   */
-  private async sendChargePublishedNotifications(
-    tenantId: string,
-    liquidationId: string,
-    liquidation: {
-      period: string;
-      buildingId: string;
-      baseCurrency: string;
-    },
-  ): Promise<NotificationDispatchResult> {
-    let sentCount = 0;
-    let failedCount = 0;
-    const errorMessages: string[] = [];
-
-    try {
-      // Load all charges for this liquidation
-      const charges = await this.prisma.charge.findMany({
-        where: { tenantId, liquidationId },
-      });
-
-      // For each charge, load unit and occupants
-      for (const charge of charges) {
-        const unit = await this.prisma.unit.findFirst({
-          where: {
-            tenantId,
-            buildingId: liquidation.buildingId,
-            id: charge.unitId,
-          },
-          include: {
-            unitOccupants: {
-              where: { tenantId, endDate: null }, // Active occupants only
-              include: {
-                member: {
-                  select: { id: true, tenantId: true, user: { select: { id: true } } },
-                },
-              },
-            },
-          },
-        });
-
-        if (!unit) continue;
-
-        // Send notification to each active resident
-        for (const occupant of unit.unitOccupants) {
-          if (occupant.member?.user?.id) {
-            const dueDateStr = charge.dueDate
-              ? new Date(charge.dueDate).toLocaleDateString('es-AR')
-              : 'N/A';
-
-            try {
-              await this.notificationsService.createNotification({
-                tenantId,
-                userId: occupant.member.user.id,
-                type: 'CHARGE_PUBLISHED',
-                title: `${liquidation.buildingId} - Nuevo cargo por ${liquidation.period}`,
-                body: `Se ha registrado un cargo de ${(charge.amount / 100).toFixed(2)} ${liquidation.baseCurrency} en la unidad ${unit.label}. Vencimiento: ${dueDateStr}`,
-                data: {
-                  chargeId: charge.id,
-                  unitLabel: unit.label,
-                  unitId: unit.id,
-                  amount: charge.amount / 100,
-                  currency: charge.currency,
-                  dueDate: charge.dueDate?.toISOString(),
-                  period: liquidation.period,
-                },
-                deliveryMethods: ['IN_APP', 'EMAIL'],
-              });
-              sentCount += 1;
-            } catch (notificationError) {
-              failedCount += 1;
-              errorMessages.push(
-                notificationError instanceof Error
-                  ? notificationError.message
-                  : String(notificationError),
-              );
-              this.logger.error(
-                `Failed to create notification for charge ${charge.id} in liquidation ${liquidationId}`,
-                notificationError instanceof Error ? notificationError.stack : String(notificationError),
-              );
-            }
-          } else {
-            failedCount += 1;
-            errorMessages.push(
-              `Missing user for occupant ${occupant.member?.id ?? 'unknown'} in unit ${unit.id}`,
-            );
-          }
-        }
-      }
-    } catch (error) {
-      failedCount += 1;
-      errorMessages.push(error instanceof Error ? error.message : String(error));
-      try {
-        await this.auditService.createLog({
-          tenantId,
-          action: 'LIQUIDATION_PUBLISH',
-          entityType: 'Liquidation',
-          entityId: liquidationId,
-          metadata: {
-            period: liquidation.period,
-            buildingId: liquidation.buildingId,
-            notificationFailure: true,
-            error: error instanceof Error ? error.message : String(error),
-          },
-        });
-      } catch (auditError) {
-        this.logger.error(
-          `Failed to persist notification failure audit for liquidation ${liquidationId}`,
-          auditError instanceof Error ? auditError.stack : String(auditError),
-        );
-      }
-
-      // Fire-and-forget: log but never fail
-      this.logger.error(
-        `Failed to send charge notifications for liquidation ${liquidationId}`,
-        error instanceof Error ? error.stack : String(error),
-      );
-    }
-
-    return { sentCount, failedCount, errorMessages };
-  }
 }

--- a/apps/api/src/finanzas/liquidations.wiring.spec.ts
+++ b/apps/api/src/finanzas/liquidations.wiring.spec.ts
@@ -1,0 +1,92 @@
+import { Test } from '@nestjs/testing';
+import { MODULE_METADATA } from '@nestjs/common/constants';
+import { AuditService } from '../audit/audit.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { FinanzasModule } from './finanzas.module';
+import { FinanzasValidators } from './finanzas.validators';
+import {
+  createLiquidationWorkflowDependencies,
+  LiquidationPublicationUseCase,
+} from './liquidation-publication.use-case';
+import { LiquidationsService } from './liquidations.service';
+
+describe('FinanzasModule wiring', () => {
+  it('registers LiquidationPublicationUseCase in module metadata and resolves the same Nest-managed instance inside LiquidationsService', async () => {
+    const providersMetadata = Reflect.getMetadata(
+      MODULE_METADATA.PROVIDERS,
+      FinanzasModule,
+    ) as unknown[];
+
+    expect(Array.isArray(providersMetadata)).toBe(true);
+    expect(providersMetadata).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ provide: LiquidationPublicationUseCase }),
+        LiquidationsService,
+      ]),
+    );
+
+    const moduleRef = await Test.createTestingModule({
+      providers: [
+        {
+          provide: PrismaService,
+          useValue: {
+            membership: { findFirst: jest.fn() },
+            liquidation: { findFirst: jest.fn(), create: jest.fn() },
+            charge: { findMany: jest.fn() },
+            unit: { findMany: jest.fn(), findFirst: jest.fn() },
+            $transaction: jest.fn(),
+          },
+        },
+        {
+          provide: AuditService,
+          useValue: {
+            createLog: jest.fn(),
+            createLogRequired: jest.fn(),
+          },
+        },
+        {
+          provide: FinanzasValidators,
+          useValue: {
+            isAdminOrOperator: jest.fn().mockReturnValue(true),
+          },
+        },
+        {
+          provide: NotificationsService,
+          useValue: {
+            createNotification: jest.fn(),
+          },
+        },
+        {
+          provide: LiquidationPublicationUseCase,
+          inject: [PrismaService, AuditService, FinanzasValidators, NotificationsService],
+          useFactory: (
+            prisma: PrismaService,
+            auditService: AuditService,
+            validators: FinanzasValidators,
+            notificationsService: NotificationsService,
+          ) =>
+            new LiquidationPublicationUseCase(
+              createLiquidationWorkflowDependencies({
+                prisma,
+                auditService,
+                validators,
+                notificationsService,
+              }),
+            ),
+        },
+        LiquidationsService,
+      ],
+    }).compile();
+
+    const service = moduleRef.get(LiquidationsService);
+    const useCase = moduleRef.get(LiquidationPublicationUseCase);
+
+    expect(service).toBeInstanceOf(LiquidationsService);
+    expect(useCase).toBeInstanceOf(LiquidationPublicationUseCase);
+    expect(
+      (service as unknown as { publicationUseCase: LiquidationPublicationUseCase })
+        .publicationUseCase,
+    ).toBe(useCase);
+  });
+});

--- a/apps/api/src/finanzas/seed-liquidation-workflow.spec.ts
+++ b/apps/api/src/finanzas/seed-liquidation-workflow.spec.ts
@@ -1,0 +1,223 @@
+import { Prisma } from '@prisma/client';
+import { ensureSeedPublishedLiquidation } from '../../prisma/lib/seed-liquidation-workflow';
+
+describe('ensureSeedPublishedLiquidation', () => {
+  const baseLiquidation = {
+    id: 'liq-1',
+    tenantId: 'tenant-1',
+    buildingId: 'building-1',
+    period: '2026-05',
+    chargePeriod: '2026-06',
+    status: 'PUBLISHED' as const,
+    baseCurrency: 'ARS',
+    totalAmountMinor: 200,
+    totalsByCurrency: { ARS: 200 },
+    expenseSnapshot: [],
+    publicationSnapshot: {
+      version: 1,
+      liquidationId: 'liq-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      period: '2026-05',
+      baseCurrency: 'ARS',
+      totalAmountMinor: 200,
+      totalsByCurrency: { ARS: 200 },
+      expenses: [],
+      allocations: [
+        { unitId: 'unit-1', unitCode: '1A', unitLabel: '1A', amountMinor: 100 },
+        { unitId: 'unit-2', unitCode: '1B', unitLabel: '1B', amountMinor: 100 },
+      ],
+      dueDate: '2026-06-10T00:00:00.000Z',
+      publishedAt: '2026-05-03T00:00:00.000Z',
+    },
+    unitCount: 2,
+    generatedByMembershipId: 'member-1',
+    generatedAt: new Date('2026-05-01T00:00:00.000Z'),
+    reviewedAt: new Date('2026-05-02T00:00:00.000Z'),
+    publishedAt: new Date('2026-05-03T00:00:00.000Z'),
+    canceledAt: null,
+    createdAt: new Date('2026-05-01T00:00:00.000Z'),
+  };
+
+  const units = [
+    { id: 'unit-1', code: '1A', label: '1A' },
+    { id: 'unit-2', code: '1B', label: '1B' },
+  ];
+
+  const createPrismaMock = () => {
+    let active = baseLiquidation;
+    return {
+      membership: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'member-1',
+          tenantId: 'tenant-1',
+          roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+        }),
+      },
+      liquidation: {
+        findFirst: jest.fn(async () => active),
+      },
+      charge: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'charge-1',
+            unitId: 'unit-1',
+            amount: 100,
+            currency: 'ARS',
+            concept: 'Expensas comunes 2026-05',
+            dueDate: new Date('2026-06-10T00:00:00.000Z'),
+            period: '2026-05',
+            buildingId: 'building-1',
+            liquidationId: 'liq-1',
+          },
+          {
+            id: 'charge-2',
+            unitId: 'unit-2',
+            amount: 100,
+            currency: 'ARS',
+            concept: 'Expensas comunes 2026-05',
+            dueDate: new Date('2026-06-10T00:00:00.000Z'),
+            period: '2026-05',
+            buildingId: 'building-1',
+            liquidationId: 'liq-1',
+          },
+        ]),
+      },
+      auditLog: { create: jest.fn().mockResolvedValue(undefined) },
+      $transaction: jest.fn(async (callback: (tx: Prisma.TransactionClient) => Promise<unknown>) =>
+        callback({
+          membership: {
+            findFirst: jest.fn().mockResolvedValue({
+              id: 'member-1',
+              tenantId: 'tenant-1',
+              roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+            }),
+          },
+          liquidation: {
+            create: jest.fn().mockResolvedValue({
+              ...baseLiquidation,
+              id: 'liq-created',
+              status: 'DRAFT',
+              publicationSnapshot: null,
+              reviewedAt: null,
+              publishedAt: null,
+            }),
+            findFirst: jest.fn().mockResolvedValue({
+              ...baseLiquidation,
+              id: 'liq-created',
+              status: 'DRAFT',
+              publicationSnapshot: null,
+              reviewedAt: null,
+              publishedAt: null,
+            }),
+            updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+          },
+          auditLog: { create: jest.fn().mockResolvedValue(undefined) },
+        } as unknown as Prisma.TransactionClient),
+      ),
+      __setActive: (next: typeof active) => {
+        active = next;
+      },
+    };
+  };
+
+  it('reuses a compatible published liquidation without duplicating it', async () => {
+    const prisma = createPrismaMock();
+
+    const result = await ensureSeedPublishedLiquidation({
+      prisma: prisma as never,
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      membershipId: 'member-1',
+      period: '2026-05',
+      chargePeriod: '2026-06',
+      baseCurrency: 'ARS',
+      totalAmountMinor: 200,
+      totalsByCurrency: { ARS: 200 },
+      expenseSnapshot: [],
+      units,
+      dueDate: new Date('2026-06-10T00:00:00.000Z'),
+      notificationPolicy: 'disabled',
+    });
+
+    expect(result).toEqual({ id: 'liq-1', created: false, status: 'PUBLISHED' });
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('fails when an active liquidation is incompatible', async () => {
+    const prisma = createPrismaMock();
+    prisma.__setActive({
+      ...baseLiquidation,
+      totalAmountMinor: 999,
+    });
+
+    await expect(
+      ensureSeedPublishedLiquidation({
+        prisma: prisma as never,
+        tenantId: 'tenant-1',
+        buildingId: 'building-1',
+        membershipId: 'member-1',
+        period: '2026-05',
+        chargePeriod: '2026-06',
+        baseCurrency: 'ARS',
+        totalAmountMinor: 200,
+        totalsByCurrency: { ARS: 200 },
+        expenseSnapshot: [],
+        units,
+        dueDate: new Date('2026-06-10T00:00:00.000Z'),
+      }),
+    ).rejects.toThrow('does not match expected invariants');
+  });
+
+  it('requeries after P2002 and safely reuses the created liquidation', async () => {
+    const prisma = createPrismaMock();
+    prisma.liquidation.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(baseLiquidation);
+    const p2002 = new Error('unique');
+    Object.assign(p2002, { code: 'P2002' });
+    Object.setPrototypeOf(p2002, Prisma.PrismaClientKnownRequestError.prototype);
+    prisma.$transaction.mockRejectedValueOnce(p2002);
+
+    const result = await ensureSeedPublishedLiquidation({
+      prisma: prisma as never,
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      membershipId: 'member-1',
+      period: '2026-05',
+      chargePeriod: '2026-06',
+      baseCurrency: 'ARS',
+      totalAmountMinor: 200,
+      totalsByCurrency: { ARS: 200 },
+      expenseSnapshot: [],
+      units,
+      dueDate: new Date('2026-06-10T00:00:00.000Z'),
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.status).toBe('PUBLISHED');
+  });
+
+  it('propagates non-P2002 prisma errors', async () => {
+    const prisma = createPrismaMock();
+    prisma.liquidation.findFirst.mockResolvedValueOnce(null);
+    prisma.$transaction.mockRejectedValueOnce(new Error('db down'));
+
+    await expect(
+      ensureSeedPublishedLiquidation({
+        prisma: prisma as never,
+        tenantId: 'tenant-1',
+        buildingId: 'building-1',
+        membershipId: 'member-1',
+        period: '2026-05',
+        chargePeriod: '2026-06',
+        baseCurrency: 'ARS',
+        totalAmountMinor: 200,
+        totalsByCurrency: { ARS: 200 },
+        expenseSnapshot: [],
+        units,
+        dueDate: new Date('2026-06-10T00:00:00.000Z'),
+      }),
+    ).rejects.toThrow('db down');
+  });
+});

--- a/apps/api/src/local-seed/local-manual-seed.postgres.spec.ts
+++ b/apps/api/src/local-seed/local-manual-seed.postgres.spec.ts
@@ -1,0 +1,176 @@
+import { PrismaClient } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
+import {
+  applyLocalManualSeed,
+  LOCAL_MANUAL_SEED,
+  readApplyCredentials,
+} from '../../prisma/lib/local-seed/local-manual-seed';
+
+const runIntegration = process.env.RUN_POSTGRES_INTEGRATION === '1';
+const describePostgres = runIntegration ? describe : describe.skip;
+
+describePostgres('local manual seed PostgreSQL integration', () => {
+  const databaseUrl = process.env.LOCAL_SEED_INTEGRATION_DATABASE_URL;
+  const prisma = databaseUrl ? new PrismaClient({ datasources: { db: { url: databaseUrl } } }) : null;
+  let createdFreePlan = false;
+
+  beforeAll(async () => {
+    if (!prisma) {
+      throw new Error('LOCAL_SEED_INTEGRATION_DATABASE_URL is required when RUN_POSTGRES_INTEGRATION=1');
+    }
+    const database = await prisma.$queryRaw<Array<{ database: string }>>`SELECT current_database() AS "database"`;
+    if (database[0]?.database === 'buildingos') {
+      throw new Error('PostgreSQL integration refuses to run against buildingos');
+    }
+    const existingPlan = await prisma.billingPlan.findUnique({ where: { planId: 'FREE' } });
+    createdFreePlan = !existingPlan;
+  });
+
+  beforeEach(async () => {
+    if (!prisma) {
+      throw new Error('Prisma client was not configured');
+    }
+    await prisma.tenant.deleteMany({ where: { name: LOCAL_MANUAL_SEED.tenantName } });
+  });
+
+  afterAll(async () => {
+    if (!prisma) {
+      return;
+    }
+    await prisma.tenant.deleteMany({ where: { name: LOCAL_MANUAL_SEED.tenantName } });
+    if (createdFreePlan) {
+      await prisma.billingPlan.deleteMany({ where: { planId: 'FREE' } });
+    }
+    await prisma.$disconnect();
+  });
+
+  it('is idempotent and leaves finance tables untouched', async () => {
+    if (!prisma) {
+      throw new Error('Prisma client was not configured');
+    }
+    const credentials = readApplyCredentials(process.env);
+    const target = { database: (await prisma.$queryRaw<Array<{ database: string }>>`SELECT current_database() AS "database"`)[0]!.database, host: 'integration-local' };
+
+    const before = await Promise.all([
+      prisma.tenant.count(),
+      prisma.building.count(),
+      prisma.unit.count(),
+      prisma.user.count(),
+      prisma.membership.count(),
+      prisma.tenantMember.count(),
+      prisma.unitOccupant.count(),
+      prisma.membershipRole.count(),
+      prisma.expense.count(),
+      prisma.liquidation.count(),
+      prisma.charge.count(),
+      prisma.payment.count(),
+    ]);
+    await applyLocalManualSeed(prisma, target, credentials);
+    const afterFirst = await Promise.all([
+      prisma.tenant.count(),
+      prisma.building.count(),
+      prisma.unit.count(),
+      prisma.user.count(),
+      prisma.membership.count(),
+      prisma.tenantMember.count(),
+      prisma.unitOccupant.count(),
+      prisma.membershipRole.count(),
+      prisma.expense.count(),
+      prisma.liquidation.count(),
+      prisma.charge.count(),
+      prisma.payment.count(),
+    ]);
+    await applyLocalManualSeed(prisma, target, credentials);
+    const afterSecond = await Promise.all([
+      prisma.tenant.count(),
+      prisma.building.count(),
+      prisma.unit.count(),
+      prisma.user.count(),
+      prisma.membership.count(),
+      prisma.tenantMember.count(),
+      prisma.unitOccupant.count(),
+      prisma.membershipRole.count(),
+      prisma.expense.count(),
+      prisma.liquidation.count(),
+      prisma.charge.count(),
+      prisma.payment.count(),
+    ]);
+    const tenant = await prisma.tenant.findUniqueOrThrow({ where: { name: LOCAL_MANUAL_SEED.tenantName } });
+    const building = await prisma.building.findUniqueOrThrow({ where: { tenantId_alias: { tenantId: tenant.id, alias: LOCAL_MANUAL_SEED.buildingAlias } } });
+    const vacantUnit = await prisma.unit.findUniqueOrThrow({ where: { buildingId_code: { buildingId: building.id, code: 'A-02-01' } } });
+    const [vacantOccupancies, tenantOwnerRoles, residentUsers] = await Promise.all([
+      prisma.unitOccupant.count({ where: { tenantId: tenant.id, unitId: vacantUnit.id, endDate: null } }),
+      prisma.membershipRole.count({ where: { tenantId: tenant.id, role: 'TENANT_OWNER', scopeType: 'TENANT' } }),
+      prisma.user.findMany({
+        where: { email: { in: [credentials.resident1, credentials.resident2] } },
+        select: { email: true, passwordHash: true },
+      }),
+    ]);
+
+    expect(afterFirst.slice(0, 8)).toEqual([
+      before[0] + 1,
+      before[1] + 1,
+      before[2] + 3,
+      before[3] + 3,
+      before[4] + 3,
+      before[5] + 3,
+      before[6] + 2,
+      before[7] + 3,
+    ]);
+    expect(afterSecond).toEqual(afterFirst);
+    expect(afterFirst.slice(8)).toEqual(before.slice(8));
+    expect(vacantOccupancies).toBe(0);
+    expect(tenantOwnerRoles).toBe(1);
+    expect(residentUsers).toHaveLength(2);
+    await expect(bcrypt.compare(credentials.resident1Password, residentUsers.find((user) => user.email === credentials.resident1)?.passwordHash ?? '')).resolves.toBe(true);
+    await expect(bcrypt.compare(credentials.resident2Password, residentUsers.find((user) => user.email === credentials.resident2)?.passwordHash ?? '')).resolves.toBe(true);
+  });
+
+  it('rolls back all seed writes when an existing building is incompatible', async () => {
+    if (!prisma) {
+      throw new Error('Prisma client was not configured');
+    }
+    const credentials = readApplyCredentials(process.env);
+    const target = {
+      database: (await prisma.$queryRaw<Array<{ database: string }>>`SELECT current_database() AS "database"`)[0]!.database,
+      host: 'integration-local',
+    };
+    const tenant = await prisma.tenant.create({
+      data: { name: LOCAL_MANUAL_SEED.tenantName, type: 'ADMINISTRADORA', isDemo: false },
+    });
+    await prisma.building.create({
+      data: {
+        tenantId: tenant.id,
+        name: LOCAL_MANUAL_SEED.buildingName,
+        alias: LOCAL_MANUAL_SEED.buildingAlias,
+        deletedAt: new Date(),
+      },
+    });
+    const before = await Promise.all([
+      prisma.billingPlan.count(),
+      prisma.subscription.count(),
+      prisma.tenant.count(),
+      prisma.building.count(),
+      prisma.unit.count(),
+      prisma.user.count(),
+      prisma.membership.count(),
+      prisma.tenantMember.count(),
+      prisma.unitOccupant.count(),
+    ]);
+
+    await expect(applyLocalManualSeed(prisma, target, credentials)).rejects.toThrow('incompatible or deleted');
+
+    const after = await Promise.all([
+      prisma.billingPlan.count(),
+      prisma.subscription.count(),
+      prisma.tenant.count(),
+      prisma.building.count(),
+      prisma.unit.count(),
+      prisma.user.count(),
+      prisma.membership.count(),
+      prisma.tenantMember.count(),
+      prisma.unitOccupant.count(),
+    ]);
+    expect(after).toEqual(before);
+  });
+});

--- a/apps/api/src/local-seed/local-manual-seed.spec.ts
+++ b/apps/api/src/local-seed/local-manual-seed.spec.ts
@@ -1,0 +1,129 @@
+import {
+  assertFreePlanCompatibility,
+  assertLocalManualBuildingCompatibility,
+  assertLocalManualOccupancyCompatibility,
+  assertLocalManualTenantCompatibility,
+  assertLocalManualTenantMemberCompatibility,
+  assertLocalManualUnitCompatibility,
+  assertLocalManualUserCompatibility,
+  assertSafeLocalSeedEnvironment,
+  inspectLocalManualSeed,
+  LOCAL_MANUAL_SEED,
+  readApplyCredentials,
+  readSeedEmails,
+} from '../../prisma/lib/local-seed/local-manual-seed';
+import { MemberStatus, PrismaClient, Role, TenantType, UnitOccupantRole } from '@prisma/client';
+
+describe('local manual seed safety', () => {
+  const validEnvironment = {
+    NODE_ENV: 'development',
+    DATABASE_URL: 'postgresql://local:secret@127.0.0.1:5434/buildingos?schema=public',
+    LOCAL_SEED_ADMIN_EMAIL: 'admin@buildingos.test',
+    LOCAL_SEED_ADMIN_PASSWORD: 'admin-password',
+    LOCAL_SEED_RESIDENT_1_EMAIL: 'resident-1@buildingos.test',
+    LOCAL_SEED_RESIDENT_1_PASSWORD: 'resident-1-password',
+    LOCAL_SEED_RESIDENT_2_EMAIL: 'resident-2@buildingos.test',
+    LOCAL_SEED_RESIDENT_2_PASSWORD: 'resident-2-password',
+  };
+
+  it('accepts a local buildingos target', () => {
+    expect(assertSafeLocalSeedEnvironment(validEnvironment)).toEqual({
+      database: 'buildingos',
+      host: '127.0.0.1',
+    });
+  });
+
+  it.each([
+    ['development', { ...validEnvironment, NODE_ENV: 'development' }],
+    ['test', { ...validEnvironment, NODE_ENV: 'test' }],
+    ['empty', { ...validEnvironment, NODE_ENV: undefined }],
+  ])('accepts %s as a local runtime env', (_label, environment) => {
+    expect(assertSafeLocalSeedEnvironment(environment)).toEqual({
+      database: 'buildingos',
+      host: '127.0.0.1',
+    });
+  });
+
+  it.each([
+    ['production', { ...validEnvironment, NODE_ENV: 'production' }],
+    ['staging', { ...validEnvironment, NODE_ENV: 'staging' }],
+    ['remote host', { ...validEnvironment, DATABASE_URL: 'postgresql://local:secret@db.example.com:5432/buildingos' }],
+    ['different database', { ...validEnvironment, DATABASE_URL: 'postgresql://local:secret@127.0.0.1:5434/other' }],
+    ['staging database', { ...validEnvironment, DATABASE_URL: 'postgresql://local:secret@localhost:5432/buildingos_staging' }],
+  ])('rejects %s', (_label, environment) => {
+    expect(() => assertSafeLocalSeedEnvironment(environment)).toThrow();
+  });
+
+  it('rejects emails outside the @buildingos.test domain', () => {
+    expect(() => readSeedEmails({
+      ...validEnvironment,
+      LOCAL_SEED_ADMIN_EMAIL: 'admin@local.test',
+    })).toThrow('must end with @buildingos.test');
+  });
+
+  it('rejects missing apply passwords before any connection is attempted', () => {
+    expect(() => readApplyCredentials({ ...validEnvironment, LOCAL_SEED_RESIDENT_2_PASSWORD: '' })).toThrow(
+      'LOCAL_SEED_RESIDENT_2_PASSWORD is required',
+    );
+  });
+
+  it('runs diagnostic inspection without exposing a write API', async () => {
+    const prisma = {
+      $queryRaw: jest.fn().mockResolvedValue([{ database: 'buildingos', user: 'buildingos', address: '127.0.0.1', port: 5432 }]),
+      billingPlan: { findUnique: jest.fn().mockResolvedValue(null) },
+      tenant: { findUnique: jest.fn().mockResolvedValue(null) },
+      user: { count: jest.fn().mockResolvedValue(0) },
+    } as unknown as PrismaClient;
+
+    const target = assertSafeLocalSeedEnvironment(validEnvironment);
+    const result = await inspectLocalManualSeed(prisma, target, readApplyCredentials(validEnvironment));
+
+    expect(result.existing).toEqual({ plan: 0, tenant: 0, building: 0, units: 0, users: 0 });
+    expect((prisma as unknown as { $transaction?: unknown }).$transaction).toBeUndefined();
+  });
+
+  it('rejects an incompatible tenant before writes', () => {
+    expect(() => assertLocalManualTenantCompatibility({ type: TenantType.EDIFICIO_AUTOGESTION, isDemo: false })).toThrow('incompatible');
+  });
+
+  it('rejects an incompatible existing FREE plan before writes', () => {
+    expect(() => assertFreePlanCompatibility({
+      ...LOCAL_MANUAL_SEED.plan,
+      maxUsers: 2,
+    })).toThrow('Existing FREE billing plan is incompatible');
+  });
+
+  it('rejects a deleted or renamed building', () => {
+    expect(() => assertLocalManualBuildingCompatibility({ name: 'Other building', deletedAt: null })).toThrow('incompatible');
+    expect(() => assertLocalManualBuildingCompatibility({ name: LOCAL_MANUAL_SEED.buildingName, deletedAt: new Date() })).toThrow('incompatible');
+  });
+
+  it('rejects incompatible unit data', () => {
+    expect(() => assertLocalManualUnitCompatibility({
+      tenantId: 'tenant-1', label: 'different', occupancyStatus: 'VACANT', isBillable: true,
+    }, 'tenant-1', LOCAL_MANUAL_SEED.units[0])).toThrow('A-01-01');
+  });
+
+  it('rejects an incompatible existing user', () => {
+    expect(() => assertLocalManualUserCompatibility(
+      { name: 'Other user' },
+      { name: 'Administrador Local', email: 'admin@local.test', password: 'password', passwordHash: 'hash', role: Role.TENANT_OWNER },
+    )).toThrow('incompatible name');
+  });
+
+  it('rejects an incompatible tenant member', () => {
+    expect(() => assertLocalManualTenantMemberCompatibility(
+      { userId: 'other-user', name: 'Residente Local 1', role: Role.RESIDENT, status: MemberStatus.ACTIVE, disabledAt: null },
+      'expected-user',
+      { name: 'Residente Local 1', email: 'resident@local.test', password: 'password', passwordHash: 'hash', role: Role.RESIDENT },
+    )).toThrow('incompatible');
+  });
+
+  it('rejects an inactive or non-primary occupancy', () => {
+    expect(() => assertLocalManualOccupancyCompatibility(
+      { tenantId: 'tenant-1', role: UnitOccupantRole.RESIDENT, isPrimary: false, endDate: null },
+      'tenant-1',
+      'resident@local.test',
+    )).toThrow('incompatible');
+  });
+});

--- a/apps/api/src/local-seed/reset-local-user-password.spec.ts
+++ b/apps/api/src/local-seed/reset-local-user-password.spec.ts
@@ -1,0 +1,264 @@
+import * as bcrypt from 'bcrypt';
+import { MemberStatus, Role, ScopeType, UnitOccupantRole } from '@prisma/client';
+import {
+  LOCAL_RESET_DATABASE,
+  LOCAL_RESET_EMAIL,
+  LOCAL_RESET_PASSWORD_HASH_ROUNDS,
+  assertConnectedToBuildingOS,
+  assertSafeLocalResetEnvironment,
+  applyLocalUserPasswordReset,
+  inspectLocalUserPasswordReset,
+  readLocalResetCredentials,
+  type LocalResetTransactionClient,
+  type LocalResetWritableClient,
+} from './reset-local-user-password';
+
+jest.mock('bcrypt', () => ({
+  hash: jest.fn(),
+  compare: jest.fn(),
+}));
+
+function buildEnvironment(overrides: Record<string, string | undefined> = {}) {
+  return {
+    NODE_ENV: 'development',
+    DATABASE_URL: 'postgresql://buildingos:secret@127.0.0.1:5434/buildingos?schema=public',
+    LOCAL_RESET_EMAIL: LOCAL_RESET_EMAIL,
+    LOCAL_RESET_PASSWORD: 'NewSecret123!',
+    ...overrides,
+  };
+}
+
+function buildUserQuery(passwordHash: string, activeSessionIds: readonly string[] = ['session-1']) {
+  return [
+    {
+      id: 'user-1',
+      email: LOCAL_RESET_EMAIL,
+      name: 'Residente 2',
+      passwordHash,
+      memberships: [
+        {
+          id: 'membership-1',
+          tenantId: 'tenant-1',
+          tenant: { name: 'BuildingOS' },
+          roles: [
+            { role: Role.RESIDENT, scopeType: ScopeType.TENANT },
+          ],
+        },
+      ],
+      tenantMembers: [
+        {
+          id: 'tenant-member-1',
+          tenantId: 'tenant-1',
+          tenant: { name: 'BuildingOS' },
+          role: Role.RESIDENT,
+          status: MemberStatus.ACTIVE,
+          disabledAt: null,
+          occupancies: [
+            {
+              id: 'occupancy-1',
+              unitId: 'unit-1',
+              role: UnitOccupantRole.RESIDENT,
+              isPrimary: true,
+              endDate: null,
+              unit: {
+                code: 'A-01-02',
+                label: 'Unidad A-01-02',
+                building: {
+                  id: 'building-1',
+                  name: 'Torre Local A',
+                  alias: 'torre-local-a',
+                },
+              },
+            },
+          ],
+        },
+      ],
+      authSessions: activeSessionIds.map((id) => ({
+        id,
+        revokedAt: null,
+        expiresAt: new Date('2030-01-01T00:00:00.000Z'),
+      })),
+    },
+  ];
+}
+
+function createMockPrisma(userQuery: ReturnType<typeof buildUserQuery>) {
+  const tx: LocalResetTransactionClient = {
+    $queryRaw: jest.fn().mockResolvedValue([
+      {
+        database: LOCAL_RESET_DATABASE,
+        address: '127.0.0.1',
+        port: 5434,
+      },
+    ]),
+    user: {
+      update: jest.fn().mockResolvedValue({}),
+      findMany: jest.fn().mockResolvedValue(userQuery),
+    },
+    authSession: {
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    },
+  };
+
+  const prisma: LocalResetWritableClient = {
+    $queryRaw: jest.fn().mockResolvedValue([
+      {
+        database: LOCAL_RESET_DATABASE,
+        address: '127.0.0.1',
+        port: 5434,
+      },
+    ]),
+    user: {
+      findMany: jest.fn().mockResolvedValue(userQuery),
+    },
+    $transaction: jest.fn(async (callback: (client: LocalResetTransactionClient) => Promise<unknown>) => callback(tx)),
+  };
+
+  return { prisma, tx };
+}
+
+describe('local user password reset', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('accepts the authorized local target and required credentials', () => {
+    const environment = buildEnvironment();
+    expect(assertSafeLocalResetEnvironment(environment)).toEqual({
+      database: LOCAL_RESET_DATABASE,
+      host: '127.0.0.1',
+    });
+    expect(readLocalResetCredentials(environment)).toEqual({
+      email: LOCAL_RESET_EMAIL,
+      password: 'NewSecret123!',
+    });
+  });
+
+  it.each([
+    ['development', { NODE_ENV: 'development' }],
+    ['test', { NODE_ENV: 'test' }],
+    ['empty', { NODE_ENV: undefined }],
+  ])('accepts %s as an allowed local runtime env', (_label, overrides) => {
+    expect(assertSafeLocalResetEnvironment(buildEnvironment(overrides))).toEqual({
+      database: LOCAL_RESET_DATABASE,
+      host: '127.0.0.1',
+    });
+  });
+
+  it.each([
+    ['production', { NODE_ENV: 'production' }],
+    ['staging', { NODE_ENV: 'staging' }],
+    ['remote host', { DATABASE_URL: 'postgresql://buildingos:secret@db.example.com:5432/buildingos?schema=public' }],
+    ['another database', { DATABASE_URL: 'postgresql://buildingos:secret@127.0.0.1:5434/other?schema=public' }],
+    ['staging database', { DATABASE_URL: 'postgresql://buildingos:secret@127.0.0.1:5434/buildingos_staging?schema=public' }],
+  ])('rejects %s', (_label, overrides) => {
+    expect(() => assertSafeLocalResetEnvironment(buildEnvironment(overrides))).toThrow();
+  });
+
+  it('rejects a missing password and an unexpected email before any write', () => {
+    expect(() => readLocalResetCredentials(buildEnvironment({ LOCAL_RESET_PASSWORD: undefined }))).toThrow('LOCAL_RESET_PASSWORD is required');
+    expect(() => readLocalResetCredentials(buildEnvironment({ LOCAL_RESET_EMAIL: 'other@buildingos.test' }))).toThrow(`Local password reset only allows ${LOCAL_RESET_EMAIL}`);
+  });
+
+  it('diagnostic mode reads the account without writing', async () => {
+    const { prisma, tx } = createMockPrisma(buildUserQuery('old-hash'));
+    const target = assertSafeLocalResetEnvironment(buildEnvironment());
+    const credentials = readLocalResetCredentials(buildEnvironment());
+
+    const result = await inspectLocalUserPasswordReset(prisma, target, credentials);
+
+    expect(result.connection.database).toBe(LOCAL_RESET_DATABASE);
+    expect(result.snapshot.userId).toBe('user-1');
+    expect(result.snapshot.activeOccupancyUnitCodes).toContain('A-01-02');
+    expect('passwordHash' in result.snapshot).toBe(false);
+    expect('rawUserId' in result.snapshot).toBe(false);
+    expect((prisma.user.findMany as jest.Mock).mock.calls).toHaveLength(1);
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(tx.user.update).not.toHaveBeenCalled();
+    expect(tx.authSession.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('hashes with bcrypt round 10 and produces a valid login password', async () => {
+    const realBcrypt = jest.requireActual('bcrypt') as typeof import('bcrypt');
+    const hash = await realBcrypt.hash('NewSecret123!', 10);
+    expect(LOCAL_RESET_PASSWORD_HASH_ROUNDS).toBe(10);
+    await expect(realBcrypt.compare('NewSecret123!', hash)).resolves.toBe(true);
+    await expect(realBcrypt.compare('OldSecret123!', hash)).resolves.toBe(false);
+  });
+
+  it('apply mode changes only the password hash and revokes sessions', async () => {
+    const beforeQuery = buildUserQuery('old-hash', ['session-1', 'session-2']);
+    const afterQuery = buildUserQuery('new-hash', ['session-1', 'session-2']);
+    const { prisma, tx } = createMockPrisma(beforeQuery);
+    (prisma.user.findMany as jest.Mock)
+      .mockResolvedValueOnce(beforeQuery)
+      .mockResolvedValueOnce(afterQuery);
+    (tx.user.findMany as jest.Mock)
+      .mockResolvedValueOnce(beforeQuery)
+      .mockResolvedValueOnce(afterQuery);
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');
+
+    const target = assertSafeLocalResetEnvironment(buildEnvironment());
+    const credentials = readLocalResetCredentials(buildEnvironment());
+    const result = await applyLocalUserPasswordReset(prisma, target, credentials);
+
+    expect(result.snapshot.userId).toBe('user-1');
+    expect('passwordHash' in result.snapshot).toBe(false);
+    expect('rawUserId' in result.snapshot).toBe(false);
+    expect(tx.user.update).toHaveBeenCalledWith({
+      where: { id: 'user-1' },
+      data: { passwordHash: 'hashed-password' },
+    });
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(tx.authSession.updateMany).toHaveBeenCalledWith({
+      where: {
+        userId: 'user-1',
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: expect.any(Date),
+      },
+    });
+    expect(result.revokedSessionCount).toBe(1);
+    expect(result.snapshot.activeOccupancyUnitCodes).toContain('A-01-02');
+  });
+
+  it('is idempotent when applying the same password twice', async () => {
+    const beforeQuery = buildUserQuery('old-hash', ['session-1']);
+    const afterQuery = buildUserQuery('new-hash', ['session-1']);
+    const { prisma, tx } = createMockPrisma(beforeQuery);
+    (prisma.user.findMany as jest.Mock)
+      .mockResolvedValueOnce(beforeQuery)
+      .mockResolvedValueOnce(afterQuery)
+      .mockResolvedValueOnce(afterQuery)
+      .mockResolvedValueOnce(afterQuery);
+    (tx.user.findMany as jest.Mock)
+      .mockResolvedValueOnce(beforeQuery)
+      .mockResolvedValueOnce(afterQuery)
+      .mockResolvedValueOnce(afterQuery)
+      .mockResolvedValueOnce(afterQuery);
+    (bcrypt.hash as jest.Mock).mockResolvedValue('hashed-password');
+    (tx.authSession.updateMany as jest.Mock)
+      .mockResolvedValueOnce({ count: 1 })
+      .mockResolvedValueOnce({ count: 0 });
+
+    const target = assertSafeLocalResetEnvironment(buildEnvironment());
+    const credentials = readLocalResetCredentials(buildEnvironment());
+
+    const first = await applyLocalUserPasswordReset(prisma, target, credentials);
+    const second = await applyLocalUserPasswordReset(prisma, target, credentials);
+
+    expect(first.snapshot).toEqual(second.snapshot);
+    expect(tx.user.update).toHaveBeenCalledTimes(2);
+    expect(tx.authSession.updateMany).toHaveBeenCalledTimes(2);
+    expect(first.revokedSessionCount).toBe(1);
+    expect(second.revokedSessionCount).toBe(0);
+  });
+
+  it('rejects an unexpected database identity before writing', async () => {
+    const { prisma } = createMockPrisma(buildUserQuery('old-hash'));
+    (prisma.$queryRaw as jest.Mock).mockResolvedValue([{ database: 'other', address: '127.0.0.1', port: 5434 }]);
+
+    await expect(assertConnectedToBuildingOS(prisma, { database: LOCAL_RESET_DATABASE, host: '127.0.0.1' })).rejects.toThrow();
+  });
+});

--- a/apps/api/src/local-seed/reset-local-user-password.ts
+++ b/apps/api/src/local-seed/reset-local-user-password.ts
@@ -1,0 +1,588 @@
+import { Prisma, PrismaClient, MemberStatus, Role, ScopeType, UnitOccupantRole } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
+
+export const LOCAL_RESET_EMAIL = 'residente2.local@buildingos.test';
+export const LOCAL_RESET_DATABASE = 'buildingos';
+export const LOCAL_RESET_PASSWORD_HASH_ROUNDS = 10;
+
+const LOCAL_RESET_ALLOWED_HOSTS = new Set(['localhost', '127.0.0.1']);
+const LOCAL_RESET_ALLOWED_NODE_ENVS = new Set(['', 'development', 'test']);
+
+interface ResetEnvironment {
+  readonly [key: string]: string | undefined;
+  readonly NODE_ENV?: string;
+  readonly DATABASE_URL?: string;
+  readonly LOCAL_RESET_EMAIL?: string;
+  readonly LOCAL_RESET_PASSWORD?: string;
+}
+
+export interface LocalResetTarget {
+  readonly database: string;
+  readonly host: string;
+}
+
+export interface LocalResetCredentials {
+  readonly email: string;
+  readonly password: string;
+}
+
+interface LocalResetConnection {
+  readonly database: string;
+  readonly address: string | null;
+  readonly port: number | null;
+}
+
+export interface LocalResetBaseClient {
+  $queryRaw<T>(query: Prisma.Sql): Promise<T>;
+  user: {
+    findMany(args: {
+      where: {
+        email: string;
+      };
+      include: typeof localResetUserInclude;
+    }): Promise<LocalResetUserQuery[]>;
+  };
+}
+
+export interface LocalResetTransactionClient extends LocalResetBaseClient {
+  user: LocalResetBaseClient['user'] & {
+    update(args: {
+      where: {
+        id: string;
+      };
+      data: {
+        passwordHash: string;
+      };
+    }): Promise<unknown>;
+  };
+  authSession: {
+    updateMany(args: {
+      where: {
+        userId: string;
+        revokedAt: null;
+      };
+      data: {
+        revokedAt: Date;
+      };
+    }): Promise<{ count: number }>;
+  };
+}
+
+export interface LocalResetWritableClient extends LocalResetBaseClient {
+  $transaction<R>(
+    callback: (tx: LocalResetTransactionClient) => Promise<R>,
+    options?: {
+      isolationLevel?: Prisma.TransactionIsolationLevel;
+    },
+  ): Promise<R>;
+}
+
+interface LocalResetRoleSnapshot {
+  readonly role: Role;
+  readonly scopeType: ScopeType;
+}
+
+interface LocalResetMembershipSnapshot {
+  readonly id: string;
+  readonly tenantId: string;
+  readonly tenantName: string;
+  readonly roles: readonly LocalResetRoleSnapshot[];
+}
+
+interface LocalResetOccupancySnapshot {
+  readonly id: string;
+  readonly unitId: string;
+  readonly unitCode: string;
+  readonly unitLabel: string | null;
+  readonly buildingId: string;
+  readonly buildingName: string;
+  readonly buildingAlias: string;
+  readonly role: UnitOccupantRole;
+  readonly isPrimary: boolean;
+  readonly endDate: Date | null;
+}
+
+interface LocalResetTenantMemberSnapshot {
+  readonly id: string;
+  readonly tenantId: string;
+  readonly tenantName: string;
+  readonly role: Role;
+  readonly status: MemberStatus;
+  readonly disabledAt: Date | null;
+  readonly occupancies: readonly LocalResetOccupancySnapshot[];
+}
+
+interface LocalResetSessionSnapshot {
+  readonly id: string;
+  readonly revokedAt: Date | null;
+  readonly expiresAt: Date;
+}
+
+export interface LocalResetSnapshot {
+  readonly userId: string;
+  readonly email: string;
+  readonly name: string;
+  readonly membershipIds: readonly string[];
+  readonly membershipRoles: readonly string[];
+  readonly tenantMemberIds: readonly string[];
+  readonly activeTenantMemberIds: readonly string[];
+  readonly activeOccupancyIds: readonly string[];
+  readonly activeOccupancyUnitCodes: readonly string[];
+  readonly activeOccupancyUnitId: string | null;
+  readonly activeOccupancyBuildingId: string | null;
+  readonly activeSessionIds: readonly string[];
+  readonly activeSessionCount: number;
+}
+
+export interface LocalResetResult {
+  readonly target: LocalResetTarget;
+  readonly connection: LocalResetConnection;
+  readonly snapshot: LocalResetSnapshot;
+  readonly revokedSessionCount: number;
+}
+
+interface LocalResetUserQuery {
+  readonly id: string;
+  readonly email: string;
+  readonly name: string;
+  readonly passwordHash: string;
+  readonly memberships: readonly {
+    readonly id: string;
+    readonly tenantId: string;
+    readonly tenant: {
+      readonly name: string;
+    };
+    readonly roles: readonly {
+      readonly role: Role;
+      readonly scopeType: ScopeType;
+    }[];
+  }[];
+  readonly tenantMembers: readonly {
+    readonly id: string;
+    readonly tenantId: string;
+    readonly tenant: {
+      readonly name: string;
+    };
+    readonly role: Role;
+    readonly status: MemberStatus;
+    readonly disabledAt: Date | null;
+    readonly occupancies: readonly {
+      readonly id: string;
+      readonly unitId: string;
+      readonly role: UnitOccupantRole;
+      readonly isPrimary: boolean;
+      readonly endDate: Date | null;
+      readonly unit: {
+        readonly code: string;
+        readonly label: string | null;
+        readonly building: {
+          readonly id: string;
+          readonly name: string;
+          readonly alias: string;
+        };
+      };
+    }[];
+  }[];
+  readonly authSessions: readonly {
+    readonly id: string;
+    readonly revokedAt: Date | null;
+    readonly expiresAt: Date;
+  }[];
+}
+
+const localResetUserInclude = {
+  memberships: {
+    include: {
+      tenant: {
+        select: {
+          name: true,
+        },
+      },
+      roles: {
+        select: {
+          role: true,
+          scopeType: true,
+        },
+      },
+    },
+  },
+  tenantMembers: {
+    include: {
+      tenant: {
+        select: {
+          name: true,
+        },
+      },
+      occupancies: {
+        where: {
+          endDate: null,
+        },
+        include: {
+          unit: {
+            select: {
+              code: true,
+              label: true,
+              building: {
+                select: {
+                  id: true,
+                  name: true,
+                  alias: true,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+  authSessions: {
+    where: {
+      revokedAt: null,
+    },
+    select: {
+      id: true,
+      revokedAt: true,
+      expiresAt: true,
+    },
+  },
+} as const;
+
+function abort(message: string): never {
+  throw new Error(message);
+}
+
+function required(environment: ResetEnvironment, key: keyof ResetEnvironment): string {
+  const value = environment[key]?.trim();
+  if (!value) {
+    abort(`${key} is required`);
+  }
+  return value;
+}
+
+function parseDatabaseName(databaseUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(databaseUrl);
+  } catch {
+    abort('DATABASE_URL must be a valid PostgreSQL URL');
+  }
+
+  if (parsed.protocol !== 'postgresql:' && parsed.protocol !== 'postgres:') {
+    abort('DATABASE_URL must use the PostgreSQL protocol');
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  if (!LOCAL_RESET_ALLOWED_HOSTS.has(host)) {
+    abort(`DATABASE_URL host must be localhost or 127.0.0.1, received ${host}`);
+  }
+
+  const database = decodeURIComponent(parsed.pathname.replace(/^\//, '')).split('/')[0] ?? '';
+  if (!database) {
+    abort('DATABASE_URL must include a database name');
+  }
+  if (/(staging|production|prod)/i.test(database)) {
+    abort('DATABASE_URL cannot point to staging, production, or prod databases');
+  }
+  if (database !== LOCAL_RESET_DATABASE) {
+    abort(`DATABASE_URL must target ${LOCAL_RESET_DATABASE}, received ${database}`);
+  }
+
+  return database;
+}
+
+function assertAllowedLocalNodeEnv(nodeEnv: string | undefined): void {
+  const normalized = nodeEnv?.trim().toLowerCase() ?? '';
+
+  if (normalized === 'production' || normalized === 'staging') {
+    abort(`Local password reset refuses to run when NODE_ENV=${normalized}`);
+  }
+
+  if (!LOCAL_RESET_ALLOWED_NODE_ENVS.has(normalized)) {
+    abort(`Local password reset only allows NODE_ENV=development, test, or empty. Received: ${normalized || 'empty'}`);
+  }
+}
+
+export function assertSafeLocalResetEnvironment(environment: ResetEnvironment): LocalResetTarget {
+  assertAllowedLocalNodeEnv(environment.NODE_ENV);
+
+  const databaseUrl = required(environment, 'DATABASE_URL');
+  const database = parseDatabaseName(databaseUrl);
+  const host = new URL(databaseUrl).hostname.toLowerCase();
+
+  return {
+    database,
+    host,
+  };
+}
+
+export function readLocalResetCredentials(environment: ResetEnvironment): LocalResetCredentials {
+  const email = required(environment, 'LOCAL_RESET_EMAIL').toLowerCase();
+  if (email !== LOCAL_RESET_EMAIL) {
+    abort(`Local password reset only allows ${LOCAL_RESET_EMAIL}`);
+  }
+  if (!email.endsWith('@buildingos.test')) {
+    abort('LOCAL_RESET_EMAIL must end with @buildingos.test');
+  }
+
+  const password = required(environment, 'LOCAL_RESET_PASSWORD');
+  return {
+    email,
+    password,
+  };
+}
+
+async function readConnection(client: LocalResetBaseClient): Promise<LocalResetConnection> {
+  const rows = await client.$queryRaw<LocalResetConnection[]>(Prisma.sql`
+    SELECT
+      current_database() AS "database",
+      inet_server_addr()::text AS "address",
+      inet_server_port() AS "port"
+  `);
+  const connection = rows[0];
+  if (!connection) {
+    abort('Could not determine the active PostgreSQL connection');
+  }
+  return connection;
+}
+
+export async function assertConnectedToBuildingOS(client: LocalResetBaseClient, target: LocalResetTarget): Promise<LocalResetConnection> {
+  const connection = await readConnection(client);
+  if (connection.database !== target.database) {
+    abort(`Local password reset connected to ${connection.database}, expected ${target.database}`);
+  }
+  if (!connection.address || !LOCAL_RESET_ALLOWED_HOSTS.has(connection.address.toLowerCase())) {
+    abort(`Local password reset connected through non-local address: ${connection.address ?? 'unknown'}`);
+  }
+  return connection;
+}
+
+function sortStrings(values: readonly string[]): string[] {
+  return [...values].sort((left, right) => left.localeCompare(right));
+}
+
+function extractSnapshot(user: LocalResetUserQuery): LocalResetSnapshot {
+  const membershipIds = sortStrings(user.memberships.map((membership) => membership.id));
+  const membershipRoles = sortStrings(
+    user.memberships.flatMap((membership) =>
+      membership.roles.map((role) => `${role.role}:${role.scopeType}`),
+    ),
+  );
+  const tenantMemberIds = sortStrings(user.tenantMembers.map((tenantMember) => tenantMember.id));
+  const activeTenantMembers = user.tenantMembers.filter(
+    (tenantMember) => tenantMember.role === Role.RESIDENT && tenantMember.status === MemberStatus.ACTIVE && tenantMember.disabledAt === null,
+  );
+  const activeOccupancies = activeTenantMembers.flatMap((tenantMember) => tenantMember.occupancies);
+  const activeSessionIds = sortStrings(user.authSessions.map((session) => session.id));
+
+  return {
+    userId: user.id,
+    email: user.email,
+    name: user.name,
+    membershipIds,
+    membershipRoles,
+    tenantMemberIds,
+    activeTenantMemberIds: sortStrings(activeTenantMembers.map((tenantMember) => tenantMember.id)),
+    activeOccupancyIds: sortStrings(activeOccupancies.map((occupancy) => occupancy.id)),
+    activeOccupancyUnitCodes: sortStrings(activeOccupancies.map((occupancy) => occupancy.unit.code)),
+    activeOccupancyUnitId: activeOccupancies[0]?.unitId ?? null,
+    activeOccupancyBuildingId: activeOccupancies[0]?.unit.building.id ?? null,
+    activeSessionIds,
+    activeSessionCount: activeSessionIds.length,
+  };
+}
+
+function assertExpectedSnapshot(snapshot: LocalResetSnapshot): void {
+  if (snapshot.userId.length === 0) {
+    abort('Local reset user snapshot is invalid');
+  }
+  if (!snapshot.membershipRoles.some((role) => role.startsWith('RESIDENT:'))) {
+    abort('Local reset user must keep a RESIDENT membership role');
+  }
+  if (!snapshot.activeTenantMemberIds.length) {
+    abort('Local reset user must keep an ACTIVE resident tenant member');
+  }
+  if (!snapshot.activeOccupancyIds.length) {
+    abort('Local reset user must keep an active occupancy');
+  }
+  if (!snapshot.activeOccupancyUnitCodes.includes('A-01-02')) {
+    abort('Local reset user must remain assigned to unit A-01-02');
+  }
+}
+
+interface LoadedLocalResetUser {
+  readonly snapshot: LocalResetSnapshot;
+  readonly passwordHash: string;
+  readonly rawUserId: string;
+}
+
+async function loadUserSnapshot(client: LocalResetBaseClient, email: string): Promise<LoadedLocalResetUser> {
+  const users = (await client.user.findMany({
+    where: {
+      email,
+    },
+    include: localResetUserInclude,
+  })) as LocalResetUserQuery[];
+
+  if (users.length !== 1) {
+    abort(`Expected exactly one local reset user for ${email}, found ${users.length}`);
+  }
+
+  const user = users[0];
+  if (!user) {
+    abort(`Expected exactly one local reset user for ${email}, found 0`);
+  }
+  const snapshot = extractSnapshot(user);
+  assertExpectedSnapshot(snapshot);
+
+  return {
+    snapshot,
+    passwordHash: user.passwordHash,
+    rawUserId: user.id,
+  };
+}
+
+export async function hashLocalResetPassword(password: string): Promise<string> {
+  return bcrypt.hash(password, LOCAL_RESET_PASSWORD_HASH_ROUNDS);
+}
+
+export async function inspectLocalUserPasswordReset(
+  client: LocalResetBaseClient,
+  target: LocalResetTarget,
+  credentials: LocalResetCredentials,
+): Promise<LocalResetResult> {
+  const connection = await assertConnectedToBuildingOS(client, target);
+  const user = await loadUserSnapshot(client, credentials.email);
+  return {
+    target,
+    connection,
+    snapshot: user.snapshot,
+    revokedSessionCount: 0,
+  };
+}
+
+async function compareSnapshotIntegrity(before: LocalResetSnapshot, after: LocalResetSnapshot): Promise<void> {
+  const beforeMembershipIds = sortStrings(before.membershipIds);
+  const afterMembershipIds = sortStrings(after.membershipIds);
+  const beforeTenantMemberIds = sortStrings(before.tenantMemberIds);
+  const afterTenantMemberIds = sortStrings(after.tenantMemberIds);
+  const beforeActiveTenantMemberIds = sortStrings(before.activeTenantMemberIds);
+  const afterActiveTenantMemberIds = sortStrings(after.activeTenantMemberIds);
+  const beforeOccupancyIds = sortStrings(before.activeOccupancyIds);
+  const afterOccupancyIds = sortStrings(after.activeOccupancyIds);
+
+  if (before.userId !== after.userId) {
+    abort('User ID changed during local password reset');
+  }
+  if (JSON.stringify(beforeMembershipIds) !== JSON.stringify(afterMembershipIds)) {
+    abort('Memberships changed during local password reset');
+  }
+  if (JSON.stringify(beforeTenantMemberIds) !== JSON.stringify(afterTenantMemberIds)) {
+    abort('TenantMember records changed during local password reset');
+  }
+  if (JSON.stringify(beforeActiveTenantMemberIds) !== JSON.stringify(afterActiveTenantMemberIds)) {
+    abort('Active TenantMember records changed during local password reset');
+  }
+  if (JSON.stringify(beforeOccupancyIds) !== JSON.stringify(afterOccupancyIds)) {
+    abort('UnitOccupant records changed during local password reset');
+  }
+  if (JSON.stringify(sortStrings(before.activeOccupancyUnitCodes)) !== JSON.stringify(sortStrings(after.activeOccupancyUnitCodes))) {
+    abort('Unit assignment changed during local password reset');
+  }
+}
+
+export async function applyLocalUserPasswordReset(
+  client: LocalResetWritableClient,
+  target: LocalResetTarget,
+  credentials: LocalResetCredentials,
+): Promise<LocalResetResult> {
+  const connection = await assertConnectedToBuildingOS(client, target);
+
+  return client.$transaction(async (tx) => {
+    const before = await loadUserSnapshot(tx, credentials.email);
+    const passwordHash = await hashLocalResetPassword(credentials.password);
+
+    await tx.user.update({
+      where: {
+        id: before.rawUserId,
+      },
+      data: {
+        passwordHash,
+      },
+    });
+
+    const revokedSessions = await tx.authSession.updateMany({
+      where: {
+        userId: before.rawUserId,
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: new Date(),
+      },
+    });
+
+    const after = await loadUserSnapshot(tx, credentials.email);
+    await compareSnapshotIntegrity(before.snapshot, after.snapshot);
+
+    return {
+      target,
+      connection,
+      snapshot: after.snapshot,
+      revokedSessionCount: revokedSessions.count,
+    };
+  }, {
+    isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+  });
+}
+
+function formatSnapshotForOutput(result: LocalResetResult): string {
+  return [
+    'Local password reset',
+    `Database: ${result.connection.database}`,
+    `Address: ${result.connection.address ?? 'unknown'}`,
+    `Port: ${result.connection.port ?? 'unknown'}`,
+    `User: ${result.snapshot.email} (${result.snapshot.userId})`,
+    `Memberships: ${result.snapshot.membershipIds.join(', ')}`,
+    `TenantMembers: ${result.snapshot.tenantMemberIds.join(', ')}`,
+    `Active unit: ${result.snapshot.activeOccupancyUnitCodes.join(', ')}`,
+    `Active sessions revoked: ${result.revokedSessionCount}`,
+  ].join('\n');
+}
+
+export async function main(argv = process.argv.slice(2), environment: ResetEnvironment = process.env): Promise<void> {
+  const apply = argv.includes('--apply');
+  const target = assertSafeLocalResetEnvironment(environment);
+  const credentials = readLocalResetCredentials(environment);
+  const databaseUrl = required(environment, 'DATABASE_URL');
+  const prisma = new PrismaClient({
+    datasources: {
+      db: {
+        url: databaseUrl,
+      },
+    },
+  });
+
+  try {
+    const diagnostic = await inspectLocalUserPasswordReset(prisma, target, credentials);
+    if (!apply) {
+      console.log(formatSnapshotForOutput(diagnostic));
+      console.log('Mode: diagnostic');
+      console.log('No data was written. Re-run with --apply to update only the password hash.');
+      return;
+    }
+
+    const applied = await applyLocalUserPasswordReset(prisma, target, credentials);
+    console.log(formatSnapshotForOutput(applied));
+    console.log('Mode: apply');
+    console.log('Only User.passwordHash and active AuthSession.revokedAt values were changed.');
+  } finally {
+    await prisma.$disconnect();
+  }
+}
+
+if (require.main === module) {
+  main().catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Local password reset failed: ${message}`);
+    process.exit(1);
+  });
+}

--- a/apps/api/src/observability/sentry-exception.filter.spec.ts
+++ b/apps/api/src/observability/sentry-exception.filter.spec.ts
@@ -1,0 +1,173 @@
+import {
+  ArgumentsHost,
+  ForbiddenException,
+  InternalServerErrorException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { SentryExceptionFilter } from './sentry-exception.filter';
+import { SentryService } from './sentry.service';
+import { LoggerService } from './logger.service';
+
+describe('SentryExceptionFilter', () => {
+  const sentryService = {
+    captureException: jest.fn(),
+    captureMessage: jest.fn(),
+  } as unknown as jest.Mocked<SentryService>;
+
+  const loggerService = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as unknown as jest.Mocked<LoggerService>;
+
+  function createHost(
+    request: {
+      id: string;
+      tenantId?: string;
+      userId?: string;
+      routePath: string;
+      path: string;
+      method: string;
+    },
+    response: { status: jest.Mock; json: jest.Mock },
+  ): ArgumentsHost {
+    return {
+      switchToHttp: () => ({
+        getRequest: () => ({
+          id: request.id,
+          tenantId: request.tenantId,
+          userId: request.userId,
+          route: { path: request.routePath },
+          path: request.path,
+          method: request.method,
+        }),
+        getResponse: () => response,
+      }),
+    } as unknown as ArgumentsHost;
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('logs 401 auth failures without sending them to Sentry', () => {
+    const filter = new SentryExceptionFilter(sentryService, loggerService);
+    const response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const host = createHost(
+      {
+        id: 'req-1',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        routePath: '/auth/refresh',
+        path: '/auth/refresh',
+        method: 'POST',
+      },
+      response,
+    );
+
+    filter.catch(new UnauthorizedException('Sesión expirada'), host);
+
+    expect(sentryService.captureException).not.toHaveBeenCalled();
+    expect(sentryService.captureMessage).not.toHaveBeenCalled();
+    expect(loggerService.info).toHaveBeenCalledWith(
+      '[req-1] POST /auth/refresh - 401',
+      expect.objectContaining({
+        requestId: 'req-1',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        route: '/auth/refresh',
+        method: 'POST',
+        statusCode: 401,
+        error: 'Sesión expirada',
+      }),
+    );
+    expect(response.status).toHaveBeenCalledWith(401);
+  });
+
+  it('logs 403 authorization failures without sending them to Sentry', () => {
+    const filter = new SentryExceptionFilter(sentryService, loggerService);
+    const response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const host = createHost(
+      {
+        id: 'req-2',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        routePath: '/tenants/tenant-1/finance',
+        path: '/tenants/tenant-1/finance',
+        method: 'GET',
+      },
+      response,
+    );
+
+    filter.catch(new ForbiddenException('Forbidden'), host);
+
+    expect(sentryService.captureException).not.toHaveBeenCalled();
+    expect(sentryService.captureMessage).not.toHaveBeenCalled();
+    expect(loggerService.warn).toHaveBeenCalledWith(
+      '[req-2] GET /tenants/tenant-1/finance - 403',
+      expect.objectContaining({
+        requestId: 'req-2',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        route: '/tenants/tenant-1/finance',
+        method: 'GET',
+        statusCode: 403,
+        error: 'Forbidden',
+      }),
+    );
+    expect(response.status).toHaveBeenCalledWith(403);
+  });
+
+  it('sends 500 errors to Sentry and logs them as errors', () => {
+    const filter = new SentryExceptionFilter(sentryService, loggerService);
+    const response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const error = new InternalServerErrorException('DB exploded');
+    const host = createHost(
+      {
+        id: 'req-3',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        routePath: '/finance',
+        path: '/finance',
+        method: 'POST',
+      },
+      response,
+    );
+
+    filter.catch(error, host);
+
+    expect(sentryService.captureException).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        requestId: 'req-3',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        route: '/finance',
+        method: 'POST',
+        statusCode: 500,
+      }),
+    );
+    expect(loggerService.error).toHaveBeenCalledWith(
+      '[req-3] POST /finance - 500',
+      error,
+      expect.objectContaining({
+        requestId: 'req-3',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        route: '/finance',
+        method: 'POST',
+        statusCode: 500,
+      }),
+    );
+    expect(response.status).toHaveBeenCalledWith(500);
+  });
+});

--- a/apps/api/src/observability/sentry-exception.filter.ts
+++ b/apps/api/src/observability/sentry-exception.filter.ts
@@ -10,10 +10,10 @@ import {
   ArgumentsHost,
   HttpStatus,
   HttpException,
-  Logger,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { SentryService } from './sentry.service';
+import { LoggerService } from './logger.service';
 
 type ExceptionRequest = Request & {
   tenantId?: string;
@@ -26,9 +26,10 @@ interface HttpExceptionResponseBody {
 
 @Catch()
 export class SentryExceptionFilter implements ExceptionFilter {
-  private logger = new Logger('SentryExceptionFilter');
-
-  constructor(private sentry: SentryService) {}
+  constructor(
+    private sentry: SentryService,
+    private logger: LoggerService,
+  ) {}
 
   catch(exception: unknown, host: ArgumentsHost) {
     const ctx = host.switchToHttp();
@@ -71,6 +72,8 @@ export class SentryExceptionFilter implements ExceptionFilter {
 
     context.statusCode = statusCode;
 
+    const logMessage = `[${context.requestId}] ${context.method} ${context.route} - ${statusCode}`;
+
     // Send to Sentry only for 5xx errors
     if (statusCode >= 500) {
       if (error) {
@@ -80,11 +83,27 @@ export class SentryExceptionFilter implements ExceptionFilter {
       }
     }
 
-    // Log the error
-    this.logger.error(
-      `[${context.requestId}] ${context.method} ${context.route} - ${statusCode}`,
-      error?.stack || message,
-    );
+    if (statusCode === 401) {
+      this.logger.info(logMessage, {
+        ...context,
+        error: message,
+      });
+    } else if (statusCode === 403) {
+      this.logger.warn(logMessage, {
+        ...context,
+        error: message,
+      });
+    } else if (statusCode >= 500) {
+      this.logger.error(logMessage, error ?? undefined, {
+        ...context,
+        error: message,
+      });
+    } else {
+      this.logger.warn(logMessage, {
+        ...context,
+        error: message,
+      });
+    }
 
     // Send response
     response.status(statusCode).json({

--- a/apps/web/features/auth/AuthBootstrap.tsx
+++ b/apps/web/features/auth/AuthBootstrap.tsx
@@ -71,9 +71,6 @@ export const AuthBootstrap = () => {
         const is401 = error instanceof HttpError && error.status === 401;
 
         if (is401) {
-          clearAllImpersonationData();
-          clearAuth();
-          redirectToLoginIfPrivate();
           return;
         }
 

--- a/apps/web/features/super-admin/__tests__/tenants.storage.test.ts
+++ b/apps/web/features/super-admin/__tests__/tenants.storage.test.ts
@@ -284,12 +284,12 @@ describe('Tenants Storage - Search & Filter', () => {
   });
 
   describe('getRecentTenants', () => {
-    it('should return most recent tenants', () => {
+    it('should return the most recently created or updated tenants first', () => {
       const recent = getRecentTenants(2);
       expect(recent.length).toBe(2);
 
-      // Most recent should be the newest tenant in the fixture set.
-      expect(recent[0].name).toBe('Acme Corp');
+      // Building Heights was updated after creation, so it should be the most recent entry.
+      expect(recent[0].name).toBe('Building Heights');
     });
 
     it('should respect limit parameter', () => {

--- a/apps/web/features/super-admin/tenants.storage.ts
+++ b/apps/web/features/super-admin/tenants.storage.ts
@@ -230,8 +230,28 @@ export function getTenantsByStatus(): Record<string, Tenant[]> {
  */
 export function getRecentTenants(limit = 10): Tenant[] {
   const tenants = listTenants();
-  return tenants
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+  return [...tenants]
+    .sort((a, b) => {
+      const aLastActivity = new Date(a.updatedAt ?? a.createdAt).getTime();
+      const bLastActivity = new Date(b.updatedAt ?? b.createdAt).getTime();
+
+      if (aLastActivity !== bLastActivity) {
+        return bLastActivity - aLastActivity;
+      }
+
+      const aWasUpdated = Boolean(a.updatedAt);
+      const bWasUpdated = Boolean(b.updatedAt);
+      if (aWasUpdated !== bWasUpdated) {
+        return aWasUpdated ? -1 : 1;
+      }
+
+      const nameComparison = a.name.localeCompare(b.name, 'es');
+      if (nameComparison !== 0) {
+        return nameComparison;
+      }
+
+      return a.id.localeCompare(b.id);
+    })
     .slice(0, limit);
 }
 

--- a/apps/web/shared/lib/http/client.test.ts
+++ b/apps/web/shared/lib/http/client.test.ts
@@ -1,0 +1,237 @@
+import { apiClient, HttpError } from './client';
+import { clearAuth } from '@/features/auth/session.storage';
+import { clearAllImpersonationData, getCurrentImpersonationToken } from '@/features/impersonation/impersonation.storage';
+import { emitAuthUnauthorized } from '@/shared/lib/auth/events';
+
+jest.mock('@/shared/lib/public-api-url', () => ({
+  getPublicApiUrl: () => 'https://api.buildingos.test',
+}));
+
+jest.mock('@/shared/lib/observability/frontend-observability', () => ({
+  recordApiResponseContext: jest.fn(),
+}));
+
+jest.mock('@/features/auth/session.storage', () => ({
+  clearAuth: jest.fn(),
+}));
+
+jest.mock('@/features/impersonation/impersonation.storage', () => ({
+  clearAllImpersonationData: jest.fn(),
+  getCurrentImpersonationToken: jest.fn(),
+}));
+
+jest.mock('@/shared/lib/auth/events', () => ({
+  emitAuthUnauthorized: jest.fn(),
+}));
+
+const mockedClearAuth = jest.mocked(clearAuth);
+const mockedClearAllImpersonationData = jest.mocked(clearAllImpersonationData);
+const mockedEmitAuthUnauthorized = jest.mocked(emitAuthUnauthorized);
+const mockedGetCurrentImpersonationToken = jest.mocked(getCurrentImpersonationToken);
+
+function jsonResponse(status: number, body?: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 401 ? 'Unauthorized' : 'OK',
+    headers: {
+      get: () => null,
+    },
+    async json() {
+      return body ?? {};
+    },
+  } as unknown as Response;
+}
+
+describe('apiClient auth refresh single-flight', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    mockedClearAuth.mockReset();
+    mockedClearAllImpersonationData.mockReset();
+    mockedEmitAuthUnauthorized.mockReset();
+    mockedGetCurrentImpersonationToken.mockReset();
+    mockedGetCurrentImpersonationToken.mockReturnValue(null);
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('shares one refresh promise across simultaneous 401s and retries each request once', async () => {
+    let refreshCalls = 0;
+    let sawRefresh = false;
+    const fetchMock = jest.mocked(global.fetch);
+
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url.endsWith('/auth/refresh')) {
+        refreshCalls += 1;
+        sawRefresh = true;
+        return jsonResponse(201, { ok: true });
+      }
+
+      if (url.endsWith('/protected')) {
+        if (!sawRefresh) {
+          return jsonResponse(401, { message: 'Unauthorized' });
+        }
+
+        return jsonResponse(200, { ok: true, retried: true });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const requests = Array.from({ length: 5 }, () =>
+      apiClient<{ ok: boolean; retried?: boolean }>({
+        path: '/protected',
+        method: 'GET',
+      }),
+    );
+
+    const responses = await Promise.all(requests);
+
+    expect(refreshCalls).toBe(1);
+    expect(fetchMock).toHaveBeenCalledTimes(11);
+    expect(responses).toEqual([
+      { ok: true, retried: true },
+      { ok: true, retried: true },
+      { ok: true, retried: true },
+      { ok: true, retried: true },
+      { ok: true, retried: true },
+    ]);
+    expect(mockedClearAuth).not.toHaveBeenCalled();
+    expect(mockedClearAllImpersonationData).not.toHaveBeenCalled();
+    expect(mockedEmitAuthUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it('clears the session once when the shared refresh fails', async () => {
+    let refreshCalls = 0;
+    const fetchMock = jest.mocked(global.fetch);
+
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url.endsWith('/auth/refresh')) {
+        refreshCalls += 1;
+        return jsonResponse(401, { message: 'refresh expired' });
+      }
+
+      if (url.endsWith('/protected')) {
+        return jsonResponse(401, { message: 'Unauthorized' });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    const requests = Array.from({ length: 5 }, () =>
+      apiClient<{ ok: boolean }>({
+        path: '/protected',
+        method: 'GET',
+      }),
+    );
+
+    await expect(Promise.all(requests)).rejects.toThrow(
+      'Sesión expirada. Vuelve a iniciar sesión.',
+    );
+
+    expect(refreshCalls).toBe(1);
+    expect(mockedClearAllImpersonationData).toHaveBeenCalledTimes(1);
+    expect(mockedClearAuth).toHaveBeenCalledTimes(1);
+    expect(mockedEmitAuthUnauthorized).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not refresh again when the retried request still returns 401', async () => {
+    let refreshCalls = 0;
+    let retryCalls = 0;
+    const fetchMock = jest.mocked(global.fetch);
+
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (url.endsWith('/auth/refresh')) {
+        refreshCalls += 1;
+        return jsonResponse(201, { ok: true });
+      }
+
+      if (url.endsWith('/protected')) {
+        if (retryCalls === 0) {
+          retryCalls += 1;
+          return jsonResponse(401, { message: 'Unauthorized' });
+        }
+
+        return jsonResponse(401, { message: 'still unauthorized' });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await expect(
+      apiClient<{ ok: boolean }>({
+        path: '/protected',
+        method: 'GET',
+      }),
+    ).rejects.toMatchObject({
+      status: 401,
+      message: 'still unauthorized',
+    });
+
+    expect(refreshCalls).toBe(1);
+    expect(mockedClearAuth).not.toHaveBeenCalled();
+    expect(mockedClearAllImpersonationData).not.toHaveBeenCalled();
+    expect(mockedEmitAuthUnauthorized).not.toHaveBeenCalled();
+  });
+
+  it('keeps auth routes out of the refresh flow', async () => {
+    const fetchMock = jest.mocked(global.fetch);
+
+    fetchMock.mockImplementation(async (input) => {
+      const url = String(input);
+
+      if (
+        url.endsWith('/auth/login') ||
+        url.endsWith('/auth/logout') ||
+        url.endsWith('/auth/refresh')
+      ) {
+        return jsonResponse(401, { message: `${url} rejected` });
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+
+    await expect(
+      apiClient<{ ok: boolean }, { email: string; password: string }>({
+        path: '/auth/login',
+        method: 'POST',
+        body: { email: 'user@example.com', password: 'secret' },
+      }),
+    ).rejects.toMatchObject({
+      status: 401,
+      message: 'https://api.buildingos.test/auth/login rejected',
+    });
+
+    await expect(
+      apiClient<{ ok: boolean }>({
+        path: '/auth/logout',
+        method: 'POST',
+      }),
+    ).rejects.toMatchObject({
+      status: 401,
+      message: 'https://api.buildingos.test/auth/logout rejected',
+    });
+
+    await expect(
+      apiClient<{ ok: boolean }>({
+        path: '/auth/refresh',
+        method: 'POST',
+      }),
+    ).rejects.toMatchObject({
+      status: 401,
+      message: 'https://api.buildingos.test/auth/refresh rejected',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/web/shared/lib/http/client.ts
+++ b/apps/web/shared/lib/http/client.ts
@@ -34,6 +34,7 @@ export class HttpError extends Error {
 }
 
 const API_URL = getPublicApiUrl();
+let refreshPromise: Promise<void> | null = null;
 
 /**
  * 204 responses intentionally have no response body.
@@ -65,7 +66,17 @@ async function parseErrorResponse(response: Response): Promise<{
   return { message: response.statusText || 'Error desconocido', data: null };
 }
 
-async function tryRefreshAuthCookie(): Promise<boolean> {
+function isAuthRoute(path: string): boolean {
+  return (
+    path === '/auth/refresh' ||
+    path === '/auth/login' ||
+    path === '/auth/logout' ||
+    path === '/auth/logout-all' ||
+    path === '/auth/signup'
+  );
+}
+
+async function requestAuthRefresh(): Promise<void> {
   try {
     const response = await fetch(`${API_URL}/auth/refresh`, {
       method: 'POST',
@@ -74,10 +85,43 @@ async function tryRefreshAuthCookie(): Promise<boolean> {
         'Content-Type': 'application/json',
       },
     });
-    return response.ok;
-  } catch {
-    return false;
+
+    captureResponseContext(response, 'POST', '/auth/refresh');
+
+    if (!response.ok) {
+      const error = await parseErrorResponse(response);
+      throw new HttpError(response.status, response.statusText, error.message, error.data);
+    }
+  } catch (error) {
+    if (error instanceof HttpError) {
+      throw error;
+    }
+
+    recordApiResponseContext({
+      requestId: undefined,
+      method: 'POST',
+      path: '/auth/refresh',
+      statusCode: 0,
+    });
+    throw error instanceof Error ? error : new Error('Auth refresh request failed');
   }
+}
+
+function ensureSharedRefreshPromise(): Promise<void> {
+  if (!refreshPromise) {
+    refreshPromise = requestAuthRefresh()
+      .catch((error) => {
+        clearAllImpersonationData();
+        clearAuth();
+        emitAuthUnauthorized();
+        throw error;
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+
+  return refreshPromise;
 }
 
 function captureResponseContext(
@@ -138,39 +182,34 @@ export async function apiClient<TRes, TReq = never>(
     // Centralized 401 handler: try refresh cookie once, then emit an auth-expired event.
     if (response.status === 401) {
       const hasImpersonationToken = !!getCurrentImpersonationToken();
-      const isAuthRoute =
-        path === '/auth/refresh' ||
-        path === '/auth/login' ||
-        path === '/auth/signup';
 
-      if (!hasImpersonationToken && !isAuthRoute) {
-        const refreshed = await tryRefreshAuthCookie();
-        if (refreshed) {
-          const retryResponse = await fetch(url, init);
-          captureResponseContext(retryResponse, method, path);
-          if (retryResponse.ok) {
-            if (retryResponse.status === 204) {
-              return noContentResponse<TRes>();
-            }
-            return retryResponse.json() as Promise<TRes>;
-          }
-
-          if (retryResponse.status !== 401) {
-            const retryError = await parseErrorResponse(retryResponse);
-            throw new HttpError(
-              retryResponse.status,
-              retryResponse.statusText,
-              retryError.message,
-              retryError.data,
-            );
-          }
+      if (!hasImpersonationToken && !isAuthRoute(path)) {
+        try {
+          await ensureSharedRefreshPromise();
+        } catch {
+          throw new HttpError(401, 'Unauthorized', 'Sesión expirada. Vuelve a iniciar sesión.');
         }
+
+        const retryResponse = await fetch(url, init);
+        captureResponseContext(retryResponse, method, path);
+        if (retryResponse.ok) {
+          if (retryResponse.status === 204) {
+            return noContentResponse<TRes>();
+          }
+          return retryResponse.json() as Promise<TRes>;
+        }
+
+        const retryError = await parseErrorResponse(retryResponse);
+        throw new HttpError(
+          retryResponse.status,
+          retryResponse.statusText,
+          retryError.message,
+          retryError.data,
+        );
       }
 
-      clearAllImpersonationData();
-      clearAuth();
-      emitAuthUnauthorized();
-      throw new HttpError(401, 'Unauthorized', 'Sesión expirada. Vuelve a iniciar sesión.');
+      const { message, data } = await parseErrorResponse(response);
+      throw new HttpError(response.status, response.statusText, message, data);
     }
 
     const { message, data } = await parseErrorResponse(response);


### PR DESCRIPTION
## Resumen

Cierra el baseline local de BuildingOS con cambios aislados y validados en:

- seed manual local protegido;
- autenticación y bootstrap de sesión;
- manejo de errores HTTP y Sentry;
- persistencia de auditoría;
- publicación de liquidaciones;
- reutilización idempotente del workflow en seeds.

## Commits

- `a4c93a2` — guarded local seed workflow
- `c1d536a` — auth and session stabilization
- `c75341b` — audit persistence behavior
- `98a061c` — liquidation publication workflow

## Validaciones

- Prisma validate: PASS
- Prisma generate: PASS
- Prisma migrate status: schema up to date
- TypeScript API: PASS
- Build API: PASS
- Build web: PASS
- API focalizado: 9 suites / 113 tests PASS
- Web focalizado: 1 suite / 4 tests PASS
- Integración PostgreSQL seed: PASS
- Integración PostgreSQL liquidaciones: PASS
- Suite general API: 113 suites PASS, 1344 tests PASS, 0 fallos
- Working tree limpio

## Seguridad

- Seed local bloquea staging y producción.
- Hosts remotos bloqueados.
- No hay contraseñas ni secretos en Git.
- Pruebas PostgreSQL usan bases temporales eliminadas al finalizar.
- El script temporal `repair-liquidation-id.ts` fue excluido.
- Staging y producción no fueron modificados.

## Despliegue

Este PR no autoriza despliegue a producción.
Staging se actualizará posteriormente mediante un procedimiento separado con backup previo.