### PR TITLE
fix(storage): sign uploads with public minio url

### DIFF
--- a/apps/api/src/storage/minio.service.spec.ts
+++ b/apps/api/src/storage/minio.service.spec.ts
@@ -1,0 +1,140 @@
+import { ConfigService } from '../config/config.service';
+import { MinioService } from './minio.service';
+import * as Minio from 'minio';
+
+jest.mock('minio', () => ({
+  Client: jest.fn(),
+}));
+
+interface ClientMock {
+  readonly statObject: jest.Mock;
+  readonly presignedPutObject: jest.Mock;
+  readonly presignedGetObject: jest.Mock;
+}
+
+const minioClientConstructor = Minio.Client as unknown as jest.Mock;
+
+function createClientMock(): ClientMock {
+  return {
+    statObject: jest.fn(),
+    presignedPutObject: jest.fn(),
+    presignedGetObject: jest.fn(),
+  };
+}
+
+function createConfig(overrides: Record<string, string | undefined> = {}): ConfigService {
+  const values: Record<string, string | undefined> = {
+    nodeEnv: 'test',
+    s3Endpoint: 'http://minio:9000',
+    s3PublicBaseUrl: 'https://buildingos-staging-files.31-220-98-21.sslip.io',
+    s3Region: 'us-east-1',
+    s3AccessKey: 'access-key',
+    s3SecretKey: 'secret-key',
+    s3Bucket: 'buildingos-staging',
+    ...overrides,
+  };
+
+  return {
+    getValue: jest.fn((key: string) => values[key]),
+  } as unknown as ConfigService;
+}
+
+describe('MinioService', () => {
+  beforeEach(() => {
+    minioClientConstructor.mockReset();
+  });
+
+  it('uses the internal endpoint for object operations and the public endpoint for presigned URLs', async () => {
+    const internalClient = createClientMock();
+    const publicClient = createClientMock();
+    internalClient.statObject.mockResolvedValue({ size: 42 });
+    publicClient.presignedPutObject.mockResolvedValue(
+      'https://buildingos-staging-files.31-220-98-21.sslip.io/buildingos-staging/proof.pdf',
+    );
+    publicClient.presignedGetObject.mockResolvedValue(
+      'https://buildingos-staging-files.31-220-98-21.sslip.io/buildingos-staging/proof.pdf',
+    );
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => publicClient);
+
+    const service = new MinioService(createConfig());
+
+    await service.statObject('buildingos-staging', 'tenant-a/proof.pdf');
+    await service.presignUpload('buildingos-staging', 'tenant-a/proof.pdf');
+    await service.presignDownload('buildingos-staging', 'tenant-a/proof.pdf');
+
+    expect(minioClientConstructor).toHaveBeenNthCalledWith(1, {
+      endPoint: 'minio',
+      port: 9000,
+      useSSL: false,
+      accessKey: 'access-key',
+      secretKey: 'secret-key',
+      region: 'us-east-1',
+      pathStyle: true,
+    });
+    expect(minioClientConstructor).toHaveBeenNthCalledWith(2, {
+      endPoint: 'buildingos-staging-files.31-220-98-21.sslip.io',
+      port: 443,
+      useSSL: true,
+      accessKey: 'access-key',
+      secretKey: 'secret-key',
+      region: 'us-east-1',
+      pathStyle: true,
+    });
+    expect(internalClient.statObject).toHaveBeenCalledWith('buildingos-staging', 'tenant-a/proof.pdf');
+    expect(internalClient.presignedPutObject).not.toHaveBeenCalled();
+    expect(internalClient.presignedGetObject).not.toHaveBeenCalled();
+    expect(publicClient.presignedPutObject).toHaveBeenCalledWith(
+      'buildingos-staging',
+      'tenant-a/proof.pdf',
+      3600,
+    );
+    expect(publicClient.presignedGetObject).toHaveBeenCalledWith(
+      'buildingos-staging',
+      'tenant-a/proof.pdf',
+      3600,
+    );
+  });
+
+  it('preserves the public protocol, host, and explicit port when signing URLs', () => {
+    const internalClient = createClientMock();
+    const publicClient = createClientMock();
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => publicClient);
+
+    new MinioService(createConfig({ s3PublicBaseUrl: 'http://files.example.test:9443' }));
+
+    expect(minioClientConstructor).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      endPoint: 'files.example.test',
+      port: 9443,
+      useSSL: false,
+      pathStyle: true,
+    }));
+  });
+
+  it('falls back to the internal local endpoint for presigning when no public endpoint is configured', () => {
+    const internalClient = createClientMock();
+    const presignClient = createClientMock();
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => presignClient);
+
+    new MinioService(createConfig({
+      s3Endpoint: 'http://localhost:9000',
+      s3PublicBaseUrl: undefined,
+    }));
+
+    expect(minioClientConstructor).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      endPoint: 'localhost',
+      port: 9000,
+      useSSL: false,
+    }));
+    expect(minioClientConstructor).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      endPoint: 'localhost',
+      port: 9000,
+      useSSL: false,
+    }));
+  });
+});

