### PR TITLE
fix(api): handle onboarding identity conflicts

### DIFF
--- a/apps/api/src/onboarding-imports/onboarding-imports.service.spec.ts
+++ b/apps/api/src/onboarding-imports/onboarding-imports.service.spec.ts
@@ -686,7 +686,13 @@ describe('OnboardingImportsService', () => {
         isBillable: true,
       },
     ]);
-    prisma.externalEntityReference.findMany.mockResolvedValue([]);
+    prisma.externalEntityReference.findMany.mockResolvedValue([
+      {
+        entityType: 'PERSON',
+        externalCode: 'P-001',
+        entityId: 'member-1',
+      },
+    ]);
     prisma.tenantMember.findMany.mockResolvedValue([
       {
         id: 'member-1',
@@ -966,5 +972,270 @@ describe('OnboardingImportsService', () => {
     expect(businessWrites.membership.create).not.toHaveBeenCalled();
     expect(businessWrites.membershipRole.create).not.toHaveBeenCalled();
     expect(businessWrites.charge.create).not.toHaveBeenCalled();
+  });
+
+  it('blocks person identity duplicates in file and stale external references', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
+    prisma.building.findMany.mockResolvedValue([
+      {
+        id: 'building-1',
+        alias: 'A',
+        name: 'Torre A',
+        address: 'Av. Principal 123',
+        deletedAt: null,
+      },
+    ]);
+    prisma.unitCategory.findMany.mockResolvedValue([]);
+    prisma.unit.findMany.mockResolvedValue([]);
+    prisma.externalEntityReference.findMany.mockResolvedValue([
+      {
+        entityType: 'PERSON',
+        externalCode: 'P-EXIST',
+        entityId: 'member-missing',
+      },
+    ]);
+    prisma.tenantMember.findMany.mockResolvedValue([]);
+    prisma.user.findMany.mockResolvedValue([]);
+    prisma.unitOccupant.findMany.mockResolvedValue([]);
+    prisma.charge.findMany.mockResolvedValue([]);
+
+    const parsedData = buildParsedData(currentPeriod);
+    parsedData.people = [
+      {
+        sheet: 'Personas',
+        rowNumber: 2,
+        raw: {
+          persona_codigo: 'P-001',
+          nombre: 'Unique One',
+          email: 'unique-1@buildingos.test',
+          telefono: '+58 412 1000000',
+          documento: 'V-1',
+        },
+        normalized: {
+          personaCodigo: 'P-001',
+          nombre: 'Unique One',
+          email: 'unique-1@buildingos.test',
+          telefono: '+58 412 1000000',
+          documento: 'V-1',
+        },
+      },
+      {
+        sheet: 'Personas',
+        rowNumber: 3,
+        raw: {
+          persona_codigo: 'P-002',
+          nombre: 'Email Duplicate',
+          email: 'unique-1@buildingos.test',
+          telefono: '+58 412 2000000',
+          documento: 'V-2',
+        },
+        normalized: {
+          personaCodigo: 'P-002',
+          nombre: 'Email Duplicate',
+          email: 'unique-1@buildingos.test',
+          telefono: '+58 412 2000000',
+          documento: 'V-2',
+        },
+      },
+      {
+        sheet: 'Personas',
+        rowNumber: 4,
+        raw: {
+          persona_codigo: 'P-003',
+          nombre: 'Phone Duplicate',
+          email: 'unique-3@buildingos.test',
+          telefono: '+58 412 1000000',
+          documento: 'V-3',
+        },
+        normalized: {
+          personaCodigo: 'P-003',
+          nombre: 'Phone Duplicate',
+          email: 'unique-3@buildingos.test',
+          telefono: '+58 412 1000000',
+          documento: 'V-3',
+        },
+      },
+      {
+        sheet: 'Personas',
+        rowNumber: 5,
+        raw: {
+          persona_codigo: 'P-004',
+          nombre: 'Document Duplicate',
+          email: 'unique-4@buildingos.test',
+          telefono: '+58 412 4000000',
+          documento: 'V-1',
+        },
+        normalized: {
+          personaCodigo: 'P-004',
+          nombre: 'Document Duplicate',
+          email: 'unique-4@buildingos.test',
+          telefono: '+58 412 4000000',
+          documento: 'V-1',
+        },
+      },
+      {
+        sheet: 'Personas',
+        rowNumber: 6,
+        raw: {
+          persona_codigo: 'P-EXIST',
+          nombre: 'External Ref Conflict',
+          email: 'unique-5@buildingos.test',
+          telefono: '+58 412 5000000',
+          documento: 'V-5',
+        },
+        normalized: {
+          personaCodigo: 'P-EXIST',
+          nombre: 'External Ref Conflict',
+          email: 'unique-5@buildingos.test',
+          telefono: '+58 412 5000000',
+          documento: 'V-5',
+        },
+      },
+    ];
+
+    const validation = await (service as any).validateWorkbook(tenantId, 'ARS', parsedData, []);
+
+    expect(validation.summary.people.new).toBe(1);
+    expect(validation.summary.people.conflict).toBe(4);
+    expect(validation.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({ sheet: 'Personas', column: 'email', code: 'DUPLICATE_IN_FILE', severity: 'BLOCKER' }),
+      expect.objectContaining({ sheet: 'Personas', column: 'telefono', code: 'DUPLICATE_IN_FILE', severity: 'BLOCKER' }),
+      expect.objectContaining({ sheet: 'Personas', column: 'documento', code: 'DUPLICATE_IN_FILE', severity: 'BLOCKER' }),
+      expect.objectContaining({ sheet: 'Personas', column: 'persona_codigo', code: 'CONFLICT_WITH_DB', severity: 'BLOCKER' }),
+    ]));
+    expect(businessWrites.tenantMember.create).not.toHaveBeenCalled();
+    expect(businessWrites.user.create).not.toHaveBeenCalled();
+  });
+
+  it('blocks existing email phone and document identities during preview without business writes', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
+    prisma.building.findMany.mockResolvedValue([
+      {
+        id: 'building-1',
+        alias: 'A',
+        name: 'Torre A',
+        address: 'Av. Principal 123',
+        deletedAt: null,
+      },
+    ]);
+    prisma.unitCategory.findMany.mockResolvedValue([]);
+    prisma.unit.findMany.mockResolvedValue([]);
+    prisma.externalEntityReference.findMany.mockResolvedValue([
+      {
+        entityType: 'PERSON_DOCUMENT',
+        externalCode: 'V-EXIST',
+        entityId: 'member-doc',
+      },
+    ]);
+    prisma.tenantMember.findMany.mockResolvedValue([
+      {
+        id: 'member-email',
+        tenantId,
+        name: 'Existing Email',
+        email: 'existing-email@buildingos.test',
+        phone: null,
+        role: 'RESIDENT',
+        status: 'ACTIVE',
+      },
+      {
+        id: 'member-phone',
+        tenantId,
+        name: 'Existing Phone',
+        email: null,
+        phone: '+58 412 9999999',
+        role: 'RESIDENT',
+        status: 'ACTIVE',
+      },
+      {
+        id: 'member-doc',
+        tenantId,
+        name: 'Existing Document',
+        email: null,
+        phone: null,
+        role: 'RESIDENT',
+        status: 'ACTIVE',
+      },
+    ]);
+    prisma.user.findMany.mockResolvedValue([
+      {
+        id: 'user-email',
+        email: 'existing-email@buildingos.test',
+        name: 'Existing Email',
+      },
+    ]);
+    prisma.unitOccupant.findMany.mockResolvedValue([]);
+    prisma.charge.findMany.mockResolvedValue([]);
+
+    const parsedData = buildParsedData(currentPeriod);
+    parsedData.people = [
+      {
+        sheet: 'Personas',
+        rowNumber: 2,
+        raw: {
+          persona_codigo: 'P-EMAIL',
+          nombre: 'Email Conflict',
+          email: 'existing-email@buildingos.test',
+          telefono: '+58 412 1000000',
+          documento: 'V-100',
+        },
+        normalized: {
+          personaCodigo: 'P-EMAIL',
+          nombre: 'Email Conflict',
+          email: 'existing-email@buildingos.test',
+          telefono: '+58 412 1000000',
+          documento: 'V-100',
+        },
+      },
+      {
+        sheet: 'Personas',
+        rowNumber: 3,
+        raw: {
+          persona_codigo: 'P-PHONE',
+          nombre: 'Phone Conflict',
+          email: 'phone-conflict@buildingos.test',
+          telefono: '+58 412 9999999',
+          documento: 'V-200',
+        },
+        normalized: {
+          personaCodigo: 'P-PHONE',
+          nombre: 'Phone Conflict',
+          email: 'phone-conflict@buildingos.test',
+          telefono: '+58 412 9999999',
+          documento: 'V-200',
+        },
+      },
+      {
+        sheet: 'Personas',
+        rowNumber: 4,
+        raw: {
+          persona_codigo: 'P-DOC',
+          nombre: 'Document Conflict',
+          email: 'document-conflict@buildingos.test',
+          telefono: '+58 412 2000000',
+          documento: 'V-EXIST',
+        },
+        normalized: {
+          personaCodigo: 'P-DOC',
+          nombre: 'Document Conflict',
+          email: 'document-conflict@buildingos.test',
+          telefono: '+58 412 2000000',
+          documento: 'V-EXIST',
+        },
+      },
+    ];
+
+    const validation = await (service as any).validateWorkbook(tenantId, 'ARS', parsedData, []);
+
+    expect(validation.summary.people.conflict).toBe(3);
+    expect(validation.summary.people.new).toBe(0);
+    expect(validation.summary.people.reusable).toBe(0);
+    expect(validation.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({ column: 'email', code: 'CONFLICT_WITH_DB', severity: 'BLOCKER' }),
+      expect.objectContaining({ column: 'telefono', code: 'CONFLICT_WITH_DB', severity: 'BLOCKER' }),
+      expect.objectContaining({ column: 'documento', code: 'CONFLICT_WITH_DB', severity: 'BLOCKER' }),
+    ]));
+    expect(businessWrites.tenantMember.create).not.toHaveBeenCalled();
+    expect(businessWrites.user.create).not.toHaveBeenCalled();
+    expect(businessWrites.externalEntityReference.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/onboarding-imports/onboarding-imports.service.ts
+++ b/apps/api/src/onboarding-imports/onboarding-imports.service.ts
@@ -92,6 +92,7 @@ interface ExistingTenantMemberRecord {
 }
 
 interface ExistingReferenceRecord {
+  readonly entityType: string;
   readonly externalCode: string;
   readonly entityId: string;
 }
@@ -633,14 +634,26 @@ export class OnboardingImportsService {
       where: {
         tenantId,
         source: 'onboarding-import',
-        entityType: 'PERSON',
+        entityType: {
+          in: ['PERSON', 'PERSON_DOCUMENT'],
+        },
       },
-      select: { externalCode: true, entityId: true },
+      select: { entityType: true, externalCode: true, entityId: true },
     });
