### PR TITLE
chore(local): add Mailpit email testing

### DIFF
--- a/apps/api/src/communications/email/adapters/smtp.adapter.ts
+++ b/apps/api/src/communications/email/adapters/smtp.adapter.ts
@@ -18,15 +18,28 @@ export class SmtpAdapter implements EmailProvider {
   }
 
   private initializeTransporter(): void {
-    this.transporter = nodemailer.createTransport({
+    const hasSmtpUser = Boolean(this.config.user);
+    const hasSmtpPass = Boolean(this.config.pass);
+    if (hasSmtpUser !== hasSmtpPass) {
+      throw new Error('SMTP authentication requires both user and password');
+    }
+
+    const transportOptions = {
       host: this.config.host,
       port: this.config.port,
       secure: this.config.port === 465,
-      auth: {
-        user: this.config.user,
-        pass: this.config.pass,
-      },
-    });
+    };
+    this.transporter = nodemailer.createTransport(
+      hasSmtpUser && hasSmtpPass
+        ? {
+            ...transportOptions,
+            auth: {
+              user: this.config.user!,
+              pass: this.config.pass!,
+            },
+          }
+        : transportOptions,
+    );
   }
 
   async send(options: SendEmailInput): Promise<SendResult> {

--- a/apps/api/src/communications/email/email-delivery.module.ts
+++ b/apps/api/src/communications/email/email-delivery.module.ts
@@ -38,8 +38,8 @@ export class EmailDeliveryModule {
             return new SmtpAdapter({
               host: options.smtpHost || '',
               port: options.smtpPort || 587,
-              user: options.smtpUser || '',
-              pass: options.smtpPass || '',
+              user: options.smtpUser,
+              pass: options.smtpPass,
               from: options.mailFrom,
             });
           case 'resend':

--- a/apps/api/src/communications/email/email-delivery.resolver.spec.ts
+++ b/apps/api/src/communications/email/email-delivery.resolver.spec.ts
@@ -61,6 +61,34 @@ describe('resolveEmailDelivery', () => {
         resolveEmailDelivery({ MAIL_PROVIDER: 'smtp' }),
       ).toThrow('SMTP_HOST is required when MAIL_PROVIDER=smtp');
     });
+
+    it('supports unauthenticated local SMTP when both credentials are empty', () => {
+      const result = resolveEmailDelivery({
+        MAIL_PROVIDER: 'smtp',
+        SMTP_HOST: '127.0.0.1',
+        SMTP_PORT: '1025',
+        SMTP_USER: '',
+        SMTP_PASS: '',
+      });
+
+      expect(result).toEqual(expect.objectContaining({
+        smtpHost: '127.0.0.1',
+        smtpPort: 1025,
+        smtpUser: undefined,
+        smtpPass: undefined,
+      }));
+    });
+
+    it.each([
+      { SMTP_USER: 'mailer' },
+      { SMTP_PASS: 'secret' },
+    ])('rejects partial SMTP credentials: %o', (credentials) => {
+      expect(() => resolveEmailDelivery({
+        MAIL_PROVIDER: 'smtp',
+        SMTP_HOST: 'smtp.example.com',
+        ...credentials,
+      })).toThrow('SMTP_USER and SMTP_PASS must both be set or both be empty');
+    });
   });
 
   describe('resend provider', () => {

--- a/apps/api/src/communications/email/email-delivery.resolver.ts
+++ b/apps/api/src/communications/email/email-delivery.resolver.ts
@@ -20,13 +20,18 @@ export function resolveEmailDelivery(env: NodeJS.ProcessEnv = process.env): Emai
         'Set the env var or switch to MAIL_PROVIDER=none.',
       );
     }
+    const smtpUser = env.SMTP_USER || undefined;
+    const smtpPass = env.SMTP_PASS || undefined;
+    if (Boolean(smtpUser) !== Boolean(smtpPass)) {
+      throw new Error('SMTP_USER and SMTP_PASS must both be set or both be empty when MAIL_PROVIDER=smtp.');
+    }
     return {
       mailProvider,
       mailFrom,
       smtpHost: env.SMTP_HOST,
       smtpPort: env.SMTP_PORT ? Number(env.SMTP_PORT) : 587,
-      smtpUser: env.SMTP_USER,
-      smtpPass: env.SMTP_PASS,
+      smtpUser,
+      smtpPass,
     };
   }
 

