### PR TITLE
chore(api): add safe local billing plans catalog

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -19,6 +19,7 @@
     "migrate:deploy": "prisma migrate deploy",
     "migrate:status": "prisma migrate status",
     "seed": "ts-node prisma/seed.ts",
+    "seed:billing-plans:local": "ts-node --compiler-options '{\"types\":[\"node\"]}' prisma/seed-billing-plans-local.ts",
     "reset:local-password": "ts-node scripts/reset-local-user-password.ts",
     "seed:local:manual": "ts-node prisma/seed-local-manual.ts",
     "seed:test": "ts-node prisma/seed.test.ts",

--- a/apps/api/prisma/seed-billing-plans-local.ts
+++ b/apps/api/prisma/seed-billing-plans-local.ts
@@ -1,0 +1,55 @@
+import { BillingPlanId, Prisma, PrismaClient } from '@prisma/client';
+
+type PlanInput = Omit<Prisma.BillingPlanCreateInput, 'planId'> & { planId: BillingPlanId };
+
+export const LOCAL_PLANS: readonly PlanInput[] = [
+  { planId: BillingPlanId.FREE, name: 'Free', description: 'Free tier for testing', monthlyPrice: 0, maxBuildings: 1, maxUnits: 10, maxUsers: 3, maxOccupants: 20, canExportReports: false, canBulkOperations: false, canUseAI: false, aiBudgetCents: 0, aiCallsMonthlyLimit: 0, aiAllowBigModel: false, aiConsultationsLimit: 0, supportLevel: 'COMMUNITY' },
+  { planId: BillingPlanId.BASIC, name: 'Basic', description: 'Small buildings', monthlyPrice: 9900, maxBuildings: 3, maxUnits: 100, maxUsers: 10, maxOccupants: 200, canExportReports: true, canBulkOperations: false, canUseAI: true, aiBudgetCents: 200, aiCallsMonthlyLimit: 100, aiAllowBigModel: false, aiConsultationsLimit: 10, supportLevel: 'EMAIL' },
+  { planId: BillingPlanId.PRO, name: 'Pro', description: 'Growing businesses', monthlyPrice: 29900, maxBuildings: 10, maxUnits: 500, maxUsers: 50, maxOccupants: 1000, canExportReports: true, canBulkOperations: true, canUseAI: true, aiBudgetCents: 800, aiCallsMonthlyLimit: 600, aiAllowBigModel: true, aiConsultationsLimit: 50, supportLevel: 'PRIORITY' },
+  { planId: BillingPlanId.ENTERPRISE, name: 'Enterprise', description: 'Large scale deployments', monthlyPrice: 0, maxBuildings: 999, maxUnits: 9999, maxUsers: 999, maxOccupants: 99999, canExportReports: true, canBulkOperations: true, canUseAI: true, aiBudgetCents: 10000, aiCallsMonthlyLimit: 9999, aiAllowBigModel: true, aiConsultationsLimit: 999999, supportLevel: 'PRIORITY' },
+];
+
+export function validateLocalBillingEnvironment(env: NodeJS.ProcessEnv): void {
+  if (!['', 'development', 'test'].includes(env.NODE_ENV ?? '')) throw new Error('NODE_ENV must be local');
+  if (!env.DATABASE_URL?.startsWith('postgresql://')) throw new Error('DATABASE_URL must use PostgreSQL');
+  const url = new URL(env.DATABASE_URL);
+  if (!['localhost', '127.0.0.1', '::1', '[::1]'].includes(url.hostname)) throw new Error('DATABASE_URL host must be local');
+  const database = url.pathname.replace(/^\//, '');
+  if (database !== 'buildingos' || /staging|production|prod/i.test(database)) throw new Error('DATABASE_URL database must be buildingos');
+}
+
+export interface BillingPlanClient {
+  billingPlan: { findMany(): Promise<Array<{ planId: BillingPlanId; maxUsers: number }>>; upsert(args: { where: { planId: BillingPlanId }; create: PlanInput; update: Prisma.BillingPlanUpdateInput }): Promise<unknown> };
+  $transaction<T>(fn: (tx: BillingPlanClient) => Promise<T>): Promise<T>;
+}
+
+export async function synchronizeBillingPlans(client: BillingPlanClient, apply: boolean) {
+  const existing = await client.billingPlan.findMany();
+  const byId = new Map(existing.map((plan) => [plan.planId, plan]));
+  const missing = LOCAL_PLANS.filter((plan) => !byId.has(plan.planId)).map((plan) => plan.planId);
+  const preserved = LOCAL_PLANS.filter((plan) => byId.has(plan.planId) && plan.planId === BillingPlanId.FREE && byId.get(plan.planId)!.maxUsers >= 3).map((plan) => plan.planId);
+  if (!apply) return { existing: existing.map((plan) => plan.planId), missing, preserved };
+  await client.$transaction(async (tx) => {
+    for (const plan of LOCAL_PLANS) {
+      const current = byId.get(plan.planId);
+      const update: Prisma.BillingPlanUpdateInput = { ...plan, maxUsers: plan.planId === BillingPlanId.FREE ? Math.max(current?.maxUsers ?? 3, 3) : plan.maxUsers };
+      await tx.billingPlan.upsert({ where: { planId: plan.planId }, create: plan, update });
+    }
+  });
+  return { existing: existing.map((plan) => plan.planId), missing, preserved };
+}
+
+async function main() {
+  validateLocalBillingEnvironment(process.env);
+  const prisma = new PrismaClient();
+  try {
+    const apply = process.argv.includes('--apply');
+    const result = await synchronizeBillingPlans(prisma as unknown as BillingPlanClient, apply);
+    console.log(`PLANES_EXISTENTES=${result.existing.join(',') || 'NINGUNO'}`);
+    console.log(`PLANES_FALTANTES=${result.missing.join(',') || 'NINGUNO'}`);
+    console.log(`PLANES_A_CONSERVAR=${result.preserved.join(',') || 'NINGUNO'}`);
+    console.log(`MODO=${apply ? 'APPLY' : 'DIAGNOSTICO'}`);
+    console.log(`DATOS_MODIFICADOS=${apply ? 'SI' : 'NO'}`);
+  } finally { await prisma.$disconnect(); }
+}
+if (require.main === module) void main().catch((error: unknown) => { console.error(error instanceof Error ? error.message : error); process.exitCode = 1; });

--- a/apps/api/src/prisma/seed-billing-plans-local.spec.ts
+++ b/apps/api/src/prisma/seed-billing-plans-local.spec.ts
@@ -1,0 +1,53 @@
+import { BillingPlanId } from '@prisma/client';
+import { LOCAL_PLANS, synchronizeBillingPlans, validateLocalBillingEnvironment } from '../../prisma/seed-billing-plans-local';
+
+const localUrl = 'postgresql://user:secret@127.0.0.1:5434/buildingos?schema=public';
+
+function inMemoryClient(initial: Array<{ planId: BillingPlanId; maxUsers: number }>) {
+  const records = new Map(initial.map((plan) => [plan.planId, { ...plan }]));
+  const upsert = jest.fn(async ({ where, create, update }) => {
+    const previous = records.get(where.planId);
+    records.set(where.planId, { planId: where.planId, maxUsers: Number(update.maxUsers ?? create.maxUsers) });
+    return previous;
+  });
+  const tx = { billingPlan: { upsert, findMany: jest.fn(async () => [...records.values()]) } };
+  return { records, upsert, client: { billingPlan: { findMany: jest.fn(async () => [...records.values()]), upsert }, $transaction: jest.fn(async (fn) => fn(tx)) } };
+}
+
+describe('local billing plans catalog', () => {
+  it.each(['production', 'staging'])('rejects NODE_ENV=%s', (NODE_ENV) => expect(() => validateLocalBillingEnvironment({ NODE_ENV, DATABASE_URL: localUrl })).toThrow());
+  it.each(['mysql://x', 'postgresql://x:y@remote.example/buildingos', 'postgresql://x:y@localhost/other', 'postgresql://x:y@localhost/buildingos_staging'])('rejects unsafe URLs', (DATABASE_URL) => expect(() => validateLocalBillingEnvironment({ DATABASE_URL })).toThrow());
+  it('accepts local PostgreSQL URLs', () => expect(() => validateLocalBillingEnvironment({ DATABASE_URL: localUrl })).not.toThrow());
+  it('does not write during diagnosis', async () => {
+    const upsert = jest.fn(); const client = { billingPlan: { findMany: jest.fn().mockResolvedValue([]), upsert }, $transaction: jest.fn() };
+    await synchronizeBillingPlans(client as never, false);
+    expect(upsert).not.toHaveBeenCalled(); expect(client.$transaction).not.toHaveBeenCalled();
+  });
+  it('upserts four plans and preserves FREE maxUsers=3', async () => {
+    const upsert = jest.fn().mockResolvedValue({}); const tx = { billingPlan: { upsert, findMany: jest.fn() }, $transaction: jest.fn() };
+    const client = { billingPlan: { findMany: jest.fn().mockResolvedValue([{ planId: BillingPlanId.FREE, maxUsers: 3 }]), upsert }, $transaction: jest.fn(async (fn) => fn(tx)) };
+    await synchronizeBillingPlans(client as never, true);
+    expect(upsert).toHaveBeenCalledTimes(4);
+    expect(upsert).toHaveBeenCalledWith(expect.objectContaining({ where: { planId: BillingPlanId.PRO }, create: expect.objectContaining({ maxBuildings: 10, maxUnits: 500, maxUsers: 50, maxOccupants: 1000 }) }));
+  });
+  it('accepts IPv6 local hosts', () => expect(() => validateLocalBillingEnvironment({ DATABASE_URL: 'postgresql://x:y@[::1]:5434/buildingos' })).not.toThrow());
+  it('contains the official premium catalogs', () => {
+    expect(LOCAL_PLANS.map((plan) => plan.planId)).toEqual([BillingPlanId.FREE, BillingPlanId.BASIC, BillingPlanId.PRO, BillingPlanId.ENTERPRISE]);
+    expect(LOCAL_PLANS.find((plan) => plan.planId === BillingPlanId.BASIC)).toMatchObject({ maxUnits: 100, supportLevel: 'EMAIL' });
+    expect(LOCAL_PLANS.find((plan) => plan.planId === BillingPlanId.PRO)).toMatchObject({ maxBuildings: 10, maxUnits: 500, maxUsers: 50, maxOccupants: 1000 });
+    expect(LOCAL_PLANS.find((plan) => plan.planId === BillingPlanId.ENTERPRISE)).toMatchObject({ maxUnits: 9999, maxOccupants: 99999 });
+  });
+  it('is idempotent and never duplicates plans', async () => {
+    const memory = inMemoryClient([{ planId: BillingPlanId.FREE, maxUsers: 3 }]);
+    await synchronizeBillingPlans(memory.client as never, true);
+    await synchronizeBillingPlans(memory.client as never, true);
+    expect([...memory.records.keys()]).toEqual(expect.arrayContaining([BillingPlanId.FREE, BillingPlanId.BASIC, BillingPlanId.PRO, BillingPlanId.ENTERPRISE]));
+    expect(memory.records.size).toBe(4);
+    expect(memory.records.get(BillingPlanId.FREE)?.maxUsers).toBe(3);
+  });
+  it('propagates transaction failures', async () => {
+    const failure = new Error('simulated transaction failure');
+    const client = { billingPlan: { findMany: jest.fn().mockResolvedValue([]), upsert: jest.fn() }, $transaction: jest.fn().mockRejectedValue(failure) };
+    await expect(synchronizeBillingPlans(client as never, true)).rejects.toThrow(failure);
+  });
+});


### PR DESCRIPTION
## Resumen

Agrega un script seguro e idempotente para completar el catálogo local de planes de facturación.

## Problema

La base local solo contenía el plan FREE. Al intentar cambiar una administradora a PRO, la API respondía:

- `404 Plan not found`

## Solución

- Agrega `seed-billing-plans-local.ts`.
- Incorpora los planes FREE, BASIC, PRO y ENTERPRISE.
- Conserva la configuración local compatible de FREE con `maxUsers=3`.
- Ejecuta en modo diagnóstico sin escrituras por defecto.
- Requiere `--apply` para modificar datos.
- Bloquea producción, staging y bases remotas.
- Opera únicamente sobre `BillingPlan`.
- Es idempotente y no genera duplicados.

## Validaciones

- Tests focalizados: 13/13 PASS.
- TypeScript API: PASS.
- `git diff --check`: PASS.
- Diagnóstico local: PASS.
- Aplicación local del catálogo: PASS.
- Cambio manual de FREE a PRO: PASS.
- Sin cambios en Prisma schema.
- Sin migraciones.
- Sin ejecución del seed general.
- Sin cambios en staging o producción.

## Alcance

Archivos modificados:

- `apps/api/package.json`
- `apps/api/prisma/seed-billing-plans-local.ts`
- `apps/api/src/prisma/seed-billing-plans-local.spec.ts`
