### PR TITLE
fix(notifications): complete global ticket alerts

### DIFF
--- a/apps/api/src/tickets/tickets.service.spec.ts
+++ b/apps/api/src/tickets/tickets.service.spec.ts
@@ -21,10 +21,12 @@ describe('TicketsService', () => {
   let auditService: AuditService;
   let validators: TicketsValidators;
   let residentAccess: jest.Mocked<ResidentAccessService>;
+  let notificationsService: jest.Mocked<NotificationsService>;
+  let testingModule: TestingModule;
 
   // ========== SETUP ==========
   beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
+    testingModule = await Test.createTestingModule({
       providers: [
         TicketsService,
         {
@@ -48,9 +50,11 @@ describe('TicketsService', () => {
             },
             tenantMember: {
               findFirst: jest.fn(),
+              findMany: jest.fn().mockResolvedValue([]),
             },
             membership: {
               findFirst: jest.fn(),
+              findMany: jest.fn().mockResolvedValue([]),
             },
           },
         },
@@ -65,6 +69,8 @@ describe('TicketsService', () => {
           useValue: {
             validateBuildingBelongsToTenant: jest.fn(),
             validateUnitBelongsToBuildingAndTenant: jest.fn(),
+            validateTicketBelongsToBuildingAndTenant: jest.fn(),
+            validateTicketScope: jest.fn(),
             canStatusTransition: jest.fn(),
           },
         },
@@ -90,19 +96,18 @@ describe('TicketsService', () => {
         {
           provide: NotificationsService,
           useValue: {
-            notifyTicketCreated: jest.fn(),
-            notifyTicketUpdated: jest.fn(),
-            notifyTicketCommentAdded: jest.fn(),
+            createNotification: jest.fn().mockResolvedValue(undefined),
           },
         },
       ],
     }).compile();
 
-    service = module.get<TicketsService>(TicketsService);
-    prismaService = module.get<PrismaService>(PrismaService);
-    auditService = module.get<AuditService>(AuditService);
-    validators = module.get<TicketsValidators>(TicketsValidators);
-    residentAccess = module.get(ResidentAccessService);
+    service = testingModule.get<TicketsService>(TicketsService);
+    prismaService = testingModule.get<PrismaService>(PrismaService);
+    auditService = testingModule.get<AuditService>(AuditService);
+    validators = testingModule.get<TicketsValidators>(TicketsValidators);
+    residentAccess = testingModule.get(ResidentAccessService);
+    notificationsService = testingModule.get(NotificationsService);
   });
 
   // ========== CLEANUP ==========
@@ -461,6 +466,349 @@ describe('TicketsService', () => {
     it('should skip delete tests - method may not exist or requires complex setup', () => {
       // Service may use soft delete or have different patterns
       expect(true).toBe(true);
+    });
+  });
+
+  // ========== TESTS: NOTIFICATIONS ==========
+  describe('notifications', () => {
+    describe('create → notifyTicketCreated', () => {
+      it('should notify all tenant admins when a ticket is created', async () => {
+        const tenantId = 'tenant-123';
+        const buildingId = 'building-123';
+        const userId = 'user-resident';
+
+        const dto: CreateTicketDto = {
+          title: 'Fuga de agua',
+          description: 'Hay una fuga en el baño',
+          category: 'MAINTENANCE',
+          priority: 'HIGH',
+          unitId: 'unit-1',
+        };
+
+        const expectedTicket = {
+          id: 'ticket-new',
+          tenantId,
+          buildingId,
+          unitId: 'unit-1',
+          createdByUserId: userId,
+          title: 'Fuga de agua',
+          description: 'Hay una fuga en el baño',
+          category: 'MAINTENANCE',
+          priority: 'HIGH',
+          status: 'OPEN',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          createdBy: { id: userId, name: 'Residente' },
+          assignedTo: null,
+          building: { id: buildingId, name: 'Edificio A' },
+          unit: { id: 'unit-1', label: '101', code: 'A01' },
+          comments: [],
+        };
+
+        jest.spyOn(validators, 'validateBuildingBelongsToTenant').mockResolvedValue(undefined);
+        jest.spyOn(validators, 'validateUnitBelongsToBuildingAndTenant').mockResolvedValue(undefined);
+        jest.spyOn(prismaService.ticket, 'create').mockResolvedValue(expectedTicket as any);
+        jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
+        jest.spyOn(prismaService.membership, 'findMany').mockResolvedValue([
+          { id: 'membership-1', userId: 'owner-1', user: { id: 'owner-1' }, roles: [{ role: 'TENANT_OWNER' }] },
+          { id: 'membership-2', userId: 'admin-1', user: { id: 'admin-1' }, roles: [{ role: 'TENANT_ADMIN' }] },
+          { id: 'membership-3', userId: 'operator-1', user: { id: 'operator-1' }, roles: [{ role: 'OPERATOR' }] },
+          { id: 'membership-4', userId: 'owner-1', user: { id: 'owner-1' }, roles: [{ role: 'TENANT_OWNER' }] },
+        ] as any);
+
+        await service.create(tenantId, buildingId, userId, dto);
+
+        // Wait for fire-and-forget
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(notificationsService.createNotification).toHaveBeenCalledTimes(3);
+        expect(prismaService.membership.findMany).toHaveBeenCalledWith(expect.objectContaining({
+          where: expect.objectContaining({
+            tenantId,
+            roles: expect.objectContaining({
+              some: expect.objectContaining({
+                role: { in: ['TENANT_OWNER', 'TENANT_ADMIN', 'OPERATOR'] },
+                OR: expect.arrayContaining([
+                  { scopeType: 'TENANT' },
+                  { scopeType: 'BUILDING', scopeBuildingId: buildingId },
+                  { scopeType: 'UNIT', scopeUnitId: 'unit-1' },
+                ]),
+              }),
+            }),
+          }),
+        }));
+        expect(notificationsService.createNotification).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tenantId,
+            userId: 'owner-1',
+            type: 'SUPPORT_TICKET_CREATED',
+            title: expect.stringContaining('Fuga de agua'),
+            deliveryMethods: ['IN_APP'],
+          }),
+        );
+        expect(notificationsService.createNotification).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tenantId,
+            userId: 'admin-1',
+            type: 'SUPPORT_TICKET_CREATED',
+          }),
+        );
+        expect(notificationsService.createNotification).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tenantId,
+            userId: 'operator-1',
+            type: 'SUPPORT_TICKET_CREATED',
+          }),
+        );
+      });
+
+      it('should include buildingId and ticketId in notification data', async () => {
+        const tenantId = 'tenant-123';
+        const buildingId = 'building-123';
+
+        jest.spyOn(validators, 'validateBuildingBelongsToTenant').mockResolvedValue(undefined);
+        jest.spyOn(prismaService.ticket, 'create').mockResolvedValue({
+          id: 'ticket-data',
+          tenantId,
+          buildingId,
+          unitId: null,
+          createdByUserId: 'user-1',
+          title: 'Test',
+          description: 'Test',
+          category: 'OTHER',
+          priority: 'MEDIUM',
+          status: 'OPEN',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          createdBy: { id: 'user-1', name: 'User' },
+          assignedTo: null,
+          building: { id: buildingId, name: 'Building' },
+          unit: null,
+          comments: [],
+        } as any);
+        jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
+        jest.spyOn(prismaService.membership, 'findMany').mockResolvedValue([
+          { id: 'membership-1', userId: 'admin-1', user: { id: 'admin-1' } },
+        ] as any);
+
+        await service.create(tenantId, buildingId, 'user-1', {
+          title: 'Test',
+          description: 'Test',
+          category: 'OTHER',
+        });
+
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(notificationsService.createNotification).toHaveBeenCalledWith(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              ticketId: 'ticket-data',
+              buildingId,
+            }),
+          }),
+        );
+      });
+    });
+
+    describe('update → notifyTicketStatusChanged', () => {
+      it('should notify ticket creator when status changes', async () => {
+        const tenantId = 'tenant-123';
+        const buildingId = 'building-123';
+        const ticketId = 'ticket-status';
+        const creatorId = 'creator-1';
+
+        jest.spyOn(prismaService.ticket, 'findFirst').mockResolvedValue({
+          id: ticketId,
+          tenantId,
+          buildingId,
+          status: 'OPEN',
+          createdByUserId: creatorId,
+        } as any);
+        jest.spyOn(prismaService.ticket, 'update').mockResolvedValue({
+          id: ticketId,
+          tenantId,
+          buildingId,
+          status: 'IN_PROGRESS',
+          createdByUserId: creatorId,
+          building: { name: 'Edificio A' },
+        } as any);
+        jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
+
+        await service.update(tenantId, buildingId, ticketId, { status: 'IN_PROGRESS' });
+
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(notificationsService.createNotification).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tenantId,
+            userId: creatorId,
+            type: 'TICKET_STATUS_CHANGED',
+            title: expect.stringContaining('Estado actualizado'),
+            data: expect.objectContaining({
+              oldStatus: 'OPEN',
+              newStatus: 'IN_PROGRESS',
+            }),
+          }),
+        );
+      });
+
+      it('should not notify anyone when status does not change', async () => {
+        jest.spyOn(prismaService.ticket, 'findFirst').mockResolvedValue({
+          id: 'ticket-same',
+          tenantId: 'tenant-123',
+          buildingId: 'building-123',
+          status: 'OPEN',
+          createdByUserId: 'creator-1',
+        } as any);
+        jest.spyOn(prismaService.ticket, 'update').mockResolvedValue({
+          id: 'ticket-same',
+          status: 'OPEN',
+        } as any);
+        jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
+
+        await service.update('tenant-123', 'building-123', 'ticket-same', {
+          title: 'Updated title only',
+        });
+
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(notificationsService.createNotification).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('addComment → notifyTicketCommentAdded', () => {
+      it('should notify ticket creator when admin adds a comment', async () => {
+        const tenantId = 'tenant-123';
+        const buildingId = 'building-123';
+        const ticketId = 'ticket-comment';
+        const creatorId = 'creator-1';
+        const adminId = 'admin-1';
+
+        jest.spyOn(validators, 'validateTicketBelongsToBuildingAndTenant').mockResolvedValue(undefined);
+        jest.spyOn(prismaService.ticketComment, 'create').mockResolvedValue({
+          id: 'comment-1',
+          tenantId,
+          ticketId,
+          authorUserId: adminId,
+          body: 'Estamos revisando el problema',
+          createdAt: new Date(),
+          author: { id: adminId, name: 'Admin User' },
+        } as any);
+        jest.spyOn(prismaService.ticket, 'findFirst').mockResolvedValue({
+          id: ticketId,
+          createdByUserId: creatorId,
+          title: 'Fuga de agua',
+          buildingId,
+          unitId: 'unit-1',
+        } as any);
+        jest.spyOn(prismaService.membership, 'findFirst').mockResolvedValue({ id: 'admin-membership' } as any);
+        jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
+
+        await service.addComment(tenantId, buildingId, ticketId, adminId, {
+          body: 'Estamos revisando el problema',
+        });
+
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(notificationsService.createNotification).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tenantId,
+            userId: creatorId,
+            type: 'TICKET_COMMENT_ADDED',
+            title: expect.stringContaining('Fuga de agua'),
+          }),
+        );
+      });
+
+      it('should not notify the author of the comment', async () => {
+        const tenantId = 'tenant-123';
+        const buildingId = 'building-123';
+        const ticketId = 'ticket-self';
+        const creatorId = 'creator-1';
+
+        jest.spyOn(validators, 'validateTicketBelongsToBuildingAndTenant').mockResolvedValue(undefined);
+        jest.spyOn(prismaService.ticketComment, 'create').mockResolvedValue({
+          id: 'comment-self',
+          tenantId,
+          ticketId,
+          authorUserId: creatorId,
+          body: 'Gracias',
+          createdAt: new Date(),
+          author: { id: creatorId, name: 'Creator' },
+        } as any);
+        jest.spyOn(prismaService.ticket, 'findFirst').mockResolvedValue({
+          id: ticketId,
+          createdByUserId: creatorId,
+          title: 'My ticket',
+          assignedToMembershipId: null,
+        } as any);
+        jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
+
+        await service.addComment(tenantId, buildingId, ticketId, creatorId, {
+          body: 'Gracias',
+        });
+
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(notificationsService.createNotification).not.toHaveBeenCalled();
+      });
+
+      it('should notify authorized administrators when resident comments on their ticket', async () => {
+        const tenantId = 'tenant-123';
+        const buildingId = 'building-123';
+        const ticketId = 'ticket-assign';
+        const creatorId = 'creator-1';
+        const operatorUserId = 'operator-1';
+
+        jest.spyOn(validators, 'validateTicketBelongsToBuildingAndTenant').mockResolvedValue(undefined);
+        jest.spyOn(prismaService.ticketComment, 'create').mockResolvedValue({
+          id: 'comment-assign',
+          tenantId,
+          ticketId,
+          authorUserId: creatorId,
+          body: 'Siguen las goteras',
+          createdAt: new Date(),
+          author: { id: creatorId, name: 'Creator' },
+        } as any);
+        jest.spyOn(prismaService.ticket, 'findFirst').mockResolvedValue({
+          id: ticketId,
+          createdByUserId: creatorId,
+          title: 'Fuga persistente',
+          buildingId,
+          unitId: 'unit-1',
+        } as any);
+        jest.spyOn(prismaService.membership, 'findFirst').mockResolvedValue(null);
+        jest.spyOn(prismaService.membership, 'findMany').mockResolvedValue([
+          { userId: operatorUserId, user: { id: operatorUserId } },
+          { userId: 'owner-1', user: { id: 'owner-1' } },
+        ] as any);
+        jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
+
+        await service.addComment(tenantId, buildingId, ticketId, creatorId, {
+          body: 'Siguen las goteras',
+        });
+
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(notificationsService.createNotification).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tenantId,
+            userId: operatorUserId,
+            type: 'TICKET_COMMENT_ADDED',
+            title: 'El residente agregó una respuesta',
+            data: expect.objectContaining({
+              ticketId,
+              buildingId,
+              unitId: 'unit-1',
+              authorId: creatorId,
+              actorType: 'RESIDENT',
+            }),
+          }),
+        );
+        expect(notificationsService.createNotification).toHaveBeenCalledWith(
+          expect.objectContaining({ tenantId, userId: 'owner-1', type: 'TICKET_COMMENT_ADDED' }),
+        );
+      });
     });
   });
 });

