### PR TITLE
fix(api): stabilize onboarding import preview and confirmation

### DIFF
--- a/apps/api/prisma/migrations/20260720000000_version_onboarding_import_preview_identity/migration.sql
+++ b/apps/api/prisma/migrations/20260720000000_version_onboarding_import_preview_identity/migration.sql
@@ -1,0 +1,5 @@
+-- Allow the same workbook to be previewed again after a validator change while preserving prior previews.
+CREATE UNIQUE INDEX "ImportJob_tenantId_type_schemaVersion_previewVersion_fileHash_key"
+  ON "ImportJob"("tenantId", "type", "schemaVersion", "previewVersion", "fileHash");
+
+DROP INDEX "ImportJob_tenantId_type_schemaVersion_fileHash_key";

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1343,7 +1343,7 @@ model ImportJob {
   issues                ImportIssue[]
   importedCharges       Charge[]
 
-  @@unique([tenantId, type, schemaVersion, fileHash])
+  @@unique([tenantId, type, schemaVersion, previewVersion, fileHash])
   @@index([tenantId, status])
   @@index([tenantId, expiresAt])
   @@index([tenantId, createdAt])

--- a/apps/api/src/onboarding-imports/onboarding-imports.constants.ts
+++ b/apps/api/src/onboarding-imports/onboarding-imports.constants.ts
@@ -1,6 +1,7 @@
 import { ImportType } from '@prisma/client';
 
 export const ONBOARDING_IMPORT_SCHEMA_VERSION = 'v1';
+export const ONBOARDING_IMPORT_PREVIEW_VERSION = 3;
 export const ONBOARDING_IMPORT_TYPE = ImportType.INITIAL_ONBOARDING;
 export const ONBOARDING_IMPORT_TEMPLATE_FILENAME = 'buildingos-importacion-inicial-v1.xlsx';
 export const ONBOARDING_IMPORT_TEMPLATE_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
@@ -16,6 +17,8 @@ export const ONBOARDING_IMPORT_MAX_CELL_TEXT_LENGTH = 5000;
 export const ONBOARDING_IMPORT_ISSUE_PAGE_SIZE_MAX = 100;
 export const ONBOARDING_IMPORT_EXPIRES_DAYS = 30;
 export const ONBOARDING_IMPORT_CONFIRM_LOCK_TIMEOUT_MS = 5 * 60 * 1000;
+export const ONBOARDING_IMPORT_CONFIRM_TRANSACTION_MAX_WAIT_MS = 10 * 1000;
+export const ONBOARDING_IMPORT_CONFIRM_TRANSACTION_TIMEOUT_MS = 60 * 1000;
 
 export const ONBOARDING_IMPORT_ALLOWED_MIME_TYPES = new Set<string>([
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',

--- a/apps/api/src/onboarding-imports/onboarding-imports.service.spec.ts
+++ b/apps/api/src/onboarding-imports/onboarding-imports.service.spec.ts
@@ -430,6 +430,79 @@ describe('OnboardingImportsService', () => {
     );
   });
 
+  it('revalidates an identical workbook when its only preview is from an older validation version', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
+    prisma.importJob.findUnique.mockImplementation(({ where }) => {
+      const previewVersion = where.tenantId_type_schemaVersion_previewVersion_fileHash.previewVersion;
+
+      return Promise.resolve(previewVersion === 1 ? {
+        id: 'import-legacy-preview',
+        tenantId,
+        type: 'INITIAL_ONBOARDING',
+        fileName: 'import.xlsx',
+        fileHash: 'legacy-hash',
+        schemaVersion: 'v1',
+        previewVersion: 1,
+        status: ImportJobStatus.BLOCKED,
+        canConfirm: false,
+        expiresAt: new Date(Date.now() + 86_400_000),
+        createdAt: new Date('2026-07-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+        summary: createSummary({ blockingIssues: 1 }),
+        counts: createSummary({ blockingIssues: 1 }),
+        issues: [{ id: 'issue-legacy' }],
+      } : null);
+    });
+    parserService.parseWorkbook.mockReturnValue({ data: buildParsedData(currentPeriod), issues: [] });
+    jest.spyOn(service as any, 'validateWorkbook').mockResolvedValue({
+      summary: createSummary(),
+      issues: [],
+    });
+    transactionCreate.mockResolvedValue({
+      id: 'import-current-preview',
+      tenantId,
+      type: 'INITIAL_ONBOARDING',
+      fileName: 'import.xlsx',
+      fileHash: 'current-hash',
+      schemaVersion: 'v1',
+      previewVersion: 3,
+      status: ImportJobStatus.READY,
+      canConfirm: true,
+      expiresAt: new Date(Date.now() + 86_400_000),
+      createdAt: new Date('2026-07-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+      summary: createSummary(),
+      counts: createSummary(),
+      issues: [],
+    });
+
+    const result = await service.previewImport(
+      { tenantId, user: buildUser(['TENANT_ADMIN']) },
+      {
+        buffer: Buffer.from('xlsx-data'),
+        originalname: 'import.xlsx',
+        mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        size: 9,
+      } as UploadableSpreadsheetFile,
+    );
+
+    expect(prisma.importJob.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          tenantId_type_schemaVersion_previewVersion_fileHash: {
+            tenantId,
+            type: 'INITIAL_ONBOARDING',
+            schemaVersion: 'v1',
+            previewVersion: 3,
+            fileHash: expect.any(String),
+          },
+        },
+      }),
+    );
+    expect(result.importId).toBe('import-current-preview');
+    expect(minio.uploadBuffer).toHaveBeenCalledTimes(2);
+  });
+
   it('serves the official template and records the access in audit logs', async () => {
     prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
 
@@ -568,8 +641,23 @@ describe('OnboardingImportsService', () => {
     expect(minio.uploadBuffer).toHaveBeenCalledTimes(1);
     expect(prisma.importJob.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
-        update: expect.objectContaining({ status: ImportJobStatus.FAILED }),
-        create: expect.objectContaining({ status: ImportJobStatus.FAILED }),
+        where: {
+          tenantId_type_schemaVersion_previewVersion_fileHash: {
+            tenantId,
+            type: 'INITIAL_ONBOARDING',
+            schemaVersion: 'v1',
+            previewVersion: 3,
+            fileHash: expect.any(String),
+          },
+        },
+        update: expect.objectContaining({
+          status: ImportJobStatus.FAILED,
+          previewVersion: 3,
+        }),
+        create: expect.objectContaining({
+          status: ImportJobStatus.FAILED,
+          previewVersion: 3,
+        }),
       }),
     );
     expect(auditService.createLog).toHaveBeenCalledWith(

--- a/apps/api/src/onboarding-imports/onboarding-imports.service.ts
+++ b/apps/api/src/onboarding-imports/onboarding-imports.service.ts
@@ -18,7 +18,7 @@ import { createHash, randomUUID } from 'crypto';
 import { AuditService } from '../audit/audit.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { MinioService } from '../storage/minio.service';
-import { ONBOARDING_IMPORT_ALLOWED_MIME_TYPES, ONBOARDING_IMPORT_EXPIRES_DAYS, ONBOARDING_IMPORT_ISSUE_PAGE_SIZE_MAX, ONBOARDING_IMPORT_MAX_FILE_SIZE_BYTES, ONBOARDING_IMPORT_OBJECT_KEY_PREFIX, ONBOARDING_IMPORT_SCHEMA_VERSION, ONBOARDING_IMPORT_TYPE } from './onboarding-imports.constants';
+import { ONBOARDING_IMPORT_ALLOWED_MIME_TYPES, ONBOARDING_IMPORT_EXPIRES_DAYS, ONBOARDING_IMPORT_ISSUE_PAGE_SIZE_MAX, ONBOARDING_IMPORT_MAX_FILE_SIZE_BYTES, ONBOARDING_IMPORT_OBJECT_KEY_PREFIX, ONBOARDING_IMPORT_PREVIEW_VERSION, ONBOARDING_IMPORT_SCHEMA_VERSION, ONBOARDING_IMPORT_TYPE } from './onboarding-imports.constants';
 import { OnboardingImportConfirmationService } from './services/onboarding-import-confirmation.service';
 import { OnboardingImportNormalizerService } from './services/onboarding-import-normalizer.service';
 import { OnboardingImportParserService } from './services/onboarding-import-parser.service';
@@ -240,7 +240,7 @@ export class OnboardingImportsService {
       const validation = await this.validateWorkbook(input.tenantId, access.tenantCurrency, parsed.data, parsed.issues);
       const status = validation.summary.blockingIssues > 0 ? ImportJobStatus.BLOCKED : ImportJobStatus.READY;
       const normalizedObjectKey = status === ImportJobStatus.READY ? keys.normalizedObjectKey : null;
-      const previewVersion = 1;
+      const previewVersion = ONBOARDING_IMPORT_PREVIEW_VERSION;
       const previewHash = this.computeHash(Buffer.from(JSON.stringify(this.buildNormalizedPayload(input.tenantId, importId, fileHash, fileName, validation, parsed.data)), 'utf8'));
 
       if (normalizedObjectKey) {
@@ -1058,10 +1058,11 @@ export class OnboardingImportsService {
 
       await this.prisma.importJob.upsert({
         where: {
-          tenantId_type_schemaVersion_fileHash: {
+          tenantId_type_schemaVersion_previewVersion_fileHash: {
             tenantId: input.tenantId,
             type: ONBOARDING_IMPORT_TYPE,
             schemaVersion: ONBOARDING_IMPORT_SCHEMA_VERSION,
+            previewVersion: ONBOARDING_IMPORT_PREVIEW_VERSION,
             fileHash: input.fileHash,
           },
         },
@@ -1069,7 +1070,7 @@ export class OnboardingImportsService {
           status: ImportJobStatus.FAILED,
           errorCode,
           errorMessage,
-          previewVersion: 1,
+          previewVersion: ONBOARDING_IMPORT_PREVIEW_VERSION,
           previewHash: null,
           summary: summary as unknown as Prisma.JsonObject,
           counts: summary as unknown as Prisma.JsonObject,
@@ -1087,7 +1088,7 @@ export class OnboardingImportsService {
           type: ONBOARDING_IMPORT_TYPE,
           status: ImportJobStatus.FAILED,
           schemaVersion: ONBOARDING_IMPORT_SCHEMA_VERSION,
-          previewVersion: 1,
+          previewVersion: ONBOARDING_IMPORT_PREVIEW_VERSION,
           fileName: input.fileName,
           fileSize: input.fileSize,
           fileMimeType: input.fileMimeType,
@@ -1112,10 +1113,11 @@ export class OnboardingImportsService {
   private async findExistingJob(tenantId: string, fileHash: string): Promise<ImportJobView | null> {
     const job = await this.prisma.importJob.findUnique({
       where: {
-        tenantId_type_schemaVersion_fileHash: {
+        tenantId_type_schemaVersion_previewVersion_fileHash: {
           tenantId,
           type: ONBOARDING_IMPORT_TYPE,
           schemaVersion: ONBOARDING_IMPORT_SCHEMA_VERSION,
+          previewVersion: ONBOARDING_IMPORT_PREVIEW_VERSION,
           fileHash,
         },
       },

--- a/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.spec.ts
+++ b/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.spec.ts
@@ -352,6 +352,14 @@ describe('OnboardingImportConfirmationService', () => {
         chargesCreated: 1,
       },
     });
+    expect(prisma.$transaction).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+        maxWait: 10_000,
+        timeout: 60_000,
+      }),
+    );
     expect(result.confirmedAt).toEqual(expect.any(String));
 
     expect(prisma.importJob.updateMany).toHaveBeenCalledWith({

--- a/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.ts
+++ b/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.ts
@@ -20,7 +20,12 @@ import { createHash } from 'crypto';
 import { AuditService } from '../../audit/audit.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { MinioService } from '../../storage/minio.service';
-import { ONBOARDING_IMPORT_CONFIRM_LOCK_TIMEOUT_MS, ONBOARDING_IMPORT_SCHEMA_VERSION } from '../onboarding-imports.constants';
+import {
+  ONBOARDING_IMPORT_CONFIRM_LOCK_TIMEOUT_MS,
+  ONBOARDING_IMPORT_CONFIRM_TRANSACTION_MAX_WAIT_MS,
+  ONBOARDING_IMPORT_CONFIRM_TRANSACTION_TIMEOUT_MS,
+  ONBOARDING_IMPORT_SCHEMA_VERSION,
+} from '../onboarding-imports.constants';
 import type {
   ConfirmOnboardingImportRequest,
   ConfirmOnboardingImportResult,
@@ -353,7 +358,11 @@ export class OnboardingImportConfirmationService {
           );
 
           return result;
-        }, { isolationLevel: Prisma.TransactionIsolationLevel.Serializable });
+        }, {
+          isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+          maxWait: ONBOARDING_IMPORT_CONFIRM_TRANSACTION_MAX_WAIT_MS,
+          timeout: ONBOARDING_IMPORT_CONFIRM_TRANSACTION_TIMEOUT_MS,
+        });
       } catch (error) {
         if (this.isSerializationConflict(error) && attempt === 0) {
           attempt += 1;


### PR DESCRIPTION
Closes #33

## Summary
- Revalidates identical onboarding workbooks after validation-version changes while preserving historical previews.
- Adds the required ImportJob unique-index migration.
- Extends the confirmation transaction limits to prevent P2028 on large imports.

## Validation
- Focused Jest: 28 tests passed.
- API TypeScript, ESLint, Prisma validation, and git diff --check passed.