### PR TITLE
fix(prisma): add receipt sequence migration

### DIFF
--- a/apps/api/prisma/migrations/20260719000000_add_receipt_sequence/migration.sql
+++ b/apps/api/prisma/migrations/20260719000000_add_receipt_sequence/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE "ReceiptSequence" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "year" INTEGER NOT NULL,
+    "lastNumber" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ReceiptSequence_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ReceiptSequence_tenantId_year_key" ON "ReceiptSequence"("tenantId", "year");
+
+-- CreateIndex
+CREATE INDEX "ReceiptSequence_tenantId_idx" ON "ReceiptSequence"("tenantId");
+
+-- AddForeignKey
+ALTER TABLE "ReceiptSequence" ADD CONSTRAINT "ReceiptSequence_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;


### PR DESCRIPTION
## Summary

Adds the missing additive Prisma migration for the existing `ReceiptSequence` model.

The model already existed in:

- `schema.prisma`
- the generated Prisma Client

However, no repository migration created the corresponding PostgreSQL table, causing Prisma queries to fail with `P2021`.

## Changes

Creates `public."ReceiptSequence"` with:

- primary key
- `tenantId`
- `year`
- `lastNumber`
- timestamps
- unique constraint on `tenantId` and `year`
- index on `tenantId`
- foreign key to `Tenant`

## Validation

- Migration tested against an isolated PostgreSQL database
- 80 migrations applied successfully
- 0 pending migrations
- 0 failed migrations
- `ReceiptSequence` table verified
- Primary key verified
- Unique constraint verified
- Tenant index verified
- Foreign key verified
- Prisma `receiptSequence.count()` verified
- Duplicate `tenantId` and `year` rejected
- API typecheck passed
- `git diff --check` passed
- Temporary database removed

## Scope

- One new migration file
- No changes to `schema.prisma`
- No historical migrations modified
- No generated files modified
- No seeds
- No staging changes
- No production changes
- Active local database not modified

## Known pre-existing validation issue

`prisma format --check` fails against the existing unchanged schema. The schema was not reformatted or modified because that issue is outside this migration's scope.