### PR TITLE
fix(resident): harden payment reporting and receipts

### DIFF
--- a/apps/api/src/documents/documents.controller.spec.ts
+++ b/apps/api/src/documents/documents.controller.spec.ts
@@ -1,11 +1,14 @@
 import { DocumentsController } from './documents.controller';
 import { DocumentsService } from './documents.service';
 import { ResidentAccessService } from '../resident-access/resident-access.service';
+import { StreamableFile } from '@nestjs/common';
 
 describe('DocumentsController', () => {
   const documentsService = {
     createDocument: jest.fn(),
     checkResidentUnitAccess: jest.fn(),
+    getDownloadUrl: jest.fn(),
+    getDocumentContent: jest.fn(),
   } as unknown as jest.Mocked<DocumentsService>;
   const residentAccess = {
     shouldEnforce: jest.fn(),
@@ -22,8 +25,12 @@ describe('DocumentsController', () => {
       {
         category: 'RECEIPT',
         title: 'Admin receipt',
-        objectKey: 'tenant-1/documents/proof.pdf',
-        size: 10,
+        file: {
+          objectKey: 'tenant-1/documents/proof.pdf',
+          originalName: 'proof.pdf',
+          mimeType: 'application/pdf',
+          size: 10,
+        },
         unitId: 'foreign-unit',
       },
       {
@@ -43,5 +50,41 @@ describe('DocumentsController', () => {
       'membership-1',
       expect.objectContaining({ unitId: 'foreign-unit' }),
     );
+  });
+
+  it('streams protected document content with safe headers for authenticated users', async () => {
+    documentsService.getDocumentContent.mockResolvedValue({
+      stream: {} as never,
+      contentType: 'application/pdf',
+      contentLength: 42,
+      fileName: 'receipt.pdf',
+      disposition: 'inline',
+    } as never);
+
+    const result = await controller.getContent(
+      'document-1',
+      {
+        tenantId: 'tenant-1',
+        user: {
+          id: 'resident-1',
+          roles: ['RESIDENT'],
+          memberships: [{ id: 'membership-1', tenantId: 'tenant-1', roles: ['RESIDENT'] }],
+        },
+      } as never,
+    );
+
+    expect(documentsService.getDocumentContent).toHaveBeenCalledWith(
+      'tenant-1',
+      'document-1',
+      'resident-1',
+      ['RESIDENT'],
+      false,
+    );
+    expect(result).toBeInstanceOf(StreamableFile);
+    expect(result.getHeaders()).toEqual({
+      type: 'application/pdf',
+      disposition: 'inline; filename="receipt.pdf"',
+      length: 42,
+    });
   });
 });

--- a/apps/api/src/documents/documents.controller.ts
+++ b/apps/api/src/documents/documents.controller.ts
@@ -140,6 +140,7 @@ export class DocumentsController {
       dto.originalName,
       dto.mimeType,
       dto.size,
+      dto.purpose,
     );
   }
 

--- a/apps/api/src/documents/documents.controller.ts
+++ b/apps/api/src/documents/documents.controller.ts
@@ -11,6 +11,8 @@ import {
   Query,
   ForbiddenException,
   BadRequestException,
+  Header,
+  StreamableFile,
 } from '@nestjs/common';
 import { DocumentCategory, DocumentVisibility } from '@prisma/client';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -122,7 +124,7 @@ export class DocumentsController {
    * POST /documents/presign
    * Generate presigned URL for file upload to MinIO
    *
-   * Body: { originalName, mimeType }
+   * Body: { originalName, mimeType, size? }
    * Returns: { url, bucket, objectKey, expiresAt }
    *
    * No permission check (any authenticated user can presign)
@@ -137,6 +139,7 @@ export class DocumentsController {
       tenantId,
       dto.originalName,
       dto.mimeType,
+      dto.size,
     );
   }
 
@@ -144,7 +147,7 @@ export class DocumentsController {
    * POST /documents
    * Create a document after file upload
    *
-   * Body: CreateDocumentDto (includes objectKey from presign)
+   * Body: CreateDocumentDto (includes nested file metadata from presign)
    * Returns: Document with file metadata
    *
    * Permission rules:
@@ -381,5 +384,40 @@ export class DocumentsController {
       userRoles,
       isSuperAdmin,
     );
+  }
+
+  /**
+   * GET /documents/:id/content
+   * Stream document content through BuildingOS
+   *
+   * Returns a protected stream with sanitized headers.
+   */
+  @Get(':documentId/content')
+  @Header('Cache-Control', 'private, no-store, max-age=0, must-revalidate')
+  @Header('Pragma', 'no-cache')
+  @Header('X-Content-Type-Options', 'nosniff')
+  async getContent(
+    @Param('documentId') documentId: string,
+    @Request() req: TenantContextRequest,
+  ): Promise<StreamableFile> {
+    const tenantId = this.getTenantId(req);
+    const userId = req.user.id;
+    const userRoles = this.getUserRoles(req);
+    const userMemberships = req.user.memberships || [];
+    const isSuperAdmin = this.isSuperAdmin(userMemberships);
+
+    const content = await this.documentsService.getDocumentContent(
+      tenantId,
+      documentId,
+      userId,
+      userRoles,
+      isSuperAdmin,
+    );
+
+    return new StreamableFile(content.stream, {
+      type: content.contentType,
+      disposition: `${content.disposition}; filename="${content.fileName}"`,
+      length: content.contentLength,
+    });
   }
 }

--- a/apps/api/src/documents/documents.module.ts
+++ b/apps/api/src/documents/documents.module.ts
@@ -5,9 +5,10 @@ import { DocumentsValidators } from './documents.validators';
 import { PrismaModule } from '../prisma/prisma.module';
 import { ResidentAccessModule } from '../resident-access/resident-access.module';
 import { StorageModule } from '../storage/storage.module';
+import { AppConfigModule } from '../config/config.module';
 
 @Module({
-  imports: [PrismaModule, ResidentAccessModule, StorageModule],
+  imports: [PrismaModule, ResidentAccessModule, StorageModule, AppConfigModule],
   controllers: [DocumentsController],
   providers: [DocumentsService, DocumentsValidators],
   exports: [DocumentsService, DocumentsValidators],

--- a/apps/api/src/documents/documents.service.spec.ts
+++ b/apps/api/src/documents/documents.service.spec.ts
@@ -1,4 +1,10 @@
-import { BadRequestException, NotFoundException, PayloadTooLargeException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+  PayloadTooLargeException,
+} from '@nestjs/common';
 import { Readable } from 'node:stream';
 import { DocumentsService } from './documents.service';
 import { DocumentsValidators } from './documents.validators';
@@ -18,6 +24,7 @@ describe('DocumentsService', () => {
       findUnique: jest.fn(),
     },
     file: {
+      findFirst: jest.fn(),
       create: jest.fn(),
     },
     tenant: {
@@ -67,7 +74,7 @@ describe('DocumentsService', () => {
 
   const uploadFile = {
     bucket: DEFAULT_BUCKET,
-    objectKey: 'tenant-1/documents/proof.pdf',
+    objectKey: 'tenant-tenant-1/documents/proof.pdf',
     originalName: 'proof.pdf',
     mimeType: 'application/pdf',
     size: 1024,
@@ -91,6 +98,7 @@ describe('DocumentsService', () => {
     validators.canAccessDocument.mockReturnValue(true);
     validators.validateResidentDocumentAccess.mockResolvedValue(undefined);
     residentAccess.shouldEnforce.mockReturnValue(false);
+    prisma.file.findFirst.mockResolvedValue(null);
     prisma.document.findFirst.mockResolvedValue({
       id: 'document-1',
       tenantId: 'tenant-1',
@@ -140,6 +148,61 @@ describe('DocumentsService', () => {
     })).rejects.toBeInstanceOf(BadRequestException);
 
     expect(minio.deleteObject).toHaveBeenCalledWith(DEFAULT_BUCKET, uploadFile.objectKey);
+    expect(prisma.file.create).not.toHaveBeenCalled();
+    expect(prisma.document.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects object keys from another tenant before touching storage', async () => {
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      file: { ...uploadFile, objectKey: 'tenant-tenant-2/documents/proof.pdf' },
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(minio.objectExists).not.toHaveBeenCalled();
+    expect(minio.statObject).not.toHaveBeenCalled();
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+    expect(prisma.file.findFirst).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'tenant-tenant-1/documents/../tenant-tenant-2/proof.pdf',
+    'tenant-tenant-1/documents\\proof.pdf',
+    'tenant-tenant-1/documents//proof.pdf',
+  ])('rejects invalid object keys without touching storage: %s', async (objectKey) => {
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      file: { ...uploadFile, objectKey },
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(minio.objectExists).not.toHaveBeenCalled();
+    expect(minio.statObject).not.toHaveBeenCalled();
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+    expect(prisma.file.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('rejects a reused object key before cleanup can delete it', async () => {
+    prisma.file.findFirst.mockResolvedValueOnce({ id: 'file-1' } as never);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBeInstanceOf(ConflictException);
+
+    expect(minio.objectExists).not.toHaveBeenCalled();
+    expect(minio.statObject).not.toHaveBeenCalled();
+    expect(minio.deleteObject).not.toHaveBeenCalled();
     expect(prisma.file.create).not.toHaveBeenCalled();
     expect(prisma.document.create).not.toHaveBeenCalled();
   });

--- a/apps/api/src/documents/documents.service.spec.ts
+++ b/apps/api/src/documents/documents.service.spec.ts
@@ -142,6 +142,45 @@ describe('DocumentsService', () => {
     expect(result.bucket).toBe(DEFAULT_BUCKET);
   });
 
+  it('preserves double dots inside generated filenames and accepts the generated key', async () => {
+    minio.presignUpload.mockResolvedValue('https://upload.example/expensas.pdf');
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    prisma.file.create.mockResolvedValueOnce({ id: 'file-1' } as never);
+    prisma.document.create.mockResolvedValueOnce({
+      id: 'document-1',
+      tenantId: 'tenant-1',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      createdByMembership: { user: { id: 'admin-1', name: 'Admin' } },
+      file: { bucket: DEFAULT_BUCKET, objectKey: 'tenant-tenant-1/documents/generated-expensas..julio.pdf' },
+    } as never);
+
+    const presignResult = await service.presignUpload('tenant-1', 'expensas..julio.pdf', 'application/pdf', 1024);
+    expect(presignResult.objectKey).toContain('expensas..julio.pdf');
+
+    const result = await service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      file: {
+        bucket: DEFAULT_BUCKET,
+        objectKey: 'tenant-tenant-1/documents/generated-expensas..julio.pdf',
+        originalName: 'expensas..julio.pdf',
+        mimeType: 'application/pdf',
+        size: 1024,
+      },
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    });
+
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+    expect(result.file.objectKey).toContain('expensas..julio.pdf');
+  });
+
   it('rejects empty uploads before creating the document record', async () => {
     minio.objectExists.mockResolvedValue(true);
     minio.statObject.mockResolvedValue({ size: 0 } as never);
@@ -178,8 +217,10 @@ describe('DocumentsService', () => {
 
   it.each([
     'tenant-tenant-1/documents/../tenant-tenant-2/proof.pdf',
+    'tenant-tenant-1/documents/./proof.pdf',
     'tenant-tenant-1/documents\\proof.pdf',
     'tenant-tenant-1/documents//proof.pdf',
+    'tenant-tenant-1/documents/proof\0.pdf',
   ])('rejects invalid object keys without touching storage: %s', async (objectKey) => {
     await expect(service.createDocument('tenant-1', 'membership-1', {
       title: 'Receipt',

--- a/apps/api/src/documents/documents.service.spec.ts
+++ b/apps/api/src/documents/documents.service.spec.ts
@@ -1,28 +1,60 @@
+import { BadRequestException, NotFoundException, PayloadTooLargeException } from '@nestjs/common';
+import { Readable } from 'node:stream';
 import { DocumentsService } from './documents.service';
 import { DocumentsValidators } from './documents.validators';
 import { ResidentAccessService } from '../resident-access/resident-access.service';
 
+const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+const DEFAULT_BUCKET = 'buildingos-test';
+
 describe('DocumentsService', () => {
   const prisma = {
+    $transaction: jest.fn(),
     document: {
       findFirst: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
+      create: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    file: {
+      create: jest.fn(),
+    },
+    tenant: {
+      findUnique: jest.fn(),
     },
   };
   const validators = {
+    validateDocumentScope: jest.fn(),
+    validateBuildingBelongsToTenant: jest.fn(),
+    validateUnitBelongsToBuilding: jest.fn(),
     validateResidentDocumentAccess: jest.fn(),
+    canAccessDocument: jest.fn(),
   } as unknown as jest.Mocked<DocumentsValidators>;
   const minio = {
+    getDefaultBucket: jest.fn(() => DEFAULT_BUCKET),
     deleteObject: jest.fn(),
+    presignUpload: jest.fn(),
+    presignDownload: jest.fn(),
+    objectExists: jest.fn(),
+    statObject: jest.fn(),
+    getObjectStream: jest.fn(),
   };
-  const notifications = {};
+  const notifications = {
+    createNotification: jest.fn(),
+  };
   const audit = {
     createLog: jest.fn(),
   };
   const residentAccess = {
     shouldEnforce: jest.fn(),
   } as unknown as jest.Mocked<ResidentAccessService>;
+  const configService = {
+    getValue: jest.fn((key: string) => {
+      if (key === 'uploadMaxBytes') return MAX_UPLOAD_BYTES;
+      return undefined;
+    }),
+  };
   const service = new DocumentsService(
     prisma as never,
     validators,
@@ -30,24 +62,295 @@ describe('DocumentsService', () => {
     notifications as never,
     audit as never,
     residentAccess,
+    configService as never,
   );
 
-  const createdDocument = {
-    id: 'document-1',
-    tenantId: 'tenant-1',
-    buildingId: 'building-1',
-    unitId: 'unit-1',
-    visibility: 'PRIVATE',
-    title: 'Receipt',
-    category: 'RECEIPT',
-    createdByMembership: { userId: 'resident-1' },
-    file: { bucket: 'tenant-1', objectKey: 'receipt.pdf' },
+  const uploadFile = {
+    bucket: DEFAULT_BUCKET,
+    objectKey: 'tenant-1/documents/proof.pdf',
+    originalName: 'proof.pdf',
+    mimeType: 'application/pdf',
+    size: 1024,
+    checksum: 'checksum-123',
   };
 
-  beforeEach(() => jest.clearAllMocks());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    minio.getDefaultBucket.mockReturnValue(DEFAULT_BUCKET);
+    prisma.$transaction.mockImplementation(async (callback: (tx: never) => Promise<unknown>) => {
+      const tx = {
+        file: prisma.file,
+        document: prisma.document,
+      } as never;
+
+      return callback(tx);
+    });
+    validators.validateDocumentScope.mockReturnValue(undefined);
+    validators.validateBuildingBelongsToTenant.mockResolvedValue(undefined);
+    validators.validateUnitBelongsToBuilding.mockResolvedValue(undefined);
+    validators.canAccessDocument.mockReturnValue(true);
+    validators.validateResidentDocumentAccess.mockResolvedValue(undefined);
+    residentAccess.shouldEnforce.mockReturnValue(false);
+    prisma.document.findFirst.mockResolvedValue({
+      id: 'document-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      visibility: 'RESIDENTS',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      createdByMembership: { userId: 'admin-1' },
+      file: { bucket: 'tenant-legacy-bucket', objectKey: 'receipt.pdf', originalName: 'receipt.pdf', mimeType: 'application/pdf' },
+    } as never);
+  });
+
+  it('rejects presign requests that exceed the backend upload limit', async () => {
+    await expect(
+      service.presignUpload('tenant-1', 'proof.pdf', 'application/pdf', MAX_UPLOAD_BYTES + 1),
+    ).rejects.toBeInstanceOf(PayloadTooLargeException);
+
+    expect(minio.presignUpload).not.toHaveBeenCalled();
+  });
+
+  it('uses the configured bucket for presign uploads', async () => {
+    minio.presignUpload.mockResolvedValue('https://upload.example/proof.pdf');
+
+    const result = await service.presignUpload('tenant-1', 'proof.pdf', 'application/pdf', 1024);
+
+    expect(minio.getDefaultBucket).toHaveBeenCalled();
+    expect(minio.presignUpload).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      expect.stringMatching(/^tenant-tenant-1\/documents\//),
+      86400,
+    );
+    expect(result.bucket).toBe(DEFAULT_BUCKET);
+  });
+
+  it('rejects empty uploads before creating the document record', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 0 } as never);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(minio.deleteObject).toHaveBeenCalledWith(DEFAULT_BUCKET, uploadFile.objectKey);
+    expect(prisma.file.create).not.toHaveBeenCalled();
+    expect(prisma.document.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects uploaded files that exceed the backend limit using the real storage size', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: MAX_UPLOAD_BYTES + 1 } as never);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBeInstanceOf(PayloadTooLargeException);
+
+    expect(minio.deleteObject).toHaveBeenCalledWith(DEFAULT_BUCKET, uploadFile.objectKey);
+    expect(prisma.file.create).not.toHaveBeenCalled();
+    expect(prisma.document.create).not.toHaveBeenCalled();
+  });
+
+  it('persists uploaded files using the configured bucket', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    prisma.file.create.mockResolvedValueOnce({ id: 'file-1' } as never);
+    prisma.document.create.mockResolvedValueOnce({
+      id: 'document-1',
+      tenantId: 'tenant-1',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      createdByMembership: { user: { id: 'admin-1', name: 'Admin' } },
+      file: { bucket: DEFAULT_BUCKET, objectKey: uploadFile.objectKey },
+    } as never);
+
+    const result = await service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    });
+
+    expect(minio.objectExists).toHaveBeenCalledWith(DEFAULT_BUCKET, uploadFile.objectKey);
+    expect(minio.statObject).toHaveBeenCalledWith(DEFAULT_BUCKET, uploadFile.objectKey);
+    expect(prisma.file.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        bucket: DEFAULT_BUCKET,
+        objectKey: uploadFile.objectKey,
+      }),
+    }));
+    expect(result.file.bucket).toBe(DEFAULT_BUCKET);
+  });
+
+  it('cleans up the uploaded object if the document row cannot be persisted', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    prisma.file.create.mockResolvedValueOnce({ id: 'file-1' } as never);
+    prisma.document.create.mockRejectedValueOnce(new Error('DB down'));
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toThrow('DB down');
+
+    expect(prisma.file.create).toHaveBeenCalled();
+    expect(prisma.document.create).toHaveBeenCalled();
+    expect(minio.deleteObject).toHaveBeenCalledWith(DEFAULT_BUCKET, uploadFile.objectKey);
+  });
+
+  it('rejects unsafe MIME types and cleans up the uploaded object', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      file: { ...uploadFile, mimeType: 'application/x-msdownload' },
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toThrow('File type not allowed');
+
+    expect(minio.deleteObject).toHaveBeenCalledWith(DEFAULT_BUCKET, uploadFile.objectKey);
+    expect(prisma.file.create).not.toHaveBeenCalled();
+    expect(prisma.document.create).not.toHaveBeenCalled();
+  });
+
+  it('returns a presigned download URL after validating resident receipt access', async () => {
+    minio.presignDownload.mockResolvedValue('https://download.example/receipt.pdf');
+
+    const result = await service.getDownloadUrl(
+      'tenant-1',
+      'document-1',
+      'resident-1',
+      ['RESIDENT'],
+      false,
+    );
+
+    expect(validators.validateResidentDocumentAccess).toHaveBeenCalledWith(
+      'tenant-1',
+      'resident-1',
+      'building-1',
+      'unit-1',
+      'RESIDENTS',
+      false,
+    );
+    expect(minio.presignDownload).toHaveBeenCalledWith('tenant-legacy-bucket', 'receipt.pdf', 86400);
+    expect(result).toEqual({
+      url: 'https://download.example/receipt.pdf',
+      expiresAt: expect.any(Date),
+    });
+  });
+
+  it('streams a protected document download using the persisted bucket and sanitized filename', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 2048 } as never);
+    minio.getObjectStream.mockResolvedValue(Readable.from(['pdf-bytes']) as never);
+
+    const result = await service.getDocumentContent(
+      'tenant-1',
+      'document-1',
+      'resident-1',
+      ['RESIDENT'],
+      false,
+    );
+
+    expect(minio.objectExists).toHaveBeenCalledWith('tenant-legacy-bucket', 'receipt.pdf');
+    expect(minio.statObject).toHaveBeenCalledWith('tenant-legacy-bucket', 'receipt.pdf');
+    expect(minio.getObjectStream).toHaveBeenCalledWith('tenant-legacy-bucket', 'receipt.pdf');
+    expect(result.contentType).toBe('application/pdf');
+    expect(result.contentLength).toBe(2048);
+    expect(result.fileName).toBe('receipt.pdf');
+    expect(result.disposition).toBe('inline');
+    expect(result.stream.readable).toBe(true);
+  });
+
+  it('rejects downloads when the file no longer exists in MinIO', async () => {
+    minio.objectExists.mockResolvedValue(false);
+
+    await expect(
+      service.getDocumentContent('tenant-1', 'document-1', 'resident-1', ['RESIDENT'], false),
+    ).rejects.toBeInstanceOf(NotFoundException);
+
+    expect(minio.statObject).not.toHaveBeenCalled();
+    expect(minio.getObjectStream).not.toHaveBeenCalled();
+  });
+
+  it('sanitizes malicious download filenames and uses attachment for non-inline types', async () => {
+    prisma.document.findFirst.mockResolvedValue({
+      id: 'document-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      visibility: 'RESIDENTS',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      createdByMembership: { userId: 'admin-1' },
+      file: {
+        bucket: 'tenant-legacy-bucket',
+        objectKey: 'receipt.bin',
+        originalName: 'receipt"\r\n.pdf',
+        mimeType: 'application/octet-stream',
+      },
+    } as never);
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    minio.getObjectStream.mockResolvedValue(Readable.from(['binary']) as never);
+
+    const result = await service.getDocumentContent(
+      'tenant-1',
+      'document-1',
+      'resident-1',
+      ['RESIDENT'],
+      false,
+    );
+
+    expect(result.fileName).toBe('receipt_.pdf');
+    expect(result.disposition).toBe('attachment');
+  });
+
+  it('blocks receipt downloads for residents without active access to the unit', async () => {
+    validators.validateResidentDocumentAccess.mockRejectedValue(new NotFoundException('Document not found or does not belong to you'));
+
+    await expect(
+      service.getDownloadUrl('tenant-1', 'document-1', 'resident-1', ['RESIDENT'], false),
+    ).rejects.toThrow(NotFoundException);
+
+    expect(minio.presignDownload).not.toHaveBeenCalled();
+  });
 
   it('requires a current occupancy before a resident creator can update a document', async () => {
-    prisma.document.findFirst.mockResolvedValue(createdDocument);
+    prisma.document.findFirst.mockResolvedValue({
+      id: 'document-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      visibility: 'PRIVATE',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      createdByMembership: { userId: 'resident-1' },
+      file: { bucket: 'tenant-1', objectKey: 'receipt.pdf' },
+    } as never);
     residentAccess.shouldEnforce.mockReturnValue(true);
     validators.validateResidentDocumentAccess.mockRejectedValue(
       new Error('Document not found or does not belong to you'),
@@ -65,7 +368,17 @@ describe('DocumentsService', () => {
   });
 
   it('requires a current occupancy before a resident creator can delete a document', async () => {
-    prisma.document.findFirst.mockResolvedValue(createdDocument);
+    prisma.document.findFirst.mockResolvedValue({
+      id: 'document-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      visibility: 'PRIVATE',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      createdByMembership: { userId: 'resident-1' },
+      file: { bucket: 'tenant-1', objectKey: 'receipt.pdf' },
+    } as never);
     residentAccess.shouldEnforce.mockReturnValue(true);
     validators.validateResidentDocumentAccess.mockRejectedValue(
       new Error('Document not found or does not belong to you'),

--- a/apps/api/src/documents/documents.service.spec.ts
+++ b/apps/api/src/documents/documents.service.spec.ts
@@ -9,9 +9,17 @@ import { Readable } from 'node:stream';
 import { DocumentsService } from './documents.service';
 import { DocumentsValidators } from './documents.validators';
 import { ResidentAccessService } from '../resident-access/resident-access.service';
+import { Prisma } from '@prisma/client';
 
 const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
 const DEFAULT_BUCKET = 'buildingos-test';
+
+function createPrismaKnownRequestError(code: string): Prisma.PrismaClientKnownRequestError {
+  const error = new Error('Prisma known request error');
+  Object.assign(error, { code });
+  Object.setPrototypeOf(error, Prisma.PrismaClientKnownRequestError.prototype);
+  return error as Prisma.PrismaClientKnownRequestError;
+}
 
 describe('DocumentsService', () => {
   const prisma = {
@@ -204,6 +212,25 @@ describe('DocumentsService', () => {
     expect(minio.statObject).not.toHaveBeenCalled();
     expect(minio.deleteObject).not.toHaveBeenCalled();
     expect(prisma.file.create).not.toHaveBeenCalled();
+    expect(prisma.document.create).not.toHaveBeenCalled();
+  });
+
+  it('preserves the uploaded object when a concurrent create already persisted the file row', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    prisma.file.create.mockRejectedValueOnce(createPrismaKnownRequestError('P2002'));
+    prisma.file.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({ id: 'file-1' } as never);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toMatchObject({ code: 'P2002' });
+
+    expect(minio.deleteObject).not.toHaveBeenCalled();
     expect(prisma.document.create).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/documents/documents.service.spec.ts
+++ b/apps/api/src/documents/documents.service.spec.ts
@@ -7,11 +7,13 @@ import {
 } from '@nestjs/common';
 import { Readable } from 'node:stream';
 import { DocumentsService } from './documents.service';
+import { DocumentUploadPurpose } from './dto/presign-upload.dto';
 import { DocumentsValidators } from './documents.validators';
 import { ResidentAccessService } from '../resident-access/resident-access.service';
 import { Prisma } from '@prisma/client';
 
-const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+const PAYMENT_PROOF_MAX_BYTES = 10 * 1024 * 1024;
+const GENERAL_DOCUMENT_MAX_BYTES = 100 * 1024 * 1024;
 const DEFAULT_BUCKET = 'buildingos-test';
 
 function createPrismaKnownRequestError(code: string): Prisma.PrismaClientKnownRequestError {
@@ -37,6 +39,9 @@ describe('DocumentsService', () => {
     },
     tenant: {
       findUnique: jest.fn(),
+    },
+    unitOccupant: {
+      findMany: jest.fn(),
     },
   };
   const validators = {
@@ -64,12 +69,6 @@ describe('DocumentsService', () => {
   const residentAccess = {
     shouldEnforce: jest.fn(),
   } as unknown as jest.Mocked<ResidentAccessService>;
-  const configService = {
-    getValue: jest.fn((key: string) => {
-      if (key === 'uploadMaxBytes') return MAX_UPLOAD_BYTES;
-      return undefined;
-    }),
-  };
   const service = new DocumentsService(
     prisma as never,
     validators,
@@ -77,7 +76,6 @@ describe('DocumentsService', () => {
     notifications as never,
     audit as never,
     residentAccess,
-    configService as never,
   );
 
   const uploadFile = {
@@ -107,6 +105,7 @@ describe('DocumentsService', () => {
     validators.validateResidentDocumentAccess.mockResolvedValue(undefined);
     residentAccess.shouldEnforce.mockReturnValue(false);
     prisma.file.findFirst.mockResolvedValue(null);
+    prisma.unitOccupant.findMany.mockResolvedValue([]);
     prisma.document.findFirst.mockResolvedValue({
       id: 'document-1',
       tenantId: 'tenant-1',
@@ -120,10 +119,56 @@ describe('DocumentsService', () => {
     } as never);
   });
 
-  it('rejects presign requests that exceed the backend upload limit', async () => {
+  it.each([9, 10, 50, 100])('allows general document presign requests at %i MiB', async (sizeInMiB) => {
+    minio.presignUpload.mockResolvedValue('https://upload.example/general.pdf');
+
     await expect(
-      service.presignUpload('tenant-1', 'proof.pdf', 'application/pdf', MAX_UPLOAD_BYTES + 1),
-    ).rejects.toBeInstanceOf(PayloadTooLargeException);
+      service.presignUpload(
+        'tenant-1',
+        'general.pdf',
+        'application/pdf',
+        sizeInMiB * 1024 * 1024,
+      ),
+    ).resolves.toEqual(expect.objectContaining({ objectKey: expect.stringContaining('/documents/') }));
+  });
+
+  it('rejects general document presign requests over 100 MiB with a 100 MB message', async () => {
+    await expect(
+      service.presignUpload(
+        'tenant-1',
+        'general.pdf',
+        'application/pdf',
+        GENERAL_DOCUMENT_MAX_BYTES + 1,
+      ),
+    ).rejects.toThrow('100 MB');
+
+    expect(minio.presignUpload).not.toHaveBeenCalled();
+  });
+
+  it.each([9, 10])('allows payment proof presign requests at %i MiB', async (sizeInMiB) => {
+    minio.presignUpload.mockResolvedValue('https://upload.example/proof.pdf');
+
+    await expect(
+      service.presignUpload(
+        'tenant-1',
+        'proof.pdf',
+        'application/pdf',
+        sizeInMiB * 1024 * 1024,
+        DocumentUploadPurpose.PAYMENT_PROOF,
+      ),
+    ).resolves.toEqual(expect.objectContaining({ objectKey: expect.stringContaining('/payment-proofs/') }));
+  });
+
+  it('rejects payment proof presign requests over 10 MiB with a 10 MB message', async () => {
+    await expect(
+      service.presignUpload(
+        'tenant-1',
+        'proof.pdf',
+        'application/pdf',
+        PAYMENT_PROOF_MAX_BYTES + 1,
+        DocumentUploadPurpose.PAYMENT_PROOF,
+      ),
+    ).rejects.toThrow('10 MB');
 
     expect(minio.presignUpload).not.toHaveBeenCalled();
   });
@@ -275,9 +320,157 @@ describe('DocumentsService', () => {
     expect(prisma.document.create).not.toHaveBeenCalled();
   });
 
+  it('preserves a winning payment-proof object during a concurrent P2002 cleanup', async () => {
+    const paymentProof = {
+      ...uploadFile,
+      objectKey: 'tenant-tenant-1/payment-proofs/shared-proof.pdf',
+    };
+    const winnerFile = { id: 'file-winner' };
+    let resolveWinnerFilePersisted!: () => void;
+    const winnerFilePersisted = new Promise<void>((resolve) => {
+      resolveWinnerFilePersisted = resolve;
+    });
+    let releaseWinnerDocument!: () => void;
+    const winnerDocumentReleased = new Promise<void>((resolve) => {
+      releaseWinnerDocument = resolve;
+    });
+    let fileLookupCount = 0;
+    let fileCreateCount = 0;
+    let documentCreateCount = 0;
+
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    prisma.file.findFirst.mockImplementation(async () => {
+      fileLookupCount += 1;
+      return fileLookupCount <= 2 ? null as never : winnerFile as never;
+    });
+    prisma.file.create.mockImplementation(async () => {
+      fileCreateCount += 1;
+      if (fileCreateCount === 1) {
+        resolveWinnerFilePersisted();
+        return winnerFile as never;
+      }
+
+      await winnerFilePersisted;
+      throw createPrismaKnownRequestError('P2002');
+    });
+    prisma.document.create.mockImplementation(async () => {
+      documentCreateCount += 1;
+      if (documentCreateCount === 1) {
+        await winnerDocumentReleased;
+      }
+
+      return {
+        id: 'document-winner',
+        tenantId: 'tenant-1',
+        file: paymentProof,
+        createdByMembership: { user: { id: 'resident-1', name: 'Resident' } },
+      } as never;
+    });
+
+    const winnerRequest = service.createDocument('tenant-1', 'membership-1', {
+      title: 'Payment proof',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      file: paymentProof,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    });
+
+    await winnerFilePersisted;
+    const losingRequest = service.createDocument('tenant-1', 'membership-1', {
+      title: 'Payment proof',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      file: paymentProof,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    });
+
+    await expect(losingRequest).rejects.toMatchObject({ code: 'P2002' });
+
+    expect(prisma.file.findFirst).toHaveBeenLastCalledWith({
+      where: {
+        tenantId: 'tenant-1',
+        bucket: DEFAULT_BUCKET,
+        objectKey: paymentProof.objectKey,
+      },
+      select: { id: true },
+    });
+    expect(minio.statObject).toHaveBeenCalledWith(DEFAULT_BUCKET, paymentProof.objectKey);
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+
+    releaseWinnerDocument();
+    await expect(winnerRequest).resolves.toEqual(expect.objectContaining({ id: 'document-winner' }));
+  });
+
+  it('cleans up an orphaned payment-proof object after a P2002', async () => {
+    const paymentProof = {
+      ...uploadFile,
+      objectKey: 'tenant-tenant-1/payment-proofs/orphaned-proof.pdf',
+    };
+
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    prisma.file.create.mockRejectedValueOnce(createPrismaKnownRequestError('P2002'));
+    prisma.file.findFirst.mockResolvedValue(null);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Payment proof',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      file: paymentProof,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toMatchObject({ code: 'P2002' });
+
+    expect(prisma.file.findFirst).toHaveBeenLastCalledWith({
+      where: {
+        tenantId: 'tenant-1',
+        bucket: DEFAULT_BUCKET,
+        objectKey: paymentProof.objectKey,
+      },
+      select: { id: true },
+    });
+    expect(minio.deleteObject).toHaveBeenCalledWith(DEFAULT_BUCKET, paymentProof.objectKey);
+  });
+
+  it('rejects payment-proof keys from another tenant before storage or cleanup', async () => {
+    const foreignPaymentProof = {
+      ...uploadFile,
+      objectKey: 'tenant-tenant-2/payment-proofs/foreign-proof.pdf',
+    };
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Payment proof',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      file: foreignPaymentProof,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(minio.objectExists).not.toHaveBeenCalled();
+    expect(minio.statObject).not.toHaveBeenCalled();
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it('extracts tenant ids only from valid document and payment-proof keys', () => {
+    const documentService = service as unknown as {
+      extractTenantIdFromObjectKey(objectKey: string): string;
+    };
+
+    expect(documentService.extractTenantIdFromObjectKey('tenant-tenant-1/documents/file.pdf')).toBe('tenant-1');
+    expect(documentService.extractTenantIdFromObjectKey('tenant-tenant-1/payment-proofs/file.pdf')).toBe('tenant-1');
+    expect(documentService.extractTenantIdFromObjectKey('tenant-/payment-proofs/file.pdf')).toBe('');
+    expect(documentService.extractTenantIdFromObjectKey('payment-proofs/tenant-1/file.pdf')).toBe('');
+    expect(documentService.extractTenantIdFromObjectKey('tenant-tenant-1/payment-proofs/../file.pdf')).toBe('');
+    expect(documentService.extractTenantIdFromObjectKey('tenant-tenant-2/payment-proofs/file.pdf')).toBe('tenant-2');
+  });
+
   it('rejects uploaded files that exceed the backend limit using the real storage size', async () => {
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: MAX_UPLOAD_BYTES + 1 } as never);
+    minio.statObject.mockResolvedValue({ size: GENERAL_DOCUMENT_MAX_BYTES + 1 } as never);
 
     await expect(service.createDocument('tenant-1', 'membership-1', {
       title: 'Receipt',
@@ -347,6 +540,75 @@ describe('DocumentsService', () => {
     expect(prisma.file.create).toHaveBeenCalled();
     expect(prisma.document.create).toHaveBeenCalled();
     expect(minio.deleteObject).toHaveBeenCalledWith(DEFAULT_BUCKET, uploadFile.objectKey);
+  });
+
+  it('accepts a 100 MiB general document using the real storage size', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: GENERAL_DOCUMENT_MAX_BYTES } as never);
+    prisma.file.create.mockResolvedValueOnce({ id: 'file-1' } as never);
+    prisma.document.create.mockResolvedValueOnce({
+      id: 'document-1',
+      tenantId: 'tenant-1',
+      title: 'Large document',
+      category: 'OTHER',
+      visibility: 'TENANT_ADMINS',
+      file: { ...uploadFile, size: GENERAL_DOCUMENT_MAX_BYTES },
+      createdByMembership: { user: { id: 'admin-1', name: 'Admin' } },
+    } as never);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Large document',
+      category: 'OTHER',
+      visibility: 'TENANT_ADMINS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).resolves.toEqual(expect.objectContaining({ id: 'document-1' }));
+  });
+
+  it.each([
+    [PAYMENT_PROOF_MAX_BYTES, true],
+    [PAYMENT_PROOF_MAX_BYTES + 1, false],
+  ])('enforces the 10 MiB real-storage limit for payment proofs (%i bytes)', async (size, allowed) => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size } as never);
+    const paymentProof = {
+      ...uploadFile,
+      objectKey: 'tenant-tenant-1/payment-proofs/proof.pdf',
+    };
+
+    if (allowed) {
+      prisma.file.create.mockResolvedValueOnce({ id: 'file-1' } as never);
+      prisma.document.create.mockResolvedValueOnce({
+        id: 'document-1',
+        tenantId: 'tenant-1',
+        title: 'Payment proof',
+        category: 'RECEIPT',
+        visibility: 'RESIDENTS',
+        file: paymentProof,
+        createdByMembership: { user: { id: 'resident-1', name: 'Resident' } },
+      } as never);
+
+      await expect(service.createDocument('tenant-1', 'membership-1', {
+        title: 'Payment proof',
+        category: 'RECEIPT',
+        visibility: 'RESIDENTS',
+        file: paymentProof,
+        buildingId: 'building-1',
+        unitId: 'unit-1',
+      })).resolves.toEqual(expect.objectContaining({ id: 'document-1' }));
+      return;
+    }
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Payment proof',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      file: paymentProof,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toThrow('10 MB');
+    expect(minio.deleteObject).toHaveBeenCalledWith(DEFAULT_BUCKET, paymentProof.objectKey);
   });
 
   it('rejects unsafe MIME types and cleans up the uploaded object', async () => {

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -278,7 +278,9 @@ export class DocumentsService {
         });
       });
     } catch (error) {
-      await this.deleteUploadedObject(uploadFile.objectKey);
+      if (!(await this.shouldPreserveUploadedObject(uploadFile.objectKey, error))) {
+        await this.deleteUploadedObject(uploadFile.objectKey);
+      }
       throw error;
     }
 
@@ -773,6 +775,40 @@ export class DocumentsService {
     } catch (error) {
       this.logger.warn(`Unable to clean up rejected upload ${objectKey}: ${error instanceof Error ? error.message : String(error)}`);
     }
+  }
+
+  private async shouldPreserveUploadedObject(objectKey: string, error: unknown): Promise<boolean> {
+    if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== 'P2002') {
+      return false;
+    }
+
+    try {
+      const existingFile = await this.prisma.file.findFirst({
+        where: {
+          tenantId: this.extractTenantIdFromObjectKey(objectKey),
+          objectKey,
+        },
+        select: { id: true },
+      });
+
+      return !!existingFile;
+    } catch (lookupError) {
+      this.logger.warn(
+        `Unable to verify concurrent file ownership for ${objectKey}: ${lookupError instanceof Error ? lookupError.message : String(lookupError)}`,
+      );
+      return false;
+    }
+  }
+
+  private extractTenantIdFromObjectKey(objectKey: string): string {
+    const prefix = 'tenant-';
+    const documentsSegment = '/documents/';
+
+    if (!objectKey.startsWith(prefix) || !objectKey.includes(documentsSegment)) {
+      return '';
+    }
+
+    return objectKey.slice(prefix.length, objectKey.indexOf(documentsSegment));
   }
 
   /**

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -18,7 +18,7 @@ import { DocumentsValidators } from './documents.validators';
 import { ResidentAccessService } from '../resident-access/resident-access.service';
 import { CreateDocumentDto } from './dto/create-document.dto';
 import { UpdateDocumentDto } from './dto/update-document.dto';
-import { ConfigService } from '../config/config.service';
+import { DocumentUploadPurpose } from './dto/presign-upload.dto';
 import {
   PresignedUrlResponse,
   DocumentResponseDto,
@@ -75,6 +75,9 @@ const ALLOWED_UPLOAD_MIME_TYPES = [
   'text/csv',
 ];
 
+const GENERAL_DOCUMENT_MAX_BYTES = 100 * 1024 * 1024;
+const PAYMENT_PROOF_MAX_BYTES = 10 * 1024 * 1024;
+
 /**
  * DocumentsService: CRUD operations for Documents and Files with MinIO integration
  *
@@ -105,7 +108,6 @@ const ALLOWED_UPLOAD_MIME_TYPES = [
 @Injectable()
 export class DocumentsService {
   private readonly logger = new Logger(DocumentsService.name);
-  private readonly maxUploadBytes: number;
 
   constructor(
     private readonly prisma: PrismaService,
@@ -114,10 +116,7 @@ export class DocumentsService {
     private readonly notificationsService: NotificationsService,
     private readonly auditService: AuditService,
     private readonly residentAccess: ResidentAccessService,
-    private readonly configService: ConfigService,
-  ) {
-    this.maxUploadBytes = this.configService.getValue('uploadMaxBytes');
-  }
+  ) {}
 
   /**
    * Generate presigned URL for file upload to MinIO
@@ -132,15 +131,16 @@ export class DocumentsService {
     originalName: string,
     mimeType: string,
     size?: number,
+    purpose: DocumentUploadPurpose = DocumentUploadPurpose.GENERAL_DOCUMENT,
   ): Promise<PresignedUrlResponse> {
     // Validate file type (prevent malicious uploads)
     this.validateMimeType(mimeType);
     if (size != null) {
-      this.validateUploadSize(size);
+      this.validateUploadSize(size, purpose);
     }
 
     // Generate objectKey with tenant isolation
-    const objectKey = this.generateObjectKey(tenantId, originalName);
+    const objectKey = this.generateObjectKey(tenantId, originalName, purpose);
     const bucket = this.minio.getDefaultBucket();
 
     // Generate presigned URL from MinIO (24 hours expiration)
@@ -195,7 +195,10 @@ export class DocumentsService {
       );
     }
 
-    this.validateUploadedObjectKeyOwnership(tenantId, uploadFile.objectKey);
+    const uploadPurpose = this.validateUploadedObjectKeyOwnership(
+      tenantId,
+      uploadFile.objectKey,
+    );
 
     const existingFile = await this.prisma.file.findFirst({
       where: {
@@ -234,10 +237,10 @@ export class DocumentsService {
       throw new BadRequestException('El archivo no puede estar vacío');
     }
 
-    if (uploadedObject.size > this.maxUploadBytes) {
+    if (uploadedObject.size > this.maxUploadBytesFor(uploadPurpose)) {
       await this.deleteUploadedObject(uploadFile.objectKey);
       throw new PayloadTooLargeException(
-        `El archivo supera el máximo de ${this.maxUploadBytes} bytes`,
+        `El archivo supera el máximo de ${this.maxUploadMegabytesFor(uploadPurpose)} MB`,
       );
     }
 
@@ -278,7 +281,7 @@ export class DocumentsService {
         });
       });
     } catch (error) {
-      if (!(await this.shouldPreserveUploadedObject(uploadFile.objectKey, error))) {
+      if (!(await this.shouldPreserveUploadedObject(tenantId, bucket, uploadFile.objectKey, error))) {
         await this.deleteUploadedObject(uploadFile.objectKey);
       }
       throw error;
@@ -728,19 +731,22 @@ export class DocumentsService {
     }
   }
 
-  private validateUploadSize(size: number): void {
+  private validateUploadSize(size: number, purpose: DocumentUploadPurpose): void {
     if (size <= 0) {
       throw new BadRequestException('El archivo no puede estar vacío');
     }
 
-    if (size > this.maxUploadBytes) {
+    if (size > this.maxUploadBytesFor(purpose)) {
       throw new PayloadTooLargeException(
-        `El archivo supera el máximo de ${this.maxUploadBytes} bytes`,
+        `El archivo supera el máximo de ${this.maxUploadMegabytesFor(purpose)} MB`,
       );
     }
   }
 
-  private validateUploadedObjectKeyOwnership(tenantId: string, objectKey: string): void {
+  private validateUploadedObjectKeyOwnership(
+    tenantId: string,
+    objectKey: string,
+  ): DocumentUploadPurpose {
     if (!objectKey || objectKey.trim().length === 0) {
       throw new BadRequestException('The uploaded file key is invalid');
     }
@@ -758,12 +764,16 @@ export class DocumentsService {
       throw new BadRequestException('The uploaded file key is invalid');
     }
 
-    const allowedPrefix = `tenant-${tenantId}/documents/`;
-    if (!objectKey.startsWith(allowedPrefix)) {
+    const prefixes: ReadonlyArray<readonly [string, DocumentUploadPurpose]> = [
+      [`tenant-${tenantId}/documents/`, DocumentUploadPurpose.GENERAL_DOCUMENT],
+      [`tenant-${tenantId}/payment-proofs/`, DocumentUploadPurpose.PAYMENT_PROOF],
+    ];
+    const prefixMatch = prefixes.find(([prefix]) => objectKey.startsWith(prefix));
+    if (!prefixMatch) {
       throw new ForbiddenException('The uploaded file key does not belong to this tenant');
     }
 
-    const relativePath = objectKey.slice(allowedPrefix.length);
+    const relativePath = objectKey.slice(prefixMatch[0].length);
     if (!relativePath) {
       throw new BadRequestException('The uploaded file key is invalid');
     }
@@ -774,6 +784,18 @@ export class DocumentsService {
     ) {
       throw new BadRequestException('The uploaded file key is invalid');
     }
+
+    return prefixMatch[1];
+  }
+
+  private maxUploadBytesFor(purpose: DocumentUploadPurpose): number {
+    return purpose === DocumentUploadPurpose.PAYMENT_PROOF
+      ? PAYMENT_PROOF_MAX_BYTES
+      : GENERAL_DOCUMENT_MAX_BYTES;
+  }
+
+  private maxUploadMegabytesFor(purpose: DocumentUploadPurpose): number {
+    return this.maxUploadBytesFor(purpose) / 1024 / 1024;
   }
 
   private async deleteUploadedObject(objectKey: string): Promise<void> {
@@ -784,15 +806,26 @@ export class DocumentsService {
     }
   }
 
-  private async shouldPreserveUploadedObject(objectKey: string, error: unknown): Promise<boolean> {
+  private async shouldPreserveUploadedObject(
+    tenantId: string,
+    bucket: string,
+    objectKey: string,
+    error: unknown,
+  ): Promise<boolean> {
     if (!(error instanceof Prisma.PrismaClientKnownRequestError) || error.code !== 'P2002') {
+      return false;
+    }
+
+    const objectKeyTenantId = this.extractTenantIdFromObjectKey(objectKey);
+    if (!objectKeyTenantId || objectKeyTenantId !== tenantId) {
       return false;
     }
 
     try {
       const existingFile = await this.prisma.file.findFirst({
         where: {
-          tenantId: this.extractTenantIdFromObjectKey(objectKey),
+          tenantId,
+          bucket,
           objectKey,
         },
         select: { id: true },
@@ -808,24 +841,42 @@ export class DocumentsService {
   }
 
   private extractTenantIdFromObjectKey(objectKey: string): string {
-    const prefix = 'tenant-';
-    const documentsSegment = '/documents/';
-
-    if (!objectKey.startsWith(prefix) || !objectKey.includes(documentsSegment)) {
+    const match = /^tenant-([^/]+)\/(?:documents|payment-proofs)\/(.+)$/.exec(objectKey);
+    if (!match) {
       return '';
     }
 
-    return objectKey.slice(prefix.length, objectKey.indexOf(documentsSegment));
+    const [, tenantId, relativePath] = match;
+    if (!tenantId || !relativePath) {
+      return '';
+    }
+
+    const normalized = pathPosix.normalize(objectKey);
+    if (
+      normalized !== objectKey ||
+      relativePath.split('/').some((segment) => segment.length === 0 || segment === '.' || segment === '..')
+    ) {
+      return '';
+    }
+
+    return tenantId;
   }
 
   /**
    * Generate object key with tenant isolation
    * Format: tenant-{tenantId}/documents/{uuid}-{originalName}
    */
-  private generateObjectKey(tenantId: string, originalName: string): string {
+  private generateObjectKey(
+    tenantId: string,
+    originalName: string,
+    purpose: DocumentUploadPurpose,
+  ): string {
     const uuid = this.generateUuid();
     const sanitized = this.sanitizeFileName(originalName);
-    return `tenant-${tenantId}/documents/${uuid}-${sanitized}`;
+    const directory = purpose === DocumentUploadPurpose.PAYMENT_PROOF
+      ? 'payment-proofs'
+      : 'documents';
+    return `tenant-${tenantId}/${directory}/${uuid}-${sanitized}`;
   }
 
   private sanitizeFileName(originalName: string): string {

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -3,10 +3,12 @@ import {
   NotFoundException,
   BadRequestException,
   ForbiddenException,
+  ConflictException,
   PayloadTooLargeException,
   Logger,
 } from '@nestjs/common';
 import { Document, AuditAction } from '@prisma/client';
+import { posix as pathPosix } from 'node:path';
 import type { Readable } from 'node:stream';
 import { PrismaService } from '../prisma/prisma.service';
 import { MinioService } from '../storage/minio.service';
@@ -190,6 +192,21 @@ export class DocumentsService {
         tenantId,
         dto.buildingId,
         dto.unitId,
+      );
+    }
+
+    this.validateUploadedObjectKeyOwnership(tenantId, uploadFile.objectKey);
+
+    const existingFile = await this.prisma.file.findFirst({
+      where: {
+        tenantId,
+        objectKey: uploadFile.objectKey,
+      },
+      select: { id: true },
+    });
+    if (existingFile) {
+      throw new ConflictException(
+        'El archivo ya fue vinculado a un documento y no puede reutilizarse',
       );
     }
 
@@ -718,6 +735,35 @@ export class DocumentsService {
       throw new PayloadTooLargeException(
         `El archivo supera el máximo de ${this.maxUploadBytes} bytes`,
       );
+    }
+  }
+
+  private validateUploadedObjectKeyOwnership(tenantId: string, objectKey: string): void {
+    if (!objectKey || objectKey.trim().length === 0) {
+      throw new BadRequestException('The uploaded file key is invalid');
+    }
+
+    if (objectKey.includes('\\')) {
+      throw new BadRequestException('The uploaded file key is invalid');
+    }
+
+    const normalized = pathPosix.normalize(objectKey);
+    if (
+      normalized !== objectKey ||
+      normalized.startsWith('..') ||
+      pathPosix.isAbsolute(objectKey)
+    ) {
+      throw new BadRequestException('The uploaded file key is invalid');
+    }
+
+    const allowedPrefix = `tenant-${tenantId}/documents/`;
+    if (!objectKey.startsWith(allowedPrefix)) {
+      throw new ForbiddenException('The uploaded file key does not belong to this tenant');
+    }
+
+    const relativePath = objectKey.slice(allowedPrefix.length);
+    if (!relativePath || relativePath.includes('..') || relativePath.includes('//')) {
+      throw new BadRequestException('The uploaded file key is invalid');
     }
   }
 

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -3,9 +3,11 @@ import {
   NotFoundException,
   BadRequestException,
   ForbiddenException,
+  PayloadTooLargeException,
   Logger,
 } from '@nestjs/common';
 import { Document, AuditAction } from '@prisma/client';
+import type { Readable } from 'node:stream';
 import { PrismaService } from '../prisma/prisma.service';
 import { MinioService } from '../storage/minio.service';
 import { NotificationsService } from '../notifications/notifications.service';
@@ -14,6 +16,7 @@ import { DocumentsValidators } from './documents.validators';
 import { ResidentAccessService } from '../resident-access/resident-access.service';
 import { CreateDocumentDto } from './dto/create-document.dto';
 import { UpdateDocumentDto } from './dto/update-document.dto';
+import { ConfigService } from '../config/config.service';
 import {
   PresignedUrlResponse,
   DocumentResponseDto,
@@ -47,6 +50,29 @@ type UnitOccupantNotificationRecipient = Prisma.UnitOccupantGetPayload<{
   };
 }>;
 
+type DocumentContentResponse = {
+  stream: Readable;
+  contentType: string;
+  contentLength: number;
+  fileName: string;
+  disposition: 'inline' | 'attachment';
+};
+
+const ALLOWED_UPLOAD_MIME_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-powerpoint',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'text/plain',
+  'text/csv',
+];
+
 /**
  * DocumentsService: CRUD operations for Documents and Files with MinIO integration
  *
@@ -77,6 +103,7 @@ type UnitOccupantNotificationRecipient = Prisma.UnitOccupantGetPayload<{
 @Injectable()
 export class DocumentsService {
   private readonly logger = new Logger(DocumentsService.name);
+  private readonly maxUploadBytes: number;
 
   constructor(
     private readonly prisma: PrismaService,
@@ -85,7 +112,10 @@ export class DocumentsService {
     private readonly notificationsService: NotificationsService,
     private readonly auditService: AuditService,
     private readonly residentAccess: ResidentAccessService,
-  ) {}
+    private readonly configService: ConfigService,
+  ) {
+    this.maxUploadBytes = this.configService.getValue('uploadMaxBytes');
+  }
 
   /**
    * Generate presigned URL for file upload to MinIO
@@ -99,20 +129,25 @@ export class DocumentsService {
     tenantId: string,
     originalName: string,
     mimeType: string,
+    size?: number,
   ): Promise<PresignedUrlResponse> {
     // Validate file type (prevent malicious uploads)
     this.validateMimeType(mimeType);
+    if (size != null) {
+      this.validateUploadSize(size);
+    }
 
     // Generate objectKey with tenant isolation
     const objectKey = this.generateObjectKey(tenantId, originalName);
+    const bucket = this.minio.getDefaultBucket();
 
     // Generate presigned URL from MinIO (24 hours expiration)
     const expirySeconds = 24 * 60 * 60;
-    const url = await this.minio.presignUpload('documents', objectKey, expirySeconds);
+    const url = await this.minio.presignUpload(bucket, objectKey, expirySeconds);
 
     return {
       url,
-      bucket: 'documents',
+      bucket,
       objectKey,
       expiresAt: new Date(Date.now() + expirySeconds * 1000),
     };
@@ -136,6 +171,8 @@ export class DocumentsService {
     userMembershipId: string,
     dto: CreateDocumentDto,
   ): Promise<DocumentWithFileResponseDto> {
+    const uploadFile = dto.file;
+
     // Validate scope constraint
     this.validators.validateDocumentScope(dto.buildingId, dto.unitId);
 
@@ -156,46 +193,82 @@ export class DocumentsService {
       );
     }
 
+    // Validate file metadata before touching storage records
+    try {
+      this.validateMimeType(uploadFile.mimeType);
+    } catch (error) {
+      await this.deleteUploadedObject(uploadFile.objectKey);
+      throw error;
+    }
+
     // Validate objectKey exists in MinIO before creating document record
-    const fileExists = await this.minio.objectExists('documents', dto.objectKey);
+    const bucket = this.minio.getDefaultBucket();
+
+    const fileExists = await this.minio.objectExists(bucket, uploadFile.objectKey);
     if (!fileExists) {
       throw new BadRequestException(
         'File not found in storage. Upload the file first and try again.',
       );
     }
 
-    // Create File and Document atomically
-    const file = await this.prisma.file.create({
-      data: {
-        tenantId,
-        bucket: 'documents', // Standard bucket for all documents
-        objectKey: dto.objectKey,
-        originalName: dto.objectKey.split('/').pop() || 'document',
-        mimeType: 'application/octet-stream', // Will be overwritten by client
-        size: dto.size,
-        checksum: dto.checksum,
-        createdByMembershipId: userMembershipId,
-      },
-    });
+    const uploadedObject = await this.minio.statObject(bucket, uploadFile.objectKey);
+    if (uploadedObject.size <= 0) {
+      await this.deleteUploadedObject(uploadFile.objectKey);
+      throw new BadRequestException('El archivo no puede estar vacío');
+    }
 
-    const document = await this.prisma.document.create({
-      data: {
-        tenantId,
-        fileId: file.id,
-        title: dto.title,
-        category: dto.category,
-        visibility: dto.visibility ?? 'TENANT_ADMINS',
-        buildingId: dto.buildingId,
-        unitId: dto.unitId,
-        createdByMembershipId: userMembershipId,
-      },
-      include: {
-        file: true,
-        createdByMembership: {
-          include: { user: true },
-        },
-      },
-    });
+    if (uploadedObject.size > this.maxUploadBytes) {
+      await this.deleteUploadedObject(uploadFile.objectKey);
+      throw new PayloadTooLargeException(
+        `El archivo supera el máximo de ${this.maxUploadBytes} bytes`,
+      );
+    }
+
+    let document: DocumentNotificationTarget | null = null;
+
+    try {
+      document = await this.prisma.$transaction(async (tx) => {
+        const file = await tx.file.create({
+          data: {
+            tenantId,
+            bucket,
+            objectKey: uploadFile.objectKey,
+            originalName: this.sanitizeFileName(uploadFile.originalName),
+            mimeType: uploadFile.mimeType,
+            size: uploadedObject.size,
+            checksum: uploadFile.checksum,
+            createdByMembershipId: userMembershipId,
+          },
+        });
+
+        return await tx.document.create({
+          data: {
+            tenantId,
+            fileId: file.id,
+            title: dto.title,
+            category: dto.category,
+            visibility: dto.visibility ?? 'TENANT_ADMINS',
+            buildingId: dto.buildingId,
+            unitId: dto.unitId,
+            createdByMembershipId: userMembershipId,
+          },
+          include: {
+            file: true,
+            createdByMembership: {
+              include: { user: true },
+            },
+          },
+        });
+      });
+    } catch (error) {
+      await this.deleteUploadedObject(uploadFile.objectKey);
+      throw error;
+    }
+
+    if (!document) {
+      await this.deleteUploadedObject(uploadFile.objectKey);
+      throw new BadRequestException('Failed to persist document metadata');
+    }
 
     // [PHASE 2 QUICK #6] Send DOCUMENT_SHARED notification if visibility=RESIDENTS
     void this.sendDocumentSharedNotification(tenantId, document, dto);
@@ -576,30 +649,83 @@ export class DocumentsService {
   }
 
   /**
+   * Get a protected document stream for authenticated downloads.
+   *
+   * Keeps the browser inside BuildingOS and never exposes MinIO URLs.
+   */
+  async getDocumentContent(
+    tenantId: string,
+    documentId: string,
+    userId: string,
+    userRoles: string[],
+    isSuperAdmin: boolean,
+  ): Promise<DocumentContentResponse> {
+    const document = await this.getDocument(
+      tenantId,
+      documentId,
+      userId,
+      userRoles,
+      isSuperAdmin,
+    );
+
+    if (!document.file) {
+      throw new NotFoundException('Document file not found');
+    }
+
+    const bucket = document.file.bucket;
+    const objectKey = document.file.objectKey;
+    const exists = await this.minio.objectExists(bucket, objectKey);
+    if (!exists) {
+      throw new NotFoundException('Document file not found');
+    }
+
+    const uploadedObject = await this.minio.statObject(bucket, objectKey);
+    if (uploadedObject.size <= 0) {
+      throw new NotFoundException('Document file not found');
+    }
+
+    const stream = await this.minio.getObjectStream(bucket, objectKey);
+    const contentType = document.file.mimeType || 'application/octet-stream';
+
+    return {
+      stream,
+      contentType,
+      contentLength: uploadedObject.size,
+      fileName: this.sanitizeDownloadFileName(document.file.originalName),
+      disposition: this.shouldRenderInline(contentType) ? 'inline' : 'attachment',
+    };
+  }
+
+  /**
    * Validate MIME type (prevent unsafe uploads)
    * Allowed: PDF, images, Office docs, spreadsheets, etc.
    * Blocked: executables, scripts, etc.
    */
   private validateMimeType(mimeType: string): void {
-    const allowedTypes = [
-      'application/pdf',
-      'image/jpeg',
-      'image/png',
-      'image/gif',
-      'application/msword',
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      'application/vnd.ms-excel',
-      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-      'application/vnd.ms-powerpoint',
-      'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-      'text/plain',
-      'text/csv',
-    ];
-
-    if (!allowedTypes.includes(mimeType)) {
+    if (!ALLOWED_UPLOAD_MIME_TYPES.includes(mimeType)) {
       throw new BadRequestException(
         `File type not allowed: ${mimeType}`,
       );
+    }
+  }
+
+  private validateUploadSize(size: number): void {
+    if (size <= 0) {
+      throw new BadRequestException('El archivo no puede estar vacío');
+    }
+
+    if (size > this.maxUploadBytes) {
+      throw new PayloadTooLargeException(
+        `El archivo supera el máximo de ${this.maxUploadBytes} bytes`,
+      );
+    }
+  }
+
+  private async deleteUploadedObject(objectKey: string): Promise<void> {
+    try {
+      await this.minio.deleteObject(this.minio.getDefaultBucket(), objectKey);
+    } catch (error) {
+      this.logger.warn(`Unable to clean up rejected upload ${objectKey}: ${error instanceof Error ? error.message : String(error)}`);
     }
   }
 
@@ -609,8 +735,22 @@ export class DocumentsService {
    */
   private generateObjectKey(tenantId: string, originalName: string): string {
     const uuid = this.generateUuid();
-    const sanitized = originalName.replace(/[^a-z0-9._-]/gi, '_');
+    const sanitized = this.sanitizeFileName(originalName);
     return `tenant-${tenantId}/documents/${uuid}-${sanitized}`;
+  }
+
+  private sanitizeFileName(originalName: string): string {
+    return originalName.replace(/[^a-z0-9._-]/gi, '_');
+  }
+
+  private sanitizeDownloadFileName(originalName: string): string {
+    return this.sanitizeFileName(originalName)
+      .replace(/_+/g, '_')
+      .replace(/^_+|_+$/g, '') || 'document';
+  }
+
+  private shouldRenderInline(mimeType: string): boolean {
+    return mimeType.startsWith('application/pdf') || mimeType.startsWith('image/');
   }
 
   /**

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -745,7 +745,7 @@ export class DocumentsService {
       throw new BadRequestException('The uploaded file key is invalid');
     }
 
-    if (objectKey.includes('\\')) {
+    if (objectKey.includes('\\') || objectKey.includes('\0')) {
       throw new BadRequestException('The uploaded file key is invalid');
     }
 
@@ -764,7 +764,14 @@ export class DocumentsService {
     }
 
     const relativePath = objectKey.slice(allowedPrefix.length);
-    if (!relativePath || relativePath.includes('..') || relativePath.includes('//')) {
+    if (!relativePath) {
+      throw new BadRequestException('The uploaded file key is invalid');
+    }
+
+    const segments = objectKey.split('/');
+    if (
+      segments.some((segment) => segment.length === 0 || segment === '.' || segment === '..')
+    ) {
       throw new BadRequestException('The uploaded file key is invalid');
     }
   }

--- a/apps/api/src/documents/dto/create-document.dto.ts
+++ b/apps/api/src/documents/dto/create-document.dto.ts
@@ -3,10 +3,32 @@ import {
   IsEnum,
   IsOptional,
   Length,
-  IsInt,
-  Min,
+  ValidateNested,
+  IsDefined,
 } from 'class-validator';
+import { Type } from 'class-transformer';
 import { DocumentCategory, DocumentVisibility } from '@prisma/client';
+
+export class DocumentUploadFileDto {
+  @IsString()
+  @Length(1, 512)
+  objectKey!: string;
+
+  @IsString()
+  @Length(1, 255)
+  originalName!: string;
+
+  @IsString()
+  @Length(1, 100)
+  mimeType!: string;
+
+  @IsOptional()
+  size?: number;
+
+  @IsOptional()
+  @IsString()
+  checksum?: string;
+}
 
 /**
  * Create a Document after file upload
@@ -30,16 +52,10 @@ export class CreateDocumentDto {
   @IsOptional()
   visibility?: DocumentVisibility; // Default: TENANT_ADMINS
 
-  @IsString()
-  objectKey!: string; // MinIO objectKey from presign response (validates file was uploaded)
-
-  @IsInt()
-  @Min(0)
-  size!: number; // File size in bytes (from upload response)
-
-  @IsOptional()
-  @IsString()
-  checksum?: string; // SHA-256 hash from MinIO (for integrity check)
+  @IsDefined()
+  @ValidateNested()
+  @Type(() => DocumentUploadFileDto)
+  file!: DocumentUploadFileDto; // Uploaded file metadata from presign/upload flow
 
   // Scope fields
   @IsOptional()

--- a/apps/api/src/documents/dto/presign-upload.dto.ts
+++ b/apps/api/src/documents/dto/presign-upload.dto.ts
@@ -1,4 +1,9 @@
-import { IsString, Length, IsOptional, IsInt, Min } from 'class-validator';
+import { IsString, Length, IsOptional, IsInt, Min, IsEnum } from 'class-validator';
+
+export enum DocumentUploadPurpose {
+  GENERAL_DOCUMENT = 'GENERAL_DOCUMENT',
+  PAYMENT_PROOF = 'PAYMENT_PROOF',
+}
 
 /**
  * Request to generate a presigned upload URL
@@ -17,6 +22,10 @@ export class PresignUploadDto {
   @IsInt()
   @Min(1)
   size?: number; // Client-provided hint for early rejection
+
+  @IsOptional()
+  @IsEnum(DocumentUploadPurpose)
+  purpose?: DocumentUploadPurpose;
 }
 
 /**

--- a/apps/api/src/documents/dto/presign-upload.dto.ts
+++ b/apps/api/src/documents/dto/presign-upload.dto.ts
@@ -1,4 +1,4 @@
-import { IsString, IsEnum, Length } from 'class-validator';
+import { IsString, Length, IsOptional, IsInt, Min } from 'class-validator';
 
 /**
  * Request to generate a presigned upload URL
@@ -12,6 +12,11 @@ export class PresignUploadDto {
   @IsString()
   @Length(1, 100)
   mimeType!: string; // MIME type (e.g., "application/pdf")
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  size?: number; // Client-provided hint for early rejection
 }
 
 /**

--- a/apps/api/src/finanzas/finanzas.dto.ts
+++ b/apps/api/src/finanzas/finanzas.dto.ts
@@ -80,6 +80,10 @@ export class SubmitPaymentDto {
   @IsString()
   unitId?: string;
 
+  @IsOptional()
+  @IsString()
+  chargeId?: string;
+
   @IsInt()
   @IsPositive()
   amount!: number; // In cents
@@ -347,6 +351,9 @@ export interface PaymentDetailDto {
   proofFileId: string | null;
   createdByUserId: string;
   reviewedByMembershipId: string | null;
+  rejectionReason?: string | null;
+  rejectionComment?: string | null;
+  reviewedAt?: Date | null;
   // Receipt fields
   receiptDocumentId?: string | null;
   receiptNumber?: string | null;

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -63,6 +63,9 @@ describe('FinanzasService', () => {
             paymentAuditLog: {
               create: jest.fn(),
             },
+            file: {
+              findFirst: jest.fn(),
+            },
             expense: {
               findMany: jest.fn(),
             },
@@ -126,6 +129,10 @@ describe('FinanzasService', () => {
     jest.spyOn(prismaService, '$transaction').mockImplementation(async (callback: (tx: never) => Promise<unknown>) => {
       return callback(prismaService as never);
     });
+    jest.spyOn(prismaService.file, 'findFirst').mockResolvedValue({
+      id: 'file-123',
+      size: 1024,
+    } as never);
   });
 
   // ========== CLEANUP ==========
@@ -525,6 +532,7 @@ describe('FinanzasService', () => {
         status: PaymentStatus.SUBMITTED,
         proofFileId: 'file-123',
         createdByUserId: userId,
+        notes: 'resident-charge-selection-requires-resubmission',
       } as any);
       jest.spyOn(prismaService.paymentAllocation, 'create').mockResolvedValue({
         id: 'allocation-123',
@@ -549,6 +557,7 @@ describe('FinanzasService', () => {
       );
 
       expect(result.status).toBe(PaymentStatus.SUBMITTED);
+      expect(result).not.toHaveProperty('notes');
       expect(prismaService.payment.create).toHaveBeenCalledWith({
         data: expect.objectContaining({
           tenantId,
@@ -558,6 +567,7 @@ describe('FinanzasService', () => {
           currency: 'ARS',
           method: PaymentMethod.TRANSFER,
           proofFileId: 'file-123',
+          notes: 'resident-charge-selection-requires-resubmission',
         }),
       });
       expect(prismaService.paymentAllocation.create).toHaveBeenCalledWith({
@@ -623,6 +633,41 @@ describe('FinanzasService', () => {
       ).rejects.toThrow(BadRequestException);
 
       expect(prismaService.payment.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects payment proofs larger than 10 MiB even when a client bypasses presign purpose', async () => {
+      jest.spyOn(prismaService.file, 'findFirst').mockResolvedValueOnce({
+        id: 'file-oversized',
+        size: 10 * 1024 * 1024 + 1,
+      } as never);
+
+      await expect(
+        service.submitPayment(tenantId, buildingId, userId, userRoles, {
+          unitId,
+          chargeId: 'charge-123',
+          amount: 10000,
+          method: PaymentMethod.TRANSFER,
+          reference: 'TRX-OVERSIZED-PROOF',
+          proofFileId: 'file-oversized',
+        }),
+      ).rejects.toThrow('El comprobante de pago supera el máximo de 10 MB');
+
+      expect(prismaService.payment.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects proof files outside the payment tenant', async () => {
+      jest.spyOn(prismaService.file, 'findFirst').mockResolvedValueOnce(null as never);
+
+      await expect(
+        service.submitPayment(tenantId, buildingId, userId, userRoles, {
+          unitId,
+          chargeId: 'charge-123',
+          amount: 10000,
+          method: PaymentMethod.TRANSFER,
+          reference: 'TRX-FOREIGN-PROOF',
+          proofFileId: 'file-other-tenant',
+        }),
+      ).rejects.toThrow('El comprobante de pago no existe en este tenant');
     });
 
     it('should reject unsupported payment methods while provider is transfer-only', async () => {
@@ -1635,6 +1680,7 @@ describe('FinanzasService', () => {
     const mockSubmittedPaymentState = (
       status: PaymentStatus = PaymentStatus.SUBMITTED,
       updateStatus: PaymentStatus = status,
+      notes: string | null = null,
     ) => {
       allocationStore = [{ tenantId, paymentId, chargeId }];
 
@@ -1649,6 +1695,7 @@ describe('FinanzasService', () => {
         reference: 'TRX-123',
         status,
         canceledAt: null,
+        notes,
         paymentAllocations: makeAllocation().map((allocation) => ({
           tenantId: allocation.tenantId,
           paymentId: allocation.paymentId,
@@ -1661,7 +1708,7 @@ describe('FinanzasService', () => {
       jest.spyOn(prismaService.paymentAllocation, 'findMany').mockImplementation(async ({ where }) =>
         makeAllocation()
           .filter((allocation) => allocation.tenantId === where.tenantId && allocation.paymentId === where.paymentId)
-          .map((allocation) => ({ chargeId: allocation.chargeId })) as any,
+          .map((allocation) => ({ chargeId: allocation.chargeId, amount: 10000 })) as any,
       );
 
       jest.spyOn(prismaService.paymentAllocation, 'count').mockImplementation(async ({ where }) =>
@@ -1761,7 +1808,11 @@ describe('FinanzasService', () => {
     });
 
     it('rejectPayment removes provisional allocations and unblocks the charge', async () => {
-      mockSubmittedPaymentState(PaymentStatus.SUBMITTED, PaymentStatus.REJECTED);
+      mockSubmittedPaymentState(
+        PaymentStatus.SUBMITTED,
+        PaymentStatus.REJECTED,
+        'resident-charge-selection-requires-resubmission',
+      );
       const notificationSpy = jest
         .spyOn(service as any, 'sendPaymentRejectedNotification')
         .mockResolvedValue(undefined);
@@ -1791,13 +1842,14 @@ describe('FinanzasService', () => {
       expect(result.reviewedByMembershipId).toBe(membershipId);
       expect(result.reviewedAt).toEqual(expect.any(Date));
       expect(result.notes).toBe('Reviewed against bank statement');
+      expect(result.notes).not.toContain('resident-charge-selection-requires-resubmission');
       expect(prismaService.payment.update).toHaveBeenCalledWith(expect.objectContaining({
         data: expect.objectContaining({
           status: PaymentStatus.REJECTED,
           reviewedByMembershipId: membershipId,
           rejectionReason: 'OTHER',
           rejectionComment: 'Rejected by admin',
-          notes: 'Reviewed against bank statement',
+          notes: 'resident-charge-selection-requires-resubmission\nReviewed against bank statement',
         }),
       }));
       expect(prismaService.paymentAllocation.deleteMany).toHaveBeenCalledWith({
@@ -1818,7 +1870,11 @@ describe('FinanzasService', () => {
     });
 
     it('rejectPaymentTenant removes provisional allocations for the tenant payment', async () => {
-      mockSubmittedPaymentState(PaymentStatus.SUBMITTED, PaymentStatus.REJECTED);
+      mockSubmittedPaymentState(
+        PaymentStatus.SUBMITTED,
+        PaymentStatus.REJECTED,
+        'resident-charge-selection-requires-resubmission',
+      );
       const notificationSpy = jest
         .spyOn(service as any, 'sendPaymentRejectedNotification')
         .mockResolvedValue(undefined);
@@ -1841,13 +1897,14 @@ describe('FinanzasService', () => {
       expect(result.reviewedByMembershipId).toBe(membershipId);
       expect(result.reviewedAt).toEqual(expect.any(Date));
       expect(result.notes).toBe('Tenant review notes');
+      expect(result.notes).not.toContain('resident-charge-selection-requires-resubmission');
       expect(prismaService.payment.update).toHaveBeenCalledWith(expect.objectContaining({
         data: expect.objectContaining({
           status: PaymentStatus.REJECTED,
           reviewedByMembershipId: membershipId,
           rejectionReason: 'OTHER',
           rejectionComment: 'Rejected at tenant level',
-          notes: 'Tenant review notes',
+          notes: 'resident-charge-selection-requires-resubmission\nTenant review notes',
         }),
       }));
       expect(prismaService.paymentAllocation.deleteMany).toHaveBeenCalledWith({
@@ -1875,6 +1932,239 @@ describe('FinanzasService', () => {
       });
       expect(makeAllocation()).toHaveLength(0);
     });
+
+    it('blocks revival of a rejected resident-directed payment instead of falling back to FIFO', async () => {
+      allocationStore = [];
+      mockSubmittedPaymentState(
+        PaymentStatus.REJECTED,
+        PaymentStatus.SUBMITTED,
+        'resident-charge-selection-requires-resubmission',
+      );
+      allocationStore = [];
+      jest.spyOn(prismaService, '$queryRaw').mockResolvedValue([] as never);
+
+      await expect(
+        service.revivePayment(
+          tenantId,
+          buildingId,
+          paymentId,
+          ['TENANT_ADMIN'],
+          membershipId,
+        ),
+      ).rejects.toThrow(
+        'No se puede reactivar este pago porque perdió la asociación con el cargo seleccionado.',
+      );
+
+      expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(prismaService.payment.update).not.toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({ status: PaymentStatus.SUBMITTED }),
+      }));
+    });
+
+    it('serializes overlapping rejection requests so the second request rereads REJECTED without overwriting the marker', async () => {
+      const marker = 'resident-charge-selection-requires-resubmission';
+      let paymentState = {
+        id: paymentId,
+        tenantId,
+        buildingId,
+        unitId: 'unit-123',
+        amount: 10000,
+        currency: 'ARS',
+        method: PaymentMethod.TRANSFER,
+        reference: 'TRX-123',
+        status: PaymentStatus.SUBMITTED,
+        canceledAt: null,
+        notes: marker,
+        paymentAllocations: [],
+      };
+      allocationStore = [{ tenantId, paymentId, chargeId }];
+
+      let resolveFirstRead!: () => void;
+      const firstReadEntered = new Promise<void>((resolve) => {
+        resolveFirstRead = resolve;
+      });
+      let releaseFirstRequest!: () => void;
+      const firstRequestReleased = new Promise<void>((resolve) => {
+        releaseFirstRequest = resolve;
+      });
+      let releasePaymentLock!: () => void;
+      const paymentLockReleased = new Promise<void>((resolve) => {
+        releasePaymentLock = resolve;
+      });
+      let lockAttempts = 0;
+      let firstRead = true;
+
+      jest.spyOn(prismaService, '$queryRaw').mockImplementation(async () => {
+        lockAttempts += 1;
+        if (lockAttempts === 2) {
+          await paymentLockReleased;
+        }
+
+        return [] as never;
+      });
+      jest.spyOn(prismaService.payment, 'findFirst').mockImplementation(async () => {
+        if (firstRead) {
+          firstRead = false;
+          resolveFirstRead();
+          await firstRequestReleased;
+        }
+
+        return paymentState as never;
+      });
+      jest.spyOn(prismaService.payment, 'update').mockImplementation(async ({ data }) => {
+        paymentState = { ...paymentState, ...data } as typeof paymentState;
+        releasePaymentLock();
+        return paymentState as never;
+      });
+      jest.spyOn(prismaService.paymentAllocation, 'findMany').mockImplementation(async () =>
+        allocationStore.map((allocation) => ({ chargeId: allocation.chargeId, amount: 10000 })) as never,
+      );
+      jest.spyOn(prismaService.paymentAllocation, 'deleteMany').mockImplementation(async () => {
+        allocationStore = [];
+        return { count: 1 } as never;
+      });
+      jest.spyOn(service as never, 'recalculateChargeStatus').mockResolvedValue(undefined);
+      jest.spyOn(service as never, 'sendPaymentRejectedNotification').mockResolvedValue(undefined);
+
+      const firstRequest = service.rejectPayment(
+        tenantId,
+        buildingId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        { reason: 'OTHER', notes: 'First reviewer note' },
+      );
+
+      await firstReadEntered;
+      const secondRequest = service.rejectPaymentTenant(
+        tenantId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        { reason: 'OTHER', notes: 'Stale second reviewer note' },
+      );
+      await Promise.resolve();
+
+      expect(lockAttempts).toBe(2);
+      expect(paymentState.status).toBe(PaymentStatus.SUBMITTED);
+
+      releaseFirstRequest();
+
+      await expect(firstRequest).resolves.toEqual(expect.objectContaining({
+        status: PaymentStatus.REJECTED,
+        notes: 'First reviewer note',
+      }));
+      await expect(secondRequest).rejects.toThrow('Cannot reject payment in status REJECTED');
+
+      expect(paymentState.notes).toBe(`${marker}\nFirst reviewer note`);
+      expect(prismaService.payment.update).toHaveBeenCalledTimes(1);
+      expect(prismaService.payment.update).not.toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({ notes: expect.stringContaining('Stale second reviewer note') }),
+      }));
+    });
+
+    it('removes only exact internal marker lines from public payment notes', () => {
+      const marker = 'resident-charge-selection-requires-resubmission';
+      const sanitizer = service as unknown as {
+        sanitizePaymentForResponse<T extends { notes?: string | null }>(payment: T): T;
+      };
+
+      const markerOnly = sanitizer.sanitizePaymentForResponse({
+        id: paymentId,
+        notes: marker,
+      });
+      const publicPayment = sanitizer.sanitizePaymentForResponse({
+        id: paymentId,
+        notes: `${marker}\nVisible reviewer note\n${marker}-similar-visible-note`,
+      });
+
+      expect(markerOnly).not.toHaveProperty('notes');
+      expect(publicPayment.notes).toBe(`Visible reviewer note\n${marker}-similar-visible-note`);
+    });
+
+    it('keeps an unmarked legacy payment with a full allocation on the existing revive path', async () => {
+      mockSubmittedPaymentState(PaymentStatus.REJECTED, PaymentStatus.SUBMITTED, null);
+      jest.spyOn(prismaService, '$queryRaw').mockResolvedValue([] as never);
+
+      await expect(
+        service.revivePayment(
+          tenantId,
+          buildingId,
+          paymentId,
+          ['TENANT_ADMIN'],
+          membershipId,
+        ),
+      ).resolves.toEqual(expect.objectContaining({ status: PaymentStatus.SUBMITTED }));
+
+      expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
+    });
+
+    it('does not revive a payment from another tenant', async () => {
+      mockSubmittedPaymentState(PaymentStatus.REJECTED, PaymentStatus.SUBMITTED);
+      jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValueOnce(null as never);
+      jest.spyOn(prismaService, '$queryRaw').mockResolvedValue([] as never);
+
+      await expect(
+        service.revivePayment(
+          tenantId,
+          buildingId,
+          paymentId,
+          ['TENANT_ADMIN'],
+          membershipId,
+        ),
+      ).rejects.toThrow('Payment not found or does not belong to this building/tenant');
+
+      expect(prismaService.payment.update).not.toHaveBeenCalled();
+    });
+
+    it('does not revive canceled rejected payments', async () => {
+      mockSubmittedPaymentState(PaymentStatus.REJECTED, PaymentStatus.SUBMITTED);
+      jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValueOnce({
+        id: paymentId,
+        tenantId,
+        buildingId,
+        unitId: 'unit-123',
+        amount: 10000,
+        status: PaymentStatus.REJECTED,
+        canceledAt: new Date('2026-07-24T12:00:00.000Z'),
+        notes: null,
+        paymentAllocations: [],
+      } as never);
+      jest.spyOn(prismaService, '$queryRaw').mockResolvedValue([] as never);
+
+      await expect(
+        service.revivePayment(
+          tenantId,
+          buildingId,
+          paymentId,
+          ['TENANT_ADMIN'],
+          membershipId,
+        ),
+      ).rejects.toThrow('No se puede reactivar un pago cancelado');
+
+      expect(prismaService.payment.update).not.toHaveBeenCalled();
+    });
+
+    it.each([PaymentStatus.APPROVED, PaymentStatus.RECONCILED])(
+      'does not revive %s payments',
+      async (status) => {
+        allocationStore = [];
+        mockSubmittedPaymentState(status, PaymentStatus.SUBMITTED);
+        jest.spyOn(prismaService, '$queryRaw').mockResolvedValue([] as never);
+
+        await expect(
+          service.revivePayment(
+            tenantId,
+            buildingId,
+            paymentId,
+            ['TENANT_ADMIN'],
+            membershipId,
+          ),
+        ).rejects.toThrow('Only REJECTED payments can be revived');
+
+        expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
+      },
+    );
 
     it.each([PaymentStatus.APPROVED, PaymentStatus.RECONCILED])(
       'does not remove allocations for %s payments',

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -20,6 +20,7 @@ describe('FinanzasService', () => {
   let auditService: AuditService;
   let validators: FinanzasValidators;
   let expensesService: ExpensesService;
+  let receiptService: PaymentReceiptService;
 
   // ========== SETUP ==========
   beforeEach(async () => {
@@ -120,6 +121,7 @@ describe('FinanzasService', () => {
     auditService = module.get<AuditService>(AuditService);
     validators = module.get<FinanzasValidators>(FinanzasValidators);
     expensesService = module.get<ExpensesService>(ExpensesService);
+    receiptService = module.get<PaymentReceiptService>(PaymentReceiptService);
 
     jest.spyOn(prismaService, '$transaction').mockImplementation(async (callback: (tx: never) => Promise<unknown>) => {
       return callback(prismaService as never);
@@ -889,9 +891,12 @@ describe('FinanzasService', () => {
         { paidAt: '2026-07-24T12:00:00.000Z' },
       );
 
-      expect(prismaService.$queryRaw).toHaveBeenCalledTimes(1);
-      const rawQuery = (prismaService.$queryRaw as jest.Mock).mock.calls[0][0] as { strings?: string[] };
-      expect(rawQuery.strings?.join(' ')).toContain('FOR UPDATE');
+      expect(prismaService.$queryRaw).toHaveBeenCalledTimes(2);
+      const rawQueries = (prismaService.$queryRaw as jest.Mock).mock.calls.map(
+        ([query]) => (query as { strings?: string[] }).strings?.join(' '),
+      );
+      expect(rawQueries.some((query) => query?.includes('FROM "Payment"'))).toBe(true);
+      expect(rawQueries.some((query) => query?.includes('FROM "Charge"'))).toBe(true);
     });
   });
 
@@ -1106,6 +1111,512 @@ describe('FinanzasService', () => {
           }),
         }),
       );
+    });
+  });
+
+  // ========== TESTS: APPROVAL LOCKING ==========
+  describe('payment approval locking', () => {
+    const tenantId = 'tenant-lock-123';
+    const buildingId = 'building-lock-123';
+    const paymentId = 'payment-lock-123';
+    const secondPaymentId = 'payment-lock-456';
+    const membershipId = 'membership-lock-123';
+    const chargeId = 'charge-lock-123';
+
+    type PaymentState = {
+      id: string;
+      tenantId: string;
+      buildingId: string;
+      unitId: string;
+      amount: number;
+      currency: string;
+      status: PaymentStatus;
+      canceledAt: Date | null;
+      reviewedByMembershipId?: string | null;
+      reviewedAt?: Date | null;
+      paidAt?: Date | null;
+      updatedAt?: Date | null;
+      rejectionReason?: string | null;
+      rejectionComment?: string | null;
+      notes?: string | null;
+      paymentAllocations: Array<{
+        chargeId: string;
+        amount: number;
+      }>;
+    };
+
+    type ChargeState = {
+      id: string;
+      tenantId: string;
+      buildingId: string;
+      unitId: string;
+      amount: number;
+      currency: string;
+      status: ChargeStatus;
+      paymentAllocations: Array<{
+        amount: number;
+        paymentStatus: PaymentStatus;
+      }>;
+    };
+
+    let paymentStates: Record<string, PaymentState>;
+    let chargeStates: Record<string, ChargeState>;
+
+    const toPaymentRecord = (paymentIdToRead: string): any => {
+      const paymentState = paymentStates[paymentIdToRead]!;
+
+      return {
+        id: paymentState.id,
+        tenantId: paymentState.tenantId,
+        buildingId: paymentState.buildingId,
+        unitId: paymentState.unitId,
+        amount: paymentState.amount,
+        currency: paymentState.currency,
+        status: paymentState.status,
+        canceledAt: paymentState.canceledAt,
+        paymentAllocations: paymentState.paymentAllocations.map((allocation) => ({
+          chargeId: allocation.chargeId,
+          amount: allocation.amount,
+          payment: { status: paymentState.status },
+        })),
+      };
+    };
+
+    const toChargeRecord = (chargeIdToRead: string): any => {
+      const chargeState = chargeStates[chargeIdToRead]!;
+
+      return {
+        id: chargeState.id,
+        tenantId: chargeState.tenantId,
+        buildingId: chargeState.buildingId,
+        unitId: chargeState.unitId,
+        amount: chargeState.amount,
+        currency: chargeState.currency,
+        status: chargeState.status,
+        paymentAllocations: chargeState.paymentAllocations.map((allocation) => ({
+          amount: allocation.amount,
+          payment: { status: allocation.paymentStatus },
+        })),
+      };
+    };
+
+    const installSerializedPaymentLock = () => {
+      const locks = new Map<string, { held: boolean; waiters: Array<() => void> }>();
+
+      jest.spyOn(prismaService, '$transaction').mockImplementation(
+        async (callback: (tx: never) => Promise<unknown>) => {
+          const tx = {
+            ...prismaService,
+            $queryRaw: jest.fn(async (query: { values?: readonly unknown[] }) => {
+              const paymentLockId = String(query.values?.[0] ?? '');
+              const lock = locks.get(paymentLockId) ?? { held: false, waiters: [] as Array<() => void> };
+
+              if (lock.held) {
+                await new Promise<void>((resolve) => {
+                  lock.waiters.push(resolve);
+                });
+              }
+
+              lock.held = true;
+              locks.set(paymentLockId, lock);
+              return [];
+            }),
+          } as never;
+
+          try {
+            return await callback(tx);
+          } finally {
+            for (const lock of locks.values()) {
+              lock.held = false;
+              const next = lock.waiters.shift();
+              if (next) {
+                next();
+              }
+            }
+          }
+        },
+      );
+    };
+
+    const installSharedApprovalState = () => {
+      paymentStates = {
+        [paymentId]: {
+          id: paymentId,
+          tenantId,
+          buildingId,
+          unitId: 'unit-123',
+          amount: 10000,
+          currency: 'ARS',
+          status: PaymentStatus.SUBMITTED,
+          canceledAt: null,
+          paymentAllocations: [],
+        },
+        [secondPaymentId]: {
+          id: secondPaymentId,
+          tenantId,
+          buildingId,
+          unitId: 'unit-456',
+          amount: 5000,
+          currency: 'ARS',
+          status: PaymentStatus.SUBMITTED,
+          canceledAt: null,
+          paymentAllocations: [],
+        },
+      };
+
+      chargeStates = {
+        [chargeId]: {
+          id: chargeId,
+          tenantId,
+          buildingId,
+          unitId: 'unit-123',
+          amount: 10000,
+          currency: 'ARS',
+          status: ChargeStatus.PENDING,
+          paymentAllocations: [],
+        },
+        'charge-lock-456': {
+          id: 'charge-lock-456',
+          tenantId,
+          buildingId,
+          unitId: 'unit-456',
+          amount: 5000,
+          currency: 'ARS',
+          status: ChargeStatus.PENDING,
+          paymentAllocations: [],
+        },
+      };
+
+      jest.spyOn(prismaService.payment, 'findFirst').mockImplementation(async ({ where }) => {
+        const paymentState = paymentStates[where.id];
+        if (
+          !paymentState ||
+          paymentState.tenantId !== where.tenantId ||
+          (where.buildingId && where.buildingId !== paymentState.buildingId)
+        ) {
+          return null as never;
+        }
+
+        return toPaymentRecord(where.id);
+      });
+
+      jest.spyOn(prismaService.payment, 'findUnique').mockImplementation(async ({ where }) => {
+        const paymentState = paymentStates[where.id];
+        if (!paymentState) {
+          return null as never;
+        }
+
+        return {
+          ...toPaymentRecord(where.id),
+          paymentAllocations: paymentState.paymentAllocations.map((allocation) => ({
+            amount: allocation.amount,
+            charge: { status: chargeStates[allocation.chargeId]?.status ?? ChargeStatus.PENDING },
+          })),
+        } as never;
+      });
+
+      jest.spyOn(prismaService.payment, 'update').mockImplementation(async ({ where, data }) => {
+        const paymentState = paymentStates[where.id];
+        if (!paymentState) {
+          throw new Error(`Missing payment state for ${where.id}`);
+        }
+
+        paymentStates[where.id] = {
+          ...paymentState,
+          status: data.status ?? paymentState.status,
+          reviewedByMembershipId: data.reviewedByMembershipId ?? null,
+          reviewedAt: data.reviewedAt ?? null,
+          paidAt: data.paidAt ?? null,
+          updatedAt: data.updatedAt ?? new Date(),
+          canceledAt: data.canceledAt ?? paymentState.canceledAt,
+        } as PaymentState;
+
+        return toPaymentRecord(where.id);
+      });
+
+      jest.spyOn(prismaService.charge, 'findMany').mockImplementation(async ({ where }) => {
+        const charges = Object.values(chargeStates).filter(
+          (chargeState) =>
+            chargeState.tenantId === where.tenantId &&
+            chargeState.buildingId === where.buildingId &&
+            chargeState.unitId === where.unitId &&
+            chargeState.status !== ChargeStatus.PAID &&
+            chargeState.status !== ChargeStatus.CANCELED,
+        );
+
+        return charges.map((chargeState) => toChargeRecord(chargeState.id)) as never;
+      });
+      jest.spyOn(prismaService.charge, 'findFirst').mockImplementation(async ({ where }) => {
+        const chargeState = chargeStates[where.id];
+        if (
+          !chargeState ||
+          chargeState.tenantId !== where.tenantId ||
+          chargeState.buildingId !== where.buildingId ||
+          chargeState.unitId !== where.unitId
+        ) {
+          return null as never;
+        }
+
+        return toChargeRecord(where.id);
+      });
+      jest.spyOn(prismaService.charge, 'findUnique').mockImplementation(async ({ where }) => {
+        const chargeState = chargeStates[where.id];
+        if (!chargeState) {
+          return null as never;
+        }
+
+        return toChargeRecord(where.id);
+      });
+      jest.spyOn(prismaService.charge, 'update').mockImplementation(async ({ where, data }) => {
+        const chargeState = chargeStates[where.id];
+        if (!chargeState) {
+          throw new Error(`Missing charge state for ${where.id}`);
+        }
+
+        chargeStates[where.id] = {
+          ...chargeState,
+          status: data.status ?? chargeState.status,
+        };
+
+        return toChargeRecord(where.id);
+      });
+      jest.spyOn(prismaService.paymentAllocation, 'create').mockImplementation(async ({ data }) => {
+        const paymentState = paymentStates[data.paymentId];
+        const chargeState = chargeStates[data.chargeId];
+
+        if (!paymentState || !chargeState) {
+          throw new Error('Missing payment or charge state for allocation');
+        }
+
+        paymentStates[data.paymentId] = {
+          ...paymentState,
+          paymentAllocations: [
+            ...paymentState.paymentAllocations,
+            {
+              chargeId: data.chargeId,
+              amount: data.amount,
+            },
+          ],
+        };
+        chargeStates[data.chargeId] = {
+          ...chargeState,
+          paymentAllocations: [
+            ...chargeState.paymentAllocations,
+            {
+              amount: data.amount,
+              paymentStatus: paymentStates[data.paymentId].status,
+            },
+          ],
+        };
+
+        return {
+          id: `allocation-${paymentStates[data.paymentId].paymentAllocations.length}`,
+          tenantId: data.tenantId,
+          paymentId: data.paymentId,
+          chargeId: data.chargeId,
+          amount: data.amount,
+        } as never;
+      });
+
+      jest.spyOn(prismaService.paymentAuditLog, 'create').mockResolvedValue({} as never);
+    };
+
+    beforeEach(() => {
+      jest.spyOn(validators, 'canReviewPayments').mockReturnValue(true);
+      jest.spyOn(service as any, 'sendPaymentReceivedNotification').mockResolvedValue(undefined);
+      jest.spyOn(receiptService, 'ensureReceiptForPayment').mockResolvedValue(undefined);
+    });
+
+    it('serializes approvePayment so the same payment cannot be applied twice', async () => {
+      installSerializedPaymentLock();
+      installSharedApprovalState();
+
+      const firstApproval = service.approvePayment(
+        tenantId,
+        buildingId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        {},
+      );
+      const secondApproval = service.approvePayment(
+        tenantId,
+        buildingId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        {},
+      );
+
+      const [firstResult, secondResult] = await Promise.allSettled([
+        firstApproval,
+        secondApproval,
+      ]);
+
+      expect(firstResult).toEqual(
+        expect.objectContaining({
+          status: 'fulfilled',
+          value: expect.objectContaining({
+            status: PaymentStatus.APPROVED,
+          }),
+        }),
+      );
+      expect(secondResult).toEqual(
+        expect.objectContaining({
+          status: 'rejected',
+          reason: expect.objectContaining({
+            message: 'Cannot approve payment in status RECONCILED. Only SUBMITTED payments can be approved.',
+          }),
+        }),
+      );
+
+      expect(prismaService.paymentAllocation.create).toHaveBeenCalledTimes(1);
+      expect(prismaService.charge.update).toHaveBeenCalledTimes(1);
+      expect(auditService.createLog).toHaveBeenCalledTimes(1);
+      expect(receiptService.ensureReceiptForPayment).toHaveBeenCalledTimes(1);
+      expect(prismaService.payment.update).toHaveBeenCalledTimes(2);
+    });
+
+    it('serializes approvePaymentTenant so the same payment cannot be applied twice', async () => {
+      installSerializedPaymentLock();
+      installSharedApprovalState();
+
+      const firstApproval = service.approvePaymentTenant(
+        tenantId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        {},
+      );
+      const secondApproval = service.approvePaymentTenant(
+        tenantId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        {},
+      );
+
+      const [firstResult, secondResult] = await Promise.allSettled([
+        firstApproval,
+        secondApproval,
+      ]);
+
+      expect(firstResult).toEqual(
+        expect.objectContaining({
+          status: 'fulfilled',
+          value: expect.objectContaining({
+            status: PaymentStatus.RECONCILED,
+          }),
+        }),
+      );
+      expect(secondResult).toEqual(
+        expect.objectContaining({
+          status: 'rejected',
+          reason: expect.objectContaining({
+            message: 'Cannot approve payment in status RECONCILED. Only SUBMITTED payments can be approved.',
+          }),
+        }),
+      );
+
+      expect(prismaService.paymentAllocation.create).toHaveBeenCalledTimes(1);
+      expect(prismaService.charge.update).toHaveBeenCalledTimes(1);
+      expect(prismaService.paymentAuditLog.create).toHaveBeenCalledTimes(1);
+      expect(receiptService.ensureReceiptForPayment).toHaveBeenCalledTimes(1);
+      expect(prismaService.payment.update).toHaveBeenCalledTimes(2);
+    });
+
+    it('allows two different payments to approve concurrently', async () => {
+      installSerializedPaymentLock();
+      installSharedApprovalState();
+
+      const firstApproval = service.approvePayment(
+        tenantId,
+        buildingId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        {},
+      );
+      const secondApproval = service.approvePayment(
+        tenantId,
+        buildingId,
+        secondPaymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        {},
+      );
+
+      const [firstResult, secondResult] = await Promise.allSettled([
+        firstApproval,
+        secondApproval,
+      ]);
+
+      expect(firstResult).toEqual(
+        expect.objectContaining({
+          status: 'fulfilled',
+          value: expect.objectContaining({ status: PaymentStatus.APPROVED }),
+        }),
+      );
+      expect(secondResult).toEqual(
+        expect.objectContaining({
+          status: 'fulfilled',
+          value: expect.objectContaining({ status: PaymentStatus.APPROVED }),
+        }),
+      );
+
+      expect(prismaService.paymentAllocation.create).toHaveBeenCalledTimes(2);
+      expect(auditService.createLog).toHaveBeenCalledTimes(2);
+      expect(receiptService.ensureReceiptForPayment).toHaveBeenCalledTimes(2);
+    });
+
+    it.each([PaymentStatus.APPROVED, PaymentStatus.RECONCILED])(
+      'rejects %s payments after the lock is reacquired',
+      async (status) => {
+        installSerializedPaymentLock();
+        installSharedApprovalState();
+        paymentStates[paymentId] = {
+          ...paymentStates[paymentId]!,
+          status,
+        };
+
+        await expect(
+          service.approvePayment(
+            tenantId,
+            buildingId,
+            paymentId,
+            ['TENANT_ADMIN'],
+            membershipId,
+            {},
+          ),
+        ).rejects.toThrow(
+          `Cannot approve payment in status ${status}. Only SUBMITTED payments can be approved.`,
+        );
+
+        expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
+        expect(prismaService.paymentAuditLog.create).not.toHaveBeenCalled();
+      },
+    );
+
+    it('rejects canceled payments after the lock is reacquired', async () => {
+      installSerializedPaymentLock();
+      installSharedApprovalState();
+      paymentStates[paymentId] = {
+        ...paymentStates[paymentId]!,
+        canceledAt: new Date('2026-07-24T12:00:00.000Z'),
+      };
+
+      await expect(
+        service.approvePaymentTenant(
+          tenantId,
+          paymentId,
+          ['TENANT_ADMIN'],
+          membershipId,
+          {},
+        ),
+      ).rejects.toThrow('Cannot approve a canceled payment');
+
+      expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(prismaService.paymentAuditLog.create).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -55,7 +55,9 @@ describe('FinanzasService', () => {
               create: jest.fn(),
               findFirst: jest.fn(),
               findMany: jest.fn(),
+              count: jest.fn(),
               delete: jest.fn(),
+              deleteMany: jest.fn(),
             },
             paymentAuditLog: {
               create: jest.fn(),
@@ -1104,6 +1106,274 @@ describe('FinanzasService', () => {
           }),
         }),
       );
+    });
+  });
+
+  // ========== TESTS: REJECT / CANCEL PAYMENT PROVISIONAL ALLOCATIONS ==========
+  describe('reject and cancel payment allocations', () => {
+    const tenantId = 'tenant-123';
+    const buildingId = 'building-123';
+    const paymentId = 'payment-123';
+    const chargeId = 'charge-123';
+    const membershipId = 'membership-123';
+
+    let allocationStore: Array<{ tenantId: string; paymentId: string; chargeId: string }> = [];
+
+    const makeAllocation = (): { tenantId: string; paymentId: string; chargeId: string }[] => allocationStore.map((allocation) => ({ ...allocation }));
+
+    const mockSubmittedPaymentState = (
+      status: PaymentStatus = PaymentStatus.SUBMITTED,
+      updateStatus: PaymentStatus = status,
+    ) => {
+      allocationStore = [{ tenantId, paymentId, chargeId }];
+
+      jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValue({
+        id: paymentId,
+        tenantId,
+        buildingId,
+        unitId: 'unit-123',
+        amount: 10000,
+        currency: 'ARS',
+        method: PaymentMethod.TRANSFER,
+        reference: 'TRX-123',
+        status,
+        canceledAt: null,
+        paymentAllocations: makeAllocation().map((allocation) => ({
+          tenantId: allocation.tenantId,
+          paymentId: allocation.paymentId,
+          chargeId: allocation.chargeId,
+          amount: 10000,
+          payment: { status },
+        })),
+      } as any);
+
+      jest.spyOn(prismaService.paymentAllocation, 'findMany').mockImplementation(async ({ where }) =>
+        makeAllocation()
+          .filter((allocation) => allocation.tenantId === where.tenantId && allocation.paymentId === where.paymentId)
+          .map((allocation) => ({ chargeId: allocation.chargeId })) as any,
+      );
+
+      jest.spyOn(prismaService.paymentAllocation, 'count').mockImplementation(async ({ where }) =>
+        makeAllocation().filter((allocation) => allocation.tenantId === where.tenantId && allocation.paymentId === where.paymentId).length as any,
+      );
+
+      jest.spyOn(prismaService.paymentAllocation, 'deleteMany').mockImplementation(async ({ where }) => {
+        const before = allocationStore.length;
+        allocationStore = allocationStore.filter(
+          (allocation) => !(allocation.tenantId === where.tenantId && allocation.paymentId === where.paymentId),
+        );
+        return { count: before - allocationStore.length } as any;
+      });
+
+      jest.spyOn(prismaService.charge, 'findFirst').mockImplementation(async ({ where }) => {
+        if (where.id !== chargeId) return null as any;
+
+        const chargeAllocations = makeAllocation().map(() => ({
+          amount: 10000,
+          payment: { status },
+        }));
+
+        return {
+          id: chargeId,
+          tenantId,
+          buildingId,
+          unitId: 'unit-123',
+          amount: 10000,
+          currency: 'ARS',
+          status: chargeAllocations.length > 0 ? ChargeStatus.PARTIAL : ChargeStatus.PENDING,
+          paymentAllocations: chargeAllocations,
+        } as any;
+      });
+
+      jest.spyOn(prismaService.charge, 'findUnique').mockImplementation(async ({ where }) => {
+        if (where.id !== chargeId) return null as any;
+
+        const chargeAllocations = makeAllocation().map(() => ({
+          amount: 10000,
+          payment: { status },
+        }));
+
+        return {
+          id: chargeId,
+          tenantId,
+          buildingId,
+          unitId: 'unit-123',
+          amount: 10000,
+          currency: 'ARS',
+          status: chargeAllocations.length > 0 ? ChargeStatus.PARTIAL : ChargeStatus.PENDING,
+          paymentAllocations: chargeAllocations,
+        } as any;
+      });
+
+      jest.spyOn(prismaService.charge, 'update').mockResolvedValue({
+        id: chargeId,
+        tenantId,
+        buildingId,
+        unitId: 'unit-123',
+        amount: 10000,
+        currency: 'ARS',
+        status: ChargeStatus.PENDING,
+        paymentAllocations: [],
+      } as any);
+
+      jest.spyOn(prismaService.payment, 'update').mockResolvedValue({
+        id: paymentId,
+        tenantId,
+        buildingId,
+        unitId: 'unit-123',
+        amount: 10000,
+        currency: 'ARS',
+        method: PaymentMethod.TRANSFER,
+        status: updateStatus,
+        canceledAt:
+          updateStatus === PaymentStatus.SUBMITTED
+            ? new Date('2026-07-24T12:00:00.000Z')
+            : null,
+      } as any);
+
+      jest.spyOn(prismaService.paymentAuditLog, 'create').mockResolvedValue({} as any);
+    };
+
+    beforeEach(() => {
+      jest.spyOn(validators, 'canReviewPayments').mockReturnValue(true);
+      jest.spyOn(validators, 'canWriteCharges').mockReturnValue(true);
+      jest.spyOn(validators, 'validateBuildingBelongsToTenant').mockResolvedValue(undefined);
+      jest
+        .spyOn(validators, 'validateUnitBelongsToBuildingAndTenant')
+        .mockResolvedValue(undefined);
+    });
+
+    it('rejectPayment removes provisional allocations and unblocks the charge', async () => {
+      mockSubmittedPaymentState(PaymentStatus.SUBMITTED, PaymentStatus.REJECTED);
+
+      await expect(
+        service.updateCharge(tenantId, buildingId, chargeId, ['TENANT_ADMIN'], {
+          concept: 'Updated concept before rejection',
+        }),
+      ).rejects.toThrow('Cannot update charge that has payment allocations');
+
+      const result = await service.rejectPayment(
+        tenantId,
+        buildingId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        {
+          reason: 'OTHER',
+          comment: 'Rejected by admin',
+        },
+      );
+
+      expect(result.status).toBe(PaymentStatus.REJECTED);
+      expect(prismaService.paymentAllocation.deleteMany).toHaveBeenCalledWith({
+        where: { tenantId, paymentId },
+      });
+      expect(makeAllocation()).toHaveLength(0);
+
+      await expect(
+        service.updateCharge(tenantId, buildingId, chargeId, ['TENANT_ADMIN'], {
+          concept: 'Updated concept after rejection',
+        }),
+      ).resolves.toEqual(
+        expect.objectContaining({
+          id: chargeId,
+        }),
+      );
+    });
+
+    it('rejectPaymentTenant removes provisional allocations for the tenant payment', async () => {
+      mockSubmittedPaymentState(PaymentStatus.SUBMITTED, PaymentStatus.REJECTED);
+
+      const result = await service.rejectPaymentTenant(
+        tenantId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        {
+          reason: 'OTHER',
+          comment: 'Rejected at tenant level',
+        },
+      );
+
+      expect(result.status).toBe(PaymentStatus.REJECTED);
+      expect(prismaService.paymentAllocation.deleteMany).toHaveBeenCalledWith({
+        where: { tenantId, paymentId },
+      });
+      expect(makeAllocation()).toHaveLength(0);
+    });
+
+    it('cancelPayment removes provisional allocations for submitted payments', async () => {
+      mockSubmittedPaymentState(PaymentStatus.SUBMITTED);
+
+      const result = await service.cancelPayment(
+        tenantId,
+        buildingId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        'Resident withdrew the report',
+      );
+
+      expect(result.canceledAt).toBeTruthy();
+      expect(prismaService.paymentAllocation.deleteMany).toHaveBeenCalledWith({
+        where: { tenantId, paymentId },
+      });
+      expect(makeAllocation()).toHaveLength(0);
+    });
+
+    it.each([PaymentStatus.APPROVED, PaymentStatus.RECONCILED])(
+      'does not remove allocations for %s payments',
+      async (status) => {
+        mockSubmittedPaymentState(status);
+        jest.spyOn(prismaService.paymentAllocation, 'count').mockResolvedValue(1 as never);
+
+        await expect(
+          service.cancelPayment(
+            tenantId,
+            buildingId,
+            paymentId,
+            ['TENANT_ADMIN'],
+            membershipId,
+            'Manual cancellation',
+          ),
+        ).rejects.toThrow('Cannot cancel payment with existing allocations. Remove allocations first.');
+
+        expect(prismaService.paymentAllocation.deleteMany).not.toHaveBeenCalled();
+        expect(makeAllocation()).toHaveLength(1);
+      },
+    );
+
+    it('rolls back provisional allocation release when rejection fails', async () => {
+      mockSubmittedPaymentState(PaymentStatus.SUBMITTED, PaymentStatus.REJECTED);
+
+      const snapshot = makeAllocation();
+      jest.spyOn(prismaService, '$transaction').mockImplementationOnce(async (callback: (tx: never) => Promise<unknown>) => {
+        try {
+          return await callback(prismaService as never);
+        } catch (error) {
+          allocationStore = snapshot;
+          throw error;
+        }
+      });
+      jest.spyOn(prismaService.payment, 'update').mockRejectedValueOnce(new Error('boom'));
+
+      await expect(
+        service.rejectPaymentTenant(
+          tenantId,
+          paymentId,
+          ['TENANT_ADMIN'],
+          membershipId,
+          {
+            reason: 'OTHER',
+            comment: 'This should rollback',
+          },
+        ),
+      ).rejects.toThrow('boom');
+
+      expect(makeAllocation()).toHaveLength(1);
+      expect(prismaService.paymentAllocation.deleteMany).toHaveBeenCalledWith({
+        where: { tenantId, paymentId },
+      });
     });
   });
 

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -53,6 +53,7 @@ describe('FinanzasService', () => {
             },
             paymentAllocation: {
               create: jest.fn(),
+              findFirst: jest.fn(),
               findMany: jest.fn(),
               delete: jest.fn(),
             },
@@ -776,6 +777,62 @@ describe('FinanzasService', () => {
       );
     });
 
+    it('ignores submitted and rejected allocations when approving a legacy FIFO payment', async () => {
+      jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValueOnce({
+        id: paymentId,
+        tenantId,
+        buildingId,
+        unitId: 'unit-123',
+        amount: 10000,
+        currency: 'ARS',
+        status: PaymentStatus.SUBMITTED,
+        canceledAt: null,
+        paymentAllocations: [],
+      } as any);
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValueOnce([
+        {
+          id: 'charge-123',
+          tenantId,
+          buildingId,
+          unitId: 'unit-123',
+          amount: 10000,
+          currency: 'ARS',
+          status: ChargeStatus.PARTIAL,
+          paymentAllocations: [
+            {
+              amount: 5000,
+              payment: { status: PaymentStatus.SUBMITTED },
+            },
+            {
+              amount: 3000,
+              payment: { status: PaymentStatus.REJECTED },
+            },
+          ],
+        },
+      ] as any);
+
+      const result = await service.approvePayment(
+        tenantId,
+        buildingId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        {},
+      );
+
+      expect(result.status).toBe(PaymentStatus.APPROVED);
+      expect(prismaService.paymentAllocation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            paymentId,
+            chargeId: 'charge-123',
+            amount: 10000,
+          }),
+        }),
+      );
+      expect(prismaService.paymentAllocation.create).toHaveBeenCalledTimes(1);
+    });
+
     it('rejects approval when the charge balance changed after submission', async () => {
       jest.spyOn(prismaService.charge, 'findFirst').mockResolvedValueOnce({
         id: 'charge-123',
@@ -1110,6 +1167,52 @@ describe('FinanzasService', () => {
         ],
         currency: 'ARS',
       });
+    });
+
+    it('ignores submitted and rejected allocations in the tenant summary balance', async () => {
+      jest.spyOn(prismaService.tenant, 'findUniqueOrThrow').mockResolvedValue({ currency: 'ARS' } as never);
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([
+        {
+          id: 'charge-mixed',
+          tenantId: 'tenant-1',
+          buildingId: 'building-1',
+          unitId: 'unit-mixed',
+          amount: 10000,
+          paymentAllocations: [
+            {
+              amount: 3000,
+              payment: { status: PaymentStatus.SUBMITTED },
+            },
+            {
+              amount: 2000,
+              payment: { status: PaymentStatus.REJECTED },
+            },
+            {
+              amount: 4000,
+              payment: { status: PaymentStatus.APPROVED },
+            },
+            {
+              amount: 1000,
+              payment: { status: PaymentStatus.RECONCILED },
+            },
+          ],
+        },
+      ] as never);
+      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue([
+        {
+          id: 'unit-mixed',
+          label: '0303',
+          buildingId: 'building-1',
+          building: { name: 'Edificio A' },
+        },
+      ] as never);
+
+      const result = await service.getTenantFinancialSummary('tenant-1', '2026-07');
+
+      expect(result.totalCharges).toBe(10000);
+      expect(result.totalPaid).toBe(5000);
+      expect(result.totalOutstanding).toBe(5000);
+      expect(result.delinquentUnitsCount).toBe(1);
     });
   });
 

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -42,6 +42,7 @@ describe('FinanzasService', () => {
             unit: {
               findMany: jest.fn(),
               findFirst: jest.fn(),
+              findUnique: jest.fn(),
             },
             payment: {
               create: jest.fn(),
@@ -54,6 +55,9 @@ describe('FinanzasService', () => {
               create: jest.fn(),
               findMany: jest.fn(),
               delete: jest.fn(),
+            },
+            paymentAuditLog: {
+              create: jest.fn(),
             },
             expense: {
               findMany: jest.fn(),
@@ -79,8 +83,8 @@ describe('FinanzasService', () => {
         {
           provide: PaymentReceiptService,
           useValue: {
-            generateForApprovedPayment: jest.fn(),
-            ensureReceiptForPayment: jest.fn(),
+            generateForApprovedPayment: jest.fn().mockResolvedValue(undefined),
+            ensureReceiptForPayment: jest.fn().mockResolvedValue(undefined),
           },
         },
         {
@@ -113,6 +117,10 @@ describe('FinanzasService', () => {
     auditService = module.get<AuditService>(AuditService);
     validators = module.get<FinanzasValidators>(FinanzasValidators);
     expensesService = module.get<ExpensesService>(ExpensesService);
+
+    jest.spyOn(prismaService, '$transaction').mockImplementation(async (callback: (tx: never) => Promise<unknown>) => {
+      return callback(prismaService as never);
+    });
   });
 
   // ========== CLEANUP ==========
@@ -488,6 +496,16 @@ describe('FinanzasService', () => {
         .spyOn(validators, 'validateUnitBelongsToBuildingAndTenant')
         .mockResolvedValue(undefined);
       jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValue(null);
+      jest.spyOn(prismaService.charge, 'findFirst').mockResolvedValue({
+        id: 'charge-123',
+        tenantId,
+        buildingId,
+        unitId,
+        amount: 10000,
+        currency: 'ARS',
+        status: ChargeStatus.PENDING,
+        paymentAllocations: [],
+      } as any);
       jest
         .spyOn(service as any, 'notifyAdminsOfPaymentSubmitted')
         .mockResolvedValue(undefined);
@@ -503,9 +521,12 @@ describe('FinanzasService', () => {
         proofFileId: 'file-123',
         createdByUserId: userId,
       } as any);
+      jest.spyOn(prismaService.paymentAllocation, 'create').mockResolvedValue({
+        id: 'allocation-123',
+      } as any);
     });
 
-    it('should create a submitted transfer payment with proof', async () => {
+    it('should create a submitted transfer payment against a selected charge with proof', async () => {
       const result = await service.submitPayment(
         tenantId,
         buildingId,
@@ -513,6 +534,7 @@ describe('FinanzasService', () => {
         userRoles,
         {
           unitId,
+          chargeId: 'charge-123',
           amount: 10000,
           currency: 'ARS',
           method: PaymentMethod.TRANSFER,
@@ -528,9 +550,59 @@ describe('FinanzasService', () => {
           buildingId,
           unitId,
           amount: 10000,
+          currency: 'ARS',
           method: PaymentMethod.TRANSFER,
           proofFileId: 'file-123',
         }),
+      });
+      expect(prismaService.paymentAllocation.create).toHaveBeenCalledWith({
+        data: {
+          tenantId,
+          paymentId: 'payment-123',
+          chargeId: 'charge-123',
+          amount: 10000,
+        },
+      });
+    });
+
+    it('should accept an overdue resident charge as long as it still has outstanding balance', async () => {
+      jest.spyOn(prismaService.charge, 'findFirst').mockResolvedValueOnce({
+        id: 'charge-123',
+        tenantId,
+        buildingId,
+        unitId,
+        amount: 10000,
+        currency: 'ARS',
+        status: ChargeStatus.PENDING,
+        dueDate: new Date('2026-04-21T00:00:00.000Z'),
+        paymentAllocations: [],
+      } as any);
+
+      const result = await service.submitPayment(
+        tenantId,
+        buildingId,
+        userId,
+        userRoles,
+        {
+          unitId,
+          chargeId: 'charge-123',
+          amount: 10000,
+          currency: 'ARS',
+          method: PaymentMethod.TRANSFER,
+          reference: 'TRX-OVERDUE',
+          proofFileId: 'file-123',
+        },
+      );
+
+      expect(result.status).toBe(PaymentStatus.SUBMITTED);
+      expect(prismaService.payment.create).toHaveBeenCalled();
+      expect(prismaService.paymentAllocation.create).toHaveBeenCalledWith({
+        data: {
+          tenantId,
+          paymentId: 'payment-123',
+          chargeId: 'charge-123',
+          amount: 10000,
+        },
       });
     });
 
@@ -538,6 +610,7 @@ describe('FinanzasService', () => {
       await expect(
         service.submitPayment(tenantId, buildingId, userId, userRoles, {
           unitId,
+          chargeId: 'charge-123',
           amount: 10000,
           method: PaymentMethod.TRANSFER,
           reference: 'TRX-123',
@@ -551,6 +624,7 @@ describe('FinanzasService', () => {
       await expect(
         service.submitPayment(tenantId, buildingId, userId, userRoles, {
           unitId,
+          chargeId: 'charge-123',
           amount: 10000,
           method: PaymentMethod.CARD,
           reference: 'CARD-123',
@@ -569,6 +643,7 @@ describe('FinanzasService', () => {
       await expect(
         service.submitPayment(tenantId, buildingId, userId, userRoles, {
           unitId: 'other-unit',
+          chargeId: 'charge-123',
           amount: 10000,
           method: PaymentMethod.TRANSFER,
           reference: 'TRX-123',
@@ -585,12 +660,152 @@ describe('FinanzasService', () => {
       await expect(
         service.submitPayment(tenantId, buildingId, userId, userRoles, {
           unitId,
+          chargeId: 'charge-123',
           amount: 10000,
           method: PaymentMethod.TRANSFER,
           reference: 'TRX-123',
           proofFileId: 'file-123',
         }),
       ).rejects.toThrow(ConflictException);
+    });
+
+    it('should reject resident payments that do not cover the full outstanding balance', async () => {
+      jest.spyOn(prismaService.charge, 'findFirst').mockResolvedValueOnce({
+        id: 'charge-123',
+        tenantId,
+        buildingId,
+        unitId,
+        amount: 4050000,
+        currency: 'ARS',
+        status: ChargeStatus.PARTIAL,
+        paymentAllocations: [
+          {
+            amount: 5000,
+            payment: { status: PaymentStatus.APPROVED },
+          },
+        ],
+      } as any);
+
+      await expect(
+        service.submitPayment(tenantId, buildingId, userId, userRoles, {
+          unitId,
+          chargeId: 'charge-123',
+          amount: 4040000,
+          method: PaymentMethod.TRANSFER,
+          reference: 'TRX-123',
+          proofFileId: 'file-123',
+        }),
+      ).rejects.toThrow('El monto debe coincidir con el saldo pendiente completo del período.');
+
+      expect(prismaService.payment.create).not.toHaveBeenCalled();
+      expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
+    });
+  });
+
+  // ========== TESTS: APPROVE PAYMENT ==========
+  describe('approvePayment', () => {
+    const tenantId = 'tenant-123';
+    const buildingId = 'building-123';
+    const paymentId = 'payment-123';
+    const membershipId = 'membership-123';
+
+    beforeEach(() => {
+      jest.spyOn(validators, 'canReviewPayments').mockReturnValue(true);
+      jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValue({
+        id: paymentId,
+        tenantId,
+        buildingId,
+        unitId: 'unit-123',
+        amount: 10000,
+        currency: 'ARS',
+        status: PaymentStatus.SUBMITTED,
+        canceledAt: null,
+        paymentAllocations: [
+          {
+            chargeId: 'charge-123',
+            amount: 10000,
+          },
+        ],
+      } as any);
+      jest.spyOn(prismaService.charge, 'findFirst').mockResolvedValue({
+        id: 'charge-123',
+        tenantId,
+        buildingId,
+        unitId: 'unit-123',
+        amount: 10000,
+        currency: 'ARS',
+        status: ChargeStatus.PENDING,
+        paymentAllocations: [
+          {
+            amount: 10000,
+            payment: { status: PaymentStatus.SUBMITTED },
+          },
+        ],
+      } as any);
+      jest.spyOn(prismaService.payment, 'update').mockResolvedValue({
+        id: paymentId,
+        status: PaymentStatus.APPROVED,
+        paidAt: new Date('2026-07-24T12:00:00.000Z'),
+      } as any);
+      jest.spyOn(prismaService.payment, 'findUnique').mockResolvedValue(null);
+      jest.spyOn(prismaService.charge, 'findUnique').mockResolvedValue(null);
+      jest.spyOn(prismaService.paymentAuditLog, 'create').mockResolvedValue({} as any);
+    });
+
+    it('keeps a resident-selected payment on a single charge without FIFO allocation', async () => {
+      const result = await service.approvePayment(
+        tenantId,
+        buildingId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        { paidAt: '2026-07-24T12:00:00.000Z' },
+      );
+
+      expect(result.status).toBe(PaymentStatus.APPROVED);
+      expect(prismaService.charge.findMany).not.toHaveBeenCalled();
+      expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(prismaService.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: paymentId },
+          data: expect.objectContaining({
+            status: PaymentStatus.APPROVED,
+            reviewedByMembershipId: membershipId,
+          }),
+        }),
+      );
+    });
+
+    it('rejects approval when the charge balance changed after submission', async () => {
+      jest.spyOn(prismaService.charge, 'findFirst').mockResolvedValueOnce({
+        id: 'charge-123',
+        tenantId,
+        buildingId,
+        unitId: 'unit-123',
+        amount: 10000,
+        currency: 'ARS',
+        status: ChargeStatus.PARTIAL,
+        paymentAllocations: [
+          {
+            amount: 5000,
+            payment: { status: PaymentStatus.APPROVED },
+          },
+        ],
+      } as any);
+
+      await expect(
+        service.approvePayment(
+          tenantId,
+          buildingId,
+          paymentId,
+          ['TENANT_ADMIN'],
+          membershipId,
+          {},
+        ),
+      ).rejects.toThrow('El monto debe coincidir con el saldo pendiente completo del período.');
+
+      expect(prismaService.payment.update).not.toHaveBeenCalled();
+      expect(prismaService.charge.findMany).not.toHaveBeenCalled();
     });
   });
 
@@ -841,6 +1056,60 @@ describe('FinanzasService', () => {
           period: '2026-06',
         }),
       }));
+    });
+
+    it('keeps totalCharges stable when an approved payment fully settles one charge', async () => {
+      jest.spyOn(prismaService.tenant, 'findUniqueOrThrow').mockResolvedValue({ currency: 'ARS' } as never);
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([
+        {
+          id: 'charge-paid',
+          tenantId: 'tenant-1',
+          buildingId: 'building-1',
+          unitId: 'unit-paid',
+          amount: 4_950_000,
+          paymentAllocations: [
+            {
+              amount: 4_950_000,
+              payment: { status: PaymentStatus.APPROVED },
+            },
+          ],
+        },
+        {
+          id: 'charge-open',
+          tenantId: 'tenant-1',
+          buildingId: 'building-1',
+          unitId: 'unit-open',
+          amount: 1_102_050_000,
+          paymentAllocations: [],
+        },
+      ] as never);
+      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue([
+        {
+          id: 'unit-open',
+          label: '0202',
+          buildingId: 'building-1',
+          building: { name: 'Edificio A' },
+        },
+      ] as never);
+
+      const result = await service.getTenantFinancialSummary('tenant-1', '2026-07');
+
+      expect(result).toEqual({
+        totalCharges: 1_107_000_000,
+        totalPaid: 4_950_000,
+        totalOutstanding: 1_102_050_000,
+        delinquentUnitsCount: 1,
+        topDelinquentUnits: [
+          {
+            unitId: 'unit-open',
+            unitLabel: '0202',
+            buildingId: 'building-1',
+            buildingName: 'Edificio A',
+            outstanding: 1_102_050_000,
+          },
+        ],
+        currency: 'ARS',
+      });
     });
   });
 

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -1663,6 +1663,121 @@ describe('FinanzasService', () => {
       expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
       expect(prismaService.paymentAuditLog.create).not.toHaveBeenCalled();
     });
+
+    it('keeps approved allocations intact when cancellation waits for an in-flight approval', async () => {
+      installSharedApprovalState();
+      paymentStates[paymentId] = {
+        ...paymentStates[paymentId]!,
+        amount: 5000,
+      };
+
+      let resolveApprovalLock!: () => void;
+      const approvalLocked = new Promise<void>((resolve) => {
+        resolveApprovalLock = resolve;
+      });
+      let releaseApproval!: () => void;
+      const approvalRelease = new Promise<void>((resolve) => {
+        releaseApproval = resolve;
+      });
+      let releasePaymentLock!: () => void;
+      const paymentLockReleased = new Promise<void>((resolve) => {
+        releasePaymentLock = resolve;
+      });
+      let paymentLockHeld = false;
+      let paymentLockAttempts = 0;
+      let resolveSecondLockAttempted!: () => void;
+      const secondLockAttempted = new Promise<void>((resolve) => {
+        resolveSecondLockAttempted = resolve;
+      });
+
+      jest.spyOn(prismaService, '$transaction').mockImplementation(
+        async (callback: (tx: never) => Promise<unknown>) => {
+          const tx = {
+            ...prismaService,
+            $queryRaw: jest.fn(async (query: { values?: readonly unknown[] }) => {
+              const lockedRecordId = String(query.values?.[0] ?? '');
+
+              if (lockedRecordId !== paymentId) {
+                return [];
+              }
+
+              paymentLockAttempts += 1;
+              if (paymentLockHeld) {
+                resolveSecondLockAttempted();
+                await paymentLockReleased;
+                return [];
+              }
+
+              paymentLockHeld = true;
+              resolveApprovalLock();
+              await approvalRelease;
+              return [];
+            }),
+          } as never;
+
+          try {
+            return await callback(tx);
+          } finally {
+            if (paymentLockHeld) {
+              paymentLockHeld = false;
+              releasePaymentLock();
+            }
+          }
+        },
+      );
+      jest.spyOn(prismaService.paymentAllocation, 'count').mockImplementation(async () =>
+        paymentStates[paymentId]!.paymentAllocations.length as never,
+      );
+      jest.spyOn(prismaService.paymentAllocation, 'findMany').mockImplementation(async () =>
+        paymentStates[paymentId]!.paymentAllocations.map((allocation) => ({
+          chargeId: allocation.chargeId,
+          amount: allocation.amount,
+        })) as never,
+      );
+
+      const approval = service.approvePayment(
+        tenantId,
+        buildingId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        {},
+      );
+      await approvalLocked;
+
+      const cancellation = service.cancelPayment(
+        tenantId,
+        buildingId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        'Manual cancellation',
+      );
+
+      await secondLockAttempted;
+      expect(paymentLockAttempts).toBe(2);
+      releaseApproval();
+
+      await expect(approval).resolves.toEqual(
+        expect.objectContaining({ status: PaymentStatus.APPROVED }),
+      );
+      await expect(cancellation).rejects.toThrow(
+        'Cannot cancel payment with existing allocations. Remove allocations first.',
+      );
+
+      expect(paymentStates[paymentId]).toEqual(
+        expect.objectContaining({
+          status: PaymentStatus.APPROVED,
+          canceledAt: null,
+          paymentAllocations: [expect.objectContaining({ chargeId, amount: 5000 })],
+        }),
+      );
+      expect(chargeStates[chargeId]).toEqual(
+        expect.objectContaining({ status: ChargeStatus.PARTIAL }),
+      );
+      expect(prismaService.paymentAllocation.deleteMany).not.toHaveBeenCalled();
+      expect(prismaService.charge.update).toHaveBeenCalledTimes(1);
+    });
   });
 
   // ========== TESTS: REJECT / CANCEL PAYMENT PROVISIONAL ALLOCATIONS ==========

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -702,7 +702,7 @@ describe('FinanzasService', () => {
       ).rejects.toThrow(BadRequestException);
     });
 
-    it('should reject duplicate transfer reference in the last 48 hours', async () => {
+    it('should reject a recent duplicate payment for the same selected charge', async () => {
       jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValue({
         id: 'payment-duplicate',
       } as any);
@@ -713,7 +713,6 @@ describe('FinanzasService', () => {
           chargeId: 'charge-123',
           amount: 10000,
           method: PaymentMethod.TRANSFER,
-          reference: 'TRX-123',
           proofFileId: 'file-123',
         }),
       ).rejects.toThrow(ConflictException);
@@ -725,8 +724,82 @@ describe('FinanzasService', () => {
             buildingId,
             unitId,
             amount: 10000,
-            reference: 'TRX-123',
+            reference: undefined,
+            paymentAllocations: {
+              some: {
+                tenantId,
+                chargeId: 'charge-123',
+              },
+            },
+            createdAt: expect.objectContaining({ gte: expect.any(Date) }),
+            status: { in: [PaymentStatus.SUBMITTED, PaymentStatus.APPROVED] },
           }),
+        }),
+      );
+    });
+
+    it('should allow the same unit and amount when the selected charge is different', async () => {
+      jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValue(null);
+      jest.spyOn(prismaService.charge, 'findFirst').mockResolvedValueOnce({
+        id: 'charge-456',
+        tenantId,
+        buildingId,
+        unitId,
+        amount: 10000,
+        currency: 'ARS',
+        status: ChargeStatus.PENDING,
+        paymentAllocations: [],
+      } as any);
+
+      const result = await service.submitPayment(
+        tenantId,
+        buildingId,
+        userId,
+        userRoles,
+        {
+          unitId,
+          chargeId: 'charge-456',
+          amount: 10000,
+          method: PaymentMethod.TRANSFER,
+          proofFileId: 'file-123',
+        },
+      );
+
+      expect(result.status).toBe(PaymentStatus.SUBMITTED);
+      expect(prismaService.payment.create).toHaveBeenCalled();
+      expect(prismaService.payment.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            paymentAllocations: {
+              some: {
+                tenantId,
+                chargeId: 'charge-456',
+              },
+            },
+          }),
+        }),
+      );
+    });
+
+    it('should preserve legacy duplicate detection for admin payments', async () => {
+      jest.spyOn(validators, 'isResidentOrOwner').mockReturnValue(false);
+      jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValue({
+        id: 'payment-legacy-duplicate',
+      } as any);
+
+      await expect(
+        service.submitPayment(tenantId, buildingId, userId, ['TENANT_ADMIN'], {
+          unitId,
+          amount: 10000,
+          method: PaymentMethod.TRANSFER,
+          reference: 'TRX-123',
+          proofFileId: 'file-123',
+        }),
+      ).rejects.toThrow(ConflictException);
+
+      expect(prismaService.payment.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.not.objectContaining({ paymentAllocations: expect.anything() }),
         }),
       );
     });

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -1216,7 +1216,7 @@ describe('FinanzasService', () => {
         paymentAllocations: [],
       } as any);
 
-      jest.spyOn(prismaService.payment, 'update').mockResolvedValue({
+      jest.spyOn(prismaService.payment, 'update').mockImplementation(async ({ data }) => ({
         id: paymentId,
         tenantId,
         buildingId,
@@ -1229,7 +1229,13 @@ describe('FinanzasService', () => {
           updateStatus === PaymentStatus.SUBMITTED
             ? new Date('2026-07-24T12:00:00.000Z')
             : null,
-      } as any);
+        reviewedByMembershipId: data.reviewedByMembershipId ?? null,
+        rejectionReason: data.rejectionReason ?? null,
+        rejectionComment: data.rejectionComment ?? null,
+        reviewedAt: data.reviewedAt ?? null,
+        notes: data.notes ?? null,
+        updatedAt: data.updatedAt ?? new Date('2026-07-24T12:00:00.000Z'),
+      } as any));
 
       jest.spyOn(prismaService.paymentAuditLog, 'create').mockResolvedValue({} as any);
     };
@@ -1245,6 +1251,9 @@ describe('FinanzasService', () => {
 
     it('rejectPayment removes provisional allocations and unblocks the charge', async () => {
       mockSubmittedPaymentState(PaymentStatus.SUBMITTED, PaymentStatus.REJECTED);
+      const notificationSpy = jest
+        .spyOn(service as any, 'sendPaymentRejectedNotification')
+        .mockResolvedValue(undefined);
 
       await expect(
         service.updateCharge(tenantId, buildingId, chargeId, ['TENANT_ADMIN'], {
@@ -1261,14 +1270,30 @@ describe('FinanzasService', () => {
         {
           reason: 'OTHER',
           comment: 'Rejected by admin',
+          notes: 'Reviewed against bank statement',
         },
       );
 
       expect(result.status).toBe(PaymentStatus.REJECTED);
+      expect(result.rejectionReason).toBe('OTHER');
+      expect(result.rejectionComment).toBe('Rejected by admin');
+      expect(result.reviewedByMembershipId).toBe(membershipId);
+      expect(result.reviewedAt).toEqual(expect.any(Date));
+      expect(result.notes).toBe('Reviewed against bank statement');
+      expect(prismaService.payment.update).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({
+          status: PaymentStatus.REJECTED,
+          reviewedByMembershipId: membershipId,
+          rejectionReason: 'OTHER',
+          rejectionComment: 'Rejected by admin',
+          notes: 'Reviewed against bank statement',
+        }),
+      }));
       expect(prismaService.paymentAllocation.deleteMany).toHaveBeenCalledWith({
         where: { tenantId, paymentId },
       });
       expect(makeAllocation()).toHaveLength(0);
+      expect(notificationSpy).toHaveBeenCalledWith(tenantId, expect.any(Object), 'OTHER');
 
       await expect(
         service.updateCharge(tenantId, buildingId, chargeId, ['TENANT_ADMIN'], {
@@ -1283,6 +1308,9 @@ describe('FinanzasService', () => {
 
     it('rejectPaymentTenant removes provisional allocations for the tenant payment', async () => {
       mockSubmittedPaymentState(PaymentStatus.SUBMITTED, PaymentStatus.REJECTED);
+      const notificationSpy = jest
+        .spyOn(service as any, 'sendPaymentRejectedNotification')
+        .mockResolvedValue(undefined);
 
       const result = await service.rejectPaymentTenant(
         tenantId,
@@ -1292,14 +1320,30 @@ describe('FinanzasService', () => {
         {
           reason: 'OTHER',
           comment: 'Rejected at tenant level',
+          notes: 'Tenant review notes',
         },
       );
 
       expect(result.status).toBe(PaymentStatus.REJECTED);
+      expect(result.rejectionReason).toBe('OTHER');
+      expect(result.rejectionComment).toBe('Rejected at tenant level');
+      expect(result.reviewedByMembershipId).toBe(membershipId);
+      expect(result.reviewedAt).toEqual(expect.any(Date));
+      expect(result.notes).toBe('Tenant review notes');
+      expect(prismaService.payment.update).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({
+          status: PaymentStatus.REJECTED,
+          reviewedByMembershipId: membershipId,
+          rejectionReason: 'OTHER',
+          rejectionComment: 'Rejected at tenant level',
+          notes: 'Tenant review notes',
+        }),
+      }));
       expect(prismaService.paymentAllocation.deleteMany).toHaveBeenCalledWith({
         where: { tenantId, paymentId },
       });
       expect(makeAllocation()).toHaveLength(0);
+      expect(notificationSpy).toHaveBeenCalledWith(tenantId, expect.any(Object), 'OTHER');
     });
 
     it('cancelPayment removes provisional allocations for submitted payments', async () => {
@@ -1345,6 +1389,9 @@ describe('FinanzasService', () => {
 
     it('rolls back provisional allocation release when rejection fails', async () => {
       mockSubmittedPaymentState(PaymentStatus.SUBMITTED, PaymentStatus.REJECTED);
+      const notificationSpy = jest
+        .spyOn(service as any, 'sendPaymentRejectedNotification')
+        .mockResolvedValue(undefined);
 
       const snapshot = makeAllocation();
       jest.spyOn(prismaService, '$transaction').mockImplementationOnce(async (callback: (tx: never) => Promise<unknown>) => {
@@ -1374,6 +1421,7 @@ describe('FinanzasService', () => {
       expect(prismaService.paymentAllocation.deleteMany).toHaveBeenCalledWith({
         where: { tenantId, paymentId },
       });
+      expect(notificationSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -893,6 +893,220 @@ describe('FinanzasService', () => {
     });
   });
 
+  // ========== TESTS: APPROVE PAYMENT TENANT ==========
+  describe('approvePaymentTenant', () => {
+    const tenantId = 'tenant-123';
+    const buildingId = 'building-123';
+    const paymentId = 'payment-tenant-123';
+    const membershipId = 'membership-123';
+
+    beforeEach(() => {
+      jest.spyOn(validators, 'canReviewPayments').mockReturnValue(true);
+      jest.spyOn(prismaService.paymentAuditLog, 'create').mockResolvedValue({} as any);
+      jest.spyOn(prismaService.charge, 'update').mockResolvedValue({
+        id: 'charge-123',
+        status: ChargeStatus.PAID,
+      } as any);
+    });
+
+    it('reconciles tenant-approved payments when all explicit allocations settle their charges', async () => {
+      jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValue({
+        id: paymentId,
+        tenantId,
+        buildingId,
+        unitId: 'unit-123',
+        amount: 10000,
+        currency: 'ARS',
+        status: PaymentStatus.SUBMITTED,
+        canceledAt: null,
+        paymentAllocations: [
+          {
+            chargeId: 'charge-123',
+            amount: 10000,
+          },
+        ],
+      } as any);
+      jest.spyOn(prismaService.charge, 'findFirst').mockResolvedValue({
+        id: 'charge-123',
+        tenantId,
+        buildingId,
+        unitId: 'unit-123',
+        amount: 10000,
+        currency: 'ARS',
+        status: ChargeStatus.PENDING,
+        paymentAllocations: [],
+      } as any);
+      const paymentUpdateSpy = jest
+        .spyOn(prismaService.payment, 'update')
+        .mockResolvedValueOnce({
+          id: paymentId,
+          tenantId,
+          buildingId,
+          unitId: 'unit-123',
+          amount: 10000,
+          currency: 'ARS',
+          method: PaymentMethod.TRANSFER,
+          status: PaymentStatus.APPROVED,
+          paidAt: new Date('2026-07-24T12:00:00.000Z'),
+        } as any)
+        .mockResolvedValueOnce({
+          id: paymentId,
+          tenantId,
+          buildingId,
+          unitId: 'unit-123',
+          amount: 10000,
+          currency: 'ARS',
+          method: PaymentMethod.TRANSFER,
+          status: PaymentStatus.RECONCILED,
+          paidAt: new Date('2026-07-24T12:00:00.000Z'),
+        } as any);
+      jest.spyOn(prismaService.payment, 'findUnique')
+        .mockResolvedValueOnce({
+          id: paymentId,
+          tenantId,
+          buildingId,
+          unitId: 'unit-123',
+          amount: 10000,
+          currency: 'ARS',
+          status: PaymentStatus.APPROVED,
+          paymentAllocations: [
+            {
+              amount: 10000,
+              charge: { status: ChargeStatus.PAID },
+            },
+          ],
+        } as any)
+        .mockResolvedValueOnce({
+          id: paymentId,
+          tenantId,
+          buildingId,
+          unitId: 'unit-123',
+          amount: 10000,
+          currency: 'ARS',
+          method: PaymentMethod.TRANSFER,
+          status: PaymentStatus.RECONCILED,
+          paidAt: new Date('2026-07-24T12:00:00.000Z'),
+        } as any)
+        .mockResolvedValueOnce({
+          id: paymentId,
+          tenantId,
+          buildingId,
+          unitId: 'unit-123',
+          amount: 10000,
+          currency: 'ARS',
+          method: PaymentMethod.TRANSFER,
+          status: PaymentStatus.RECONCILED,
+          paidAt: new Date('2026-07-24T12:00:00.000Z'),
+        } as any);
+
+      const result = await service.approvePaymentTenant(
+        tenantId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        { paidAt: '2026-07-24T12:00:00.000Z' },
+      );
+
+      expect(result.status).toBe(PaymentStatus.RECONCILED);
+      expect(paymentUpdateSpy).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          where: { id: paymentId },
+          data: expect.objectContaining({
+            status: PaymentStatus.APPROVED,
+            reviewedByMembershipId: membershipId,
+          }),
+        }),
+      );
+      expect(paymentUpdateSpy).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          where: { id: paymentId },
+          data: expect.objectContaining({
+            status: PaymentStatus.RECONCILED,
+          }),
+        }),
+      );
+    });
+
+    it('keeps tenant-approved payments approved when the remaining balance is still open', async () => {
+      jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValue({
+        id: paymentId,
+        tenantId,
+        buildingId,
+        unitId: 'unit-123',
+        amount: 5000,
+        currency: 'ARS',
+        status: PaymentStatus.SUBMITTED,
+        canceledAt: null,
+        paymentAllocations: [
+          {
+            chargeId: 'charge-123',
+            amount: 5000,
+          },
+        ],
+      } as any);
+      jest.spyOn(prismaService.charge, 'findFirst').mockResolvedValue({
+        id: 'charge-123',
+        tenantId,
+        buildingId,
+        unitId: 'unit-123',
+        amount: 10000,
+        currency: 'ARS',
+        status: ChargeStatus.PARTIAL,
+        paymentAllocations: [
+          {
+            amount: 5000,
+            payment: { status: PaymentStatus.APPROVED },
+          },
+        ],
+      } as any);
+      const paymentUpdateSpy = jest
+        .spyOn(prismaService.payment, 'update')
+        .mockResolvedValueOnce({
+          id: paymentId,
+          tenantId,
+          buildingId,
+          unitId: 'unit-123',
+          amount: 5000,
+          currency: 'ARS',
+          method: PaymentMethod.TRANSFER,
+          status: PaymentStatus.APPROVED,
+          paidAt: new Date('2026-07-24T12:00:00.000Z'),
+        } as any);
+      jest.spyOn(prismaService.payment, 'findUnique').mockResolvedValueOnce({
+        id: paymentId,
+        tenantId,
+        buildingId,
+        unitId: 'unit-123',
+        amount: 5000,
+        currency: 'ARS',
+        method: PaymentMethod.TRANSFER,
+        status: PaymentStatus.APPROVED,
+        paidAt: new Date('2026-07-24T12:00:00.000Z'),
+        paymentAllocations: [],
+      } as any);
+
+      const result = await service.approvePaymentTenant(
+        tenantId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        {},
+      );
+
+      expect(result.status).toBe(PaymentStatus.APPROVED);
+      expect(paymentUpdateSpy).toHaveBeenCalledTimes(1);
+      expect(prismaService.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: PaymentStatus.APPROVED,
+          }),
+        }),
+      );
+    });
+  });
+
   // ========== TESTS: CHECK PAYMENT DUPLICATE ==========
   describe('checkPaymentDuplicate', () => {
     it('scopes duplicate detection to the payment unit', async () => {

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -668,6 +668,18 @@ describe('FinanzasService', () => {
           proofFileId: 'file-123',
         }),
       ).rejects.toThrow(ConflictException);
+
+      expect(prismaService.payment.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tenantId,
+            buildingId,
+            unitId,
+            amount: 10000,
+            reference: 'TRX-123',
+          }),
+        }),
+      );
     });
 
     it('should reject resident payments that do not cover the full outstanding balance', async () => {
@@ -863,6 +875,53 @@ describe('FinanzasService', () => {
 
       expect(prismaService.payment.update).not.toHaveBeenCalled();
       expect(prismaService.charge.findMany).not.toHaveBeenCalled();
+    });
+
+    it('locks the selected charge before approving a resident-selected payment', async () => {
+      await service.approvePayment(
+        tenantId,
+        buildingId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        { paidAt: '2026-07-24T12:00:00.000Z' },
+      );
+
+      expect(prismaService.$queryRaw).toHaveBeenCalledTimes(1);
+      const rawQuery = (prismaService.$queryRaw as jest.Mock).mock.calls[0][0] as { strings?: string[] };
+      expect(rawQuery.strings?.join(' ')).toContain('FOR UPDATE');
+    });
+  });
+
+  // ========== TESTS: CHECK PAYMENT DUPLICATE ==========
+  describe('checkPaymentDuplicate', () => {
+    it('scopes duplicate detection to the payment unit', async () => {
+      jest
+        .spyOn(prismaService.payment, 'findFirst')
+        .mockResolvedValueOnce({
+          id: 'payment-123',
+          tenantId: 'tenant-123',
+          buildingId: 'building-123',
+          unitId: 'unit-123',
+          amount: 10000,
+          reference: 'TRX-123',
+        } as any)
+        .mockResolvedValueOnce({ id: 'payment-duplicate', amount: 10000, reference: 'TRX-123' } as any);
+
+      const result = await service.checkPaymentDuplicate('tenant-123', 'payment-123');
+
+      expect(result.hasDuplicate).toBe(true);
+      expect(prismaService.payment.findFirst).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tenantId: 'tenant-123',
+            unitId: 'unit-123',
+            amount: 10000,
+            reference: 'TRX-123',
+          }),
+        }),
+      );
     });
   });
 

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -65,6 +65,30 @@ interface RawDelinquencyTotalsRow {
   accumulatedDebt: bigint | number | string;
 }
 
+type ChargeWithAllocations = Prisma.ChargeGetPayload<{
+  include: {
+    paymentAllocations: {
+      include: {
+        payment: {
+          select: {
+            status: true;
+          };
+        };
+      };
+    };
+  };
+}>;
+
+type PaymentWithAllocations = Prisma.PaymentGetPayload<{
+  include: {
+    paymentAllocations: {
+      include: {
+        charge: true;
+      };
+    };
+  };
+}>;
+
 @Injectable()
 export class FinanzasService {
   private readonly logger = new Logger(FinanzasService.name);
@@ -425,6 +449,7 @@ export class FinanzasService {
     if (!this.validators.canSubmitPayments(userRoles)) {
       this.validators.throwForbidden('payments', 'submit');
     }
+    const isResidentPayment = this.validators.isResidentOrOwner(userRoles);
 
     // 2. Validate building
     await this.validators.validateBuildingBelongsToTenant(
@@ -433,7 +458,7 @@ export class FinanzasService {
     );
 
     // 3. If RESIDENT/OWNER, unitId is REQUIRED
-    if (this.validators.isResidentOrOwner(userRoles)) {
+    if (isResidentPayment) {
       if (!dto.unitId) {
         throw new BadRequestException(
           'RESIDENT must specify unitId when submitting a payment',
@@ -444,6 +469,11 @@ export class FinanzasService {
         userId,
         dto.unitId,
       );
+      if (!dto.chargeId) {
+        throw new BadRequestException(
+          'RESIDENT must specify chargeId when submitting a payment',
+        );
+      }
     }
 
     // 4. If unitId provided, validate it belongs to building
@@ -487,6 +517,86 @@ export class FinanzasService {
       throw new BadRequestException(
         'Los pagos por transferencia requieren subir el comprobante de pago',
       );
+    }
+
+    if (isResidentPayment) {
+      const payment = await this.prisma.$transaction(async (tx) => {
+        const charge = await tx.charge.findFirst({
+          where: {
+            id: dto.chargeId,
+            tenantId,
+            buildingId,
+            unitId: dto.unitId,
+            canceledAt: null,
+          },
+          include: {
+            paymentAllocations: {
+              include: {
+                payment: {
+                  select: {
+                    status: true,
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        if (!charge) {
+          throw new NotFoundException(
+            'Charge not found or does not belong to this unit/building/tenant',
+          );
+        }
+
+        if (charge.status === ChargeStatus.CANCELED || charge.status === ChargeStatus.PAID) {
+          throw new ConflictException(
+            'El cargo seleccionado no admite pagos',
+          );
+        }
+
+        const paymentCurrency = dto.currency || charge.currency;
+        if (paymentCurrency !== charge.currency) {
+          throw new BadRequestException(
+            'La moneda del pago debe coincidir con la moneda del cargo',
+          );
+        }
+
+        const outstanding = this.calculateApprovedChargeOutstanding(charge);
+        if (dto.amount !== outstanding) {
+          throw new ConflictException(
+            'El monto debe coincidir con el saldo pendiente completo del período.',
+          );
+        }
+
+        const payment = await tx.payment.create({
+          data: {
+            tenantId,
+            buildingId,
+            unitId: dto.unitId || null,
+            amount: dto.amount,
+            currency: paymentCurrency,
+            method: dto.method,
+            status: PaymentStatus.SUBMITTED,
+            reference: dto.reference,
+            proofFileId: dto.proofFileId || null,
+            createdByUserId: userId,
+          },
+        });
+
+        await tx.paymentAllocation.create({
+          data: {
+            tenantId,
+            paymentId: payment.id,
+            chargeId: charge.id,
+            amount: outstanding,
+          },
+        });
+
+        return payment;
+      });
+
+      void this.notifyAdminsOfPaymentSubmitted(tenantId, payment);
+      return payment;
     }
 
     // 8. Create payment with SUBMITTED status
@@ -641,6 +751,9 @@ export class FinanzasService {
         tenantId,
         buildingId,
       },
+      include: {
+        paymentAllocations: true,
+      },
     });
 
     if (!payment) {
@@ -656,9 +769,81 @@ export class FinanzasService {
       );
     }
 
-    // 3. Approve + FIFO allocation in transaction
+    // 3. Approve payment with either resident-selected allocations or legacy FIFO allocation
     const result = await this.prisma.$transaction(async (tx) => {
-      // 3a. Update to APPROVED
+      if (payment.paymentAllocations.length > 0) {
+        const totalAllocated = payment.paymentAllocations.reduce(
+          (sum, allocation) => sum + allocation.amount,
+          0,
+        );
+
+        if (totalAllocated !== payment.amount) {
+          throw new ConflictException(
+            'El monto debe coincidir con el saldo pendiente completo del período.',
+          );
+        }
+
+        for (const allocation of payment.paymentAllocations) {
+          const charge = await tx.charge.findFirst({
+            where: {
+              id: allocation.chargeId,
+              tenantId,
+              buildingId,
+              unitId: payment.unitId ?? undefined,
+              canceledAt: null,
+            },
+            include: {
+              paymentAllocations: {
+                include: {
+                  payment: {
+                    select: {
+                      status: true,
+                    },
+                  },
+                },
+              },
+            },
+          });
+
+          if (!charge) {
+            throw new NotFoundException(
+              'Charge not found or does not belong to this building/tenant',
+            );
+          }
+
+          if (charge.status === ChargeStatus.PAID || charge.status === ChargeStatus.CANCELED) {
+            throw new ConflictException(
+              'El cargo seleccionado no admite pagos',
+            );
+          }
+
+          const outstanding = this.calculateApprovedChargeOutstanding(charge);
+          if (allocation.amount !== outstanding) {
+            throw new ConflictException(
+              'El monto debe coincidir con el saldo pendiente completo del período.',
+            );
+          }
+        }
+
+        const approvedPayment = await tx.payment.update({
+          where: { id: paymentId },
+          data: {
+            status: PaymentStatus.APPROVED,
+            paidAt: dto.paidAt ? new Date(dto.paidAt) : new Date(),
+            reviewedByMembershipId: membershipId,
+            updatedAt: new Date(),
+          },
+        });
+
+        for (const allocation of payment.paymentAllocations) {
+          await this.recalculateChargeStatus(allocation.chargeId, tx);
+        }
+
+        await this.tryReconcilePayment(paymentId, tx);
+        return approvedPayment;
+      }
+
+      // Legacy FIFO allocation for admin-submitted payments without an explicit charge selection
       const approvedPayment = await tx.payment.update({
         where: { id: paymentId },
         data: {
@@ -669,8 +854,6 @@ export class FinanzasService {
         },
       });
 
-      // 3b. FIFO allocation: if unitId exists, auto-allocate to oldest charges
-      // Include all charges except PAID and CANCELED (some may be incorrectly marked PAID without allocations)
       if (payment.unitId) {
         const pendingCharges = await tx.charge.findMany({
           where: {
@@ -681,7 +864,7 @@ export class FinanzasService {
             canceledAt: null,
           },
           include: { paymentAllocations: true },
-          orderBy: { dueDate: 'asc' }, // FIFO: oldest first
+          orderBy: { dueDate: 'asc' },
         });
 
         let remainingAmount = payment.amount;
@@ -698,7 +881,6 @@ export class FinanzasService {
 
           if (toAllocate <= 0) continue;
 
-          // Verify no existing allocation for this pair
           const existingAllocation = await tx.paymentAllocation.findFirst({
             where: { tenantId, paymentId, chargeId: charge.id },
           });
@@ -718,9 +900,7 @@ export class FinanzasService {
         }
       }
 
-      // 3c. Try to reconcile if all charges are paid
       await this.tryReconcilePayment(paymentId, tx);
-
       return approvedPayment;
     });
 
@@ -1094,6 +1274,19 @@ export class FinanzasService {
         },
       });
     }
+  }
+
+  private calculateApprovedChargeOutstanding(charge: ChargeWithAllocations): number {
+    const approvedAllocated = charge.paymentAllocations.reduce((sum, allocation) => {
+      const status = allocation.payment?.status;
+      if (status === PaymentStatus.APPROVED || status === PaymentStatus.RECONCILED) {
+        return sum + allocation.amount;
+      }
+
+      return sum;
+    }, 0);
+
+    return Math.max(0, charge.amount - approvedAllocated);
   }
 
   // ============================================================================
@@ -1894,39 +2087,41 @@ export class FinanzasService {
       },
     });
 
-    // 3. Calculate totals by REAL outstanding using approved/reconciled payments
-    const chargesWithOutstanding = charges
-      .map((c) => {
-        const allocated = c.paymentAllocations.reduce((asum, a) => {
-          return asum +
-            (a.payment &&
-            (a.payment.status === PaymentStatus.APPROVED ||
-              a.payment.status === PaymentStatus.RECONCILED)
-              ? a.amount
-              : 0);
-        }, 0);
+    // 3. Calculate totals using the original charge amount and the approved allocations
+    const chargesAnnotated = charges.map((c) => {
+      const allocated = c.paymentAllocations.reduce((asum, a) => {
+        return asum +
+          (a.payment &&
+          (a.payment.status === PaymentStatus.APPROVED ||
+            a.payment.status === PaymentStatus.RECONCILED)
+            ? a.amount
+            : 0);
+      }, 0);
 
-        return {
-          charge: c,
-          allocated,
-          outstanding: Math.max(0, c.amount - allocated),
-        };
-      })
-      .filter((item) => item.outstanding > 0);
+      return {
+        charge: c,
+        allocated,
+        outstanding: Math.max(0, c.amount - allocated),
+      };
+    });
 
-    const totalCharges = chargesWithOutstanding.reduce(
+    const totalCharges = chargesAnnotated.reduce(
       (sum, item) => sum + item.charge.amount,
       0,
     );
 
-    const totalPaid = chargesWithOutstanding.reduce(
+    const totalPaid = chargesAnnotated.reduce(
       (sum, item) => sum + item.allocated,
       0,
     );
 
-    const totalOutstanding = chargesWithOutstanding.reduce(
-      (sum, item) => sum + item.outstanding,
+    const totalOutstanding = Math.max(
       0,
+      chargesAnnotated.reduce((sum, item) => sum + item.outstanding, 0),
+    );
+
+    const chargesWithOutstanding = chargesAnnotated.filter(
+      (item) => item.outstanding > 0,
     );
 
     // 4. Find delinquent units by real outstanding
@@ -2270,73 +2465,140 @@ export class FinanzasService {
       throw new BadRequestException('Cannot approve a canceled payment');
     }
 
-    // Execute approval with auto-allocation
+    // Execute approval with either explicit resident allocation or legacy FIFO allocation
     let approvedPaymentResult: Payment | null = null;
-    
-    await this.prisma.$transaction(async (tx) => {
-      // Update payment status
-      const approvedPayment = await tx.payment.update({
-        where: { id: paymentId },
-        data: {
-          status: PaymentStatus.APPROVED,
-          reviewedByMembershipId: membershipId,
-          reviewedAt: new Date(),
-          paidAt: dto.paidAt ? new Date(dto.paidAt) : new Date(),
-          updatedAt: new Date(),
-        },
-      });
-      
-      approvedPaymentResult = approvedPayment;
 
-      // Auto-allocation: find pending charges for the unit and allocate
-      if (payment.unitId) {
-        const pendingCharges = await tx.charge.findMany({
-          where: {
-            tenantId,
-            buildingId: payment.buildingId,
-            unitId: payment.unitId,
-            status: { in: [ChargeStatus.PENDING, ChargeStatus.PARTIAL] },
-            canceledAt: null,
+    await this.prisma.$transaction(async (tx) => {
+      if (payment.paymentAllocations.length > 0) {
+        const totalAllocated = payment.paymentAllocations.reduce(
+          (sum, allocation) => sum + allocation.amount,
+          0,
+        );
+
+        if (totalAllocated !== payment.amount) {
+          throw new ConflictException(
+            'El monto debe coincidir con el saldo pendiente completo del período.',
+          );
+        }
+
+        for (const allocation of payment.paymentAllocations) {
+          const charge = await tx.charge.findFirst({
+            where: {
+              id: allocation.chargeId,
+              tenantId,
+              buildingId: payment.buildingId,
+              unitId: payment.unitId ?? undefined,
+              canceledAt: null,
+            },
+            include: {
+              paymentAllocations: {
+                include: {
+                  payment: {
+                    select: {
+                      status: true,
+                    },
+                  },
+                },
+              },
+            },
+          });
+
+          if (!charge) {
+            throw new NotFoundException(
+              'Charge not found or does not belong to this building/tenant',
+            );
+          }
+
+          if (charge.status === ChargeStatus.PAID || charge.status === ChargeStatus.CANCELED) {
+            throw new ConflictException('El cargo seleccionado no admite pagos');
+          }
+
+          const outstanding = this.calculateApprovedChargeOutstanding(charge);
+          if (allocation.amount !== outstanding) {
+            throw new ConflictException(
+              'El monto debe coincidir con el saldo pendiente completo del período.',
+            );
+          }
+        }
+
+        const approvedPayment = await tx.payment.update({
+          where: { id: paymentId },
+          data: {
+            status: PaymentStatus.APPROVED,
+            reviewedByMembershipId: membershipId,
+            reviewedAt: new Date(),
+            paidAt: dto.paidAt ? new Date(dto.paidAt) : new Date(),
+            updatedAt: new Date(),
           },
-          orderBy: { dueDate: 'asc' }, // FIFO by due date
         });
 
-        let remainingAmount = payment.amount;
+        approvedPaymentResult = approvedPayment;
 
-        for (const charge of pendingCharges) {
-          if (remainingAmount <= 0) break;
+        for (const allocation of payment.paymentAllocations) {
+          await this.recalculateChargeStatus(allocation.chargeId, tx);
+        }
+      } else {
+        const approvedPayment = await tx.payment.update({
+          where: { id: paymentId },
+          data: {
+            status: PaymentStatus.APPROVED,
+            reviewedByMembershipId: membershipId,
+            reviewedAt: new Date(),
+            paidAt: dto.paidAt ? new Date(dto.paidAt) : new Date(),
+            updatedAt: new Date(),
+          },
+        });
 
-          const allocatedAmount = Math.min(remainingAmount, charge.amount);
-          const existingAllocations = await tx.paymentAllocation.aggregate({
-            where: { chargeId: charge.id },
-            _sum: { amount: true },
+        approvedPaymentResult = approvedPayment;
+
+        if (payment.unitId) {
+          const pendingCharges = await tx.charge.findMany({
+            where: {
+              tenantId,
+              buildingId: payment.buildingId,
+              unitId: payment.unitId,
+              status: { in: [ChargeStatus.PENDING, ChargeStatus.PARTIAL] },
+              canceledAt: null,
+            },
+            orderBy: { dueDate: 'asc' },
           });
-          const alreadyAllocated = existingAllocations._sum.amount || 0;
-          const chargeRemaining = charge.amount - alreadyAllocated;
 
-          const allocationAmount = Math.min(allocatedAmount, chargeRemaining);
+          let remainingAmount = payment.amount;
 
-          if (allocationAmount > 0) {
-            await tx.paymentAllocation.create({
-              data: {
-                tenantId,
-                paymentId: payment.id,
-                chargeId: charge.id,
-                amount: allocationAmount,
-              },
+          for (const charge of pendingCharges) {
+            if (remainingAmount <= 0) break;
+
+            const allocatedAmount = Math.min(remainingAmount, charge.amount);
+            const existingAllocations = await tx.paymentAllocation.aggregate({
+              where: { chargeId: charge.id },
+              _sum: { amount: true },
             });
+            const alreadyAllocated = existingAllocations._sum.amount || 0;
+            const chargeRemaining = charge.amount - alreadyAllocated;
 
-            // Update charge status
-            const newChargeAllocated = alreadyAllocated + allocationAmount;
-            const newChargeStatus =
-              newChargeAllocated >= charge.amount ? ChargeStatus.PAID : ChargeStatus.PARTIAL;
+            const allocationAmount = Math.min(allocatedAmount, chargeRemaining);
 
-            await tx.charge.update({
-              where: { id: charge.id },
-              data: { status: newChargeStatus, updatedAt: new Date() },
-            });
+            if (allocationAmount > 0) {
+              await tx.paymentAllocation.create({
+                data: {
+                  tenantId,
+                  paymentId: payment.id,
+                  chargeId: charge.id,
+                  amount: allocationAmount,
+                },
+              });
 
-            remainingAmount -= allocationAmount;
+              const newChargeAllocated = alreadyAllocated + allocationAmount;
+              const newChargeStatus =
+                newChargeAllocated >= charge.amount ? ChargeStatus.PAID : ChargeStatus.PARTIAL;
+
+              await tx.charge.update({
+                where: { id: charge.id },
+                data: { status: newChargeStatus, updatedAt: new Date() },
+              });
+
+              remainingAmount -= allocationAmount;
+            }
           }
         }
       }
@@ -2359,7 +2621,7 @@ export class FinanzasService {
         },
       });
 
-      return approvedPayment;
+      return approvedPaymentResult;
     });
 
     // Send notification to resident about approval (outside transaction, using returned payment)

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -745,33 +745,25 @@ export class FinanzasService {
       this.validators.throwForbidden('payments', 'approve');
     }
 
-    // 2. Validate payment
-    const payment = await this.prisma.payment.findFirst({
-      where: {
-        id: paymentId,
-        tenantId,
-        buildingId,
-      },
-      include: {
-        paymentAllocations: true,
-      },
-    });
-
-    if (!payment) {
-      throw new NotFoundException(
-        `Payment not found or does not belong to this building/tenant`,
-      );
-    }
-
-    // Validate payment is in SUBMITTED status (can only approve submitted payments)
-    if (payment.status !== PaymentStatus.SUBMITTED) {
-      throw new ConflictException(
-        `Cannot approve payment in status ${payment.status}. Only SUBMITTED payments can be approved.`,
-      );
-    }
-
-    // 3. Approve payment with either resident-selected allocations or legacy FIFO allocation
+    // 2. Approve payment with either resident-selected allocations or legacy FIFO allocation
     const result = await this.prisma.$transaction(async (tx) => {
+      const payment = await this.lockSubmittedPaymentForApproval(
+        tx,
+        tenantId,
+        paymentId,
+        buildingId,
+      );
+
+      if (payment.status !== PaymentStatus.SUBMITTED) {
+        throw new ConflictException(
+          `Cannot approve payment in status ${payment.status}. Only SUBMITTED payments can be approved.`,
+        );
+      }
+
+      if (payment.canceledAt) {
+        throw new ConflictException('Cannot approve a canceled payment');
+      }
+
       if (payment.paymentAllocations.length > 0) {
         const totalAllocated = payment.paymentAllocations.reduce(
           (sum, allocation) => sum + allocation.amount,
@@ -828,7 +820,7 @@ export class FinanzasService {
         }
 
         const approvedPayment = await tx.payment.update({
-          where: { id: paymentId },
+          where: { id: payment.id },
           data: {
             status: PaymentStatus.APPROVED,
             paidAt: dto.paidAt ? new Date(dto.paidAt) : new Date(),
@@ -841,13 +833,13 @@ export class FinanzasService {
           await this.recalculateChargeStatus(allocation.chargeId, tx);
         }
 
-        await this.tryReconcilePayment(paymentId, tx);
+        await this.tryReconcilePayment(payment.id, tx);
         return approvedPayment;
       }
 
       // Legacy FIFO allocation for admin-submitted payments without an explicit charge selection
       const approvedPayment = await tx.payment.update({
-        where: { id: paymentId },
+        where: { id: payment.id },
         data: {
           status: PaymentStatus.APPROVED,
           paidAt: dto.paidAt ? new Date(dto.paidAt) : new Date(),
@@ -939,7 +931,7 @@ export class FinanzasService {
         }
       }
 
-      await this.tryReconcilePayment(paymentId, tx);
+      await this.tryReconcilePayment(payment.id, tx);
       return approvedPayment;
     });
 
@@ -951,14 +943,14 @@ export class FinanzasService {
       entityType: 'Payment',
       entityId: paymentId,
       metadata: {
-        amount: payment.amount,
+        amount: result.amount,
         paidAt: result.paidAt,
-        fifoAllocated: payment.unitId ? true : false,
+        fifoAllocated: result.unitId ? true : false,
       },
     });
 
     // [PHASE 2 QUICK #3] Send PAYMENT_RECEIVED notification
-    void this.sendPaymentReceivedNotification(tenantId, payment);
+    void this.sendPaymentReceivedNotification(tenantId, result);
 
     // Generate receipt for approved payment (async, non-blocking)
     void this.receiptService.ensureReceiptForPayment(paymentId).catch((err) => {
@@ -1385,6 +1377,48 @@ export class FinanzasService {
     chargeId: string,
   ): Promise<void> {
     await tx.$queryRaw(Prisma.sql`SELECT 1 FROM "Charge" WHERE id = ${chargeId} FOR UPDATE`);
+  }
+
+  private async lockSubmittedPaymentForApproval(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    paymentId: string,
+    buildingId?: string,
+  ): Promise<PaymentWithAllocations> {
+    if (buildingId) {
+      await tx.$queryRaw(
+        Prisma.sql`SELECT 1 FROM "Payment" WHERE id = ${paymentId} AND "tenantId" = ${tenantId} AND "buildingId" = ${buildingId} FOR UPDATE`,
+      );
+    } else {
+      await tx.$queryRaw(
+        Prisma.sql`SELECT 1 FROM "Payment" WHERE id = ${paymentId} AND "tenantId" = ${tenantId} FOR UPDATE`,
+      );
+    }
+
+    const payment = await tx.payment.findFirst({
+      where: {
+        id: paymentId,
+        tenantId,
+        ...(buildingId ? { buildingId } : {}),
+      },
+      include: {
+        paymentAllocations: {
+          include: {
+            charge: true,
+          },
+        },
+      },
+    });
+
+    if (!payment) {
+      throw buildingId
+        ? new NotFoundException(
+          'Payment not found or does not belong to this building/tenant',
+        )
+        : new NotFoundException('Payment not found');
+    }
+
+    return payment;
   }
 
   private isEffectivePaymentStatus(status?: PaymentStatus | null): boolean {
@@ -2543,36 +2577,22 @@ export class FinanzasService {
       this.validators.throwForbidden('payments', 'approve');
     }
 
-    // Find payment - tenant level (any building)
-    const payment = await this.prisma.payment.findFirst({
-      where: {
-        id: paymentId,
-        tenantId,
-      },
-      include: {
-        paymentAllocations: true,
-      },
-    });
-
-    if (!payment) {
-      throw new NotFoundException('Payment not found');
-    }
-
-    // Validate current status
-    if (payment.status !== PaymentStatus.SUBMITTED) {
-      throw new BadRequestException(
-        `Cannot approve payment in status ${payment.status}. Only SUBMITTED payments can be approved.`,
-      );
-    }
-
-    if (payment.canceledAt) {
-      throw new BadRequestException('Cannot approve a canceled payment');
-    }
-
     // Execute approval with either explicit resident allocation or legacy FIFO allocation
     let approvedPaymentResult: Payment | null = null;
 
     await this.prisma.$transaction(async (tx) => {
+      const payment = await this.lockSubmittedPaymentForApproval(tx, tenantId, paymentId);
+
+      if (payment.status !== PaymentStatus.SUBMITTED) {
+        throw new BadRequestException(
+          `Cannot approve payment in status ${payment.status}. Only SUBMITTED payments can be approved.`,
+        );
+      }
+
+      if (payment.canceledAt) {
+        throw new BadRequestException('Cannot approve a canceled payment');
+      }
+
       if (payment.paymentAllocations.length > 0) {
         const totalAllocated = payment.paymentAllocations.reduce(
           (sum, allocation) => sum + allocation.amount,
@@ -2627,7 +2647,7 @@ export class FinanzasService {
         }
 
         const approvedPayment = await tx.payment.update({
-          where: { id: paymentId },
+          where: { id: payment.id },
           data: {
             status: PaymentStatus.APPROVED,
             reviewedByMembershipId: membershipId,
@@ -2643,16 +2663,16 @@ export class FinanzasService {
           await this.recalculateChargeStatus(allocation.chargeId, tx);
         }
 
-        await this.tryReconcilePayment(paymentId, tx);
+        await this.tryReconcilePayment(payment.id, tx);
         const reconciledPayment = await tx.payment.findUnique({
-          where: { id: paymentId },
+          where: { id: payment.id },
         });
         if (reconciledPayment) {
           approvedPaymentResult = reconciledPayment;
         }
       } else {
         const approvedPayment = await tx.payment.update({
-          where: { id: paymentId },
+          where: { id: payment.id },
           data: {
             status: PaymentStatus.APPROVED,
             reviewedByMembershipId: membershipId,
@@ -2754,9 +2774,9 @@ export class FinanzasService {
           }
         }
 
-        await this.tryReconcilePayment(paymentId, tx);
+        await this.tryReconcilePayment(payment.id, tx);
         const reconciledPayment = await tx.payment.findUnique({
-          where: { id: paymentId },
+          where: { id: payment.id },
         });
         if (reconciledPayment) {
           approvedPaymentResult = reconciledPayment;

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -1002,26 +1002,50 @@ export class FinanzasService {
       );
     }
 
-    // 3. Update to REJECTED
-    const result = await this.prisma.payment.update({
-      where: { id: paymentId },
-      data: {
-        status: PaymentStatus.REJECTED,
-        reviewedByMembershipId: membershipId,
-        updatedAt: new Date(),
-      },
-    });
+    if (payment.status !== PaymentStatus.SUBMITTED) {
+      throw new BadRequestException(
+        `Cannot reject payment in status ${payment.status}. Only SUBMITTED payments can be rejected.`,
+      );
+    }
 
-    // Audit: PAYMENT_REJECT
-    void this.auditService.createLog({
-      tenantId,
-      actorUserId: membershipId,
-      action: AuditAction.PAYMENT_REJECT,
-      entityType: 'Payment',
-      entityId: paymentId,
-      metadata: {
-        reason: dto.reason,
-      },
+    if (payment.canceledAt) {
+      throw new BadRequestException('Cannot reject a canceled payment');
+    }
+
+    const result = await this.prisma.$transaction(async (tx) => {
+      const chargeIds = await this.releaseSubmittedPaymentAllocations(tx, paymentId, tenantId);
+
+      const rejectedPayment = await tx.payment.update({
+        where: { id: paymentId },
+        data: {
+          status: PaymentStatus.REJECTED,
+          reviewedByMembershipId: membershipId,
+          updatedAt: new Date(),
+        },
+      });
+
+      for (const chargeId of chargeIds) {
+        await this.recalculateChargeStatus(chargeId, tx);
+      }
+
+      await tx.paymentAuditLog.create({
+        data: {
+          tenantId,
+          paymentId,
+          action: PaymentAuditAction.REJECTED,
+          membershipId,
+          reason: dto.reason,
+          comment: dto.comment || null,
+          metadata: {
+            amount: payment.amount,
+            currency: payment.currency,
+            method: payment.method,
+            reference: payment.reference,
+          },
+        },
+      });
+
+      return rejectedPayment;
     });
 
     // [PHASE 2 QUICK #4] Send PAYMENT_REJECTED notification
@@ -1309,6 +1333,35 @@ export class FinanzasService {
         },
       });
     }
+  }
+
+  private async releaseSubmittedPaymentAllocations(
+    tx: Prisma.TransactionClient,
+    paymentId: string,
+    tenantId: string,
+  ): Promise<string[]> {
+    const allocations = await tx.paymentAllocation.findMany({
+      where: {
+        tenantId,
+        paymentId,
+      },
+      select: {
+        chargeId: true,
+      },
+    });
+
+    if (allocations.length === 0) {
+      return [];
+    }
+
+    await tx.paymentAllocation.deleteMany({
+      where: {
+        tenantId,
+        paymentId,
+      },
+    });
+
+    return [...new Set(allocations.map((allocation) => allocation.chargeId))];
   }
 
   private calculateApprovedChargeOutstanding(charge: ChargeWithAllocations): number {
@@ -2039,31 +2092,44 @@ export class FinanzasService {
       );
     }
 
-    // 3. Cannot cancel if has allocations
     const allocationCount = await this.prisma.paymentAllocation.count({
       where: { tenantId, paymentId },
     });
 
-    if (allocationCount > 0) {
+    if (payment.status !== PaymentStatus.SUBMITTED && allocationCount > 0) {
       throw new ConflictException(
         `Cannot cancel payment with existing allocations. Remove allocations first.`,
       );
     }
 
-    // 4. Update canceledAt
-    const result = await this.prisma.payment.update({
-      where: { id: paymentId },
-      data: { canceledAt: new Date(), updatedAt: new Date() },
-    });
+    const result = await this.prisma.$transaction(async (tx) => {
+      const chargeIds =
+        payment.status === PaymentStatus.SUBMITTED
+          ? await this.releaseSubmittedPaymentAllocations(tx, paymentId, tenantId)
+          : [];
 
-    // Audit
-    void this.auditService.createLog({
-      tenantId,
-      actorUserId: membershipId,
-      action: AuditAction.PAYMENT_CANCEL,
-      entityType: 'Payment',
-      entityId: paymentId,
-      metadata: { reason: reason || 'No reason provided' },
+      const canceledPayment = await tx.payment.update({
+        where: { id: paymentId },
+        data: { canceledAt: new Date(), updatedAt: new Date() },
+      });
+
+      for (const chargeId of chargeIds) {
+        await this.recalculateChargeStatus(chargeId, tx);
+      }
+
+      await tx.paymentAuditLog.create({
+        data: {
+          tenantId,
+          paymentId,
+          action: PaymentAuditAction.CANCELLED,
+          membershipId,
+          reason: reason || 'No reason provided',
+          comment: null,
+          metadata: { reason: reason || 'No reason provided' },
+        },
+      });
+
+      return canceledPayment;
     });
 
     return result;
@@ -2770,36 +2836,44 @@ export class FinanzasService {
       throw new BadRequestException('Cannot reject a canceled payment');
     }
 
-    // Update payment status with full audit trail
-    const rejectedPayment = await this.prisma.payment.update({
-      where: { id: paymentId },
-      data: {
-        status: PaymentStatus.REJECTED,
-        reviewedByMembershipId: membershipId,
-        rejectionReason: dto.reason as RejectionReason,
-        rejectionComment: dto.comment || null,
-        reviewedAt: new Date(),
-        notes: dto.notes || null,
-        updatedAt: new Date(),
-      },
-    });
+    const rejectedPayment = await this.prisma.$transaction(async (tx) => {
+      const chargeIds = await this.releaseSubmittedPaymentAllocations(tx, paymentId, tenantId);
 
-    // Registrar auditoría
-    await this.prisma.paymentAuditLog.create({
-      data: {
-        tenantId,
-        paymentId,
-        action: PaymentAuditAction.REJECTED,
-        membershipId,
-        reason: dto.reason,
-        comment: dto.comment || null,
-        metadata: {
-          amount: payment.amount,
-          currency: payment.currency,
-          method: payment.method,
-          reference: payment.reference,
+      const updatedPayment = await tx.payment.update({
+        where: { id: paymentId },
+        data: {
+          status: PaymentStatus.REJECTED,
+          reviewedByMembershipId: membershipId,
+          rejectionReason: dto.reason as RejectionReason,
+          rejectionComment: dto.comment || null,
+          reviewedAt: new Date(),
+          notes: dto.notes || null,
+          updatedAt: new Date(),
         },
-      },
+      });
+
+      for (const chargeId of chargeIds) {
+        await this.recalculateChargeStatus(chargeId, tx);
+      }
+
+      await tx.paymentAuditLog.create({
+        data: {
+          tenantId,
+          paymentId,
+          action: PaymentAuditAction.REJECTED,
+          membershipId,
+          reason: dto.reason,
+          comment: dto.comment || null,
+          metadata: {
+            amount: payment.amount,
+            currency: payment.currency,
+            method: payment.method,
+            reference: payment.reference,
+          },
+        },
+      });
+
+      return updatedPayment;
     });
 
     // Send notification to resident

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, ConflictException, NotFoundException, BadRequestException, Logger } from '@nestjs/common';
+import { Injectable, ConflictException, NotFoundException, BadRequestException, Logger, PayloadTooLargeException } from '@nestjs/common';
 import { Charge, Payment, PaymentAllocation, Prisma, ChargeStatus, PaymentStatus, PaymentMethod, AuditAction, PaymentAuditAction, RejectionReason, ReceiptStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
@@ -88,6 +88,9 @@ type PaymentWithAllocations = Prisma.PaymentGetPayload<{
     };
   };
 }>;
+
+const RESIDENT_DIRECTED_PAYMENT_PREFIX = 'resident-charge-selection-requires-resubmission';
+const PAYMENT_PROOF_MAX_BYTES = 10 * 1024 * 1024;
 
 @Injectable()
 export class FinanzasService {
@@ -519,6 +522,7 @@ export class FinanzasService {
         'Los pagos por transferencia requieren subir el comprobante de pago',
       );
     }
+    await this.validatePaymentProofFile(tenantId, dto.proofFileId);
 
     if (isResidentPayment) {
       const payment = await this.prisma.$transaction(async (tx) => {
@@ -581,6 +585,7 @@ export class FinanzasService {
             reference: dto.reference,
             proofFileId: dto.proofFileId || null,
             createdByUserId: userId,
+            notes: this.createResidentDirectedPaymentMarker(),
           },
         });
 
@@ -597,7 +602,7 @@ export class FinanzasService {
       });
 
       void this.notifyAdminsOfPaymentSubmitted(tenantId, payment);
-      return payment;
+      return this.sanitizePaymentForResponse(payment);
     }
 
     // 8. Create payment with SUBMITTED status
@@ -619,7 +624,7 @@ export class FinanzasService {
     // 9. Notify admins about new payment submitted
     void this.notifyAdminsOfPaymentSubmitted(tenantId, payment);
 
-    return payment;
+    return this.sanitizePaymentForResponse(payment);
   }
 
   /**
@@ -723,7 +728,7 @@ export class FinanzasService {
       }))
     );
 
-    return resolvedPayments as Payment[];
+    return resolvedPayments.map((payment) => this.sanitizePaymentForResponse(payment)) as Payment[];
   }
 
   /**
@@ -957,7 +962,7 @@ export class FinanzasService {
       this.logger.error(`Failed to generate receipt for payment ${paymentId}: ${err.message}`);
     });
 
-    return result;
+    return this.sanitizePaymentForResponse(result);
   }
 
   /**
@@ -974,38 +979,34 @@ export class FinanzasService {
     membershipId: string,
     dto: RejectPaymentDto,
   ): Promise<Payment> {
-    // 1. Permission check
     if (!this.validators.canReviewPayments(userRoles)) {
       this.validators.throwForbidden('payments', 'reject');
     }
 
-    // 2. Validate payment
-    const payment = await this.prisma.payment.findFirst({
-      where: {
-        id: paymentId,
-        tenantId,
-        buildingId,
-      },
-    });
-
-    if (!payment) {
-      throw new NotFoundException(
-        `Payment not found or does not belong to this building/tenant`,
-      );
-    }
-
-    if (payment.status !== PaymentStatus.SUBMITTED) {
-      throw new BadRequestException(
-        `Cannot reject payment in status ${payment.status}. Only SUBMITTED payments can be rejected.`,
-      );
-    }
-
-    if (payment.canceledAt) {
-      throw new BadRequestException('Cannot reject a canceled payment');
-    }
-
     const result = await this.prisma.$transaction(async (tx) => {
-      const chargeIds = await this.releaseSubmittedPaymentAllocations(tx, paymentId, tenantId);
+      const payment = await this.lockSubmittedPaymentForApproval(
+        tx,
+        tenantId,
+        paymentId,
+        buildingId,
+      );
+
+      if (payment.status !== PaymentStatus.SUBMITTED) {
+        throw new BadRequestException(
+          `Cannot reject payment in status ${payment.status}. Only SUBMITTED payments can be rejected.`,
+        );
+      }
+
+      if (payment.canceledAt) {
+        throw new BadRequestException('Cannot reject a canceled payment');
+      }
+
+      const releasedAllocations = await this.releaseSubmittedPaymentAllocations(
+        tx,
+        paymentId,
+        tenantId,
+      );
+      const chargeIds = releasedAllocations.map((allocation) => allocation.chargeId);
 
       const rejectedPayment = await tx.payment.update({
         where: { id: paymentId },
@@ -1015,7 +1016,7 @@ export class FinanzasService {
           rejectionReason: dto.reason as RejectionReason,
           rejectionComment: dto.comment || null,
           reviewedAt: new Date(),
-          notes: dto.notes || null,
+          notes: this.mergeResidentResubmissionMarker(payment.notes, dto.notes),
           updatedAt: new Date(),
         },
       });
@@ -1044,10 +1045,9 @@ export class FinanzasService {
       return rejectedPayment;
     });
 
-    // [PHASE 2 QUICK #4] Send PAYMENT_REJECTED notification
-    void this.sendPaymentRejectedNotification(tenantId, payment, dto.reason);
+    void this.sendPaymentRejectedNotification(tenantId, result, dto.reason);
 
-    return result;
+    return this.sanitizePaymentForResponse(result);
   }
 
   // ============================================================================
@@ -1335,7 +1335,7 @@ export class FinanzasService {
     tx: Prisma.TransactionClient,
     paymentId: string,
     tenantId: string,
-  ): Promise<string[]> {
+  ): Promise<Array<{ chargeId: string; amount: number }>> {
     const allocations = await tx.paymentAllocation.findMany({
       where: {
         tenantId,
@@ -1343,6 +1343,7 @@ export class FinanzasService {
       },
       select: {
         chargeId: true,
+        amount: true,
       },
     });
 
@@ -1357,7 +1358,72 @@ export class FinanzasService {
       },
     });
 
-    return [...new Set(allocations.map((allocation) => allocation.chargeId))];
+    return allocations;
+  }
+
+  private async validatePaymentProofFile(
+    tenantId: string,
+    proofFileId: string,
+  ): Promise<void> {
+    const proofFile = await this.prisma.file.findFirst({
+      where: { id: proofFileId, tenantId },
+      select: { id: true, size: true },
+    });
+
+    if (!proofFile) {
+      throw new NotFoundException('El comprobante de pago no existe en este tenant');
+    }
+
+    if (proofFile.size <= 0) {
+      throw new BadRequestException('El comprobante de pago no puede estar vacío');
+    }
+
+    if (proofFile.size > PAYMENT_PROOF_MAX_BYTES) {
+      throw new PayloadTooLargeException('El comprobante de pago supera el máximo de 10 MB');
+    }
+  }
+
+  private createResidentDirectedPaymentMarker(): string {
+    return RESIDENT_DIRECTED_PAYMENT_PREFIX;
+  }
+
+  private hasResidentDirectedPaymentMarker(notes: string | null | undefined): boolean {
+    return notes?.split('\n').some((line) => line === RESIDENT_DIRECTED_PAYMENT_PREFIX) ?? false;
+  }
+
+  private mergeResidentResubmissionMarker(
+    existingNotes: string | null | undefined,
+    reviewerNotes: string | undefined,
+  ): string | null {
+    if (!this.hasResidentDirectedPaymentMarker(existingNotes)) {
+      return reviewerNotes || null;
+    }
+
+    return reviewerNotes
+      ? `${RESIDENT_DIRECTED_PAYMENT_PREFIX}\n${reviewerNotes}`
+      : RESIDENT_DIRECTED_PAYMENT_PREFIX;
+  }
+
+  private stripInternalPaymentMarkers(notes: string | null | undefined): string | null {
+    if (!notes) {
+      return null;
+    }
+
+    const publicNotes = notes
+      .split('\n')
+      .filter((line) => line !== RESIDENT_DIRECTED_PAYMENT_PREFIX)
+      .join('\n');
+
+    return publicNotes || null;
+  }
+
+  private sanitizePaymentForResponse<T extends { notes?: string | null }>(payment: T): T {
+    const publicNotes = this.stripInternalPaymentMarkers(payment.notes);
+    const { notes: _internalNotes, ...publicPayment } = payment;
+
+    return (publicNotes === null
+      ? publicPayment
+      : { ...publicPayment, notes: publicNotes }) as T;
   }
 
   private calculateApprovedChargeOutstanding(charge: ChargeWithAllocations): number {
@@ -2000,30 +2066,36 @@ export class FinanzasService {
       this.validators.throwForbidden('payments', 'revive');
     }
 
-    // 2. Validate payment
-    const payment = await this.prisma.payment.findFirst({
-      where: { id: paymentId, tenantId, buildingId },
-    });
-
-    if (!payment) {
-      throw new NotFoundException(
-        `Payment not found or does not belong to this building/tenant`,
+    const result = await this.prisma.$transaction(async (tx) => {
+      const payment = await this.lockSubmittedPaymentForApproval(
+        tx,
+        tenantId,
+        paymentId,
+        buildingId,
       );
-    }
 
-    // 3. Validate status is REJECTED
-    if (payment.status !== PaymentStatus.REJECTED) {
-      throw new ConflictException(`Only REJECTED payments can be revived`);
-    }
+      if (payment.status !== PaymentStatus.REJECTED) {
+        throw new ConflictException('Only REJECTED payments can be revived');
+      }
 
-    // 4. Update to SUBMITTED
-    const result = await this.prisma.payment.update({
-      where: { id: paymentId },
-      data: {
-        status: PaymentStatus.SUBMITTED,
-        reviewedByMembershipId: null,
-        updatedAt: new Date(),
-      },
+      if (payment.canceledAt) {
+        throw new ConflictException('No se puede reactivar un pago cancelado');
+      }
+
+      if (this.hasResidentDirectedPaymentMarker(payment.notes)) {
+        throw new BadRequestException(
+          'No se puede reactivar este pago porque perdió la asociación con el cargo seleccionado. El residente debe reportarlo nuevamente.',
+        );
+      }
+
+      return tx.payment.update({
+        where: { id: payment.id },
+        data: {
+          status: PaymentStatus.SUBMITTED,
+          reviewedByMembershipId: null,
+          updatedAt: new Date(),
+        },
+      });
     });
 
     // Audit
@@ -2036,7 +2108,7 @@ export class FinanzasService {
       metadata: { action: 'REVIVED', previousStatus: 'REJECTED' },
     });
 
-    return result;
+    return this.sanitizePaymentForResponse(result);
   }
 
   /**
@@ -2096,7 +2168,7 @@ export class FinanzasService {
       );
     }
 
-    return payment as Payment & { paymentAllocations: PaymentAllocation[] };
+    return this.sanitizePaymentForResponse(payment) as Payment & { paymentAllocations: PaymentAllocation[] };
   }
 
   /**
@@ -2141,10 +2213,11 @@ export class FinanzasService {
     }
 
     const result = await this.prisma.$transaction(async (tx) => {
-      const chargeIds =
+      const releasedAllocations =
         payment.status === PaymentStatus.SUBMITTED
           ? await this.releaseSubmittedPaymentAllocations(tx, paymentId, tenantId)
           : [];
+      const chargeIds = releasedAllocations.map((allocation) => allocation.chargeId);
 
       const canceledPayment = await tx.payment.update({
         where: { id: paymentId },
@@ -2170,7 +2243,7 @@ export class FinanzasService {
       return canceledPayment;
     });
 
-    return result;
+    return this.sanitizePaymentForResponse(result);
   }
 
   /**
@@ -2559,7 +2632,7 @@ export class FinanzasService {
       }))
     );
 
-    return resolvedPayments as PendingPaymentListItem[];
+    return resolvedPayments.map((payment) => this.sanitizePaymentForResponse(payment)) as PendingPaymentListItem[];
   }
 
   /**
@@ -2814,7 +2887,7 @@ export class FinanzasService {
       });
     }
 
-    return approvedPaymentResult!;
+    return this.sanitizePaymentForResponse(approvedPaymentResult!);
   }
 
   /**
@@ -2827,43 +2900,39 @@ export class FinanzasService {
     membershipId: string,
     dto: RejectPaymentDto,
   ): Promise<Payment> {
-    // Permission check
     if (!this.validators.canReviewPayments(userRoles)) {
       this.validators.throwForbidden('payments', 'reject');
     }
 
-    // Validate reason
     if (!dto.reason || dto.reason.trim().length === 0) {
       throw new BadRequestException('Rejection reason is required');
     }
 
-    // Find payment - tenant level (any building)
-    const payment = await this.prisma.payment.findFirst({
-      where: {
-        id: paymentId,
+    const result = await this.prisma.$transaction(async (tx) => {
+      const payment = await this.lockSubmittedPaymentForApproval(
+        tx,
         tenantId,
-      },
-    });
-
-    if (!payment) {
-      throw new NotFoundException('Payment not found');
-    }
-
-    // Validate current status
-    if (payment.status !== PaymentStatus.SUBMITTED) {
-      throw new BadRequestException(
-        `Cannot reject payment in status ${payment.status}. Only SUBMITTED payments can be rejected.`,
+        paymentId,
       );
-    }
 
-    if (payment.canceledAt) {
-      throw new BadRequestException('Cannot reject a canceled payment');
-    }
+      if (payment.status !== PaymentStatus.SUBMITTED) {
+        throw new BadRequestException(
+          `Cannot reject payment in status ${payment.status}. Only SUBMITTED payments can be rejected.`,
+        );
+      }
 
-    const rejectedPayment = await this.prisma.$transaction(async (tx) => {
-      const chargeIds = await this.releaseSubmittedPaymentAllocations(tx, paymentId, tenantId);
+      if (payment.canceledAt) {
+        throw new BadRequestException('Cannot reject a canceled payment');
+      }
 
-      const updatedPayment = await tx.payment.update({
+      const releasedAllocations = await this.releaseSubmittedPaymentAllocations(
+        tx,
+        paymentId,
+        tenantId,
+      );
+      const chargeIds = releasedAllocations.map((allocation) => allocation.chargeId);
+
+      const rejectedPayment = await tx.payment.update({
         where: { id: paymentId },
         data: {
           status: PaymentStatus.REJECTED,
@@ -2871,7 +2940,7 @@ export class FinanzasService {
           rejectionReason: dto.reason as RejectionReason,
           rejectionComment: dto.comment || null,
           reviewedAt: new Date(),
-          notes: dto.notes || null,
+          notes: this.mergeResidentResubmissionMarker(payment.notes, dto.notes),
           updatedAt: new Date(),
         },
       });
@@ -2897,13 +2966,12 @@ export class FinanzasService {
         },
       });
 
-      return updatedPayment;
+      return rejectedPayment;
     });
 
-    // Send notification to resident
-    void this.sendPaymentRejectedNotification(tenantId, payment, dto.reason);
+    void this.sendPaymentRejectedNotification(tenantId, result, dto.reason);
 
-    return rejectedPayment;
+    return this.sanitizePaymentForResponse(result);
   }
 
   // ============================================================================

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -863,7 +863,17 @@ export class FinanzasService {
             status: { notIn: [ChargeStatus.PAID, ChargeStatus.CANCELED] },
             canceledAt: null,
           },
-          include: { paymentAllocations: true },
+          include: {
+            paymentAllocations: {
+              include: {
+                payment: {
+                  select: {
+                    status: true,
+                  },
+                },
+              },
+            },
+          },
           orderBy: { dueDate: 'asc' },
         });
 
@@ -873,7 +883,8 @@ export class FinanzasService {
           if (remainingAmount <= 0) break;
 
           const alreadyAllocated = charge.paymentAllocations.reduce(
-            (sum, a) => sum + a.amount,
+            (sum, a) =>
+              sum + (this.isEffectivePaymentStatus(a.payment?.status) ? a.amount : 0),
             0,
           );
           const outstanding = charge.amount - alreadyAllocated;
@@ -1244,11 +1255,7 @@ export class FinanzasService {
 
     const allocationsSum = charge.paymentAllocations.reduce(
       (sum, a) => {
-        const status = a.payment?.status;
-        if (
-          status === PaymentStatus.APPROVED ||
-          status === PaymentStatus.RECONCILED
-        ) {
+        if (this.isEffectivePaymentStatus(a.payment?.status)) {
           return sum + a.amount;
         }
         return sum;
@@ -1278,8 +1285,7 @@ export class FinanzasService {
 
   private calculateApprovedChargeOutstanding(charge: ChargeWithAllocations): number {
     const approvedAllocated = charge.paymentAllocations.reduce((sum, allocation) => {
-      const status = allocation.payment?.status;
-      if (status === PaymentStatus.APPROVED || status === PaymentStatus.RECONCILED) {
+      if (this.isEffectivePaymentStatus(allocation.payment?.status)) {
         return sum + allocation.amount;
       }
 
@@ -1287,6 +1293,10 @@ export class FinanzasService {
     }, 0);
 
     return Math.max(0, charge.amount - approvedAllocated);
+  }
+
+  private isEffectivePaymentStatus(status?: PaymentStatus | null): boolean {
+    return status === PaymentStatus.APPROVED || status === PaymentStatus.RECONCILED;
   }
 
   // ============================================================================
@@ -1350,12 +1360,7 @@ export class FinanzasService {
     // 3. Calculate totals using approved/reconciled payments across ALL charges
     const chargesAnnotated = charges.map((c) => {
       const allocated = c.paymentAllocations.reduce((asum, a) => {
-        return asum +
-          (a.payment &&
-          (a.payment.status === PaymentStatus.APPROVED ||
-            a.payment.status === PaymentStatus.RECONCILED)
-            ? a.amount
-            : 0);
+        return asum + (this.isEffectivePaymentStatus(a.payment?.status) ? a.amount : 0);
       }, 0);
 
       return {
@@ -1728,8 +1733,7 @@ export class FinanzasService {
     // and only for charges with real outstanding > 0.
     const chargesWithApprovedAllocated = charges.map((charge) => {
       const approvedAllocated = charge.paymentAllocations.reduce((sum, allocation) => {
-        const status = allocation.payment?.status;
-        if (status === PaymentStatus.APPROVED || status === PaymentStatus.RECONCILED) {
+        if (this.isEffectivePaymentStatus(allocation.payment?.status)) {
           return sum + allocation.amount;
         }
         return sum;
@@ -2090,12 +2094,7 @@ export class FinanzasService {
     // 3. Calculate totals using the original charge amount and the approved allocations
     const chargesAnnotated = charges.map((c) => {
       const allocated = c.paymentAllocations.reduce((asum, a) => {
-        return asum +
-          (a.payment &&
-          (a.payment.status === PaymentStatus.APPROVED ||
-            a.payment.status === PaymentStatus.RECONCILED)
-            ? a.amount
-            : 0);
+        return asum + (this.isEffectivePaymentStatus(a.payment?.status) ? a.amount : 0);
       }, 0);
 
       return {
@@ -2560,6 +2559,17 @@ export class FinanzasService {
               status: { in: [ChargeStatus.PENDING, ChargeStatus.PARTIAL] },
               canceledAt: null,
             },
+            include: {
+              paymentAllocations: {
+                include: {
+                  payment: {
+                    select: {
+                      status: true,
+                    },
+                  },
+                },
+              },
+            },
             orderBy: { dueDate: 'asc' },
           });
 
@@ -2569,11 +2579,13 @@ export class FinanzasService {
             if (remainingAmount <= 0) break;
 
             const allocatedAmount = Math.min(remainingAmount, charge.amount);
-            const existingAllocations = await tx.paymentAllocation.aggregate({
-              where: { chargeId: charge.id },
-              _sum: { amount: true },
-            });
-            const alreadyAllocated = existingAllocations._sum.amount || 0;
+            const alreadyAllocated = charge.paymentAllocations.reduce((sum, allocation) => {
+              if (this.isEffectivePaymentStatus(allocation.payment?.status)) {
+                return sum + allocation.amount;
+              }
+
+              return sum;
+            }, 0);
             const chargeRemaining = charge.amount - alreadyAllocated;
 
             const allocationAmount = Math.min(allocatedAmount, chargeRemaining);

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -2191,28 +2191,30 @@ export class FinanzasService {
       this.validators.throwForbidden('payments', 'cancel');
     }
 
-    // 2. Validate payment (only active payments)
-    const payment = await this.prisma.payment.findFirst({
-      where: { id: paymentId, tenantId, buildingId, canceledAt: null },
-    });
-
-    if (!payment) {
-      throw new NotFoundException(
-        `Payment not found or does not belong to this building/tenant`,
-      );
-    }
-
-    const allocationCount = await this.prisma.paymentAllocation.count({
-      where: { tenantId, paymentId },
-    });
-
-    if (payment.status !== PaymentStatus.SUBMITTED && allocationCount > 0) {
-      throw new ConflictException(
-        `Cannot cancel payment with existing allocations. Remove allocations first.`,
-      );
-    }
-
     const result = await this.prisma.$transaction(async (tx) => {
+      const payment = await this.lockSubmittedPaymentForApproval(
+        tx,
+        tenantId,
+        paymentId,
+        buildingId,
+      );
+
+      if (payment.canceledAt) {
+        throw new NotFoundException(
+          `Payment not found or does not belong to this building/tenant`,
+        );
+      }
+
+      const allocationCount = await tx.paymentAllocation.count({
+        where: { tenantId, paymentId },
+      });
+
+      if (payment.status !== PaymentStatus.SUBMITTED && allocationCount > 0) {
+        throw new ConflictException(
+          `Cannot cancel payment with existing allocations. Remove allocations first.`,
+        );
+      }
+
       const releasedAllocations =
         payment.status === PaymentStatus.SUBMITTED
           ? await this.releaseSubmittedPaymentAllocations(tx, paymentId, tenantId)

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -1020,6 +1020,10 @@ export class FinanzasService {
         data: {
           status: PaymentStatus.REJECTED,
           reviewedByMembershipId: membershipId,
+          rejectionReason: dto.reason as RejectionReason,
+          rejectionComment: dto.comment || null,
+          reviewedAt: new Date(),
+          notes: dto.notes || null,
           updatedAt: new Date(),
         },
       });

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -507,6 +507,16 @@ export class FinanzasService {
         reference: dto.reference,
         createdAt: { gte: duplicateWindow },
         status: { in: [PaymentStatus.SUBMITTED, PaymentStatus.APPROVED] },
+        ...(isResidentPayment
+          ? {
+              paymentAllocations: {
+                some: {
+                  tenantId,
+                  chargeId: dto.chargeId!,
+                },
+              },
+            }
+          : {}),
       },
     });
 

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -2572,6 +2572,14 @@ export class FinanzasService {
         for (const allocation of payment.paymentAllocations) {
           await this.recalculateChargeStatus(allocation.chargeId, tx);
         }
+
+        await this.tryReconcilePayment(paymentId, tx);
+        const reconciledPayment = await tx.payment.findUnique({
+          where: { id: paymentId },
+        });
+        if (reconciledPayment) {
+          approvedPaymentResult = reconciledPayment;
+        }
       } else {
         const approvedPayment = await tx.payment.update({
           where: { id: paymentId },
@@ -2674,6 +2682,14 @@ export class FinanzasService {
               remainingAmount -= allocationAmount;
             }
           }
+        }
+
+        await this.tryReconcilePayment(paymentId, tx);
+        const reconciledPayment = await tx.payment.findUnique({
+          where: { id: paymentId },
+        });
+        if (reconciledPayment) {
+          approvedPaymentResult = reconciledPayment;
         }
       }
 

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -499,6 +499,7 @@ export class FinanzasService {
       where: {
         tenantId,
         buildingId,
+        unitId: dto.unitId ?? undefined,
         amount: dto.amount,
         reference: dto.reference,
         createdAt: { gte: duplicateWindow },
@@ -784,6 +785,7 @@ export class FinanzasService {
         }
 
         for (const allocation of payment.paymentAllocations) {
+          await this.lockChargeForApproval(tx, allocation.chargeId);
           const charge = await tx.charge.findFirst({
             where: {
               id: allocation.chargeId,
@@ -879,8 +881,34 @@ export class FinanzasService {
 
         let remainingAmount = payment.amount;
 
-        for (const charge of pendingCharges) {
+        for (const pendingCharge of pendingCharges) {
           if (remainingAmount <= 0) break;
+
+          await this.lockChargeForApproval(tx, pendingCharge.id);
+          const charge = await tx.charge.findFirst({
+            where: {
+              id: pendingCharge.id,
+              tenantId,
+              buildingId,
+              unitId: payment.unitId,
+              canceledAt: null,
+            },
+            include: {
+              paymentAllocations: {
+                include: {
+                  payment: {
+                    select: {
+                      status: true,
+                    },
+                  },
+                },
+              },
+            },
+          });
+
+          if (!charge) {
+            continue;
+          }
 
           const alreadyAllocated = charge.paymentAllocations.reduce(
             (sum, a) =>
@@ -1293,6 +1321,13 @@ export class FinanzasService {
     }, 0);
 
     return Math.max(0, charge.amount - approvedAllocated);
+  }
+
+  private async lockChargeForApproval(
+    tx: Prisma.TransactionClient,
+    chargeId: string,
+  ): Promise<void> {
+    await tx.$queryRaw(Prisma.sql`SELECT 1 FROM "Charge" WHERE id = ${chargeId} FOR UPDATE`);
   }
 
   private isEffectivePaymentStatus(status?: PaymentStatus | null): boolean {
@@ -2481,6 +2516,7 @@ export class FinanzasService {
         }
 
         for (const allocation of payment.paymentAllocations) {
+          await this.lockChargeForApproval(tx, allocation.chargeId);
           const charge = await tx.charge.findFirst({
             where: {
               id: allocation.chargeId,
@@ -2575,8 +2611,34 @@ export class FinanzasService {
 
           let remainingAmount = payment.amount;
 
-          for (const charge of pendingCharges) {
+          for (const pendingCharge of pendingCharges) {
             if (remainingAmount <= 0) break;
+
+            await this.lockChargeForApproval(tx, pendingCharge.id);
+            const charge = await tx.charge.findFirst({
+              where: {
+                id: pendingCharge.id,
+                tenantId,
+                buildingId: payment.buildingId,
+                unitId: payment.unitId,
+                canceledAt: null,
+              },
+              include: {
+                paymentAllocations: {
+                  include: {
+                    payment: {
+                      select: {
+                        status: true,
+                      },
+                    },
+                  },
+                },
+              },
+            });
+
+            if (!charge) {
+              continue;
+            }
 
             const allocatedAmount = Math.min(remainingAmount, charge.amount);
             const alreadyAllocated = charge.paymentAllocations.reduce((sum, allocation) => {
@@ -2923,6 +2985,7 @@ export class FinanzasService {
       where: {
         tenantId,
         id: { not: paymentId }, // Exclude self
+        unitId: payment.unitId ?? undefined,
         amount: payment.amount,
         reference: payment.reference,
         createdAt: { gte: duplicateWindow },

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -1,6 +1,6 @@
 import { PaymentReceiptService } from './payment-receipt.service';
 import { ReceiptStatus } from '@prisma/client';
-import { execFileSync } from 'node:child_process';
+import { execFileSync, spawnSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 
 describe('PaymentReceiptService', () => {
@@ -130,13 +130,10 @@ describe('PaymentReceiptService', () => {
     expect(normalizedPdfText).toContain('ARS 40.500,00');
     writeFileSync(tmpReceiptPath, uploadedBuffer);
     expect(execFileSync('file', [tmpReceiptPath], { encoding: 'utf8' })).toContain('PDF document');
-    try {
-      const pdfInfo = execFileSync('pdfinfo', [tmpReceiptPath], { encoding: 'utf8' });
-      expect(pdfInfo).toContain('Pages:');
-    } catch (error) {
-      if (!(error instanceof Error) || !('code' in error) || (error as NodeJS.ErrnoException).code !== 'ENOENT') {
-        throw error;
-      }
+    const pdfInfo = spawnSync('pdfinfo', [tmpReceiptPath], { encoding: 'utf8' });
+    if (!pdfInfo.error || (pdfInfo.error as NodeJS.ErrnoException).code !== 'ENOENT') {
+      expect(pdfInfo.status).toBe(0);
+      expect(pdfInfo.stdout).toContain('Pages:');
     }
     expect(prisma.file.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -6,6 +6,35 @@ import { writeFileSync } from 'node:fs';
 describe('PaymentReceiptService', () => {
   const DEFAULT_BUCKET = 'buildingos-test';
   const RECEIPT_MAX_TEXT_WIDTH = 595 - 72 - 72;
+  const WIN_ANSI_DECODE_MAP: Record<number, string> = {
+    0x80: '€',
+    0x82: '‚',
+    0x83: 'ƒ',
+    0x84: '„',
+    0x85: '…',
+    0x86: '†',
+    0x87: '‡',
+    0x88: 'ˆ',
+    0x89: '‰',
+    0x8a: 'Š',
+    0x8b: '‹',
+    0x8c: 'Œ',
+    0x8e: 'Ž',
+    0x91: '‘',
+    0x92: '’',
+    0x93: '“',
+    0x94: '”',
+    0x95: '•',
+    0x96: '–',
+    0x97: '—',
+    0x98: '˜',
+    0x99: '™',
+    0x9a: 'š',
+    0x9b: '›',
+    0x9c: 'œ',
+    0x9e: 'ž',
+    0x9f: 'Ÿ',
+  };
 
   const prisma = {
     payment: {
@@ -58,6 +87,17 @@ describe('PaymentReceiptService', () => {
         .replace(/\\\)/g, ')')
         .replace(/\\\\/g, '\\'),
     );
+  }
+
+  function decodeWinAnsiText(text: string): string {
+    return Array.from(text, (character) => {
+      const code = character.charCodeAt(0);
+      return WIN_ANSI_DECODE_MAP[code] ?? character;
+    }).join('');
+  }
+
+  function extractDecodedPdfTextLines(buffer: Buffer): string[] {
+    return extractPdfTextLines(buffer).map(decodeWinAnsiText);
   }
 
   function measureReceiptTextWidth(text: string): number {
@@ -256,6 +296,92 @@ describe('PaymentReceiptService', () => {
       3600,
     );
     expect(result?.fileKey).toContain('/receipt_R-');
+  });
+
+  it('encodes WinAnsi punctuation and falls back safely for unsupported characters', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({
+      name: 'Consorcio “Central”',
+      brandName: 'Administración “Central” — Horizonte €',
+    } as never);
+    prisma.user.findUnique.mockResolvedValue({ name: 'Niñez' } as never);
+    prisma.payment.findUnique.mockResolvedValueOnce({
+      id: 'payment-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      amount: 4050000,
+      currency: 'ARS',
+      method: 'TRANSFER',
+      createdByUserId: 'resident-1',
+      approvedByUserId: 'admin-1',
+      approvedAt: '2026-07-24T12:00:00.000Z',
+      reference: 'Referencia “curva” € 🙂 / validado \\ soporte',
+      paymentAllocations: [{
+        chargeId: 'charge-1',
+        amount: 4050000,
+        charge: {
+          period: '2025-10',
+          concept: 'Condominio – especial…',
+          expensePeriod: { year: 2025, month: 10 },
+        },
+      }],
+      unit: { label: 'TN-01-01' },
+      building: { name: 'Torre “A”' },
+      receiptDocumentId: null,
+      receiptNumber: null,
+    } as never);
+
+    await service.ensureReceiptForPayment('payment-1');
+
+    const uploadedBuffer = minio.uploadBuffer.mock.calls[0][2] as Buffer;
+    const decodedPdfText = extractDecodedPdfTextLines(uploadedBuffer).join('\n');
+
+    expect(decodedPdfText).toContain('Administración “Central” — Horizonte €');
+    expect(decodedPdfText).toContain('Niñez');
+    expect(decodedPdfText).toContain('Referencia “curva” € ? / validado \\ soporte');
+    expect(decodedPdfText).toContain('Condominio – especial…');
+    expect(decodedPdfText).toContain('Torre “A”');
+    expect(decodedPdfText).toContain('Página 1 de 1');
+    expect(decodedPdfText).not.toContain('🙂');
+    expect(uploadedBuffer.subarray(0, 5).toString('ascii')).toBe('%PDF-');
+  });
+
+  it('escapes parentheses and backslashes in the PDF stream after WinAnsi encoding', async () => {
+    prisma.payment.findUnique.mockResolvedValueOnce({
+      id: 'payment-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      amount: 4050000,
+      currency: 'ARS',
+      method: 'TRANSFER',
+      createdByUserId: 'resident-1',
+      approvedByUserId: 'admin-1',
+      approvedAt: '2026-07-24T12:00:00.000Z',
+      reference: 'Pago (confirmado) \\ soporte',
+      paymentAllocations: [{
+        chargeId: 'charge-1',
+        amount: 4050000,
+        charge: {
+          period: '2025-10',
+          concept: 'Condominio ordinario 2025-10',
+          expensePeriod: { year: 2025, month: 10 },
+        },
+      }],
+      unit: { label: 'TN-01-01' },
+      building: { name: 'Complejo Horizonte' },
+      receiptDocumentId: null,
+      receiptNumber: null,
+    } as never);
+
+    await service.ensureReceiptForPayment('payment-1');
+
+    const uploadedBuffer = minio.uploadBuffer.mock.calls[0][2] as Buffer;
+    const pdfText = uploadedBuffer.toString('latin1');
+
+    expect(pdfText).toContain('\\(confirmado\\)');
+    expect(pdfText).toContain('\\\\ soporte');
+    expect(uploadedBuffer.subarray(0, 5).toString('ascii')).toBe('%PDF-');
   });
 
   it('uses the persisted file bucket when reusing an existing receipt', async () => {

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -5,6 +5,7 @@ import { writeFileSync } from 'node:fs';
 
 describe('PaymentReceiptService', () => {
   const DEFAULT_BUCKET = 'buildingos-test';
+  const RECEIPT_MAX_TEXT_WIDTH = 595 - 72 - 72;
 
   const prisma = {
     payment: {
@@ -48,6 +49,105 @@ describe('PaymentReceiptService', () => {
     minio as never,
     notificationsService as never,
   );
+
+  function extractPdfTextLines(buffer: Buffer): string[] {
+    const pdfText = buffer.toString('latin1');
+    return Array.from(pdfText.matchAll(/\(([^()]*)\) Tj/g)).map((match) =>
+      match[1]
+        .replace(/\\\(/g, '(')
+        .replace(/\\\)/g, ')')
+        .replace(/\\\\/g, '\\'),
+    );
+  }
+
+  function measureReceiptTextWidth(text: string): number {
+    const widths: Record<string, number> = {
+      ' ': 2.5,
+      '.': 2.5,
+      ',': 2.5,
+      ':': 2.5,
+      ';': 2.5,
+      '!': 2.5,
+      '?': 4.5,
+      '|': 2.5,
+      'i': 2.75,
+      'l': 2.75,
+      'I': 3,
+      'j': 2.75,
+      't': 3.5,
+      'f': 3.5,
+      'r': 3.5,
+      's': 4.25,
+      'a': 4.5,
+      'c': 4.5,
+      'e': 4.5,
+      'o': 4.5,
+      'n': 4.5,
+      'u': 4.5,
+      'v': 4.5,
+      'x': 4.5,
+      'y': 4.5,
+      'k': 4.75,
+      'd': 4.75,
+      'g': 4.75,
+      'h': 4.75,
+      'b': 4.75,
+      'p': 4.75,
+      'm': 7.25,
+      'w': 7.25,
+      'M': 8.5,
+      'W': 8.5,
+      '0': 5,
+      '1': 5,
+      '2': 5,
+      '3': 5,
+      '4': 5,
+      '5': 5,
+      '6': 5,
+      '7': 5,
+      '8': 5,
+      '9': 5,
+      '-': 3.5,
+      '/': 3.5,
+      '(': 3.5,
+      ')': 3.5,
+      '%': 7,
+      'Ñ': 7,
+      'Á': 6,
+      'É': 6,
+      'Í': 6,
+      'Ó': 6,
+      'Ú': 6,
+      'Ü': 6,
+      'ñ': 4.75,
+      'á': 4.5,
+      'é': 4.5,
+      'í': 4.5,
+      'ó': 4.5,
+      'ú': 4.5,
+      'ü': 4.5,
+    };
+
+    let width = 0;
+    for (const character of text) {
+      if (widths[character] !== undefined) {
+        width += widths[character];
+      } else if (character.toUpperCase() === character && character.toLowerCase() !== character.toUpperCase()) {
+        width += 6;
+      } else {
+        width += 5;
+      }
+    }
+
+    return width;
+  }
+
+  function expectPdfTextWithinWidth(lines: string[]) {
+    for (const line of lines) {
+      if (!line) continue;
+      expect(measureReceiptTextWidth(line)).toBeLessThanOrEqual(RECEIPT_MAX_TEXT_WIDTH);
+    }
+  }
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -124,6 +224,7 @@ describe('PaymentReceiptService', () => {
     expect(normalizedPdfText).toContain('Aplicación del pago');
     expect(normalizedPdfText).toContain('Período aplicado: 2025-10');
     expect(normalizedPdfText).toContain('2025-10 - Condominio ordinario 2025-10 - ARS 40.500,00');
+    expect(normalizedPdfText).toContain('Página 1 de 1');
     expect(normalizedPdfText).not.toContain('œ');
     expect(normalizedPdfText).not.toContain('Ø');
     expect(normalizedPdfText).not.toContain('¢');
@@ -230,5 +331,61 @@ describe('PaymentReceiptService', () => {
 
     expect(pageObjects.length).toBe(2);
     expect(pdfText).toContain('Continúa en la siguiente página.');
+    expect(pdfText).toContain('Página 1 de 2');
+    expect(pdfText).toContain('Página 2 de 2');
+  });
+
+  it('wraps long receipt fields and keeps every line within the available width', async () => {
+    const longTenantName = 'Consorcio Complejo Residencial Horizonte Torre Norte y Torre Sur con Administración Extendida y Consejo Vecinal';
+    const longBuildingName = 'Torre Horizonte A con Hall Principal, Cocheras y SUM del Complejo Residencial Horizonte';
+    const longReference = 'TRANSFERENCIA-EXTREMADAMENTE-LARGA-SIN-ESPACIOS-0123456789ABCDEFGHIJKLMN';
+    const longConcept = 'Condominio ordinario con descripción extremadamente larga para validar el wrapping del PDF multipágina';
+
+    prisma.payment.findUnique.mockResolvedValueOnce({
+      id: 'payment-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      amount: 4050000,
+      currency: 'ARS',
+      method: 'TRANSFER',
+      createdByUserId: 'resident-1',
+      approvedByUserId: 'admin-1',
+      approvedAt: '2026-07-24T12:00:00.000Z',
+      reference: longReference,
+      paymentAllocations: [{
+        chargeId: 'charge-1',
+        amount: 4050000,
+        charge: {
+          period: '2025-10',
+          concept: longConcept,
+          expensePeriod: { year: 2025, month: 10 },
+        },
+      }],
+      unit: { label: 'TN-01-01-BIS-EXTRA-LARGA' },
+      building: { name: longBuildingName },
+      receiptDocumentId: null,
+      receiptNumber: null,
+    } as never);
+    prisma.tenant.findUnique.mockResolvedValueOnce({ name: longTenantName, brandName: null } as never);
+    prisma.user.findUnique.mockResolvedValueOnce({ name: 'Admin' } as never);
+
+    const result = await service.ensureReceiptForPayment('payment-1');
+    expect(result?.documentId).toBe('document-1');
+
+    const uploadedBuffer = minio.uploadBuffer.mock.calls[0][2] as Buffer;
+    const pdfText = uploadedBuffer.toString('latin1');
+    const normalizedPdfText = pdfText.replace(/\u00a0/g, ' ');
+    const pdfLines = extractPdfTextLines(uploadedBuffer);
+    const wrappedLines = pdfLines.filter((line) => line.length > 0);
+    const reconstructedText = wrappedLines.join(' ');
+
+    expect(uploadedBuffer.subarray(0, 5).toString('ascii')).toBe('%PDF-');
+    expect(reconstructedText).toContain(longBuildingName);
+    expect(normalizedPdfText).toContain('Página 1 de 1');
+    expect(normalizedPdfText).toContain('Documento generado por la Administración del');
+    expect(reconstructedText).toContain(longConcept);
+    expect(reconstructedText).toContain(longReference);
+    expectPdfTextWithinWidth(wrappedLines);
   });
 });

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -193,4 +193,42 @@ describe('PaymentReceiptService', () => {
       url: 'https://download.example/receipt.pdf',
     });
   });
+
+  it('splits long allocation lists across multiple PDF pages', async () => {
+    prisma.payment.findUnique.mockResolvedValueOnce({
+      id: 'payment-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      amount: 4050000,
+      currency: 'ARS',
+      method: 'TRANSFER',
+      createdByUserId: 'resident-1',
+      approvedByUserId: 'admin-1',
+      approvedAt: '2026-07-24T12:00:00.000Z',
+      reference: 'TRX-001',
+      paymentAllocations: Array.from({ length: 10 }, (_, index) => ({
+        chargeId: `charge-${index + 1}`,
+        amount: 405000,
+        charge: {
+          period: `2025-${String(index + 1).padStart(2, '0')}`,
+          concept: `Condominio ${index + 1}`,
+          expensePeriod: { year: 2025, month: index + 1 },
+        },
+      })),
+      unit: { label: 'TN-01-01' },
+      building: { name: 'Complejo Horizonte' },
+      receiptDocumentId: null,
+      receiptNumber: null,
+    } as never);
+
+    await service.ensureReceiptForPayment('payment-1');
+
+    const uploadedBuffer = minio.uploadBuffer.mock.calls[0][2] as Buffer;
+    const pdfText = uploadedBuffer.toString('latin1');
+    const pageObjects = pdfText.match(/\/Type \/Page(?!s)/g) || [];
+
+    expect(pageObjects.length).toBe(2);
+    expect(pdfText).toContain('Continúa en la siguiente página.');
+  });
 });

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -89,6 +89,13 @@ describe('PaymentReceiptService', () => {
     );
   }
 
+  function extractPdfContentStreams(buffer: Buffer): string[] {
+    const pdfText = buffer.toString('latin1');
+    return Array.from(pdfText.matchAll(/stream\n([\s\S]*?)\nendstream/g)).map(
+      (match) => match[1],
+    );
+  }
+
   function decodeWinAnsiText(text: string): string {
     return Array.from(text, (character) => {
       const code = character.charCodeAt(0);
@@ -453,9 +460,20 @@ describe('PaymentReceiptService', () => {
 
     const uploadedBuffer = minio.uploadBuffer.mock.calls[0][2] as Buffer;
     const pdfText = uploadedBuffer.toString('latin1');
+    const contentStreams = extractPdfContentStreams(uploadedBuffer);
     const pageObjects = pdfText.match(/\/Type \/Page(?!s)/g) || [];
 
     expect(pageObjects.length).toBe(2);
+    expect(contentStreams).toHaveLength(2);
+    for (const streamText of contentStreams) {
+      expect(streamText).toContain('BT');
+      expect(streamText).toContain('ET');
+    }
+    expect(contentStreams[0]).toContain('14 TL');
+    const continuationLeadingIndex = contentStreams[1].indexOf('14 TL');
+    const continuationAdvanceIndex = contentStreams[1].indexOf('T*');
+    expect(continuationLeadingIndex).toBeGreaterThan(-1);
+    expect(continuationLeadingIndex).toBeLessThan(continuationAdvanceIndex);
     expect(pdfText).toContain('Continúa en la siguiente página.');
     expect(pdfText).toContain('Página 1 de 2');
     expect(pdfText).toContain('Página 2 de 2');

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -1,0 +1,199 @@
+import { PaymentReceiptService } from './payment-receipt.service';
+import { ReceiptStatus } from '@prisma/client';
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+describe('PaymentReceiptService', () => {
+  const DEFAULT_BUCKET = 'buildingos-test';
+
+  const prisma = {
+    payment: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    document: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+    file: {
+      create: jest.fn(),
+    },
+    tenant: {
+      findUnique: jest.fn(),
+    },
+    paymentAuditLog: {
+      create: jest.fn(),
+    },
+    receiptSequence: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    $transaction: jest.fn(),
+    user: {
+      findUnique: jest.fn(),
+    },
+  };
+  const minio = {
+    getDefaultBucket: jest.fn(() => DEFAULT_BUCKET),
+    uploadBuffer: jest.fn(),
+    presignDownload: jest.fn(),
+  };
+  const notificationsService = {
+    createNotification: jest.fn(),
+  };
+
+  const service = new PaymentReceiptService(
+    prisma as never,
+    minio as never,
+    notificationsService as never,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    minio.getDefaultBucket.mockReturnValue(DEFAULT_BUCKET);
+    prisma.$transaction.mockImplementation(async (callback: (tx: never) => Promise<unknown>) => {
+      const tx = {
+        receiptSequence: prisma.receiptSequence,
+      } as never;
+      return callback(tx);
+    });
+    prisma.payment.findUnique.mockResolvedValue({
+      id: 'payment-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      amount: 4050000,
+      currency: 'ARS',
+      method: 'TRANSFER',
+      createdByUserId: 'resident-1',
+      approvedByUserId: 'admin-1',
+      approvedAt: '2026-07-24T12:00:00.000Z',
+      reference: 'TRX-001',
+      paymentAllocations: [{
+        chargeId: 'charge-1',
+        amount: 4050000,
+        charge: {
+          period: '2025-10',
+          concept: 'Condominio ordinario 2025-10',
+          expensePeriod: { year: 2025, month: 10 },
+        },
+      }],
+      unit: { label: 'TN-01-01' },
+      building: { name: 'Complejo Horizonte' },
+      receiptDocumentId: null,
+      receiptNumber: null,
+    } as never);
+    prisma.tenant.findUnique.mockResolvedValue({ name: 'Complejo Horizonte', brandName: null } as never);
+    prisma.user.findUnique.mockResolvedValue({ name: 'Admin' } as never);
+    prisma.receiptSequence.findUnique.mockResolvedValue(null);
+    prisma.receiptSequence.create.mockResolvedValue({ id: 'sequence-1', lastNumber: 0 } as never);
+    prisma.receiptSequence.update.mockResolvedValue({ id: 'sequence-1' } as never);
+    prisma.file.create.mockResolvedValue({ id: 'file-1' } as never);
+    prisma.document.create.mockResolvedValue({ id: 'document-1', file: { bucket: DEFAULT_BUCKET, objectKey: 'object-1' } } as never);
+    prisma.payment.update.mockResolvedValue({} as never);
+    prisma.paymentAuditLog.create.mockResolvedValue({} as never);
+    notificationsService.createNotification.mockResolvedValue({} as never);
+    minio.presignDownload.mockResolvedValue('https://download.example/receipt.pdf');
+  });
+
+  it('uses the configured bucket when generating a new receipt', async () => {
+    const result = await service.ensureReceiptForPayment('payment-1');
+    const uploadedBuffer = minio.uploadBuffer.mock.calls[0][2] as Buffer;
+    const tmpReceiptPath = '/tmp/buildingos-payment-receipt-test.pdf';
+
+    expect(minio.uploadBuffer).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      expect.stringContaining('/receipt_R-'),
+      expect.any(Buffer),
+      'application/pdf',
+    );
+    expect(Buffer.isBuffer(uploadedBuffer)).toBe(true);
+    expect(uploadedBuffer.length).toBeGreaterThan(0);
+    expect(uploadedBuffer.subarray(0, 5).toString('ascii')).toBe('%PDF-');
+    expect(uploadedBuffer.includes(Buffer.from('%%EOF'))).toBe(true);
+    const pdfText = uploadedBuffer.toString('latin1');
+    const normalizedPdfText = pdfText.replace(/\u00a0/g, ' ');
+    expect(normalizedPdfText).toContain('Complejo Horizonte');
+    expect(normalizedPdfText).not.toContain('BuildingOS -');
+    expect(normalizedPdfText).toContain('Emitido por la Administración del Complejo Horizonte');
+    expect(normalizedPdfText).not.toContain('endpoint protegido');
+    expect(normalizedPdfText).not.toContain('Documento generado por BuildingOS');
+    expect(normalizedPdfText).toContain('Número de recibo');
+    expect(normalizedPdfText).toContain('Método');
+    expect(normalizedPdfText).toContain('Aplicación del pago');
+    expect(normalizedPdfText).toContain('Período aplicado: 2025-10');
+    expect(normalizedPdfText).toContain('2025-10 - Condominio ordinario 2025-10 - ARS 40.500,00');
+    expect(normalizedPdfText).not.toContain('œ');
+    expect(normalizedPdfText).not.toContain('Ø');
+    expect(normalizedPdfText).not.toContain('¢');
+    expect(normalizedPdfText).toContain('ARS 40.500,00');
+    writeFileSync(tmpReceiptPath, uploadedBuffer);
+    expect(execFileSync('file', [tmpReceiptPath], { encoding: 'utf8' })).toContain('PDF document');
+    try {
+      const pdfInfo = execFileSync('pdfinfo', [tmpReceiptPath], { encoding: 'utf8' });
+      expect(pdfInfo).toContain('Pages:');
+    } catch (error) {
+      if (!(error instanceof Error) || !('code' in error) || (error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
+    }
+    expect(prisma.file.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        bucket: DEFAULT_BUCKET,
+        originalName: expect.stringMatching(/\.pdf$/),
+        mimeType: 'application/pdf',
+        size: uploadedBuffer.length,
+      }),
+    }));
+    expect(prisma.payment.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        receiptStatus: ReceiptStatus.READY,
+        receiptError: null,
+      }),
+    }));
+    expect(minio.presignDownload).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      expect.stringContaining('/receipt_R-'),
+      3600,
+    );
+    expect(result?.fileKey).toContain('/receipt_R-');
+  });
+
+  it('uses the persisted file bucket when reusing an existing receipt', async () => {
+    prisma.payment.findUnique.mockResolvedValueOnce({
+      id: 'payment-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      amount: 12345,
+      currency: 'ARS',
+      method: 'TRANSFER',
+      createdByUserId: 'resident-1',
+      approvedByUserId: 'admin-1',
+      approvedAt: '2026-07-24T12:00:00.000Z',
+      reference: 'TRX-001',
+      paymentAllocations: [],
+      unit: { label: 'TN-01-01' },
+      building: { name: 'Complejo Horizonte' },
+      receiptDocumentId: 'document-1',
+      receiptNumber: 'R-HZ-2026-000001',
+    } as never);
+    prisma.document.findUnique.mockResolvedValueOnce({
+      id: 'document-1',
+      file: { bucket: 'tenant-legacy-bucket', objectKey: 'receipt.pdf' },
+    } as never);
+
+    const result = await service.ensureReceiptForPayment('payment-1');
+
+    expect(minio.presignDownload).toHaveBeenCalledWith('tenant-legacy-bucket', 'receipt.pdf', 3600);
+    expect(minio.uploadBuffer).not.toHaveBeenCalled();
+    expect(prisma.file.create).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      receiptNumber: 'R-HZ-2026-000001',
+      documentId: 'document-1',
+      fileKey: 'receipt.pdf',
+      url: 'https://download.example/receipt.pdf',
+    });
+  });
+});

--- a/apps/api/src/receipts/payment-receipt.service.ts
+++ b/apps/api/src/receipts/payment-receipt.service.ts
@@ -58,6 +58,36 @@ const RECEIPT_PDF_MARGIN_RIGHT = 72;
 const RECEIPT_PDF_MAX_TEXT_WIDTH = RECEIPT_PDF_PAGE_WIDTH - RECEIPT_PDF_MARGIN_LEFT - RECEIPT_PDF_MARGIN_RIGHT;
 const RECEIPT_PDF_MAX_BODY_LINES_PER_PAGE = 22;
 
+const WIN_ANSI_CHAR_MAP: Record<string, string> = {
+  '€': String.fromCharCode(0x80),
+  '‚': String.fromCharCode(0x82),
+  'ƒ': String.fromCharCode(0x83),
+  '„': String.fromCharCode(0x84),
+  '…': String.fromCharCode(0x85),
+  '†': String.fromCharCode(0x86),
+  '‡': String.fromCharCode(0x87),
+  'ˆ': String.fromCharCode(0x88),
+  '‰': String.fromCharCode(0x89),
+  'Š': String.fromCharCode(0x8A),
+  '‹': String.fromCharCode(0x8B),
+  'Œ': String.fromCharCode(0x8C),
+  'Ž': String.fromCharCode(0x8E),
+  '‘': String.fromCharCode(0x91),
+  '’': String.fromCharCode(0x92),
+  '“': String.fromCharCode(0x93),
+  '”': String.fromCharCode(0x94),
+  '•': String.fromCharCode(0x95),
+  '–': String.fromCharCode(0x96),
+  '—': String.fromCharCode(0x97),
+  '˜': String.fromCharCode(0x98),
+  '™': String.fromCharCode(0x99),
+  'š': String.fromCharCode(0x9A),
+  '›': String.fromCharCode(0x9B),
+  'œ': String.fromCharCode(0x9C),
+  'ž': String.fromCharCode(0x9E),
+  'Ÿ': String.fromCharCode(0x9F),
+};
+
 @Injectable()
 export class PaymentReceiptService {
   private readonly logger = new Logger(PaymentReceiptService.name);
@@ -624,6 +654,14 @@ export class PaymentReceiptService {
       '(': 3.5,
       ')': 3.5,
       '%': 7,
+      '€': 5.5,
+      '‘': 2.5,
+      '’': 2.5,
+      '“': 3.5,
+      '”': 3.5,
+      '–': 4.5,
+      '—': 6,
+      '…': 7,
       'Ñ': 7,
       'Á': 6,
       'É': 6,
@@ -697,7 +735,7 @@ export class PaymentReceiptService {
   }
 
   private pdfText(text: string): string {
-    return `(${this.escapePdfText(text)}) Tj`;
+    return `(${this.escapePdfText(this.encodeWinAnsi(text))}) Tj`;
   }
 
   private escapePdfText(text: string): string {
@@ -705,6 +743,33 @@ export class PaymentReceiptService {
       .replace(/\\/g, '\\\\')
       .replace(/\(/g, '\\(')
       .replace(/\)/g, '\\)');
+  }
+
+  private encodeWinAnsi(text: string): string {
+    let encoded = '';
+
+    for (const character of text) {
+      const mappedCharacter = WIN_ANSI_CHAR_MAP[character];
+      if (mappedCharacter) {
+        encoded += mappedCharacter;
+        continue;
+      }
+
+      const codePoint = character.codePointAt(0) ?? 0;
+      if (codePoint >= 0x20 && codePoint <= 0x7E) {
+        encoded += character;
+        continue;
+      }
+
+      if (codePoint >= 0xA0 && codePoint <= 0xFF) {
+        encoded += character;
+        continue;
+      }
+
+      encoded += '?';
+    }
+
+    return encoded;
   }
 
   private formatCurrencyForReceipt(amountMinor: number, currency: string): string {

--- a/apps/api/src/receipts/payment-receipt.service.ts
+++ b/apps/api/src/receipts/payment-receipt.service.ts
@@ -33,15 +33,32 @@ type PaymentReceiptPayment = Prisma.PaymentGetPayload<{
   };
 }>;
 
+type ChargeWithAllocations = Prisma.ChargeGetPayload<{
+  include: {
+    paymentAllocations: {
+      include: {
+        payment: {
+          select: {
+            status: true;
+          };
+        };
+      };
+    };
+  };
+}>;
+
 @Injectable()
 export class PaymentReceiptService {
   private readonly logger = new Logger(PaymentReceiptService.name);
+  private readonly bucket: string;
 
   constructor(
     private readonly prisma: PrismaService,
     private readonly minio: MinioService,
     private readonly notificationsService: NotificationsService,
-  ) {}
+  ) {
+    this.bucket = this.minio.getDefaultBucket();
+  }
 
   /**
    * Ensure a receipt exists for the given payment.
@@ -91,7 +108,7 @@ export class PaymentReceiptService {
       });
 
       if (document?.file) {
-        const url = await this.minio.presignDownload('documents', document.file.objectKey, 3600);
+        const url = await this.minio.presignDownload(document.file.bucket, document.file.objectKey, 3600);
         return {
           receiptNumber: payment.receiptNumber,
           documentId: payment.receiptDocumentId,
@@ -114,13 +131,13 @@ export class PaymentReceiptService {
 
       // Save to storage
       const objectKey = `tenant/${payment.tenantId}/payments/${paymentId}/receipt_${receiptNumber}.pdf`;
-      await this.minio.uploadBuffer('documents', objectKey, pdfContent, 'application/pdf');
+      await this.minio.uploadBuffer(this.bucket, objectKey, pdfContent, 'application/pdf');
 
       // Create File record
       const file = await this.prisma.file.create({
         data: {
           tenantId: payment.tenantId,
-          bucket: 'documents',
+          bucket: this.bucket,
           objectKey,
           originalName: `receipt_${receiptNumber}.pdf`,
           mimeType: 'application/pdf',
@@ -174,7 +191,7 @@ export class PaymentReceiptService {
         },
       });
 
-      const url = await this.minio.presignDownload('documents', objectKey, 3600);
+      const url = await this.minio.presignDownload(this.bucket, objectKey, 3600);
 
       // Notify resident
       await this.notifyResidentReceiptReady(payment, receiptNumber, url, approvedByUserName);
@@ -258,7 +275,6 @@ export class PaymentReceiptService {
 
   /**
    * Generate receipt PDF content.
-   * Currently returns simple text - can be upgraded to proper PDF library later.
    */
   private async generateReceiptPDF(
     payment: PaymentReceiptPayment,
@@ -271,69 +287,176 @@ export class PaymentReceiptService {
     });
     const tenantDisplayName = tenant?.brandName || tenant?.name || 'Consorcio';
 
-    const approvedBy = approvedByUserName;
-    const approvedAt = payment.approvedAt 
-      ? new Date(payment.approvedAt).toLocaleString('es-AR', {
-          day: '2-digit',
-          month: '2-digit',
-          year: 'numeric',
-          hour: '2-digit',
-          minute: '2-digit',
-        })
-      : new Date().toLocaleString('es-AR');
-
+    const approvedAt = this.formatReceiptDate(payment.approvedAt ?? new Date());
     const unitLabel = payment.unit?.label || payment.unitId || 'N/A';
     const buildingName = payment.building?.name || 'Edificio';
-    const amountFormatted = (payment.amount / 100).toFixed(2);
     const currency = payment.currency || 'ARS';
-
-    // Build allocations text
-    let allocationsText = '';
-    if (payment.paymentAllocations && payment.paymentAllocations.length > 0) {
-      allocationsText = payment.paymentAllocations
-        .map((alloc) => {
+    const amountFormatted = this.formatCurrencyForReceipt(payment.amount, currency);
+    const allocations = payment.paymentAllocations?.length
+      ? payment.paymentAllocations.map((alloc, index) => {
           const expensePeriod = alloc.charge?.expensePeriod;
           const period = expensePeriod
             ? `${expensePeriod.year}-${String(expensePeriod.month).padStart(2, '0')}`
             : alloc.charge?.period || 'N/A';
           const concept = alloc.charge?.concept || 'Cargo';
-          const amount = (alloc.amount / 100).toFixed(2);
-          return `  - ${period}: ${concept} = ${currency} ${amount}`;
+          return `${period} - ${concept} - ${this.formatCurrencyForReceipt(alloc.amount, currency)}`;
         })
-        .join('\n');
-    } else {
-      allocationsText = '  (Sin aplicación específica - saldo a favor)';
+      : ['Sin aplicación específica - saldo a favor'];
+    const primaryPeriod = payment.paymentAllocations?.[0]
+      ? (() => {
+          const expensePeriod = payment.paymentAllocations[0].charge?.expensePeriod;
+          return expensePeriod
+            ? `${expensePeriod.year}-${String(expensePeriod.month).padStart(2, '0')}`
+            : payment.paymentAllocations[0].charge?.period || 'N/A';
+        })()
+      : 'N/A';
+
+    return this.buildReceiptPdfBuffer({
+      tenantDisplayName,
+      receiptNumber,
+      approvedAt,
+      approvedByUserName,
+      unitLabel,
+      buildingName,
+      amountFormatted,
+      method: payment.method,
+      reference: payment.reference || 'N/A',
+      primaryPeriod,
+      allocations,
+    });
+  }
+
+  private buildReceiptPdfBuffer(input: {
+    tenantDisplayName: string;
+    receiptNumber: string;
+    approvedAt: string;
+    approvedByUserName: string;
+    unitLabel: string;
+    buildingName: string;
+    amountFormatted: string;
+    method: string;
+    reference: string;
+    primaryPeriod: string;
+    allocations: readonly string[];
+  }): Buffer {
+    const contentCommands = [
+      'BT',
+      '/F2 18 Tf',
+      '22 TL',
+      '72 792 Td',
+      this.pdfText(input.tenantDisplayName),
+      '/F1 11 Tf',
+      '14 TL',
+      'T*',
+      this.pdfText('Recibo de pago aprobado'),
+      'T*',
+      this.pdfText(`Emitido por la Administración del ${input.tenantDisplayName}`),
+      'T*',
+      'T*',
+      '/F2 12 Tf',
+      this.pdfText('Datos del recibo'),
+      '/F1 11 Tf',
+      '14 TL',
+      'T*',
+      this.pdfText(`Número de recibo: ${input.receiptNumber}`),
+      'T*',
+      this.pdfText(`Fecha de aprobación: ${input.approvedAt}`),
+      'T*',
+      this.pdfText(`Aprobado por: ${input.approvedByUserName}`),
+      'T*',
+      'T*',
+      '/F2 12 Tf',
+      this.pdfText('Datos del pago'),
+      '/F1 11 Tf',
+      '14 TL',
+      'T*',
+      this.pdfText(`Unidad: ${input.unitLabel}`),
+      'T*',
+      this.pdfText(`Edificio: ${input.buildingName}`),
+      'T*',
+      this.pdfText(`Monto: ${input.amountFormatted}`),
+      'T*',
+      this.pdfText(`Método: ${input.method}`),
+      'T*',
+      this.pdfText(`Referencia: ${input.reference}`),
+      'T*',
+      this.pdfText(`Período aplicado: ${input.primaryPeriod}`),
+      'T*',
+      'T*',
+      '/F2 12 Tf',
+      this.pdfText('Aplicación del pago'),
+      '/F1 11 Tf',
+      '14 TL',
+      ...input.allocations.flatMap((allocation) => [
+        'T*',
+        this.pdfText(allocation),
+      ]),
+      'T*',
+      this.pdfText('Este documento es una constancia de pago y no constituye factura fiscal.'),
+      'T*',
+      this.pdfText(`Documento generado por la Administración del ${input.tenantDisplayName}.`),
+      'ET',
+    ];
+
+    const contentStreamText = contentCommands.join('\n');
+    const contentStream = Buffer.from(contentStreamText, 'latin1');
+    const objects = [
+      '<< /Type /Catalog /Pages 2 0 R >>',
+      '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+      '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 4 0 R /F2 5 0 R >> >> /Contents 6 0 R >>',
+      '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>',
+      '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>',
+      `<< /Length ${contentStream.length} >>\nstream\n${contentStreamText}\nendstream`,
+    ];
+
+    const header = '%PDF-1.4\n%âãÏÓ\n';
+    const objectBuffers = objects.map((body, index) => Buffer.from(`${index + 1} 0 obj\n${body}\nendobj\n`, 'latin1'));
+    const offsets = ['0000000000 65535 f \n'];
+    let offset = Buffer.byteLength(header, 'latin1');
+
+    for (const objectBuffer of objectBuffers) {
+      offsets.push(`${String(offset).padStart(10, '0')} 00000 n \n`);
+      offset += objectBuffer.length;
     }
 
-    const content = `
-================================================================================
-                         ${tenantDisplayName.toUpperCase()}
-================================================================================
+    const xref = `xref\n0 ${objects.length + 1}\n${offsets.join('')}`;
+    const trailer = `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R >>\nstartxref\n${offset}\n%%EOF\n`;
 
-RECIBO DE PAGO APROBADO
---------------------------------------------------------------------------------
-Número de recibo: ${receiptNumber}
-Fecha de aprobación: ${approvedAt}
+    return Buffer.concat([
+      Buffer.from(header, 'latin1'),
+      ...objectBuffers,
+      Buffer.from(xref + trailer, 'latin1'),
+    ]);
+  }
 
-DATOS DEL PAGO
---------------------------------------------------------------------------------
-Unidad: ${unitLabel}
-Edificio: ${buildingName}
-Monto: ${currency} ${amountFormatted}
-Método: ${payment.method}
-Referencia: ${payment.reference || 'N/A'}
+  private pdfText(text: string): string {
+    return `(${this.escapePdfText(text)}) Tj`;
+  }
 
-APLICACIÓN DEL PAGO
---------------------------------------------------------------------------------
-${allocationsText}
+  private escapePdfText(text: string): string {
+    return text
+      .replace(/\\/g, '\\\\')
+      .replace(/\(/g, '\\(')
+      .replace(/\)/g, '\\)');
+  }
 
-================================================================================
-Aprobado por: ${approvedBy}
-Este documento es una CONSTANCIA DE PAGO, no constituye factura fiscal.
-================================================================================
-    `.trim();
+  private formatCurrencyForReceipt(amountMinor: number, currency: string): string {
+    const safeCurrency = /^[A-Z]{3}$/.test(currency) ? currency : 'ARS';
+    return new Intl.NumberFormat('es-AR', {
+      style: 'currency',
+      currency: safeCurrency,
+      currencyDisplay: 'code',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amountMinor / 100);
+  }
 
-    return Buffer.from(content, 'utf-8');
+  private formatReceiptDate(dateValue: string | Date): string {
+    const date = dateValue instanceof Date ? dateValue : new Date(dateValue);
+    return new Intl.DateTimeFormat('es-AR', {
+      dateStyle: 'short',
+      timeStyle: 'short',
+    }).format(date);
   }
 
   /**

--- a/apps/api/src/receipts/payment-receipt.service.ts
+++ b/apps/api/src/receipts/payment-receipt.service.ts
@@ -339,6 +339,37 @@ export class PaymentReceiptService {
     primaryPeriod: string;
     allocations: readonly string[];
   }): Buffer {
+    const allocations = input.allocations.length > 0
+      ? [...input.allocations]
+      : ['Sin aplicación específica - saldo a favor'];
+    const allocationPages = this.chunkReceiptAllocations(allocations);
+    const contentStreams = allocationPages.map((allocationPage, index) =>
+      this.buildReceiptPageContent({
+        ...input,
+        allocations: allocationPage,
+        pageIndex: index,
+        pageCount: allocationPages.length,
+      }),
+    );
+
+    return this.serializePdf(contentStreams);
+  }
+
+  private buildReceiptPageContent(input: {
+    tenantDisplayName: string;
+    receiptNumber: string;
+    approvedAt: string;
+    approvedByUserName: string;
+    unitLabel: string;
+    buildingName: string;
+    amountFormatted: string;
+    method: string;
+    reference: string;
+    primaryPeriod: string;
+    allocations: readonly string[];
+    pageIndex: number;
+    pageCount: number;
+  }): string {
     const contentCommands = [
       'BT',
       '/F2 18 Tf',
@@ -384,7 +415,7 @@ export class PaymentReceiptService {
       'T*',
       'T*',
       '/F2 12 Tf',
-      this.pdfText('Aplicación del pago'),
+      this.pdfText(input.pageCount > 1 && input.pageIndex > 0 ? 'Aplicación del pago (continuación)' : 'Aplicación del pago'),
       '/F1 11 Tf',
       '14 TL',
       ...input.allocations.flatMap((allocation) => [
@@ -392,21 +423,52 @@ export class PaymentReceiptService {
         this.pdfText(allocation),
       ]),
       'T*',
-      this.pdfText('Este documento es una constancia de pago y no constituye factura fiscal.'),
-      'T*',
-      this.pdfText(`Documento generado por la Administración del ${input.tenantDisplayName}.`),
-      'ET',
     ];
 
-    const contentStreamText = contentCommands.join('\n');
-    const contentStream = Buffer.from(contentStreamText, 'latin1');
+    if (input.pageIndex === input.pageCount - 1) {
+      contentCommands.push(
+        this.pdfText('Este documento es una constancia de pago y no constituye factura fiscal.'),
+        'T*',
+        this.pdfText(`Documento generado por la Administración del ${input.tenantDisplayName}.`),
+      );
+    } else {
+      contentCommands.push(
+        this.pdfText('Continúa en la siguiente página.'),
+      );
+    }
+
+    contentCommands.push('ET');
+    return contentCommands.join('\n');
+  }
+
+  private chunkReceiptAllocations(allocations: readonly string[]): string[][] {
+    const chunkSize = 8;
+    const pages: string[][] = [];
+
+    for (let index = 0; index < allocations.length; index += chunkSize) {
+      pages.push(allocations.slice(index, index + chunkSize));
+    }
+
+    return pages.length > 0 ? pages : [['Sin aplicación específica - saldo a favor']];
+  }
+
+  private serializePdf(contentStreams: readonly string[]): Buffer {
+    const pageCount = contentStreams.length;
+    const fontObjectNumber = 3 + pageCount;
+    const boldFontObjectNumber = 4 + pageCount;
+    const contentStartObjectNumber = 5 + pageCount;
+    const pageObjectNumbers = Array.from({ length: pageCount }, (_, index) => 3 + index);
+
     const objects = [
       '<< /Type /Catalog /Pages 2 0 R >>',
-      '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
-      '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 4 0 R /F2 5 0 R >> >> /Contents 6 0 R >>',
+      `<< /Type /Pages /Kids [${pageObjectNumbers.map((objectNumber) => `${objectNumber} 0 R`).join(' ')}] /Count ${pageCount} >>`,
+      ...pageObjectNumbers.map((pageObjectNumber, index) => {
+        const contentObjectNumber = contentStartObjectNumber + index;
+        return `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Resources << /Font << /F1 ${fontObjectNumber} 0 R /F2 ${boldFontObjectNumber} 0 R >> >> /Contents ${contentObjectNumber} 0 R >>`;
+      }),
       '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>',
       '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>',
-      `<< /Length ${contentStream.length} >>\nstream\n${contentStreamText}\nendstream`,
+      ...contentStreams.map((contentStreamText) => `<< /Length ${Buffer.byteLength(contentStreamText, 'latin1')} >>\nstream\n${contentStreamText}\nendstream`),
     ];
 
     const header = '%PDF-1.4\n%âãÏÓ\n';

--- a/apps/api/src/receipts/payment-receipt.service.ts
+++ b/apps/api/src/receipts/payment-receipt.service.ts
@@ -47,6 +47,17 @@ type ChargeWithAllocations = Prisma.ChargeGetPayload<{
   };
 }>;
 
+interface ReceiptPdfLine {
+  text: string;
+  kind: 'title' | 'heading' | 'body' | 'blank';
+}
+
+const RECEIPT_PDF_PAGE_WIDTH = 595;
+const RECEIPT_PDF_MARGIN_LEFT = 72;
+const RECEIPT_PDF_MARGIN_RIGHT = 72;
+const RECEIPT_PDF_MAX_TEXT_WIDTH = RECEIPT_PDF_PAGE_WIDTH - RECEIPT_PDF_MARGIN_LEFT - RECEIPT_PDF_MARGIN_RIGHT;
+const RECEIPT_PDF_MAX_BODY_LINES_PER_PAGE = 22;
+
 @Injectable()
 export class PaymentReceiptService {
   private readonly logger = new Logger(PaymentReceiptService.name);
@@ -339,20 +350,65 @@ export class PaymentReceiptService {
     primaryPeriod: string;
     allocations: readonly string[];
   }): Buffer {
-    const allocations = input.allocations.length > 0
-      ? [...input.allocations]
-      : ['Sin aplicación específica - saldo a favor'];
-    const allocationPages = this.chunkReceiptAllocations(allocations);
-    const contentStreams = allocationPages.map((allocationPage, index) =>
+    const bodyLines = this.buildReceiptBodyLines(input);
+    const allocationPages = this.chunkReceiptBodyLines(bodyLines);
+    const contentStreams = allocationPages.map((pageLines, index) =>
       this.buildReceiptPageContent({
         ...input,
-        allocations: allocationPage,
+        lines: pageLines,
         pageIndex: index,
         pageCount: allocationPages.length,
       }),
     );
 
     return this.serializePdf(contentStreams);
+  }
+
+  private buildReceiptBodyLines(input: {
+    tenantDisplayName: string;
+    receiptNumber: string;
+    approvedAt: string;
+    approvedByUserName: string;
+    unitLabel: string;
+    buildingName: string;
+    amountFormatted: string;
+    method: string;
+    reference: string;
+    primaryPeriod: string;
+    allocations: readonly string[];
+  }): ReceiptPdfLine[] {
+    const lines: ReceiptPdfLine[] = [];
+
+    this.pushWrappedReceiptLine(lines, input.tenantDisplayName, 'title');
+    this.pushBlankReceiptLine(lines);
+    this.pushWrappedReceiptLine(lines, 'Recibo de pago aprobado', 'heading');
+    this.pushWrappedReceiptLine(lines, `Emitido por la Administración del ${input.tenantDisplayName}`);
+    this.pushBlankReceiptLine(lines);
+
+    this.pushWrappedReceiptLine(lines, 'Datos del recibo', 'heading');
+    this.pushWrappedReceiptLine(lines, `Número de recibo: ${input.receiptNumber}`);
+    this.pushWrappedReceiptLine(lines, `Fecha de aprobación: ${input.approvedAt}`);
+    this.pushWrappedReceiptLine(lines, `Aprobado por: ${input.approvedByUserName}`);
+    this.pushBlankReceiptLine(lines);
+
+    this.pushWrappedReceiptLine(lines, 'Datos del pago', 'heading');
+    this.pushWrappedReceiptLine(lines, `Unidad: ${input.unitLabel}`);
+    this.pushWrappedReceiptLine(lines, `Edificio: ${input.buildingName}`);
+    this.pushWrappedReceiptLine(lines, `Monto: ${input.amountFormatted}`);
+    this.pushWrappedReceiptLine(lines, `Método: ${input.method}`);
+    this.pushWrappedReceiptLine(lines, `Referencia: ${input.reference}`);
+    this.pushWrappedReceiptLine(lines, `Período aplicado: ${input.primaryPeriod}`);
+    this.pushBlankReceiptLine(lines);
+
+    this.pushWrappedReceiptLine(lines, 'Aplicación del pago', 'heading');
+    const allocations = input.allocations.length > 0
+      ? [...input.allocations]
+      : ['Sin aplicación específica - saldo a favor'];
+    for (const allocation of allocations) {
+      this.pushWrappedReceiptLine(lines, allocation);
+    }
+
+    return lines;
   }
 
   private buildReceiptPageContent(input: {
@@ -366,90 +422,239 @@ export class PaymentReceiptService {
     method: string;
     reference: string;
     primaryPeriod: string;
-    allocations: readonly string[];
+    lines: readonly ReceiptPdfLine[];
     pageIndex: number;
     pageCount: number;
   }): string {
-    const contentCommands = [
-      'BT',
-      '/F2 18 Tf',
-      '22 TL',
-      '72 792 Td',
-      this.pdfText(input.tenantDisplayName),
-      '/F1 11 Tf',
-      '14 TL',
-      'T*',
-      this.pdfText('Recibo de pago aprobado'),
-      'T*',
-      this.pdfText(`Emitido por la Administración del ${input.tenantDisplayName}`),
-      'T*',
-      'T*',
-      '/F2 12 Tf',
-      this.pdfText('Datos del recibo'),
-      '/F1 11 Tf',
-      '14 TL',
-      'T*',
-      this.pdfText(`Número de recibo: ${input.receiptNumber}`),
-      'T*',
-      this.pdfText(`Fecha de aprobación: ${input.approvedAt}`),
-      'T*',
-      this.pdfText(`Aprobado por: ${input.approvedByUserName}`),
-      'T*',
-      'T*',
-      '/F2 12 Tf',
-      this.pdfText('Datos del pago'),
-      '/F1 11 Tf',
-      '14 TL',
-      'T*',
-      this.pdfText(`Unidad: ${input.unitLabel}`),
-      'T*',
-      this.pdfText(`Edificio: ${input.buildingName}`),
-      'T*',
-      this.pdfText(`Monto: ${input.amountFormatted}`),
-      'T*',
-      this.pdfText(`Método: ${input.method}`),
-      'T*',
-      this.pdfText(`Referencia: ${input.reference}`),
-      'T*',
-      this.pdfText(`Período aplicado: ${input.primaryPeriod}`),
-      'T*',
-      'T*',
-      '/F2 12 Tf',
-      this.pdfText(input.pageCount > 1 && input.pageIndex > 0 ? 'Aplicación del pago (continuación)' : 'Aplicación del pago'),
-      '/F1 11 Tf',
-      '14 TL',
-      ...input.allocations.flatMap((allocation) => [
-        'T*',
-        this.pdfText(allocation),
-      ]),
-      'T*',
-    ];
+    const lines = input.lines;
+    const contentCommands: string[] = ['BT', '72 792 Td'];
+    let currentFont = '';
+    let currentLeading = 14;
 
-    if (input.pageIndex === input.pageCount - 1) {
-      contentCommands.push(
-        this.pdfText('Este documento es una constancia de pago y no constituye factura fiscal.'),
-        'T*',
-        this.pdfText(`Documento generado por la Administración del ${input.tenantDisplayName}.`),
-      );
-    } else {
-      contentCommands.push(
-        this.pdfText('Continúa en la siguiente página.'),
-      );
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index]!;
+      const renderedText = line.kind === 'heading' && line.text === 'Aplicación del pago' && input.pageIndex > 0
+        ? 'Aplicación del pago (continuación)'
+        : line.text;
+
+      if (index > 0) {
+        contentCommands.push('T*');
+      }
+
+      const fontCommand = line.kind === 'title'
+        ? '/F2 18 Tf'
+        : line.kind === 'heading'
+          ? '/F2 12 Tf'
+          : '/F1 11 Tf';
+      const leading = line.kind === 'title'
+        ? 22
+        : line.kind === 'heading'
+          ? 14
+          : 14;
+
+      if (currentFont !== fontCommand) {
+        contentCommands.push(fontCommand);
+        currentFont = fontCommand;
+      }
+
+      if (currentLeading !== leading) {
+        contentCommands.push(`${leading} TL`);
+        currentLeading = leading;
+      }
+
+      if (line.kind !== 'blank') {
+        contentCommands.push(this.pdfText(renderedText));
+      }
     }
 
+    contentCommands.push('T*');
+    if (input.pageIndex === input.pageCount - 1) {
+      contentCommands.push('/F1 10 Tf', '12 TL');
+      contentCommands.push(this.pdfText('Este documento es una constancia de pago y no constituye factura fiscal.'));
+      contentCommands.push('T*');
+      contentCommands.push(this.pdfText(`Documento generado por la Administración del ${input.tenantDisplayName}.`));
+    } else {
+      contentCommands.push('/F1 10 Tf', '12 TL');
+      contentCommands.push(this.pdfText('Continúa en la siguiente página.'));
+    }
+
+    contentCommands.push('T*');
+    contentCommands.push(this.pdfText(`Página ${input.pageIndex + 1} de ${input.pageCount}`));
     contentCommands.push('ET');
     return contentCommands.join('\n');
   }
 
-  private chunkReceiptAllocations(allocations: readonly string[]): string[][] {
-    const chunkSize = 8;
-    const pages: string[][] = [];
-
-    for (let index = 0; index < allocations.length; index += chunkSize) {
-      pages.push(allocations.slice(index, index + chunkSize));
+  private chunkReceiptBodyLines(lines: readonly ReceiptPdfLine[]): ReceiptPdfLine[][] {
+    const pages: ReceiptPdfLine[][] = [];
+    for (let index = 0; index < lines.length; index += RECEIPT_PDF_MAX_BODY_LINES_PER_PAGE) {
+      pages.push(lines.slice(index, index + RECEIPT_PDF_MAX_BODY_LINES_PER_PAGE));
     }
 
-    return pages.length > 0 ? pages : [['Sin aplicación específica - saldo a favor']];
+    return pages.length > 0 ? pages : [[{ text: 'Sin aplicación específica - saldo a favor', kind: 'body' }]];
+  }
+
+  private pushBlankReceiptLine(lines: ReceiptPdfLine[]): void {
+    lines.push({ text: '', kind: 'blank' });
+  }
+
+  private pushWrappedReceiptLine(
+    lines: ReceiptPdfLine[],
+    text: string,
+    kind: 'title' | 'heading' | 'body' = 'body',
+  ): void {
+    const wrappedLines = this.wrapReceiptText(text);
+    for (const wrappedLine of wrappedLines) {
+      lines.push({ text: wrappedLine, kind });
+    }
+  }
+
+  private wrapReceiptText(text: string): string[] {
+    const trimmedText = text.trim();
+    if (!trimmedText) {
+      return [''];
+    }
+
+    const words = trimmedText.split(/\s+/);
+    const lines: string[] = [];
+    let currentLine = '';
+
+    for (const word of words) {
+      const candidateLine = currentLine ? `${currentLine} ${word}` : word;
+      if (this.measureReceiptTextWidth(candidateLine) <= RECEIPT_PDF_MAX_TEXT_WIDTH) {
+        currentLine = candidateLine;
+        continue;
+      }
+
+      if (currentLine) {
+        lines.push(currentLine);
+        currentLine = '';
+      }
+
+      if (this.measureReceiptTextWidth(word) <= RECEIPT_PDF_MAX_TEXT_WIDTH) {
+        currentLine = word;
+        continue;
+      }
+
+      const splitTokenLines = this.splitReceiptToken(word);
+      for (let index = 0; index < splitTokenLines.length - 1; index += 1) {
+        lines.push(splitTokenLines[index]!);
+      }
+      currentLine = splitTokenLines[splitTokenLines.length - 1] ?? '';
+    }
+
+    if (currentLine) {
+      lines.push(currentLine);
+    }
+
+    return lines.length > 0 ? lines : [''];
+  }
+
+  private splitReceiptToken(token: string): string[] {
+    const lines: string[] = [];
+    let currentLine = '';
+
+    for (const character of token) {
+      const candidateLine = `${currentLine}${character}`;
+      if (this.measureReceiptTextWidth(candidateLine) <= RECEIPT_PDF_MAX_TEXT_WIDTH) {
+        currentLine = candidateLine;
+      } else {
+        if (currentLine) {
+          lines.push(currentLine);
+        }
+        currentLine = character;
+      }
+    }
+
+    if (currentLine) {
+      lines.push(currentLine);
+    }
+
+    return lines.length > 0 ? lines : [token];
+  }
+
+  private measureReceiptTextWidth(text: string): number {
+    const widths: Record<string, number> = {
+      ' ': 2.5,
+      '.': 2.5,
+      ',': 2.5,
+      ':': 2.5,
+      ';': 2.5,
+      '!': 2.5,
+      '?': 4.5,
+      '|': 2.5,
+      'i': 2.75,
+      'l': 2.75,
+      'I': 3,
+      'j': 2.75,
+      't': 3.5,
+      'f': 3.5,
+      'r': 3.5,
+      's': 4.25,
+      'a': 4.5,
+      'c': 4.5,
+      'e': 4.5,
+      'o': 4.5,
+      'n': 4.5,
+      'u': 4.5,
+      'v': 4.5,
+      'x': 4.5,
+      'y': 4.5,
+      'k': 4.75,
+      'd': 4.75,
+      'g': 4.75,
+      'h': 4.75,
+      'b': 4.75,
+      'p': 4.75,
+      'm': 7.25,
+      'w': 7.25,
+      'M': 8.5,
+      'W': 8.5,
+      '0': 5,
+      '1': 5,
+      '2': 5,
+      '3': 5,
+      '4': 5,
+      '5': 5,
+      '6': 5,
+      '7': 5,
+      '8': 5,
+      '9': 5,
+      '-': 3.5,
+      '/': 3.5,
+      '(': 3.5,
+      ')': 3.5,
+      '%': 7,
+      'Ñ': 7,
+      'Á': 6,
+      'É': 6,
+      'Í': 6,
+      'Ó': 6,
+      'Ú': 6,
+      'Ü': 6,
+      'ñ': 4.75,
+      'á': 4.5,
+      'é': 4.5,
+      'í': 4.5,
+      'ó': 4.5,
+      'ú': 4.5,
+      'ü': 4.5,
+    };
+
+    let width = 0;
+    for (const character of text) {
+      if (widths[character] !== undefined) {
+        width += widths[character];
+        continue;
+      }
+
+      if (character.toUpperCase() === character && character.toLowerCase() !== character.toUpperCase()) {
+        width += 6;
+      } else {
+        width += 5;
+      }
+    }
+
+    return width;
   }
 
   private serializePdf(contentStreams: readonly string[]): Buffer {

--- a/apps/api/src/receipts/payment-receipt.service.ts
+++ b/apps/api/src/receipts/payment-receipt.service.ts
@@ -459,7 +459,7 @@ export class PaymentReceiptService {
     const lines = input.lines;
     const contentCommands: string[] = ['BT', '72 792 Td'];
     let currentFont = '';
-    let currentLeading = 14;
+    let currentLeading: number | null = null;
 
     for (let index = 0; index < lines.length; index += 1) {
       const line = lines[index]!;

--- a/apps/api/src/storage/minio.service.ts
+++ b/apps/api/src/storage/minio.service.ts
@@ -1,12 +1,20 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '../config/config.service';
 import * as Minio from 'minio';
+import type { Readable } from 'node:stream';
 
 interface MinioErrorLike {
   code?: string;
   statusCode?: number;
   message?: string;
   stack?: string;
+}
+
+export interface MinioObjectStat {
+  size: number;
+  etag?: string;
+  lastModified?: Date;
+  metaData?: Record<string, string>;
 }
 
 /**
@@ -79,6 +87,13 @@ export class MinioService {
   }
 
   /**
+   * Return the configured default bucket for the current environment.
+   */
+  getDefaultBucket(): string {
+    return this.bucket;
+  }
+
+  /**
    * Generate presigned URL for file upload (PUT)
    *
    * @param bucketName - Bucket name (or undefined to use default)
@@ -87,7 +102,8 @@ export class MinioService {
    * @returns Presigned URL for PUT request
    *
    * @example
-   * const url = await minioService.presignUpload('documents', 'tenant-123/docs/file.pdf', 3600);
+   * const bucket = minioService.getDefaultBucket();
+   * const url = await minioService.presignUpload(bucket, 'tenant-123/docs/file.pdf', 3600);
    * // Client can then: fetch(url, { method: 'PUT', body: file })
    */
   async presignUpload(
@@ -123,7 +139,8 @@ export class MinioService {
    * @returns Presigned URL for GET request
    *
    * @example
-   * const url = await minioService.presignDownload('documents', 'tenant-123/docs/file.pdf', 3600);
+   * const bucket = minioService.getDefaultBucket();
+   * const url = await minioService.presignDownload(bucket, 'tenant-123/docs/file.pdf', 3600);
    * // Client can then: window.location.href = url;
    */
   async presignDownload(
@@ -151,13 +168,32 @@ export class MinioService {
   }
 
   /**
+   * Get object metadata from MinIO.
+   * Useful for real size validation before persisting document metadata.
+   */
+  async statObject(
+    bucketName: string = this.bucket,
+    objectKey: string,
+  ): Promise<MinioObjectStat> {
+    try {
+      return await this.minioClient.statObject(bucketName, objectKey) as MinioObjectStat;
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to stat object: ${this.getErrorMessage(error)}`,
+        this.getErrorStack(error),
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Delete an object from MinIO
    *
    * @param bucketName - Bucket name (or undefined to use default)
    * @param objectKey - Object path in bucket
    *
    * @example
-   * await minioService.deleteObject('documents', 'tenant-123/docs/file.pdf');
+   * await minioService.deleteObject(minioService.getDefaultBucket(), 'tenant-123/docs/file.pdf');
    */
   async deleteObject(
     bucketName: string = this.bucket,
@@ -183,7 +219,7 @@ export class MinioService {
    * @returns true if object exists, false otherwise
    *
    * @example
-   * const exists = await minioService.objectExists('documents', 'tenant-123/docs/file.pdf');
+   * const exists = await minioService.objectExists(minioService.getDefaultBucket(), 'tenant-123/docs/file.pdf');
    */
   async objectExists(
     bucketName: string = this.bucket,
@@ -325,6 +361,24 @@ export class MinioService {
   }
 
   /**
+   * Read an object from MinIO as a stream.
+   */
+  async getObjectStream(
+    bucketName: string = this.bucket,
+    objectKey: string,
+  ): Promise<Readable> {
+    try {
+      return await this.minioClient.getObject(bucketName, objectKey);
+    } catch (error: unknown) {
+      this.logger.error(
+        `Failed to open object stream: ${this.getErrorMessage(error)}`,
+        this.getErrorStack(error),
+      );
+      throw error;
+    }
+  }
+
+  /**
    * Upload a buffer directly to MinIO
    *
    * @param bucketName - Bucket name
@@ -333,7 +387,7 @@ export class MinioService {
    * @param contentType - MIME type (default: application/octet-stream)
    *
    * @example
-   * await minioService.uploadBuffer('documents', 'tenant-123/receipt.pdf', buffer, 'application/pdf');
+   * await minioService.uploadBuffer(minioService.getDefaultBucket(), 'tenant-123/receipt.pdf', buffer, 'application/pdf');
    */
   async uploadBuffer(
     bucketName: string = this.bucket,

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
@@ -297,6 +297,88 @@ describe('ResidentPaymentsPage', () => {
     expect(screen.queryByText('Recibo en generación')).toBeNull();
   });
 
+  it('shows receipt generation progress for approved and reconciled payments only', async () => {
+    mockedListPayments.mockResolvedValueOnce([
+      makePayment({
+        id: 'payment-approved-pending',
+        status: PaymentStatus.APPROVED,
+        receiptStatus: 'PENDING',
+        receiptDocumentId: undefined,
+        receiptError: undefined,
+      }),
+      makePayment({
+        id: 'payment-reconciled-pending',
+        status: PaymentStatus.RECONCILED,
+        receiptStatus: 'PENDING',
+        receiptDocumentId: undefined,
+        receiptError: undefined,
+      }),
+      makePayment({
+        id: 'payment-submitted-pending',
+        status: PaymentStatus.SUBMITTED,
+        receiptStatus: 'PENDING',
+        receiptDocumentId: undefined,
+        receiptError: undefined,
+      }),
+      makePayment({
+        id: 'payment-rejected-pending',
+        status: PaymentStatus.REJECTED,
+        receiptStatus: 'PENDING',
+        receiptDocumentId: undefined,
+        receiptError: undefined,
+      }),
+    ]);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    expect(await screen.findAllByText('Recibo en generación')).toHaveLength(2);
+    expect(screen.queryByText('No pudimos generar el recibo. La administración ya fue notificada.')).toBeNull();
+    expect(screen.queryByRole('button', { name: /ver recibo del pago de/i })).toBeNull();
+  });
+
+  it('shows receipt errors for approved and reconciled payments and allows opening the reconciled receipt', async () => {
+    mockedListPayments.mockResolvedValueOnce([
+      makePayment({
+        id: 'payment-approved-failed',
+        status: PaymentStatus.APPROVED,
+        receiptStatus: 'FAILED',
+        receiptError: 'Error al generar el recibo aprobado',
+        receiptDocumentId: undefined,
+      }),
+      makePayment({
+        id: 'payment-reconciled-failed',
+        status: PaymentStatus.RECONCILED,
+        receiptStatus: 'FAILED',
+        receiptError: 'Error al generar el recibo conciliado',
+        receiptDocumentId: undefined,
+      }),
+      makePayment({
+        id: 'payment-reconciled-ready',
+        status: PaymentStatus.RECONCILED,
+        receiptStatus: 'READY',
+        receiptDocumentId: 'receipt-doc-1',
+        receiptError: undefined,
+      }),
+    ]);
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    expect(await screen.findByText('Error al generar el recibo aprobado')).toBeTruthy();
+    expect(screen.getByText('Error al generar el recibo conciliado')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /ver recibo del pago de/i }));
+
+    await waitFor(() => {
+      expect(mockedDownloadDocumentContent).toHaveBeenCalledWith('tenant-1', 'receipt-doc-1');
+      expect(openSpy).toHaveBeenCalledWith('blob:download-url', '_blank', 'noopener,noreferrer');
+    });
+
+    openSpy.mockRestore();
+  });
+
   it('does not show an invalid receipt action for payments without an approved receipt', async () => {
     mockedListPayments.mockResolvedValueOnce([
       makePayment({

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
@@ -1,0 +1,650 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { useParams } from 'next/navigation';
+import ResidentPaymentsPage from './page';
+import { useResidentContext } from '@/features/resident/hooks/useResidentContext';
+import { useContextOptions } from '@/features/context/useContextOptions';
+import { useTenants } from '@/features/tenants/tenants.hooks';
+import { getResidentLedger } from '@/features/resident/api/resident-context.api';
+import { listPayments, submitPayment, PaymentMethod, PaymentStatus, ChargeStatus, ChargeType, type Payment } from '@/features/finance/services/finance.api';
+import { createDocument, downloadDocumentContent, presignUpload, uploadFileToMinio } from '@/features/buildings/services/documents.api';
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+}));
+
+jest.mock('@/features/resident/hooks/useResidentContext', () => ({
+  useResidentContext: jest.fn(),
+}));
+
+jest.mock('@/features/context/useContextOptions', () => ({
+  useContextOptions: jest.fn(),
+}));
+
+jest.mock('@/features/tenants/tenants.hooks', () => ({
+  useTenants: jest.fn(),
+}));
+
+jest.mock('@/features/resident/api/resident-context.api', () => ({
+  getResidentLedger: jest.fn(),
+}));
+
+jest.mock('@/features/finance/services/finance.api', () => ({
+  listPayments: jest.fn(),
+  submitPayment: jest.fn(),
+  PaymentMethod: {
+    TRANSFER: 'TRANSFER',
+  },
+  ChargeType: {
+    COMMON_EXPENSE: 'COMMON_EXPENSE',
+  },
+  PaymentStatus: {
+    SUBMITTED: 'SUBMITTED',
+    APPROVED: 'APPROVED',
+    REJECTED: 'REJECTED',
+    RECONCILED: 'RECONCILED',
+  },
+  ChargeStatus: {
+    PENDING: 'PENDING',
+    PARTIAL: 'PARTIAL',
+    PAID: 'PAID',
+    CANCELED: 'CANCELED',
+  },
+}));
+
+jest.mock('@/features/buildings/services/documents.api', () => ({
+  downloadDocumentContent: jest.fn(),
+  presignUpload: jest.fn(),
+  uploadFileToMinio: jest.fn(),
+  createDocument: jest.fn(),
+}));
+
+const mockedUseParams = jest.mocked(useParams);
+const mockedUseResidentContext = jest.mocked(useResidentContext);
+const mockedUseContextOptions = jest.mocked(useContextOptions);
+const mockedUseTenants = jest.mocked(useTenants);
+const mockedGetResidentLedger = jest.mocked(getResidentLedger);
+const mockedListPayments = jest.mocked(listPayments);
+const mockedSubmitPayment = jest.mocked(submitPayment);
+const mockedDownloadDocumentContent = jest.mocked(downloadDocumentContent);
+const mockedPresignUpload = jest.mocked(presignUpload);
+const mockedUploadFileToMinio = jest.mocked(uploadFileToMinio);
+const mockedCreateDocument = jest.mocked(createDocument);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+function makeLedger(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    unitId: 'unit-1',
+    unitLabel: 'TN-01-01',
+    buildingId: 'building-1',
+    buildingName: 'Complejo Horizonte',
+    charges: [makeCharge()],
+    payments: [],
+    totals: {
+      balance: 9998,
+      currency: 'ARS',
+      totalCharges: 9998,
+      totalPaid: 0,
+      totalAllocated: 0,
+    },
+    ...overrides,
+  };
+}
+
+function makePayment(overrides: Partial<Payment> = {}): Payment {
+  return {
+    id: 'payment-1',
+    buildingId: 'building-1',
+    unitId: 'unit-1',
+    amount: 12345,
+    currency: 'ARS',
+    method: PaymentMethod.TRANSFER,
+    status: PaymentStatus.SUBMITTED,
+    reference: 'TRX-001',
+    proofFileId: undefined,
+    proofDocumentId: undefined,
+    receiptDocumentId: undefined,
+    receiptNumber: undefined,
+    receiptStatus: 'PENDING',
+    receiptError: undefined,
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    paidAt: '2026-07-01T00:00:00.000Z',
+    rejectionReason: null,
+    rejectionComment: null,
+    ...overrides,
+  };
+}
+
+function makeCharge(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'charge-1',
+    unitId: 'unit-1',
+    type: ChargeType.COMMON_EXPENSE,
+    concept: 'Expensas Julio 2026',
+    period: '2026-07',
+    amount: 9998,
+    allocated: 0,
+    currency: 'ARS',
+    dueDate: '2026-07-24T00:00:00.000Z',
+    status: ChargeStatus.PENDING,
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('ResidentPaymentsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseParams.mockReturnValue({ tenantId: 'tenant-1' } as never);
+    mockedUseTenants.mockReturnValue({
+      data: [{ id: 'tenant-1', name: 'Complejo Horizonte' }],
+    } as never);
+    mockedUseResidentContext.mockReturnValue({
+      data: {
+        activeBuildingId: 'building-1',
+        activeUnitId: 'unit-1',
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    mockedUseContextOptions.mockReturnValue({
+      data: {
+        buildings: [{ id: 'building-1', name: 'Complejo Horizonte' }],
+        unitsByBuilding: {
+          'building-1': [{ id: 'unit-1', label: 'TN-01-01' }],
+        },
+      },
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    mockedGetResidentLedger.mockResolvedValue(makeLedger());
+    mockedListPayments.mockResolvedValue([]);
+    mockedSubmitPayment.mockResolvedValue(undefined as never);
+    mockedDownloadDocumentContent.mockResolvedValue(new Blob(['pdf'], { type: 'application/pdf' }));
+    mockedPresignUpload.mockResolvedValue({
+      url: 'https://upload.example/proof.pdf',
+      bucket: 'documents',
+      objectKey: 'tenant-1/documents/proof.pdf',
+      expiresAt: '2026-07-24T00:00:00.000Z',
+    });
+    mockedUploadFileToMinio.mockResolvedValue(undefined);
+    mockedCreateDocument.mockResolvedValue({
+      id: 'document-1',
+      file: { id: 'file-1' },
+    } as never);
+    (window.URL as typeof window.URL & {
+      createObjectURL: jest.Mock;
+      revokeObjectURL: jest.Mock;
+    }).createObjectURL = jest.fn(() => 'blob:download-url');
+    (window.URL as typeof window.URL & {
+      createObjectURL: jest.Mock;
+      revokeObjectURL: jest.Mock;
+    }).revokeObjectURL = jest.fn();
+    jest.useRealTimers();
+  });
+
+  it('shows loading and error states before rendering the resident payment history', async () => {
+    mockedUseResidentContext.mockReturnValue({
+      data: null,
+      isLoading: true,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    expect(screen.queryByRole('button', { name: /reportar pago/i })).toBeNull();
+
+    mockedUseResidentContext.mockReturnValue({
+      data: {
+        activeBuildingId: 'building-1',
+        activeUnitId: 'unit-1',
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    mockedGetResidentLedger.mockRejectedValueOnce(new Error('Sin conexión'));
+    mockedListPayments.mockResolvedValueOnce([]);
+
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    expect(await screen.findByText('No pudimos cargar tus pagos.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Reintentar' })).toBeTruthy();
+  });
+
+  it('renders an empty state when the resident has no payments yet', async () => {
+    mockedGetResidentLedger.mockResolvedValueOnce(makeLedger({ charges: [] }));
+    mockedListPayments.mockResolvedValueOnce([]);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    expect(await screen.findByText('Todavía no tenés pagos registrados.')).toBeTruthy();
+    expect(screen.getByText('No tenés cargos pendientes por ahora.')).toBeTruthy();
+  });
+
+  it('shows receipt actions and rejection reason only when the backend returns them', async () => {
+    mockedListPayments.mockResolvedValueOnce([
+      makePayment({
+        id: 'payment-approved',
+        status: PaymentStatus.APPROVED,
+        proofDocumentId: 'proof-doc-1',
+        receiptDocumentId: 'receipt-doc-1',
+        receiptNumber: 'R-HORIZ-2026-000001',
+        receiptStatus: 'READY',
+      }),
+      makePayment({
+        id: 'payment-rejected',
+        status: PaymentStatus.REJECTED,
+        proofDocumentId: 'proof-doc-2',
+        receiptDocumentId: undefined,
+        receiptStatus: 'PENDING',
+        rejectionReason: 'SIN_COMPROBANTE',
+        rejectionComment: 'Falta el respaldo bancario',
+      }),
+    ]);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    expect(await screen.findByRole('button', { name: /ver recibo del pago de/i })).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: /ver comprobante del pago de/i })).toHaveLength(2);
+    expect(screen.getByText(/Motivo: Sin comprobante/)).toBeTruthy();
+    expect(screen.getByText(/Falta el respaldo bancario/)).toBeTruthy();
+    expect(screen.queryByText('Recibo en generación')).toBeNull();
+  });
+
+  it('does not show an invalid receipt action for payments without an approved receipt', async () => {
+    mockedListPayments.mockResolvedValueOnce([
+      makePayment({
+        id: 'payment-submitted',
+        status: PaymentStatus.SUBMITTED,
+        receiptDocumentId: undefined,
+        receiptStatus: 'PENDING',
+      }),
+    ]);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    expect(await screen.findByText('Enviado')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /ver recibo del pago de/i })).toBeNull();
+  });
+
+  it('downloads an approved receipt through the protected document endpoint as a blob URL', async () => {
+    mockedListPayments.mockResolvedValueOnce([
+      makePayment({
+        id: 'payment-approved',
+        status: PaymentStatus.APPROVED,
+        proofDocumentId: 'proof-doc-1',
+        receiptDocumentId: 'receipt-doc-1',
+        receiptStatus: 'READY',
+      }),
+    ]);
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+    jest.useFakeTimers();
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    fireEvent.click(await screen.findByRole('button', { name: /ver recibo del pago de/i }));
+
+    await waitFor(() => {
+      expect(mockedDownloadDocumentContent).toHaveBeenCalledWith('tenant-1', 'receipt-doc-1');
+      expect(openSpy).toHaveBeenCalledWith('blob:download-url', '_blank', 'noopener,noreferrer');
+      expect((window.URL as typeof window.URL & { createObjectURL: jest.Mock }).createObjectURL).toHaveBeenCalled();
+    });
+
+    expect((window.URL as typeof window.URL & { revokeObjectURL: jest.Mock }).revokeObjectURL).not.toHaveBeenCalled();
+    await act(async () => {
+      jest.advanceTimersByTime(60_000);
+    });
+    expect((window.URL as typeof window.URL & { revokeObjectURL: jest.Mock }).revokeObjectURL).toHaveBeenCalledWith('blob:download-url');
+    openSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it('shows a download error when the protected document endpoint returns 401 or 404', async () => {
+    mockedListPayments.mockResolvedValueOnce([
+      makePayment({
+        id: 'payment-approved',
+        status: PaymentStatus.APPROVED,
+        receiptDocumentId: 'receipt-doc-1',
+        receiptStatus: 'READY',
+      }),
+    ]);
+
+    mockedDownloadDocumentContent
+      .mockRejectedValueOnce(new Error('Sesión expirada. Vuelve a iniciar sesión.'))
+      .mockRejectedValueOnce(new Error('Document not found'));
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    fireEvent.click(await screen.findByRole('button', { name: /ver recibo del pago de/i }));
+
+    expect(await screen.findByText('No pudimos abrir el documento.')).toBeTruthy();
+    expect(screen.getByText('Sesión expirada. Vuelve a iniciar sesión.')).toBeTruthy();
+    expect(mockedDownloadDocumentContent).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a download error when the protected document endpoint fails with 404 on proof download', async () => {
+    mockedListPayments.mockResolvedValueOnce([
+      makePayment({
+        id: 'payment-approved',
+        status: PaymentStatus.APPROVED,
+        proofDocumentId: 'proof-doc-1',
+        receiptDocumentId: 'receipt-doc-1',
+        receiptStatus: 'READY',
+      }),
+    ]);
+    mockedDownloadDocumentContent.mockRejectedValueOnce(new Error('Document not found'));
+    const openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    fireEvent.click(await screen.findByRole('button', { name: /ver comprobante del pago de/i }));
+
+    expect(await screen.findByText('No pudimos abrir el documento.')).toBeTruthy();
+    expect(screen.getByText('Document not found')).toBeTruthy();
+    expect(openSpy).not.toHaveBeenCalled();
+    openSpy.mockRestore();
+  });
+
+  it('blocks oversized payment proofs before uploading them', async () => {
+    mockedListPayments.mockResolvedValueOnce([]);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    fireEvent.click(await screen.findByRole('button', { name: /reportar pago/i }));
+    const fileInput = screen.getByLabelText(/comprobante de pago/i);
+    const file = new File([new Uint8Array(11 * 1024 * 1024)], 'proof.pdf', { type: 'application/pdf' });
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(await screen.findByText(/El archivo no puede superar 10MB/)).toBeTruthy();
+    expect(mockedPresignUpload).not.toHaveBeenCalled();
+  });
+
+  it('blocks invalid payment proof MIME types before upload', async () => {
+    mockedListPayments.mockResolvedValueOnce([]);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    fireEvent.click(await screen.findByRole('button', { name: /reportar pago/i }));
+    const fileInput = screen.getByLabelText(/comprobante de pago/i);
+    const file = new File([new Uint8Array([1, 2, 3])], 'notes.txt', { type: 'text/plain' });
+
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(await screen.findByText('El comprobante debe ser PDF, JPG o PNG')).toBeTruthy();
+    expect(mockedPresignUpload).not.toHaveBeenCalled();
+  });
+
+  it('opens a confirmation modal with the selected charge and keeps the form when canceled', async () => {
+    mockedListPayments.mockResolvedValueOnce([]);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    fireEvent.click(await screen.findByRole('button', { name: /reportar pago/i }));
+    expect((screen.getByLabelText(/cargo pendiente/i) as HTMLSelectElement).value).toBe('charge-1');
+    fireEvent.change(screen.getByLabelText(/comprobante de pago/i), {
+      target: {
+        files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
+      },
+    });
+
+    await waitFor(() => expect(mockedPresignUpload).toHaveBeenCalled());
+    expect(await screen.findByText(/proof\.pdf subido correctamente/i)).toBeTruthy();
+    expect(screen.getByText('Monto a reportar')).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Enviar pago' }));
+
+    const dialog = await screen.findByRole('dialog', { name: /confirmar reporte de pago/i });
+    expect(dialog.textContent).toContain('99,98');
+    expect(dialog.textContent).toContain('24/07/2026');
+    expect(dialog.textContent).not.toContain('23/07/2026');
+    expect(dialog.textContent).toContain('Expensas Julio 2026');
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancelar' }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: /confirmar reporte de pago/i })).toBeNull());
+    expect((screen.getByLabelText(/fecha de pago/i) as HTMLInputElement).value).toBe('2026-07-24');
+    expect((screen.getByLabelText(/cargo pendiente/i) as HTMLSelectElement).value).toBe('charge-1');
+    expect((screen.getByLabelText(/comprobante de pago/i) as HTMLInputElement).files?.[0]?.name).toBe('proof.pdf');
+    expect(mockedSubmitPayment).not.toHaveBeenCalled();
+  });
+
+  it('submits the selected charge at the full outstanding amount and refreshes the payment list after submission', async () => {
+    const initialPayments: Payment[] = [
+      makePayment({
+        id: 'payment-existing',
+        reference: 'TRX-001',
+        status: PaymentStatus.SUBMITTED,
+        proofDocumentId: 'proof-doc-1',
+      }),
+    ];
+    const updatedPayments: Payment[] = [
+      ...initialPayments,
+      makePayment({
+        id: 'payment-new',
+        reference: 'TRX-NEW',
+        amount: 20000,
+        proofFileId: 'file-1',
+        status: PaymentStatus.SUBMITTED,
+      }),
+    ];
+    let paymentsResponse: Payment[] = initialPayments;
+    mockedListPayments.mockImplementation(() => Promise.resolve(paymentsResponse));
+    const deferred = createDeferred<Payment>();
+    mockedSubmitPayment.mockImplementation(async () => {
+      paymentsResponse = updatedPayments;
+      return deferred.promise;
+    });
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    fireEvent.click(await screen.findByRole('button', { name: /reportar pago/i }));
+    fireEvent.change(screen.getByLabelText(/comprobante de pago/i), {
+      target: {
+        files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
+      },
+    });
+
+    await waitFor(() => expect(mockedPresignUpload).toHaveBeenCalled());
+    expect(await screen.findByText(/proof\.pdf subido correctamente/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Enviar pago' }));
+
+    const dialog = await screen.findByRole('dialog', { name: /confirmar reporte de pago/i });
+    expect(dialog.textContent).toContain('99,98');
+    expect(dialog.textContent).toContain('Expensas Julio 2026');
+    expect(dialog.textContent).toContain('24/07/2026');
+
+    const confirmButton = screen.getByRole('button', { name: 'Confirmar pago' });
+    expect(confirmButton.hasAttribute('disabled')).toBe(false);
+    fireEvent.click(confirmButton);
+    expect(confirmButton.hasAttribute('disabled')).toBe(true);
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      expect(mockedSubmitPayment).toHaveBeenCalledWith(
+        'building-1',
+        expect.objectContaining({
+          unitId: 'unit-1',
+          chargeId: 'charge-1',
+          amount: 9998,
+          currency: 'ARS',
+          method: PaymentMethod.TRANSFER,
+          proofFileId: 'file-1',
+        }),
+      );
+    });
+    expect(mockedSubmitPayment).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      deferred.resolve(makePayment({ id: 'payment-submitted' }));
+    });
+
+    await waitFor(() => {
+      expect(mockedListPayments).toHaveBeenCalledTimes(2);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/TRX-NEW/)).toBeTruthy();
+    }, { timeout: 3000 });
+  });
+
+  it('keeps the same civil payment date in history and the confirmation modal', async () => {
+    mockedListPayments.mockResolvedValueOnce([
+      makePayment({
+        id: 'payment-existing',
+        paidAt: '2026-07-24T00:00:00.000Z',
+        createdAt: '2026-07-24T00:00:00.000Z',
+      }),
+    ]);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.queryAllByText('24/07/2026').length).toBeGreaterThan(0);
+    });
+    expect(screen.queryAllByText('23/07/2026')).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole('button', { name: /reportar pago/i }));
+    fireEvent.change(screen.getByLabelText(/fecha de pago/i), { target: { value: '2026-07-24' } });
+    fireEvent.change(screen.getByLabelText(/comprobante de pago/i), {
+      target: {
+        files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
+      },
+    });
+
+    await waitFor(() => expect(mockedPresignUpload).toHaveBeenCalled());
+    expect(await screen.findByText(/proof\.pdf subido correctamente/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Enviar pago' }));
+
+    const dialog = await screen.findByRole('dialog', { name: /confirmar reporte de pago/i });
+    expect(dialog.textContent).toContain('24/07/2026');
+    expect(dialog.textContent).not.toContain('23/07/2026');
+
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Cancelar' }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: /confirmar reporte de pago/i })).toBeNull());
+    expect((screen.getByLabelText(/fecha de pago/i) as HTMLInputElement).value).toBe('2026-07-24');
+  });
+
+  it('lets the resident switch pending charges and always shows the selected full balance', async () => {
+    mockedGetResidentLedger.mockResolvedValueOnce(
+      makeLedger({
+        charges: [
+          makeCharge({
+            id: 'charge-1',
+            concept: 'Expensas Julio 2026',
+            amount: 9998,
+            allocated: 0,
+          }),
+          makeCharge({
+            id: 'charge-2',
+            concept: 'Expensas Agosto 2026',
+            period: '2026-08',
+            amount: 2500,
+            allocated: 0,
+          }),
+        ],
+        totals: {
+          balance: 12498,
+          currency: 'ARS',
+          totalCharges: 12498,
+          totalPaid: 0,
+          totalAllocated: 0,
+        },
+      }),
+    );
+    mockedListPayments.mockResolvedValueOnce([]);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    fireEvent.click(await screen.findByRole('button', { name: /reportar pago/i }));
+    fireEvent.change(screen.getByLabelText(/cargo pendiente/i), { target: { value: 'charge-2' } });
+    fireEvent.change(screen.getByLabelText(/comprobante de pago/i), {
+      target: {
+        files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
+      },
+    });
+
+    await waitFor(() => expect(mockedPresignUpload).toHaveBeenCalled());
+    expect(await screen.findByText(/proof\.pdf subido correctamente/i)).toBeTruthy();
+    expect(screen.getByText('Monto a reportar')).toBeTruthy();
+    expect((screen.getByLabelText(/cargo pendiente/i) as HTMLSelectElement).value).toBe('charge-2');
+    fireEvent.click(screen.getByRole('button', { name: 'Enviar pago' }));
+
+    const dialog = await screen.findByRole('dialog', { name: /confirmar reporte de pago/i });
+    expect(dialog.textContent).toContain('25,00');
+    expect(dialog.textContent).toContain('Expensas Agosto 2026');
+    expect(dialog.textContent).toContain('24/07/2026');
+  });
+
+  it('surfaces backend validation failures from the proof upload pipeline', async () => {
+    mockedListPayments.mockResolvedValueOnce([]);
+    mockedCreateDocument.mockRejectedValueOnce(new Error('El archivo supera el máximo de 10485760 bytes'));
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    fireEvent.click(await screen.findByRole('button', { name: /reportar pago/i }));
+    fireEvent.change(screen.getByLabelText(/comprobante de pago/i), {
+      target: {
+        files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
+      },
+    });
+
+    expect(await screen.findByText(/Error al subir el comprobante/)).toBeTruthy();
+    expect(screen.getByText(/El archivo supera el máximo/)).toBeTruthy();
+    expect(mockedSubmitPayment).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
@@ -524,6 +524,13 @@ describe('ResidentPaymentsPage', () => {
     });
 
     await waitFor(() => expect(mockedPresignUpload).toHaveBeenCalled());
+    expect(mockedPresignUpload).toHaveBeenCalledWith(
+      'tenant-1',
+      'proof.pdf',
+      'application/pdf',
+      3,
+      'PAYMENT_PROOF',
+    );
     expect(await screen.findByText(/proof\.pdf subido correctamente/i)).toBeTruthy();
     expect(screen.getByText('Monto a reportar')).toBeTruthy();
 

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
@@ -136,9 +136,9 @@ function makePayment(overrides: Partial<Payment> = {}): Payment {
     receiptNumber: undefined,
     receiptStatus: 'PENDING',
     receiptError: undefined,
-    createdAt: '2026-07-01T00:00:00.000Z',
+    createdAt: '2026-07-01',
     updatedAt: '2026-07-01T00:00:00.000Z',
-    paidAt: '2026-07-01T00:00:00.000Z',
+    paidAt: '2026-07-01',
     rejectionReason: null,
     rejectionComment: null,
     ...overrides,
@@ -155,7 +155,7 @@ function makeCharge(overrides: Partial<Record<string, unknown>> = {}) {
     amount: 9998,
     allocated: 0,
     currency: 'ARS',
-    dueDate: '2026-07-24T00:00:00.000Z',
+    dueDate: '2026-07-24',
     status: ChargeStatus.PENDING,
     createdAt: '2026-07-01T00:00:00.000Z',
     updatedAt: '2026-07-01T00:00:00.000Z',
@@ -546,8 +546,8 @@ describe('ResidentPaymentsPage', () => {
     mockedListPayments.mockResolvedValueOnce([
       makePayment({
         id: 'payment-existing',
-        paidAt: '2026-07-24T00:00:00.000Z',
-        createdAt: '2026-07-24T00:00:00.000Z',
+        paidAt: '2026-07-24',
+        createdAt: '2026-07-24',
       }),
     ]);
 
@@ -580,6 +580,58 @@ describe('ResidentPaymentsPage', () => {
 
     await waitFor(() => expect(screen.queryByRole('dialog', { name: /confirmar reporte de pago/i })).toBeNull());
     expect((screen.getByLabelText(/fecha de pago/i) as HTMLInputElement).value).toBe('2026-07-24');
+  });
+
+  it('keeps civil dates exact and formats timestamps in local time in the history list', async () => {
+    mockedGetResidentLedger.mockResolvedValueOnce(makeLedger({ charges: [] }));
+    mockedListPayments.mockResolvedValueOnce([
+      makePayment({
+        id: 'payment-civil',
+        paidAt: '2026-07-24',
+        createdAt: '2026-07-24',
+        reference: 'CIVIL',
+      }),
+      makePayment({
+        id: 'payment-timestamp',
+        paidAt: '2026-07-26T01:00:00.000Z',
+        createdAt: '2026-07-26T01:00:00.000Z',
+        reference: 'TIMESTAMP',
+      }),
+      makePayment({
+        id: 'payment-fallback',
+        paidAt: undefined,
+        createdAt: '2026-07-26T01:00:00.000Z',
+        reference: 'FALLBACK',
+      }),
+      makePayment({
+        id: 'payment-invalid',
+        paidAt: 'invalid-date',
+        createdAt: 'invalid-date',
+        reference: 'INVALID',
+      }),
+    ]);
+
+    const expectedTimestampDate = new Intl.DateTimeFormat('es-AR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    }).format(new Date('2026-07-26T01:00:00.000Z'));
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    await screen.findByText('Historial de pagos');
+
+    expect(
+      screen.getByText((_, element) => element?.tagName === 'P' && element.textContent?.includes('24/07/2026') === true),
+    ).toBeTruthy();
+    expect(
+      screen.getAllByText(
+        (_, element) => element?.tagName === 'P' && element.textContent?.includes(expectedTimestampDate) === true,
+      ),
+    ).toHaveLength(2);
+    expect(screen.queryByText('23/07/2026')).toBeNull();
+    expect(screen.queryByText('invalid-date')).toBeNull();
   });
 
   it('lets the resident switch pending charges and always shows the selected full balance', async () => {

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
@@ -165,6 +165,8 @@ function makeCharge(overrides: Partial<Record<string, unknown>> = {}) {
 
 describe('ResidentPaymentsPage', () => {
   beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-07-24T12:00:00.000Z'));
     jest.clearAllMocks();
     mockedUseParams.mockReturnValue({ tenantId: 'tenant-1' } as never);
     mockedUseTenants.mockReturnValue({
@@ -214,6 +216,9 @@ describe('ResidentPaymentsPage', () => {
       createObjectURL: jest.Mock;
       revokeObjectURL: jest.Mock;
     }).revokeObjectURL = jest.fn();
+  });
+
+  afterEach(() => {
     jest.useRealTimers();
   });
 

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
@@ -448,7 +448,13 @@ export const ResidentPaymentsPage = () => {
     setSubmitError(null);
 
     try {
-      const presignRes = await presignUpload(tenantId, file.name, file.type, file.size);
+      const presignRes = await presignUpload(
+        tenantId,
+        file.name,
+        file.type,
+        file.size,
+        'PAYMENT_PROOF',
+      );
       await uploadFileToMinio(presignRes.url, file);
       const createdDocument = await createDocument(tenantId, {
         title: `Comprobante pago - ${file.name}`,

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
@@ -31,14 +31,45 @@ import Button from '@/shared/components/ui/Button';
 import Skeleton from '@/shared/components/ui/Skeleton';
 import { formatCurrency, getLocaleForCurrency } from '@/shared/lib/format/money';
 
-function formatDate(dateStr: string | undefined): string {
-  if (!dateStr) return '—';
+const CIVIL_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
-  const [datePart] = dateStr.split('T');
-  const [year, month, day] = datePart.split('-');
-  if (!year || !month || !day) return dateStr;
+function formatCivilDate(dateValue: string | undefined | null): string {
+  if (!dateValue || !CIVIL_DATE_PATTERN.test(dateValue)) return '—';
+
+  const [year, month, day] = dateValue.split('-');
+  if (!year || !month || !day) return '—';
 
   return `${day}/${month}/${year}`;
+}
+
+function formatLocalTimestampDate(dateValue: string | undefined | null): string {
+  if (!dateValue) return '—';
+
+  const parsedDate = new Date(dateValue);
+  if (Number.isNaN(parsedDate.getTime())) return '—';
+
+  return new Intl.DateTimeFormat('es-AR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  }).format(parsedDate);
+}
+
+function formatPaymentDisplayDate(dateValue: string | undefined | null): string {
+  if (!dateValue) return '—';
+
+  return CIVIL_DATE_PATTERN.test(dateValue)
+    ? formatCivilDate(dateValue)
+    : formatLocalTimestampDate(dateValue);
+}
+
+function getCurrentCivilDateInputValue(): string {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
 }
 
 function getChargeStatusFromDebt(amount: number, allocated: number | undefined, status: ChargeStatus): string {
@@ -350,7 +381,7 @@ export const ResidentPaymentsPage = () => {
     selectedChargeId: '',
     method: PaymentMethod.TRANSFER,
     reference: '',
-    paidAt: new Date().toISOString().split('T')[0],
+    paidAt: getCurrentCivilDateInputValue(),
   });
   const [proofFile, setProofFile] = useState<File | null>(null);
   const [proofFileId, setProofFileId] = useState<string | null>(null);
@@ -449,7 +480,7 @@ export const ResidentPaymentsPage = () => {
       selectedChargeId: '',
       method: PaymentMethod.TRANSFER,
       reference: '',
-      paidAt: new Date().toISOString().split('T')[0],
+      paidAt: getCurrentCivilDateInputValue(),
     });
     setProofFile(null);
     setProofFileId(null);
@@ -514,7 +545,7 @@ export const ResidentPaymentsPage = () => {
       amountLabel,
       chargeLabel,
       currency: selectedCharge.currency,
-      paidAtLabel: formatDate(formData.paidAt),
+      paidAtLabel: formatCivilDate(formData.paidAt),
       referenceLabel: formData.reference.trim() || undefined,
       proofFileName: proofFile.name,
     });
@@ -734,7 +765,7 @@ export const ResidentPaymentsPage = () => {
             <div>
               <p className="text-sm font-medium text-muted-foreground">Próximo vencimiento</p>
               <p className="text-2xl font-bold text-gray-900">
-                {nextDueCharge ? formatDate(nextDueCharge.dueDate) : '—'}
+                {nextDueCharge ? formatPaymentDisplayDate(nextDueCharge.dueDate) : '—'}
               </p>
               {nextDueCharge && (
                 <p className="text-xs text-muted-foreground">
@@ -755,7 +786,7 @@ export const ResidentPaymentsPage = () => {
               </p>
               {lastPayment && (
                 <p className="text-xs text-muted-foreground">
-                  {formatDate(lastPayment.paidAt ?? lastPayment.createdAt)}
+                  {formatPaymentDisplayDate(lastPayment.paidAt ?? lastPayment.createdAt)}
                 </p>
               )}
             </div>
@@ -778,7 +809,7 @@ export const ResidentPaymentsPage = () => {
                 <div>
                   <p className="font-medium">{charge.concept}</p>
                   <p className="text-sm text-muted-foreground">
-                    Período {charge.period} • Vence: {formatDate(charge.dueDate)}
+                    Período {charge.period} • Vence: {formatPaymentDisplayDate(charge.dueDate)}
                   </p>
                 </div>
                 <div className="text-right">
@@ -830,7 +861,7 @@ export const ResidentPaymentsPage = () => {
               const hasReceipt = !!receiptDocumentId;
               const hasProof = !!proofDocumentId;
               const downloadDisabled = downloadingDocumentId !== null;
-              const paymentDate = formatDate(payment.paidAt ?? payment.createdAt);
+              const paymentDate = formatPaymentDisplayDate(payment.paidAt ?? payment.createdAt);
 
               return (
                 <div key={payment.id} className="flex justify-between items-start gap-3 p-3 bg-muted/50 rounded-lg">

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   CreditCard,
   AlertCircle,
@@ -19,7 +19,7 @@ import { getResidentLedger, type UnitLedger } from '@/features/resident/api/resi
 import { useTenants } from '@/features/tenants/tenants.hooks';
 import { listPayments, submitPayment, type Payment, PaymentMethod, ChargeStatus } from '@/features/finance/services/finance.api';
 import {
-  getDownloadUrl,
+  downloadDocumentContent,
   presignUpload,
   uploadFileToMinio,
   createDocument,
@@ -29,15 +29,16 @@ import Input from '@/shared/components/ui/Input';
 import Select from '@/shared/components/ui/Select';
 import Button from '@/shared/components/ui/Button';
 import Skeleton from '@/shared/components/ui/Skeleton';
-import { formatCurrency, toCents, getLocaleForCurrency } from '@/shared/lib/format/money';
+import { formatCurrency, getLocaleForCurrency } from '@/shared/lib/format/money';
 
 function formatDate(dateStr: string | undefined): string {
   if (!dateStr) return '—';
-  return new Intl.DateTimeFormat('es-AR', {
-    day: '2-digit',
-    month: '2-digit',
-    year: 'numeric',
-  }).format(new Date(dateStr));
+
+  const [datePart] = dateStr.split('T');
+  const [year, month, day] = datePart.split('-');
+  if (!year || !month || !day) return dateStr;
+
+  return `${day}/${month}/${year}`;
 }
 
 function getChargeStatusFromDebt(amount: number, allocated: number | undefined, status: ChargeStatus): string {
@@ -69,11 +70,210 @@ function paymentStatusColor(status: string): string {
 }
 
 interface PaymentFormData {
-  amount: number;
+  selectedChargeId: string;
   method: PaymentMethod;
   reference: string;
   paidAt: string;
   proofFileId?: string;
+}
+
+interface PaymentConfirmationData {
+  chargeId: string;
+  amountMinor: number;
+  amountLabel: string;
+  chargeLabel: string;
+  currency: string;
+  paidAtLabel: string;
+  referenceLabel?: string;
+  proofFileName: string;
+}
+
+const MAX_PAYMENT_PROOF_SIZE_BYTES = 10 * 1024 * 1024;
+const PAYMENT_PROOF_ALLOWED_MIME_TYPES = [
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+] as const;
+
+const PAYMENT_REJECTION_REASON_LABELS: Record<string, string> = {
+  MONTO_INCORRECTO: 'Monto incorrecto',
+  REFERENCIA_INVALIDA: 'Referencia inválida',
+  SIN_COMPROBANTE: 'Sin comprobante',
+  COMPROBANTE_ILEGIBLE: 'Comprobante ilegible',
+  PAGO_DUPLICADO: 'Pago duplicado',
+  CUENTA_DESTINO_INVALIDA: 'Cuenta destino inválida',
+  OTRO: 'Otro',
+};
+
+function getPaymentRejectionReasonLabel(reason?: string | null): string | null {
+  if (!reason) return null;
+  return PAYMENT_REJECTION_REASON_LABELS[reason] ?? reason;
+}
+
+interface PaymentConfirmDialogProps {
+  isOpen: boolean;
+  data: PaymentConfirmationData | null;
+  errorMessage: string | null;
+  isLoading: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+function PaymentConfirmDialog({
+  isOpen,
+  data,
+  errorMessage,
+  isLoading,
+  onCancel,
+  onConfirm,
+}: PaymentConfirmDialogProps) {
+  const dialogSurfaceRef = useRef<HTMLDivElement | null>(null);
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      lastFocusedElementRef.current?.focus();
+      lastFocusedElementRef.current = null;
+      return;
+    }
+
+    lastFocusedElementRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+
+    const timer = window.setTimeout(() => {
+      dialogSurfaceRef.current?.querySelector<HTMLButtonElement>('[data-payment-confirm-primary]')?.focus();
+    }, 0);
+
+    return () => window.clearTimeout(timer);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        if (!isLoading) {
+          onCancel();
+        }
+        return;
+      }
+
+      if (event.key !== 'Tab') return;
+
+      const focusable = Array.from(
+        dialogSurfaceRef.current?.querySelectorAll<HTMLElement>('button:not([disabled])') ?? [],
+      );
+      if (focusable.length === 0) return;
+
+      const activeElement = document.activeElement as HTMLElement | null;
+      const currentIndex = activeElement ? focusable.indexOf(activeElement) : -1;
+      const nextIndex = event.shiftKey
+        ? (currentIndex <= 0 ? focusable.length - 1 : currentIndex - 1)
+        : (currentIndex === focusable.length - 1 ? 0 : currentIndex + 1);
+
+      event.preventDefault();
+      focusable[nextIndex]?.focus();
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isLoading, isOpen, onCancel]);
+
+  if (!isOpen || !data) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div
+        ref={dialogSurfaceRef}
+        className="w-full max-w-lg rounded-xl border border-border bg-card p-4 text-card-foreground shadow-sm"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="payment-confirm-title"
+        aria-describedby="payment-confirm-description"
+      >
+        <div className="flex items-start justify-between gap-4 mb-4">
+          <div>
+            <h2 id="payment-confirm-title" className="text-lg font-semibold text-foreground">
+              Confirmar reporte de pago
+            </h2>
+            <p className="text-sm text-muted-foreground mt-1">
+              Revisá los datos antes de enviarlo a administración.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onCancel}
+            disabled={isLoading}
+            aria-label="Cerrar confirmación"
+            data-payment-confirm-close
+          >
+            ×
+          </Button>
+        </div>
+
+        <div id="payment-confirm-description" className="space-y-3">
+          <div className="grid grid-cols-[auto,1fr] gap-x-4 gap-y-2 text-sm">
+            <span className="font-medium text-muted-foreground">Monto</span>
+            <span className="text-foreground">{data.amountLabel}</span>
+
+            <span className="font-medium text-muted-foreground">Fecha de pago</span>
+            <span className="text-foreground">{data.paidAtLabel}</span>
+
+            <span className="font-medium text-muted-foreground">Cargo / período</span>
+            <span className="text-foreground">{data.chargeLabel}</span>
+
+            {data.referenceLabel ? (
+              <>
+                <span className="font-medium text-muted-foreground">Referencia</span>
+                <span className="text-foreground">{data.referenceLabel}</span>
+              </>
+            ) : null}
+
+            <span className="font-medium text-muted-foreground">Comprobante</span>
+            <span className="text-foreground">{data.proofFileName}</span>
+          </div>
+
+          <p className="text-sm text-muted-foreground">
+            La administración revisará el comprobante antes de aprobarlo.
+          </p>
+
+          {errorMessage ? (
+            <div className="rounded-lg border border-red-200 bg-red-50 p-3 dark:border-red-900/60 dark:bg-red-950/40">
+              <p className="text-sm text-red-700 dark:text-red-200" aria-live="polite">
+                {errorMessage}
+              </p>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={onCancel}
+            disabled={isLoading}
+            data-payment-confirm-cancel
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            onClick={onConfirm}
+            disabled={isLoading}
+            className="gap-2"
+            data-payment-confirm-primary
+          >
+            {isLoading && <Loader2 className="w-4 h-4 animate-spin" />}
+            {isLoading ? 'Confirmando...' : 'Confirmar pago'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
 }
 
 /**
@@ -147,7 +347,7 @@ export const ResidentPaymentsPage = () => {
 
   const [showForm, setShowForm] = useState(false);
   const [formData, setFormData] = useState<PaymentFormData>({
-    amount: 0,
+    selectedChargeId: '',
     method: PaymentMethod.TRANSFER,
     reference: '',
     paidAt: new Date().toISOString().split('T')[0],
@@ -159,24 +359,43 @@ export const ResidentPaymentsPage = () => {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [downloadError, setDownloadError] = useState<string | null>(null);
   const [submitSuccess, setSubmitSuccess] = useState(false);
-  const [downloadingId, setDownloadingId] = useState<string | null>(null);
-  const [downloadUrls, setDownloadUrls] = useState<Record<string, string>>({});
+  const [downloadingDocumentId, setDownloadingDocumentId] = useState<string | null>(null);
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const [paymentToConfirm, setPaymentToConfirm] = useState<PaymentConfirmationData | null>(null);
+  const activeDownloadObjectUrlsRef = useRef<string[]>([]);
+  const activeDownloadTimersRef = useRef<number[]>([]);
 
-  const handleViewProof = async (paymentId: string, documentId: string) => {
-    if (downloadUrls[paymentId]) {
-      window.open(downloadUrls[paymentId], '_blank');
+  useEffect(() => {
+    return () => {
+      activeDownloadTimersRef.current.forEach((timerId) => window.clearTimeout(timerId));
+      activeDownloadTimersRef.current = [];
+      activeDownloadObjectUrlsRef.current.forEach((objectUrl) => window.URL.revokeObjectURL(objectUrl));
+      activeDownloadObjectUrlsRef.current = [];
+    };
+  }, []);
+
+  const handleOpenDocument = async (documentId: string) => {
+    if (downloadingDocumentId) {
       return;
     }
-    setDownloadingId(paymentId);
+    setDownloadingDocumentId(documentId);
     try {
       setDownloadError(null);
-      const response = await getDownloadUrl(tenantId, documentId);
-      setDownloadUrls((prev) => ({ ...prev, [paymentId]: response.url }));
-      window.open(response.url, '_blank');
+      const blob = await downloadDocumentContent(tenantId, documentId);
+      const objectUrl = window.URL.createObjectURL(blob);
+      activeDownloadObjectUrlsRef.current.push(objectUrl);
+      window.open(objectUrl, '_blank', 'noopener,noreferrer');
+
+      const timerId = window.setTimeout(() => {
+        window.URL.revokeObjectURL(objectUrl);
+        activeDownloadObjectUrlsRef.current = activeDownloadObjectUrlsRef.current.filter((url) => url !== objectUrl);
+        activeDownloadTimersRef.current = activeDownloadTimersRef.current.filter((id) => id !== timerId);
+      }, 60_000);
+      activeDownloadTimersRef.current.push(timerId);
     } catch (error) {
-      setDownloadError(error instanceof Error ? error.message : 'No pudimos abrir el comprobante. Intentá nuevamente.');
+      setDownloadError(error instanceof Error ? error.message : 'No pudimos abrir el documento. Intentá nuevamente.');
     } finally {
-      setDownloadingId(null);
+      setDownloadingDocumentId(null);
     }
   };
 
@@ -184,8 +403,13 @@ export const ResidentPaymentsPage = () => {
     const file = e.target.files?.[0];
     if (!file || !tenantId) return;
 
-    if (file.size > 10 * 1024 * 1024) {
-      setSubmitError('El archivo no puede superar 10MB');
+    if (file.size > MAX_PAYMENT_PROOF_SIZE_BYTES) {
+      setSubmitError(`El archivo no puede superar ${Math.round(MAX_PAYMENT_PROOF_SIZE_BYTES / 1024 / 1024)}MB`);
+      return;
+    }
+
+    if (!PAYMENT_PROOF_ALLOWED_MIME_TYPES.includes(file.type as (typeof PAYMENT_PROOF_ALLOWED_MIME_TYPES)[number])) {
+      setSubmitError('El comprobante debe ser PDF, JPG o PNG');
       return;
     }
 
@@ -222,7 +446,7 @@ export const ResidentPaymentsPage = () => {
 
   const resetForm = () => {
     setFormData({
-      amount: 0,
+      selectedChargeId: '',
       method: PaymentMethod.TRANSFER,
       reference: '',
       paidAt: new Date().toISOString().split('T')[0],
@@ -234,12 +458,16 @@ export const ResidentPaymentsPage = () => {
   const pendingCharges = ledger?.charges?.filter(
     (c) => (c.amount - (c.allocated ?? 0)) > 0
   ) ?? [];
+  const selectedChargeId = pendingCharges.some((charge) => charge.id === formData.selectedChargeId)
+    ? formData.selectedChargeId
+    : pendingCharges[0]?.id ?? '';
+  const selectedCharge = pendingCharges.find((charge) => charge.id === selectedChargeId) ?? null;
+  const selectedChargeOutstandingMinor = selectedCharge ? selectedCharge.amount - (selectedCharge.allocated ?? 0) : 0;
 
   const balance = ledger?.totals?.balance ?? 0;
   const currency = ledger?.totals?.currency ?? 'ARS';
 
-  const canSubmit = !!proofFileId;
-  const paymentAmountId = 'resident-payment-amount';
+  const canSubmit = !!proofFileId && !!selectedCharge && selectedChargeOutstandingMinor > 0;
   const paymentDateId = 'resident-payment-date';
   const paymentReferenceId = 'resident-payment-reference';
   const paymentMethodId = 'resident-payment-method';
@@ -258,19 +486,43 @@ export const ResidentPaymentsPage = () => {
     e.preventDefault();
     if (!buildingId || !unitId) return;
 
-    const amountLabel = formatCurrency(formData.amount || 0, currency, getLocaleForCurrency(currency));
-    const chargeLabel = nextDueCharge
-      ? `${nextDueCharge.concept} • Período ${nextDueCharge.period}`
-      : 'Tu saldo actual';
-    const confirmationMessage = [
-      `Vas a enviar un reporte de pago por ${amountLabel}.`,
-      `Cargo o período de referencia: ${chargeLabel}.`,
-      'La administración revisará el comprobante antes de aprobarlo.',
-    ].join('\n\n');
-
-    if (!window.confirm(confirmationMessage)) {
+    if (!selectedCharge) {
+      setSubmitError('Seleccioná un cargo pendiente para continuar.');
       return;
     }
+
+    const amountMinor = selectedChargeOutstandingMinor;
+    if (amountMinor <= 0) {
+      setSubmitError('Ese cargo ya no tiene saldo pendiente. Actualizá la información.');
+      refetchLedger();
+      refetchPayments();
+      return;
+    }
+
+    const amountLabel = formatCurrency(amountMinor, selectedCharge.currency, getLocaleForCurrency(selectedCharge.currency));
+    const chargeLabel = `${selectedCharge.concept} • Período ${selectedCharge.period}`;
+    if (!proofFileId || !proofFile) {
+      setSubmitError('Subí un comprobante antes de continuar.');
+      return;
+    }
+
+    setSubmitError(null);
+    setSubmitSuccess(false);
+    setPaymentToConfirm({
+      chargeId: selectedCharge.id,
+      amountMinor,
+      amountLabel,
+      chargeLabel,
+      currency: selectedCharge.currency,
+      paidAtLabel: formatDate(formData.paidAt),
+      referenceLabel: formData.reference.trim() || undefined,
+      proofFileName: proofFile.name,
+    });
+    setIsConfirmOpen(true);
+  };
+
+  const handleConfirmPayment = async () => {
+    if (!buildingId || !unitId || !paymentToConfirm || submitting) return;
 
     setSubmitting(true);
     setSubmitError(null);
@@ -279,8 +531,9 @@ export const ResidentPaymentsPage = () => {
     try {
       await submitPayment(buildingId, {
         unitId,
-        amount: toCents(formData.amount),
-        currency,
+        chargeId: paymentToConfirm.chargeId,
+        amount: paymentToConfirm.amountMinor,
+        currency: paymentToConfirm.currency,
         method: formData.method,
         reference: formData.reference.trim() || undefined,
         paidAt: formData.paidAt || undefined,
@@ -289,6 +542,8 @@ export const ResidentPaymentsPage = () => {
 
       setSubmitSuccess(true);
       resetForm();
+      setIsConfirmOpen(false);
+      setPaymentToConfirm(null);
       refetchLedger();
       refetchPayments();
       setTimeout(() => {
@@ -297,6 +552,8 @@ export const ResidentPaymentsPage = () => {
       }, 2000);
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : 'Error al enviar pago');
+      void refetchLedger();
+      void refetchPayments();
     } finally {
       setSubmitting(false);
     }
@@ -444,7 +701,7 @@ export const ResidentPaymentsPage = () => {
           <div className="flex items-start gap-3">
             <AlertCircle className="text-red-600 mt-0.5" size={20} />
             <div className="space-y-1">
-              <p className="font-medium text-red-800">No pudimos abrir el comprobante.</p>
+              <p className="font-medium text-red-800">No pudimos abrir el documento.</p>
               <p className="text-sm text-red-700">{downloadError}</p>
             </div>
           </div>
@@ -568,40 +825,77 @@ export const ResidentPaymentsPage = () => {
           <div className="space-y-2">
             {payments.map((payment) => {
               const proofDocumentId = payment.proofDocumentId;
+              const receiptDocumentId = payment.receiptDocumentId;
+              const rejectionReasonLabel = getPaymentRejectionReasonLabel(payment.rejectionReason);
+              const hasReceipt = !!receiptDocumentId;
+              const hasProof = !!proofDocumentId;
+              const downloadDisabled = downloadingDocumentId !== null;
+              const paymentDate = formatDate(payment.paidAt ?? payment.createdAt);
 
               return (
-              <div key={payment.id} className="flex justify-between items-start gap-3 p-3 bg-muted/50 rounded-lg">
-                <div className="flex-1">
-                  <p className="font-medium">{formatCurrency(payment.amount, payment.currency, getLocaleForCurrency(payment.currency))}</p>
-                  <p className="text-sm text-muted-foreground">
-                    {payment.method} • {formatDate(payment.paidAt ?? payment.createdAt)}
-                    {payment.reference && ` • ${payment.reference}`}
-                  </p>
+                <div key={payment.id} className="flex justify-between items-start gap-3 p-3 bg-muted/50 rounded-lg">
+                  <div className="flex-1 space-y-1">
+                    <p className="font-medium">{formatCurrency(payment.amount, payment.currency, getLocaleForCurrency(payment.currency))}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {payment.method} • {paymentDate}
+                      {payment.reference && ` • ${payment.reference}`}
+                    </p>
+                    {payment.status === 'REJECTED' && (rejectionReasonLabel || payment.rejectionComment) && (
+                      <p className="text-sm text-red-700">
+                        {rejectionReasonLabel && <span className="font-medium">Motivo: {rejectionReasonLabel}</span>}
+                        {rejectionReasonLabel && payment.rejectionComment ? ' — ' : null}
+                        {payment.rejectionComment}
+                      </p>
+                    )}
+                    {payment.status === 'APPROVED' && !hasReceipt && payment.receiptStatus === 'PENDING' && (
+                      <p className="text-sm text-muted-foreground">Recibo en generación</p>
+                    )}
+                    {payment.status === 'APPROVED' && !hasReceipt && payment.receiptStatus === 'FAILED' && (
+                      <p className="text-sm text-red-700">
+                        No pudimos generar el recibo. La administración ya fue notificada.
+                      </p>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap items-center justify-end gap-2">
+                    {hasProof ? (
+                      <button
+                        onClick={() => handleOpenDocument(proofDocumentId)}
+                        disabled={downloadDisabled}
+                        type="button"
+                        aria-label={`Ver comprobante del pago de ${formatCurrency(payment.amount, payment.currency, getLocaleForCurrency(payment.currency))}`}
+                        className="flex items-center gap-1 text-blue-600 hover:text-blue-800 text-sm disabled:opacity-50"
+                      >
+                        {downloadingDocumentId === proofDocumentId ? (
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                        ) : (
+                          <FileText className="w-4 h-4" />
+                        )}
+                        Ver comprobante
+                      </button>
+                    ) : payment.proofFileId ? (
+                      <span className="text-xs text-amber-600">Comprobante en procesamiento</span>
+                    ) : null}
+                    {hasReceipt ? (
+                      <button
+                        onClick={() => handleOpenDocument(receiptDocumentId)}
+                        disabled={downloadDisabled}
+                        type="button"
+                        aria-label={`Ver recibo del pago de ${formatCurrency(payment.amount, payment.currency, getLocaleForCurrency(payment.currency))}`}
+                        className="flex items-center gap-1 text-emerald-600 hover:text-emerald-800 text-sm disabled:opacity-50"
+                      >
+                        {downloadingDocumentId === receiptDocumentId ? (
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                        ) : (
+                          <FileText className="w-4 h-4" />
+                        )}
+                        Ver recibo
+                      </button>
+                    ) : null}
+                    <span className={`px-2 py-1 rounded text-xs font-medium border whitespace-nowrap ${paymentStatusColor(payment.status)}`}>
+                      {paymentStatusLabel(payment.status)}
+                    </span>
+                  </div>
                 </div>
-                <div className="flex items-center gap-2">
-                  {proofDocumentId ? (
-                    <button
-                      onClick={() => handleViewProof(payment.id, proofDocumentId)}
-                      disabled={downloadingId === payment.id}
-                      type="button"
-                      aria-label={`Ver comprobante del pago de ${formatCurrency(payment.amount, payment.currency, getLocaleForCurrency(payment.currency))}`}
-                      className="flex items-center gap-1 text-blue-600 hover:text-blue-800 text-sm disabled:opacity-50"
-                    >
-                      {downloadingId === payment.id ? (
-                        <Loader2 className="w-4 h-4 animate-spin" />
-                      ) : (
-                        <FileText className="w-4 h-4" />
-                      )}
-                      Ver
-                    </button>
-                  ) : payment.proofFileId ? (
-                    <span className="text-xs text-amber-600">Subiendo...</span>
-                  ) : null}
-                  <span className={`px-2 py-1 rounded text-xs font-medium border whitespace-nowrap ${paymentStatusColor(payment.status)}`}>
-                    {paymentStatusLabel(payment.status)}
-                  </span>
-                </div>
-              </div>
               );
             })}
           </div>
@@ -615,18 +909,45 @@ export const ResidentPaymentsPage = () => {
           <form onSubmit={handleSubmitPayment} className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label htmlFor={paymentAmountId} className="block text-sm font-medium mb-1">Monto ({currency})</label>
-                <Input
-                  id={paymentAmountId}
-                  type="number"
-                  step="0.01"
-                  min="0.01"
-                  max="999999.99"
-                  value={formData.amount || ''}
-                  onChange={(e) => setFormData({ ...formData, amount: parseFloat(e.target.value) || 0 })}
-                  placeholder="Ej: 350.00"
-                  required
-                />
+                <label htmlFor="resident-payment-charge" className="block text-sm font-medium mb-1">
+                  Cargo pendiente
+                </label>
+                <Select
+                  id="resident-payment-charge"
+                  value={selectedChargeId}
+                  onChange={(e) => setFormData((current) => ({ ...current, selectedChargeId: e.target.value }))}
+                  disabled={pendingCharges.length === 0}
+                >
+                  {pendingCharges.length === 0 ? (
+                    <option value="">No tenés cargos pendientes</option>
+                  ) : (
+                    pendingCharges.map((charge) => {
+                      const outstandingMinor = charge.amount - (charge.allocated ?? 0);
+                      return (
+                        <option key={charge.id} value={charge.id}>
+                          {charge.concept} • Período {charge.period} • {formatCurrency(outstandingMinor, charge.currency, getLocaleForCurrency(charge.currency))}
+                        </option>
+                      );
+                    })
+                  )}
+                </Select>
+                {selectedCharge ? (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    Los pagos informados por residentes deben cubrir el saldo completo del período.
+                  </p>
+                ) : (
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    No hay cargos pendientes disponibles para reportar.
+                  </p>
+                )}
+                {selectedCharge ? (
+                  <div className="mt-3 rounded-lg border border-border bg-muted/40 p-3">
+                    <p className="text-xs uppercase tracking-wide text-muted-foreground">Monto a reportar</p>
+                    <p className="text-lg font-semibold">
+                      {formatCurrency(selectedChargeOutstandingMinor, selectedCharge.currency, getLocaleForCurrency(selectedCharge.currency))}
+                    </p>
+                  </div>
+                ) : null}
               </div>
               <div>
                 <label className="block text-sm font-medium mb-1" htmlFor={paymentMethodId}>Método de pago</label>
@@ -670,7 +991,7 @@ export const ResidentPaymentsPage = () => {
               <input
                 id={paymentProofId}
                 type="file"
-                accept="image/*,.pdf"
+                accept=".pdf,image/jpeg,image/png"
                 onChange={handleFileChange}
                 className="block w-full text-sm text-muted-foreground
                   file:mr-4 file:py-2 file:px-4
@@ -719,9 +1040,16 @@ export const ResidentPaymentsPage = () => {
                 type="submit" 
                 disabled={submitting || !canSubmit} 
                 className="gap-2"
+                id="resident-payment-submit-trigger"
               >
                 {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
-                {submitting ? 'Enviando...' : !canSubmit ? 'Subí el comprobante' : 'Enviar pago'}
+                {submitting
+                  ? 'Enviando...'
+                  : !selectedCharge
+                    ? 'Seleccioná un cargo'
+                    : !proofFile
+                      ? 'Subí el comprobante'
+                      : 'Enviar pago'}
               </Button>
               <Button type="button" variant="secondary" onClick={() => setShowForm(false)}>
                 Cancelar
@@ -730,6 +1058,21 @@ export const ResidentPaymentsPage = () => {
           </form>
         </Card>
       )}
+
+      <PaymentConfirmDialog
+        isOpen={isConfirmOpen}
+        data={paymentToConfirm}
+        errorMessage={submitError}
+        isLoading={submitting}
+        onCancel={() => {
+          setIsConfirmOpen(false);
+          setPaymentToConfirm(null);
+          window.setTimeout(() => {
+            document.getElementById('resident-payment-submit-trigger')?.focus();
+          }, 0);
+        }}
+        onConfirm={handleConfirmPayment}
+      />
     </div>
   );
 };

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
@@ -17,7 +17,7 @@ import { useResidentContext } from '@/features/resident/hooks/useResidentContext
 import { useContextOptions } from '@/features/context/useContextOptions';
 import { getResidentLedger, type UnitLedger } from '@/features/resident/api/resident-context.api';
 import { useTenants } from '@/features/tenants/tenants.hooks';
-import { listPayments, submitPayment, type Payment, PaymentMethod, ChargeStatus } from '@/features/finance/services/finance.api';
+import { listPayments, submitPayment, type Payment, PaymentMethod, ChargeStatus, PaymentStatus } from '@/features/finance/services/finance.api';
 import {
   downloadDocumentContent,
   presignUpload,
@@ -860,6 +860,17 @@ export const ResidentPaymentsPage = () => {
               const rejectionReasonLabel = getPaymentRejectionReasonLabel(payment.rejectionReason);
               const hasReceipt = !!receiptDocumentId;
               const hasProof = !!proofDocumentId;
+              const isReceiptTrackingPayment =
+                payment.status === PaymentStatus.APPROVED ||
+                payment.status === PaymentStatus.RECONCILED;
+              const showReceiptGenerationState =
+                isReceiptTrackingPayment &&
+                !hasReceipt &&
+                payment.receiptStatus === 'PENDING';
+              const showReceiptErrorState =
+                isReceiptTrackingPayment &&
+                !hasReceipt &&
+                payment.receiptStatus === 'FAILED';
               const downloadDisabled = downloadingDocumentId !== null;
               const paymentDate = formatPaymentDisplayDate(payment.paidAt ?? payment.createdAt);
 
@@ -878,12 +889,12 @@ export const ResidentPaymentsPage = () => {
                         {payment.rejectionComment}
                       </p>
                     )}
-                    {payment.status === 'APPROVED' && !hasReceipt && payment.receiptStatus === 'PENDING' && (
+                    {showReceiptGenerationState && (
                       <p className="text-sm text-muted-foreground">Recibo en generación</p>
                     )}
-                    {payment.status === 'APPROVED' && !hasReceipt && payment.receiptStatus === 'FAILED' && (
+                    {showReceiptErrorState && (
                       <p className="text-sm text-red-700">
-                        No pudimos generar el recibo. La administración ya fue notificada.
+                        {payment.receiptError || 'No pudimos generar el recibo. La administración ya fue notificada.'}
                       </p>
                     )}
                   </div>

--- a/apps/web/features/buildings/services/documents.api.ts
+++ b/apps/web/features/buildings/services/documents.api.ts
@@ -368,3 +368,30 @@ export async function getDownloadUrl(
     throw error;
   }
 }
+
+/**
+ * Download protected document content through the BuildingOS API.
+ *
+ * GET /documents/:id/content
+ * response: Blob
+ */
+export async function downloadDocumentContent(
+  tenantId: string,
+  documentId: string,
+): Promise<Blob> {
+  const endpoint = `/tenants/${tenantId}/documents/${documentId}/content`;
+  logRequest('GET', endpoint);
+
+  try {
+    return await apiClient<Blob>({
+      path: endpoint,
+      method: 'GET',
+      headers: getTenantHeaders(tenantId),
+      responseType: 'blob',
+    });
+  } catch (error) {
+    const message = `Failed to download document content: ${(error as Error).message}`;
+    logError(endpoint, 500, message);
+    throw error;
+  }
+}

--- a/apps/web/features/buildings/services/documents.api.ts
+++ b/apps/web/features/buildings/services/documents.api.ts
@@ -131,9 +131,10 @@ export async function presignUpload(
   originalName: string,
   mimeType: string,
   size?: number,
+  purpose: 'GENERAL_DOCUMENT' | 'PAYMENT_PROOF' = 'GENERAL_DOCUMENT',
 ): Promise<PresignResponse> {
   const endpoint = `/tenants/${tenantId}/documents/presign`;
-  const body = { originalName, mimeType, ...(size && { size }) };
+  const body = { originalName, mimeType, ...(size && { size }), purpose };
   logRequest('POST', endpoint, body);
 
   try {

--- a/apps/web/features/finance/components/BuildingsFinanceSummary.test.tsx
+++ b/apps/web/features/finance/components/BuildingsFinanceSummary.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { BuildingsFinanceSummary } from './BuildingsFinanceSummary';
+import { financeApi } from '../services/finance.api';
+
+jest.mock('../services/finance.api', () => ({
+  financeApi: {
+    getFinancialSummary: jest.fn(),
+  },
+}));
+
+jest.mock('@/features/tenancy/hooks/useTenantBranding', () => ({
+  useTenantCurrency: () => ({
+    format: (value: number) => `ARS ${value.toLocaleString('es-AR')}`,
+  }),
+}));
+
+const mockedGetFinancialSummary = jest.mocked(financeApi.getFinancialSummary);
+
+describe('BuildingsFinanceSummary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedGetFinancialSummary.mockResolvedValue({
+      totalCharges: 100000,
+      totalPaid: 30000,
+      totalOutstanding: 70000,
+      delinquentUnitsCount: 1,
+      topDelinquentUnits: [],
+      currency: 'ARS',
+    });
+  });
+
+  it('requests the selected period for each building and refreshes when the period changes', async () => {
+    const { rerender } = render(
+      <BuildingsFinanceSummary
+        tenantId="tenant-1"
+        period="2026-07"
+        buildingIds={['building-a']}
+        buildingNames={{ 'building-a': 'Torre Sur' }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockedGetFinancialSummary).toHaveBeenCalledWith('building-a', '2026-07');
+    });
+    expect(await screen.findByText('Torre Sur')).toBeTruthy();
+    expect(await screen.findByText('ARS 100.000')).toBeTruthy();
+    expect(await screen.findByText('ARS 30.000')).toBeTruthy();
+    expect(await screen.findByText('ARS 70.000')).toBeTruthy();
+    expect(await screen.findByText('30%')).toBeTruthy();
+
+    mockedGetFinancialSummary.mockResolvedValueOnce({
+      totalCharges: 120000,
+      totalPaid: 50000,
+      totalOutstanding: 70000,
+      delinquentUnitsCount: 1,
+      topDelinquentUnits: [],
+      currency: 'ARS',
+    });
+
+    rerender(
+      <BuildingsFinanceSummary
+        tenantId="tenant-1"
+        period="2026-08"
+        buildingIds={['building-a']}
+        buildingNames={{ 'building-a': 'Torre Sur' }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockedGetFinancialSummary).toHaveBeenCalledWith('building-a', '2026-08');
+    });
+  });
+});

--- a/apps/web/features/finance/components/BuildingsFinanceSummary.test.tsx
+++ b/apps/web/features/finance/components/BuildingsFinanceSummary.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { BuildingsFinanceSummary } from './BuildingsFinanceSummary';
 import { financeApi } from '../services/finance.api';
 
@@ -19,6 +19,18 @@ jest.mock('@/features/tenancy/hooks/useTenantBranding', () => ({
 }));
 
 const mockedGetFinancialSummary = jest.mocked(financeApi.getFinancialSummary);
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
 
 describe('BuildingsFinanceSummary', () => {
   beforeEach(() => {
@@ -73,5 +85,135 @@ describe('BuildingsFinanceSummary', () => {
     await waitFor(() => {
       expect(mockedGetFinancialSummary).toHaveBeenCalledWith('building-a', '2026-08');
     });
+  });
+
+  it('keeps the latest period summary when an older request resolves later', async () => {
+    const june = createDeferred<{
+      totalCharges: number;
+      totalPaid: number;
+      totalOutstanding: number;
+      delinquentUnitsCount: number;
+      topDelinquentUnits: never[];
+      currency: string;
+    }>();
+    const july = createDeferred<{
+      totalCharges: number;
+      totalPaid: number;
+      totalOutstanding: number;
+      delinquentUnitsCount: number;
+      topDelinquentUnits: never[];
+      currency: string;
+    }>();
+
+    mockedGetFinancialSummary
+      .mockImplementationOnce(() => june.promise)
+      .mockImplementationOnce(() => july.promise);
+
+    const { rerender } = render(
+      <BuildingsFinanceSummary
+        tenantId="tenant-1"
+        period="2026-06"
+        buildingIds={['building-a']}
+        buildingNames={{ 'building-a': 'Torre Sur' }}
+      />,
+    );
+
+    rerender(
+      <BuildingsFinanceSummary
+        tenantId="tenant-1"
+        period="2026-07"
+        buildingIds={['building-a']}
+        buildingNames={{ 'building-a': 'Torre Sur' }}
+      />,
+    );
+
+    await act(async () => {
+      july.resolve({
+        totalCharges: 120000,
+        totalPaid: 50000,
+        totalOutstanding: 70000,
+        delinquentUnitsCount: 1,
+        topDelinquentUnits: [],
+        currency: 'ARS',
+      });
+    });
+
+    expect(await screen.findByText('ARS 120.000')).toBeTruthy();
+    expect(screen.queryByText('ARS 100.000')).toBeNull();
+
+    await act(async () => {
+      june.resolve({
+        totalCharges: 100000,
+        totalPaid: 30000,
+        totalOutstanding: 70000,
+        delinquentUnitsCount: 1,
+        topDelinquentUnits: [],
+        currency: 'ARS',
+      });
+    });
+
+    expect(screen.getByText('ARS 120.000')).toBeTruthy();
+    expect(screen.queryByText('ARS 100.000')).toBeNull();
+  });
+
+  it('keeps a stale error from replacing a newer summary', async () => {
+    const june = createDeferred<{
+      totalCharges: number;
+      totalPaid: number;
+      totalOutstanding: number;
+      delinquentUnitsCount: number;
+      topDelinquentUnits: never[];
+      currency: string;
+    }>();
+    const july = createDeferred<{
+      totalCharges: number;
+      totalPaid: number;
+      totalOutstanding: number;
+      delinquentUnitsCount: number;
+      topDelinquentUnits: never[];
+      currency: string;
+    }>();
+
+    mockedGetFinancialSummary
+      .mockImplementationOnce(() => june.promise)
+      .mockImplementationOnce(() => july.promise);
+
+    const { rerender } = render(
+      <BuildingsFinanceSummary
+        tenantId="tenant-1"
+        period="2026-06"
+        buildingIds={['building-a']}
+        buildingNames={{ 'building-a': 'Torre Sur' }}
+      />,
+    );
+
+    rerender(
+      <BuildingsFinanceSummary
+        tenantId="tenant-1"
+        period="2026-07"
+        buildingIds={['building-a']}
+        buildingNames={{ 'building-a': 'Torre Sur' }}
+      />,
+    );
+
+    await act(async () => {
+      july.resolve({
+        totalCharges: 120000,
+        totalPaid: 50000,
+        totalOutstanding: 70000,
+        delinquentUnitsCount: 1,
+        topDelinquentUnits: [],
+        currency: 'ARS',
+      });
+    });
+
+    expect(await screen.findByText('ARS 120.000')).toBeTruthy();
+
+    await act(async () => {
+      june.reject(new Error('Periodo anterior falló'));
+    });
+
+    expect(screen.getByText('ARS 120.000')).toBeTruthy();
+    expect(screen.queryByText(/Error al cargar datos/i)).toBeNull();
   });
 });

--- a/apps/web/features/finance/components/BuildingsFinanceSummary.tsx
+++ b/apps/web/features/finance/components/BuildingsFinanceSummary.tsx
@@ -18,6 +18,7 @@ interface BuildingFinanceSummary {
 
 interface BuildingsFinanceSummaryProps {
   tenantId: string;
+  period?: string;
   buildingIds: string[];
   buildingNames: Record<string, string>;
 }
@@ -27,6 +28,7 @@ const formatPercentage = (val: number) => `${Math.round(val)}%`;
 export function BuildingsFinanceSummary({
   buildingIds,
   buildingNames,
+  period,
 }: BuildingsFinanceSummaryProps) {
   const { format } = useTenantCurrency();
   const [summaries, setSummaries] = useState<BuildingFinanceSummary[]>([]);
@@ -41,7 +43,7 @@ export function BuildingsFinanceSummary({
         const results = await Promise.all(
           buildingIds.map(async (bId) => {
             try {
-              const summary = await financeApi.getFinancialSummary(bId);
+              const summary = await financeApi.getFinancialSummary(bId, period);
               return {
                 buildingId: bId,
                 buildingName: buildingNames[bId] || bId,
@@ -79,7 +81,7 @@ export function BuildingsFinanceSummary({
     if (buildingIds.length > 0) {
       fetchSummaries();
     }
-  }, [buildingIds, buildingNames]);
+  }, [buildingIds, buildingNames, period]);
 
   if (loading) {
     return (

--- a/apps/web/features/finance/components/BuildingsFinanceSummary.tsx
+++ b/apps/web/features/finance/components/BuildingsFinanceSummary.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { financeApi } from '../services/finance.api';
 import { Skeleton } from '@/shared/components/ui';
 import { Table, THead, TBody, TR, TH, TD } from '@/shared/components/ui/Table';
@@ -32,11 +32,15 @@ export function BuildingsFinanceSummary({
 }: BuildingsFinanceSummaryProps) {
   const { format } = useTenantCurrency();
   const [summaries, setSummaries] = useState<BuildingFinanceSummary[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(buildingIds.length > 0);
   const [error, setError] = useState<Error | null>(null);
+  const requestIdRef = useRef(0);
   const failedCount = summaries.filter((summary) => summary.errorMessage).length;
 
   useEffect(() => {
+    const requestId = ++requestIdRef.current;
+    let cancelled = false;
+
     const fetchSummaries = async () => {
       try {
         setLoading(true);
@@ -68,12 +72,25 @@ export function BuildingsFinanceSummary({
             }
           }),
         );
+
+        if (cancelled || requestId !== requestIdRef.current) {
+          return;
+        }
+
         setSummaries(results);
         setError(null);
       } catch (err) {
+        if (cancelled || requestId !== requestIdRef.current) {
+          return;
+        }
+
         setError(err instanceof Error ? err : new Error('Failed to fetch summaries'));
         setSummaries([]);
       } finally {
+        if (cancelled || requestId !== requestIdRef.current) {
+          return;
+        }
+
         setLoading(false);
       }
     };
@@ -81,6 +98,10 @@ export function BuildingsFinanceSummary({
     if (buildingIds.length > 0) {
       fetchSummaries();
     }
+
+    return () => {
+      cancelled = true;
+    };
   }, [buildingIds, buildingNames, period]);
 
   if (loading) {

--- a/apps/web/features/finance/components/TenantFinanceDashboard.test.tsx
+++ b/apps/web/features/finance/components/TenantFinanceDashboard.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { TenantFinanceDashboard } from './TenantFinanceDashboard';
+
+const routerReplace = jest.fn();
+const routerPush = jest.fn();
+const routerRefresh = jest.fn();
+const useQueryMock = jest.fn();
+const useMutationMock = jest.fn();
+const useQueryClientMock = jest.fn();
+const useTenantFinanceSummaryMock = jest.fn();
+const useBuildingsMock = jest.fn();
+const useExpensesMock = jest.fn();
+let searchParams = new URLSearchParams();
+
+jest.mock('next/navigation', () => ({
+  usePathname: () => '/tenant-1/finanzas',
+  useRouter: () => ({
+    replace: routerReplace,
+    push: routerPush,
+    refresh: routerRefresh,
+  }),
+  useSearchParams: () => searchParams,
+  useParams: () => ({ tenantId: 'tenant-1' }),
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: (...args: unknown[]) => useQueryMock(...args),
+  useMutation: (...args: unknown[]) => useMutationMock(...args),
+  useQueryClient: (...args: unknown[]) => useQueryClientMock(...args),
+}));
+
+jest.mock('../hooks/useTenantFinanceSummary', () => ({
+  useTenantFinanceSummary: (...args: unknown[]) => useTenantFinanceSummaryMock(...args),
+}));
+
+jest.mock('@/features/buildings/hooks', () => ({
+  useBuildings: (...args: unknown[]) => useBuildingsMock(...args),
+}));
+
+jest.mock('../hooks/useExpenseLedger', () => ({
+  useExpenses: (...args: unknown[]) => useExpensesMock(...args),
+}));
+
+jest.mock('../services/finance.api', () => ({
+  PaymentStatus: { SUBMITTED: 'SUBMITTED' },
+  approvePaymentTenant: jest.fn(),
+  listPendingPayments: jest.fn(),
+}));
+
+jest.mock('@/features/buildings/services/documents.api', () => ({
+  getDownloadUrl: jest.fn(),
+}));
+
+jest.mock('@/shared/components/ui/Toast', () => ({
+  useToast: () => ({
+    toast: jest.fn(),
+  }),
+}));
+
+jest.mock('./FinanceSummaryCards', () => ({
+  FinanceSummaryCards: () => <div>Finance summary cards</div>,
+}));
+
+jest.mock('./BuildingsFinanceSummary', () => ({
+  BuildingsFinanceSummary: () => <div>Buildings summary</div>,
+}));
+
+jest.mock('./TenantDelinquentUnitsList', () => ({
+  TenantDelinquentUnitsList: () => <div>Delinquent units</div>,
+}));
+
+jest.mock('./PaymentApproveModal', () => ({
+  PaymentApproveModal: () => null,
+}));
+
+jest.mock('./TenantChargesTab', () => ({
+  TenantChargesTab: () => <div>Charges tab</div>,
+}));
+
+jest.mock('./ExpenseLedgerCategoriesManager', () => ({
+  ExpenseLedgerCategoriesManager: () => <div>Rubros manager</div>,
+}));
+
+jest.mock('./TenantExpensesList', () => ({
+  TenantExpensesList: () => <div>Expenses list</div>,
+}));
+
+jest.mock('./ExpenseHistoryReport', () => ({
+  ExpenseHistoryReport: () => <div>Expense history</div>,
+}));
+
+jest.mock('./NotasRevelatoriasPanel', () => ({
+  NotasRevelatoriasPanel: () => <div>Notas Revelatorias panel</div>,
+}));
+
+jest.mock('@/shared/lib/format/money', () => ({
+  formatCurrency: (value: number) => `$${value.toLocaleString('es-AR')}`,
+}));
+
+jest.mock('lucide-react', () => ({
+  FileText: () => <span>FileText</span>,
+  Loader2: () => <span>Loader2</span>,
+}));
+
+describe('TenantFinanceDashboard', () => {
+  beforeEach(() => {
+    searchParams = new URLSearchParams();
+    routerReplace.mockReset();
+    routerPush.mockReset();
+    routerRefresh.mockReset();
+    useQueryMock.mockReturnValue({ data: [], isLoading: false, error: null });
+    useMutationMock.mockReturnValue({ mutateAsync: jest.fn(), isPending: false });
+    useQueryClientMock.mockReturnValue({ invalidateQueries: jest.fn() });
+    useTenantFinanceSummaryMock.mockReturnValue({
+      data: {
+        totalCharges: 1000,
+        totalPaid: 250,
+        totalOutstanding: 750,
+        delinquentUnitsCount: 0,
+        topDelinquentUnits: [],
+        currency: 'ARS',
+      },
+      isPending: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    useBuildingsMock.mockReturnValue({
+      buildings: [{ id: 'building-a', name: 'Torre Sur' }],
+      loading: false,
+    });
+    useExpensesMock.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+  });
+
+  it('opens the payments tab from the query string and updates when navigation changes', () => {
+    const { rerender } = render(<TenantFinanceDashboard />);
+
+    expect(screen.getByText('Buildings summary')).toBeTruthy();
+    expect(screen.queryByText('No hay pagos para aprobar')).toBeNull();
+
+    searchParams = new URLSearchParams('tab=payments');
+    rerender(<TenantFinanceDashboard />);
+
+    expect(screen.getByText('No hay pagos para aprobar')).toBeTruthy();
+    expect(screen.queryByText('Buildings summary')).toBeNull();
+
+    searchParams = new URLSearchParams('tab=notas');
+    rerender(<TenantFinanceDashboard />);
+
+    expect(screen.getByText('Notas Revelatorias panel')).toBeTruthy();
+    expect(screen.queryByText('No hay pagos para aprobar')).toBeNull();
+  });
+
+  it('updates the URL while preserving the existing query string and local period state', () => {
+    searchParams = new URLSearchParams('foo=bar');
+    render(<TenantFinanceDashboard />);
+
+    const periodInput = screen.getByDisplayValue(new Date().toISOString().slice(0, 7)) as HTMLInputElement;
+    fireEvent.change(periodInput, { target: { value: '2026-08' } });
+    expect(periodInput.value).toBe('2026-08');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Pagos (0)' }));
+
+    expect(routerReplace).toHaveBeenCalledWith('/tenant-1/finanzas?foo=bar&tab=payments', { scroll: false });
+    expect(periodInput.value).toBe('2026-08');
+  });
+});

--- a/apps/web/features/finance/components/TenantFinanceDashboard.tsx
+++ b/apps/web/features/finance/components/TenantFinanceDashboard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useMemo } from 'react';
-import { useParams, useSearchParams } from 'next/navigation';
+import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import Card from '@/shared/components/ui/Card';
 import Button from '@/shared/components/ui/Button';
@@ -38,20 +38,20 @@ interface Params {
  */
 export const TenantFinanceDashboard = () => {
   const params = useParams<Params>();
+  const router = useRouter();
+  const pathname = usePathname();
   const searchParams = useSearchParams();
   const tenantId = params?.tenantId;
   const currentMonth = new Date().toISOString().slice(0, 7);
-  const initialTab = (() => {
+  const allowedTabs: readonly Tab[] = ['overview', 'rubros', 'expenses', 'payments', 'charges', 'delinquent', 'reports', 'notas'];
+  const activeTab = (() => {
     const tabParam = searchParams.get('tab');
-    if (tabParam && ['overview', 'rubros', 'expenses', 'payments', 'charges', 'delinquent', 'reports', 'notas'].includes(tabParam)) {
+    if (tabParam && allowedTabs.includes(tabParam as Tab)) {
       return tabParam as Tab;
     }
 
     return 'overview';
   })();
-  
-  // Initialize tab from URL query param
-  const [activeTab, setActiveTab] = useState<Tab>(initialTab);
   const [period, setPeriod] = useState<string>(currentMonth);
   const periodInputId = 'tenant-finance-period';
 
@@ -98,6 +98,20 @@ export const TenantFinanceDashboard = () => {
     () => buildings.reduce((acc, b) => ({ ...acc, [b.id]: b.name }), {} as Record<string, string>),
     [buildings]
   );
+
+  const updateTab = (nextTab: Tab) => {
+    const nextParams = new URLSearchParams(searchParams.toString());
+    if (nextTab === 'overview') {
+      nextParams.delete('tab');
+    } else {
+      nextParams.set('tab', nextTab);
+    }
+
+    const nextQuery = nextParams.toString();
+    if (nextQuery === searchParams.toString()) return;
+
+    router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname, { scroll: false });
+  };
 
   // Convert React Query error to string message
   const errorMsg = error ? (error instanceof Error ? error.message : String(error)) : null;
@@ -166,7 +180,7 @@ export const TenantFinanceDashboard = () => {
              ].map((tab) => (
              <button
                key={tab.id}
-               onClick={() => setActiveTab(tab.id as Tab)}
+               onClick={() => updateTab(tab.id as Tab)}
                className={cn(
                  'px-3 py-2 rounded-md text-sm font-medium transition-all',
                  activeTab === tab.id

--- a/apps/web/features/finance/components/TenantFinanceDashboard.tsx
+++ b/apps/web/features/finance/components/TenantFinanceDashboard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, useEffect } from 'react';
+import { useState, useMemo } from 'react';
 import { useParams, useSearchParams } from 'next/navigation';
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import Card from '@/shared/components/ui/Card';
@@ -41,19 +41,19 @@ export const TenantFinanceDashboard = () => {
   const searchParams = useSearchParams();
   const tenantId = params?.tenantId;
   const currentMonth = new Date().toISOString().slice(0, 7);
-  
-  // Initialize tab from URL query param
-  const [activeTab, setActiveTab] = useState<Tab>('overview');
-  const [period, setPeriod] = useState<string>(currentMonth);
-  const periodInputId = 'tenant-finance-period';
-  
-  // Set initial tab from URL after mount
-  useEffect(() => {
+  const initialTab = (() => {
     const tabParam = searchParams.get('tab');
     if (tabParam && ['overview', 'rubros', 'expenses', 'payments', 'charges', 'delinquent', 'reports', 'notas'].includes(tabParam)) {
-      setActiveTab(tabParam as Tab);
+      return tabParam as Tab;
     }
-  }, [searchParams]);
+
+    return 'overview';
+  })();
+  
+  // Initialize tab from URL query param
+  const [activeTab, setActiveTab] = useState<Tab>(initialTab);
+  const [period, setPeriod] = useState<string>(currentMonth);
+  const periodInputId = 'tenant-finance-period';
 
   const [selectedPaymentId, setSelectedPaymentId] = useState<string | null>(null);
   const [downloadingProof, setDownloadingProof] = useState<string | null>(null);
@@ -200,6 +200,7 @@ export const TenantFinanceDashboard = () => {
             ) : (
               <BuildingsFinanceSummary
                 tenantId={tenantId || ''}
+                period={period}
                 buildingIds={buildingIds}
                 buildingNames={buildingNames}
               />

--- a/apps/web/features/finance/services/finance.api.ts
+++ b/apps/web/features/finance/services/finance.api.ts
@@ -94,6 +94,9 @@ export interface Payment {
     user: { name: string };
   };
   // Receipt fields
+  rejectionReason?: string | null;
+  rejectionComment?: string | null;
+  reviewedAt?: string | null;
   receiptDocumentId?: string;
   receiptNumber?: string;
   receiptStatus?: 'PENDING' | 'READY' | 'FAILED';
@@ -330,6 +333,7 @@ export async function submitPayment(
   buildingId: string,
   data: {
     unitId?: string;
+    chargeId?: string;
     amount: number;
     currency?: string;
     method: PaymentMethod;


### PR DESCRIPTION
## Resumen

Completa la fase 3 del plan secuencial del módulo RESIDENT y endurece el flujo
completo de reporte, aprobación y recepción de pagos.

## Cambios principales

### Reporte residente

- selección de un cargo pendiente específico;
- monto derivado del saldo completo;
- rechazo backend de pagos parciales;
- soporte de cargos vencidos y saldos parciales previos;
- modal de confirmación integrado;
- fechas civiles sin desfase por timezone.

### Comprobantes

- límite backend de 10 MB;
- validación de tamaño real, archivo vacío y MIME;
- bucket configurable por ambiente;
- cleanup de objetos huérfanos;
- persistencia transaccional.

### Seguridad documental

- nuevo acceso autenticado al contenido;
- comprobantes y recibos mediante blob;
- validación tenant y self-scope;
- sin exposición de MinIO, bucket, objectKey o X-Amz.

### Recibos

- PDF binario real;
- identidad de la administración del condominio;
- contenido y formato en español;
- acceso protegido;
- idempotencia y estados coherentes.

### Exactitud financiera

- total cargado conserva lo facturado;
- total cobrado refleja aplicaciones aprobadas;
- saldo pendiente y morosos reconcilian;
- rendimiento por edificio usa el período seleccionado;
- tabla y tarjetas producen los mismos totales.

## Validación

### API

- 5 suites;
- 51 tests;
- typecheck;
- ESLint focalizado;
- build.

### Web

- 2 suites;
- 15 tests;
- typecheck;
- ESLint focalizado;
- build.

### Smoke local

- reporte residente;
- comprobante;
- aprobación administrativa;
- cargo completamente pagado;
- recibo PDF;
- descarga protegida;
- resumen consolidado;
- rendimiento por edificio;
- cambio entre períodos.

## Base de datos

- sin cambios de schema;
- sin migraciones;
- sin seeds.

## Fuera de alcance

- documentos generales;
- notificaciones;
- selector multiunidad;
- perfil residente;
- asistente;
- producción.

Closes #54
