### PR TITLE
fix(tickets): complete resident and admin ticket workflow

### DIFF
--- a/apps/api/src/reports/reports.service.ts
+++ b/apps/api/src/reports/reports.service.ts
@@ -16,6 +16,19 @@ export interface TicketsReportData {
   topCategories: Array<{ category: string; count: number }>;
   avgTimeToFirstResponseHours: number;
   avgTimeToResolveHours: number;
+  tickets: Array<{
+    id: string;
+    title: string;
+    description: string;
+    createdAt: Date;
+    status: string;
+    priority: string;
+    category: string;
+    buildingId: string;
+    building: { id: string; name: string };
+    unitId: string | null;
+    unit: { id: string; label: string | null; code: string } | null;
+  }>;
 }
 
 export interface DelinquentUnit {
@@ -92,7 +105,10 @@ export class ReportsService {
 
     const tickets = await this.prisma.ticket.findMany({
       where: whereBase,
+      orderBy: { createdAt: 'desc' },
       include: {
+        building: { select: { id: true, name: true } },
+        unit: { select: { id: true, label: true, code: true } },
         comments: {
           orderBy: { createdAt: 'asc' },
           take: 1,
@@ -172,6 +188,19 @@ export class ReportsService {
       topCategories,
       avgTimeToFirstResponseHours,
       avgTimeToResolveHours,
+      tickets: tickets.map((ticket) => ({
+        id: ticket.id,
+        title: ticket.title,
+        description: ticket.description,
+        createdAt: ticket.createdAt,
+        status: ticket.status,
+        priority: ticket.priority,
+        category: ticket.category,
+        buildingId: ticket.buildingId,
+        building: ticket.building,
+        unitId: ticket.unitId,
+        unit: ticket.unit,
+      })),
     };
   }
 

--- a/apps/api/src/tickets/dto/update-ticket.dto.ts
+++ b/apps/api/src/tickets/dto/update-ticket.dto.ts
@@ -1,5 +1,5 @@
 import { IsString, IsOptional, IsEnum, Length } from 'class-validator';
-import { TicketPriority, TicketStatus } from '@prisma/client';
+import { TicketCategory, TicketPriority, TicketStatus } from '@prisma/client';
 
 export class UpdateTicketDto {
   @IsOptional()
@@ -13,9 +13,9 @@ export class UpdateTicketDto {
   description?: string;
 
   @IsOptional()
-  @IsString()
+  @IsEnum(TicketCategory)
   @Length(1, 100)
-  category?: string;
+  category?: TicketCategory;
 
   @IsOptional()
   @IsEnum(TicketPriority)

--- a/apps/api/src/tickets/tickets.contract.spec.ts
+++ b/apps/api/src/tickets/tickets.contract.spec.ts
@@ -1,0 +1,37 @@
+import { validate } from 'class-validator';
+import { TicketCategory } from '@prisma/client';
+import { CreateTicketDto } from './dto/create-ticket.dto';
+
+const canonicalCategories = [
+  'MAINTENANCE',
+  'REPAIR',
+  'CLEANING',
+  'COMPLAINT',
+  'SAFETY',
+  'BILLING',
+  'OTHER',
+] as const;
+
+describe('resident ticket category contract', () => {
+  it.each(canonicalCategories)('accepts frontend category %s', async (category) => {
+    const dto = Object.assign(new CreateTicketDto(), {
+      title: 'Valid ticket',
+      description: 'A valid ticket description',
+      category,
+    });
+
+    await expect(validate(dto)).resolves.toEqual([]);
+    expect(Object.values(TicketCategory)).toContain(category);
+  });
+
+  it.each(['GENERAL', 'RUIDO', 'MANTENIMIENTO', 'OTROS'])('rejects legacy category %s', async (category) => {
+    const dto = Object.assign(new CreateTicketDto(), {
+      title: 'Invalid category',
+      description: 'A valid ticket description',
+      category,
+    });
+
+    const errors = await validate(dto);
+    expect(errors.some((error) => error.property === 'category')).toBe(true);
+  });
+});

--- a/apps/api/src/tickets/tickets.controller.spec.ts
+++ b/apps/api/src/tickets/tickets.controller.spec.ts
@@ -5,6 +5,11 @@ import { ResidentAccessService } from '../resident-access/resident-access.servic
 describe('TicketsController', () => {
   const ticketsService = {
     findAll: jest.fn(),
+    create: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+    addComment: jest.fn(),
+    validateResidentUnitAccess: jest.fn(),
   } as unknown as jest.Mocked<TicketsService>;
   const residentAccess = {
     shouldEnforce: jest.fn(),
@@ -26,5 +31,64 @@ describe('TicketsController', () => {
     expect(residentAccess.shouldEnforce).toHaveBeenCalledWith(['TENANT_ADMIN', 'RESIDENT']);
     expect(residentAccess.getActiveUnitIds).not.toHaveBeenCalled();
     expect(ticketsService.findAll).toHaveBeenCalledWith('tenant-1', 'building-1', {});
+  });
+
+  it('forces resident-created tickets to canonical defaults and removes assignment', async () => {
+    residentAccess.shouldEnforce.mockReturnValue(true);
+    residentAccess.getActiveUnitIds.mockResolvedValue(['unit-1']);
+    ticketsService.create.mockResolvedValue({ id: 'ticket-1' } as never);
+
+    await controller.create(
+      'building-1',
+      { title: 'Leak', description: 'Water leak', unitId: 'unit-1', assignedToMembershipId: 'member-1', priority: 'URGENT', category: 'REPAIR' } as never,
+      { tenantId: 'tenant-1', user: { id: 'resident-1', roles: ['RESIDENT'] } } as never,
+    );
+
+    expect(ticketsService.create).toHaveBeenCalledWith(
+      'tenant-1',
+      'building-1',
+      'resident-1',
+      expect.objectContaining({ category: 'REPAIR', priority: 'MEDIUM', assignedToMembershipId: undefined }),
+    );
+  });
+
+  it('rejects resident ticket mutation endpoints', async () => {
+    residentAccess.shouldEnforce.mockReturnValue(true);
+    const request = { tenantId: 'tenant-1', user: { id: 'resident-1', roles: ['RESIDENT'] } } as never;
+
+    await expect(controller.update('building-1', 'ticket-1', {}, request)).rejects.toThrow('Missing required ticket permission: tickets.manage');
+    await expect(controller.remove('building-1', 'ticket-1', request)).rejects.toThrow('Missing required ticket permission: tickets.manage');
+    expect(ticketsService.update).not.toHaveBeenCalled();
+    expect(ticketsService.remove).not.toHaveBeenCalled();
+  });
+
+  it('allows operator and tenant admin management', async () => {
+    residentAccess.shouldEnforce.mockReturnValue(false);
+    const operatorRequest = { tenantId: 'tenant-1', user: { id: 'operator-1', roles: ['OPERATOR'] } } as never;
+    ticketsService.update.mockResolvedValue({ id: 'ticket-1', title: 'Updated' } as never);
+    await expect(controller.update('building-1', 'ticket-1', { title: 'Updated' }, operatorRequest)).resolves.toEqual({ id: 'ticket-1', title: 'Updated' });
+
+    const adminRequest = { tenantId: 'tenant-1', user: { id: 'admin-1', roles: ['TENANT_ADMIN'] } } as never;
+    await expect(controller.update('building-1', 'ticket-1', { title: 'Updated' }, adminRequest)).resolves.toEqual({ id: 'ticket-1', title: 'Updated' });
+  });
+
+  it('allows an operator to add an administrative comment within the building scope', async () => {
+    residentAccess.shouldEnforce.mockReturnValue(false);
+    ticketsService.addComment.mockResolvedValue({ id: 'comment-1', body: 'Estamos revisando' } as never);
+
+    await expect(controller.addComment(
+      'building-1',
+      'ticket-1',
+      { body: 'Estamos revisando' },
+      { tenantId: 'tenant-1', user: { id: 'operator-1', roles: ['OPERATOR'] } } as never,
+    )).resolves.toEqual({ id: 'comment-1', body: 'Estamos revisando' });
+
+    expect(ticketsService.addComment).toHaveBeenCalledWith(
+      'tenant-1',
+      'building-1',
+      'ticket-1',
+      'operator-1',
+      { body: 'Estamos revisando' },
+    );
   });
 });

--- a/apps/api/src/tickets/tickets.controller.ts
+++ b/apps/api/src/tickets/tickets.controller.ts
@@ -9,8 +9,9 @@ import {
   UseGuards,
   Request,
   Query,
+  ForbiddenException,
 } from '@nestjs/common';
-import { TicketPriority, TicketStatus } from '@prisma/client';
+import { TicketCategory, TicketPriority, TicketStatus } from '@prisma/client';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { BuildingAccessGuard } from '../tenancy/building-access.guard';
 import { TicketsService } from './tickets.service';
@@ -21,6 +22,8 @@ import { CreateTicketDto } from './dto/create-ticket.dto';
 import { UpdateTicketDto } from './dto/update-ticket.dto';
 import { AddTicketCommentDto } from './dto/add-ticket-comment.dto';
 import type { TenantContextRequest } from '../common/types/request.types';
+import { can } from '../rbac/can';
+import type { Permission } from '../rbac/permissions';
 
 /**
  * TicketsController: Tickets management endpoints
@@ -66,6 +69,18 @@ export class TicketsController {
   private readonly ticketPriorities = Object.values(TicketPriority);
   private readonly ticketStatuses = Object.values(TicketStatus);
 
+  private sanitizeResidentTicket(ticket: object): object {
+    const safeTicket = { ...ticket } as Record<string, unknown>;
+    delete safeTicket.assignedTo;
+    return safeTicket;
+  }
+
+  private requirePermission(req: TenantContextRequest, permission: Permission): void {
+    if (!can(req.user.roles || [], permission)) {
+      throw new ForbiddenException(`Missing required ticket permission: ${permission}`);
+    }
+  }
+
   /**
    * Check if user has RESIDENT role in their current memberships
    */
@@ -92,6 +107,7 @@ export class TicketsController {
     @Body() dto: CreateTicketDto,
     @Request() req: TenantContextRequest,
   ) {
+    this.requirePermission(req, 'tickets.write');
     const tenantId = req.tenantId; // Populated by BuildingAccessGuard
     const userId = req.user.id;
     const userRoles = req.user.roles || [];
@@ -103,11 +119,15 @@ export class TicketsController {
       await this.ticketsService.validateResidentUnitAccess(tenantId, userId, dto.unitId, buildingId);
     }
 
+    const residentDto = this.shouldEnforceResidentScope(userRoles)
+      ? { ...dto, category: dto.category ?? TicketCategory.OTHER, priority: TicketPriority.MEDIUM, assignedToMembershipId: undefined }
+      : dto;
+
     return await this.ticketsService.create(
       tenantId,
       buildingId,
       userId,
-      dto,
+      residentDto,
     );
   }
 
@@ -140,6 +160,7 @@ export class TicketsController {
     @Query('sortBy') sortBy?: string,
     @Query('sortOrder') sortOrder?: string,
   ) {
+    this.requirePermission(req, 'tickets.read');
     const tenantId = req.tenantId;
     const userId = req.user.id;
     const userRoles = req.user.roles || [];
@@ -171,7 +192,10 @@ export class TicketsController {
       filters.sortOrder = sortOrder as NonNullable<typeof filters.sortOrder>;
     }
 
-    return await this.ticketsService.findAll(tenantId, buildingId, filters);
+    const result = await this.ticketsService.findAll(tenantId, buildingId, filters);
+    return this.shouldEnforceResidentScope(userRoles)
+      ? { ...result, tickets: result.tickets.map((ticket) => this.sanitizeResidentTicket(ticket)) }
+      : result;
   }
 
   /**
@@ -189,6 +213,7 @@ export class TicketsController {
     @Param('ticketId') ticketId: string,
     @Request() req: TenantContextRequest,
   ) {
+    this.requirePermission(req, 'tickets.read');
     const tenantId = req.tenantId; // Populated by BuildingAccessGuard
     const userId = req.user.id;
     const userRoles = req.user.roles || [];
@@ -206,7 +231,9 @@ export class TicketsController {
       );
     }
 
-    return ticket;
+    return this.shouldEnforceResidentScope(userRoles)
+      ? this.sanitizeResidentTicket(ticket)
+      : ticket;
   }
 
   /**
@@ -231,14 +258,11 @@ export class TicketsController {
     @Body() dto: UpdateTicketDto,
     @Request() req: TenantContextRequest,
   ) {
+    this.requirePermission(req, 'tickets.manage');
     const tenantId = req.tenantId; // Populated by BuildingAccessGuard
-    const userId = req.user.id;
     const userRoles = req.user.roles || [];
     if (this.shouldEnforceResidentScope(userRoles)) {
-      const ticket = await this.ticketsService.findOne(tenantId, buildingId, ticketId);
-      if (!ticket.unitId) throw new BadRequestException('Residents can only access unit-scoped tickets');
-      await this.ticketsService.validateResidentUnitAccess(tenantId, userId, ticket.unitId, buildingId);
-      if (dto.unitId) await this.ticketsService.validateResidentUnitAccess(tenantId, userId, dto.unitId, buildingId);
+      throw new BadRequestException('Residents cannot modify tickets');
     }
 
     // If status is changing, validate transition first
@@ -267,11 +291,10 @@ export class TicketsController {
     @Param('ticketId') ticketId: string,
     @Request() req: TenantContextRequest,
   ) {
+    this.requirePermission(req, 'tickets.manage');
     const tenantId = req.tenantId; // Populated by BuildingAccessGuard
     if (this.shouldEnforceResidentScope(req.user.roles || [])) {
-      const ticket = await this.ticketsService.findOne(tenantId, buildingId, ticketId);
-      if (!ticket.unitId) throw new BadRequestException('Residents can only access unit-scoped tickets');
-      await this.ticketsService.validateResidentUnitAccess(tenantId, req.user.id, ticket.unitId, buildingId);
+      throw new BadRequestException('Residents cannot delete tickets');
     }
     return await this.ticketsService.remove(tenantId, buildingId, ticketId);
   }
@@ -295,6 +318,7 @@ export class TicketsController {
     @Body() dto: AddTicketCommentDto,
     @Request() req: TenantContextRequest,
   ) {
+    this.requirePermission(req, 'tickets.read');
     const tenantId = req.tenantId; // Populated by BuildingAccessGuard
     const userId = req.user.id;
     const userRoles = req.user.roles || [];
@@ -334,6 +358,7 @@ export class TicketsController {
     @Param('ticketId') ticketId: string,
     @Request() req: TenantContextRequest,
   ) {
+    this.requirePermission(req, 'tickets.read');
     const tenantId = req.tenantId; // Populated by BuildingAccessGuard
     if (this.shouldEnforceResidentScope(req.user.roles || [])) {
       const ticket = await this.ticketsService.findOne(tenantId, buildingId, ticketId);

--- a/apps/api/src/tickets/tickets.service.ts
+++ b/apps/api/src/tickets/tickets.service.ts
@@ -47,9 +47,9 @@ interface TicketFilters {
 
 const ticketFindAllArgs = Prisma.validator<Prisma.TicketDefaultArgs>()({
   include: {
-    createdBy: { select: { id: true, name: true, email: true } },
+    createdBy: { select: { id: true, name: true } },
     assignedTo: {
-      include: { user: { select: { id: true, name: true, email: true } } },
+      include: { user: { select: { id: true, name: true } } },
     },
     building: { select: { id: true, name: true } },
     unit: { select: { id: true, label: true, code: true } },
@@ -211,9 +211,9 @@ export class TicketsService {
         status: 'OPEN',
       },
       include: {
-        createdBy: { select: { id: true, name: true, email: true } },
+        createdBy: { select: { id: true, name: true } },
         assignedTo: {
-          include: { user: { select: { id: true, name: true, email: true } } },
+          include: { user: { select: { id: true, name: true } } },
         },
         building: { select: { id: true, name: true } },
         unit: { select: { id: true, label: true, code: true } },
@@ -234,6 +234,9 @@ export class TicketsService {
         unitId: ticket.unitId,
       },
     });
+
+    // Fire-and-forget: notify tenant admins of new ticket
+    void this.notifyTicketCreated(tenantId, buildingId, ticket);
 
     // FASE 2: Fire-and-forget AI categorization (never blocks user response)
     // Only run if user didn't explicitly provide category/priority
@@ -423,15 +426,15 @@ export class TicketsService {
     const ticket = await this.prisma.ticket.findFirst({
       where: { id: ticketId, tenantId, buildingId },
       include: {
-        createdBy: { select: { id: true, name: true, email: true } },
+        createdBy: { select: { id: true, name: true } },
         assignedTo: {
-          include: { user: { select: { id: true, name: true, email: true } } },
+          include: { user: { select: { id: true, name: true } } },
         },
         building: { select: { id: true, name: true } },
         unit: { select: { id: true, label: true, code: true } },
         comments: {
           orderBy: { createdAt: 'asc' },
-          include: { author: { select: { id: true, name: true, email: true } } },
+          include: { author: { select: { id: true, name: true } } },
         },
       },
     });
@@ -558,9 +561,9 @@ export class TicketsService {
       where: { id: ticketId },
       data,
       include: {
-        createdBy: { select: { id: true, name: true, email: true } },
+        createdBy: { select: { id: true, name: true } },
         assignedTo: {
-          include: { user: { select: { id: true, name: true, email: true } } },
+          include: { user: { select: { id: true, name: true } } },
         },
         building: { select: { id: true, name: true } },
         unit: { select: { id: true, label: true, code: true } },
@@ -585,6 +588,15 @@ export class TicketsService {
           newStatus: dto.status,
         },
       });
+
+      // Fire-and-forget: notify ticket creator of status change
+      void this.notifyTicketStatusChanged(
+        tenantId,
+        currentTicket.createdByUserId,
+        ticket,
+        currentTicket.status,
+        dto.status,
+      );
     }
 
     return ticket;
@@ -606,7 +618,7 @@ export class TicketsService {
       },
       include: {
         user: {
-          select: { id: true, name: true, email: true },
+          select: { id: true, name: true },
         },
         roles: {
           select: { role: true },
@@ -667,7 +679,7 @@ export class TicketsService {
         body: dto.body,
       },
       include: {
-        author: { select: { id: true, name: true, email: true } },
+        author: { select: { id: true, name: true } },
       },
     });
 
@@ -682,6 +694,9 @@ export class TicketsService {
         ticketId,
       },
     });
+
+    // Fire-and-forget: notify ticket participants of new comment
+    void this.notifyTicketCommentAdded(tenantId, ticketId, userId, comment);
 
     return comment;
   }
@@ -707,7 +722,7 @@ export class TicketsService {
     return await this.prisma.ticketComment.findMany({
       where: { ticketId, tenantId },
       include: {
-        author: { select: { id: true, name: true, email: true } },
+        author: { select: { id: true, name: true } },
       },
       orderBy: { createdAt: 'asc' },
     });
@@ -803,5 +818,152 @@ export class TicketsService {
     }
 
     return { escalatedCount };
+  }
+
+  /**
+   * Fire-and-forget: notify tenant admins when a new ticket is created
+   */
+  private async notifyTicketCreated(
+    tenantId: string,
+    buildingId: string,
+    ticket: Ticket & { building?: { name: string } | null; unit?: { label: string | null; code: string | null } | null },
+  ): Promise<void> {
+    try {
+      const admins = await this.prisma.tenantMember.findMany({
+        where: {
+          tenantId,
+          role: 'TENANT_ADMIN',
+          status: 'ACTIVE',
+          userId: { not: null },
+        },
+        include: { user: { select: { id: true } } },
+      });
+
+      const buildingName = ticket.building?.name || 'Edificio';
+      const unitLabel = ticket.unit?.label || ticket.unit?.code || '';
+
+      for (const admin of admins) {
+        if (!admin.user?.id) continue;
+        await this.notificationsService.createNotification({
+          tenantId,
+          userId: admin.user.id,
+          type: 'SUPPORT_TICKET_CREATED',
+          title: `Nuevo reclamo: ${ticket.title}`,
+          body: `Se creó un reclamo en ${buildingName}${unitLabel ? ` (${unitLabel})` : ''}. Categoría: ${ticket.category}.`,
+          data: {
+            ticketId: ticket.id,
+            ticketTitle: ticket.title,
+            buildingId,
+            buildingName,
+            category: ticket.category,
+          },
+          deliveryMethods: ['IN_APP'],
+        });
+      }
+    } catch (err) {
+      this.logger.error(
+        `[notifyTicketCreated] Failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Fire-and-forget: notify ticket creator when status changes
+   */
+  private async notifyTicketStatusChanged(
+    tenantId: string,
+    creatorUserId: string,
+    ticket: Ticket & { building?: { name: string } | null },
+    oldStatus: string,
+    newStatus: string,
+  ): Promise<void> {
+    try {
+      const statusLabels: Record<string, string> = {
+        OPEN: 'Abierto',
+        IN_PROGRESS: 'En progreso',
+        RESOLVED: 'Resuelto',
+        CLOSED: 'Cerrado',
+      };
+
+      await this.notificationsService.createNotification({
+        tenantId,
+        userId: creatorUserId,
+        type: 'TICKET_STATUS_CHANGED',
+        title: `Estado actualizado: ${ticket.title}`,
+        body: `Tu reclamo pasó de "${statusLabels[oldStatus] || oldStatus}" a "${statusLabels[newStatus] || newStatus}".`,
+        data: {
+          ticketId: ticket.id,
+          ticketTitle: ticket.title,
+          oldStatus,
+          newStatus,
+          buildingName: ticket.building?.name || '',
+        },
+        deliveryMethods: ['IN_APP'],
+      });
+    } catch (err) {
+      this.logger.error(
+        `[notifyTicketStatusChanged] Failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  /**
+   * Fire-and-forget: notify ticket participants when a comment is added
+   */
+  private async notifyTicketCommentAdded(
+    tenantId: string,
+    ticketId: string,
+    authorUserId: string,
+    comment: TicketComment & { author?: { name: string | null } | null },
+  ): Promise<void> {
+    try {
+      const ticket = await this.prisma.ticket.findFirst({
+        where: { id: ticketId },
+        select: { createdByUserId: true, title: true, assignedToMembershipId: true },
+      });
+
+      if (!ticket) return;
+
+      const recipientIds: string[] = [];
+
+      // Notify ticket creator (if not the author)
+      if (ticket.createdByUserId !== authorUserId) {
+        recipientIds.push(ticket.createdByUserId);
+      }
+
+      // Notify assigned operator (if not the author)
+      if (ticket.assignedToMembershipId) {
+        const assignee = await this.prisma.membership.findFirst({
+          where: { id: ticket.assignedToMembershipId },
+          select: { userId: true },
+        });
+        if (assignee?.userId && assignee.userId !== authorUserId) {
+          recipientIds.push(assignee.userId);
+        }
+      }
+
+      const authorName = comment.author?.name || 'Alguien';
+
+      for (const recipientId of recipientIds) {
+        await this.notificationsService.createNotification({
+          tenantId,
+          userId: recipientId,
+          type: 'TICKET_COMMENT_ADDED',
+          title: `Nuevo comentario: ${ticket.title}`,
+          body: `${authorName} comentó: "${comment.body.slice(0, 100)}${comment.body.length > 100 ? '...' : ''}"`,
+          data: {
+            ticketId,
+            ticketTitle: ticket.title,
+            commentId: comment.id,
+            authorName,
+          },
+          deliveryMethods: ['IN_APP'],
+        });
+      }
+    } catch (err) {
+      this.logger.error(
+        `[notifyTicketCommentAdded] Failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 }

--- a/apps/web/app/(tenant)/[tenantId]/reports/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/reports/page.tsx
@@ -85,7 +85,7 @@ const ReportsPage = () => {
       <div className="flex items-start justify-between">
         <div>
           <h1 className="text-3xl font-bold">Reportes</h1>
-          <p className="text-gray-600">Vista general de operaciones del edificio</p>
+          <p className="text-muted-foreground">Vista general de operaciones del edificio</p>
         </div>
         <FeatureGatedButton
           features={features}
@@ -116,8 +116,8 @@ const ReportsPage = () => {
       />
 
       {/* Tabs */}
-      <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
-        <div className="flex border-b border-gray-200">
+      <div className="overflow-hidden rounded-lg border border-border bg-card text-card-foreground">
+        <div className="flex border-b border-border">
           {tabs.map((tab) => (
             <button
               key={tab.id}
@@ -125,7 +125,7 @@ const ReportsPage = () => {
               className={`px-6 py-3 font-medium text-sm transition-colors ${
                 activeTab === tab.id
                   ? 'border-b-2 border-blue-600 text-blue-600'
-                  : 'text-gray-600 hover:text-gray-900'
+                  : 'text-muted-foreground hover:text-foreground'
               }`}
             >
               {tab.label}

--- a/apps/web/app/(tenant)/[tenantId]/resident/tickets/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/tickets/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   MessageSquare,
   Plus,
@@ -11,11 +11,14 @@ import {
   CheckCircle,
   Loader2,
   Filter,
+  ChevronRight,
 } from 'lucide-react';
 import { useResidentContext } from '../../../../../features/resident/hooks/useResidentContext';
 import { getResidentTickets } from '../../../../../features/resident/api/resident-context.api';
-import { createTicket, type Ticket } from '../../../../../features/tickets/services/tickets.api';
+import { createTicket, getTicket, addComment, type Ticket } from '../../../../../features/tickets/services/tickets.api';
+import { ticketCategoryLabel } from '../../../../../features/tickets/ticket-labels';
 import { useTenants } from '../../../../../features/tenants/tenants.hooks';
+import { useAuthSession } from '../../../../../features/auth/useAuthSession';
 import Card from '../../../../../shared/components/ui/Card';
 import Skeleton from '../../../../../shared/components/ui/Skeleton';
 
@@ -71,17 +74,24 @@ function formatDate(dateStr: string | undefined): string {
 export default function ResidentTicketsPage() {
   const params = useParams<{ tenantId: string }>();
   const tenantId = params.tenantId;
+  const session = useAuthSession();
+  const userId = session?.user.id ?? null;
+  const queryClient = useQueryClient();
 
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [creating, setCreating] = useState(false);
   const [newTicket, setNewTicket] = useState({
     title: '',
     description: '',
-    category: 'GENERAL',
-    priority: 'MEDIUM' as Ticket['priority'],
+    category: 'OTHER',
   });
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const [commentBody, setCommentBody] = useState('');
+  const [commentLoading, setCommentLoading] = useState(false);
 
   const { data: tenants } = useTenants();
   const tenantName = tenants?.find((t) => t.id === tenantId)?.name ?? tenantId;
@@ -89,6 +99,21 @@ export default function ResidentTicketsPage() {
   const { data: context, isLoading: contextLoading } = useResidentContext(tenantId ?? null);
   const buildingId = context?.activeBuildingId;
   const unitId = context?.activeUnitId;
+  const identityMatchesRoute = Boolean(
+    userId && tenantId && session?.activeTenantId === tenantId && context?.tenantId === tenantId,
+  );
+
+  useEffect(() => {
+    queueMicrotask(() => {
+      setSelectedTicket(null);
+      setShowCreateForm(false);
+      setCommentBody('');
+      setDetailError(null);
+      setError(null);
+      setSuccess(null);
+    });
+    void queryClient.removeQueries({ queryKey: ['residentTickets'] });
+  }, [queryClient, userId, tenantId, buildingId, unitId]);
 
   const {
     data: tickets = [],
@@ -97,15 +122,16 @@ export default function ResidentTicketsPage() {
     error: ticketsErrorValue,
     refetch,
   } = useQuery<Ticket[]>({
-    queryKey: ['residentTickets', buildingId, unitId],
+    queryKey: ['residentTickets', userId, tenantId, buildingId, unitId],
     queryFn: () => getResidentTickets(buildingId!, unitId!, 50),
-    enabled: !!buildingId && !!unitId,
-    staleTime: 2 * 60 * 1000,
+    enabled: identityMatchesRoute && !!buildingId && !!unitId && !contextLoading,
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
   });
 
   const handleCreate = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!buildingId || !unitId) return;
+    if (!identityMatchesRoute || !buildingId || !unitId || contextLoading) return;
 
     const title = newTicket.title.trim();
     const description = newTicket.description.trim();
@@ -120,17 +146,16 @@ export default function ResidentTicketsPage() {
 
     try {
       await createTicket(buildingId, {
-        ...newTicket,
         title,
         description,
+        category: newTicket.category as Ticket['category'],
         unitId,
       });
       setSuccess('Reclamo creado correctamente');
       setNewTicket({
         title: '',
         description: '',
-        category: 'GENERAL',
-        priority: 'MEDIUM',
+        category: 'OTHER',
       });
       setShowCreateForm(false);
       refetch();
@@ -146,6 +171,35 @@ export default function ResidentTicketsPage() {
     ? tickets 
     : tickets.filter(t => t.status === statusFilter);
 
+  const openTicketDetail = async (ticketId: string) => {
+    if (!identityMatchesRoute || !buildingId) return;
+    setDetailLoading(true);
+    setDetailError(null);
+    try {
+      setSelectedTicket(await getTicket(buildingId, ticketId));
+    } catch (err) {
+      setDetailError(err instanceof Error ? err.message : 'No pudimos cargar el reclamo.');
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  const submitComment = async () => {
+    if (!identityMatchesRoute || !selectedTicket || !buildingId || !commentBody.trim()) return;
+    setCommentLoading(true);
+    setDetailError(null);
+    try {
+      await addComment(buildingId, selectedTicket.id, { body: commentBody.trim() });
+      setCommentBody('');
+      setSelectedTicket(await getTicket(buildingId, selectedTicket.id));
+      void queryClient.invalidateQueries({ queryKey: ['residentTickets'] });
+    } catch (err) {
+      setDetailError(err instanceof Error ? err.message : 'No pudimos enviar el comentario.');
+    } finally {
+      setCommentLoading(false);
+    }
+  };
+
   if (contextLoading) {
     return (
       <div className="space-y-6">
@@ -159,7 +213,7 @@ export default function ResidentTicketsPage() {
     );
   }
 
-  if (!buildingId || !unitId) {
+  if (!identityMatchesRoute || !buildingId || !unitId) {
     return (
       <div>
         <h1 className="text-2xl font-semibold flex items-center gap-2">
@@ -196,6 +250,7 @@ export default function ResidentTicketsPage() {
         </div>
         <button
           onClick={() => setShowCreateForm(!showCreateForm)}
+          disabled={!identityMatchesRoute || contextLoading}
           className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition"
           type="button"
         >
@@ -245,25 +300,13 @@ export default function ResidentTicketsPage() {
                   onChange={(e) => setNewTicket({ ...newTicket, category: e.target.value })}
                   className="w-full px-3 py-2 border rounded-md"
                 >
-                  <option value="GENERAL">General</option>
-                  <option value="MANTENIMIENTO">Mantenimiento</option>
-                  <option value="RUIDO">Ruido</option>
-                  <option value="SEGURIDAD">Seguridad</option>
-                  <option value="OTROS">Otros</option>
-                </select>
-              </div>
-              <div>
-                <label htmlFor="resident-ticket-priority" className="block text-sm font-medium mb-1">Prioridad</label>
-                <select
-                  id="resident-ticket-priority"
-                  value={newTicket.priority}
-                  onChange={(e) => setNewTicket({ ...newTicket, priority: e.target.value as Ticket['priority'] })}
-                  className="w-full px-3 py-2 border rounded-md"
-                >
-                  <option value="LOW">Baja</option>
-                  <option value="MEDIUM">Media</option>
-                  <option value="HIGH">Alta</option>
-                  <option value="URGENT">Urgente</option>
+                  <option value="MAINTENANCE">Mantenimiento</option>
+                  <option value="REPAIR">Reparación</option>
+                  <option value="CLEANING">Limpieza</option>
+                  <option value="COMPLAINT">Reclamo</option>
+                  <option value="SAFETY">Seguridad</option>
+                  <option value="BILLING">Facturación</option>
+                  <option value="OTHER">Otro</option>
                 </select>
               </div>
             </div>
@@ -339,6 +382,13 @@ export default function ResidentTicketsPage() {
         <div className="space-y-3">
           {filteredTickets.map((ticket) => (
             <Card key={ticket.id} className="p-4 hover:shadow-md transition">
+              <button
+                type="button"
+                className="w-full text-left focus:outline-none focus:ring-2 focus:ring-blue-500 rounded cursor-pointer"
+                onClick={() => void openTicketDetail(ticket.id)}
+                disabled={detailLoading}
+                aria-label={`Ver reclamo ${ticket.title}`}
+              >
               <div className="flex items-start justify-between gap-4">
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">
@@ -355,7 +405,7 @@ export default function ResidentTicketsPage() {
                     </span>
                     <span className="flex items-center gap-1">
                       <Filter className="w-3 h-3" />
-                      {ticket.category}
+                      {ticketCategoryLabel(ticket.category)}
                     </span>
                   </div>
                 </div>
@@ -363,8 +413,55 @@ export default function ResidentTicketsPage() {
                   {ticketStatusLabel(ticket.status)}
                 </div>
               </div>
+              <div className="flex items-center justify-end gap-1 mt-3 text-sm text-blue-600 font-medium">
+                Ver reclamo
+                <ChevronRight className="w-4 h-4" />
+              </div>
+              </button>
             </Card>
           ))}
+        </div>
+      )}
+
+      {detailLoading && <p role="status" className="mt-4 text-sm text-muted-foreground">Cargando reclamo…</p>}
+      {detailError && !selectedTicket && <p role="alert" className="mt-4 text-sm text-red-700">{detailError}</p>}
+      {selectedTicket && (
+        <div className="fixed inset-0 z-50 flex items-end bg-black/50 sm:items-center" role="dialog" aria-modal="true" aria-labelledby="resident-ticket-detail-title">
+          <Card className="w-full max-h-[90vh] overflow-y-auto rounded-t-lg p-6 sm:mx-auto sm:w-[600px] sm:rounded-lg">
+            <div className="flex items-start justify-between gap-4">
+              <h2 id="resident-ticket-detail-title" className="text-xl font-semibold">{selectedTicket.title}</h2>
+              <button type="button" onClick={() => setSelectedTicket(null)} aria-label="Cerrar detalle" className="text-gray-500">×</button>
+            </div>
+            <p className="mt-4 text-sm">{selectedTicket.description}</p>
+            <div className="mt-3 grid grid-cols-2 gap-3 text-sm text-muted-foreground">
+              <span>Estado: {ticketStatusLabel(selectedTicket.status)}</span>
+              <span>Prioridad: {priorityLabel(selectedTicket.priority)}</span>
+              <span>Categoría: {ticketCategoryLabel(selectedTicket.category)}</span>
+              <span>Fecha: {formatDate(selectedTicket.createdAt)}</span>
+              <span>Unidad: {selectedTicket.unit?.label ?? selectedTicket.unit?.code ?? 'Tu unidad'}</span>
+            </div>
+            {detailError && <p role="alert" className="mt-3 text-sm text-red-700">{detailError}</p>}
+            <div className="mt-6 space-y-3">
+              <h3 className="font-medium">Comentarios ({selectedTicket.comments?.length ?? 0})</h3>
+              {selectedTicket.comments?.length ? selectedTicket.comments.map((comment) => (
+                <div key={comment.id} className="rounded bg-muted p-3 text-sm">
+                  <p className="font-medium">{comment.author.name}</p>
+                  <p className="mt-1">{comment.body}</p>
+                </div>
+              )) : <p className="text-sm text-muted-foreground">Todavía no hay comentarios.</p>}
+              <textarea
+                value={commentBody}
+                onChange={(event) => setCommentBody(event.target.value)}
+                placeholder="Escribí un comentario"
+                rows={3}
+                disabled={commentLoading}
+                className="w-full rounded border p-2"
+              />
+              <button type="button" onClick={() => void submitComment()} disabled={commentLoading || !commentBody.trim()} className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50">
+                {commentLoading ? 'Enviando…' : 'Enviar comentario'}
+              </button>
+            </div>
+          </Card>
         </div>
       )}
     </div>

--- a/apps/web/features/reports/components/TicketsReport.tsx
+++ b/apps/web/features/reports/components/TicketsReport.tsx
@@ -1,7 +1,10 @@
 'use client';
 
+import { useState } from 'react';
 import { Card, Badge, Skeleton, ErrorState, EmptyState } from '@/shared/components/ui';
-import type { TicketsReport } from '../services/reports.api';
+import { addComment, getTicket, updateTicket, type Ticket } from '@/features/tickets/services/tickets.api';
+import { ticketCategoryLabel, ticketPriorityLabel, ticketStatusLabel } from '@/features/tickets/ticket-labels';
+import type { TicketsReport, ReportTicket } from '../services/reports.api';
 
 interface TicketsReportProps {
   data: TicketsReport | null;
@@ -38,6 +41,55 @@ export function TicketsReportComponent({
   error,
   onRetry,
 }: TicketsReportProps) {
+  const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const [status, setStatus] = useState<Ticket['status']>('OPEN');
+  const [commentBody, setCommentBody] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+
+  const openTicket = async (ticket: ReportTicket) => {
+    setDetailLoading(true);
+    setDetailError(null);
+    try {
+      const detail = await getTicket(ticket.buildingId, ticket.id);
+      setSelectedTicket(detail);
+      setStatus(detail.status);
+      setCommentBody('');
+      setSaveMessage(null);
+    } catch (err) {
+      setDetailError(err instanceof Error ? err.message : 'No pudimos cargar el reclamo.');
+    } finally {
+      setDetailLoading(false);
+    }
+  };
+
+  const saveTicketChanges = async () => {
+    if (!selectedTicket) return;
+    setSaving(true);
+    setDetailError(null);
+    setSaveMessage(null);
+    try {
+      if (status !== selectedTicket.status) {
+        await updateTicket(selectedTicket.building.id, selectedTicket.id, { status });
+      }
+      if (commentBody.trim()) {
+        await addComment(selectedTicket.building.id, selectedTicket.id, { body: commentBody.trim() });
+      }
+      const refreshed = await getTicket(selectedTicket.building.id, selectedTicket.id);
+      setSelectedTicket(refreshed);
+      setStatus(refreshed.status);
+      setCommentBody('');
+      setSaveMessage('Cambios guardados correctamente.');
+      onRetry?.();
+    } catch (err) {
+      setDetailError(err instanceof Error ? err.message : 'No pudimos guardar los cambios.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
   if (loading) {
     return (
       <div className="space-y-4">
@@ -75,7 +127,7 @@ export function TicketsReportComponent({
         <SimpleTable
           headers={['Estado', 'Cantidad']}
           rows={data.byStatus.map((item) => [
-            <Badge key={item.status} className="border border-border bg-muted text-foreground">{item.status}</Badge>,
+            <Badge key={item.status} className="border border-border bg-muted text-foreground">{ticketStatusLabel(item.status)}</Badge>,
             item.count,
           ])}
         />
@@ -87,7 +139,7 @@ export function TicketsReportComponent({
         <SimpleTable
           headers={['Prioridad', 'Cantidad']}
           rows={data.byPriority.map((item) => [
-            <Badge key={item.priority} className="border border-border bg-muted text-foreground">{item.priority}</Badge>,
+            <Badge key={item.priority} className="border border-border bg-muted text-foreground">{ticketPriorityLabel(item.priority)}</Badge>,
             item.count,
           ])}
         />
@@ -99,11 +151,52 @@ export function TicketsReportComponent({
         <SimpleTable
           headers={['Categoría', 'Cantidad']}
           rows={data.topCategories.map((item) => [
-            item.category,
+            ticketCategoryLabel(item.category),
             item.count,
           ])}
         />
       </div>
+
+      <div>
+        <h3 className="text-lg font-semibold mb-4">Reclamos</h3>
+        {data.tickets.length === 0 ? <EmptyState title="Sin reclamos" description="No hay reclamos en el período seleccionado" /> : (
+          <div className="space-y-2">
+            {data.tickets.map((ticket) => (
+              <button key={ticket.id} type="button" onClick={() => void openTicket(ticket)} className="w-full rounded-lg border border-border bg-card p-4 text-left hover:bg-muted" aria-label={`Ver reclamo ${ticket.title}`}>
+                <div className="flex items-center justify-between gap-3"><span className="font-medium">{ticket.title}</span><Badge>{ticketStatusLabel(ticket.status)}</Badge></div>
+                <p className="mt-1 text-sm text-muted-foreground">{ticket.building.name}{ticket.unit ? ` · ${ticket.unit.label ?? ticket.unit.code}` : ''} · {ticketCategoryLabel(ticket.category)} · {ticketPriorityLabel(ticket.priority)}</p>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {detailLoading && <div role="status" className="text-sm text-muted-foreground">Cargando reclamo…</div>}
+      {detailError && <ErrorState message={detailError} />}
+      {selectedTicket && (
+        <div role="dialog" aria-modal="true" aria-labelledby="ticket-detail-title" className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+          <Card className="max-h-[90vh] w-full max-w-2xl overflow-y-auto p-6">
+            <div className="flex items-start justify-between gap-4"><h2 id="ticket-detail-title" className="text-xl font-bold">{selectedTicket.title}</h2><button type="button" onClick={() => setSelectedTicket(null)} aria-label="Cerrar detalle">Cerrar</button></div>
+            <p className="mt-4 text-sm">{selectedTicket.description}</p>
+            <div className="mt-4 grid grid-cols-2 gap-3 text-sm"><span>Prioridad: {ticketPriorityLabel(selectedTicket.priority)}</span><span>Categoría: {ticketCategoryLabel(selectedTicket.category)}</span><span>Creado: {new Date(selectedTicket.createdAt).toLocaleString()}</span></div>
+            <label className="mt-4 block text-sm font-medium" htmlFor="report-ticket-status">Estado</label>
+            <select id="report-ticket-status" value={status} onChange={(event) => setStatus(event.target.value as Ticket['status'])} disabled={saving} className="mt-1 w-full rounded-md border border-input bg-background px-3 py-2 text-sm">
+              <option value="OPEN">Abierto</option>
+              <option value="IN_PROGRESS">En progreso</option>
+              <option value="RESOLVED">Resuelto</option>
+              <option value="CLOSED">Cerrado</option>
+            </select>
+            <h3 className="mt-6 font-semibold">Comentarios ({selectedTicket.comments?.length ?? 0})</h3>
+            <div className="mt-2 space-y-2">{selectedTicket.comments?.map((comment) => <div key={comment.id} className="rounded border border-border p-3 text-sm"><p>{comment.body}</p><p className="mt-1 text-xs text-muted-foreground">{comment.author.name}</p></div>)}</div>
+            <label className="mt-4 block text-sm font-medium" htmlFor="report-ticket-comment">Respuesta administrativa</label>
+            <textarea id="report-ticket-comment" value={commentBody} onChange={(event) => setCommentBody(event.target.value)} disabled={saving} rows={3} className="mt-1 w-full rounded-md border border-input bg-background p-2 text-sm" placeholder="Escribí una respuesta" />
+            {saveMessage && <p className="mt-2 text-sm text-green-600" role="status">{saveMessage}</p>}
+            <button type="button" onClick={() => void saveTicketChanges()} disabled={saving || (status === selectedTicket.status && !commentBody.trim())} className="mt-3 rounded-md bg-primary px-4 py-2 text-primary-foreground disabled:opacity-50">
+              {saving ? 'Guardando…' : 'Guardar cambios'}
+            </button>
+          </Card>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/features/reports/services/reports.api.ts
+++ b/apps/web/features/reports/services/reports.api.ts
@@ -39,6 +39,21 @@ export interface TicketsReport {
   topCategories: Array<{ category: string; count: number }>;
   avgTimeToFirstResponseHours: number;
   avgTimeToResolveHours: number;
+  tickets: ReportTicket[];
+}
+
+export interface ReportTicket {
+  id: string;
+  title: string;
+  description: string;
+  createdAt: string;
+  status: string;
+  priority: string;
+  category: string;
+  buildingId: string;
+  building: { id: string; name: string };
+  unitId: string | null;
+  unit: { id: string; label: string | null; code: string } | null;
 }
 
 export interface DelinquentUnit {

--- a/apps/web/features/resident/hooks/useResidentContext.test.tsx
+++ b/apps/web/features/resident/hooks/useResidentContext.test.tsx
@@ -89,4 +89,18 @@ describe('useResidentContext', () => {
     expect(mockedGetResidentContext).toHaveBeenNthCalledWith(1, 'tenant-1');
     expect(mockedGetResidentContext).toHaveBeenNthCalledWith(2, 'tenant-1');
   });
+
+  it('does not fetch a resident context for a route outside the active session tenant', async () => {
+    mockedUseAuthSession.mockReturnValue({
+      user: { id: 'user-1', email: 'resident@buildingos.test', name: 'Resident' },
+      memberships: [],
+      activeTenantId: 'tenant-current',
+    });
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useResidentContext('tenant-previous'), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockedGetResidentContext).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/features/resident/hooks/useResidentContext.ts
+++ b/apps/web/features/resident/hooks/useResidentContext.ts
@@ -15,7 +15,10 @@ export function useResidentContext(tenantId: string | null) {
   return useQuery<ResidentContext>({
     queryKey: ['residentContext', tenantId, userId],
     queryFn: () => getResidentContext(tenantId!),
-    enabled: !!tenantId && !!userId,
+    // A resident route must match the tenant selected by the authenticated
+    // session. This prevents a previous route/context from being reused while
+    // a different account or tenant is still settling.
+    enabled: !!tenantId && !!userId && session?.activeTenantId === tenantId,
     staleTime: 2 * 60 * 1000, // 2 minutes
     gcTime: 5 * 60 * 1000,
     retry: 1,

--- a/apps/web/features/tickets/components/TicketForm.tsx
+++ b/apps/web/features/tickets/components/TicketForm.tsx
@@ -5,7 +5,7 @@ import Button from '@/shared/components/ui/Button';
 import { useToast } from '@/shared/components/ui/Toast';
 import { useTickets } from '../hooks/useTickets';
 import { Loader2 } from 'lucide-react';
-import type { Ticket } from '../services/tickets.api';
+import type { Ticket, TicketCategory } from '../services/tickets.api';
 import type { Unit } from '@/features/units/units.types';
 import { t } from '@/i18n';
 import type { TicketPriority } from '@/types/enums';
@@ -30,7 +30,7 @@ export default function TicketForm({
 
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [category, setCategory] = useState('MAINTENANCE');
+  const [category, setCategory] = useState<TicketCategory>('MAINTENANCE');
   const [priority, setPriority] = useState('MEDIUM');
   const [unitId, setUnitId] = useState('');
   const [submitting, setSubmitting] = useState(false);
@@ -116,7 +116,7 @@ export default function TicketForm({
           <label className="block text-sm font-medium mb-1">{t('tickets.category')} *</label>
           <select
             value={category}
-            onChange={(e) => setCategory(e.target.value)}
+            onChange={(e) => setCategory(e.target.value as TicketCategory)}
             className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
             disabled={submitting}
           >

--- a/apps/web/features/tickets/components/TicketsList.tsx
+++ b/apps/web/features/tickets/components/TicketsList.tsx
@@ -188,6 +188,8 @@ export function TicketsList({ buildingId, tenantId }: TicketsListProps) {
       REPAIR: 'Reparación',
       CLEANING: 'Limpieza',
       COMPLAINT: 'Reclamo',
+      SAFETY: 'Seguridad',
+      BILLING: 'Facturación',
       OTHER: 'Otro',
     };
     return config[category] || category;

--- a/apps/web/features/tickets/components/UnitTicketsList.test.tsx
+++ b/apps/web/features/tickets/components/UnitTicketsList.test.tsx
@@ -1,0 +1,163 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ToastProvider } from '@/shared/components/ui/Toast';
+import { UnitTicketsList } from './UnitTicketsList';
+import * as ticketsApi from '../services/tickets.api';
+import type { Ticket, PaginatedTickets } from '../services/tickets.api';
+
+jest.mock('../services/tickets.api', () => ({
+  listTickets: jest.fn(),
+  getTicket: jest.fn(),
+  addComment: jest.fn(),
+  createTicket: jest.fn(),
+}));
+
+const mockListTickets = jest.mocked(ticketsApi.listTickets);
+const mockGetTicket = jest.mocked(ticketsApi.getTicket);
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>{ui}</ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const mockTicket1: Ticket = {
+  id: 'ticket-1',
+  title: 'Fuga de agua en baño',
+  description: 'Hay una fuga que gotea constantemente',
+  status: 'OPEN',
+  priority: 'HIGH',
+  category: 'MAINTENANCE',
+  createdAt: '2025-01-15T10:00:00Z',
+  updatedAt: '2025-01-15T10:00:00Z',
+  closedAt: null,
+  createdBy: { id: 'user-1', name: 'Residente' },
+  assignedTo: null,
+  building: { id: 'b1', name: 'Edificio Test' },
+  unit: { id: 'unit-1', label: 'Apt 101', code: '101' },
+  comments: [],
+};
+
+const mockTicket2: Ticket = {
+  id: 'ticket-2',
+  title: 'Ruido en el pasillo',
+  description: 'Se escucha ruido constante por la noche',
+  status: 'IN_PROGRESS',
+  priority: 'MEDIUM',
+  category: 'COMPLAINT',
+  createdAt: '2025-01-10T10:00:00Z',
+  updatedAt: '2025-01-12T10:00:00Z',
+  closedAt: null,
+  createdBy: { id: 'user-1', name: 'Residente' },
+  assignedTo: null,
+  building: { id: 'b1', name: 'Edificio Test' },
+  unit: { id: 'unit-1', label: 'Apt 101', code: '101' },
+  comments: [
+    { id: 'c1', body: 'Estamos revisando', author: { id: 'user-2', name: 'Admin' }, createdAt: '2025-01-11T10:00:00Z' },
+  ],
+};
+
+const mockPaginatedTickets: PaginatedTickets = {
+  tickets: [mockTicket1, mockTicket2],
+  total: 2,
+  page: 1,
+  limit: 50,
+  totalPages: 1,
+};
+
+describe('UnitTicketsList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockListTickets.mockResolvedValue(mockPaginatedTickets);
+  });
+
+  it('renders visible "Ver reclamo" text as visible content (not only aria-label)', async () => {
+    renderWithProviders(<UnitTicketsList buildingId="b1" unitId="u1" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('Ver reclamo')).toHaveLength(2);
+    });
+
+    const visibleTexts = screen.getAllByText('Ver reclamo');
+    visibleTexts.forEach((el) => {
+      expect(el.tagName).not.toBe('SCRIPT');
+      expect(el.closest('[aria-hidden]')).toBeNull();
+    });
+  });
+
+  it('renders ticket titles correctly', async () => {
+    renderWithProviders(<UnitTicketsList buildingId="b1" unitId="u1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Fuga de agua en baño')).toBeTruthy();
+      expect(screen.getByText('Ruido en el pasillo')).toBeTruthy();
+    });
+  });
+
+  it('calls openTicketDetail with correct ticketId when card is clicked', async () => {
+    mockGetTicket.mockResolvedValue(mockTicket1);
+
+    renderWithProviders(<UnitTicketsList buildingId="b1" unitId="u1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Fuga de agua en baño')).toBeTruthy();
+    });
+
+    const buttons = screen.getAllByRole('button', { name: /Ver reclamo/ });
+    expect(buttons).toHaveLength(2);
+
+    fireEvent.click(buttons[0]);
+
+    await waitFor(() => {
+      expect(mockGetTicket).toHaveBeenCalledWith('b1', 'ticket-1');
+    });
+  });
+
+  it('does not render admin-only controls', async () => {
+    renderWithProviders(<UnitTicketsList buildingId="b1" unitId="u1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Fuga de agua en baño')).toBeTruthy();
+    });
+
+    expect(screen.queryByText(/Asignar/)).toBeNull();
+    expect(screen.queryByText(/Cambiar estado/)).toBeNull();
+    expect(screen.queryByText(/Cerrar solicitud/)).toBeNull();
+  });
+
+  it('each ticket button is a single button element (no nested buttons)', async () => {
+    renderWithProviders(<UnitTicketsList buildingId="b1" unitId="u1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Fuga de agua en baño')).toBeTruthy();
+    });
+
+    const outerButtons = screen.getAllByRole('button', { name: /Ver reclamo/ });
+    outerButtons.forEach((btn) => {
+      const nestedButtons = btn.querySelectorAll('button');
+      expect(nestedButtons).toHaveLength(0);
+    });
+  });
+
+  it('ticket button has cursor-pointer class', async () => {
+    renderWithProviders(<UnitTicketsList buildingId="b1" unitId="u1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Fuga de agua en baño')).toBeTruthy();
+    });
+
+    const buttons = screen.getAllByRole('button', { name: /Ver reclamo/ });
+    buttons.forEach((btn) => {
+      expect(btn.className).toContain('cursor-pointer');
+    });
+  });
+});

--- a/apps/web/features/tickets/components/UnitTicketsList.tsx
+++ b/apps/web/features/tickets/components/UnitTicketsList.tsx
@@ -2,18 +2,18 @@
 
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { listTickets, addComment as addCommentApi, createTicket } from '../services/tickets.api';
+import { listTickets, getTicket, addComment as addCommentApi, createTicket } from '../services/tickets.api';
 import Button from '@/shared/components/ui/Button';
 import Card from '@/shared/components/ui/Card';
 import EmptyState from '@/shared/components/ui/EmptyState';
 import ErrorState from '@/shared/components/ui/ErrorState';
 import Skeleton from '@/shared/components/ui/Skeleton';
 import { useToast } from '@/shared/components/ui/Toast';
-import { Ticket as TicketIcon, Plus, Send, X, AlertCircle } from 'lucide-react';
-import type { Ticket } from '../services/tickets.api';
+import { Ticket as TicketIcon, Plus, Send, X, AlertCircle, ChevronRight } from 'lucide-react';
+import type { Ticket, TicketCategory } from '../services/tickets.api';
 import { t } from '@/i18n';
-import type { TicketPriority } from '@/types/enums';
 import { ErrorBoundary } from '@/shared/components/error-boundary';
+import { ticketCategoryLabel, ticketPriorityLabel, ticketStatusLabel } from '../ticket-labels';
 interface UnitTicketsListProps {
   buildingId: string;
   unitId: string;
@@ -31,8 +31,11 @@ export function UnitTicketsList({ buildingId, unitId }: UnitTicketsListProps) {
   const queryClient = useQueryClient();
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [selectedTicket, setSelectedTicket] = useState<Ticket | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
   const [commentBody, setCommentBody] = useState('');
   const [addingComment, setAddingComment] = useState(false);
+  const [commentError, setCommentError] = useState<string | null>(null);
 
   // Fetch tickets using React Query for better caching and no flash
   const { data: ticketsData, isLoading: loading, error, refetch } = useQuery({
@@ -68,6 +71,7 @@ export function UnitTicketsList({ buildingId, unitId }: UnitTicketsListProps) {
     }
 
     setAddingComment(true);
+    setCommentError(null);
     try {
       await addCommentMutation.mutateAsync({
         ticketId: selectedTicket.id,
@@ -77,14 +81,24 @@ export function UnitTicketsList({ buildingId, unitId }: UnitTicketsListProps) {
       setCommentBody('');
       // React Query automatically invalidates, but update selected ticket manually
       await refetch();
-      const updated = tickets.find((t) => t.id === selectedTicket.id);
-      if (updated) {
-        setSelectedTicket(updated);
-      }
-    } catch {
+      setSelectedTicket(await getTicket(buildingId, selectedTicket.id));
+    } catch (err) {
+      setCommentError(err instanceof Error ? err.message : t('tickets.errors.commentFailed'));
       toast(t('tickets.errors.commentFailed'), 'error');
     } finally {
       setAddingComment(false);
+    }
+  };
+
+  const openTicketDetail = async (ticketId: string) => {
+    setDetailLoading(true);
+    setDetailError(null);
+    try {
+      setSelectedTicket(await getTicket(buildingId, ticketId));
+    } catch (err) {
+      setDetailError(err instanceof Error ? err.message : 'No pudimos cargar el reclamo.');
+    } finally {
+      setDetailLoading(false);
     }
   };
 
@@ -157,9 +171,15 @@ export function UnitTicketsList({ buildingId, unitId }: UnitTicketsListProps) {
           {tickets.map((ticket) => (
             <Card
               key={ticket.id}
-              className="cursor-pointer hover:shadow-md transition p-4"
-              onClick={() => setSelectedTicket(ticket)}
+              className="hover:shadow-md transition p-4"
             >
+              <button
+                type="button"
+                className="w-full text-left focus:outline-none focus:ring-2 focus:ring-blue-500 rounded cursor-pointer"
+                onClick={() => void openTicketDetail(ticket.id)}
+                disabled={detailLoading}
+                aria-label={`Ver reclamo ${ticket.title}`}
+              >
               <div className="flex justify-between items-start mb-2">
                 <div className="flex-1">
                   <h3 className="font-semibold text-foreground">{ticket.title}</h3>
@@ -173,21 +193,26 @@ export function UnitTicketsList({ buildingId, unitId }: UnitTicketsListProps) {
                       ticket.status
                     )}`}
                   >
-                    {ticket.status}
+                    {ticketStatusLabel(ticket.status)}
                   </span>
                   <span
                     className={`text-xs font-medium px-2 py-1 rounded ${getPriorityColor(
                       ticket.priority
                     )}`}
                   >
-                    {ticket.priority}
+                    {ticketPriorityLabel(ticket.priority)}
                   </span>
                 </div>
               </div>
               <div className="flex justify-between items-center text-xs text-muted-foreground">
-                <span>{ticket.category}</span>
+                <span>{ticketCategoryLabel(ticket.category)}</span>
                 <span>{ticket.comments?.length || 0} {t('common.comments')}</span>
               </div>
+              <div className="flex items-center justify-end gap-1 mt-3 text-sm text-blue-600 font-medium">
+                {t('tickets.viewDetail')}
+                <ChevronRight className="w-4 h-4" />
+              </div>
+              </button>
             </Card>
           ))}
         </div>
@@ -261,7 +286,7 @@ export function UnitTicketsList({ buildingId, unitId }: UnitTicketsListProps) {
                 <label className="block text-sm font-medium text-muted-foreground mb-1">
                   {t('tickets.category')}
                 </label>
-                <p className="text-sm">{selectedTicket.category}</p>
+                <p className="text-sm">{ticketCategoryLabel(selectedTicket.category)}</p>
               </div>
 
               {/* Comments */}
@@ -292,6 +317,7 @@ export function UnitTicketsList({ buildingId, unitId }: UnitTicketsListProps) {
                 </div>
 
                 {/* Add Comment Form */}
+                {commentError && <p role="alert" className="mb-2 text-sm text-red-700">{commentError}</p>}
                 <div className="flex gap-2">
                   <textarea
                     value={commentBody}
@@ -314,6 +340,12 @@ export function UnitTicketsList({ buildingId, unitId }: UnitTicketsListProps) {
           </Card>
         </div>
       )}
+      {detailLoading && !selectedTicket && (
+        <div role="status" className="p-4 text-sm text-muted-foreground">Cargando reclamo…</div>
+      )}
+      {detailError && !selectedTicket && (
+        <div role="alert" className="p-4 text-sm text-red-700">{detailError}</div>
+      )}
       </div>
     </ErrorBoundary>
   );
@@ -321,7 +353,7 @@ export function UnitTicketsList({ buildingId, unitId }: UnitTicketsListProps) {
 
 /**
  * UnitTicketForm: Form for creating a maintenance request (resident view)
- * - Title, description, category, priority
+ * - Title, description, category
  * - unitId is pre-filled and not editable
  */
 function UnitTicketForm({
@@ -339,8 +371,7 @@ function UnitTicketForm({
 
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
-  const [category, setCategory] = useState('MAINTENANCE');
-  const [priority, setPriority] = useState('MEDIUM');
+  const [category, setCategory] = useState<TicketCategory>('MAINTENANCE');
   const [submitting, setSubmitting] = useState(false);
   const [validationError, setValidationError] = useState('');
 
@@ -372,7 +403,6 @@ function UnitTicketForm({
         title: title.trim(),
         description: description.trim(),
         category,
-        priority: priority as TicketPriority,
         unitId, // Pre-filled from unit context
       });
 
@@ -425,7 +455,7 @@ function UnitTicketForm({
           <label className="block text-sm font-medium mb-1">{t('tickets.category')} *</label>
           <select
             value={category}
-            onChange={(e) => setCategory(e.target.value)}
+            onChange={(e) => setCategory(e.target.value as TicketCategory)}
             className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
             disabled={submitting}
           >
@@ -433,22 +463,9 @@ function UnitTicketForm({
             <option value="REPAIR">{t('tickets.categories.repair')}</option>
             <option value="CLEANING">{t('tickets.categories.cleaning')}</option>
             <option value="COMPLAINT">{t('tickets.categories.complaint')}</option>
+            <option value="SAFETY">{t('tickets.categories.safety')}</option>
+            <option value="BILLING">{t('tickets.categories.billing')}</option>
             <option value="OTHER">{t('tickets.categories.other')}</option>
-          </select>
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium mb-1">{t('tickets.priority')}</label>
-          <select
-            value={priority}
-            onChange={(e) => setPriority(e.target.value)}
-            className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-            disabled={submitting}
-          >
-            <option value="LOW">{t('tickets.priorities.low')}</option>
-            <option value="MEDIUM">{t('tickets.priorities.medium')}</option>
-            <option value="HIGH">{t('tickets.priorities.high')}</option>
-            <option value="URGENT">{t('tickets.priorities.urgent')}</option>
           </select>
         </div>
       </div>

--- a/apps/web/features/tickets/services/tickets.api.ts
+++ b/apps/web/features/tickets/services/tickets.api.ts
@@ -21,27 +21,29 @@ export interface AiCategorySuggestion {
   reasoning: string;
 }
 
+export type TicketCategory =
+  | 'MAINTENANCE' | 'REPAIR' | 'CLEANING' | 'COMPLAINT'
+  | 'SAFETY' | 'BILLING' | 'OTHER';
+
 export interface Ticket {
   id: string;
   status: 'OPEN' | 'IN_PROGRESS' | 'RESOLVED' | 'CLOSED';
   priority: 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT';
   title: string;
   description: string;
-  category: string;
+  category: TicketCategory;
   createdAt: string;
   updatedAt: string;
   closedAt: string | null;
   createdBy: {
     id: string;
     name: string;
-    email: string;
   };
   assignedTo: {
     id: string;
     user: {
       id: string;
       name: string;
-      email: string;
     };
   } | null;
   building: {
@@ -65,7 +67,6 @@ export interface TicketComment {
   author: {
     id: string;
     name: string;
-    email: string;
   };
   createdAt: string;
 }
@@ -73,7 +74,7 @@ export interface TicketComment {
 export interface CreateTicketInput {
   title: string;
   description: string;
-  category: string;
+  category: TicketCategory;
   priority?: 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT';
   unitId?: string;
   assignedToMembershipId?: string;
@@ -82,7 +83,7 @@ export interface CreateTicketInput {
 export interface UpdateTicketInput {
   title?: string;
   description?: string;
-  category?: string;
+  category?: TicketCategory;
   priority?: 'LOW' | 'MEDIUM' | 'HIGH' | 'URGENT';
   status?: 'OPEN' | 'IN_PROGRESS' | 'RESOLVED' | 'CLOSED';
   unitId?: string | null;

--- a/apps/web/features/tickets/ticket-labels.ts
+++ b/apps/web/features/tickets/ticket-labels.ts
@@ -1,0 +1,37 @@
+import type { TicketCategory } from './services/tickets.api';
+
+const CATEGORY_LABELS: Record<TicketCategory, string> = {
+  MAINTENANCE: 'Mantenimiento',
+  REPAIR: 'Reparación',
+  CLEANING: 'Limpieza',
+  COMPLAINT: 'Reclamo',
+  SAFETY: 'Seguridad',
+  BILLING: 'Facturación',
+  OTHER: 'Otro',
+};
+
+export function ticketCategoryLabel(category: string): string {
+  return CATEGORY_LABELS[category as TicketCategory] ?? category;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  OPEN: 'Abierto',
+  IN_PROGRESS: 'En proceso',
+  RESOLVED: 'Resuelto',
+  CLOSED: 'Cerrado',
+};
+
+const PRIORITY_LABELS: Record<string, string> = {
+  LOW: 'Baja',
+  MEDIUM: 'Media',
+  HIGH: 'Alta',
+  URGENT: 'Urgente',
+};
+
+export function ticketStatusLabel(status: string): string {
+  return STATUS_LABELS[status] ?? status;
+}
+
+export function ticketPriorityLabel(priority: string): string {
+  return PRIORITY_LABELS[priority] ?? priority;
+}

--- a/apps/web/i18n/es-419.json
+++ b/apps/web/i18n/es-419.json
@@ -347,6 +347,8 @@
       "repair": "Reparación",
       "cleaning": "Limpieza",
       "complaint": "Reclamo",
+      "safety": "Seguridad",
+      "billing": "Facturación",
       "other": "Otro"
     },
     "priority": "Prioridad",
@@ -389,6 +391,7 @@
     "closeConfirmTitle": "¿Cerrar solicitud?",
     "closeConfirmMessage": "¿Estás seguro de que deseas cerrar esta solicitud? Puedes reabrirla más tarde si es necesario.",
     "closeButton": "Cerrar solicitud",
+    "viewDetail": "Ver reclamo",
     "statusManagedByStaff": "(Estado gestionado por el personal)",
     "submitComment": "Enviar comentario",
     "commentRequired": "El comentario es requerido",

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -7,7 +7,7 @@ import { useTenants } from '../../../features/tenants/tenants.hooks';
 import type { TenantSummary } from '../../../features/tenants/tenants.service';
 import type { Membership } from '../../../features/auth/auth.types';
 import Select from '../ui/Select';
-import { Bell, CreditCard, X, Clock, CheckCircle, XCircle } from 'lucide-react';
+import { Bell, CreditCard, X, Clock, CheckCircle, XCircle, MessageSquare } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useEffect, useRef } from 'react';
 import { listNotifications, markAsRead, type Notification } from '@/features/notifications/notifications.api';
@@ -57,25 +57,36 @@ function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
   // Filter notifications based on role
   const allNotifs = notificationResult?.notifications ?? [];
   
+  const TICKET_TYPES = new Set([
+    'TICKET_STATUS_CHANGED',
+    'TICKET_COMMENT_ADDED',
+    'SUPPORT_TICKET_CREATED',
+    'URGENT_TICKET_UNASSIGNED',
+  ]);
+
   let filteredNotifications: Notification[] = [];
   let badgeCount = 0;
 
   if (isAdmin) {
-    // Admin: show BUILDING_ALERT for new payments pending review
-    filteredNotifications = allNotifs.filter((n: Notification) => 
+    // Admin: payments + ticket notifications
+    filteredNotifications = allNotifs.filter((n: Notification) =>
       (n.type === 'BUILDING_ALERT' && n.data?.event === 'PAYMENT_SUBMITTED') ||
-      n.data?.paymentId
+      n.data?.paymentId ||
+      TICKET_TYPES.has(n.type)
     );
-    badgeCount = pendingCount; // Badge shows pending payments count
+    const unreadTicketCount = filteredNotifications.filter(
+      (n: Notification) => !n.isRead && TICKET_TYPES.has(n.type),
+    ).length;
+    badgeCount = pendingCount + unreadTicketCount;
   } else {
-    // Resident: show PAYMENT_RECEIVED and PAYMENT_REJECTED
-    filteredNotifications = allNotifs.filter((n: Notification) => 
-      n.type === 'PAYMENT_RECEIVED' || 
+    // Resident: payments + ticket notifications
+    filteredNotifications = allNotifs.filter((n: Notification) =>
+      n.type === 'PAYMENT_RECEIVED' ||
       n.type === 'PAYMENT_REJECTED' ||
       n.data?.event === 'PAYMENT_APPROVED' ||
-      n.data?.event === 'PAYMENT_REJECTED'
+      n.data?.event === 'PAYMENT_REJECTED' ||
+      TICKET_TYPES.has(n.type)
     );
-    // Badge shows count of unread personal payment notifications
     badgeCount = filteredNotifications.filter((n: Notification) => !n.isRead).length;
   }
 
@@ -96,8 +107,15 @@ function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
       await markReadMutation.mutateAsync(notification.id);
     }
     
-    // Route based on role
-    if (isAdmin) {
+    // Route based on notification type
+    if (TICKET_TYPES.has(notification.type)) {
+      if (isAdmin) {
+        const buildingId = notification.data?.buildingId;
+        router.push(buildingId ? `/${tenantId}/buildings/${buildingId}/tickets` : `/${tenantId}/support`);
+      } else {
+        router.push(`/${tenantId}/resident/tickets`);
+      }
+    } else if (isAdmin) {
       router.push(`/${tenantId}/finanzas?tab=payments`);
     } else {
       router.push(`/${tenantId}/resident/payments`);
@@ -124,15 +142,18 @@ function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
     if (notification.type === 'BUILDING_ALERT') {
       return <Clock className="w-4 h-4 text-amber-600" />;
     }
+    if (TICKET_TYPES.has(notification.type)) {
+      return <MessageSquare className="w-4 h-4 text-blue-600" />;
+    }
     return <CreditCard className="w-4 h-4 text-blue-600" />;
   };
 
   // Determine empty state message based on role
   const getEmptyMessage = () => {
     if (isAdmin) {
-      return { icon: <CheckCircle className="w-8 h-8 mx-auto mb-2 text-green-500" />, text: 'No hay pagos pendientes por revisar' };
+      return { icon: <CheckCircle className="w-8 h-8 mx-auto mb-2 text-green-500" />, text: 'No hay notificaciones nuevas' };
     } else {
-      return { icon: <Bell className="w-8 h-8 mx-auto mb-2 opacity-50" />, text: 'No tenés notificaciones de pagos' };
+      return { icon: <Bell className="w-8 h-8 mx-auto mb-2 opacity-50" />, text: 'No tenés notificaciones nuevas' };
     }
   };
 
@@ -143,7 +164,7 @@ function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="relative p-2 rounded-lg hover:bg-muted transition-colors"
-        title={isAdmin ? 'Pagos pendientes por aprobar' : 'Mis notificaciones de pagos'}
+        title="Notificaciones"
       >
         <Bell className="w-5 h-5" />
         {badgeCount > 0 && (
@@ -157,7 +178,7 @@ function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
         <div className="absolute right-0 top-full mt-2 w-80 bg-card border rounded-lg shadow-lg z-50 overflow-hidden">
           <div className="flex items-center justify-between p-3 border-b">
             <span className="font-semibold">
-              {isAdmin ? 'Pagos pendientes' : 'Mis pagos'}
+              Notificaciones
             </span>
             <button 
               onClick={() => setIsOpen(false)}

--- a/packages/permissions/src/permissions.ts
+++ b/packages/permissions/src/permissions.ts
@@ -26,7 +26,7 @@ export const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
     "buildings.read",
     "units.read",
     "payments.review",
-    "tickets.read","tickets.write",
+    "tickets.read","tickets.write","tickets.manage",
   ],
   RESIDENT: [
     "tickets.read","tickets.write",


### PR DESCRIPTION
Closes #47

## Resumen

Cierra el Punto 2 del módulo de reclamos/tickets de BuildingOS.

También incluye dos commits posteriores e independientes:
- interfaz visual inicial del Punto 9 para notificaciones globales;
- mejora visual de reportes en dark mode.

## Punto 2 — Reclamos/Tickets

Se validó:
- creación de tickets por residentes;
- listado administrativo;
- apertura del detalle;
- cambio de estado;
- comentarios y respuestas administrativas;
- visualización de respuestas por el residente;
- actualización controlada de la interfaz;
- permisos y aislamiento por tenant, edificio y residente;
- labels en español.

Commit:
147e27b fix(tickets): complete resident admin ticket workflow

## Punto 9 — Notificaciones globales

Se agregó la parte visual inicial:
- campanita;
- badge o contador;
- integración en el Topbar.

Commit:
52243ac feat(notifications): add global notification bell and badge

Importante:
El Punto 9 todavía no se considera completamente cerrado hasta validar el flujo funcional de notificaciones de extremo a extremo.

## Reportes

Se agregó una corrección visual para dark mode.

Commit:
5260309 fix(reports): improve dark mode presentation

## Validaciones

- Tests API de tickets: 33 PASS
- Tests frontend relacionados: 8 PASS
- Typecheck API/web: PASS
- ESLint focalizado: PASS
- Build API/web: PASS
- git diff --check: PASS

## Fuera de alcance

- No incluye deploy.
- No incluye cambios en staging ni producción.
- No incluye migraciones.
- No incluye seeds.
- No incluye WebSocket.
- No debe cerrarse todavía el Punto 9 completo.
