### PR TITLE
chore(infra): add Mailpit to staging

### DIFF
--- a/infra/docker/.env.staging.example
+++ b/infra/docker/.env.staging.example
@@ -45,8 +45,13 @@ S3_PUBLIC_BASE_URL=https://buildingos-staging-files.31-220-98-21.sslip.io
 S3_FORCE_PATH_STYLE=true
 
 # --- Mail / Payments ---
-MAIL_PROVIDER=none
-MAIL_FROM=noreply@buildingos-staging.local
+MAIL_PROVIDER=smtp
+MAIL_FROM=BuildingOS Staging <no-reply@buildingos.local>
+SMTP_HOST=mailpit
+SMTP_PORT=1025
+SMTP_USER=
+SMTP_PASS=
+MAILPIT_UI_PORT=8026
 PAYMENT_PROVIDER=none
 
 # --- Assistant / AI ---

--- a/infra/docker/README.md
+++ b/infra/docker/README.md
@@ -2,14 +2,11 @@
 
 ## Mailpit
 
-Mailpit is available only through the local Compose stack. It captures SMTP
-messages locally and does not relay them to external providers.
+Mailpit is available only through the local and staging Compose stacks. It
+captures SMTP messages locally and does not relay them to external providers.
+Mailpit is never used in production and is not published through Traefik.
 
-Start it with:
-
-```bash
-docker compose -f infra/docker/docker-compose.yml up -d mailpit
-```
+### Local
 
 The web inbox is available at `http://127.0.0.1:8025` and SMTP listens at
 `127.0.0.1:1025`.
@@ -27,3 +24,21 @@ SMTP_PASS=
 
 Both SMTP credentials must be set together for authenticated SMTP, or both be
 empty for Mailpit. No credentials are required for Mailpit.
+
+### Staging
+
+In the staging stack Mailpit listens internally on port `1025` (SMTP) and
+exposes the web UI on the VPS loopback at `127.0.0.1:8026`. The API connects
+to `mailpit:1025` over the internal Docker network `buildingos_staging_net`.
+
+To open the Mailpit inbox from a Mac via SSH tunnel:
+
+```bash
+ssh -L 8026:127.0.0.1:8026 pawtech
+```
+
+Then open `http://localhost:8026` in your browser. Press `Ctrl+C` in the
+terminal where the tunnel was opened to close it.
+
+Mailpit captures every email sent by the staging API but never delivers them
+to real recipients.

--- a/infra/docker/docker-compose.staging.yml
+++ b/infra/docker/docker-compose.staging.yml
@@ -95,6 +95,15 @@ services:
         exit 0;
     restart: on-failure
 
+  mailpit:
+    image: axllent/mailpit:v1.30.0
+    container_name: buildingos-staging-mailpit
+    networks:
+      - buildingos_staging_net
+    ports:
+      - "127.0.0.1:${MAILPIT_UI_PORT:-8026}:8025"
+    restart: unless-stopped
+
   buildingos-api:
     build:
       context: ../../
@@ -110,6 +119,8 @@ services:
         condition: service_healthy
       minio:
         condition: service_healthy
+      mailpit:
+        condition: service_started
     ports:
       - "127.0.0.1:${API_PORT:-4010}:3000"
     labels:
@@ -140,6 +151,10 @@ services:
       SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-staging}
       MAIL_PROVIDER: ${MAIL_PROVIDER:?MAIL_PROVIDER is required}
       MAIL_FROM: ${MAIL_FROM:?MAIL_FROM is required}
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASS: ${SMTP_PASS:-}
       PAYMENT_PROVIDER: ${PAYMENT_PROVIDER:?PAYMENT_PROVIDER is required}
       AI_PROVIDER: ${AI_PROVIDER:?AI_PROVIDER is required}
       AI_OLLAMA_URL: ${AI_OLLAMA_URL:-}


### PR DESCRIPTION
## Summary

Adds Mailpit to the BuildingOS staging Docker stack for safe inspection of test emails without delivering them to real recipients.

### Changes

- adds `mailpit` to `infra/docker/docker-compose.staging.yml` using `axllent/mailpit:v1.30.0`;
- exposes only the Mailpit web UI on VPS loopback at `127.0.0.1:${MAILPIT_UI_PORT:-8026}:8025`;
- keeps SMTP internal to Docker at `mailpit:1025`;
- adds no Traefik labels and no public SMTP mapping;
- passes `SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, and `SMTP_PASS` to the staging API;
- makes the API wait for the Mailpit container to start with `service_started`;
- updates the staging environment example and Docker documentation, including SSH tunnel access from macOS.

## Operator configuration

Update `/opt/pawtech/env/buildingos-staging.env` outside Git with:

```dotenv
MAIL_PROVIDER=smtp
SMTP_HOST=mailpit
SMTP_PORT=1025
SMTP_USER=
SMTP_PASS=
MAILPIT_UI_PORT=8026
```

## Access

```bash
ssh -L 8026:127.0.0.1:8026 pawtech
```

Then open `http://localhost:8026`.

## Scope and safety

- production was not changed;
- no VPS deployment was performed;
- no migrations or seeds were run;
- no secrets were committed;
- Mailpit is not exposed through Traefik or `0.0.0.0`;
- no TypeScript application code changed, so full API tests are not required for this infrastructure-only PR.