### PR TITLE
fix(security): protect public lead submissions

### DIFF
--- a/apps/api/src/leads/leads.dto.ts
+++ b/apps/api/src/leads/leads.dto.ts
@@ -63,6 +63,11 @@ export class CreateLeadDto {
   @IsOptional()
   @IsIn(['DEMO', 'CONTACT'])
   intent?: 'DEMO' | 'CONTACT'; // Defaults to CONTACT
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  website?: string;
 }
 
 export class UpdateLeadDto {

--- a/apps/api/src/leads/leads.service.ts
+++ b/apps/api/src/leads/leads.service.ts
@@ -36,9 +36,10 @@ export class LeadsService {
    * - NO TENANT CREATION
    */
   async createLead(dto: CreateLeadDto): Promise<Lead> {
+    const email = dto.email.trim().toLowerCase();
     // Check if email already exists
     const existingLead = await this.prisma.lead.findUnique({
-      where: { email: dto.email },
+      where: { email },
     });
 
     if (existingLead) {
@@ -49,7 +50,7 @@ export class LeadsService {
     const lead = await this.prisma.lead.create({
       data: {
         fullName: dto.fullName,
-        email: dto.email,
+        email,
         phone: dto.phoneWhatsapp,
         tenantType: dto.tenantType,
         buildingsCount: dto.buildingsCount,

--- a/apps/api/src/leads/public-leads.controller.ts
+++ b/apps/api/src/leads/public-leads.controller.ts
@@ -4,6 +4,7 @@ import {
   Body,
   HttpCode,
   HttpStatus,
+  ConflictException,
 } from '@nestjs/common';
 import { LeadsService } from './leads.service';
 import { CreateLeadDto, SelfRegisterDto } from './leads.dto';
@@ -30,14 +31,24 @@ export class PublicLeadsController {
   @Post('public')
   @HttpCode(HttpStatus.CREATED)
   async submitLead(@Body() dto: CreateLeadDto) {
-    const lead = await this.leadsService.createLead(dto);
+    if (dto.website?.trim()) {
+      return this.publicResponse();
+    }
 
+    try {
+      await this.leadsService.createLead(dto);
+    } catch (error) {
+      if (error instanceof ConflictException) {
+        return this.publicResponse();
+      }
+      throw error;
+    }
+
+    return this.publicResponse();
+  }
+
+  private publicResponse() {
     return {
-      id: lead.id,
-      email: lead.email,
-      fullName: lead.fullName,
-      status: lead.status,
-      createdAt: lead.createdAt,
       message: 'Lead received. Our sales team will contact you shortly.',
     };
   }

--- a/apps/api/src/security/rate-limit.middleware.spec.ts
+++ b/apps/api/src/security/rate-limit.middleware.spec.ts
@@ -98,4 +98,20 @@ describe('RateLimitMiddleware', () => {
     expect(unrelatedGet.next).toHaveBeenCalledWith();
     expect(unrelatedGet.response.setHeader).not.toHaveBeenCalled();
   });
+
+  it('limits public lead submissions by IP, method, and path without email buckets', async () => {
+    const middleware = createMiddleware();
+
+    for (let index = 0; index < 10; index++) {
+      const request = createRequest('POST', '/leads/public', '203.0.113.10');
+      request.body = { email: `person-${index}@example.com` };
+      const { next } = await invoke(middleware, request);
+      expect(next).toHaveBeenCalledWith();
+    }
+
+    const duplicateRoute = createRequest('POST', '/leads/public', '203.0.113.10');
+    duplicateRoute.body = { email: 'different@example.com' };
+    const limited = await invoke(middleware, duplicateRoute);
+    expect((limited.next.mock.calls[0][0] as HttpException).getStatus()).toBe(429);
+  });
 });

--- a/apps/api/src/security/rate-limit.middleware.ts
+++ b/apps/api/src/security/rate-limit.middleware.ts
@@ -145,6 +145,10 @@ export class RateLimitMiddleware implements NestMiddleware {
     const ip = this.getClientIp(req);
     const path = req.path;
 
+    if (path === '/leads/public' && req.method === 'POST') {
+      return `${ip}:${req.method}:${path}`;
+    }
+
     // Include email if present in body (for auth/invitations)
     let suffix = '';
     if (req.body?.email) {

--- a/apps/web/features/public/components/UnifiedLeadForm.tsx
+++ b/apps/web/features/public/components/UnifiedLeadForm.tsx
@@ -115,11 +115,6 @@ export function UnifiedLeadForm({
   });
 
   const onSubmit = async (data: LeadFormData) => {
-    if (data.website) {
-      console.warn('Honeypot field filled, ignoring submission');
-      return;
-    }
-
     const normalizedFullName = data.fullName.trim();
     const normalizedEmail = data.email.trim().toLowerCase();
     const normalizedPhoneWhatsapp = data.phoneWhatsapp?.trim() || undefined;
@@ -155,6 +150,7 @@ export function UnifiedLeadForm({
           message: normalizedMessage,
           source: intent === 'DEMO' ? 'landing' : 'contact-form',
           intent,
+          website: data.website || undefined,
         };
 
         console.log(`📤 Enviando lead ${intent}:`, submitData);
@@ -432,7 +428,16 @@ export function UnifiedLeadForm({
           )}
 
           {/* Honeypot */}
-          <input type="hidden" {...register('website')} />
+          <div aria-hidden="true" className="absolute -left-[10000px] top-auto h-px w-px overflow-hidden">
+            <label htmlFor={`lead-${intent.toLowerCase()}-website`}>Website</label>
+            <input
+              id={`lead-${intent.toLowerCase()}-website`}
+              type="text"
+              tabIndex={-1}
+              autoComplete="off"
+              {...register('website')}
+            />
+          </div>
 
           {/* Submit Button */}
           <Button

--- a/apps/web/shared/api/leads.api.ts
+++ b/apps/web/shared/api/leads.api.ts
@@ -15,14 +15,10 @@ export interface CreateLeadRequest {
   message?: string;
   source?: string;
   intent?: 'DEMO' | 'CONTACT' | 'SIGNUP';
+  website?: string;
 }
 
 export interface LeadResponse {
-  id: string;
-  email: string;
-  fullName: string;
-  status: string;
-  createdAt: string;
   message: string;
 }
 


### PR DESCRIPTION
## Summary

Adds backend-enforced anti-spam protections to the public lead submission flow.

This change:

- validates the honeypot on the backend;
- prevents honeypot submissions from creating leads or notifications;
- applies a dedicated rate limit to `POST /leads/public`;
- uses an IP, method and normalized path bucket;
- excludes email and query parameters from the rate-limit key;
- normalizes submitted email addresses;
- returns generic public responses to avoid email enumeration;
- preserves private lead routes and invitation rate limiting.

## Duplicate handling

This PR avoids exposing duplicate status through the public response.

It does not add historical deduplication, database constraints or new indexes.

## Validation

- Focused rate-limit middleware tests: 3 passed
- API typecheck passed
- Web typecheck passed
- API ESLint passed
- Web ESLint passed
- Pre-commit hook passed
- `git diff --check` passed

## Not included

- CAPTCHA
- Historical lead deduplication
- Consent persistence
- Plan selection
- Public auto-registration
- Schema or migrations
- Staging or production changes