### PR TITLE
fix(ci): isolate migrator stdin during staging deploy

### DIFF
--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -98,7 +98,13 @@ compose=(docker compose --project-name "$PROJECT_NAME" --env-file "$ENV_FILE" --
 "${compose[@]}" --profile migrate config --quiet
 
 "${compose[@]}" --profile migrate build api-migrate
-"${compose[@]}" --profile migrate run --rm --no-deps api-migrate
+"${compose[@]}" \
+  --profile migrate \
+  run \
+  --rm \
+  --no-deps \
+  -T \
+  api-migrate < /dev/null
 "${compose[@]}" build buildingos-api buildingos-web
 "${compose[@]}" up --detach --no-deps --force-recreate buildingos-api buildingos-web
 


### PR DESCRIPTION
Closes #45

## Problema

El migrador ejecutado con `docker compose run` consumía el stdin que transportaba el resto de `scripts/deploy-staging.sh` por SSH.

El workflow terminaba en SUCCESS después de migrar, sin ejecutar:

- build de API y web;
- recreate de API y web;
- health checks;
- registro final del deployment.

## Corrección

El migrador se ejecuta ahora con:

```bash
"${compose[@]}" \\
  --profile migrate \\
  run \\
  --rm \\
  --no-deps \\
  -T \\
  api-migrate < /dev/null
```

Esto aísla completamente el stdin del migrador y permite que el script continúe.

## Validaciones

- bash -n: PASS
- YAML: PASS
- git diff --check: PASS
- Regresión shell de stdin: PASS
- Fallo del migrador se propaga: PASS
- No se ejecutaron migraciones reales, SSH ni deploy.
