### PR TITLE
fix(billing): honor selected plan during lead conversion

### DIFF
--- a/apps/api/src/leads/admin-leads.controller.ts
+++ b/apps/api/src/leads/admin-leads.controller.ts
@@ -74,6 +74,14 @@ export class AdminLeadsController {
   }
 
   /**
+   * List persisted billing plans available for a lead conversion.
+   */
+  @Get('billing-plans')
+  async listConversionBillingPlans() {
+    return this.leadsService.listConversionBillingPlans();
+  }
+
+  /**
    * Get a single lead by ID
    *
    * GET /leads/admin/:id

--- a/apps/api/src/leads/leads.service.spec.ts
+++ b/apps/api/src/leads/leads.service.spec.ts
@@ -8,6 +8,7 @@ import { LeadsService } from './leads.service';
 
 interface ConversionTransaction {
   readonly tenant: { create: jest.Mock };
+  readonly billingPlan: { findUnique: jest.Mock; findFirst: jest.Mock };
   readonly subscription: { findUnique: jest.Mock; create: jest.Mock };
   readonly user: { findUnique: jest.Mock; create: jest.Mock };
   readonly membership: { create: jest.Mock };
@@ -20,6 +21,12 @@ function createConversionFixture(emailResult: Promise<unknown>) {
   let transactionCompleted = false;
   const transaction: ConversionTransaction = {
     tenant: { create: jest.fn().mockResolvedValue({ id: 'tenant-1' }) },
+    billingPlan: {
+      findUnique: jest.fn().mockImplementation(({ where }: { where: { id: string } }) =>
+        Promise.resolve({ id: where.id, planId: 'BASIC' }),
+      ),
+      findFirst: jest.fn().mockResolvedValue({ id: 'plan-basic', planId: 'BASIC' }),
+    },
     subscription: {
       findUnique: jest.fn().mockResolvedValue(null),
       create: jest.fn().mockResolvedValue({ id: 'subscription-1' }),
@@ -70,6 +77,7 @@ function createConversionFixture(emailResult: Promise<unknown>) {
     service: new LeadsService(prisma, emailService, auditService, configService),
     transaction,
     emailService,
+    prisma,
   };
 }
 
@@ -126,6 +134,57 @@ describe('LeadsService', () => {
     const result = await service.convertLeadToTenant('lead-1', dto, 'super-admin-1');
 
     expect(result).toEqual(expect.objectContaining({ invitationEmailStatus: 'DISABLED', inviteSent: false }));
+  });
+
+  it.each([
+    ['FREE', 'plan-free'],
+    ['BASIC', 'plan-basic'],
+    ['PRO', 'plan-pro'],
+    ['ENTERPRISE', 'plan-enterprise'],
+  ])('uses the selected %s billing plan for the created subscription', async (planId, selectedPlanId) => {
+    const { service, transaction } = createConversionFixture(Promise.resolve({ success: true }));
+    transaction.billingPlan.findUnique.mockResolvedValue({ id: selectedPlanId, planId });
+
+    const result = await service.convertLeadToTenant(
+      'lead-1',
+      { ...dto, planId: selectedPlanId },
+      'super-admin-1',
+    );
+
+    expect(transaction.billingPlan.findUnique).toHaveBeenCalledWith({ where: { id: selectedPlanId } });
+    expect(transaction.subscription.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ planId: selectedPlanId, status: 'TRIAL' }) }),
+    );
+    expect(result).toEqual(expect.objectContaining({ plan: planId, subscriptionStatus: 'TRIAL' }));
+  });
+
+  it('uses the canonical BASIC fallback when no plan id is supplied', async () => {
+    const { service, transaction } = createConversionFixture(Promise.resolve({ success: true }));
+
+    await service.convertLeadToTenant('lead-1', dto, 'super-admin-1');
+
+    expect(transaction.billingPlan.findUnique).not.toHaveBeenCalled();
+    expect(transaction.billingPlan.findFirst).toHaveBeenCalledWith({ where: { planId: 'BASIC' } });
+    expect(transaction.subscription.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ planId: 'plan-basic' }) }),
+    );
+  });
+
+  it('rejects an unknown selected plan before creating partial conversion resources or sending an invitation', async () => {
+    const { service, transaction, emailService } = createConversionFixture(Promise.resolve({ success: true }));
+    transaction.billingPlan.findUnique.mockResolvedValue(null);
+
+    await expect(
+      service.convertLeadToTenant('lead-1', { ...dto, planId: 'missing-plan' }, 'super-admin-1'),
+    ).rejects.toThrow('Selected billing plan not found');
+
+    expect(transaction.tenant.create).not.toHaveBeenCalled();
+    expect(transaction.subscription.create).not.toHaveBeenCalled();
+    expect(transaction.user.create).not.toHaveBeenCalled();
+    expect(transaction.membership.create).not.toHaveBeenCalled();
+    expect(transaction.invitation.create).not.toHaveBeenCalled();
+    expect(transaction.lead.update).not.toHaveBeenCalled();
+    expect(emailService.sendEmail).not.toHaveBeenCalled();
   });
 
   it('rotates only the converted owner pending invitation before resending it', async () => {

--- a/apps/api/src/leads/leads.service.ts
+++ b/apps/api/src/leads/leads.service.ts
@@ -636,6 +636,14 @@ export class LeadsService {
 
     // The transaction contains only durable domain writes. Email is sent after commit.
     const conversion = await this.prisma.$transaction(async (tx) => {
+      const billingPlan = dto.planId
+        ? await tx.billingPlan.findUnique({ where: { id: dto.planId } })
+        : await this.getDefaultBillingPlan(tx);
+
+      if (!billingPlan) {
+        throw new BadRequestException('Selected billing plan not found');
+      }
+
       // 3. Create tenant
       this.logger.log(`[CONVERT] Creating tenant with name="${dto.tenantName}", type="${tenantType}"`);
 
@@ -650,9 +658,6 @@ export class LeadsService {
 
       // 4. Create subscription with plan
       this.logger.log(`[CONVERT] Creating subscription...`);
-
-      // Get billing plan (default BASIC, fallback to FREE)
-      const billingPlan = await this.getDefaultBillingPlan();
 
       // Calculate trial period (14 days from now)
       const now = new Date();
@@ -880,15 +885,27 @@ export class LeadsService {
    * Get default plan (BASIC with fallback to FREE)
    * Used for new tenant conversions
    */
