### PR TITLE
fix(email): make lead invitation delivery recoverable

### DIFF
--- a/apps/api/src/leads/admin-leads.controller.ts
+++ b/apps/api/src/leads/admin-leads.controller.ts
@@ -14,7 +14,12 @@ import {
 } from '@nestjs/common';
 import { AuthenticatedRequest } from '../common/types/request.types';
 import { LeadsService } from './leads.service';
-import { UpdateLeadDto, ConvertLeadDto, ConvertLeadResponseDto } from './leads.dto';
+import {
+  UpdateLeadDto,
+  ConvertLeadDto,
+  ConvertLeadResponseDto,
+  ResendLeadInvitationResponseDto,
+} from './leads.dto';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { SuperAdminGuard } from '../auth/super-admin.guard';
 
@@ -134,6 +139,17 @@ export class AdminLeadsController {
   ): Promise<ConvertLeadResponseDto> {
     const superAdminUserId = req.user?.id;
     return this.leadsService.convertLeadToTenant(id, dto, superAdminUserId);
+  }
+
+  /**
+   * Rotate and resend the pending owner invitation for a converted lead.
+   */
+  @Post(':id/resend-invitation')
+  async resendLeadInvitation(
+    @Param('id') id: string,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<ResendLeadInvitationResponseDto> {
+    return this.leadsService.resendLeadInvitation(id, req.user?.id);
   }
 
   /**

--- a/apps/api/src/leads/leads.dto.ts
+++ b/apps/api/src/leads/leads.dto.ts
@@ -107,9 +107,14 @@ export class ConvertLeadResponseDto {
   tenantId!: string;
   ownerUserId!: string;
   inviteSent!: boolean;
+  invitationEmailStatus!: 'SENT' | 'FAILED' | 'DISABLED';
   plan!: string; // FREE | BASIC | PRO | ENTERPRISE (BillingPlanId)
   subscriptionStatus!: string; // TRIAL
   trialEndDate!: string; // ISO 8601 date
+}
+
+export class ResendLeadInvitationResponseDto {
+  invitationEmailStatus!: 'SENT' | 'FAILED' | 'DISABLED';
 }
 
 export class LeadResponseDto {

--- a/apps/api/src/leads/leads.service.spec.ts
+++ b/apps/api/src/leads/leads.service.spec.ts
@@ -1,13 +1,10 @@
 import { Role } from '@prisma/client';
-import * as bcrypt from 'bcrypt';
 import { AuditService } from '../audit/audit.service';
 import { ConfigService } from '../config/config.service';
 import { EmailService } from '../email/email.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { ConvertLeadDto } from './leads.dto';
 import { LeadsService } from './leads.service';
-
-jest.mock('bcrypt');
 
 interface ConversionTransaction {
   readonly tenant: { create: jest.Mock };
@@ -19,71 +16,163 @@ interface ConversionTransaction {
   readonly lead: { update: jest.Mock };
 }
 
-describe('LeadsService', () => {
-  it('creates a converted lead owner without a password until invitation acceptance', async () => {
-    const transaction: ConversionTransaction = {
-      tenant: { create: jest.fn().mockResolvedValue({ id: 'tenant-1' }) },
-      subscription: {
-        findUnique: jest.fn().mockResolvedValue(null),
-        create: jest.fn().mockResolvedValue({ id: 'subscription-1' }),
-      },
-      user: {
-        findUnique: jest.fn().mockResolvedValue(null),
-        create: jest.fn().mockResolvedValue({ id: 'user-1' }),
-      },
-      membership: { create: jest.fn().mockResolvedValue({ id: 'membership-1' }) },
-      membershipRole: { createMany: jest.fn().mockResolvedValue({ count: 2 }) },
-      invitation: { create: jest.fn().mockResolvedValue({ id: 'invitation-1' }) },
-      lead: { update: jest.fn().mockResolvedValue({}) },
-    };
-    const prisma = {
-      lead: {
-        findUnique: jest.fn().mockResolvedValue({
-          id: 'lead-1',
-          status: 'NEW',
-          convertedTenantId: null,
-          email: 'owner@example.com',
-          fullName: 'Owner Example',
-          tenantType: 'CONDOMINIUM',
-        }),
-      },
-      billingPlan: {
-        findFirst: jest.fn().mockResolvedValue({ id: 'plan-1', planId: 'BASIC' }),
-      },
-      $transaction: jest.fn(async (callback: (tx: ConversionTransaction) => Promise<unknown>) =>
-        callback(transaction),
-      ),
-    } as unknown as PrismaService;
-    const emailService = {
-      sendEmail: jest.fn().mockResolvedValue(undefined),
-    } as unknown as EmailService;
-    const auditService = {
-      createLog: jest.fn().mockResolvedValue(undefined),
-    } as unknown as AuditService;
-    const configService = {
-      getValue: jest.fn().mockReturnValue('https://app.example.com'),
-    } as unknown as ConfigService;
-    const service = new LeadsService(prisma, emailService, auditService, configService);
-    const dto = {
-      tenantName: 'Example Building',
-      tenantType: 'CONDOMINIUM',
-    } as ConvertLeadDto;
+function createConversionFixture(emailResult: Promise<unknown>) {
+  let transactionCompleted = false;
+  const transaction: ConversionTransaction = {
+    tenant: { create: jest.fn().mockResolvedValue({ id: 'tenant-1' }) },
+    subscription: {
+      findUnique: jest.fn().mockResolvedValue(null),
+      create: jest.fn().mockResolvedValue({ id: 'subscription-1' }),
+    },
+    user: {
+      findUnique: jest.fn().mockResolvedValue(null),
+      create: jest.fn().mockResolvedValue({ id: 'user-1' }),
+    },
+    membership: { create: jest.fn().mockResolvedValue({ id: 'membership-1' }) },
+    membershipRole: { createMany: jest.fn().mockResolvedValue({ count: 2 }) },
+    invitation: { create: jest.fn().mockResolvedValue({ id: 'invitation-1' }) },
+    lead: { update: jest.fn().mockResolvedValue({}) },
+  };
+  const prisma = {
+    lead: {
+      findUnique: jest.fn().mockResolvedValue({
+        id: 'lead-1',
+        status: 'NEW',
+        convertedTenantId: null,
+        email: 'owner@example.com',
+        fullName: 'Owner Example',
+        tenantType: 'CONDOMINIUM',
+      }),
+    },
+    billingPlan: {
+      findFirst: jest.fn().mockResolvedValue({ id: 'plan-1', planId: 'BASIC' }),
+    },
+    $transaction: jest.fn(async (callback: (tx: ConversionTransaction) => Promise<unknown>) => {
+      const result = await callback(transaction);
+      transactionCompleted = true;
+      return result;
+    }),
+  } as unknown as PrismaService;
+  const emailService = {
+    sendEmail: jest.fn(async () => {
+      expect(transactionCompleted).toBe(true);
+      return emailResult;
+    }),
+  } as unknown as EmailService;
+  const auditService = {
+    createLog: jest.fn().mockResolvedValue(undefined),
+  } as unknown as AuditService;
+  const configService = {
+    getValue: jest.fn().mockReturnValue('https://app.example.com'),
+  } as unknown as ConfigService;
 
-    await service.convertLeadToTenant('lead-1', dto, 'super-admin-1');
+  return {
+    service: new LeadsService(prisma, emailService, auditService, configService),
+    transaction,
+    emailService,
+  };
+}
+
+describe('LeadsService', () => {
+  const dto = {
+    tenantName: 'Example Building',
+    tenantType: 'CONDOMINIUM',
+  } as ConvertLeadDto;
+
+  it('commits a new owner without a password before sending its invitation once', async () => {
+    const { service, transaction, emailService } = createConversionFixture(
+      Promise.resolve({ success: true }),
+    );
+
+    const result = await service.convertLeadToTenant('lead-1', dto, 'super-admin-1');
 
     expect(transaction.user.create).toHaveBeenCalledWith({
-      data: {
-        email: 'owner@example.com',
-        name: 'Owner Example',
-        passwordHash: '',
-      },
+      data: { email: 'owner@example.com', name: 'Owner Example', passwordHash: '' },
     });
-    expect(bcrypt.hash).not.toHaveBeenCalled();
     expect(transaction.membershipRole.createMany).toHaveBeenCalledWith({
       data: [
         { tenantId: 'tenant-1', membershipId: 'membership-1', role: Role.TENANT_OWNER },
         { tenantId: 'tenant-1', membershipId: 'membership-1', role: Role.TENANT_ADMIN },
       ],
     });
+    expect(emailService.sendEmail).toHaveBeenCalledTimes(1);
+    expect(emailService.sendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ to: 'owner@example.com', tenantId: 'tenant-1' }),
+      'INVITATION',
+    );
+    expect(result).toEqual(expect.objectContaining({ invitationEmailStatus: 'SENT', inviteSent: true }));
+    expect(result).not.toHaveProperty('inviteToken');
+  });
+
+  it('keeps the conversion committed and reports a safe failure when email sending throws', async () => {
+    const { service, transaction, emailService } = createConversionFixture(
+      Promise.reject(new Error('provider failure')),
+    );
+
+    const result = await service.convertLeadToTenant('lead-1', dto, 'super-admin-1');
+
+    expect(transaction.tenant.create).toHaveBeenCalledTimes(1);
+    expect(transaction.user.create).toHaveBeenCalledTimes(1);
+    expect(transaction.membership.create).toHaveBeenCalledTimes(1);
+    expect(transaction.invitation.create).toHaveBeenCalledTimes(1);
+    expect(emailService.sendEmail).toHaveBeenCalledTimes(1);
+    expect(result).toEqual(expect.objectContaining({ invitationEmailStatus: 'FAILED', inviteSent: false }));
+    expect(JSON.stringify(result)).not.toContain('provider failure');
+  });
+
+  it('reports a disabled provider without claiming the invitation was sent', async () => {
+    const { service } = createConversionFixture(Promise.resolve({ success: true, skipped: true }));
+
+    const result = await service.convertLeadToTenant('lead-1', dto, 'super-admin-1');
+
+    expect(result).toEqual(expect.objectContaining({ invitationEmailStatus: 'DISABLED', inviteSent: false }));
+  });
+
+  it('rotates only the converted owner pending invitation before resending it', async () => {
+    let transactionCompleted = false;
+    const transaction = {
+      invitation: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'invitation-1',
+          email: 'owner@example.com',
+          tokenHash: 'old-token-hash',
+        }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      tenant: { findUnique: jest.fn().mockResolvedValue({ name: 'Example Building' }) },
+    };
+    const prisma = {
+      lead: { findUnique: jest.fn().mockResolvedValue({ convertedTenantId: 'tenant-1' }) },
+      $transaction: jest.fn(async (callback: (tx: typeof transaction) => Promise<unknown>) => {
+        const result = await callback(transaction);
+        transactionCompleted = true;
+        return result;
+      }),
+    } as unknown as PrismaService;
+    const emailService = {
+      sendEmail: jest.fn(async () => {
+        expect(transactionCompleted).toBe(true);
+        return { success: true };
+      }),
+    } as unknown as EmailService;
+    const service = new LeadsService(
+      prisma,
+      emailService,
+      { createLog: jest.fn().mockResolvedValue(undefined) } as unknown as AuditService,
+      { getValue: jest.fn().mockReturnValue('https://app.example.com') } as unknown as ConfigService,
+    );
+
+    const result = await service.resendLeadInvitation('lead-1', 'super-admin-1');
+
+    expect(transaction.invitation.findFirst).toHaveBeenCalledWith({
+      where: expect.objectContaining({ tenantId: 'tenant-1', status: 'PENDING' }),
+    });
+    expect(transaction.invitation.updateMany).toHaveBeenCalledWith({
+      where: expect.objectContaining({ id: 'invitation-1', tokenHash: 'old-token-hash' }),
+      data: expect.objectContaining({ tokenHash: expect.any(String), expiresAt: expect.any(Date) }),
+    });
+    expect(transaction.invitation.updateMany.mock.calls[0][0].data.tokenHash).not.toBe('old-token-hash');
+    expect(emailService.sendEmail).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({ invitationEmailStatus: 'SENT' });
   });
 });

--- a/apps/api/src/leads/leads.service.ts
+++ b/apps/api/src/leads/leads.service.ts
@@ -3,8 +3,15 @@ import { PrismaService } from '../prisma/prisma.service';
 import { EmailService } from '../email/email.service';
 import { AuditService } from '../audit/audit.service';
 import { ConfigService } from '../config/config.service';
-import { CreateLeadDto, UpdateLeadDto, ConvertLeadDto, ConvertLeadResponseDto, SelfRegisterDto } from './leads.dto';
-import { AuditAction, Role, Lead, LeadStatus, Prisma } from '@prisma/client';
+import {
+  CreateLeadDto,
+  UpdateLeadDto,
+  ConvertLeadDto,
+  ConvertLeadResponseDto,
+  ResendLeadInvitationResponseDto,
+  SelfRegisterDto,
+} from './leads.dto';
+import { AuditAction, InvitationStatus, Role, Lead, LeadStatus, Prisma } from '@prisma/client';
 import { EmailType } from '../email/email.types';
 import { EmailTemplates } from '../email/email.templates';
 import { LeadResponse, LeadsListResponse, SelfRegisterResponse } from './leads.types';
@@ -380,7 +387,6 @@ export class LeadsService {
       throw new ConflictException('An account with this email already exists');
     }
 
-    // Start atomic transaction
     return await this.prisma.$transaction(async (tx) => {
       // 1. Create Lead (NEW status, DEMO intent, self-registration source)
       this.logger.log(`[SELF-REGISTER] Creating Lead for ${email}`);
@@ -627,8 +633,8 @@ export class LeadsService {
 
     this.logger.log(`[CONVERT] Using owner email: ${ownerEmail}`);
 
-    // Start atomic transaction
-    return await this.prisma.$transaction(async (tx) => {
+    // The transaction contains only durable domain writes. Email is sent after commit.
+    const conversion = await this.prisma.$transaction(async (tx) => {
       // 3. Create tenant
       this.logger.log(`[CONVERT] Creating tenant with name="${dto.tenantName}", type="${tenantType}"`);
 
@@ -731,13 +737,7 @@ export class LeadsService {
       });
       this.logger.log(`[CONVERT] ✓ Invitation created`);
 
-      // 8. Send invitation email (fire-and-forget)
-      this.logger.log(`[CONVERT] Sending invitation email...`);
-      void this.sendInvitationEmail(ownerEmail, inviteToken, dto.tenantName).catch((error) => {
-        this.logger.error(`Failed to send invitation email: ${error.message}`);
-      });
-
-      // 9. Update lead status and mark as converted
+      // 8. Update lead status and mark as converted
       this.logger.log(`[CONVERT] Updating lead status and marking as converted...`);
       await tx.lead.update({
         where: { id: leadId },
@@ -749,51 +749,130 @@ export class LeadsService {
       });
       this.logger.log(`[CONVERT] ✓ Lead updated`);
 
-      // 10. Audit events (fire-and-forget)
-      void this.auditService
-        .createLog({
-          tenantId: tenant.id,
-          actorUserId: superAdminUserId,
-          action: AuditAction.TENANT_CREATE,
-          entityType: 'Tenant',
-          entityId: tenant.id,
-          metadata: {
-            source: 'lead_conversion',
-            leadId,
-            tenantType,
-          },
-        })
-        .catch((error) => {
-          this.logger.error(`Failed to audit tenant create: ${error.message}`);
-        });
-
-      void this.auditService
-        .createLog({
-          tenantId: tenant.id,
-          actorUserId: superAdminUserId,
-          action: AuditAction.LEAD_CONVERTED,
-          entityType: 'Lead',
-          entityId: leadId,
-          metadata: {
-            tenantId: tenant.id,
-            ownerUserId: ownerUser.id,
-          },
-        })
-        .catch((error) => {
-          this.logger.error(`Failed to audit lead converted: ${error.message}`);
-        });
-
-      this.logger.log(`[CONVERT] ✓✓✓ CONVERSION COMPLETE: tenantId=${tenant.id}, leadId=${leadId}, plan=${billingPlan.planId}`);
-
       return {
         tenantId: tenant.id,
         ownerUserId: ownerUser.id,
-        inviteSent: true,
+        invitationId: invitation.id,
+        ownerEmail,
+        inviteToken,
+        tenantName: dto.tenantName,
         plan: billingPlan.planId,
         subscriptionStatus: 'TRIAL',
         trialEndDate: trialEndDate.toISOString(),
       };
     });
+
+    void this.auditService
+      .createLog({
+        tenantId: conversion.tenantId,
+        actorUserId: superAdminUserId,
+        action: AuditAction.TENANT_CREATE,
+        entityType: 'Tenant',
+        entityId: conversion.tenantId,
+        metadata: { source: 'lead_conversion', leadId, tenantType },
+      })
+      .catch((error) => this.logger.error(`Failed to audit tenant creation: ${error.message}`));
+    void this.auditService
+      .createLog({
+        tenantId: conversion.tenantId,
+        actorUserId: superAdminUserId,
+        action: AuditAction.LEAD_CONVERTED,
+        entityType: 'Lead',
+        entityId: leadId,
+        metadata: { tenantId: conversion.tenantId, ownerUserId: conversion.ownerUserId },
+      })
+      .catch((error) => this.logger.error(`Failed to audit lead conversion: ${error.message}`));
+
+    const invitationEmailStatus = await this.sendInvitationEmail(
+      conversion.ownerEmail,
+      conversion.inviteToken,
+      conversion.tenantName,
+      conversion.tenantId,
+    );
+
+    this.logger.log(`[CONVERT] Completed lead conversion for ${leadId}; invitation email status=${invitationEmailStatus}`);
+    return {
+      tenantId: conversion.tenantId,
+      ownerUserId: conversion.ownerUserId,
+      inviteSent: invitationEmailStatus === 'SENT',
+      invitationEmailStatus,
+      plan: conversion.plan,
+      subscriptionStatus: conversion.subscriptionStatus,
+      trialEndDate: conversion.trialEndDate,
+    };
+  }
+
+  /**
+   * Rotates the converted owner's pending invitation before a single post-commit resend.
+   */
+  async resendLeadInvitation(
+    leadId: string,
+    superAdminUserId: string,
+  ): Promise<ResendLeadInvitationResponseDto> {
+    const lead = await this.prisma.lead.findUnique({
+      where: { id: leadId },
+      select: { convertedTenantId: true },
+    });
+
+    const tenantId = lead?.convertedTenantId;
+    if (!tenantId) {
+      throw new NotFoundException('Converted lead not found');
+    }
+
+    const resend = await this.prisma.$transaction(async (tx) => {
+      const invitation = await tx.invitation.findFirst({
+        where: {
+          tenantId,
+          status: InvitationStatus.PENDING,
+          roles: { array_contains: Role.TENANT_OWNER },
+        },
+      });
+
+      if (!invitation) {
+        throw new NotFoundException('Pending owner invitation not found');
+      }
+
+      const token = crypto.randomBytes(32).toString('hex');
+      const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+      const rotation = await tx.invitation.updateMany({
+        where: { id: invitation.id, tokenHash: invitation.tokenHash, status: InvitationStatus.PENDING },
+        data: { tokenHash, expiresAt },
+      });
+
+      if (rotation.count !== 1) {
+        throw new ConflictException('Invitation was updated concurrently');
+      }
+
+      const tenant = await tx.tenant.findUnique({
+        where: { id: tenantId },
+        select: { name: true },
+      });
+
+      if (!tenant) {
+        throw new NotFoundException('Tenant not found');
+      }
+
+      return { invitationId: invitation.id, email: invitation.email, token, tenantName: tenant.name };
+    });
+
+    void this.auditService
+      .createLog({
+        tenantId,
+        actorUserId: superAdminUserId,
+        action: AuditAction.MEMBERSHIP_INVITE_RESENT,
+        entityType: 'Invitation',
+        entityId: resend.invitationId,
+      })
+      .catch((error) => this.logger.error(`Failed to audit invitation resend: ${error.message}`));
+
+    const invitationEmailStatus = await this.sendInvitationEmail(
+      resend.email,
+      resend.token,
+      resend.tenantName,
+      tenantId,
+    );
+    return { invitationEmailStatus };
   }
 
   /**
@@ -830,7 +909,8 @@ export class LeadsService {
     email: string,
     token: string,
     tenantName: string,
-  ): Promise<void> {
+    tenantId: string,
+  ): Promise<'SENT' | 'FAILED' | 'DISABLED'> {
     const inviteLink = `${this.configService.getValue('appBaseUrl')}/invite?token=${token}`;
 
     const htmlBody = `
@@ -841,13 +921,20 @@ export class LeadsService {
       <p style="color: #999; font-size: 12px;">If you didn't request this, please ignore this email.</p>
     `;
 
-    await this.emailService.sendEmail(
-      {
-        to: email,
-        subject: `Invitation to ${tenantName} - BuildingOS`,
-        htmlBody,
-      },
-      EmailType.INVITATION,
-    );
+    try {
+      const result = await this.emailService.sendEmail(
+        {
+          to: email,
+          subject: `Invitation to ${tenantName} - BuildingOS`,
+          htmlBody,
+          tenantId,
+        },
+        EmailType.INVITATION,
+      );
+      return result.skipped ? 'DISABLED' : result.success ? 'SENT' : 'FAILED';
+    } catch (error) {
+      this.logger.error(`Failed to send invitation email for tenant ${tenantId}: ${error instanceof Error ? error.message : 'unknown error'}`);
+      return 'FAILED';
+    }
   }
 }

--- a/apps/web/app/super-admin/leads/[id]/page.tsx
+++ b/apps/web/app/super-admin/leads/[id]/page.tsx
@@ -49,13 +49,15 @@ export default function LeadDetailPage() {
   const params = useParams();
   const leadId = params?.id as string;
 
-  const { fetchLead, update, convert } = useLeads();
+  const { fetchLead, update, convert, resendInvitation } = useLeads();
 
   const [lead, setLead] = useState<Lead | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isSaving, setIsSaving] = useState(false);
   const [isConverting, setIsConverting] = useState(false);
+  const [isResendingInvitation, setIsResendingInvitation] = useState(false);
+  const [invitationDeliveryFailed, setInvitationDeliveryFailed] = useState(false);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [successTenantId, setSuccessTenantId] = useState<string | null>(null);
 
@@ -131,7 +133,13 @@ export default function LeadDetailPage() {
         ownerEmail: ownerEmail.trim(),
       });
       if (result && result.tenantId) {
-        setSuccessMessage('Lead converted successfully!');
+        const deliveryFailed = result.invitationEmailStatus !== 'SENT';
+        setInvitationDeliveryFailed(deliveryFailed);
+        setSuccessMessage(
+          deliveryFailed
+            ? 'Administración creada, pero no se pudo enviar la invitación. Podés reenviarla.'
+            : 'Administración creada e invitación enviada.',
+        );
         setSuccessTenantId(result.tenantId);
         setShowConvertForm(false);
         setTenantName('');
@@ -157,6 +165,25 @@ export default function LeadDetailPage() {
     }
   };
 
+  const handleResendInvitation = async () => {
+    try {
+      setIsResendingInvitation(true);
+      setError(null);
+      const result = await resendInvitation(leadId);
+      const deliveryFailed = result.invitationEmailStatus !== 'SENT';
+      setInvitationDeliveryFailed(deliveryFailed);
+      setSuccessMessage(
+        deliveryFailed
+          ? 'La invitación fue renovada, pero no se pudo enviar el correo. Podés volver a intentarlo.'
+          : 'Invitación reenviada.',
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo reenviar la invitación');
+    } finally {
+      setIsResendingInvitation(false);
+    }
+  };
+
   if (loading) {
     return (
       <div className="flex justify-center items-center py-24">
@@ -171,7 +198,7 @@ export default function LeadDetailPage() {
         <Button onClick={() => router.back()}>← Back to Leads</Button>
         <div className="bg-red-50 border border-red-200 rounded-lg p-4">
           <h3 className="font-medium text-red-900">Lead Not Found</h3>
-          <p className="text-sm text-red-700">The lead doesn't exist.</p>
+          <p className="text-sm text-red-700">The lead doesn&apos;t exist.</p>
         </div>
       </div>
     );
@@ -439,6 +466,12 @@ export default function LeadDetailPage() {
                     <p className="text-sm font-medium text-green-700">✓ {t('superAdmin.leads.converted')}</p>
                   </div>
 
+                  {invitationDeliveryFailed && (
+                    <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+                      La administración fue creada, pero el correo de invitación no pudo enviarse. Podés reenviarlo.
+                    </div>
+                  )}
+
                   <div className="space-y-3 border-t border-green-200 pt-4">
                     <div>
                       <p className="text-xs font-medium text-muted-foreground">Nombre del Tenant</p>
@@ -472,6 +505,15 @@ export default function LeadDetailPage() {
                         className="flex-1 bg-green-600 hover:bg-green-700 text-white"
                       >
                         Ver Tenant
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="secondary"
+                        onClick={handleResendInvitation}
+                        disabled={isResendingInvitation}
+                        className="flex-1"
+                      >
+                        {isResendingInvitation ? 'Reenviando...' : 'Reenviar invitación'}
                       </Button>
                       <Button
                         size="sm"

--- a/apps/web/features/super-admin/leads/leads.api.test.ts
+++ b/apps/web/features/super-admin/leads/leads.api.test.ts
@@ -1,0 +1,25 @@
+import { apiClient } from '@/shared/lib/http/client';
+import { resendLeadInvitation } from './leads.api';
+
+jest.mock('@/shared/lib/http/client', () => ({
+  apiClient: jest.fn(),
+}));
+
+const mockedApiClient = jest.mocked(apiClient);
+
+describe('lead API', () => {
+  beforeEach(() => {
+    mockedApiClient.mockReset();
+  });
+
+  it('resends a converted lead owner invitation through the protected lead endpoint', async () => {
+    mockedApiClient.mockResolvedValue({ invitationEmailStatus: 'SENT' });
+
+    await resendLeadInvitation('lead-1');
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/leads/admin/lead-1/resend-invitation',
+      method: 'POST',
+    });
+  });
+});

--- a/apps/web/features/super-admin/leads/leads.api.ts
+++ b/apps/web/features/super-admin/leads/leads.api.ts
@@ -47,6 +47,11 @@ export interface ConvertLeadResponse {
   tenantId: string;
   ownerUserId: string;
   inviteSent: boolean;
+  invitationEmailStatus: 'SENT' | 'FAILED' | 'DISABLED';
+}
+
+export interface ResendLeadInvitationResponse {
+  invitationEmailStatus: 'SENT' | 'FAILED' | 'DISABLED';
 }
 
 /**
@@ -108,6 +113,13 @@ export async function convertLead(
     path: `/leads/admin/${id}/convert`,
     method: 'POST',
     body: dto,
+  });
+}
+
+export async function resendLeadInvitation(id: string): Promise<ResendLeadInvitationResponse> {
+  return apiClient<ResendLeadInvitationResponse>({
+    path: `/leads/admin/${id}/resend-invitation`,
+    method: 'POST',
   });
 }
 

--- a/apps/web/features/super-admin/leads/useLeads.ts
+++ b/apps/web/features/super-admin/leads/useLeads.ts
@@ -9,6 +9,7 @@ import {
   getLead,
   updateLead,
   convertLead,
+  resendLeadInvitation,
   deleteLead,
   Lead,
   ListLeadsResponse,
@@ -103,6 +104,8 @@ export function useLeads() {
     return result;
   };
 
+  const resendInvitation = async (id: string) => resendLeadInvitation(id);
+
   // Delete lead
   const remove = async (id: string): Promise<boolean> => {
     try {
@@ -127,6 +130,7 @@ export function useLeads() {
     fetchLead,
     update,
     convert,
+    resendInvitation,
     remove,
     pageSize,
   };


### PR DESCRIPTION
## Summary

Improves invitation email handling after SuperAdmin lead conversion.

The database conversion now completes before the external email operation. The API reports conversion and email delivery as separate outcomes, allowing SuperAdmin to recover from delivery failures without repeating tenant creation.

This change:

- sends invitation email only after the conversion transaction commits;
- awaits and reports the delivery attempt;
- preserves completed conversion when email delivery fails;
- records tenant context through the existing email infrastructure;
- supports safe invitation resend with token rotation;
- provides clear SuperAdmin feedback;
- prevents duplicate actions from repeated clicks.

## Delivery semantics

`SENT` means the provider accepted the message. It does not guarantee final delivery to the recipient.

## Validation

- 5 focused test suites passed
- API typecheck passed
- Web typecheck passed
- API ESLint passed
- Web ESLint passed with 4 pre-existing warnings
- Pre-commit hook passed
- `git diff --check` passed

## Not included

- Email queues or outbox
- Automatic background retries
- Delivery webhooks
- CAPTCHA or public rate limiting
- Plan selection
- Schema or migrations
- Staging or production changes