### PR TITLE
feat(finance): add operational building delinquency list

### DIFF
--- a/apps/api/src/finanzas/finanzas.controller.ts
+++ b/apps/api/src/finanzas/finanzas.controller.ts
@@ -47,9 +47,11 @@ import {
   GetPaymentAllocationsParamDto,
   FinancialSummaryParamDto,
   FinancialSummaryQueryDto,
+  BuildingDelinquencyQueryDto,
   ChargeDetailDto,
   PaymentDetailDto,
   FinancialSummaryDto,
+  BuildingDelinquencyResponseDto,
   FinanceTrendQueryDto,
   MonthlyTrendDto,
 } from './finanzas.dto';
@@ -545,6 +547,28 @@ export class FinanzasController {
       tenantId,
       params.buildingId,
       query.period || undefined,
+    );
+  }
+
+  /**
+   * GET /buildings/:buildingId/finance/delinquency?period=&page=&pageSize=
+   * Return the complete operational delinquency list for one building.
+   */
+  @Get('finance/delinquency')
+  async getBuildingDelinquency(
+    @Param() params: FinancialSummaryParamDto,
+    @Query() query: BuildingDelinquencyQueryDto,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<BuildingDelinquencyResponseDto> {
+    const userRoles = req.user.roles || [];
+    if (!this.adminRoles.some((role) => userRoles.includes(role))) {
+      throw new ForbiddenException('Solo administradores pueden consultar la morosidad completa');
+    }
+
+    return this.finanzasService.getBuildingDelinquency(
+      req.tenantId!,
+      params.buildingId,
+      query,
     );
   }
 

--- a/apps/api/src/finanzas/finanzas.dto.ts
+++ b/apps/api/src/finanzas/finanzas.dto.ts
@@ -1,4 +1,5 @@
-import { IsString, IsOptional, IsInt, IsPositive, IsEnum, IsDateString, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { IsString, IsOptional, IsInt, IsPositive, IsEnum, IsDateString, IsIn, Matches, MaxLength, Min, Max } from 'class-validator';
 import { ChargeType, ChargeStatus, PaymentStatus, PaymentMethod } from '@prisma/client';
 import {
   BuildingChargeParamDto,
@@ -436,6 +437,85 @@ export class FinancialSummaryQueryDto {
   @IsOptional()
   @IsString()
   period?: string;
+}
+
+export enum BuildingDelinquencyAging {
+  ALL = 'ALL',
+  ONE_PERIOD = 'ONE_PERIOD',
+  TWO_TO_THREE_PERIODS = 'TWO_TO_THREE_PERIODS',
+  MORE_THAN_THREE_PERIODS = 'MORE_THAN_THREE_PERIODS',
+}
+
+export enum BuildingDelinquencySortBy {
+  ACCUMULATED_DEBT = 'ACCUMULATED_DEBT',
+  PERIOD_DEBT = 'PERIOD_DEBT',
+  OVERDUE_PERIODS = 'OVERDUE_PERIODS',
+  UNIT = 'UNIT',
+}
+
+export enum BuildingDelinquencySortOrder {
+  ASC = 'asc',
+  DESC = 'desc',
+}
+
+export class BuildingDelinquencyQueryDto {
+  @IsString()
+  @Matches(/^\d{4}-(0[1-9]|1[0-2])$/)
+  period!: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @IsIn([25, 50, 100])
+  pageSize?: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  search?: string;
+
+  @IsOptional()
+  @IsEnum(BuildingDelinquencyAging)
+  aging?: BuildingDelinquencyAging;
+
+  @IsOptional()
+  @IsEnum(BuildingDelinquencySortBy)
+  sortBy?: BuildingDelinquencySortBy;
+
+  @IsOptional()
+  @IsEnum(BuildingDelinquencySortOrder)
+  sortOrder?: BuildingDelinquencySortOrder;
+}
+
+export interface BuildingDelinquencyItemDto {
+  unitId: string;
+  unitCode: string;
+  unitLabel: string;
+  responsibleName: string | null;
+  periodDebt: number;
+  accumulatedDebt: number;
+  overduePeriods: number;
+}
+
+export interface BuildingDelinquencyResponseDto {
+  items: BuildingDelinquencyItemDto[];
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+  totals: {
+    periodDebt: number;
+    accumulatedDebt: number;
+  };
+  currency: string;
 }
 
 // ============================================================================

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -58,6 +58,8 @@ describe('FinanzasService', () => {
             expense: {
               findMany: jest.fn(),
             },
+            $queryRaw: jest.fn(),
+            $transaction: jest.fn(),
           },
         },
         {
@@ -675,6 +677,85 @@ describe('FinanzasService', () => {
           period: '2026-06',
         }),
       }));
+    });
+  });
+
+  describe('getBuildingDelinquency', () => {
+    it('returns a server-side page with period and accumulated debt totals', async () => {
+      jest.spyOn(validators, 'validateBuildingBelongsToTenant').mockResolvedValue(undefined);
+      jest.spyOn(prismaService.tenant, 'findUniqueOrThrow').mockResolvedValue({ currency: 'ARS' } as never);
+      jest.spyOn(prismaService, '$transaction').mockResolvedValue([
+        [
+          {
+            unitId: 'unit-1',
+            unitCode: 'TS-01-07',
+            unitLabel: 'Piso 01 - Apartamento 07',
+            responsibleName: 'Ana Pérez',
+            periodDebt: 6900000n,
+            accumulatedDebt: 75420000n,
+            overduePeriods: 4n,
+          },
+        ],
+        [{ total: 96n }],
+        [{ periodDebt: 565800000n, accumulatedDebt: 6426000000n }],
+      ] as never);
+
+      const result = await service.getBuildingDelinquency('tenant-1', 'building-1', {
+        period: '2026-07',
+        page: 1,
+        pageSize: 25,
+        sortBy: 'ACCUMULATED_DEBT' as never,
+        sortOrder: 'desc' as never,
+      });
+
+      expect(validators.validateBuildingBelongsToTenant).toHaveBeenCalledWith('tenant-1', 'building-1');
+      expect(prismaService.$transaction).toHaveBeenCalledWith(expect.any(Array));
+      expect(result).toEqual({
+        items: [
+          {
+            unitId: 'unit-1',
+            unitCode: 'TS-01-07',
+            unitLabel: 'Piso 01 - Apartamento 07',
+            responsibleName: 'Ana Pérez',
+            periodDebt: 6900000,
+            accumulatedDebt: 75420000,
+            overduePeriods: 4,
+          },
+        ],
+        page: 1,
+        pageSize: 25,
+        total: 96,
+        totalPages: 4,
+        totals: {
+          periodDebt: 565800000,
+          accumulatedDebt: 6426000000,
+        },
+        currency: 'ARS',
+      });
+    });
+
+    it('preserves the selected period boundary and resets an empty result to zero pages', async () => {
+      jest.spyOn(validators, 'validateBuildingBelongsToTenant').mockResolvedValue(undefined);
+      jest.spyOn(prismaService.tenant, 'findUniqueOrThrow').mockResolvedValue({ currency: 'ARS' } as never);
+      jest.spyOn(prismaService, '$transaction').mockResolvedValue([
+        [],
+        [{ total: 0n }],
+        [{ periodDebt: 0n, accumulatedDebt: 0n }],
+      ] as never);
+
+      const result = await service.getBuildingDelinquency('tenant-1', 'building-1', {
+        period: '2026-07',
+        aging: 'MORE_THAN_THREE_PERIODS' as never,
+      });
+
+      expect(result).toMatchObject({
+        items: [],
+        page: 1,
+        pageSize: 25,
+        total: 0,
+        totalPages: 0,
+      });
+      expect(prismaService.$queryRaw).toHaveBeenCalledTimes(3);
     });
   });
 

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -18,6 +18,12 @@ import {
   ListPaymentsQueryDto,
   ListPendingPaymentsQueryDto,
   FinancialSummaryDto,
+  BuildingDelinquencyAging,
+  BuildingDelinquencyItemDto,
+  BuildingDelinquencyQueryDto,
+  BuildingDelinquencyResponseDto,
+  BuildingDelinquencySortBy,
+  BuildingDelinquencySortOrder,
   PaymentMetricsQueryDto,
   PaymentMetricsDto,
   PaymentAuditLogDto,
@@ -38,6 +44,25 @@ export interface PendingPaymentListItem extends Payment {
 export interface BuildingFinancialSummaryPeriodFilter {
   period?: string;
   periods?: string[];
+}
+
+interface RawDelinquencyRow {
+  unitId: string;
+  unitCode: string;
+  unitLabel: string;
+  responsibleName: string | null;
+  periodDebt: bigint | number | string;
+  accumulatedDebt: bigint | number | string;
+  overduePeriods: bigint | number | string;
+}
+
+interface RawDelinquencyCountRow {
+  total: bigint | number | string;
+}
+
+interface RawDelinquencyTotalsRow {
+  periodDebt: bigint | number | string;
+  accumulatedDebt: bigint | number | string;
 }
 
 @Injectable()
@@ -1211,6 +1236,218 @@ export class FinanzasService {
       topDelinquentUnits,
       currency: tenant.currency,
     };
+  }
+
+  /**
+   * Return a server-side paginated operational delinquency list for one building.
+   *
+   * A unit is included only when it has an outstanding balance for the selected
+   * period. Its accumulated balance and overdue-period count include only charges
+   * from that period or an earlier period.
+   */
+  async getBuildingDelinquency(
+    tenantId: string,
+    buildingId: string,
+    query: BuildingDelinquencyQueryDto,
+  ): Promise<BuildingDelinquencyResponseDto> {
+    await this.validators.validateBuildingBelongsToTenant(tenantId, buildingId);
+
+    const tenant = await this.prisma.tenant.findUniqueOrThrow({
+      where: { id: tenantId },
+      select: { currency: true },
+    });
+    const page = query.page ?? 1;
+    const pageSize = query.pageSize ?? 25;
+    const skip = (page - 1) * pageSize;
+    const search = query.search?.trim();
+    const searchPattern = search ? `%${search}%` : null;
+
+    const searchClause = searchPattern
+      ? Prisma.sql`AND (
+          unit_rows."unitCode" ILIKE ${searchPattern}
+          OR unit_rows."unitLabel" ILIKE ${searchPattern}
+          OR unit_rows."responsibleName" ILIKE ${searchPattern}
+        )`
+      : Prisma.empty;
+    const agingClause = this.buildDelinquencyAgingClause(query.aging);
+    const orderBy = this.getDelinquencyOrderBy(query.sortBy, query.sortOrder);
+
+    const baseQuery = Prisma.sql`
+      WITH charge_balances AS (
+        SELECT
+          charge."unitId",
+          charge.period,
+          GREATEST(
+            charge.amount - COALESCE(
+              SUM(
+                CASE
+                  WHEN payment.status IN ('APPROVED', 'RECONCILED')
+                    THEN allocation.amount
+                  ELSE 0
+                END
+              ),
+              0
+            ),
+            0
+          ) AS outstanding
+        FROM "Charge" AS charge
+        LEFT JOIN "PaymentAllocation" AS allocation
+          ON allocation."chargeId" = charge.id
+          AND allocation."tenantId" = ${tenantId}
+        LEFT JOIN "Payment" AS payment
+          ON payment.id = allocation."paymentId"
+          AND payment."tenantId" = ${tenantId}
+          AND payment."canceledAt" IS NULL
+        WHERE charge."tenantId" = ${tenantId}
+          AND charge."buildingId" = ${buildingId}
+          AND charge."canceledAt" IS NULL
+          AND charge.period <= ${query.period}
+        GROUP BY charge.id, charge."unitId", charge.period, charge.amount
+      ),
+      unit_debts AS (
+        SELECT
+          "unitId",
+          SUM(CASE WHEN period = ${query.period} THEN outstanding ELSE 0 END) AS "periodDebt",
+          SUM(outstanding) AS "accumulatedDebt",
+          COUNT(DISTINCT period) FILTER (WHERE outstanding > 0) AS "overduePeriods"
+        FROM charge_balances
+        GROUP BY "unitId"
+        HAVING SUM(CASE WHEN period = ${query.period} THEN outstanding ELSE 0 END) > 0
+      ),
+      unit_rows AS (
+        SELECT
+          debt."unitId",
+          unit.code AS "unitCode",
+          COALESCE(unit.label, unit.code) AS "unitLabel",
+          responsible.name AS "responsibleName",
+          debt."periodDebt",
+          debt."accumulatedDebt",
+          debt."overduePeriods"
+        FROM unit_debts AS debt
+        INNER JOIN "Unit" AS unit
+          ON unit.id = debt."unitId"
+          AND unit."tenantId" = ${tenantId}
+          AND unit."buildingId" = ${buildingId}
+        LEFT JOIN LATERAL (
+          SELECT member.name
+          FROM "UnitOccupant" AS occupant
+          INNER JOIN "TenantMember" AS member
+            ON member.id = occupant."memberId"
+            AND member."tenantId" = ${tenantId}
+            AND member."disabledAt" IS NULL
+            AND member.status = 'ACTIVE'
+          WHERE occupant."tenantId" = ${tenantId}
+            AND occupant."unitId" = unit.id
+            AND occupant."endDate" IS NULL
+          ORDER BY occupant."isPrimary" DESC, occupant."startDate" ASC
+          LIMIT 1
+        ) AS responsible ON TRUE
+      ),
+      filtered_units AS (
+        SELECT *
+        FROM unit_rows
+        WHERE TRUE
+        ${searchClause}
+        ${agingClause}
+      )
+    `;
+
+    const [items, countRows, totalsRows] = await this.prisma.$transaction([
+      this.prisma.$queryRaw<RawDelinquencyRow[]>(Prisma.sql`
+        ${baseQuery}
+        SELECT
+          "unitId",
+          "unitCode",
+          "unitLabel",
+          "responsibleName",
+          "periodDebt",
+          "accumulatedDebt",
+          "overduePeriods"
+        FROM filtered_units
+        ORDER BY ${orderBy}
+        LIMIT ${pageSize}
+        OFFSET ${skip}
+      `),
+      this.prisma.$queryRaw<RawDelinquencyCountRow[]>(Prisma.sql`
+        ${baseQuery}
+        SELECT COUNT(*) AS total
+        FROM filtered_units
+      `),
+      this.prisma.$queryRaw<RawDelinquencyTotalsRow[]>(Prisma.sql`
+        ${baseQuery}
+        SELECT
+          COALESCE(SUM("periodDebt"), 0) AS "periodDebt",
+          COALESCE(SUM("accumulatedDebt"), 0) AS "accumulatedDebt"
+        FROM unit_debts
+      `),
+    ]);
+
+    const total = this.toSafeFinancialNumber(countRows[0]?.total ?? 0);
+    const totals = totalsRows[0] ?? { periodDebt: 0, accumulatedDebt: 0 };
+
+    return {
+      items: items.map((item) => this.mapDelinquencyItem(item)),
+      page,
+      pageSize,
+      total,
+      totalPages: total === 0 ? 0 : Math.ceil(total / pageSize),
+      totals: {
+        periodDebt: this.toSafeFinancialNumber(totals.periodDebt),
+        accumulatedDebt: this.toSafeFinancialNumber(totals.accumulatedDebt),
+      },
+      currency: tenant.currency,
+    };
+  }
+
+  private buildDelinquencyAgingClause(
+    aging: BuildingDelinquencyAging | undefined,
+  ): Prisma.Sql {
+    switch (aging) {
+      case BuildingDelinquencyAging.ONE_PERIOD:
+        return Prisma.sql`AND unit_rows."overduePeriods" = 1`;
+      case BuildingDelinquencyAging.TWO_TO_THREE_PERIODS:
+        return Prisma.sql`AND unit_rows."overduePeriods" BETWEEN 2 AND 3`;
+      case BuildingDelinquencyAging.MORE_THAN_THREE_PERIODS:
+        return Prisma.sql`AND unit_rows."overduePeriods" > 3`;
+      case BuildingDelinquencyAging.ALL:
+      case undefined:
+        return Prisma.empty;
+    }
+  }
+
+  private getDelinquencyOrderBy(
+    sortBy: BuildingDelinquencySortBy | undefined,
+    sortOrder: BuildingDelinquencySortOrder | undefined,
+  ): Prisma.Sql {
+    const direction = sortOrder === BuildingDelinquencySortOrder.ASC ? 'ASC' : 'DESC';
+    const column = {
+      [BuildingDelinquencySortBy.ACCUMULATED_DEBT]: '"accumulatedDebt"',
+      [BuildingDelinquencySortBy.PERIOD_DEBT]: '"periodDebt"',
+      [BuildingDelinquencySortBy.OVERDUE_PERIODS]: '"overduePeriods"',
+      [BuildingDelinquencySortBy.UNIT]: '"unitLabel"',
+    }[sortBy ?? BuildingDelinquencySortBy.ACCUMULATED_DEBT];
+
+    return Prisma.raw(`${column} ${direction}, "unitLabel" ASC`);
+  }
+
+  private mapDelinquencyItem(item: RawDelinquencyRow): BuildingDelinquencyItemDto {
+    return {
+      unitId: item.unitId,
+      unitCode: item.unitCode,
+      unitLabel: item.unitLabel,
+      responsibleName: item.responsibleName,
+      periodDebt: this.toSafeFinancialNumber(item.periodDebt),
+      accumulatedDebt: this.toSafeFinancialNumber(item.accumulatedDebt),
+      overduePeriods: this.toSafeFinancialNumber(item.overduePeriods),
+    };
+  }
+
+  private toSafeFinancialNumber(value: bigint | number | string): number {
+    const numericValue = typeof value === 'bigint' ? Number(value) : Number(value);
+    if (!Number.isSafeInteger(numericValue)) {
+      throw new Error('Financial aggregate exceeds the supported integer range');
+    }
+    return numericValue;
   }
 
   /**

--- a/apps/web/app/(tenant)/[tenantId]/buildings/[buildingId]/units/[unitId]/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/buildings/[buildingId]/units/[unitId]/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import Button from '@/shared/components/ui/Button';
 import Card from '@/shared/components/ui/Card';
 import ErrorState from '@/shared/components/ui/ErrorState';
@@ -47,6 +47,7 @@ const UnitDashboardPage = () => {
   const buildingId = params?.buildingId;
   const unitId = params?.unitId;
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { toast } = useToast();
   const { currentUser } = useAuth();
 
@@ -71,7 +72,9 @@ const UnitDashboardPage = () => {
     occupantId: null,
   });
   const [isDeleting, setIsDeleting] = useState(false);
-  const [activeTab, setActiveTab] = useState<'overview' | 'finance' | 'tickets' | 'messages' | 'documents'>('overview');
+  const [activeTab, setActiveTab] = useState<'overview' | 'finance' | 'tickets' | 'messages' | 'documents'>(
+    searchParams.get('tab') === 'finance' ? 'finance' : 'overview',
+  );
   const [showAssignModal, setShowAssignModal] = useState(false);
 
   const unit = units.find((u) => u.id === unitId);

--- a/apps/web/features/finance/components/BuildingDelinquencyList.tsx
+++ b/apps/web/features/finance/components/BuildingDelinquencyList.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import Button from '@/shared/components/ui/Button';
+import Card from '@/shared/components/ui/Card';
+import EmptyState from '@/shared/components/ui/EmptyState';
+import Skeleton from '@/shared/components/ui/Skeleton';
+import { Table, TBody, TD, TH, THead, TR } from '@/shared/components/ui/Table';
+import { formatCurrency } from '@/shared/lib/format/money';
+import { useBuildingDelinquency } from '../hooks/useBuildingDelinquency';
+import {
+  type BuildingDelinquencyAging,
+  type BuildingDelinquencySortBy,
+  type BuildingDelinquencySortOrder,
+} from '../services/finance.api';
+
+interface BuildingDelinquencyListProps {
+  tenantId: string;
+  buildingId: string;
+  period: string;
+}
+
+const PAGE_SIZES = [25, 50, 100] as const;
+
+function getMonthLabel(period: string): string {
+  const label = new Intl.DateTimeFormat('es-AR', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(`${period}-01T00:00:00.000Z`));
+
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+function getPositiveInteger(value: string | null, fallback: number): number {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+export function BuildingDelinquencyList({
+  tenantId,
+  buildingId,
+  period,
+}: BuildingDelinquencyListProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const page = getPositiveInteger(searchParams.get('delinquencyPage'), 1);
+  const requestedPageSize = getPositiveInteger(searchParams.get('delinquencyPageSize'), 25);
+  const pageSize = PAGE_SIZES.includes(requestedPageSize as (typeof PAGE_SIZES)[number])
+    ? requestedPageSize
+    : 25;
+  const search = searchParams.get('delinquencySearch') ?? '';
+  const aging = (searchParams.get('delinquencyAging') ?? 'ALL') as BuildingDelinquencyAging;
+  const sortBy = (searchParams.get('delinquencySortBy') ?? 'ACCUMULATED_DEBT') as BuildingDelinquencySortBy;
+  const sortOrder = (searchParams.get('delinquencySortOrder') ?? 'desc') as BuildingDelinquencySortOrder;
+  const { data, isPending, isError, error, refetch } = useBuildingDelinquency(buildingId, {
+    period,
+    page,
+    pageSize,
+    search: search || undefined,
+    aging,
+    sortBy,
+    sortOrder,
+  });
+
+  const updateQuery = (updates: Record<string, string | undefined>) => {
+    const nextParams = new URLSearchParams(searchParams.toString());
+    for (const [key, value] of Object.entries(updates)) {
+      if (value === undefined || value === '') {
+        nextParams.delete(key);
+      } else {
+        nextParams.set(key, value);
+      }
+    }
+
+    const nextQuery = nextParams.toString();
+    if (nextQuery === searchParams.toString()) return;
+    router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
+  };
+
+  const resetPage = (updates: Record<string, string | undefined>) => {
+    updateQuery({ ...updates, delinquencyPage: undefined });
+  };
+
+  if (isPending) {
+    return (
+      <Card className="space-y-4 p-4" aria-live="polite">
+        <p className="text-sm text-muted-foreground">Cargando unidades morosas…</p>
+        <Skeleton className="h-10 w-full" />
+        <Skeleton className="h-64 w-full" />
+      </Card>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Card className="border-red-200 bg-red-50 p-4">
+        <p className="font-medium text-red-900">No pudimos cargar la morosidad. Intenta nuevamente.</p>
+        <p className="mt-1 text-sm text-red-700">
+          {error instanceof Error ? error.message : 'Error al cargar la morosidad'}
+        </p>
+        <Button className="mt-3" size="sm" variant="secondary" onClick={() => refetch()}>
+          Reintentar
+        </Button>
+      </Card>
+    );
+  }
+
+  const firstResult = data && data.total > 0 ? (data.page - 1) * data.pageSize + 1 : 0;
+  const lastResult = data ? Math.min(data.page * data.pageSize, data.total) : 0;
+  const hasFilters = Boolean(search) || aging !== 'ALL';
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="text-xl font-semibold">Morosidad de {getMonthLabel(period)}</h2>
+        <p className="text-sm text-muted-foreground">
+          {data?.total ?? 0} unidades con cargos pendientes en el período.
+        </p>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Card className="p-4">
+          <p className="text-sm text-muted-foreground">Pendiente del período</p>
+          <p className="mt-1 text-xl font-semibold text-orange-600">
+            {formatCurrency(data?.totals.periodDebt ?? 0, data?.currency ?? 'ARS')}
+          </p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-sm text-muted-foreground">Deuda acumulada hasta {getMonthLabel(period)}</p>
+          <p className="mt-1 text-xl font-semibold text-red-600">
+            {formatCurrency(data?.totals.accumulatedDebt ?? 0, data?.currency ?? 'ARS')}
+          </p>
+        </Card>
+      </div>
+
+      <Card className="space-y-4 p-4">
+        <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_220px_220px_160px]">
+          <label className="space-y-1">
+            <span className="text-sm font-medium">Buscar</span>
+            <input
+              aria-label="Buscar por unidad o responsable"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              placeholder="Buscar por unidad o responsable"
+              value={search}
+              onChange={(event) => resetPage({ delinquencySearch: event.target.value || undefined })}
+            />
+          </label>
+          <label className="space-y-1">
+            <span className="text-sm font-medium">Antigüedad</span>
+            <select
+              aria-label="Filtrar por períodos vencidos"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              value={aging}
+              onChange={(event) => resetPage({ delinquencyAging: event.target.value === 'ALL' ? undefined : event.target.value })}
+            >
+              <option value="ALL">Todos</option>
+              <option value="ONE_PERIOD">1 período vencido</option>
+              <option value="TWO_TO_THREE_PERIODS">2 a 3 períodos vencidos</option>
+              <option value="MORE_THAN_THREE_PERIODS">Más de 3 períodos vencidos</option>
+            </select>
+          </label>
+          <label className="space-y-1">
+            <span className="text-sm font-medium">Ordenar por</span>
+            <select
+              aria-label="Ordenar morosidad"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              value={`${sortBy}:${sortOrder}`}
+              onChange={(event) => {
+                const [nextSortBy, nextSortOrder] = event.target.value.split(':');
+                resetPage({
+                  delinquencySortBy: nextSortBy,
+                  delinquencySortOrder: nextSortOrder,
+                });
+              }}
+            >
+              <option value="ACCUMULATED_DEBT:desc">Mayor deuda acumulada</option>
+              <option value="PERIOD_DEBT:desc">Mayor deuda del período</option>
+              <option value="OVERDUE_PERIODS:desc">Más períodos vencidos</option>
+              <option value="UNIT:asc">Unidad ascendente</option>
+              <option value="UNIT:desc">Unidad descendente</option>
+            </select>
+          </label>
+          <label className="space-y-1">
+            <span className="text-sm font-medium">Por página</span>
+            <select
+              aria-label="Resultados por página"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+              value={pageSize}
+              onChange={(event) => resetPage({ delinquencyPageSize: event.target.value })}
+            >
+              {PAGE_SIZES.map((size) => <option key={size} value={size}>{size}</option>)}
+            </select>
+          </label>
+        </div>
+
+        {!data || data.total === 0 ? (
+          <EmptyState
+            title={hasFilters ? 'No encontramos unidades que coincidan con los filtros aplicados.' : `No hay unidades con saldo pendiente en ${getMonthLabel(period)}.`}
+            description={hasFilters ? 'Ajusta la búsqueda o los filtros para continuar.' : 'Todas las unidades están al día para el período seleccionado.'}
+          />
+        ) : (
+          <>
+            <div className="overflow-x-auto">
+              <Table>
+                <THead>
+                  <TR>
+                    <TH>Unidad</TH>
+                    <TH>Responsable</TH>
+                    <TH className="text-right">Deuda del período</TH>
+                    <TH className="text-right">Deuda acumulada</TH>
+                    <TH className="text-right">Períodos vencidos</TH>
+                    <TH className="text-right">Acción</TH>
+                  </TR>
+                </THead>
+                <TBody>
+                  {data.items.map((item) => (
+                    <TR key={item.unitId}>
+                      <TD className="font-medium">{item.unitLabel}</TD>
+                      <TD>{item.responsibleName ?? 'Sin responsable asignado'}</TD>
+                      <TD className="text-right text-orange-600">{formatCurrency(item.periodDebt, data.currency)}</TD>
+                      <TD className="text-right font-semibold text-red-600">{formatCurrency(item.accumulatedDebt, data.currency)}</TD>
+                      <TD className="text-right">{item.overduePeriods}</TD>
+                      <TD className="text-right">
+                        <Button
+                          aria-label={`Ver cuenta de ${item.unitLabel}`}
+                          size="sm"
+                          variant="secondary"
+                          onClick={() => router.push(`/${tenantId}/buildings/${buildingId}/units/${item.unitId}?tab=finance`)}
+                        >
+                          Ver cuenta
+                        </Button>
+                      </TD>
+                    </TR>
+                  ))}
+                </TBody>
+              </Table>
+            </div>
+
+            <div className="flex flex-col gap-3 border-t pt-4 text-sm sm:flex-row sm:items-center sm:justify-between">
+              <p>Mostrando {firstResult}–{lastResult} de {data.total} unidades</p>
+              <div className="flex items-center gap-2">
+                <Button
+                  aria-label="Página anterior"
+                  size="sm"
+                  variant="secondary"
+                  disabled={data.page <= 1}
+                  onClick={() => updateQuery({ delinquencyPage: String(data.page - 1) })}
+                >
+                  Anterior
+                </Button>
+                <span>Página {data.page} de {data.totalPages}</span>
+                <Button
+                  aria-label="Página siguiente"
+                  size="sm"
+                  variant="secondary"
+                  disabled={data.page >= data.totalPages}
+                  onClick={() => updateQuery({ delinquencyPage: String(data.page + 1) })}
+                >
+                  Siguiente
+                </Button>
+              </div>
+            </div>
+          </>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/features/finance/components/FinanceDashboard.tsx
+++ b/apps/web/features/finance/components/FinanceDashboard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useFinanceSummary } from '../hooks/useFinanceSummary';
 import { useCharges } from '../hooks/useCharges';
 import { usePaymentsReview, usePaymentHistory } from '../hooks/usePaymentsReview';
@@ -8,7 +9,7 @@ import { FinanceSummaryCards } from './FinanceSummaryCards';
 import { PaymentsReviewList } from './PaymentsReviewList';
 import { PaymentHistoryList } from './PaymentHistoryList';
 import { ChargesTab } from './ChargesTab';
-import { DelinquentUnitsList } from './DelinquentUnitsList';
+import { BuildingDelinquencyList } from './BuildingDelinquencyList';
 import { FinanceChartsPanel } from './FinanceChartsPanel';
 import { ExpensesList } from './ExpensesList';
 import { ExpenseLedgerCategoriesManager } from './ExpenseLedgerCategoriesManager';
@@ -40,8 +41,25 @@ type TabType =
 export function FinanceDashboard({ buildingId, tenantId }: FinanceDashboardProps) {
   const [activeTab, setActiveTab] = useState<TabType>('rubros');
   const currentMonth = new Date().toISOString().slice(0, 7); // YYYY-MM
-  const [period, setPeriod] = useState<string>(currentMonth);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const period = searchParams.get('period') || currentMonth;
   const periodInputId = 'building-finance-period';
+
+  const updatePeriod = (nextPeriod: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (nextPeriod === currentMonth) {
+      params.delete('period');
+    } else {
+      params.set('period', nextPeriod);
+    }
+    params.delete('delinquencyPage');
+
+    const nextQuery = params.toString();
+    if (nextQuery === searchParams.toString()) return;
+    router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
+  };
 
   // Load data from hooks
   const { data: summary, isPending: summaryLoading, error: summaryError, refetch: refetchSummaryRaw } = useFinanceSummary(buildingId, period);
@@ -129,7 +147,7 @@ export function FinanceDashboard({ buildingId, tenantId }: FinanceDashboardProps
             id={periodInputId}
             type="month"
             value={period}
-            onChange={(e) => setPeriod(e.target.value)}
+            onChange={(e) => updatePeriod(e.target.value)}
             className="px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary"
           />
         </div>
@@ -145,7 +163,7 @@ export function FinanceDashboard({ buildingId, tenantId }: FinanceDashboardProps
 
       {/* Tabs */}
       <div className="border-b mb-6">