-    const personRefByCode = new Map(personRefs.map((ref) => [this.normalizeCode(ref.externalCode), ref] as const));
+    const personRefByCode = new Map(
+      personRefs
+        .filter((ref) => ref.entityType === 'PERSON')
+        .map((ref) => [this.normalizeCode(ref.externalCode), ref] as const),
+    );
+    const personRefByDocument = new Map(
+      personRefs
+        .filter((ref) => ref.entityType === 'PERSON_DOCUMENT')
+        .map((ref) => [this.normalizeDocument(ref.externalCode), ref] as const),
+    );
 
     const personEmails = Array.from(new Set(data.people.flatMap((row) => (row.normalized?.email ? [this.normalizeEmail(row.normalized.email)] : []))));
     const personPhones = Array.from(new Set(data.people.flatMap((row) => (row.normalized?.telefono ? [this.normalizeText(row.normalized.telefono)] : [])).filter((phone): phone is string => Boolean(phone))));
+    const referencedMemberIds = Array.from(new Set(personRefs.map((ref) => ref.entityId)));
 
     const tenantMemberWhere: Prisma.TenantMemberWhereInput = { tenantId };
     const tenantMemberOr: Prisma.TenantMemberWhereInput[] = [];
@@ -649,6 +662,9 @@ export class OnboardingImportsService {
     }
     if (personPhones.length > 0) {
       tenantMemberOr.push({ phone: { in: personPhones } });
+    }
+    if (referencedMemberIds.length > 0) {
+      tenantMemberOr.push({ id: { in: referencedMemberIds } });
     }
     if (tenantMemberOr.length > 0) {
       tenantMemberWhere.OR = tenantMemberOr;
@@ -669,6 +685,10 @@ export class OnboardingImportsService {
     const userByEmail = new Map(usersByEmail.map((user) => [this.normalizeEmail(user.email), user] as const));
     const memberByEmail = new Map(tenantMembers.filter((member) => member.email).map((member) => [this.normalizeEmail(member.email ?? ''), member] as const));
     const memberByPhone = new Map(tenantMembers.filter((member) => member.phone).map((member) => [this.normalizeText(member.phone ?? ''), member] as const));
+    const memberById = new Map(tenantMembers.map((member) => [member.id, member] as const));
+    const personEmailOwners = new Map<string, string>();
+    const personPhoneOwners = new Map<string, string>();
+    const personDocumentOwners = new Map<string, string>();
 
     const personRowsByCode = new Map<string, ParsedRow<ParsedPersonRowRaw, ParsedPersonRowNormalized>>();
     const personStatusByCode = new Map<string, 'new' | 'reusable' | 'conflict' | 'invalid'>();
@@ -689,11 +709,58 @@ export class OnboardingImportsService {
       personRowsByCode.set(code, row);
 
       const existingRef = personRefByCode.get(code);
+      const normalizedDocument = normalized.documento ? this.normalizeDocument(normalized.documento) : null;
       const normalizedEmail = normalized.email ? this.normalizeEmail(normalized.email) : null;
       const normalizedPhone = normalized.telefono ? this.normalizeText(normalized.telefono) : null;
-      const existingMember = normalizedEmail ? memberByEmail.get(normalizedEmail) : undefined;
+      const existingDocumentRef = normalizedDocument ? personRefByDocument.get(normalizedDocument) : undefined;
+      const existingMember = existingRef ? memberById.get(existingRef.entityId) : undefined;
+      const existingDocumentMember = existingDocumentRef ? memberById.get(existingDocumentRef.entityId) : undefined;
+      const existingEmailMember = normalizedEmail ? memberByEmail.get(normalizedEmail) : undefined;
       const existingPhoneMember = normalizedPhone ? memberByPhone.get(normalizedPhone) : undefined;
       const existingUser = normalizedEmail ? userByEmail.get(normalizedEmail) : undefined;
+
+      if (normalizedEmail) {
+        const previousCode = personEmailOwners.get(normalizedEmail);
+        if (previousCode && previousCode !== code) {
+          this.bump(summary.people, 'conflict');
+          personStatusByCode.set(code, 'conflict');
+          issues.push(this.makeIssue(row.sheet, row.rowNumber, 'email', 'DUPLICATE_IN_FILE', 'BLOCKER', `Duplicate person email in file: ${normalizedEmail}`, normalizedEmail, normalizedEmail));
+          continue;
+        }
+
+        personEmailOwners.set(normalizedEmail, code);
+      }
+
+      if (normalizedPhone) {
+        const previousCode = personPhoneOwners.get(normalizedPhone);
+        if (previousCode && previousCode !== code) {
+          this.bump(summary.people, 'conflict');
+          personStatusByCode.set(code, 'conflict');
+          issues.push(this.makeIssue(row.sheet, row.rowNumber, 'telefono', 'DUPLICATE_IN_FILE', 'BLOCKER', `Duplicate person phone in file: ${normalizedPhone}`, normalizedPhone, normalizedPhone));
+          continue;
+        }
+
+        personPhoneOwners.set(normalizedPhone, code);
+      }
+
+      if (normalizedDocument) {
+        const previousCode = personDocumentOwners.get(normalizedDocument);
+        if (previousCode && previousCode !== code) {
+          this.bump(summary.people, 'conflict');
+          personStatusByCode.set(code, 'conflict');
+          issues.push(this.makeIssue(row.sheet, row.rowNumber, 'documento', 'DUPLICATE_IN_FILE', 'BLOCKER', `Duplicate person document in file: ${normalizedDocument}`, normalizedDocument, normalizedDocument));
+          continue;
+        }
+
+        personDocumentOwners.set(normalizedDocument, code);
+      }
+
+      if (existingRef && !existingMember) {
+        this.bump(summary.people, 'conflict');
+        personStatusByCode.set(code, 'conflict');
+        issues.push(this.makeIssue(row.sheet, row.rowNumber, 'persona_codigo', 'CONFLICT_WITH_DB', 'BLOCKER', `Person ${code} references a missing tenant member`, code, code));
+        continue;
+      }
 
       if (existingRef) {
         this.bump(summary.people, 'reusable');
@@ -701,26 +768,41 @@ export class OnboardingImportsService {
         continue;
       }
 
-      if (existingMember || existingPhoneMember || existingUser) {
-        const sameName = [existingMember?.name, existingPhoneMember?.name, existingUser?.name].some((name) => name ? this.normalizeText(name) === this.normalizeText(normalized.nombre) : false);
-        const sameContact = Boolean(
-          (normalizedEmail && existingUser && this.normalizeEmail(existingUser.email) === normalizedEmail) ||
-          (normalizedEmail && existingMember && this.normalizeEmail(existingMember.email ?? '') === normalizedEmail) ||
-          (normalizedPhone && existingPhoneMember && this.normalizeText(existingPhoneMember.phone ?? '') === normalizedPhone)
-        );
+      const sameName = [existingEmailMember?.name, existingPhoneMember?.name, existingDocumentMember?.name, existingUser?.name].some((name) => name ? this.normalizeText(name) === this.normalizeText(normalized.nombre) : false);
+      const sameIdentity = Boolean(
+        (normalizedEmail && (
+          (existingEmailMember && this.normalizeEmail(existingEmailMember.email ?? '') === normalizedEmail) ||
+          (existingUser && this.normalizeEmail(existingUser.email) === normalizedEmail)
+        )) ||
+        (normalizedPhone && existingPhoneMember && this.normalizeText(existingPhoneMember.phone ?? '') === normalizedPhone) ||
+        (normalizedDocument && existingDocumentMember && existingDocumentRef && this.normalizeDocument(existingDocumentRef.externalCode) === normalizedDocument)
+      );
 
-        if (sameName || sameContact) {
-          this.bump(summary.people, 'reusable');
-          personStatusByCode.set(code, 'reusable');
-        } else {
-          this.bump(summary.people, 'conflict');
-          personStatusByCode.set(code, 'conflict');
-          issues.push(this.makeIssue(row.sheet, row.rowNumber, 'persona_codigo', 'CONFLICT_WITH_DB', 'BLOCKER', `Person ${code} conflicts with an existing user or tenant member`, code, code));
-        }
-      } else {
-        this.bump(summary.people, 'new');
-        personStatusByCode.set(code, 'new');
+      if (sameName && sameIdentity) {
+        this.bump(summary.people, 'reusable');
+        personStatusByCode.set(code, 'reusable');
+        continue;
       }
+
+      if (existingEmailMember || existingPhoneMember || existingDocumentMember || existingUser || existingDocumentRef) {
+        this.bump(summary.people, 'conflict');
+        personStatusByCode.set(code, 'conflict');
+        const conflictColumn = existingEmailMember || existingUser ? 'email' : existingPhoneMember ? 'telefono' : 'documento';
+        issues.push(this.makeIssue(
+          row.sheet,
+          row.rowNumber,
+          conflictColumn,
+          'CONFLICT_WITH_DB',
+          'BLOCKER',
+          'La persona entra en conflicto con una identidad existente del tenant',
+          conflictColumn === 'email' ? normalizedEmail : conflictColumn === 'telefono' ? normalizedPhone : normalizedDocument,
+          conflictColumn === 'email' ? normalizedEmail : conflictColumn === 'telefono' ? normalizedPhone : normalizedDocument,
+        ));
+        continue;
+      }
+
+      this.bump(summary.people, 'new');
+      personStatusByCode.set(code, 'new');
     }
 
     const occupantRows = await this.prisma.unitOccupant.findMany({
@@ -1224,6 +1306,10 @@ export class OnboardingImportsService {
 
   private normalizeEmail(value: string): string {
     return this.normalizeText(value).toLowerCase();
+  }
+
+  private normalizeDocument(value: string): string {
+    return this.normalizeText(value).toUpperCase();
   }
 
   private compareNullableNumber(left: number | null, right: number | null): boolean {

--- a/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.spec.ts
+++ b/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.spec.ts
@@ -490,6 +490,182 @@ describe('OnboardingImportConfirmationService', () => {
     );
   });
 
+  it('loads members referenced only by document refs when confirming people', async () => {
+    const currentJob = createCurrentJob();
+    const { payload } = createPayload(currentJob.id, currentJob.tenantId, currentJob.fileHash);
+    payload.data.people[0].normalized.email = null;
+    payload.data.people[0].normalized.telefono = null;
+    payload.data.people[0].raw.email = '';
+    payload.data.people[0].raw.telefono = '';
+    const serialized = JSON.stringify(payload);
+    const previewHash = createHash('sha256').update(serialized, 'utf8').digest('hex');
+    currentJob.previewHash = previewHash;
+
+    const confirmingJob = {
+      ...currentJob,
+      status: ImportJobStatus.CONFIRMING,
+      confirmingLockExpiresAt: new Date('2030-01-01T00:05:00.000Z'),
+    };
+
+    (prisma.importJob.findFirst as jest.Mock)
+      .mockResolvedValueOnce(currentJob)
+      .mockResolvedValueOnce(confirmingJob);
+    (prisma.importJob.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+    (minio.getObjectBuffer as jest.Mock).mockResolvedValue(Buffer.from(serialized, 'utf8'));
+
+    const tx = createTransactionMocks();
+    (tx.externalEntityReference.findMany as jest.Mock).mockResolvedValue([
+      {
+        entityType: 'PERSON_DOCUMENT',
+        externalCode: 'V-12345678',
+        entityId: 'member-1',
+      },
+    ]);
+    (tx.tenantMember.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'member-1',
+        tenantId: currentJob.tenantId,
+        userId: null,
+        name: 'Residente Uno',
+        email: null,
+        phone: null,
+        role: Role.RESIDENT,
+        status: MemberStatus.ACTIVE,
+      },
+    ]);
+    (tx.user.findMany as jest.Mock).mockResolvedValue([]);
+    (tx.importJob.findFirst as jest.Mock).mockResolvedValue(confirmingJob);
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx));
+
+    const result = await service.confirmImport({
+      tenantId: currentJob.tenantId,
+      tenantCurrency: 'ARS',
+      userId: 'user-admin',
+      membershipId: 'membership-1',
+      roles: [Role.TENANT_ADMIN],
+      isSuperAdmin: false,
+      importId: currentJob.id,
+      expectedPreviewVersion: 1,
+    });
+
+    expect(result.summary.peopleReused).toBe(1);
+    expect(tx.tenantMember.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          OR: expect.arrayContaining([
+            expect.objectContaining({
+              id: {
+                in: ['member-1'],
+              },
+            }),
+          ]),
+        }),
+      }),
+    );
+    expect(tx.externalEntityReference.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          tenantId_source_entityType_externalCode: {
+            tenantId: currentJob.tenantId,
+            source: 'onboarding-import',
+            entityType: 'PERSON_DOCUMENT',
+            externalCode: 'V-12345678',
+          },
+        },
+        update: { entityId: 'member-1' },
+        create: {
+          tenantId: currentJob.tenantId,
+          source: 'onboarding-import',
+          entityType: 'PERSON_DOCUMENT',
+          externalCode: 'V-12345678',
+          entityId: 'member-1',
+        },
+      }),
+    );
+  });
+
+  it('rejects a document ref that belongs to another member before updating the candidate', async () => {
+    const currentJob = createCurrentJob();
+    const { serialized } = createPayload(currentJob.id, currentJob.tenantId, currentJob.fileHash);
+    const previewHash = createHash('sha256').update(serialized, 'utf8').digest('hex');
+    currentJob.previewHash = previewHash;
+
+    const confirmingJob = {
+      ...currentJob,
+      status: ImportJobStatus.CONFIRMING,
+      confirmingLockExpiresAt: new Date('2030-01-01T00:05:00.000Z'),
+    };
+
+    (prisma.importJob.findFirst as jest.Mock)
+      .mockResolvedValueOnce(currentJob)
+      .mockResolvedValueOnce(confirmingJob);
+    (prisma.importJob.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+    (minio.getObjectBuffer as jest.Mock).mockResolvedValue(Buffer.from(serialized, 'utf8'));
+
+    const tx = createTransactionMocks();
+    (tx.externalEntityReference.findMany as jest.Mock).mockResolvedValue([
+      {
+        entityType: 'PERSON',
+        externalCode: 'P-1',
+        entityId: 'member-1',
+      },
+      {
+        entityType: 'PERSON_DOCUMENT',
+        externalCode: 'V-12345678',
+        entityId: 'member-2',
+      },
+    ]);
+    (tx.tenantMember.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'member-1',
+        tenantId: currentJob.tenantId,
+        userId: 'user-1',
+        name: 'Residente Uno',
+        email: 'resident@example.com',
+        phone: '555-0101',
+        role: Role.RESIDENT,
+        status: MemberStatus.ACTIVE,
+      },
+      {
+        id: 'member-2',
+        tenantId: currentJob.tenantId,
+        userId: null,
+        name: 'Otra Persona',
+        email: null,
+        phone: null,
+        role: Role.RESIDENT,
+        status: MemberStatus.ACTIVE,
+      },
+    ]);
+    (tx.user.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'user-1',
+        email: 'resident@example.com',
+        name: 'Residente Uno',
+      },
+    ]);
+    (tx.importJob.findFirst as jest.Mock).mockResolvedValue(confirmingJob);
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx));
+
+    await expect(service.confirmImport({
+      tenantId: currentJob.tenantId,
+      tenantCurrency: 'ARS',
+      userId: 'user-admin',
+      membershipId: 'membership-1',
+      roles: [Role.TENANT_ADMIN],
+      isSuperAdmin: false,
+      importId: currentJob.id,
+      expectedPreviewVersion: 1,
+    })).rejects.toThrow('document en el tenant');
+
+    expect(tx.tenantMember.update).not.toHaveBeenCalled();
+    expect(
+      (tx.externalEntityReference.upsert as jest.Mock).mock.calls.some(([args]) => (
+        args?.where?.tenantId_source_entityType_externalCode?.entityType === 'PERSON_DOCUMENT'
+      )),
+    ).toBe(false);
+  });
+
   it('returns the stored result when the import was already confirmed', async () => {
     const currentJob = {
       ...createCurrentJob(),

--- a/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.spec.ts
+++ b/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.spec.ts
@@ -1,4 +1,5 @@
-import { AuditAction, ImportJobStatus, MemberStatus, Role, UnitOccupantRole } from '@prisma/client';
+import { ConflictException } from '@nestjs/common';
+import { AuditAction, ImportJobStatus, MemberStatus, Prisma, Role, UnitOccupantRole } from '@prisma/client';
 import { createHash } from 'crypto';
 import { AuditService } from '../../../audit/audit.service';
 import { PrismaService } from '../../../prisma/prisma.service';
@@ -263,6 +264,13 @@ function createTransactionMocks() {
   };
 }
 
+function createPrismaKnownError(code: string, target: string[]): Prisma.PrismaClientKnownRequestError {
+  const error = new Error(`Prisma ${code}`);
+  Object.assign(error, { code, meta: { target } });
+  Object.setPrototypeOf(error, Prisma.PrismaClientKnownRequestError.prototype);
+  return error as Prisma.PrismaClientKnownRequestError;
+}
+
 describe('OnboardingImportConfirmationService', () => {
   const auditService = {
     createLog: jest.fn().mockResolvedValue(undefined),
@@ -427,6 +435,48 @@ describe('OnboardingImportConfirmationService', () => {
         importJobId: currentJob.id,
       },
     });
+    expect(
+      (tx.externalEntityReference.upsert as jest.Mock).mock.calls.map(([args]) => args),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          where: {
+            tenantId_source_entityType_externalCode: {
+              tenantId: currentJob.tenantId,
+              source: 'onboarding-import',
+              entityType: 'PERSON',
+              externalCode: 'P-1',
+            },
+          },
+          update: { entityId: 'member-1' },
+          create: {
+            tenantId: currentJob.tenantId,
+            source: 'onboarding-import',
+            entityType: 'PERSON',
+            externalCode: 'P-1',
+            entityId: 'member-1',
+          },
+        }),
+        expect.objectContaining({
+          where: {
+            tenantId_source_entityType_externalCode: {
+              tenantId: currentJob.tenantId,
+              source: 'onboarding-import',
+              entityType: 'PERSON_DOCUMENT',
+              externalCode: 'V-12345678',
+            },
+          },
+          update: { entityId: 'member-1' },
+          create: {
+            tenantId: currentJob.tenantId,
+            source: 'onboarding-import',
+            entityType: 'PERSON_DOCUMENT',
+            externalCode: 'V-12345678',
+            entityId: 'member-1',
+          },
+        }),
+      ]),
+    );
     expect(auditService.createLogRequired).toHaveBeenCalledTimes(2);
     expect(auditService.createLogRequired).toHaveBeenNthCalledWith(
       1,
@@ -476,6 +526,180 @@ describe('OnboardingImportConfirmationService', () => {
     expect(auditService.createLog).toHaveBeenCalledWith(
       expect.objectContaining({ action: AuditAction.IMPORT_RECONFIRM_ATTEMPT }),
     );
+  });
+
+  it('translates a post-preview P2002 into a sanitized conflict and preserves rollback', async () => {
+    const currentJob = createCurrentJob();
+    const { serialized } = createPayload(currentJob.id, currentJob.tenantId, currentJob.fileHash);
+    const previewHash = createHash('sha256').update(serialized, 'utf8').digest('hex');
+    currentJob.previewHash = previewHash;
+
+    const confirmingJob = {
+      ...currentJob,
+      status: ImportJobStatus.CONFIRMING,
+      confirmingLockExpiresAt: new Date('2030-01-01T00:05:00.000Z'),
+    };
+
+    (prisma.importJob.findFirst as jest.Mock)
+      .mockResolvedValueOnce(currentJob)
+      .mockResolvedValueOnce(confirmingJob);
+    (prisma.importJob.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+    (minio.getObjectBuffer as jest.Mock).mockResolvedValue(Buffer.from(serialized, 'utf8'));
+
+    const tx = createTransactionMocks();
+    const uniqueError = new Error('Unique constraint failed on the fields: (`tenantId`,`phone`)');
+    Object.assign(uniqueError, { code: 'P2002', meta: { target: ['tenantId', 'phone'] } });
+    Object.setPrototypeOf(uniqueError, Prisma.PrismaClientKnownRequestError.prototype);
+    (tx.tenantMember.create as jest.Mock).mockRejectedValueOnce(uniqueError);
+    (tx.importJob.findFirst as jest.Mock).mockResolvedValue(confirmingJob);
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx));
+
+    await expect(service.confirmImport({
+      tenantId: currentJob.tenantId,
+      tenantCurrency: 'ARS',
+      userId: 'user-admin',
+      membershipId: 'membership-1',
+      roles: [Role.TENANT_ADMIN],
+      isSuperAdmin: false,
+      importId: currentJob.id,
+      expectedPreviewVersion: 1,
+    })).rejects.toThrow(ConflictException);
+
+    expect(tx.importJob.update).not.toHaveBeenCalled();
+    expect(prisma.importJob.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ id: currentJob.id, tenantId: currentJob.tenantId }),
+        data: expect.objectContaining({
+          status: ImportJobStatus.FAILED,
+          confirmingAt: null,
+          confirmingLockExpiresAt: null,
+          confirmingByMembershipId: null,
+          canConfirm: false,
+        }),
+      }),
+    );
+    expect(auditService.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({ action: AuditAction.IMPORT_CONFIRM_STARTED }),
+      tx,
+    );
+    expect(auditService.createLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: AuditAction.IMPORT_CONFIRM_FAILED }),
+    );
+  });
+
+  it('sanitizes unknown P2002 targets without exposing constraint details', async () => {
+    const currentJob = createCurrentJob();
+    const { serialized } = createPayload(currentJob.id, currentJob.tenantId, currentJob.fileHash);
+    const previewHash = createHash('sha256').update(serialized, 'utf8').digest('hex');
+    currentJob.previewHash = previewHash;
+
+    const confirmingJob = {
+      ...currentJob,
+      status: ImportJobStatus.CONFIRMING,
+      confirmingLockExpiresAt: new Date('2030-01-01T00:05:00.000Z'),
+    };
+
+    (prisma.importJob.findFirst as jest.Mock)
+      .mockResolvedValueOnce(currentJob)
+      .mockResolvedValueOnce(confirmingJob);
+    (prisma.importJob.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+    (minio.getObjectBuffer as jest.Mock).mockResolvedValue(Buffer.from(serialized, 'utf8'));
+
+    const tx = createTransactionMocks();
+    (tx.importJob.findFirst as jest.Mock).mockResolvedValue(confirmingJob);
+    (tx.tenantMember.create as jest.Mock).mockRejectedValueOnce(createPrismaKnownError('P2002', ['tenantId', 'email', 'status']));
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx));
+
+    await expect(service.confirmImport({
+      tenantId: currentJob.tenantId,
+      tenantCurrency: 'ARS',
+      userId: 'user-admin',
+      membershipId: 'membership-1',
+      roles: [Role.TENANT_ADMIN],
+      isSuperAdmin: false,
+      importId: currentJob.id,
+      expectedPreviewVersion: 1,
+    })).rejects.toThrow('Error de base de datos durante la confirmación');
+
+    expect(tx.importJob.update).not.toHaveBeenCalled();
+    expect(auditService.createLog).toHaveBeenCalledWith(
+      expect.objectContaining({ action: AuditAction.IMPORT_CONFIRM_FAILED }),
+    );
+  });
+
+  it('sanitizes Prisma errors that are not P2002', async () => {
+    const currentJob = createCurrentJob();
+    const { serialized } = createPayload(currentJob.id, currentJob.tenantId, currentJob.fileHash);
+    const previewHash = createHash('sha256').update(serialized, 'utf8').digest('hex');
+    currentJob.previewHash = previewHash;
+
+    const confirmingJob = {
+      ...currentJob,
+      status: ImportJobStatus.CONFIRMING,
+      confirmingLockExpiresAt: new Date('2030-01-01T00:05:00.000Z'),
+    };
+
+    (prisma.importJob.findFirst as jest.Mock)
+      .mockResolvedValueOnce(currentJob)
+      .mockResolvedValueOnce(confirmingJob);
+    (prisma.importJob.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+    (minio.getObjectBuffer as jest.Mock).mockResolvedValue(Buffer.from(serialized, 'utf8'));
+
+    const tx = createTransactionMocks();
+    const prismaError = new Error('Prisma failed');
+    Object.assign(prismaError, { code: 'P2025' });
+    Object.setPrototypeOf(prismaError, Prisma.PrismaClientKnownRequestError.prototype);
+    (tx.tenantMember.create as jest.Mock).mockRejectedValueOnce(prismaError);
+    (tx.importJob.findFirst as jest.Mock).mockResolvedValue(confirmingJob);
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx));
+
+    await expect(service.confirmImport({
+      tenantId: currentJob.tenantId,
+      tenantCurrency: 'ARS',
+      userId: 'user-admin',
+      membershipId: 'membership-1',
+      roles: [Role.TENANT_ADMIN],
+      isSuperAdmin: false,
+      importId: currentJob.id,
+      expectedPreviewVersion: 1,
+    })).rejects.toThrow('Error de base de datos durante la confirmación');
+
+    expect(tx.importJob.update).not.toHaveBeenCalled();
+  });
+
+  it('propagates non-Prisma errors without converting them into conflicts', async () => {
+    const currentJob = createCurrentJob();
+    const { serialized } = createPayload(currentJob.id, currentJob.tenantId, currentJob.fileHash);
+    const previewHash = createHash('sha256').update(serialized, 'utf8').digest('hex');
+    currentJob.previewHash = previewHash;
+
+    const confirmingJob = {
+      ...currentJob,
+      status: ImportJobStatus.CONFIRMING,
+      confirmingLockExpiresAt: new Date('2030-01-01T00:05:00.000Z'),
+    };
+
+    (prisma.importJob.findFirst as jest.Mock)
+      .mockResolvedValueOnce(currentJob)
+      .mockResolvedValueOnce(confirmingJob);
+    (prisma.importJob.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+    (minio.getObjectBuffer as jest.Mock).mockResolvedValue(Buffer.from(serialized, 'utf8'));
+
+    const tx = createTransactionMocks();
+    (tx.importJob.findFirst as jest.Mock).mockResolvedValue(confirmingJob);
+    (tx.tenantMember.create as jest.Mock).mockRejectedValueOnce(new Error('unexpected failure'));
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback: (client: typeof tx) => Promise<unknown>) => callback(tx));
+
+    await expect(service.confirmImport({
+      tenantId: currentJob.tenantId,
+      tenantCurrency: 'ARS',
+      userId: 'user-admin',
+      membershipId: 'membership-1',
+      roles: [Role.TENANT_ADMIN],
+      isSuperAdmin: false,
+      importId: currentJob.id,
+      expectedPreviewVersion: 1,
+    })).rejects.toThrow('unexpected failure');
   });
 
   it('rejects a stale preview version before any write', async () => {

--- a/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.ts
+++ b/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.ts
@@ -624,22 +624,32 @@ export class OnboardingImportConfirmationService {
       return normalized.telefono ? this.normalizeText(normalized.telefono) : null;
     }).filter((value): value is string => Boolean(value))));
 