--- a/apps/api/src/storage/minio.service.spec.ts
+++ b/apps/api/src/storage/minio.service.spec.ts
@@ -22,14 +22,15 @@ function createClientMock(): ClientMock {
   };
 }
 
-function createConfig(overrides: Record<string, string | undefined> = {}): ConfigService {
-  const values: Record<string, string | undefined> = {
+function createConfig(overrides: Record<string, string | boolean | undefined> = {}): ConfigService {
+  const values: Record<string, string | boolean | undefined> = {
     nodeEnv: 'test',
     s3Endpoint: 'http://minio:9000',
     s3PublicBaseUrl: 'https://buildingos-staging-files.31-220-98-21.sslip.io',
     s3Region: 'us-east-1',
     s3AccessKey: 'access-key',
     s3SecretKey: 'secret-key',
+    s3ForcePathStyle: true,
     s3Bucket: 'buildingos-staging',
     ...overrides,
   };
@@ -97,7 +98,28 @@ describe('MinioService', () => {
     );
   });
 
-  it('preserves the public protocol, host, and explicit port when signing URLs', () => {
+  it('uses the protocol default port for a public HTTP endpoint', async () => {
+    const internalClient = createClientMock();
+    const publicClient = createClientMock();
+    publicClient.presignedPutObject.mockResolvedValue(
+      'http://files.example.test/buildingos-staging/proof.pdf?signature=abc',
+    );
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => publicClient);
+
+    const service = new MinioService(createConfig({ s3PublicBaseUrl: 'http://files.example.test' }));
+    const signedUrl = await service.presignUpload('buildingos-staging', 'proof.pdf');
+
+    expect(minioClientConstructor).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      endPoint: 'files.example.test',
+      port: 80,
+      useSSL: false,
+    }));
+    expect(signedUrl).not.toContain(':9000');
+  });
+
+  it('preserves an explicit public port when signing URLs', () => {
     const internalClient = createClientMock();
     const publicClient = createClientMock();
     minioClientConstructor
@@ -110,8 +132,20 @@ describe('MinioService', () => {
       endPoint: 'files.example.test',
       port: 9443,
       useSSL: false,
-      pathStyle: true,
     }));
+  });
+
+  it.each([true, false])('passes s3ForcePathStyle=%s to both clients', (pathStyle) => {
+    const internalClient = createClientMock();
+    const publicClient = createClientMock();
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => publicClient);
+
+    new MinioService(createConfig({ s3ForcePathStyle: pathStyle }));
+
+    expect(minioClientConstructor).toHaveBeenNthCalledWith(1, expect.objectContaining({ pathStyle }));
+    expect(minioClientConstructor).toHaveBeenNthCalledWith(2, expect.objectContaining({ pathStyle }));
   });
 
   it('falls back to the internal local endpoint for presigning when no public endpoint is configured', () => {

--- a/apps/api/src/storage/minio.service.ts
+++ b/apps/api/src/storage/minio.service.ts
@@ -28,6 +28,9 @@ export interface MinioObjectStat {
 @Injectable()
 export class MinioService {
   private readonly logger = new Logger(MinioService.name);
+  private readonly minioClient: Minio.Client;
+  private readonly presignClient: Minio.Client;
+  private readonly bucket: string;
 
   private getErrorLike(error: unknown): MinioErrorLike | undefined {
     return typeof error === 'object' && error !== null
@@ -49,9 +52,6 @@ export class MinioService {
       || errorLike?.statusCode === 404
       || errorLike?.message?.includes('NotFound') === true;
   }
-  private readonly minioClient: Minio.Client;
-  private readonly bucket: string;
-
   constructor(private configService: ConfigService) {
     const nodeEnv = this.configService.getValue('nodeEnv');
     const isDevelopment = nodeEnv === 'development' || nodeEnv === 'test';
@@ -68,22 +68,47 @@ export class MinioService {
     }
     this.bucket = bucket || 'buildingos-local';
 
-    // Parse endpoint to extract host and port
-    const url = new URL(endpoint || 'http://localhost:9000');
-    const host = url.hostname;
-    const port = url.port ? parseInt(url.port, 10) : url.protocol === 'https:' ? 443 : 9000;
-    const useSSL = url.protocol === 'https:';
+    const internalEndpoint = endpoint || 'http://localhost:9000';
+    const publicEndpoint = this.configService.getValue('s3PublicBaseUrl') || internalEndpoint;
 
-    this.minioClient = new Minio.Client({
-      endPoint: host,
-      port,
-      useSSL,
+    this.minioClient = this.createClient(
+      internalEndpoint,
       accessKey,
       secretKey,
       region,
-    });
+    );
+    this.presignClient = this.createClient(
+      publicEndpoint,
+      accessKey,
+      secretKey,
+      region,
+    );
 
-    this.logger.log(`MinIO client initialized: ${host}:${port} (bucket: ${this.bucket})`);
+    this.logger.log(`MinIO client initialized: ${new URL(internalEndpoint).host} (bucket: ${this.bucket})`);
+  }
+
+  private createClient(
+    endpoint: string,
+    accessKey: string,
+    secretKey: string,
+    region: string,
+  ): Minio.Client {
+    const url = new URL(endpoint);
+    const port = url.port
+      ? Number.parseInt(url.port, 10)
+      : url.protocol === 'https:'
+        ? 443
+        : 9000;
+
+    return new Minio.Client({
+      endPoint: url.hostname,
+      port,
+      useSSL: url.protocol === 'https:',
+      accessKey,
+      secretKey,
+      region,
+      pathStyle: true,
+    });
   }
 
   /**
@@ -112,7 +137,7 @@ export class MinioService {
     expirySeconds: number = 3600,
   ): Promise<string> {
     try {
-      const url = await this.minioClient.presignedPutObject(
+      const url = await this.presignClient.presignedPutObject(
         bucketName,
         objectKey,
         expirySeconds,
@@ -149,7 +174,7 @@ export class MinioService {
     expirySeconds: number = 3600,
   ): Promise<string> {
     try {
-      const url = await this.minioClient.presignedGetObject(
+      const url = await this.presignClient.presignedGetObject(
         bucketName,
         objectKey,
         expirySeconds,

--- a/apps/api/src/storage/minio.service.ts
+++ b/apps/api/src/storage/minio.service.ts
@@ -23,7 +23,7 @@ export interface MinioObjectStat {
  * Uses S3-compatible MinIO endpoint configured via environment variables:
  * - S3_ENDPOINT: localhost only for local development fallback
  * - S3_ACCESS_KEY / S3_SECRET_KEY / S3_BUCKET: required outside development
- * - S3_FORCE_PATH_STYLE: true (required for MinIO)
+ * - S3_FORCE_PATH_STYLE: controls whether bucket names are included in the URL path
  */
 @Injectable()
 export class MinioService {
@@ -60,6 +60,7 @@ export class MinioService {
       throw new Error('S3_ENDPOINT is required outside development');
     }
     const region = this.configService.getValue('s3Region') || 'us-east-1';
+    const pathStyle = this.configService.getValue('s3ForcePathStyle');
     const accessKey = this.configService.getValue('s3AccessKey');
     const secretKey = this.configService.getValue('s3SecretKey');
     const bucket = this.configService.getValue('s3Bucket');
@@ -76,12 +77,14 @@ export class MinioService {
       accessKey,
       secretKey,
       region,
+      pathStyle,
     );
     this.presignClient = this.createClient(
       publicEndpoint,
       accessKey,
       secretKey,
       region,
+      pathStyle,
     );
 
     this.logger.log(`MinIO client initialized: ${new URL(internalEndpoint).host} (bucket: ${this.bucket})`);
@@ -92,13 +95,14 @@ export class MinioService {
     accessKey: string,
     secretKey: string,
     region: string,
+    pathStyle: boolean,
   ): Minio.Client {
     const url = new URL(endpoint);
     const port = url.port
       ? Number.parseInt(url.port, 10)
       : url.protocol === 'https:'
         ? 443
-        : 9000;
+        : 80;
 
     return new Minio.Client({
       endPoint: url.hostname,
@@ -107,7 +111,7 @@ export class MinioService {
       accessKey,
       secretKey,
       region,
-      pathStyle: true,
+      pathStyle,
     });
   }
 


### PR DESCRIPTION
## Resumen

Corrige las URLs presignadas de MinIO para que el navegador use el dominio público de almacenamiento en lugar del hostname interno de Docker.

## Cambios

- mantiene `S3_ENDPOINT` para operaciones internas del backend;
- usa `S3_PUBLIC_BASE_URL` para firmar cargas y descargas;
- agrega un cliente MinIO separado para presigned URLs;
- conserva fallback local para desarrollo y tests;
- no reescribe URLs después de firmarlas.

## Validación

- tests focalizados de MinioService: 3 PASS;
- typecheck API: PASS;
- lint API: PASS;
- git diff --check: PASS.

## Base de datos

- sin cambios de schema;
- sin migraciones;
- sin seeds.

## Alcance

Corrige el error de staging donde el navegador intentaba subir archivos a `http://minio:9000`.