--- a/apps/api/src/tickets/tickets.service.ts
+++ b/apps/api/src/tickets/tickets.service.ts
@@ -823,30 +823,66 @@ export class TicketsService {
   /**
    * Fire-and-forget: notify tenant admins when a new ticket is created
    */
+  private async resolveAdministrativeRecipientIds(
+    tenantId: string,
+    buildingId: string,
+    unitId?: string | null,
+  ): Promise<string[]> {
+    const adminMemberships = await this.prisma.membership.findMany({
+      where: {
+        tenantId,
+        roles: {
+          some: {
+            role: { in: ['TENANT_OWNER', 'TENANT_ADMIN', 'OPERATOR'] },
+            OR: [
+              { scopeType: 'TENANT' },
+              { scopeType: 'BUILDING', scopeBuildingId: buildingId },
+              ...(unitId ? [{ scopeType: 'UNIT' as const, scopeUnitId: unitId }] : []),
+            ],
+          },
+        },
+      },
+      include: { user: { select: { id: true } } },
+    });
+
+    const adminTenantMembers = await this.prisma.tenantMember.findMany({
+      where: {
+        tenantId,
+        role: { in: ['TENANT_OWNER', 'TENANT_ADMIN', 'OPERATOR'] },
+        status: 'ACTIVE',
+        userId: { not: null },
+      },
+      include: { user: { select: { id: true } } },
+    });
+
+    const recipientIds = new Set<string>();
+    for (const userId of [
+      ...adminMemberships.map((admin) => admin.user?.id),
+      ...adminTenantMembers.map((admin) => admin.user?.id),
+    ]) {
+      if (userId) recipientIds.add(userId);
+    }
+
+    this.logger.debug(
+      `[resolveAdministrativeRecipientIds] Found ${recipientIds.size} recipients for tenant ${tenantId}, building ${buildingId}`,
+    );
+    return [...recipientIds];
+  }
+
   private async notifyTicketCreated(
     tenantId: string,
     buildingId: string,
     ticket: Ticket & { building?: { name: string } | null; unit?: { label: string | null; code: string | null } | null },
   ): Promise<void> {
     try {
-      const admins = await this.prisma.tenantMember.findMany({
-        where: {
-          tenantId,
-          role: 'TENANT_ADMIN',
-          status: 'ACTIVE',
-          userId: { not: null },
-        },
-        include: { user: { select: { id: true } } },
-      });
-
       const buildingName = ticket.building?.name || 'Edificio';
       const unitLabel = ticket.unit?.label || ticket.unit?.code || '';
 
-      for (const admin of admins) {
-        if (!admin.user?.id) continue;
+      const recipients = await this.resolveAdministrativeRecipientIds(tenantId, buildingId, ticket.unitId);
+      for (const userId of recipients) {
         await this.notificationsService.createNotification({
           tenantId,
-          userId: admin.user.id,
+          userId,
           type: 'SUPPORT_TICKET_CREATED',
           title: `Nuevo reclamo: ${ticket.title}`,
           body: `Se creó un reclamo en ${buildingName}${unitLabel ? ` (${unitLabel})` : ''}. Categoría: ${ticket.category}.`,
@@ -918,44 +954,60 @@ export class TicketsService {
   ): Promise<void> {
     try {
       const ticket = await this.prisma.ticket.findFirst({
-        where: { id: ticketId },
-        select: { createdByUserId: true, title: true, assignedToMembershipId: true },
+        where: { id: ticketId, tenantId },
+        select: {
+          createdByUserId: true,
+          title: true,
+          buildingId: true,
+          unitId: true,
+          assignedToMembershipId: true,
+        },
       });
 
       if (!ticket) return;
 
-      const recipientIds: string[] = [];
+      const authorIsAdministrator = Boolean(await this.prisma.membership.findFirst({
+        where: {
+          tenantId,
+          userId: authorUserId,
+          roles: {
+            some: {
+              role: { in: ['TENANT_OWNER', 'TENANT_ADMIN', 'OPERATOR'] },
+              OR: [
+                { scopeType: 'TENANT' },
+                { scopeType: 'BUILDING', scopeBuildingId: ticket.buildingId },
+                ...(ticket.unitId ? [{ scopeType: 'UNIT' as const, scopeUnitId: ticket.unitId }] : []),
+              ],
+            },
+          },
+        },
+        select: { id: true },
+      }));
 
-      // Notify ticket creator (if not the author)
-      if (ticket.createdByUserId !== authorUserId) {
-        recipientIds.push(ticket.createdByUserId);
-      }
-
-      // Notify assigned operator (if not the author)
-      if (ticket.assignedToMembershipId) {
-        const assignee = await this.prisma.membership.findFirst({
-          where: { id: ticket.assignedToMembershipId },
-          select: { userId: true },
-        });
-        if (assignee?.userId && assignee.userId !== authorUserId) {
-          recipientIds.push(assignee.userId);
-        }
-      }
+      const recipientIds = authorIsAdministrator
+        ? [ticket.createdByUserId]
+        : await this.resolveAdministrativeRecipientIds(tenantId, ticket.buildingId, ticket.unitId);
 
       const authorName = comment.author?.name || 'Alguien';
 
-      for (const recipientId of recipientIds) {
+      for (const recipientId of new Set(recipientIds.filter((id) => id !== authorUserId))) {
         await this.notificationsService.createNotification({
           tenantId,
           userId: recipientId,
           type: 'TICKET_COMMENT_ADDED',
-          title: `Nuevo comentario: ${ticket.title}`,
+          title: authorIsAdministrator
+            ? `La administración respondió: ${ticket.title}`
+            : 'El residente agregó una respuesta',
           body: `${authorName} comentó: "${comment.body.slice(0, 100)}${comment.body.length > 100 ? '...' : ''}"`,
           data: {
             ticketId,
             ticketTitle: ticket.title,
             commentId: comment.id,
             authorName,
+            authorId: authorUserId,
+            actorType: authorIsAdministrator ? 'ADMIN' : 'RESIDENT',
+            buildingId: ticket.buildingId,
+            unitId: ticket.unitId,
           },
           deliveryMethods: ['IN_APP'],
         });

--- a/apps/web/app/(tenant)/[tenantId]/notifications/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/notifications/page.tsx
@@ -22,7 +22,7 @@ const NotificationsPage = () => {
   const [skip, setSkip] = useState(0);
 
   const { notifications, total, unreadCount, loading, error, fetch, markAsRead, markAllAsRead, deleteNotification } =
-    useNotifications();
+    useNotifications(tenantId);
 
   const { toast } = useToast();
   const take = 50;

--- a/apps/web/features/notifications/notifications.api.ts
+++ b/apps/web/features/notifications/notifications.api.ts
@@ -2,6 +2,18 @@
 
 import { apiClient } from '@/shared/lib/http/client';
 
+export interface NotificationData {
+  event?: string;
+  paymentId?: string;
+  paymentAmount?: number;
+  paymentCurrency?: string;
+  ticketId?: string;
+  buildingId?: string;
+  tenantId?: string;
+  unitId?: string;
+  url?: string;
+}
+
 export interface Notification {
   id: string;
   tenantId: string;
@@ -9,7 +21,7 @@ export interface Notification {
   type: string;
   title: string;
   body: string;
-  data?: Record<string, any>;
+  data?: NotificationData;
   deliveryMethods: string[];
   isRead: boolean;
   readAt?: string | null;
@@ -17,65 +29,70 @@ export interface Notification {
   deletedAt?: string | null;
 }
 
-/**
- * List user's notifications
- */
-export async function listNotifications(params?: {
+export interface ListNotificationsParams {
   isRead?: boolean;
   type?: string;
   skip?: number;
   take?: number;
-}): Promise<{ notifications: Notification[]; total: number }> {
+}
+
+function basePath(tenantId: string): string {
+  return `/tenants/${encodeURIComponent(tenantId)}/notifications`;
+}
+
+export async function listNotifications(
+  tenantId: string,
+  params?: ListNotificationsParams,
+): Promise<{ notifications: Notification[]; total: number }> {
   const query = new URLSearchParams();
 
   if (params?.isRead !== undefined) query.append('isRead', String(params.isRead));
   if (params?.type) query.append('type', params.type);
-  if (params?.skip) query.append('skip', String(params.skip));
-  if (params?.take) query.append('take', String(params.take));
+  if (params?.skip !== undefined && params.skip > 0) query.append('skip', String(params.skip));
+  if (params?.take !== undefined) query.append('take', String(params.take));
+
+  const qs = query.toString();
+  const path = qs ? `${basePath(tenantId)}?${qs}` : basePath(tenantId);
 
   return apiClient({
-    path: `/me/notifications?${query}`,
+    path,
     method: 'GET',
   });
 }
 
-/**
- * Get unread notification count
- */
-export async function getUnreadCount(): Promise<number> {
+export async function getUnreadCount(tenantId: string): Promise<number> {
   const data = await apiClient<{ unreadCount: number }>({
-    path: '/me/notifications/unread-count',
+    path: `${basePath(tenantId)}/unread-count`,
     method: 'GET',
   });
   return data.unreadCount;
 }
 
-/**
- * Mark notification as read
- */
-export async function markAsRead(id: string): Promise<Notification> {
+export async function markAsRead(
+  tenantId: string,
+  notificationId: string,
+): Promise<Notification> {
   return apiClient<Notification>({
-    path: `/me/notifications/${id}/read`,
+    path: `${basePath(tenantId)}/${encodeURIComponent(notificationId)}/read`,
     method: 'PATCH',
   });
 }
 
-/**
- * Mark all notifications as read
- */
-export async function markAllAsRead(): Promise<{ count: number }> {
-  return apiClient<{ count: number }>({
-    path: '/me/notifications/read-all',
+export async function markAllAsRead(
+  tenantId: string,
+): Promise<{ success: boolean }> {
+  return apiClient<{ success: boolean }>({
+    path: `${basePath(tenantId)}/read-all`,
     method: 'PATCH',
   });
 }
 
-/**
- * Delete notification
- */
-export async function deleteNotification(id: string): Promise<void> {
+export async function deleteNotification(
+  tenantId: string,
+  notificationId: string,
+): Promise<void> {
   await apiClient<void>({
-    path: `/me/notifications/${id}`,
+    path: `${basePath(tenantId)}/${encodeURIComponent(notificationId)}`,
     method: 'DELETE',
   });
 }

--- a/apps/web/features/notifications/useNotifications.ts
+++ b/apps/web/features/notifications/useNotifications.ts
@@ -2,98 +2,87 @@
 
 import { useState, useCallback, useEffect } from 'react';
 import * as api from './notifications.api';
-import type { Notification } from './notifications.api';
+import type { Notification, ListNotificationsParams } from './notifications.api';
 
-export function useNotifications() {
+export function useNotifications(tenantId: string) {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [total, setTotal] = useState(0);
   const [unreadCount, setUnreadCount] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  /**
-   * Fetch notifications with optional filters
-   */
-  const fetch = useCallback(
-    async (params?: { isRead?: boolean; type?: string; skip?: number; take?: number }) => {
+  const fetchNotifications = useCallback(
+    async (params?: ListNotificationsParams) => {
+      if (!tenantId) return;
       setLoading(true);
       setError(null);
 
       try {
-        const result = await api.listNotifications(params);
+        const result = await api.listNotifications(tenantId, params);
         setNotifications(result.notifications);
         setTotal(result.total);
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch notifications');
+        setError(err instanceof Error ? err.message : 'Error al obtener notificaciones');
       } finally {
         setLoading(false);
       }
     },
-    [],
+    [tenantId],
   );
 
-  /**
-   * Fetch unread count
-   */
   const fetchUnreadCount = useCallback(async () => {
+    if (!tenantId) return;
     try {
-      const count = await api.getUnreadCount();
+      const count = await api.getUnreadCount(tenantId);
       setUnreadCount(count);
-    } catch (err) {
-      console.error('Failed to fetch unread count:', err);
+    } catch {
+      // silently ignore — badge will retry on next poll
     }
-  }, []);
+  }, [tenantId]);
 
-  /**
-   * Mark single notification as read
-   */
   const markAsRead = useCallback(async (id: string) => {
+    if (!tenantId) return;
     try {
-      const updated = await api.markAsRead(id);
+      const updated = await api.markAsRead(tenantId, id);
       setNotifications((prev) =>
         prev.map((n) => (n.id === id ? updated : n)),
       );
       await fetchUnreadCount();
       return updated;
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to mark as read');
+      setError(err instanceof Error ? err.message : 'Error al marcar como leída');
       throw err;
     }
-  }, [fetchUnreadCount]);
+  }, [tenantId, fetchUnreadCount]);
 
-  /**
-   * Mark all notifications as read
-   */
   const markAllAsRead = useCallback(async () => {
+    if (!tenantId) return;
     try {
-      const result = await api.markAllAsRead();
+      const result = await api.markAllAsRead(tenantId);
       setNotifications((prev) =>
         prev.map((n) => ({ ...n, isRead: true })),
       );
       await fetchUnreadCount();
       return result;
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to mark all as read');
+      setError(err instanceof Error ? err.message : 'Error al marcar todas como leídas');
       throw err;
     }
-  }, [fetchUnreadCount]);
+  }, [tenantId, fetchUnreadCount]);
 
-  /**
-   * Delete notification
-   */
   const deleteNotification = useCallback(async (id: string) => {
+    if (!tenantId) return;
     try {
-      await api.deleteNotification(id);
+      await api.deleteNotification(tenantId, id);
       setNotifications((prev) => prev.filter((n) => n.id !== id));
       setTotal((prev) => prev - 1);
       await fetchUnreadCount();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to delete notification');
+      setError(err instanceof Error ? err.message : 'Error al eliminar notificación');
       throw err;
     }
-  }, [fetchUnreadCount]);
+  }, [tenantId, fetchUnreadCount]);
 
-  // Fetch unread count on mount
   useEffect(() => {
     fetchUnreadCount();
   }, [fetchUnreadCount]);
@@ -104,7 +93,7 @@ export function useNotifications() {
     unreadCount,
     loading,
     error,
-    fetch,
+    fetch: fetchNotifications,
     fetchUnreadCount,
     markAsRead,
     markAllAsRead,

--- a/apps/web/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/shared/components/layout/Topbar.test.tsx
@@ -1,0 +1,356 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import * as notificationsApi from '@/features/notifications/notifications.api';
+import * as financeApi from '@/features/finance/services/finance.api';
+import * as sessionModule from '@/features/auth/session.storage';
+
+jest.mock('@/features/notifications/notifications.api', () => ({
+  listNotifications: jest.fn(),
+  getUnreadCount: jest.fn(),
+  markAsRead: jest.fn(),
+  markAllAsRead: jest.fn(),
+  deleteNotification: jest.fn(),
+}));
+
+jest.mock('@/features/finance/services/finance.api', () => ({
+  listPendingPayments: jest.fn(),
+  PaymentStatus: { SUBMITTED: 'SUBMITTED' },
+}));
+
+jest.mock('@/features/auth/session.storage', () => ({
+  getSession: jest.fn(),
+  setSession: jest.fn(),
+  setLastTenant: jest.fn(),
+  clearAuth: jest.fn(),
+}));
+
+jest.mock('@/features/impersonation/impersonation.storage', () => ({
+  clearAllImpersonationData: jest.fn(),
+}));
+
+jest.mock('@/features/tenants/tenants.hooks', () => ({
+  useTenants: () => ({ data: [], isLoading: false, error: null }),
+}));
+
+jest.mock('@/features/notifications/components/PushPermissionControl', () => ({
+  PushPermissionControl: () => null,
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  useParams: () => ({ tenantId: 'tenant-1' }),
+}));
+
+const mockGetUnreadCount = jest.mocked(notificationsApi.getUnreadCount);
+const mockListNotifications = jest.mocked(notificationsApi.listNotifications);
+const mockMarkAsRead = jest.mocked(notificationsApi.markAsRead);
+const mockMarkAllAsRead = jest.mocked(notificationsApi.markAllAsRead);
+const mockListPendingPayments = jest.mocked(financeApi.listPendingPayments);
+const mockGetSession = jest.mocked(sessionModule.getSession);
+
+const TENANT_ID = 'tenant-1';
+
+let PaymentNotificationBell: React.ComponentType<{ tenantId: string }>;
+
+beforeAll(async () => {
+  const mod = await import('@/shared/components/layout/Topbar');
+  PaymentNotificationBell = mod.PaymentNotificationBell;
+});
+
+function renderBell(tenantId = TENANT_ID) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return {
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <PaymentNotificationBell tenantId={tenantId} />
+      </QueryClientProvider>,
+    ),
+    queryClient,
+  };
+}
+
+describe('PaymentNotificationBell', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetSession.mockReturnValue({
+      user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
+      memberships: [{ tenantId: TENANT_ID, roles: ['RESIDENT'] }],
+      activeTenantId: TENANT_ID,
+    });
+    mockGetUnreadCount.mockResolvedValue(0);
+    mockListNotifications.mockResolvedValue({ notifications: [], total: 0 });
+    mockListPendingPayments.mockResolvedValue([]);
+    mockMarkAsRead.mockResolvedValue({ id: 'n1', isRead: true } as Awaited<ReturnType<typeof notificationsApi.markAsRead>>);
+    mockMarkAllAsRead.mockResolvedValue({ success: true });
+  });
+
+  it('renders the bell button', () => {
+    renderBell();
+    expect(screen.getByRole('button', { name: /notificaciones/i })).toBeTruthy();
+  });
+
+  it('queries unread count with tenantId', async () => {
+    renderBell();
+    await waitFor(() => {
+      expect(mockGetUnreadCount).toHaveBeenCalledWith(TENANT_ID);
+    });
+  });
+
+  it('shows badge when there are unread notifications', async () => {
+    mockGetUnreadCount.mockResolvedValue(3);
+    renderBell();
+    await waitFor(() => {
+      expect(screen.getByText('3')).toBeTruthy();
+    });
+  });
+
+  it('shows 9+ when unread count exceeds 9', async () => {
+    mockGetUnreadCount.mockResolvedValue(15);
+    renderBell();
+    await waitFor(() => {
+      expect(screen.getByText('9+')).toBeTruthy();
+    });
+  });
+
+  it('does not show badge when count is 0', async () => {
+    mockGetUnreadCount.mockResolvedValue(0);
+    renderBell();
+    await waitFor(() => {
+      expect(mockGetUnreadCount).toHaveBeenCalled();
+    });
+    expect(screen.queryByText('0')).toBeNull();
+  });
+
+  it('opens dropdown on click and shows notifications', async () => {
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n1',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'TICKET_COMMENT_ADDED',
+          title: 'Nuevo comentario',
+          body: 'Admin respondió tu reclamo',
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(mockListNotifications).toHaveBeenCalledWith(TENANT_ID, { take: 20 });
+      expect(screen.getByText('Nuevo comentario')).toBeTruthy();
+      expect(screen.getByText('Admin respondió tu reclamo')).toBeTruthy();
+    });
+  });
+
+  it('shows loading state while fetching', async () => {
+    mockListNotifications.mockReturnValue(new Promise(() => {}));
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/cargando notificaciones/i)).toBeTruthy();
+    });
+  });
+
+  it('shows error state on failure', async () => {
+    mockListNotifications.mockRejectedValue(new Error('Network error'));
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/no se pudieron cargar las notificaciones/i)).toBeTruthy();
+    });
+  });
+
+  it('shows empty state when no notifications', async () => {
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/no hay notificaciones nuevas/i)).toBeTruthy();
+    });
+  });
+
+  it('clicking a notification marks it as read with tenantId and navigates', async () => {
+    const mockPush = jest.fn();
+    jest.requireMock('next/navigation').useRouter = () => ({ push: mockPush, replace: jest.fn() });
+
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n1',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'TICKET_STATUS_CHANGED',
+          title: 'Estado actualizado',
+          body: 'Tu reclamo cambió de estado',
+          data: { buildingId: 'building-1' },
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Estado actualizado')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('Estado actualizado'));
+
+    await waitFor(() => {
+      expect(mockMarkAsRead).toHaveBeenCalledWith(TENANT_ID, 'n1');
+      expect(mockPush).toHaveBeenCalledWith('/tenant-1/resident/tickets');
+    });
+  });
+
+  it('markAllAsRead calls single API endpoint with tenantId', async () => {
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n1',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'TICKET_COMMENT_ADDED',
+          title: 'Test',
+          body: 'Test body',
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Test')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('Marcar todas como leídas'));
+
+    await waitFor(() => {
+      expect(mockMarkAllAsRead).toHaveBeenCalledWith(TENANT_ID);
+      expect(mockMarkAsRead).not.toHaveBeenCalled();
+    });
+  });
+
+  it('badge updates after marking all as read', async () => {
+    mockGetUnreadCount
+      .mockResolvedValueOnce(2)
+      .mockResolvedValueOnce(0);
+
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n1',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'TICKET_COMMENT_ADDED',
+          title: 'Test',
+          body: 'Body',
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+
+    await waitFor(() => {
+      expect(screen.getByText('2')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Marcar todas como leídas')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('Marcar todas como leídas'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('2')).toBeNull();
+    });
+  });
+
+  it('has correct accessibility attributes', () => {
+    renderBell();
+    const button = screen.getByRole('button', { name: /notificaciones/i });
+    expect(button.getAttribute('aria-expanded')).toBe('false');
+    expect(button.getAttribute('aria-controls')).toBe('notification-dropdown');
+  });
+
+  it('Escape closes the dropdown', async () => {
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Notificaciones')).toBeTruthy();
+    });
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Marcar todas como leídas')).toBeNull();
+    });
+  });
+
+  it('admin sees pending payments card when no notifications', async () => {
+    mockGetSession.mockReturnValue({
+      user: { id: 'admin-1', email: 'admin@test.com', name: 'Admin User' },
+      memberships: [{ tenantId: TENANT_ID, roles: ['TENANT_ADMIN'] }],
+      activeTenantId: TENANT_ID,
+    });
+    mockListPendingPayments.mockResolvedValue([
+      { id: 'p1', status: 'SUBMITTED' },
+    ] as Awaited<ReturnType<typeof financeApi.listPendingPayments>>);
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 pago pendiente por revisar/)).toBeTruthy();
+    });
+  });
+
+  it('recognizes an admin when the membership also includes RESIDENT', async () => {
+    mockGetSession.mockReturnValue({
+      user: { id: 'admin-1', email: 'admin@test.com', name: 'Admin User' },
+      memberships: [{ tenantId: TENANT_ID, roles: ['RESIDENT', 'TENANT_ADMIN'] }],
+      activeTenantId: TENANT_ID,
+    });
+    mockListPendingPayments.mockResolvedValue([
+      { id: 'p1', status: 'SUBMITTED' },
+    ] as Awaited<ReturnType<typeof financeApi.listPendingPayments>>);
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 pago pendiente por revisar/)).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -10,76 +10,95 @@ import Select from '../ui/Select';
 import { Bell, CreditCard, X, Clock, CheckCircle, XCircle, MessageSquare } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useEffect, useRef } from 'react';