-        <nav className="flex gap-1 overflow-x-auto whitespace-nowrap pb-1">
+          <nav className="flex gap-1 overflow-x-auto whitespace-nowrap pb-1 lg:flex-wrap lg:overflow-visible lg:whitespace-normal">
           {tabs.map((tab) => (
             <button
               key={tab.id}
@@ -235,11 +253,7 @@ export function FinanceDashboard({ buildingId, tenantId }: FinanceDashboardProps
         )}
 
         {activeTab === 'delinquent' && (
-          <DelinquentUnitsList
-            units={summary?.topDelinquentUnits || []}
-            loading={summaryLoading}
-            currency={summary?.currency || 'ARS'}
-          />
+          <BuildingDelinquencyList tenantId={tenantId} buildingId={buildingId} period={period} />
         )}
 
         {activeTab === 'analysis' && (

--- a/apps/web/features/finance/components/__tests__/BuildingDelinquencyList.test.tsx
+++ b/apps/web/features/finance/components/__tests__/BuildingDelinquencyList.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { BuildingDelinquencyList } from '../BuildingDelinquencyList';
+import type { BuildingDelinquencyResponse } from '../../services/finance.api';
+
+const replace = jest.fn();
+const push = jest.fn();
+const refetch = jest.fn();
+const useBuildingDelinquencyMock = jest.fn();
+let params = new URLSearchParams();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace, push }),
+  usePathname: () => '/tenant-1/buildings/building-1/finance',
+  useSearchParams: () => params,
+}));
+
+jest.mock('../../hooks/useBuildingDelinquency', () => ({
+  useBuildingDelinquency: (...args: unknown[]) => useBuildingDelinquencyMock(...args),
+}));
+
+function buildData(overrides: Partial<BuildingDelinquencyResponse> = {}): BuildingDelinquencyResponse {
+  return {
+    items: Array.from({ length: 25 }, (_, index) => ({
+      unitId: `unit-${index + 1}`,
+      unitCode: `TS-01-${String(index + 1).padStart(2, '0')}`,
+      unitLabel: `Apartamento ${index + 1}`,
+      responsibleName: index === 0 ? 'Ana Pérez' : null,
+      periodDebt: 6900000,
+      accumulatedDebt: 75420000,
+      overduePeriods: 4,
+    })),
+    page: 1,
+    pageSize: 25,
+    total: 96,
+    totalPages: 4,
+    totals: { periodDebt: 565800000, accumulatedDebt: 6426000000 },
+    currency: 'ARS',
+    ...overrides,
+  };
+}
+
+function renderList() {
+  return render(
+    <BuildingDelinquencyList
+      tenantId="tenant-1"
+      buildingId="building-1"
+      period="2026-07"
+    />,
+  );
+}
+
+describe('BuildingDelinquencyList', () => {
+  beforeEach(() => {
+    params = new URLSearchParams();
+    replace.mockReset();
+    push.mockReset();
+    refetch.mockReset();
+    useBuildingDelinquencyMock.mockReset();
+    useBuildingDelinquencyMock.mockReturnValue({
+      data: buildData(),
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch,
+    });
+  });
+
+  it('renders the complete page metadata without repeating the building column', () => {
+    renderList();
+
+    expect(screen.getAllByRole('row')).toHaveLength(26);
+    expect(screen.getByText('Mostrando 1–25 de 96 unidades')).toBeTruthy();
+    expect(screen.queryByRole('columnheader', { name: 'Edificio' })).toBeNull();
+    expect(screen.getByRole('columnheader', { name: 'Deuda del período' })).toBeTruthy();
+    expect(screen.getByRole('columnheader', { name: 'Deuda acumulada' })).toBeTruthy();
+  });
+
+  it('requests the next server-side page', () => {
+    renderList();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Página siguiente' }));
+
+    expect(replace).toHaveBeenCalledWith(
+      '/tenant-1/buildings/building-1/finance?delinquencyPage=2',
+      { scroll: false },
+    );
+  });
+
+  it('resets pagination when the search changes', () => {
+    params = new URLSearchParams('delinquencyPage=3');
+    renderList();
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Buscar por unidad o responsable' }), {
+      target: { value: '07' },
+    });
+
+    expect(replace).toHaveBeenCalledWith(
+      '/tenant-1/buildings/building-1/finance?delinquencySearch=07',
+      { scroll: false },
+    );
+  });
+
+  it('resets pagination when the aging filter changes', () => {
+    params = new URLSearchParams('delinquencyPage=2');
+    renderList();
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Filtrar por períodos vencidos' }), {
+      target: { value: 'MORE_THAN_THREE_PERIODS' },
+    });
+
+    expect(replace).toHaveBeenCalledWith(
+      '/tenant-1/buildings/building-1/finance?delinquencyAging=MORE_THAN_THREE_PERIODS',
+      { scroll: false },
+    );
+  });
+
+  it('uses an allowed server-side page size and resets pagination', () => {
+    params = new URLSearchParams('delinquencyPage=3');
+    renderList();
+
+    fireEvent.change(screen.getByRole('combobox', { name: 'Resultados por página' }), {
+      target: { value: '50' },
+    });
+
+    expect(replace).toHaveBeenCalledWith(
+      '/tenant-1/buildings/building-1/finance?delinquencyPageSize=50',
+      { scroll: false },
+    );
+  });
+
+  it('navigates to the existing unit account with its finance tab selected', () => {
+    renderList();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ver cuenta de Apartamento 1' }));
+
+    expect(push).toHaveBeenCalledWith('/tenant-1/buildings/building-1/units/unit-1?tab=finance');
+  });
+
+  it('shows the filtered empty state', () => {
+    params = new URLSearchParams('delinquencySearch=ZZ');
+    useBuildingDelinquencyMock.mockReturnValue({
+      data: buildData({ items: [], total: 0, totalPages: 0 }),
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch,
+    });
+
+    renderList();
+
+    expect(screen.getByText('No encontramos unidades que coincidan con los filtros aplicados.')).toBeTruthy();
+  });
+
+  it('keeps an error visible and allows an explicit retry', () => {
+    useBuildingDelinquencyMock.mockReturnValue({
+      data: undefined,
+      isPending: false,
+      isError: true,
+      error: new Error('Network failed'),
+      refetch,
+    });
+
+    renderList();
+
+    expect(screen.getByText('No pudimos cargar la morosidad. Intenta nuevamente.')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Reintentar' }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/features/finance/hooks/useBuildingDelinquency.ts
+++ b/apps/web/features/finance/hooks/useBuildingDelinquency.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import {
+  getBuildingDelinquency,
+  type BuildingDelinquencyQuery,
+} from '../services/finance.api';
+
+/** Load one server-side page of operational building delinquency. */
+export function useBuildingDelinquency(
+  buildingId: string,
+  query: BuildingDelinquencyQuery,
+) {
+  return useQuery({
+    queryKey: ['buildingDelinquency', buildingId, query],
+    queryFn: () => getBuildingDelinquency(buildingId, query),
+    enabled: Boolean(buildingId && query.period),
+    placeholderData: (previousData) => previousData,
+  });
+}

--- a/apps/web/features/finance/services/finance.api.ts
+++ b/apps/web/features/finance/services/finance.api.ts
@@ -142,6 +142,43 @@ export interface FinancialSummary {
   currency: string;
 }
 
+export type BuildingDelinquencyAging = 'ALL' | 'ONE_PERIOD' | 'TWO_TO_THREE_PERIODS' | 'MORE_THAN_THREE_PERIODS';
+export type BuildingDelinquencySortBy = 'ACCUMULATED_DEBT' | 'PERIOD_DEBT' | 'OVERDUE_PERIODS' | 'UNIT';
+export type BuildingDelinquencySortOrder = 'asc' | 'desc';
+
+export interface BuildingDelinquencyQuery {
+  period: string;
+  page?: number;
+  pageSize?: number;
+  search?: string;
+  aging?: BuildingDelinquencyAging;
+  sortBy?: BuildingDelinquencySortBy;
+  sortOrder?: BuildingDelinquencySortOrder;
+}
+
+export interface BuildingDelinquencyItem {
+  unitId: string;
+  unitCode: string;
+  unitLabel: string;
+  responsibleName: string | null;
+  periodDebt: number;
+  accumulatedDebt: number;
+  overduePeriods: number;
+}
+
+export interface BuildingDelinquencyResponse {
+  items: BuildingDelinquencyItem[];
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+  totals: {
+    periodDebt: number;
+    accumulatedDebt: number;
+  };
+  currency: string;
+}
+
 export interface UnitLedger {
   unitId: string;
   unitLabel?: string;
@@ -418,6 +455,25 @@ export async function getFinancialSummary(
   const query = period ? `?period=${period}` : '';
   return apiClient<FinancialSummary>({
     path: `/buildings/${buildingId}/finance/summary${query}`,
+    method: 'GET',
+  });
+}
+
+/** Get a server-side paginated operational delinquency list for one building. */
+export async function getBuildingDelinquency(
+  buildingId: string,
+  query: BuildingDelinquencyQuery,
+): Promise<BuildingDelinquencyResponse> {
+  const params = new URLSearchParams({ period: query.period });
+  if (query.page !== undefined) params.set('page', String(query.page));
+  if (query.pageSize !== undefined) params.set('pageSize', String(query.pageSize));
+  if (query.search) params.set('search', query.search);
+  if (query.aging && query.aging !== 'ALL') params.set('aging', query.aging);
+  if (query.sortBy) params.set('sortBy', query.sortBy);
+  if (query.sortOrder) params.set('sortOrder', query.sortOrder);
+
+  return apiClient<BuildingDelinquencyResponse>({
+    path: `/buildings/${buildingId}/finance/delinquency?${params.toString()}`,
     method: 'GET',
   });
 }


### PR DESCRIPTION
Closes #35

## Summary
- Replaces the top-10-only building delinquency table with a complete server-paginated operational list.
- Separates selected-period debt from accumulated debt through that period, with search, aging, sorting, responsible occupant, and a unit-account link.
- Keeps queries tenant/building scoped and does not change schema, migrations, or financial data.

## Changes
| Area | Change |
| --- | --- |
| Finance API | Adds a validated `GET /buildings/:buildingId/finance/delinquency` endpoint with pagination, filters, sorting, and financial aggregates. |
| Building finance UI | Adds operational delinquency controls, totals, pagination, loading/error/empty states, and URL-backed state. |
| Unit account | Supports `?tab=finance` from the delinquency action. |

## Validation
- [x] `npm test -- finanzas.service.spec.ts --runInBand` (21 tests)
- [x] `npm test -- BuildingDelinquencyList.test.tsx --runInBand` (8 tests)
- [x] TypeScript checks for API and Web
- [x] ESLint on changed files (0 errors; 3 pre-existing warnings in the unit page)
- [x] `git diff --check`

## Checklist
- [x] Linked approved issue
- [x] Conventional commit
- [x] No schema, migration, seed, or environment changes
- [x] No `Co-Authored-By` trailer