--- a/apps/api/src/config/config-production.spec.ts
+++ b/apps/api/src/config/config-production.spec.ts
@@ -288,7 +288,7 @@ describe('Production Readiness Config Validation', () => {
   });
 
   describe('SMTP config validation', () => {
-    it('requires SMTP_USER when MAIL_PROVIDER is smtp', () => {
+    it('rejects SMTP_PASS without SMTP_USER', () => {
       const schema = createConfigSchema('test');
       const result = schema.safeParse({
         ...baseEnv,
@@ -305,7 +305,7 @@ describe('Production Readiness Config Validation', () => {
       }
     });
 
-    it('requires SMTP_PASS when MAIL_PROVIDER is smtp', () => {
+    it('rejects SMTP_USER without SMTP_PASS', () => {
       const schema = createConfigSchema('test');
       const result = schema.safeParse({
         ...baseEnv,
@@ -322,7 +322,7 @@ describe('Production Readiness Config Validation', () => {
       }
     });
 
-    it('rejects blank SMTP_USER and SMTP_PASS when MAIL_PROVIDER is smtp', () => {
+    it('accepts blank SMTP_USER and SMTP_PASS for local unauthenticated SMTP', () => {
       const schema = createConfigSchema('test');
       const result = schema.safeParse({
         ...baseEnv,
@@ -333,12 +333,7 @@ describe('Production Readiness Config Validation', () => {
         SMTP_PASS: '',
       });
 
-      expect(result.success).toBe(false);
-      if (!result.success) {
-        const issues = result.error.issues.map((i) => i.message);
-        expect(issues.some((m) => m.includes('SMTP_USER'))).toBe(true);
-        expect(issues.some((m) => m.includes('SMTP_PASS'))).toBe(true);
-      }
+      expect(result.success).toBe(true);
     });
 
     it('accepts smtp provider with all runtime-required fields', () => {

--- a/apps/api/src/config/config.ts
+++ b/apps/api/src/config/config.ts
@@ -244,18 +244,18 @@ export const createConfigSchema = (_nodeEnv: string) => {
           message: 'SMTP_PORT is required when MAIL_PROVIDER=smtp',
         });
       }
-      if (!data.SMTP_USER) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ['SMTP_USER'],
-          message: 'SMTP_USER is required when MAIL_PROVIDER=smtp',
-        });
-      }
-      if (!data.SMTP_PASS) {
+      if (data.SMTP_USER && !data.SMTP_PASS) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ['SMTP_PASS'],
-          message: 'SMTP_PASS is required when MAIL_PROVIDER=smtp',
+          message: 'SMTP_PASS is required when SMTP_USER is set',
+        });
+      }
+      if (data.SMTP_PASS && !data.SMTP_USER) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['SMTP_USER'],
+          message: 'SMTP_USER is required when SMTP_PASS is set',
         });
       }
     }

--- a/apps/api/src/email/email.service.spec.ts
+++ b/apps/api/src/email/email.service.spec.ts
@@ -2,8 +2,20 @@ import { ConfigService } from '../config/config.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { EmailService } from './email.service';
 import { EmailType } from './email.types';
+import { Logger } from '@nestjs/common';
+import * as nodemailer from 'nodemailer';
+
+jest.mock('nodemailer', () => ({
+  createTransport: jest.fn(),
+}));
+
+const mockedCreateTransport = jest.mocked(nodemailer.createTransport);
 
 describe('EmailService', () => {
+  beforeEach(() => {
+    mockedCreateTransport.mockReset();
+  });
+
   it('reports skipped success and does not write an email log when provider is none', async () => {
     const configService = {
       getValue: jest.fn().mockReturnValue('none'),
@@ -31,5 +43,82 @@ describe('EmailService', () => {
 
     expect(result).toEqual({ success: true, skipped: true });
     expect(prismaService.emailLog.create).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { description: 'authenticated SMTP', smtpUser: 'mailer', smtpPass: 'secret', smtpPort: 587, secure: false, auth: { user: 'mailer', pass: 'secret' } },
+    { description: 'unauthenticated SMTP', smtpUser: undefined, smtpPass: undefined, smtpPort: 1025, secure: false, auth: undefined },
+    { description: 'blank local SMTP credentials', smtpUser: '', smtpPass: '', smtpPort: 1025, secure: false, auth: undefined },
+    { description: 'SMTPS', smtpUser: 'mailer', smtpPass: 'secret', smtpPort: 465, secure: true, auth: { user: 'mailer', pass: 'secret' } },
+  ])('configures $description without exposing credentials', async ({ smtpUser, smtpPass, smtpPort, secure, auth }) => {
+    const transporter = { verify: jest.fn().mockResolvedValue(undefined) };
+    mockedCreateTransport.mockReturnValue(transporter as unknown as nodemailer.Transporter);
+    const logger = jest.spyOn(Logger.prototype, 'log');
+    const service = new EmailService(
+      {
+        getValue: jest.fn().mockReturnValue('smtp'),
+        get: jest.fn().mockReturnValue({
+          mailProvider: 'smtp',
+          smtpHost: '127.0.0.1',
+          smtpPort,
+          smtpUser,
+          smtpPass,
+        }),
+      } as unknown as ConfigService,
+      { emailLog: { create: jest.fn() } } as unknown as PrismaService,
+    );
+
+    expect(mockedCreateTransport).toHaveBeenCalledWith(expect.objectContaining({
+      host: '127.0.0.1',
+      port: smtpPort,
+      secure,
+    }));
+    const options = mockedCreateTransport.mock.calls[0][0] as { auth?: unknown };
+    expect(options.auth).toEqual(auth);
+    await expect(service.checkHealth()).resolves.toEqual({ status: 'up', provider: 'smtp' });
+    expect(transporter.verify).toHaveBeenCalledTimes(1);
+    expect(logger).not.toHaveBeenCalledWith(expect.stringContaining('secret'));
+    logger.mockRestore();
+  });
+
+  it.each([
+    ['mailer', undefined],
+    [undefined, 'secret'],
+  ])('rejects partial SMTP credentials', (smtpUser, smtpPass) => {
+    expect(() => new EmailService(
+      {
+        getValue: jest.fn().mockReturnValue('smtp'),
+        get: jest.fn().mockReturnValue({
+          mailProvider: 'smtp',
+          smtpHost: '127.0.0.1',
+          smtpPort: 1025,
+          smtpUser,
+          smtpPass,
+        }),
+      } as unknown as ConfigService,
+      { emailLog: { create: jest.fn() } } as unknown as PrismaService,
+    )).toThrow('SMTP configuration incomplete');
+  });
+
+  it('reports SMTP readiness as down when transporter verification fails', async () => {
+    const transporter = { verify: jest.fn().mockRejectedValue(new Error('connection refused')) };
+    mockedCreateTransport.mockReturnValue(transporter as unknown as nodemailer.Transporter);
+    const service = new EmailService(
+      {
+        getValue: jest.fn().mockReturnValue('smtp'),
+        get: jest.fn().mockReturnValue({
+          mailProvider: 'smtp',
+          smtpHost: '127.0.0.1',
+          smtpPort: 1025,
+        }),
+      } as unknown as ConfigService,
+      { emailLog: { create: jest.fn() } } as unknown as PrismaService,
+    );
+
+    await expect(service.checkHealth()).resolves.toEqual({
+      status: 'down',
+      provider: 'smtp',
+      error: 'connection refused',
+    });
   });
 });

--- a/apps/api/src/email/email.service.ts
+++ b/apps/api/src/email/email.service.ts
@@ -48,22 +48,33 @@ export class EmailService {
   private initializeSMTP(): void {
     const config = this.config.get();
 
-    if (!config.smtpHost || !config.smtpPort || !config.smtpUser || !config.smtpPass) {
+    const hasSmtpUser = Boolean(config.smtpUser);
+    const hasSmtpPass = Boolean(config.smtpPass);
+
+    if (!config.smtpHost || !config.smtpPort || hasSmtpUser !== hasSmtpPass) {
       throw new Error('SMTP configuration incomplete');
     }
 
-    this.smtpTransporter = nodemailer.createTransport({
+    const transportOptions = {
       host: config.smtpHost,
       port: config.smtpPort,
       secure: config.smtpPort === 465, // TLS for 465, STARTTLS for 587
       connectionTimeout: 3000,
       greetingTimeout: 3000,
       socketTimeout: 3000,
-      auth: {
-        user: config.smtpUser,
-        pass: config.smtpPass,
-      },
-    });
+    };
+
+    this.smtpTransporter = nodemailer.createTransport(
+      hasSmtpUser && hasSmtpPass
+        ? {
+            ...transportOptions,
+            auth: {
+              user: config.smtpUser!,
+              pass: config.smtpPass!,
+            },
+          }
+        : transportOptions,
+    );
 
     this.logger.log(`[Email] SMTP configured: ${config.smtpHost}:${config.smtpPort}`);
   }

--- a/apps/api/src/email/email.types.ts
+++ b/apps/api/src/email/email.types.ts
@@ -50,8 +50,8 @@ export interface EmailLog {
 export interface SMTPConfig {
   host: string;
   port: number;
-  user: string;
-  pass: string;
+  user?: string;
+  pass?: string;
   from: string;
   secure?: boolean; // TLS
 }

--- a/infra/docker/README.md
+++ b/infra/docker/README.md
@@ -1,0 +1,29 @@
+# Local Docker services
+
+## Mailpit
+
+Mailpit is available only through the local Compose stack. It captures SMTP
+messages locally and does not relay them to external providers.
+
+Start it with:
+
+```bash
+docker compose -f infra/docker/docker-compose.yml up -d mailpit
+```
+
+The web inbox is available at `http://127.0.0.1:8025` and SMTP listens at
+`127.0.0.1:1025`.
+
+The API runs directly on macOS in the local workflow. Configure its ignored
+`apps/api/.env` file without adding it to Git:
+
+```dotenv
+MAIL_PROVIDER=smtp
+SMTP_HOST=127.0.0.1
+SMTP_PORT=1025
+SMTP_USER=
+SMTP_PASS=
+```
+
+Both SMTP credentials must be set together for authenticated SMTP, or both be
+empty for Mailpit. No credentials are required for Mailpit.

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -82,6 +82,16 @@ services:
       "
     restart: on-failure
 
+  mailpit:
+    image: axllent/mailpit:v1.30.0
+    container_name: buildingos-mailpit
+    networks:
+      - buildingos_net
+    ports:
+      - "127.0.0.1:1025:1025"
+      - "127.0.0.1:8025:8025"
+    restart: unless-stopped
+
 volumes:
   buildingos_pgdata:
   buildingos_miniodata:


### PR DESCRIPTION
## Summary

Adds Mailpit to the local BuildingOS development environment for safe email testing without Gmail or an external provider.

This change:

- adds a local Mailpit service to Docker Compose;
- exposes SMTP on `127.0.0.1:1025`;
- exposes the local inbox on `127.0.0.1:8025`;
- supports SMTP without authentication when both credentials are absent;
- preserves authenticated SMTP when both credentials are configured;
- rejects incomplete SMTP credentials;
- keeps staging and production unchanged.

## Validation

- 71 focused tests passed
- API typecheck passed
- API ESLint passed
- Docker Compose configuration passed
- `git diff --check` passed
- Mailpit container healthy
- Mailpit `/livez` returned 200
- Mailpit `/readyz` returned 200
- SMTP port 1025 accessible
- API `/health` returned `ok`
- API `/ready` returned `healthy`
- API `/readyz` returned `healthy`
- Email readiness reported SMTP `up`

## Not included

- External email provider
- Gmail credentials
- Resend configuration
- Staging changes
- Production changes
- Schema changes
- Migrations
- Seeds
- Database changes

## Pending manual validation

- Generate an invitation from BuildingOS
- Confirm the email is captured in Mailpit
- Open the invitation and define the administrator password