### PR TITLE
fix(security): rate limit invitation validation

### DIFF
--- a/apps/api/src/security/rate-limit.middleware.spec.ts
+++ b/apps/api/src/security/rate-limit.middleware.spec.ts
@@ -1,0 +1,101 @@
+import { HttpException } from '@nestjs/common';
+import { NextFunction, Request, Response } from 'express';
+import { ConfigService } from '../config/config.service';
+import { RedisService } from '../redis/redis.service';
+import { RateLimitMiddleware } from './rate-limit.middleware';
+
+interface MiddlewareResult {
+  readonly next: jest.Mock;
+  readonly response: Response;
+}
+
+function createRequest(
+  method: string,
+  path: string,
+  ip: string,
+): Request {
+  return {
+    method,
+    path,
+    ip,
+    headers: {},
+    body: {},
+    socket: { remoteAddress: ip },
+  } as unknown as Request;
+}
+
+function invoke(
+  middleware: RateLimitMiddleware,
+  request: Request,
+): Promise<MiddlewareResult> {
+  const response = { setHeader: jest.fn() } as unknown as Response;
+  return new Promise((resolve) => {
+    const next = jest.fn((error?: unknown) => resolve({ next, response: error ? response : response }));
+    middleware.use(request, response, next as NextFunction);
+  });
+}
+
+describe('RateLimitMiddleware', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = 'development';
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  function createMiddleware(): RateLimitMiddleware {
+    return new RateLimitMiddleware(
+      { incrementCounter: jest.fn().mockResolvedValue(null) } as unknown as RedisService,
+      { getValue: jest.fn().mockReturnValue('development') } as unknown as ConfigService,
+    );
+  }
+
+  it('limits GET invitation validation before the controller can run without using the token query', async () => {
+    const middleware = createMiddleware();
+    const firstRequest = createRequest('GET', '/invitations/validate', '203.0.113.10');
+
+    for (let index = 0; index < 10; index++) {
+      const { next } = await invoke(middleware, firstRequest);
+      expect(next).toHaveBeenCalledWith();
+    }
+
+    const { next, response } = await invoke(middleware, firstRequest);
+    const error = next.mock.calls[0][0] as HttpException;
+    expect(error).toBeInstanceOf(HttpException);
+    expect(error.getStatus()).toBe(429);
+    expect(JSON.stringify(error.getResponse())).not.toContain('token');
+    expect(response.setHeader).toHaveBeenCalledWith('RateLimit-Limit', 10);
+
+    const otherIp = await invoke(
+      middleware,
+      createRequest('GET', '/invitations/validate', '2001:db8::1'),
+    );
+    expect(otherIp.next).toHaveBeenCalledWith();
+  });
+
+  it('keeps POST acceptance protected and leaves unrelated GET routes unbounded', async () => {
+    const middleware = createMiddleware();
+    const acceptRequest = createRequest('POST', '/invitations/accept', '203.0.113.10');
+
+    for (let index = 0; index < 10; index++) {
+      const { next } = await invoke(middleware, acceptRequest);
+      expect(next).toHaveBeenCalledWith();
+    }
+
+    const limitedAccept = await invoke(middleware, acceptRequest);
+    expect((limitedAccept.next.mock.calls[0][0] as HttpException).getStatus()).toBe(429);
+
+    const unrelatedGet = await invoke(
+      middleware,
+      createRequest('GET', '/health', '203.0.113.10'),
+    );
+    expect(unrelatedGet.next).toHaveBeenCalledWith();
+    expect(unrelatedGet.response.setHeader).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/security/rate-limit.middleware.ts
+++ b/apps/api/src/security/rate-limit.middleware.ts
@@ -154,7 +154,7 @@ export class RateLimitMiddleware implements NestMiddleware {
       suffix += `:${req.body.tenantId}`;
     }
 
-    return `${ip}:${path}${suffix}`;
+    return `${ip}:${req.method}:${path}${suffix}`;
   }
 
   /**
@@ -164,7 +164,13 @@ export class RateLimitMiddleware implements NestMiddleware {
     const path = req.path;
     const method = req.method;
 
-    // Exempt authenticated GET requests from rate limiting (they're safe from abuse)
+    // Public invitation validation is intentionally rate limited before the
+    // broad GET exemption. req.path excludes the token query string.
+    if (path === '/invitations/validate' && method === 'GET') {
+      return { max: 10, windowMs: 15 * 60 * 1000 };
+    }
+
+    // Exempt other GET requests from rate limiting.
     if (method === 'GET') {
       return null;
     }
@@ -190,10 +196,6 @@ export class RateLimitMiddleware implements NestMiddleware {
     }
 
     // Invitation endpoints - moderate limits
-    if (path.includes('/invitations/validate') && method === 'POST') {
-      return { max: 10, windowMs: 15 * 60 * 1000 }; // 10 attempts per 15 minutes
-    }
-
     if (path.includes('/invitations/accept') && method === 'POST') {
       return { max: 10, windowMs: 15 * 60 * 1000 }; // 10 attempts per 15 minutes
     }


### PR DESCRIPTION
## Summary

Adds the missing rate limit coverage for the public invitation validation endpoint.

The middleware previously exempted all GET requests before evaluating invitation routes, while the existing invitation matcher only covered POST requests.

This change:

- applies the canonical limiter to `GET /invitations/validate`;
- preserves the existing protection for `POST /invitations/accept`;
- uses an IP, HTTP method and normalized path bucket;
- excludes query parameters and invitation tokens from the rate-limit key;
- prevents token query variations from bypassing the limit;
- preserves unrelated GET routes.

## Validation

- Focused middleware tests passed
- API typecheck passed
- API ESLint passed
- Pre-commit hook passed
- `git diff --check` passed

## Not included

- CAPTCHA
- Public lead anti-spam changes
- Invitation token redesign
- Email changes
- Schema or migrations
- Staging or production changes