### PR TITLE
ci: enable automatic staging deployments from main

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -8,6 +8,9 @@ on:
         required: false
         default: ""
         type: string
+  push:
+    branches:
+      - main
 
 concurrency:
   group: staging-deploy


### PR DESCRIPTION
Closes #43

## Objetivo

Activar el despliegue automático de cada commit integrado en `main` hacia staging.

## Cambio

- Conserva `workflow_dispatch`.
- Agrega `push` únicamente sobre `main`.
- En despliegues automáticos utiliza `github.sha`.
- Mantiene la restricción `refs/heads/main`.
- Conserva migraciones obligatorias, concurrencia, health checks y controles SSH.
- No automatiza producción.
- No ejecuta seeds.

## Validaciones

- YAML: PASS
- git diff --check: PASS
- Solo se modificó `.github/workflows/deploy-staging.yml`

## Comportamiento esperado después del merge

El squash commit generado en `main` activará automáticamente:

`main → migraciones staging → reconstrucción API/web → health checks → registro del SHA`

Producción permanece manual.

No se ejecutó workflow, deploy, SSH, migración ni seed.