-import { listNotifications, markAsRead, type Notification } from '@/features/notifications/notifications.api';
+import { listNotifications, markAsRead, markAllAsRead, getUnreadCount, type Notification } from '@/features/notifications/notifications.api';
 import { formatCurrency } from '@/shared/lib/format/money';
 import { listPendingPayments, PaymentStatus } from '@/features/finance/services/finance.api';
 import { PushPermissionControl } from '@/features/notifications/components/PushPermissionControl';
 
-function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
+const TICKET_TYPES = new Set([
+  'TICKET_STATUS_CHANGED',
+  'TICKET_COMMENT_ADDED',
+  'SUPPORT_TICKET_CREATED',
+  'URGENT_TICKET_UNASSIGNED',
+]);
+const ADMIN_ROLES = new Set(['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR', 'SUPER_ADMIN']);
+
+const POLL_INTERVAL = 30_000;
+
+export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
   const queryClient = useQueryClient();
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
 
-  // Get user role from session
   const session = getSession();
   const activeMembership = session?.memberships?.find((membership: Membership) => membership.tenantId === tenantId);
-  const role = activeMembership?.roles?.[0] || 'RESIDENT';
-  
-  const isAdmin = ['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR', 'SUPER_ADMIN'].includes(role);
+  const isAdmin = activeMembership?.roles?.some((candidateRole) => ADMIN_ROLES.has(candidateRole)) ?? false;
+  const hasSession = Boolean(session);
 
