### PR TITLE
fix(e2e): restore and stabilize authentication workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -248,7 +248,7 @@ jobs:
               email: process.env.LOGIN_EMAIL,
               password: process.env.TEST_E2E_PASSWORD,
             }));
-NODE
+          NODE
           )"
 
           login_status="$(
@@ -308,7 +308,7 @@ NODE
             console.error(`AUTH_SESSION_INVALID_PAYLOAD ${message.replace(/\s+/g, ' ').trim()}`);
             process.exit(1);
           }
-NODE
+          NODE
 
           echo "AUTH_PREFLIGHT_OK login=$login_status session=$session_status"
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -41,7 +41,7 @@ jobs:
       WEB_ORIGIN: http://localhost:3000
       APP_BASE_URL: http://localhost:3000
       NEXT_PUBLIC_API_URL: http://localhost:4000
-      TEST_E2E_PASSWORD: ${{ secrets.TEST_E2E_PASSWORD }}
+      TEST_E2E_PASSWORD: TestPass123!
       S3_ENDPOINT: http://localhost:9000
       S3_BUCKET: buildingos-test
       S3_PUBLIC_BASE_URL: http://localhost:9000/buildingos-test

--- a/apps/web/features/auth/session.storage.test.ts
+++ b/apps/web/features/auth/session.storage.test.ts
@@ -1,0 +1,43 @@
+import { emitBoStorageChange } from '@/shared/lib/storage/events';
+import { clearLastTenant, getLastTenant, setLastTenant } from './session.storage';
+
+jest.mock('@/shared/lib/storage/events', () => ({
+  emitBoStorageChange: jest.fn(),
+}));
+
+const mockedEmitBoStorageChange = jest.mocked(emitBoStorageChange);
+
+describe('session.storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockedEmitBoStorageChange.mockReset();
+  });
+
+  it('does not emit a storage change when setting the same last tenant twice', () => {
+    setLastTenant('tenant-a');
+
+    expect(getLastTenant()).toBe('tenant-a');
+    expect(mockedEmitBoStorageChange).toHaveBeenCalledTimes(1);
+
+    setLastTenant('tenant-a');
+
+    expect(getLastTenant()).toBe('tenant-a');
+    expect(mockedEmitBoStorageChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits a storage change when the last tenant changes', () => {
+    setLastTenant('tenant-a');
+    setLastTenant('tenant-b');
+
+    expect(getLastTenant()).toBe('tenant-b');
+    expect(mockedEmitBoStorageChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the last tenant key and emits a storage change', () => {
+    setLastTenant('tenant-a');
+    clearLastTenant();
+
+    expect(getLastTenant()).toBeNull();
+    expect(mockedEmitBoStorageChange).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/features/auth/session.storage.ts
+++ b/apps/web/features/auth/session.storage.ts
@@ -55,6 +55,11 @@ export function clearSession(): void {
  * @param tenantId - The tenant ID to remember as the last active one
  */
 export function setLastTenant(tenantId: string): void {
+  const currentTenantId = localStorage.getItem(KEY_LAST_TENANT);
+  if (currentTenantId === tenantId) {
+    return;
+  }
+
   localStorage.setItem(KEY_LAST_TENANT, tenantId);
   emitBoStorageChange();
 }

--- a/apps/web/tests/auth-helper.test.ts
+++ b/apps/web/tests/auth-helper.test.ts
@@ -1,0 +1,122 @@
+import type { Page } from '@playwright/test';
+
+process.env.TEST_E2E_PASSWORD = 'TestPass123!';
+
+jest.mock('@playwright/test', () => ({
+  expect: jest.fn(),
+}));
+
+const { login, TEST_USERS } = require('../tests/e2e/helpers/auth') as typeof import('../tests/e2e/helpers/auth');
+
+interface MockResponse {
+  ok: boolean;
+  status: number;
+  text: string;
+}
+
+function createResponse(response: MockResponse): Response {
+  return {
+    ok: () => response.ok,
+    status: () => response.status,
+    statusText: response.status === 401 ? 'Unauthorized' : 'OK',
+    text: async () => response.text,
+  } as unknown as Response;
+}
+
+function createMockPage(options?: {
+  readonly loginResponse?: MockResponse;
+  readonly sessionResponse?: MockResponse;
+  readonly sessionRejects?: Error;
+  readonly finalUrl?: string;
+}): Page & {
+  request: {
+    get: jest.Mock;
+  };
+  evaluate: jest.Mock;
+} {
+  const loginResponse = createResponse(
+    options?.loginResponse ?? {
+      ok: true,
+      status: 201,
+      text: JSON.stringify({ ok: true }),
+    },
+  );
+
+  const sessionResponse = createResponse(
+    options?.sessionResponse ?? {
+      ok: true,
+      status: 200,
+      text: JSON.stringify({ user: { id: 'user-1' } }),
+    },
+  );
+
+  const page = {
+    goto: jest.fn().mockResolvedValue(undefined),
+    fill: jest.fn().mockResolvedValue(undefined),
+    getByRole: jest.fn().mockReturnValue({ click: jest.fn().mockResolvedValue(undefined) }),
+    waitForResponse: jest.fn().mockResolvedValue(loginResponse),
+    waitForURL: jest.fn().mockResolvedValue(undefined),
+    context: jest.fn().mockReturnValue({
+      cookies: jest.fn().mockResolvedValue([
+        { name: 'bo_access_token' },
+        { name: 'bo_refresh_token' },
+      ]),
+    }),
+    request: {
+      get: jest.fn(),
+    },
+    evaluate: jest.fn(),
+    url: jest.fn().mockReturnValue(
+      options?.finalUrl ?? 'http://localhost:3000/cmrnigdhz0008qb1f1hyjn717/dashboard',
+    ),
+  } as unknown as Page & {
+    request: {
+      get: jest.Mock;
+    };
+    evaluate: jest.Mock;
+  };
+
+  if (options?.sessionRejects) {
+    page.request.get.mockRejectedValue(options.sessionRejects);
+  } else {
+    page.request.get.mockResolvedValue(sessionResponse);
+  }
+
+  return page;
+}
+
+describe('auth E2E helper', () => {
+  it('logs in successfully and probes session through the request context', async () => {
+    const page = createMockPage();
+
+    const tenantId = await login(page, TEST_USERS.tenantAdminA);
+
+    expect(tenantId).toBe('cmrnigdhz0008qb1f1hyjn717');
+    expect(page.request.get).toHaveBeenCalledTimes(1);
+    expect(page.evaluate).not.toHaveBeenCalled();
+  });
+
+  it('fails fast when the login response is unauthorized', async () => {
+    const page = createMockPage({
+      loginResponse: {
+        ok: false,
+        status: 401,
+        text: JSON.stringify({ message: 'Invalid credentials' }),
+      },
+    });
+
+    await expect(login(page, TEST_USERS.tenantAdminA)).rejects.toThrow(
+      /AUTH_LOGIN_FAILED status=401 endpoint=\/auth\/login message=\{"message":"Invalid credentials"\}/,
+    );
+  });
+
+  it('reports a controlled error when the session probe endpoint is unavailable', async () => {
+    const page = createMockPage({
+      sessionRejects: new Error('connect ECONNREFUSED 127.0.0.1:4000'),
+    });
+
+    await expect(login(page, TEST_USERS.tenantAdminA)).rejects.toThrow(
+      /AUTH_SESSION_FAILED status=0 endpoint=\/auth\/me/,
+    );
+  });
+});

--- a/apps/web/tests/e2e/helpers/auth.ts
+++ b/apps/web/tests/e2e/helpers/auth.ts
@@ -81,28 +81,22 @@ export async function login(page: Page, user: TestUser): Promise<string> {
     );
   }
 
-  const sessionProbe = await page.evaluate(async (targetUrl) => {
-    try {
-      const response = await fetch(targetUrl, {
-        credentials: 'include',
-        headers: {
-          Accept: 'application/json',
-        },
-      });
-
-      return {
-        ok: response.ok,
-        status: response.status,
-        text: await response.text(),
-      };
-    } catch (error) {
-      return {
-        ok: false,
-        status: 0,
-        text: error instanceof Error ? error.message : String(error),
-      };
-    }
-  }, sessionUrl);
+  const sessionProbe = await page.request
+    .get(sessionUrl, {
+      headers: {
+        Accept: 'application/json',
+      },
+    })
+    .then(async (response) => ({
+      ok: response.ok(),
+      status: response.status(),
+      text: await response.text(),
+    }))
+    .catch((error: unknown) => ({
+      ok: false,
+      status: 0,
+      text: error instanceof Error ? error.message : String(error),
+    }));
 
   if (!sessionProbe.ok) {
     throw new Error(


### PR DESCRIPTION
## Summary

This PR now covers three related fixes in the E2E auth workflow:

1. The heredoc markers in `.github/workflows/e2e-tests.yml` are indented correctly.
2. The workflow uses the deterministic `TestPass123!` password required by the CI seed.
3. The shared E2E authentication helper no longer hangs in `page.evaluate`; it probes session state through Playwright's request context, and the tenant storage helper no longer re-emits storage changes when the tenant ID is unchanged.

## Root cause

The recurring E2E timeout was preexisting. The first real failure in run `29468575526` was a `page.evaluate` timeout, and local reproduction showed the same auth flow could recurse through tenant validation when the same tenant ID was written back to storage repeatedly.

## Validation

- Confirmed the workflow YAML fix and the deterministic password on the branch.
- Reproduced the auth-helper flake locally as a browser/runtime issue in this environment, then validated the fix with focused and full web unit tests.
- Verified the auth helper now uses Playwright's request context for the session probe.
- Verified the storage helper is idempotent for the same tenant ID.

## Impact

This change also updates `apps/web/features/auth/session.storage.ts`, which is application code used by the frontend. The behavior change is intentionally narrow: it only suppresses redundant same-value tenant writes and duplicate storage events. It does not change authentication, permissions, tenant selection, or persisted data. `TestPass123!` is used only as the deterministic credential in the ephemeral CI E2E seed, not in staging or production.
