### PR TITLE
fix(auth): persist lead owner invitation password

### DIFF
--- a/apps/api/src/leads/leads.service.spec.ts
+++ b/apps/api/src/leads/leads.service.spec.ts
@@ -1,0 +1,89 @@
+import { Role } from '@prisma/client';
+import * as bcrypt from 'bcrypt';
+import { AuditService } from '../audit/audit.service';
+import { ConfigService } from '../config/config.service';
+import { EmailService } from '../email/email.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { ConvertLeadDto } from './leads.dto';
+import { LeadsService } from './leads.service';
+
+jest.mock('bcrypt');
+
+interface ConversionTransaction {
+  readonly tenant: { create: jest.Mock };
+  readonly subscription: { findUnique: jest.Mock; create: jest.Mock };
+  readonly user: { findUnique: jest.Mock; create: jest.Mock };
+  readonly membership: { create: jest.Mock };
+  readonly membershipRole: { createMany: jest.Mock };
+  readonly invitation: { create: jest.Mock };
+  readonly lead: { update: jest.Mock };
+}
+
+describe('LeadsService', () => {
+  it('creates a converted lead owner without a password until invitation acceptance', async () => {
+    const transaction: ConversionTransaction = {
+      tenant: { create: jest.fn().mockResolvedValue({ id: 'tenant-1' }) },
+      subscription: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'subscription-1' }),
+      },
+      user: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'user-1' }),
+      },
+      membership: { create: jest.fn().mockResolvedValue({ id: 'membership-1' }) },
+      membershipRole: { createMany: jest.fn().mockResolvedValue({ count: 2 }) },
+      invitation: { create: jest.fn().mockResolvedValue({ id: 'invitation-1' }) },
+      lead: { update: jest.fn().mockResolvedValue({}) },
+    };
+    const prisma = {
+      lead: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'lead-1',
+          status: 'NEW',
+          convertedTenantId: null,
+          email: 'owner@example.com',
+          fullName: 'Owner Example',
+          tenantType: 'CONDOMINIUM',
+        }),
+      },
+      billingPlan: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'plan-1', planId: 'BASIC' }),
+      },
+      $transaction: jest.fn(async (callback: (tx: ConversionTransaction) => Promise<unknown>) =>
+        callback(transaction),
+      ),
+    } as unknown as PrismaService;
+    const emailService = {
+      sendEmail: jest.fn().mockResolvedValue(undefined),
+    } as unknown as EmailService;
+    const auditService = {
+      createLog: jest.fn().mockResolvedValue(undefined),
+    } as unknown as AuditService;
+    const configService = {
+      getValue: jest.fn().mockReturnValue('https://app.example.com'),
+    } as unknown as ConfigService;
+    const service = new LeadsService(prisma, emailService, auditService, configService);
+    const dto = {
+      tenantName: 'Example Building',
+      tenantType: 'CONDOMINIUM',
+    } as ConvertLeadDto;
+
+    await service.convertLeadToTenant('lead-1', dto, 'super-admin-1');
+
+    expect(transaction.user.create).toHaveBeenCalledWith({
+      data: {
+        email: 'owner@example.com',
+        name: 'Owner Example',
+        passwordHash: '',
+      },
+    });
+    expect(bcrypt.hash).not.toHaveBeenCalled();
+    expect(transaction.membershipRole.createMany).toHaveBeenCalledWith({
+      data: [
+        { tenantId: 'tenant-1', membershipId: 'membership-1', role: Role.TENANT_OWNER },
+        { tenantId: 'tenant-1', membershipId: 'membership-1', role: Role.TENANT_ADMIN },
+      ],
+    });
+  });
+});

--- a/apps/api/src/leads/leads.service.ts
+++ b/apps/api/src/leads/leads.service.ts
@@ -9,7 +9,6 @@ import { EmailType } from '../email/email.types';
 import { EmailTemplates } from '../email/email.templates';
 import { LeadResponse, LeadsListResponse, SelfRegisterResponse } from './leads.types';
 import * as crypto from 'crypto';
-import * as bcrypt from 'bcrypt';
 
 @Injectable()
 export class LeadsService {
@@ -679,16 +678,14 @@ export class LeadsService {
       let ownerUser = await tx.user.findUnique({ where: { email: ownerEmail } });
 
       if (!ownerUser) {
-        // Create new user with temporary password
+        // New owners activate their account by accepting the invitation.
         this.logger.log(`[CONVERT] Creating new user ${ownerEmail}`);
-        const tempPassword = this.generateTemporaryPassword();
-        const passwordHash = await this.hashPassword(tempPassword);
 
         ownerUser = await tx.user.create({
           data: {
             email: ownerEmail,
             name: ownerFullName,
-            passwordHash,
+            passwordHash: '',
           },
         });
 
@@ -824,20 +821,6 @@ export class LeadsService {
 
     this.logger.log(`[CONVERT] Using default plan: ${plan.planId}`);
     return plan;
-  }
-
-  /**
-   * Hash password (simple bcrypt)
-   */
-  private async hashPassword(password: string): Promise<string> {
-    return bcrypt.hash(password, 10);
-  }
-
-  /**
-   * Generate temporary password
-   */
-  private generateTemporaryPassword(): string {
-    return crypto.randomBytes(12).toString('hex');
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes password activation for new tenant owners created through SuperAdmin lead conversion.

Previously, lead conversion stored a random temporary password hash. Invitation acceptance only persisted the selected password when the existing hash was empty, so the password entered on `/invite` was ignored.

This change:

- creates newly converted owners with no usable password;
- lets invitation acceptance persist the selected password;
- preserves passwords for pre-existing users;
- keeps the existing invitation activation behavior.

## Validation

- Focused test passed
- ESLint passed
- Pre-commit review gate passed
- `git diff --check` passed

## Not included

- Email delivery changes
- Rate limiting
- CAPTCHA
- Plan selection
- Schema or migrations
- Staging or production changes