-  // For admin: show pending SUBMITTED payments in badge
+  // 1. Always-polling unread count for the badge
+  const { data: unreadCount = 0 } = useQuery({
+    queryKey: ['notificationUnreadCount', tenantId],
+    queryFn: () => getUnreadCount(tenantId),
+    enabled: hasSession && Boolean(tenantId),
+    refetchInterval: POLL_INTERVAL,
+    refetchOnWindowFocus: true,
+    staleTime: 10_000,
+  });
+
+  // 2. Pending payments (admin only)
   const { data: pendingPayments = [] } = useQuery({
     queryKey: ['pendingPaymentsCount', tenantId],
     queryFn: () => listPendingPayments(tenantId, { status: PaymentStatus.SUBMITTED }),
     enabled: isAdmin,
-    refetchInterval: 180000, // Poll every 3 minutes
+    refetchInterval: POLL_INTERVAL,
     refetchOnWindowFocus: true,
   });
 
   const pendingCount = pendingPayments.length;
 
-  // For everyone: get notifications (different filter based on role)
-  const { data: notificationResult } = useQuery({
+  // 3. Notification list — only when dropdown is open
+  const {
+    data: notificationResult,
+    isLoading: listLoading,
+    error: listError,
+  } = useQuery({
     queryKey: ['notificationList', tenantId],
-    queryFn: () => listNotifications({ take: 20, isRead: false }),
-    enabled: isOpen,
-    refetchInterval: 180000,
+    queryFn: () => listNotifications(tenantId, { take: 20 }),
+    enabled: hasSession && Boolean(tenantId) && isOpen,
+    refetchInterval: isOpen ? POLL_INTERVAL : false,
+    refetchOnWindowFocus: true,
   });
 
+  // 4. Mutations
   const markReadMutation = useMutation({
-    mutationFn: markAsRead,
+    mutationFn: (notificationId: string) => markAsRead(tenantId, notificationId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['notificationList'] });
+      queryClient.invalidateQueries({ queryKey: ['notificationUnreadCount', tenantId] });
+      queryClient.invalidateQueries({ queryKey: ['notificationList', tenantId] });
     },
   });
 