-  private async getDefaultBillingPlan() {
+  async listConversionBillingPlans() {
+    return this.prisma.billingPlan.findMany({
+      select: {
+        id: true,
+        planId: true,
+        name: true,
+        monthlyPrice: true,
+      },
+      orderBy: { monthlyPrice: 'asc' },
+    });
+  }
+
+  private async getDefaultBillingPlan(client: Prisma.TransactionClient | PrismaService = this.prisma) {
     // Try BASIC first
-    let plan = await this.prisma.billingPlan.findFirst({
+    let plan = await client.billingPlan.findFirst({
       where: { planId: 'BASIC' },
     });
 
     // Fallback to FREE if BASIC doesn't exist
     if (!plan) {
-      plan = await this.prisma.billingPlan.findFirst({
+      plan = await client.billingPlan.findFirst({
         where: { planId: 'FREE' },
       });
     }

--- a/apps/web/app/super-admin/leads/[id]/page.test.tsx
+++ b/apps/web/app/super-admin/leads/[id]/page.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import LeadDetailPage from './page';
+import { listConversionBillingPlans } from '@/features/super-admin/leads/leads.api';
+import { useLeads } from '@/features/super-admin/leads/useLeads';
+
+jest.mock('next/navigation', () => ({
+  useParams: () => ({ id: 'lead-1' }),
+  useRouter: () => ({ back: jest.fn(), push: jest.fn() }),
+}));
+
+jest.mock('@/features/super-admin/leads/leads.api', () => ({
+  listConversionBillingPlans: jest.fn(),
+}));
+
+jest.mock('@/features/super-admin/leads/useLeads', () => ({
+  useLeads: jest.fn(),
+}));
+
+const mockedListConversionBillingPlans = jest.mocked(listConversionBillingPlans);
+const mockedUseLeads = jest.mocked(useLeads);
+
+describe('LeadDetailPage', () => {
+  it('sends the selected persisted plan id when converting a lead', async () => {
+    const convert = jest.fn().mockResolvedValue({
+      tenantId: 'tenant-1',
+      ownerUserId: 'user-1',
+      inviteSent: true,
+      invitationEmailStatus: 'SENT',
+      plan: 'PRO',
+      subscriptionStatus: 'TRIAL',
+      trialEndDate: '2026-08-01T00:00:00.000Z',
+    });
+    const fetchLead = jest.fn().mockResolvedValue({
+      id: 'lead-1',
+      fullName: 'Owner Example',
+      email: 'owner@example.com',
+      tenantType: 'ADMINISTRADORA',
+      status: 'NEW',
+      createdAt: '2026-07-01T00:00:00.000Z',
+      updatedAt: '2026-07-01T00:00:00.000Z',
+    });
+    mockedUseLeads.mockReturnValue({
+      fetchLead,
+      update: jest.fn(),
+      convert,
+      resendInvitation: jest.fn(),
+    } as unknown as ReturnType<typeof useLeads>);
+    mockedListConversionBillingPlans.mockResolvedValue([
+      { id: 'plan-pro-id', planId: 'PRO', name: 'Professional', monthlyPrice: 2900 },
+    ]);
+
+    render(<LeadDetailPage />);
+
+    await screen.findByRole('heading', { name: 'Owner Example' });
+    fireEvent.click(screen.getByRole('button', { name: /convert/i }));
+    fireEvent.change(screen.getByLabelText(/nombre del inquilino/i), { target: { value: 'Example Building' } });
+    fireEvent.change(screen.getByLabelText('Plan *'), { target: { value: 'plan-pro-id' } });
+    fireEvent.click(screen.getByRole('button', { name: /convert/i }));
+
+    await waitFor(() => expect(convert).toHaveBeenCalledWith(
+      'lead-1',
+      expect.objectContaining({ planId: 'plan-pro-id' }),
+    ));
+    expect(await screen.findByText(/plan PRO/i)).toBeTruthy();
+  });
+});

--- a/apps/web/app/super-admin/leads/[id]/page.tsx
+++ b/apps/web/app/super-admin/leads/[id]/page.tsx
@@ -9,6 +9,10 @@ import Textarea from '@/shared/components/ui/Textarea';
 import Select from '@/shared/components/ui/Select';
 import Badge from '@/shared/components/ui/Badge';
 import { useLeads } from '@/features/super-admin/leads/useLeads';
+import {
+  ConversionBillingPlan,
+  listConversionBillingPlans,
+} from '@/features/super-admin/leads/leads.api';
 import { t } from '@/i18n';
 import { ErrorBoundary } from '@/shared/components/error-boundary';
 
@@ -66,6 +70,9 @@ export default function LeadDetailPage() {
   const [notes, setNotes] = useState<string>('');
   const [tenantName, setTenantName] = useState<string>('');
   const [ownerEmail, setOwnerEmail] = useState<string>('');
+  const [plans, setPlans] = useState<ConversionBillingPlan[]>([]);
+  const [selectedPlanId, setSelectedPlanId] = useState<string>('');
+  const [plansError, setPlansError] = useState<string | null>(null);
   const [showConvertForm, setShowConvertForm] = useState(false);
 
   useEffect(() => {
@@ -90,6 +97,23 @@ export default function LeadDetailPage() {
 
     if (leadId) {
       loadLead();
+    }
+  }, [leadId]);
+
+  useEffect(() => {
+    const loadPlans = async () => {
+      try {
+        setPlansError(null);
+        setSelectedPlanId('');
+        setPlans(await listConversionBillingPlans());
+      } catch {
+        setPlans([]);
+        setPlansError('No se pudieron cargar los planes disponibles. Intentá nuevamente.');
+      }
+    };
+
+    if (leadId) {
+      void loadPlans();
     }
   }, [leadId]);
 
@@ -124,6 +148,11 @@ export default function LeadDetailPage() {
       return;
     }
 
+    if (!selectedPlanId) {
+      setError('Seleccioná un plan para la administración');
+      return;
+    }
+
     try {
       setIsConverting(true);
       setError(null);
@@ -131,19 +160,21 @@ export default function LeadDetailPage() {
         tenantName: tenantName.trim(),
         tenantType: lead?.tenantType,
         ownerEmail: ownerEmail.trim(),
+        planId: selectedPlanId,
       });
       if (result && result.tenantId) {
         const deliveryFailed = result.invitationEmailStatus !== 'SENT';
         setInvitationDeliveryFailed(deliveryFailed);
         setSuccessMessage(
           deliveryFailed
-            ? 'Administración creada, pero no se pudo enviar la invitación. Podés reenviarla.'
-            : 'Administración creada e invitación enviada.',
+            ? `Administración creada con plan ${result.plan}, pero no se pudo enviar la invitación. Podés reenviarla.`
+            : `Administración creada con plan ${result.plan} e invitación enviada.`,
         );
         setSuccessTenantId(result.tenantId);
         setShowConvertForm(false);
         setTenantName('');
         setOwnerEmail('');
+        setSelectedPlanId('');
         // Refresh lead data
         const updated = await fetchLead(leadId);
         if (updated) {
@@ -415,10 +446,11 @@ export default function LeadDetailPage() {
                 ) : (
                   <>
                     <div>
-                      <label className="block text-xs font-medium mb-2">
+                      <label className="block text-xs font-medium mb-2" htmlFor="conversion-tenant-name">
                         {t('superAdmin.leads.tenantName')} *
                       </label>
                       <Input
+                        id="conversion-tenant-name"
                         value={tenantName}
                         onChange={(e) => setTenantName(e.target.value)}
                         placeholder={t('forms.placeholder')}
@@ -435,10 +467,29 @@ export default function LeadDetailPage() {
                         placeholder="owner@example.com"
                       />
                     </div>
+                    <div>
+                      <label className="block text-xs font-medium mb-2" htmlFor="conversion-plan">
+                        Plan *
+                      </label>
+                      <Select
+                        id="conversion-plan"
+                        value={selectedPlanId}
+                        onChange={(event) => setSelectedPlanId(event.target.value)}
+                        disabled={isConverting || plans.length === 0}
+                      >
+                        <option value="">Seleccioná un plan</option>
+                        {plans.map((plan) => (
+                          <option key={plan.id} value={plan.id}>
+                            {plan.name} ({plan.planId})
+                          </option>
+                        ))}
+                      </Select>
+                      {plansError && <p className="mt-1 text-xs text-red-700">{plansError}</p>}
+                    </div>
                     <div className="flex gap-2">
                       <Button
                         onClick={handleConvertLead}
-                        disabled={isConverting || !tenantName.trim() || !ownerEmail.trim()}
+                        disabled={isConverting || !tenantName.trim() || !ownerEmail.trim() || !selectedPlanId}
                         className="flex-1"
                       >
                         {isConverting ? t('superAdmin.leads.converting') : t('superAdmin.leads.convertButton')}
@@ -448,6 +499,7 @@ export default function LeadDetailPage() {
                           setShowConvertForm(false);
                           setTenantName('');
                           setOwnerEmail('');
+                          setSelectedPlanId('');
                         }}
                         className="flex-1"
                       >

--- a/apps/web/features/super-admin/leads/leads.api.test.ts
+++ b/apps/web/features/super-admin/leads/leads.api.test.ts
@@ -1,5 +1,5 @@
 import { apiClient } from '@/shared/lib/http/client';
-import { resendLeadInvitation } from './leads.api';
+import { convertLead, listConversionBillingPlans, resendLeadInvitation } from './leads.api';
 
 jest.mock('@/shared/lib/http/client', () => ({
   apiClient: jest.fn(),
@@ -20,6 +20,35 @@ describe('lead API', () => {
     expect(mockedApiClient).toHaveBeenCalledWith({
       path: '/leads/admin/lead-1/resend-invitation',
       method: 'POST',
+    });
+  });
+
+  it('sends the selected persisted billing plan id when converting a lead', async () => {
+    mockedApiClient.mockResolvedValue({} as Awaited<ReturnType<typeof convertLead>>);
+
+    await convertLead('lead-1', {
+      tenantName: 'Example Building',
+      planId: 'billing-plan-pro-id',
+    });
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/leads/admin/lead-1/convert',
+      method: 'POST',
+      body: {
+        tenantName: 'Example Building',
+        planId: 'billing-plan-pro-id',
+      },
+    });
+  });
+
+  it('loads persisted billing plans for the conversion selector', async () => {
+    mockedApiClient.mockResolvedValue([]);
+
+    await listConversionBillingPlans();
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/leads/admin/billing-plans',
+      method: 'GET',
     });
   });
 });

--- a/apps/web/features/super-admin/leads/leads.api.ts
+++ b/apps/web/features/super-admin/leads/leads.api.ts
@@ -48,6 +48,16 @@ export interface ConvertLeadResponse {
   ownerUserId: string;
   inviteSent: boolean;
   invitationEmailStatus: 'SENT' | 'FAILED' | 'DISABLED';
+  plan: string;
+  subscriptionStatus: string;
+  trialEndDate: string;
+}
+
+export interface ConversionBillingPlan {
+  id: string;
+  planId: string;
+  name: string;
+  monthlyPrice: number;
 }
 
 export interface ResendLeadInvitationResponse {
@@ -113,6 +123,13 @@ export async function convertLead(
     path: `/leads/admin/${id}/convert`,
     method: 'POST',
     body: dto,
+  });
+}
+
+export async function listConversionBillingPlans(): Promise<ConversionBillingPlan[]> {
+  return apiClient<ConversionBillingPlan[]>({
+    path: '/leads/admin/billing-plans',
+    method: 'GET',
   });
 }
 


### PR DESCRIPTION
## Summary

Ensures that SuperAdmin lead conversion assigns the billing plan explicitly selected during conversion.

This change:

- sends the persisted BillingPlan ID from the SuperAdmin interface;
- validates the selected plan inside the conversion transaction;
- assigns exactly the selected plan to the new subscription;
- preserves the canonical BASIC → FREE fallback when no plan is supplied;
- prevents partial tenant, user, membership, subscription or invitation creation when the plan is invalid;
- returns the billing plan code actually assigned;
- keeps invitation delivery outside failed conversions.

## Validation

- API focused tests: 10 passed
- Web API focused tests: 3 passed
- Web page focused test: 1 passed
- API typecheck passed
- Web typecheck passed
- API ESLint passed
- Web ESLint passed
- Pre-commit hook passed
- \`git diff --check\` passed

## Plan behavior

- A submitted \`planId\` is resolved by persisted BillingPlan ID.
- An unknown plan returns HTTP 400 without database writes.
- When \`planId\` is absent, the existing BASIC → FREE fallback is preserved.
- BillingPlan currently has no active/inactive field, so inactive-plan validation is not applicable.

## Not included

- Billing catalog changes
- BillingPlan active status
- Schema or migrations
- Consent
- CAPTCHA
- Mail configuration
- Staging or production changes