### PR TITLE
fix(super-admin): read tenant detail route params

### DIFF
--- a/apps/web/app/super-admin/tenants/[tenantId]/page.test.tsx
+++ b/apps/web/app/super-admin/tenants/[tenantId]/page.test.tsx
@@ -1,23 +1,39 @@
 import { render, screen } from '@testing-library/react';
+import { useParams } from 'next/navigation';
 import TenantDetailPage from './page';
 import { getTenant } from '@/features/super-admin/tenants.api';
 
+jest.mock('next/navigation', () => ({ useParams: jest.fn() }));
 jest.mock('@/features/super-admin/tenants.api', () => ({ getTenant: jest.fn() }));
 jest.mock('@/features/billing/components/SubscriptionPanel', () => () => <div>Suscripción</div>);
 jest.mock('@/features/demo-seed/DemoSeedWizard', () => ({ DemoSeedWizard: () => <div>Demo</div> }));
 const mockedGetTenant = jest.mocked(getTenant);
+const mockedUseParams = jest.mocked(useParams);
 
 describe('TenantDetailPage', () => {
+  beforeEach(() => {
+    mockedUseParams.mockReturnValue({ tenantId: 'tenant-001' });
+  });
+
   it('loads only the requested tenant from the API', async () => {
     mockedGetTenant.mockResolvedValue({ id: 'tenant-001', name: 'Administración API', type: 'ADMINISTRADORA', isDemo: false, createdAt: '2026-01-01T00:00:00.000Z', updatedAt: '2026-01-01T00:00:00.000Z', subscription: { planId: 'PRO', status: 'ACTIVE' } });
-    render(<TenantDetailPage params={{ tenantId: 'tenant-001' }} />);
+    render(<TenantDetailPage />);
     expect(await screen.findByRole('heading', { name: 'Administración API' })).toBeTruthy();
     expect(mockedGetTenant).toHaveBeenCalledWith('tenant-001');
   });
 
   it('shows the existing not-found state when the API rejects', async () => {
+    mockedUseParams.mockReturnValue({ tenantId: 'tenant-404' });
     mockedGetTenant.mockRejectedValue(new Error('Not found'));
-    render(<TenantDetailPage params={{ tenantId: 'missing' }} />);
+    render(<TenantDetailPage />);
     expect(await screen.findByText('Administradora no encontrada')).toBeTruthy();
+  });
+
+  it('does not request the API when the route has no tenant ID', async () => {
+    mockedUseParams.mockReturnValue({});
+    render(<TenantDetailPage />);
+    expect(await screen.findByText('Administradora no encontrada')).toBeTruthy();
+    expect(screen.getByText(/\(sin ID\)/)).toBeTruthy();
+    expect(mockedGetTenant).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/super-admin/tenants/[tenantId]/page.tsx
+++ b/apps/web/app/super-admin/tenants/[tenantId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { useParams } from 'next/navigation';
 import Button from '@/shared/components/ui/Button';
 import Card from '@/shared/components/ui/Card';
 import SubscriptionPanel from '@/features/billing/components/SubscriptionPanel';
@@ -9,15 +10,8 @@ import { DemoSeedWizard } from '@/features/demo-seed/DemoSeedWizard';
 import { getTenant, type TenantFromAPI } from '@/features/super-admin/tenants.api';
 import { ChevronLeft } from 'lucide-react';
 
-interface TenantDetailPageProps {
-  params: {
-    tenantId: string;
-  };
-}
-
-export default function TenantDetailPage({
-  params,
-}: TenantDetailPageProps) {
+export default function TenantDetailPage() {
+  const params = useParams<{ tenantId: string }>();
   const [tenant, setTenant] = useState<TenantFromAPI | null>(null);
   const [loading, setLoading] = useState(true);
   const tenantId = params?.tenantId?.trim();


### PR DESCRIPTION
## Resumen

Corrige el detalle dinámico de administradoras en SuperAdmin para leer `tenantId` mediante `useParams()` en el Client Component.

## Problema

La URL contenía un tenantId válido, pero la pantalla mostraba:

- Administradora no encontrada.
- `(sin ID)`.

La petición a la API no llegaba a ejecutarse porque el componente esperaba `params` como propiedad síncrona.

## Corrección

- Se usa `useParams<{ tenantId: string }>()`.
- Se elimina el contrato incorrecto de `params` como prop.
- Se actualiza la prueba para reproducir el runtime real de Next.js.

## Validaciones

- Test focalizado: 1 suite / 3 tests — PASS.
- Web SuperAdmin: 7 suites / 71 tests — PASS.
- TypeScript Web — PASS.
- `git diff --check` — PASS.
- Smoke manual local — PASS.

## Alcance

- Sin cambios en API.
- Sin cambios en Prisma.
- Sin migraciones.
- Sin modificaciones de datos.
- Sin cambios en staging o producción.