-  // Filter notifications based on role
+  const markAllReadMutation = useMutation({
+    mutationFn: () => markAllAsRead(tenantId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['notificationUnreadCount', tenantId] });
+      queryClient.invalidateQueries({ queryKey: ['notificationList', tenantId] });
+    },
+  });
+
+  // 5. Filter notifications for display
   const allNotifs = notificationResult?.notifications ?? [];
-  
-  const TICKET_TYPES = new Set([
-    'TICKET_STATUS_CHANGED',
-    'TICKET_COMMENT_ADDED',
-    'SUPPORT_TICKET_CREATED',
-    'URGENT_TICKET_UNASSIGNED',
-  ]);
 
   let filteredNotifications: Notification[] = [];
-  let badgeCount = 0;
-
   if (isAdmin) {
-    // Admin: payments + ticket notifications
     filteredNotifications = allNotifs.filter((n: Notification) =>
       (n.type === 'BUILDING_ALERT' && n.data?.event === 'PAYMENT_SUBMITTED') ||
       n.data?.paymentId ||
       TICKET_TYPES.has(n.type)
     );
-    const unreadTicketCount = filteredNotifications.filter(
-      (n: Notification) => !n.isRead && TICKET_TYPES.has(n.type),
-    ).length;
-    badgeCount = pendingCount + unreadTicketCount;
   } else {
-    // Resident: payments + ticket notifications
     filteredNotifications = allNotifs.filter((n: Notification) =>
       n.type === 'PAYMENT_RECEIVED' ||
       n.type === 'PAYMENT_REJECTED' ||
@@ -87,27 +106,49 @@ function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
       n.data?.event === 'PAYMENT_REJECTED' ||
       TICKET_TYPES.has(n.type)
     );
-    badgeCount = filteredNotifications.filter((n: Notification) => !n.isRead).length;
   }
 