-    const [existingRefs, existingMembers, existingUsers] = await Promise.all([
-      tx.externalEntityReference.findMany({
-        where: {
-          tenantId: input.tenantId,
-          source: 'onboarding-import',
-          entityType: { in: ['PERSON', 'PERSON_DOCUMENT'] },
-          externalCode: { in: [...personCodes, ...personDocuments] },
-        },
-        select: { entityType: true, externalCode: true, entityId: true },
-      }),
+    const existingRefs = await tx.externalEntityReference.findMany({
+      where: {
+        tenantId: input.tenantId,
+        source: 'onboarding-import',
+        entityType: { in: ['PERSON', 'PERSON_DOCUMENT'] },
+        externalCode: { in: [...personCodes, ...personDocuments] },
+      },
+      select: { entityType: true, externalCode: true, entityId: true },
+    });
+    const documentRefMemberIds = Array.from(
+      new Set(
+        existingRefs
+          .filter((ref) => ref.entityType === 'PERSON_DOCUMENT')
+          .map((ref) => ref.entityId)
+          .filter((entityId): entityId is string => Boolean(entityId)),
+      ),
+    );
+
+    const [existingMembers, existingUsers] = await Promise.all([
       tx.tenantMember.findMany({
         where: {
           tenantId: input.tenantId,
           OR: [
             emails.length > 0 ? { email: { in: emails } } : undefined,
             phones.length > 0 ? { phone: { in: phones } } : undefined,
+            documentRefMemberIds.length > 0 ? { id: { in: documentRefMemberIds } } : undefined,
           ].filter((value): value is NonNullable<typeof value> => Boolean(value)),
         },
         select: { id: true, tenantId: true, userId: true, name: true, email: true, phone: true, role: true, status: true },
@@ -677,6 +687,10 @@ export class OnboardingImportConfirmationService {
       if (candidate) {
         if (candidate.role !== Role.RESIDENT) {
           throw new ConflictException(`Person ${code} is linked to a non-resident member`);
+        }
+
+        if (document && existingDocumentRef && existingDocumentRef.entityId !== candidate.id) {
+          throw new ConflictException(`La persona entra en conflicto con una identidad existente por document en el tenant`);
         }
 
         const sameName = this.normalizeText(candidate.name) === this.normalizeText(normalized.nombre);

--- a/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.ts
+++ b/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.ts
@@ -359,6 +359,10 @@ export class OnboardingImportConfirmationService {
           continue;
         }
 
+        if (this.isKnownImportP2002(error)) {
+          throw new ConflictException('Se detectó un conflicto de identidad durante la confirmación');
+        }
+
         throw error;
       }
     }
@@ -607,6 +611,10 @@ export class OnboardingImportConfirmationService {
   ): Promise<Map<string, string>> {
     const memberMap = new Map<string, string>();
     const personCodes = rows.map((row) => this.normalizeCode(this.requireNormalizedRow(row, 'People').personaCodigo));
+    const personDocuments = Array.from(new Set(rows.map((row) => {
+      const normalized = this.requireNormalizedRow(row, 'People');
+      return normalized.documento ? this.normalizeDocument(normalized.documento) : null;
+    }).filter((value): value is string => Boolean(value))));
     const emails = Array.from(new Set(rows.map((row) => {
       const normalized = this.requireNormalizedRow(row, 'People');
       return normalized.email ? this.normalizeEmail(normalized.email) : null;
@@ -621,8 +629,8 @@ export class OnboardingImportConfirmationService {
         where: {
           tenantId: input.tenantId,
           source: 'onboarding-import',
-          entityType: 'PERSON',
-          externalCode: { in: personCodes },
+          entityType: { in: ['PERSON', 'PERSON_DOCUMENT'] },
+          externalCode: { in: [...personCodes, ...personDocuments] },
         },
         select: { entityType: true, externalCode: true, entityId: true },
       }),
@@ -639,24 +647,26 @@ export class OnboardingImportConfirmationService {
       emails.length > 0 ? tx.user.findMany({ where: { email: { in: emails } }, select: { id: true, email: true, name: true } }) : Promise.resolve([]),
     ]);
 
-    const refByCode = new Map(existingRefs.map((ref) => [this.normalizeCode(ref.externalCode), ref] as const));
+    const refByCode = new Map(existingRefs.filter((ref) => ref.entityType === 'PERSON').map((ref) => [this.normalizeCode(ref.externalCode), ref] as const));
+    const refByDocument = new Map(existingRefs.filter((ref) => ref.entityType === 'PERSON_DOCUMENT').map((ref) => [this.normalizeDocument(ref.externalCode), ref] as const));
     const memberByEmail = new Map(existingMembers.filter((member) => member.email).map((member) => [this.normalizeEmail(member.email ?? ''), member] as const));
     const memberByPhone = new Map(existingMembers.filter((member) => member.phone).map((member) => [this.normalizeText(member.phone ?? ''), member] as const));
+    const memberById = new Map(existingMembers.map((member) => [member.id, member] as const));
     const userByEmail = new Map(existingUsers.map((user) => [this.normalizeEmail(user.email), user] as const));
 
     for (const row of rows) {
       const normalized = this.requireNormalizedRow(row, 'People');
       const code = this.normalizeCode(normalized.personaCodigo);
+      const document = normalized.documento ? this.normalizeDocument(normalized.documento) : null;
       const email = normalized.email ? this.normalizeEmail(normalized.email) : null;
       const phone = normalized.telefono ? this.normalizeText(normalized.telefono) : null;
       const existingRef = refByCode.get(code);
-      const existingMember = existingRef
-        ? existingMembers.find((member) => member.id === existingRef.entityId)
-        : email
-          ? memberByEmail.get(email)
-          : phone
-            ? memberByPhone.get(phone)
-            : undefined;
+      const existingDocumentRef = document ? refByDocument.get(document) : undefined;
+      const existingMemberFromRef = existingRef ? memberById.get(existingRef.entityId) : undefined;
+      const existingMemberFromEmail = email ? memberByEmail.get(email) : undefined;
+      const existingMemberFromPhone = phone ? memberByPhone.get(phone) : undefined;
+      const existingMemberFromDocument = document && existingDocumentRef ? memberById.get(existingDocumentRef.entityId) : undefined;
+      const existingMember = existingMemberFromRef ?? existingMemberFromEmail ?? existingMemberFromPhone ?? existingMemberFromDocument;
       const existingUser = email ? userByEmail.get(email) : undefined;
 
       if (existingRef && !existingMember) {
@@ -667,6 +677,20 @@ export class OnboardingImportConfirmationService {
       if (candidate) {
         if (candidate.role !== Role.RESIDENT) {
           throw new ConflictException(`Person ${code} is linked to a non-resident member`);
+        }
+
+        const sameName = this.normalizeText(candidate.name) === this.normalizeText(normalized.nombre);
+        const sameIdentity = Boolean(
+          (email && (
+            (existingMemberFromEmail && this.normalizeEmail(existingMemberFromEmail.email ?? '') === email) ||
+            (existingUser && this.normalizeEmail(existingUser.email) === email)
+          )) ||
+          (phone && existingMemberFromPhone && this.normalizeText(existingMemberFromPhone.phone ?? '') === phone) ||
+          (document && existingDocumentRef && existingDocumentRef.entityId === candidate.id)
+        );
+
+        if (!sameName || !sameIdentity) {
+          throw new ConflictException(`La persona entra en conflicto con una identidad existente por ${email ? 'email' : phone ? 'phone' : 'document'} en el tenant`);
         }
 
         const conflictingMember = this.findConflictingMember(existingMembers, candidate.id, email, phone);
@@ -689,7 +713,24 @@ export class OnboardingImportConfirmationService {
         memberMap.set(code, updated.id);
         summary.people.reused += 1;
         await this.upsertExternalReference(tx, input.tenantId, 'PERSON', code, updated.id);
+        if (document) {
+          await this.upsertExternalReference(tx, input.tenantId, 'PERSON_DOCUMENT', document, updated.id);
+        }
         continue;
+      }
+
+      if (existingUser) {
+        if (this.normalizeText(existingUser.name ?? '') !== this.normalizeText(normalized.nombre)) {
+          throw new ConflictException(`La persona entra en conflicto con una identidad existente por email en el tenant`);
+        }
+
+        if (email && this.normalizeEmail(existingUser.email) !== email) {
+          throw new ConflictException(`La persona entra en conflicto con una identidad existente por email en el tenant`);
+        }
+      }
+
+      if (existingMemberFromEmail || existingMemberFromPhone || existingDocumentRef) {
+        throw new ConflictException(`La persona entra en conflicto con una identidad existente por ${existingMemberFromEmail ? 'email' : existingMemberFromPhone ? 'phone' : 'document'} en el tenant`);
       }
 
       const created = await tx.tenantMember.create({
@@ -707,6 +748,9 @@ export class OnboardingImportConfirmationService {
       memberMap.set(code, created.id);
       summary.people.created += 1;
       await this.upsertExternalReference(tx, input.tenantId, 'PERSON', code, created.id);
+      if (document) {
+        await this.upsertExternalReference(tx, input.tenantId, 'PERSON_DOCUMENT', document, created.id);
+      }
     }
 
     return memberMap;
@@ -1455,7 +1499,52 @@ export class OnboardingImportConfirmationService {
     return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2034';
   }
 
+  private isKnownImportP2002(error: unknown): boolean {
+    if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== 'P2002') {
+      return false;
+    }
+
+    return this.isKnownImportUniqueTarget(this.getUniqueTarget(error));
+  }
+
+  private isKnownImportUniqueTarget(target: string[]): boolean {
+    return (
+      this.matchesUniqueTarget(target, ['tenantId', 'email']) ||
+      this.matchesUniqueTarget(target, ['tenantId', 'phone']) ||
+      this.matchesUniqueTarget(target, ['tenantId', 'source', 'entityType', 'externalCode']) ||
+      this.matchesUniqueTarget(target, ['tenantId', 'unitId', 'memberId']) ||
+      this.matchesUniqueTarget(target, ['tenantId', 'importJobId', 'unitId', 'period', 'concept'])
+    );
+  }
+
+  private matchesUniqueTarget(target: string[], expectedFields: string[]): boolean {
+    if (target.length !== expectedFields.length) {
+      return false;
+    }
+
+    const normalizedTarget = [...target].sort().join('|');
+    const normalizedExpected = [...expectedFields].sort().join('|');
+    return normalizedTarget === normalizedExpected;
+  }
+
+  private getUniqueTarget(error: Prisma.PrismaClientKnownRequestError): string[] {
+    const meta = error.meta as { target?: unknown } | undefined;
+    if (!Array.isArray(meta?.target)) {
+      return [];
+    }
+
+    return meta.target.filter((value): value is string => typeof value === 'string');
+  }
+
   private sanitizeErrorMessage(error: unknown): string {
+    if (this.isKnownImportP2002(error)) {
+      return 'Se detectó un conflicto de identidad durante la confirmación';
+    }
+
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      return 'Error de base de datos durante la confirmación';
+    }
+
     if (error instanceof Error) {
       return error.message.slice(0, 200);
     }
@@ -1471,7 +1560,19 @@ export class OnboardingImportConfirmationService {
     return 'IMPORT_ERROR';
   }
 
+  private normalizeDocument(value: string): string {
+    return this.normalizeText(value).toUpperCase();
+  }
+
   private rethrow(error: unknown): never {
+    if (this.isKnownImportP2002(error)) {
+      throw new ConflictException('Se detectó un conflicto de identidad durante la confirmación');
+    }
+
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      throw new Error('Error de base de datos durante la confirmación');
+    }
+
     if (error instanceof Error) {
       throw error;
     }


### PR DESCRIPTION
## Summary

- Hardens onboarding import identity conflict detection for people, documents, memberships, and occupants.
- Sanitizes conflict and persistence errors so validation stays deterministic and safe.
- Preserves the existing preview and confirmation workflow while tightening reuse rules.

Closes #16

## Changes

| File | Change |
|------|--------|
| `apps/api/src/onboarding-imports/onboarding-imports.service.ts` | Tightens preview conflict detection and sanitizes reuse/error handling |
| `apps/api/src/onboarding-imports/onboarding-imports.service.spec.ts` | Adds regression coverage for identity conflict detection |
| `apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.ts` | Hardens confirmation conflict handling and Prisma error mapping |
| `apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.spec.ts` | Adds regression coverage for confirmation and error handling |

## Validation

- Prisma validate: PASS
- Prisma generate: PASS
- TypeScript API: PASS
- API tests: PASS
- Build API: PASS
- Build web: PASS
- git diff --check: PASS
- Local smoke checks: PASS

## Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran the relevant checks
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers