### PR TITLE
ci: add controlled staging deployment workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,6 +38,20 @@ logs
 **/.env
 **/.env.*
 
+# Private keys and certificates
+*.pem
+*.key
+*.p12
+*.pfx
+*.jks
+*.keystore
+**/*.pem
+**/*.key
+**/*.p12
+**/*.pfx
+**/*.jks
+**/*.keystore
+
 # Editor, OS, and local scratch files
 .idea
 .vscode

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,84 @@
+name: Deploy main to staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: "Exact 40-character main commit SHA to deploy"
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: staging-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  REMOTE_APP_DIR: /opt/pawtech/apps/buildingos-staging/buildingos-app
+
+jobs:
+  deploy:
+    name: Deploy exact SHA to staging
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: staging
+    steps:
+      - name: Checkout requested commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Validate exact main SHA
+        shell: bash
+        env:
+          DEPLOY_SHA: ${{ inputs.sha || github.sha }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$GITHUB_REF" == "refs/heads/main" ]] || { echo "Manual deployment must run from refs/heads/main" >&2; exit 1; }
+          [[ "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]]
+          git cat-file -e "$DEPLOY_SHA^{commit}"
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$DEPLOY_SHA" FETCH_HEAD
+
+      - name: Deploy over SSH
+        shell: bash
+        env:
+          DEPLOY_SHA: ${{ inputs.sha || github.sha }}
+          SSH_HOST: ${{ secrets.STAGING_SSH_HOST }}
+          SSH_USER: ${{ secrets.STAGING_SSH_USER }}
+          SSH_PRIVATE_KEY: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+          SSH_PORT: ${{ vars.STAGING_SSH_PORT || '22' }}
+          KNOWN_HOSTS: ${{ secrets.STAGING_SSH_KNOWN_HOSTS }}
+          APP_PATH: /opt/pawtech/apps/buildingos-staging/buildingos-app
+          COMPOSE_FILE: infra/docker/docker-compose.staging.yml
+          COMPOSE_PROJECT: buildingos-staging
+          ENV_FILE: /opt/pawtech/env/buildingos-staging.env
+          API_HEALTH: ${{ vars.STAGING_API_LOCAL_HEALTH_URL }}
+          API_READY: ${{ vars.STAGING_API_LOCAL_READY_URL }}
+          API_READYZ: ${{ vars.STAGING_API_LOCAL_READYZ_URL }}
+          WEB_LOCAL: ${{ vars.STAGING_WEB_LOCAL_URL }}
+          API_PUBLIC_HEALTH: ${{ vars.STAGING_API_PUBLIC_HEALTH_URL }}
+          WEB_PUBLIC_LOGIN: ${{ vars.STAGING_WEB_PUBLIC_LOGIN_URL }}
+        run: |
+          set -Eeuo pipefail
+          [[ -n "$SSH_HOST" && -n "$SSH_USER" && -n "$SSH_PRIVATE_KEY" && -n "$SSH_PORT" && -n "$KNOWN_HOSTS" ]] || { echo "SSH settings are incomplete" >&2; exit 1; }
+          [[ -n "$APP_PATH" && -n "$COMPOSE_FILE" && -n "$COMPOSE_PROJECT" && -n "$ENV_FILE" ]] || { echo "Staging path settings are incomplete" >&2; exit 1; }
+          [[ -n "$API_HEALTH" && -n "$API_READY" && -n "$API_READYZ" && -n "$WEB_LOCAL" && -n "$API_PUBLIC_HEALTH" && -n "$WEB_PUBLIC_LOGIN" ]] || { echo "Staging health URL settings are incomplete" >&2; exit 1; }
+          key_file="$(mktemp)"
+          known_hosts_file="$(mktemp)"
+          cleanup_ssh() { rm -f "$key_file" "$known_hosts_file"; }
+          trap cleanup_ssh EXIT
+          chmod 600 "$key_file" "$known_hosts_file"
+          printf '%s\n' "$SSH_PRIVATE_KEY" > "$key_file"
+          printf '%s\n' "$KNOWN_HOSTS" > "$known_hosts_file"
+          ssh_opts=(-i "$key_file" -o UserKnownHostsFile="$known_hosts_file" -p "$SSH_PORT" -o BatchMode=yes -o StrictHostKeyChecking=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=6)
+          remote_args=()
+          for arg in "$DEPLOY_SHA" "$APP_PATH" "$COMPOSE_FILE" "$COMPOSE_PROJECT" "$ENV_FILE" "$API_HEALTH" "$API_READY" "$API_READYZ" "$WEB_LOCAL" "$API_PUBLIC_HEALTH" "$WEB_PUBLIC_LOGIN"; do
+            printf -v quoted '%q' "$arg"
+            remote_args+=("$quoted")
+          done
+          ssh "${ssh_opts[@]}" "$SSH_USER@$SSH_HOST" "bash -s -- ${remote_args[*]}" < scripts/deploy-staging.sh

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -26,7 +26,7 @@ RUN npm run build -w packages/contracts && npm run build -w packages/permissions
 
 # Copy Prisma schema and generate client
 COPY apps/api/prisma ./apps/api/prisma
-RUN cd apps/api && npx prisma generate
+RUN cd apps/api && ../../node_modules/.bin/prisma generate
 
 # Copy API source code
 COPY apps/api ./apps/api
@@ -53,11 +53,19 @@ RUN npm ci --only=production
 # Copy Prisma schema and regenerate client
 COPY apps/api/prisma ./apps/api/prisma
 # Install prisma CLI temporarily to generate client
-RUN cd apps/api && npm install prisma@5.22.0 && npx prisma generate && npm uninstall prisma
+RUN cd apps/api && npm install prisma@5.22.0 && ../../node_modules/.bin/prisma generate && npm uninstall prisma
 
 # ---- Stage 3: Dev Tools (migrate, seed) ----
 # Uses builder which has all deps (dev + prod) including ts-node
 FROM builder AS dev-tools
+
+# ---- Stage 4: Migration Runner ----
+# Ephemeral target containing the pinned Prisma CLI from npm ci.
+FROM builder AS migrate
+
+WORKDIR /app
+ENTRYPOINT ["./node_modules/.bin/prisma"]
+CMD ["migrate", "deploy", "--schema", "apps/api/prisma/schema.prisma"]
 
 # ---- Stage 4: Runtime ----
 FROM node:20-alpine AS runtime

--- a/docs/release/STAGING_DEPLOY_RUNBOOK.md
+++ b/docs/release/STAGING_DEPLOY_RUNBOOK.md
@@ -1,0 +1,36 @@
+# Staging deployment runbook
+
+The `Deploy main to staging` workflow is intentionally **manual only** (`workflow_dispatch`). It deploys one exact commit already reachable from `origin/main`; there is no `push` trigger.
+
+## GitHub Environment `staging`
+
+Configure these **secrets** (never commit values): `STAGING_SSH_HOST`, `STAGING_SSH_USER`, `STAGING_SSH_PRIVATE_KEY`, `STAGING_SSH_KNOWN_HOSTS`. Configure `STAGING_SSH_PORT` as a variable (or secret if policy requires).
+
+Configure these non-sensitive **variables**: `STAGING_APP_PATH`, `STAGING_COMPOSE_FILE`, `STAGING_COMPOSE_PROJECT`, `STAGING_ENV_FILE`, `STAGING_API_LOCAL_HEALTH_URL`, `STAGING_API_LOCAL_READY_URL`, `STAGING_API_LOCAL_READYZ_URL`, `STAGING_WEB_LOCAL_URL`, `STAGING_API_PUBLIC_HEALTH_URL`, and `STAGING_WEB_PUBLIC_LOGIN_URL`.
+
+## Migrator architecture
+
+`apps/api/Dockerfile` has a dedicated `migrate` target based on the dependency builder. Dependencies are installed only by the lockfile-backed `npm ci`; the image entrypoint is the local `./node_modules/.bin/prisma` binary (Prisma `5.22.0` from the root devDependencies and lockfile). It receives `DATABASE_URL` from the external staging env file and uses the internal Compose network to reach PostgreSQL. Compose service `api-migrate` uses the `migrate` profile, has no ports or persistent volumes, and is configured with `restart: "no"`. It is never started by a normal Compose up.
+
+The command is `prisma migrate deploy --schema apps/api/prisma/schema.prisma`; it cannot resolve packages from the network at runtime and never runs seeds.
+
+## Deployment order and controls
+
+1. Validate the SHA format and all required path/URL settings.
+2. Require a clean remote checkout (tracked, staged, untracked, and ignored files block; ignored files are treated as possible artifacts, secrets, or real environments).
+3. Fetch `origin/main`, verify SHA ancestry, then detach at the exact SHA.
+4. Validate Compose (normal and `migrate` profile).
+5. Build and always run `api-migrate` as an ephemeral container; stop on any non-zero exit.
+6. Build and force-recreate only `buildingos-api` and `buildingos-web`.
+7. Check local API `/health`, `/ready`, `/readyz`, local web, public API health, and public web login URLs.
+8. Write previous/new SHA and migration status to `/opt/pawtech/apps/buildingos-staging/deployments/` outside the repository.
+
+PostgreSQL, Redis, MinIO, networks, and named volumes are excluded from build/recreate commands. No production path is referenced. Concurrency serializes workflow runs and the job timeout is 45 minutes. SSH uses a temporary 0600 key and known-hosts file cleaned by an exit trap, pinned known hosts, and keepalives (30 seconds, six failures). The script is streamed over SSH stdin; it is not copied to a predictable remote path. Success and failure records include UTC time, previous/new SHA, migration status, services, and seed status; failure logging is attempted from an `ERR` trap.
+
+## Dispatch and failure handling
+
+The runner checks out the trusted workflow commit (`github.sha`) only. Separately, provide a 40-character target SHA input (or omit it to use the dispatch ref SHA); the runner and remote script validate that target SHA and require it to be an ancestor of `origin/main`, so an input cannot select arbitrary workflow code. The remote checkout blocks tracked and untracked files; ignored files are permitted when harmless, while real environment/secret artifacts remain excluded by `.dockerignore` and must never be placed in the context. No automatic `git clean` is used. Every run executes the migrator after reviewing the migration set. A migration failure stops before API/web build or recreation; there is no automatic database migration rollback. Seeds are prohibited.
+
+After success, verify the external record and `git rev-parse HEAD` in the remote checkout. For an application rollback, dispatch a previously known-good SHA through the same gates. Database recovery is a separate approved procedure; Prisma does not provide automatic rollback of applied migrations.
+
+Production is out of scope. Enabling a future `push` to `main` trigger requires a separate reviewed change after manual runs, secret/variable verification, and operational approval.

--- a/infra/docker/docker-compose.staging.yml
+++ b/infra/docker/docker-compose.staging.yml
@@ -104,6 +104,21 @@ services:
       - "127.0.0.1:${MAILPIT_UI_PORT:-8026}:8025"
     restart: unless-stopped
 
+  api-migrate:
+    profiles: ["migrate"]
+    build:
+      context: ../../
+      dockerfile: apps/api/Dockerfile
+      target: migrate
+    networks:
+      - buildingos_staging_net
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB is required}
+    restart: "no"
+
   buildingos-api:
     build:
       context: ../../

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+usage() {
+  echo "Usage: $0 <sha> <app_path> <compose_file> <project> <env_file> <api_health> <api_ready> <api_readyz> <web_local> <api_public_health> <web_public_login>" >&2
+  exit 64
+}
+
+[[ $# -eq 11 ]] || usage
+readonly TARGET_SHA="$1"
+readonly APP_DIR="$2"
+readonly COMPOSE_FILE="$3"
+readonly PROJECT_NAME="$4"
+readonly ENV_FILE="$5"
+readonly API_HEALTH_URL="$6"
+readonly API_READY_URL="$7"
+readonly API_READYZ_URL="$8"
+readonly WEB_LOCAL_URL="$9"
+readonly API_PUBLIC_HEALTH_URL="${10}"
+readonly WEB_PUBLIC_LOGIN_URL="${11}"
+readonly DEPLOYMENTS_DIR="$(dirname "$APP_DIR")/deployments"
+readonly RECORD="$DEPLOYMENTS_DIR/$(date -u +%Y%m%dT%H%M%SZ)-$TARGET_SHA.txt"
+readonly EXPECTED_APP_DIR="/opt/pawtech/apps/buildingos-staging/buildingos-app"
+readonly EXPECTED_COMPOSE_FILE="infra/docker/docker-compose.staging.yml"
+readonly EXPECTED_PROJECT_NAME="buildingos-staging"
+readonly EXPECTED_ENV_FILE="/opt/pawtech/env/buildingos-staging.env"
+
+write_record() {
+  local state="$1"
+  install -d -m 700 "$DEPLOYMENTS_DIR"
+  umask 077
+  {
+    echo "deployed_at=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "status=$state"
+    echo "previous_sha=${BEFORE_SHA:-unknown}"
+    echo "new_sha=$TARGET_SHA"
+    echo "migrations=api-migrate (required)"
+    echo "services=buildingos-api buildingos-web"
+    echo "seeds=no"
+  } > "$RECORD"
+  chmod 600 "$RECORD"
+}
+
+on_error() {
+  local rc=$?
+  trap - ERR
+  if ! write_record FAILED; then
+    echo "Unable to write FAILED deployment record" >&2
+  fi
+  echo "Deployment failed (exit $rc)" >&2
+  exit "$rc"
+}
+trap on_error ERR
+
+check_ignored_sensitive_files() {
+  local path
+  while IFS= read -r path; do
+    case "$path" in
+      .env|.env.*|*/.env|*/.env.*|*.pem|*.key|*.p12|*.pfx|*.crt|*.log|*.dump|*.sql|*.bak|*.backup)
+        echo "Sensitive ignored file would enter the Docker context: $path" >&2
+        return 1
+        ;;
+    esac
+  done < <(git ls-files --others --ignored --exclude-standard)
+}
+
+[[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "Invalid SHA" >&2; exit 2; }
+for value in "$APP_DIR" "$COMPOSE_FILE" "$PROJECT_NAME" "$ENV_FILE" "$API_HEALTH_URL" "$API_READY_URL" "$API_READYZ_URL" "$WEB_LOCAL_URL" "$API_PUBLIC_HEALTH_URL" "$WEB_PUBLIC_LOGIN_URL"; do
+  [[ -n "$value" ]] || { echo "Required deployment setting is empty" >&2; exit 2; }
+done
+[[ "$APP_DIR" == "$EXPECTED_APP_DIR" ]] || { echo "Unexpected staging app path" >&2; exit 2; }
+[[ "$COMPOSE_FILE" == "$EXPECTED_COMPOSE_FILE" ]] || { echo "Unexpected staging compose file" >&2; exit 2; }
+[[ "$PROJECT_NAME" == "$EXPECTED_PROJECT_NAME" ]] || { echo "Unexpected staging Compose project" >&2; exit 2; }
+[[ "$ENV_FILE" == "$EXPECTED_ENV_FILE" ]] || { echo "Unexpected staging env file" >&2; exit 2; }
+for url in "$API_HEALTH_URL" "$API_READY_URL" "$API_READYZ_URL" "$WEB_LOCAL_URL" "$API_PUBLIC_HEALTH_URL" "$WEB_PUBLIC_LOGIN_URL"; do
+  [[ "$url" =~ ^https?://[A-Za-z0-9._:/?=%+\&-]+$ ]] || { echo "Unsafe health URL" >&2; exit 2; }
+done
+[[ -d "$APP_DIR/.git" ]] || { echo "Remote checkout missing: $APP_DIR" >&2; exit 1; }
+[[ -r "$ENV_FILE" ]] || { echo "Environment file missing or unreadable" >&2; exit 1; }
+command -v git >/dev/null || { echo "git is required" >&2; exit 1; }
+command -v docker >/dev/null || { echo "docker is required" >&2; exit 1; }
+command -v curl >/dev/null || { echo "curl is required" >&2; exit 1; }
+
+cd "$APP_DIR"
+[[ -z "$(git status --porcelain --untracked-files=all)" ]] || { echo "Remote checkout has tracked, untracked, or staged changes" >&2; exit 1; }
+check_ignored_sensitive_files
+readonly BEFORE_SHA="$(git rev-parse HEAD)"
+git fetch --prune origin main
+git cat-file -e "$TARGET_SHA^{commit}"
+git merge-base --is-ancestor "$TARGET_SHA" origin/main || { echo "SHA is not reachable from origin/main" >&2; exit 1; }
+git switch --detach --quiet "$TARGET_SHA"
+[[ "$(git rev-parse HEAD)" == "$TARGET_SHA" ]] || { echo "Detached checkout did not reach requested SHA" >&2; exit 1; }
+[[ -z "$(git status --porcelain --untracked-files=all)" ]] || { echo "Checkout became dirty after checkout" >&2; exit 1; }
+check_ignored_sensitive_files
+
+compose=(docker compose --project-name "$PROJECT_NAME" --env-file "$ENV_FILE" --file "$COMPOSE_FILE")
+"${compose[@]}" config --quiet
+"${compose[@]}" --profile migrate config --quiet
+
+"${compose[@]}" --profile migrate build api-migrate
+"${compose[@]}" --profile migrate run --rm --no-deps api-migrate
+"${compose[@]}" build buildingos-api buildingos-web
+"${compose[@]}" up --detach --no-deps --force-recreate buildingos-api buildingos-web
+
+check_http() {
+  local name="$1"
+  local url="$2"
+  local attempt=1
+  local max_attempts=8
+  while (( attempt <= max_attempts )); do
+    echo "Health check $name attempt $attempt/$max_attempts"
+    if curl --fail --silent --show-error --connect-timeout 5 --max-time 15 "$url" >/dev/null; then
+      echo "Health check $name passed"
+      return 0
+    fi
+    if (( attempt == max_attempts )); then
+      echo "Health check $name failed after $max_attempts attempts" >&2
+      return 1
+    fi
+    sleep 5
+    ((attempt++))
+  done
+}
+check_http "api-health" "$API_HEALTH_URL"
+check_http "api-ready" "$API_READY_URL"
+check_http "api-readyz" "$API_READYZ_URL"
+check_http "web-local" "$WEB_LOCAL_URL"
+check_http "api-public-health" "$API_PUBLIC_HEALTH_URL"
+check_http "web-public-login" "$WEB_PUBLIC_LOGIN_URL"
+
+write_record SUCCESS
+echo "Deployment completed: $TARGET_SHA"


### PR DESCRIPTION
Closes #41

## Objetivo

Agregar una primera versión manual y controlada del despliegue de `main` hacia staging.

## Implementación

- Workflow activado únicamente mediante `workflow_dispatch`.
- GitHub Environment `staging`.
- Concurrencia serializada.
- Timeout de 45 minutos.
- Validación de SHA exacto y pertenencia a `origin/main`.
- Checkout remoto limpio y detached HEAD.
- SSH con known_hosts, keepalive y `StrictHostKeyChecking`.
- Migrador Docker efímero con Prisma 5.22.0 fijado por lockfile.
- `prisma migrate deploy` obligatorio antes de actualizar la aplicación.
- Reconstrucción y recreación únicamente de API y web.
- Health checks locales y públicos con reintentos.
- Registro externo del SHA anterior y nuevo.
- Rollback manual de aplicación documentado.
- Sin seeds.
- Sin rollback automático de migraciones.
- Producción fuera del alcance.

## Archivos

- `.dockerignore`
- `.github/workflows/deploy-staging.yml`
- `scripts/deploy-staging.sh`
- `docs/release/STAGING_DEPLOY_RUNBOOK.md`
- `apps/api/Dockerfile`
- `infra/docker/docker-compose.staging.yml`

## Validaciones

- bash syntax: PASS
- YAML parse: PASS
- Compose base: PASS
- Compose profile migrate: PASS
- Migrator build: PASS
- Prisma CLI: 5.22.0
- git diff --check: PASS
- Secret scan: PASS

## Activación gradual

Esta versión es únicamente manual.

Después de fusionarla:

1. se configurará el Environment `staging`;
2. se ejecutará un deploy manual controlado;
3. se verificará staging;
4. la activación automática por push a `main` requerirá una modificación posterior.

No se ejecutó workflow, SSH, deploy, migración ni seed.