-  // Close dropdown when clicking outside
+  // Badge: pending payments (admin) + unread notifications
+  const badgeCount = isAdmin ? pendingCount + unreadCount : unreadCount;
+
+  // 6. Close on click outside
   useEffect(() => {
+    if (!isOpen) return;
     function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(event.target as Node) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(event.target as Node)
+      ) {
         setIsOpen(false);
       }
     }
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, []);
+  }, [isOpen]);
+
+  // 7. Close on Escape
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        setIsOpen(false);
+        buttonRef.current?.focus();
+      }
+    }
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [isOpen]);
+
+  // 8. Handlers
+  const handleToggle = () => setIsOpen((prev) => !prev);
 
   const handleNotificationClick = async (notification: Notification) => {
-    // Mark as read
     if (!notification.isRead) {
       await markReadMutation.mutateAsync(notification.id);
     }
-    
-    // Route based on notification type
+
     if (TICKET_TYPES.has(notification.type)) {
       if (isAdmin) {
         const buildingId = notification.data?.buildingId;
@@ -123,15 +164,10 @@ function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
     setIsOpen(false);
   };
 
-  const handleMarkAllRead = async () => {
-    for (const n of filteredNotifications) {
-      if (!n.isRead) {
-        await markReadMutation.mutateAsync(n.id);
-      }
-    }
+  const handleMarkAllRead = () => {
+    markAllReadMutation.mutate();
   };
 
-  // Get icon and color based on notification type
   const getNotificationIcon = (notification: Notification) => {
     if (notification.type === 'PAYMENT_RECEIVED' || notification.data?.event === 'PAYMENT_APPROVED') {
       return <CheckCircle className="w-4 h-4 text-green-600" />;
@@ -148,62 +184,72 @@ function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
     return <CreditCard className="w-4 h-4 text-blue-600" />;
   };
 
-  // Determine empty state message based on role
-  const getEmptyMessage = () => {
-    if (isAdmin) {
-      return { icon: <CheckCircle className="w-8 h-8 mx-auto mb-2 text-green-500" />, text: 'No hay notificaciones nuevas' };
-    } else {
-      return { icon: <Bell className="w-8 h-8 mx-auto mb-2 opacity-50" />, text: 'No tenés notificaciones nuevas' };
-    }
-  };
-
-  const emptyState = getEmptyMessage();
-
   return (
     <div className="relative" ref={dropdownRef}>
       <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="relative p-2 rounded-lg hover:bg-muted transition-colors"
+        ref={buttonRef}
+        onClick={handleToggle}
+        className="relative p-2 rounded-lg hover:bg-muted transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
         title="Notificaciones"
+        aria-label={`Notificaciones${badgeCount > 0 ? `, ${badgeCount} sin leer` : ''}`}
+        aria-expanded={isOpen}
+        aria-controls="notification-dropdown"
       >
         <Bell className="w-5 h-5" />
         {badgeCount > 0 && (
-          <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs font-bold rounded-full w-5 h-5 flex items-center justify-center">
+          <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs font-bold rounded-full w-5 h-5 flex items-center justify-center" aria-hidden="true">
             {badgeCount > 9 ? '9+' : badgeCount}
           </span>
         )}
       </button>
 
       {isOpen && (
-        <div className="absolute right-0 top-full mt-2 w-80 bg-card border rounded-lg shadow-lg z-50 overflow-hidden">
+        <div
+          id="notification-dropdown"
+          role="menu"
+          className="absolute right-0 top-full mt-2 w-80 bg-card border rounded-lg shadow-lg z-50 overflow-hidden"
+        >
           <div className="flex items-center justify-between p-3 border-b">
-            <span className="font-semibold">
-              Notificaciones
-            </span>
-            <button 
+            <span className="font-semibold">Notificaciones</span>
+            <button
               onClick={() => setIsOpen(false)}
               className="text-muted-foreground hover:text-foreground"
+              aria-label="Cerrar notificaciones"
             >
               <X className="w-4 h-4" />
             </button>
           </div>
 
           <div className="max-h-96 overflow-y-auto">
-            {filteredNotifications.length === 0 && pendingCount === 0 ? (
-              <div className="p-4 text-center text-muted-foreground">
-                {emptyState.icon}
-                <p className="text-sm">{emptyState.text}</p>
+            {listLoading && (
+              <div className="p-4 text-center text-muted-foreground text-sm">
+                Cargando notificaciones…
               </div>
-            ) : filteredNotifications.length === 0 && pendingCount > 0 ? (
+            )}
+
+            {listError && (
+              <div className="p-4 text-center text-red-600 text-sm" role="alert">
+                No se pudieron cargar las notificaciones
+              </div>
+            )}
+
+            {!listLoading && !listError && filteredNotifications.length === 0 && pendingCount === 0 && (
+              <div className="p-4 text-center text-muted-foreground">
+                <Bell className="w-8 h-8 mx-auto mb-2 opacity-50" />
+                <p className="text-sm">No hay notificaciones nuevas</p>
+              </div>
+            )}
+
+            {!listLoading && !listError && filteredNotifications.length === 0 && pendingCount > 0 && (
               <div className="p-4">
-                <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 mb-3">
+                <div className="bg-amber-50 border border-amber-200 rounded-lg p-3 mb-3 dark:bg-amber-950 dark:border-amber-800">
                   <div className="flex items-start gap-2">
                     <Clock className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
                     <div>
-                      <p className="font-medium text-sm text-amber-800">
+                      <p className="font-medium text-sm text-amber-800 dark:text-amber-200">
                         {pendingCount} pago{pendingCount > 1 ? 's' : ''} pendiente{pendingCount > 1 ? 's' : ''} por revisar
                       </p>
-                      <p className="text-xs text-amber-700 mt-1">
+                      <p className="text-xs text-amber-700 dark:text-amber-300 mt-1">
                         Hay pagos que necesitan aprobación
                       </p>
                     </div>
@@ -219,14 +265,17 @@ function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
                   Revisar pagos →
                 </button>
               </div>
-            ) : (
+            )}
+
+            {!listLoading && !listError && filteredNotifications.length > 0 && (
               <div>
                 {filteredNotifications.map((notification) => (
                   <button
                     key={notification.id}
+                    role="menuitem"
                     onClick={() => handleNotificationClick(notification)}
                     className={`w-full text-left p-3 border-b hover:bg-muted/50 transition-colors ${
-                      !notification.isRead ? 'bg-blue-50/50' : ''
+                      !notification.isRead ? 'bg-blue-50/50 dark:bg-blue-950/30' : ''
                     }`}
                   >
                     <div className="flex items-start gap-2">
@@ -251,7 +300,7 @@ function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
                         </p>
                       </div>
                       {!notification.isRead && (
-                        <div className="w-2 h-2 bg-blue-500 rounded-full flex-shrink-0 mt-2" />
+                        <div className="w-2 h-2 bg-blue-500 rounded-full flex-shrink-0 mt-2" aria-label="No leída" />
                       )}
                     </div>
                   </button>
@@ -265,10 +314,10 @@ function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
               {filteredNotifications.length > 0 && (
                 <button
                   onClick={handleMarkAllRead}
-                  disabled={markReadMutation.isPending}
-                  className="w-full text-xs text-blue-600 hover:text-blue-800 font-medium"
+                  disabled={markAllReadMutation.isPending}
+                  className="w-full text-xs text-blue-600 hover:text-blue-800 font-medium disabled:opacity-50"
                 >
-                  {markReadMutation.isPending ? 'Marcando...' : 'Marcar todas como leídas'}
+                  {markAllReadMutation.isPending ? 'Marcando…' : 'Marcar todas como leídas'}
                 </button>
               )}
               <button
@@ -278,7 +327,7 @@ function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
                 }}
                 className="w-full text-xs text-muted-foreground hover:text-foreground mt-1"
               >
-                Ver todos los pagos →
+                Ver pagos →
               </button>
             </div>
           )}


### PR DESCRIPTION
## Resumen

Completa el Punto 9 de BuildingOS: notificaciones globales para tickets y reclamos.

## Problemas corregidos

- rutas frontend incompatibles con los endpoints reales del backend;
- badge dependiente de abrir primero la campanita;
- polling demasiado lento;
- clasificación incorrecta de usuarios con varios roles;
- destinatarios administrativos buscados únicamente en `TenantMember`;
- administradores definidos mediante `Membership` y `MembershipRole` sin recibir alertas;
- ausencia de alerta administrativa cuando el residente respondía un ticket.

## Backend

- resolución de administradores mediante `Membership` y `MembershipRole`;
- soporte para `TENANT_OWNER`, `TENANT_ADMIN` y `OPERATOR`;
- respeto de scopes `TENANT`, `BUILDING` y `UNIT`;
- fallback legacy mediante `TenantMember`;
- deduplicación por `userId`;
- notificaciones por creación y respuestas de tickets;
- aislamiento por tenant, edificio, unidad y usuario.

## Frontend

- endpoints tenant-scoped;
- campanita global;
- badge de no leídas;
- polling aproximado de 30 segundos;
- actualización al recuperar foco;
- soporte para múltiples roles;
- marcar una notificación como leída;
- marcar todas mediante una única petición;
- estados de carga, error y vacío;
- accesibilidad;
- dark mode.

## Smoke manual

Validado:

- residente crea ticket y administración recibe badge;
- residente responde y administración recibe alerta;
- administración responde o cambia estado y residente recibe alerta;
- las notificaciones aparecen desde otras pantallas;
- no es necesario recargar manualmente.

## Validaciones

- API: 49 tests PASS
- Web: 52 tests PASS
- Typecheck API: PASS
- Typecheck web: PASS
- ESLint focalizado: PASS
- Build API: PASS
- Build web: PASS
- `git diff --check`: PASS

## Fuera de alcance

- WebSocket;
- push móvil;
- correo electrónico;
- WhatsApp;
- rediseño del detalle de tickets;
- cambios en Reportes;
- migraciones;
- producción.

Closes #49
