### PR TITLE
fix(web): harden resident document access

### DIFF
--- a/apps/web/app/(tenant)/[tenantId]/resident/documents/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/documents/page.test.tsx
@@ -1,0 +1,434 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useParams } from 'next/navigation';
+import ResidentDocumentsPage from './page';
+import { useResidentContext } from '../../../../../features/resident/hooks/useResidentContext';
+import { useContextOptions } from '../../../../../features/context/useContextOptions';
+import { useTenants } from '../../../../../features/tenants/tenants.hooks';
+import * as reactQuery from '@tanstack/react-query';
+import {
+  downloadProtectedDocumentContent,
+  listDocuments,
+  type Document,
+} from '../../../../../features/buildings/services/documents.api';
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+}));
+
+jest.mock('../../../../../features/resident/hooks/useResidentContext', () => ({
+  useResidentContext: jest.fn(),
+}));
+
+jest.mock('../../../../../features/context/useContextOptions', () => ({
+  useContextOptions: jest.fn(),
+}));
+
+jest.mock('../../../../../features/tenants/tenants.hooks', () => ({
+  useTenants: jest.fn(),
+}));
+
+jest.mock('@tanstack/react-query', () => ({
+  useQuery: jest.fn(),
+}));
+
+jest.mock('../../../../../features/buildings/services/documents.api', () => ({
+  listDocuments: jest.fn(),
+  downloadProtectedDocumentContent: jest.fn(),
+}));
+
+const mockedUseParams = jest.mocked(useParams);
+const mockedUseResidentContext = jest.mocked(useResidentContext);
+const mockedUseContextOptions = jest.mocked(useContextOptions);
+const mockedUseTenants = jest.mocked(useTenants);
+const mockedUseQuery = jest.mocked(reactQuery.useQuery);
+const mockedListDocuments = jest.mocked(listDocuments);
+const mockedDownloadProtectedDocumentContent = jest.mocked(downloadProtectedDocumentContent);
+
+function makeDocument(overrides: Partial<Document> = {}): Document {
+  return {
+    id: 'document-1',
+    tenantId: 'tenant-1',
+    title: 'Reglamento',
+    category: 'MINUTES',
+    visibility: 'RESIDENTS',
+    buildingId: 'building-1',
+    unitId: 'unit-1',
+    file: {
+      id: 'file-1',
+      bucket: 'documents',
+      objectKey: 'tenant-1/documents/document-1',
+      originalName: 'reglamento.pdf',
+      mimeType: 'application/pdf',
+      size: 1024,
+      checksum: 'checksum-1',
+      createdAt: '2026-07-01T00:00:00.000Z',
+    },
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('ResidentDocumentsPage', () => {
+  let openSpy: jest.SpyInstance;
+  let appendSpy: jest.SpyInstance | null = null;
+  const originalAppendChild = document.body.appendChild.bind(document.body);
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    appendSpy = null;
+
+    mockedUseParams.mockReturnValue({ tenantId: 'tenant-1' } as never);
+    mockedUseResidentContext.mockReturnValue({
+      data: {
+        activeBuildingId: 'building-1',
+        activeUnitId: 'unit-1',
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    mockedUseContextOptions.mockReturnValue({
+      data: {
+        buildings: [{ id: 'building-1', name: 'Complejo Horizonte' }],
+      },
+    } as never);
+    mockedUseTenants.mockReturnValue({
+      data: [{ id: 'tenant-1', name: 'Tenant Uno' }],
+    } as never);
+    mockedListDocuments.mockResolvedValue([]);
+    mockedDownloadProtectedDocumentContent.mockResolvedValue({
+      blob: new Blob(['pdf'], { type: 'application/pdf' }),
+      fileName: 'reglamento.pdf',
+      contentType: 'application/pdf',
+    });
+
+    (window.URL as typeof window.URL & {
+      createObjectURL: jest.Mock;
+      revokeObjectURL: jest.Mock;
+    }).createObjectURL = jest.fn(() => 'blob:document-url');
+    (window.URL as typeof window.URL & {
+      createObjectURL: jest.Mock;
+      revokeObjectURL: jest.Mock;
+    }).revokeObjectURL = jest.fn();
+    openSpy = jest.spyOn(window, 'open').mockImplementation(() => null);
+  });
+
+  afterEach(() => {
+    appendSpy?.mockRestore();
+    appendSpy = null;
+    openSpy.mockRestore();
+    jest.useRealTimers();
+  });
+
+  it('shows loading, empty, and list retry states', () => {
+    mockedUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+
+    const { rerender } = render(<ResidentDocumentsPage />);
+    expect(screen.queryByRole('button', { name: /abrir/i })).toBeNull();
+
+    mockedUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    rerender(<ResidentDocumentsPage />);
+    expect(screen.getByText('No hay documentos disponibles para tu unidad.')).toBeTruthy();
+
+    const refetch = jest.fn();
+    mockedUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('Sin conexión'),
+      refetch,
+    } as never);
+    rerender(<ResidentDocumentsPage />);
+
+    expect(screen.getByText('No pudimos cargar los documentos')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Reintentar' }));
+    expect(refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders file metadata from document.file and tolerates incomplete metadata', async () => {
+    mockedUseQuery.mockReturnValue({
+      data: [
+        makeDocument({
+          file: {
+            ...makeDocument().file,
+            originalName: 'contrato.pdf',
+            mimeType: 'application/pdf',
+            size: 1536000,
+          },
+        }),
+        makeDocument({
+          id: 'document-2',
+          title: 'Sin metadatos completos',
+          file: {
+            id: 'file-2',
+            bucket: 'documents',
+            objectKey: 'tenant-1/documents/document-2',
+            originalName: '',
+            mimeType: '',
+            size: undefined as never,
+            checksum: undefined,
+            createdAt: '2026-07-02T00:00:00.000Z',
+          },
+        }),
+      ],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+
+    render(<ResidentDocumentsPage />);
+
+    expect(await screen.findByText('contrato.pdf')).toBeTruthy();
+    expect(screen.getByText('application/pdf')).toBeTruthy();
+    expect(screen.getByText('1.5 MB')).toBeTruthy();
+    expect(screen.getByText('Archivo sin nombre')).toBeTruthy();
+    expect(screen.getByText('Tipo desconocido')).toBeTruthy();
+    expect(screen.getByText('Tamaño desconocido')).toBeTruthy();
+  });
+
+  it('opens PDFs through a protected blob URL and revokes it later', async () => {
+    const previewWindow = { location: { href: '' }, close: jest.fn() } as unknown as Window;
+    openSpy.mockImplementation(() => previewWindow);
+    mockedUseQuery.mockReturnValue({
+      data: [makeDocument({ title: 'Reglamento', file: { ...makeDocument().file, mimeType: 'application/pdf' } })],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+
+    render(<ResidentDocumentsPage />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Abrir Reglamento' }));
+
+    await waitFor(() => {
+      expect(mockedDownloadProtectedDocumentContent).toHaveBeenCalledWith('tenant-1', 'document-1', 'reglamento.pdf');
+      expect(openSpy).toHaveBeenCalledWith('', '_blank', 'noopener,noreferrer');
+      expect(previewWindow.location.href).toBe('blob:document-url');
+    });
+
+    expect((window.URL as typeof window.URL & { revokeObjectURL: jest.Mock }).revokeObjectURL).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(60_000);
+    expect((window.URL as typeof window.URL & { revokeObjectURL: jest.Mock }).revokeObjectURL).toHaveBeenCalledWith('blob:document-url');
+  });
+
+  it('opens images through a protected blob URL and keeps the button disabled while opening', async () => {
+    const previewWindow = { location: { href: '' }, close: jest.fn() } as unknown as Window;
+    openSpy.mockImplementation(() => previewWindow);
+    const deferred = createDeferred<{
+      blob: Blob;
+      fileName: string;
+      contentType: string;
+    }>();
+
+    mockedDownloadProtectedDocumentContent.mockReturnValue(deferred.promise as never);
+    mockedUseQuery.mockReturnValue({
+      data: [makeDocument({ id: 'document-image', title: 'Plano', file: { ...makeDocument().file, mimeType: 'image/png', originalName: 'plano.png' } })],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+
+    render(<ResidentDocumentsPage />);
+    const button = (await screen.findByRole('button', { name: 'Abrir Plano' })) as HTMLButtonElement;
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(button.disabled).toBe(true);
+    expect(mockedDownloadProtectedDocumentContent).toHaveBeenCalledTimes(1);
+
+    deferred.resolve({
+      blob: new Blob(['image'], { type: 'image/png' }),
+      fileName: 'plano.png',
+      contentType: 'image/png',
+    });
+
+    await waitFor(() => {
+      expect(previewWindow.location.href).toBe('blob:document-url');
+    });
+  });
+
+  it('downloads non-previewable documents with the resolved filename', async () => {
+    const clickedAnchors: HTMLAnchorElement[] = [];
+    appendSpy = jest.spyOn(document.body, 'appendChild').mockImplementation((node: Node) => {
+      if (node instanceof HTMLAnchorElement) {
+        clickedAnchors.push(node);
+      }
+      return originalAppendChild(node);
+    });
+    mockedDownloadProtectedDocumentContent.mockResolvedValue({
+      blob: new Blob(['csv'], { type: 'text/csv' }),
+      fileName: 'listado.csv',
+      contentType: 'text/csv',
+    });
+    mockedUseQuery.mockReturnValue({
+      data: [
+        makeDocument({
+          id: 'document-csv',
+          title: 'Listado',
+          category: 'OTHER',
+          file: {
+            ...makeDocument().file,
+            mimeType: 'text/csv',
+            originalName: 'listado.csv',
+          },
+        }),
+      ],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+
+    render(<ResidentDocumentsPage />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Descargar Listado' }));
+
+    await waitFor(() => {
+      expect(mockedDownloadProtectedDocumentContent).toHaveBeenCalledWith('tenant-1', 'document-csv', 'listado.csv');
+      expect(openSpy).not.toHaveBeenCalled();
+      expect(clickedAnchors[0].download).toBe('listado.csv');
+    });
+  });
+
+  it('surfaces an opening error without reusing the list error copy', async () => {
+    mockedDownloadProtectedDocumentContent.mockRejectedValueOnce(new Error('No pudimos abrir el archivo. Intentá nuevamente.'));
+    mockedUseQuery.mockReturnValue({
+      data: [makeDocument({ title: 'Reglamento' })],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+
+    render(<ResidentDocumentsPage />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Abrir Reglamento' }));
+
+    expect(await screen.findByText('No pudimos abrir “Reglamento”')).toBeTruthy();
+    expect(screen.getByText('No pudimos abrir el archivo. Intentá nuevamente.')).toBeTruthy();
+    expect(screen.queryByText('No pudimos cargar los documentos')).toBeNull();
+  });
+
+  it('falls back to anchor download when window.open is blocked for a previewable document', async () => {
+    openSpy.mockImplementation(() => null);
+
+    const clickedAnchors: HTMLAnchorElement[] = [];
+    appendSpy = jest.spyOn(document.body, 'appendChild').mockImplementation((node: Node) => {
+      if (node instanceof HTMLAnchorElement) {
+        clickedAnchors.push(node);
+      }
+      return originalAppendChild(node);
+    });
+    mockedDownloadProtectedDocumentContent.mockResolvedValue({
+      blob: new Blob(['image'], { type: 'image/png' }),
+      fileName: 'plano.png',
+      contentType: 'image/png',
+    });
+
+    mockedUseQuery.mockReturnValue({
+      data: [
+        makeDocument({
+          id: 'doc-popup-blocked',
+          title: 'Plano Bloqueado',
+          file: {
+            ...makeDocument().file,
+            mimeType: 'image/png',
+            originalName: 'plano.png',
+          },
+        }),
+      ],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+
+    render(<ResidentDocumentsPage />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Abrir Plano Bloqueado' }));
+
+    await waitFor(() => {
+      expect(mockedDownloadProtectedDocumentContent).toHaveBeenCalledTimes(1);
+      expect(mockedDownloadProtectedDocumentContent).toHaveBeenCalledWith('tenant-1', 'doc-popup-blocked', 'plano.png');
+    });
+
+    expect(clickedAnchors.length).toBe(1);
+    expect(clickedAnchors[0].download).toBe('plano.png');
+    expect(screen.queryByText('No pudimos abrir')).toBeNull();
+
+    await waitFor(() => {
+      expect((screen.queryByRole('button', { name: /abrir plano bloqueado/i }) as HTMLButtonElement | null)?.disabled).toBe(false);
+    });
+  });
+
+  it('prevents duplicate requests while a document is opening', async () => {
+    const deferred = createDeferred<{
+      blob: Blob;
+      fileName: string;
+      contentType: string;
+    }>();
+    mockedDownloadProtectedDocumentContent.mockReturnValue(deferred.promise as never);
+    mockedUseQuery.mockReturnValue({
+      data: [makeDocument({ title: 'Reglamento' })],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+
+    render(<ResidentDocumentsPage />);
+    const button = (await screen.findByRole('button', { name: 'Abrir Reglamento' })) as HTMLButtonElement;
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(mockedDownloadProtectedDocumentContent).toHaveBeenCalledTimes(1);
+    expect(button.disabled).toBe(true);
+
+    deferred.resolve({
+      blob: new Blob(['pdf'], { type: 'application/pdf' }),
+      fileName: 'reglamento.pdf',
+      contentType: 'application/pdf',
+    });
+
+    await waitFor(() => expect(button.disabled).toBe(false));
+  });
+
+  it('does not reference the legacy download route or MinIO metadata in the resident screen source', () => {
+    const source = fs.readFileSync(path.join(__dirname, 'page.tsx'), 'utf8');
+    expect(source).not.toContain('/download');
+    expect(source).not.toContain('bucket');
+    expect(source).not.toContain('objectKey');
+    expect(source).not.toContain('minio');
+  });
+});
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}

--- a/apps/web/app/(tenant)/[tenantId]/resident/documents/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/documents/page.tsx
@@ -1,119 +1,134 @@
 'use client';
 
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
-import { useState } from 'react';
-import {
-  FileText,
-  Download,
-  AlertCircle,
-  Building2,
-  Folder,
-  Calendar,
-} from 'lucide-react';
+import { AlertCircle, Building2, Calendar, Download, FileText, Folder, Loader2 } from 'lucide-react';
 import { useResidentContext } from '../../../../../features/resident/hooks/useResidentContext';
 import { useContextOptions } from '../../../../../features/context/useContextOptions';
 import { useTenants } from '../../../../../features/tenants/tenants.hooks';
-import { apiClient } from '../../../../../shared/lib/http/client';
 import Card from '../../../../../shared/components/ui/Card';
 import Skeleton from '../../../../../shared/components/ui/Skeleton';
+import {
+  Document,
+  downloadProtectedDocumentContent,
+  listDocuments,
+} from '../../../../../features/buildings/services/documents.api';
 
-interface Document {
-  id: string;
-  title: string;
-  category: string;
-  visibility: 'TENANT_ADMIN' | 'RESIDENTS' | 'PRIVATE';
-  buildingId: string | null;
-  unitId: string | null;
-  fileName: string;
-  mimeType: string;
-  size: number;
-  createdAt: string;
-  createdBy: {
-    name: string;
-    email: string;
-  };
+const CATEGORY_LABELS: Record<string, string> = {
+  MINUTES: 'Actas',
+  CONTRACT: 'Contrato',
+  BUDGET: 'Presupuesto',
+  INVOICE: 'Factura',
+  RECEIPT: 'Recibo',
+  OTHER: 'Otro',
+};
+
+const PREVIEWABLE_MIME_PREFIXES = ['application/pdf', 'image/'];
+const PREVIEW_URL_REVOKE_DELAY_MS = 60_000;
+const DOWNLOAD_URL_REVOKE_DELAY_MS = 5_000;
+
+function formatDate(dateValue: string): string {
+  return new Intl.DateTimeFormat('es-AR', {
+    day: '2-digit',
+    month: 'short',
+    year: 'numeric',
+  }).format(new Date(dateValue));
 }
 
-async function getResidentDocuments(
-  tenantId: string,
-  buildingId?: string,
-  unitId?: string
-): Promise<Document[]> {
-  const params = new URLSearchParams();
-  if (buildingId) params.append('buildingId', buildingId);
-  if (unitId) params.append('unitId', unitId);
-  
-  const query = params.toString();
-  const endpoint = `/tenants/${tenantId}/documents${query ? '?' + query : ''}`;
-  
-  return apiClient<Document[]>({
-    path: endpoint,
-    method: 'GET',
-  });
+function formatFileSize(bytes?: number): string {
+  if (typeof bytes !== 'number' || Number.isNaN(bytes) || bytes < 0) {
+    return 'Tamaño desconocido';
+  }
+
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-async function getDownloadUrl(tenantId: string, documentId: string): Promise<string> {
-  return apiClient<string>({
-    path: `/tenants/${tenantId}/documents/${documentId}/download`,
-    method: 'GET',
-  });
+function isPreviewableMimeType(mimeType?: string): boolean {
+  if (!mimeType) return false;
+  const normalizedMimeType = mimeType.toLowerCase();
+  return PREVIEWABLE_MIME_PREFIXES.some((prefix) => normalizedMimeType.startsWith(prefix));
 }
 
-function categoryLabel(category: string): string {
-  const labels: Record<string, string> = {
-    RULES: 'Reglamento',
-    FINANCIAL: 'Financiero',
-    ASSEMBLY: 'Asambleas',
-    MAINTENANCE: 'Mantenimiento',
-    OTHER: 'Otros',
-  };
-  return labels[category] ?? category;
+function getSafeFileName(document: Document): string {
+  return document.file?.originalName?.trim() || 'Archivo sin nombre';
 }
 
-function scopeLabel(buildingId: string | null, unitId: string | null): string {
+function getSafeMimeType(document: Document): string {
+  return document.file?.mimeType?.trim() || 'Tipo desconocido';
+}
+
+function getSafeSize(document: Document): string {
+  return formatFileSize(document.file?.size);
+}
+
+function getFileIcon(mimeType?: string): string {
+  if (!mimeType) return '📁';
+  const normalizedMimeType = mimeType.toLowerCase();
+  if (normalizedMimeType.includes('pdf')) return '📄';
+  if (normalizedMimeType.startsWith('image/')) return '🖼️';
+  if (normalizedMimeType.includes('word') || normalizedMimeType.includes('document')) return '📝';
+  if (normalizedMimeType.includes('sheet') || normalizedMimeType.includes('excel')) return '📊';
+  return '📁';
+}
+
+function getDocumentScopeLabel(buildingId: string | null | undefined, unitId: string | null | undefined): string {
   if (unitId) return 'Unidad';
   if (buildingId) return 'Edificio';
   return 'General';
 }
 
-function formatDate(dateStr: string): string {
-  return new Intl.DateTimeFormat('es-AR', {
-    day: '2-digit',
-    month: 'short',
-    year: 'numeric',
-  }).format(new Date(dateStr));
+function renderErrorMessage(error: unknown, fallback: string): string {
+  if (error instanceof Error && error.message.trim() !== '') {
+    return error.message;
+  }
+  return fallback;
 }
 
-function formatFileSize(bytes: number): string {
-  if (bytes < 1024) return bytes + ' B';
-  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
-  return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
-}
-
-function getFileIcon(mimeType: string) {
-  if (mimeType.includes('pdf')) return '📄';
-  if (mimeType.includes('image')) return '🖼️';
-  if (mimeType.includes('word') || mimeType.includes('document')) return '📝';
-  if (mimeType.includes('sheet') || mimeType.includes('excel')) return '📊';
-  return '📁';
+function downloadBlob(blob: Blob, fileName: string): string {
+  const objectUrl = window.URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = objectUrl;
+  anchor.download = fileName;
+  anchor.rel = 'noopener noreferrer';
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  return objectUrl;
 }
 
 export default function ResidentDocumentsPage() {
   const params = useParams<{ tenantId: string }>();
   const tenantId = params.tenantId;
-  const [downloadError, setDownloadError] = useState<string | null>(null);
+
+  const [openError, setOpenError] = useState<string | null>(null);
+  const [openErrorDocumentTitle, setOpenErrorDocumentTitle] = useState<string | null>(null);
+  const [openingDocumentId, setOpeningDocumentId] = useState<string | null>(null);
+  const openingDocumentIdRef = useRef<string | null>(null);
+  const activeObjectUrlsRef = useRef<string[]>([]);
+  const activeTimersRef = useRef<number[]>([]);
 
   const { data: tenants } = useTenants();
-  const tenantName = tenants?.find((t) => t.id === tenantId)?.name ?? tenantId;
+  const tenantName = tenants?.find((tenant) => tenant.id === tenantId)?.name ?? tenantId;
 
   const { data: context, isLoading: contextLoading } = useResidentContext(tenantId ?? null);
   const buildingId = context?.activeBuildingId;
   const unitId = context?.activeUnitId;
 
   const { data: contextOptions } = useContextOptions(tenantId ?? null);
+  const buildingName = contextOptions?.buildings.find((building) => building.id === buildingId)?.name ?? null;
 
-  const buildingName = contextOptions?.buildings.find((b) => b.id === buildingId)?.name ?? null;
+  useEffect(() => {
+    return () => {
+      activeTimersRef.current.forEach((timerId) => window.clearTimeout(timerId));
+      activeTimersRef.current = [];
+      activeObjectUrlsRef.current.forEach((objectUrl) => window.URL.revokeObjectURL(objectUrl));
+      activeObjectUrlsRef.current = [];
+    };
+  }, []);
 
   const {
     data: documents = [],
@@ -123,18 +138,75 @@ export default function ResidentDocumentsPage() {
     refetch,
   } = useQuery<Document[]>({
     queryKey: ['residentDocuments', tenantId, buildingId, unitId],
-    queryFn: () => getResidentDocuments(tenantId!, buildingId ?? undefined, unitId ?? undefined),
-    enabled: !!tenantId,
+    queryFn: () => listDocuments(tenantId!, { buildingId: buildingId ?? undefined, unitId: unitId ?? undefined }),
+    enabled: !!tenantId && !!buildingId && !!unitId,
     staleTime: 5 * 60 * 1000,
   });
 
-  const handleDownload = async (doc: Document) => {
+  const listErrorMessage = useMemo(() => {
+    if (!docsError) return null;
+    return renderErrorMessage(docsErrorValue, 'No pudimos cargar los documentos. Intentá nuevamente.');
+  }, [docsError, docsErrorValue]);
+
+  const registerObjectUrl = (objectUrl: string, revokeDelayMs: number): void => {
+    activeObjectUrlsRef.current.push(objectUrl);
+    const timerId = window.setTimeout(() => {
+      window.URL.revokeObjectURL(objectUrl);
+      activeObjectUrlsRef.current = activeObjectUrlsRef.current.filter((url) => url !== objectUrl);
+      activeTimersRef.current = activeTimersRef.current.filter((id) => id !== timerId);
+    }, revokeDelayMs);
+    activeTimersRef.current.push(timerId);
+  };
+
+  const handleOpenDocument = async (document: Document) => {
+    if (openingDocumentIdRef.current) return;
+    if (!tenantId) return;
+
+    openingDocumentIdRef.current = document.id;
+    setOpeningDocumentId(document.id);
+    setOpenError(null);
+    setOpenErrorDocumentTitle(null);
+
+    const previewable = isPreviewableMimeType(document.file?.mimeType);
+    const popupWindow = previewable ? window.open('', '_blank', 'noopener,noreferrer') : null;
+
     try {
-      setDownloadError(null);
-      const url = await getDownloadUrl(tenantId!, doc.id);
-      window.open(url, '_blank');
+      const protectedContent = await downloadProtectedDocumentContent(
+        tenantId,
+        document.id,
+        getSafeFileName(document),
+      );
+
+      const blob = protectedContent.blob;
+      const resolvedFileName = protectedContent.fileName || getSafeFileName(document);
+      const contentType = protectedContent.contentType || getSafeMimeType(document);
+
+      if (previewable && popupWindow) {
+        const objectUrl = window.URL.createObjectURL(blob);
+        registerObjectUrl(objectUrl, PREVIEW_URL_REVOKE_DELAY_MS);
+        popupWindow.location.href = objectUrl;
+        return;
+      }
+
+      const objectUrl = downloadBlob(
+        blob.type ? blob : new Blob([blob], { type: contentType }),
+        resolvedFileName,
+      );
+      registerObjectUrl(objectUrl, DOWNLOAD_URL_REVOKE_DELAY_MS);
+      popupWindow?.close();
     } catch (error) {
-      setDownloadError(error instanceof Error ? error.message : 'No pudimos abrir el documento. Intentá nuevamente.');
+      popupWindow?.close();
+
+      if (error instanceof Error) {
+        setOpenError(error.message);
+      } else {
+        setOpenError('No pudimos abrir el documento. Intentá nuevamente.');
+      }
+
+      setOpenErrorDocumentTitle(document.title || getSafeFileName(document));
+    } finally {
+      openingDocumentIdRef.current = null;
+      setOpeningDocumentId(null);
     }
   };
 
@@ -143,8 +215,8 @@ export default function ResidentDocumentsPage() {
       <div className="space-y-6">
         <Skeleton className="h-8 w-48" />
         <div className="grid gap-4">
-          {[1, 2, 3].map((i) => (
-            <Skeleton key={i} className="h-24" />
+          {[1, 2, 3].map((index) => (
+            <Skeleton key={index} className="h-24" />
           ))}
         </div>
       </div>
@@ -154,13 +226,13 @@ export default function ResidentDocumentsPage() {
   if (!buildingId || !unitId) {
     return (
       <div>
-        <h1 className="text-2xl font-semibold flex items-center gap-2">
-          <FileText className="w-6 h-6" />
+        <h1 className="flex items-center gap-2 text-2xl font-semibold">
+          <FileText className="h-6 w-6" />
           Documentos
         </h1>
-        <p className="text-muted-foreground mt-1">{tenantName}</p>
+        <p className="mt-1 text-muted-foreground">{tenantName}</p>
 
-        <Card className="p-4 mt-6 border-yellow-300 bg-yellow-50">
+        <Card className="mt-6 border-yellow-300 bg-yellow-50 p-4">
           <div className="flex items-center gap-2">
             <AlertCircle className="text-yellow-600" size={20} />
             <div>
@@ -175,33 +247,27 @@ export default function ResidentDocumentsPage() {
 
   return (
     <div className="space-y-6">
-      {/* Header */}
       <div>
-        <h1 className="text-2xl font-semibold flex items-center gap-2">
-          <FileText className="w-6 h-6" />
+        <h1 className="flex items-center gap-2 text-2xl font-semibold">
+          <FileText className="h-6 w-6" />
           Documentos
         </h1>
-        <p className="text-muted-foreground mt-1">
+        <p className="mt-1 text-muted-foreground">
           {tenantName}
           {buildingName && ` • ${buildingName}`}
         </p>
       </div>
 
-      {(docsError || downloadError) && (
-        <Card className="p-4 border-red-200 bg-red-50">
+      {listErrorMessage && (
+        <Card className="border-red-200 bg-red-50 p-4">
           <div className="flex items-start gap-3">
-            <AlertCircle className="text-red-600 mt-0.5" size={20} />
+            <AlertCircle className="mt-0.5 text-red-600" size={20} />
             <div className="space-y-1">
               <p className="font-medium text-red-800">No pudimos cargar los documentos</p>
-              <p className="text-sm text-red-700">
-                {downloadError ?? (docsErrorValue instanceof Error ? docsErrorValue.message : 'Intentá nuevamente en unos segundos.')}
-              </p>
+              <p className="text-sm text-red-700">{listErrorMessage}</p>
               <button
                 type="button"
-                onClick={() => {
-                  setDownloadError(null);
-                  refetch();
-                }}
+                onClick={() => void refetch()}
                 className="text-sm font-medium text-red-700 hover:underline"
               >
                 Reintentar
@@ -211,59 +277,98 @@ export default function ResidentDocumentsPage() {
         </Card>
       )}
 
-      {/* Documents List */}
+      {openError && (
+        <Card className="border-red-200 bg-red-50 p-4">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="mt-0.5 text-red-600" size={20} />
+            <div className="space-y-1">
+              <p className="font-medium text-red-800">
+                {openErrorDocumentTitle
+                  ? `No pudimos abrir “${openErrorDocumentTitle}”`
+                  : 'No pudimos abrir el documento'}
+              </p>
+              <p className="text-sm text-red-700">{openError}</p>
+              <button
+                type="button"
+                onClick={() => {
+                  setOpenError(null);
+                  setOpenErrorDocumentTitle(null);
+                }}
+                className="text-sm font-medium text-red-700 hover:underline"
+              >
+                Cerrar
+              </button>
+            </div>
+          </div>
+        </Card>
+      )}
+
       {docsLoading ? (
         <div className="space-y-4">
-          {[1, 2, 3].map((i) => (
-            <Skeleton key={i} className="h-24" />
+          {[1, 2, 3].map((index) => (
+            <Skeleton key={index} className="h-24" />
           ))}
         </div>
       ) : documents.length === 0 ? (
         <Card className="p-8 text-center">
-          <Folder className="w-12 h-12 mx-auto text-muted-foreground mb-4" />
+          <Folder className="mx-auto mb-4 h-12 w-12 text-muted-foreground" />
           <p className="text-muted-foreground">No hay documentos disponibles para tu unidad.</p>
-          <p className="text-sm text-muted-foreground mt-1">
+          <p className="mt-1 text-sm text-muted-foreground">
             Cuando la administración comparta documentos con tu unidad o edificio, los vas a ver acá.
           </p>
         </Card>
       ) : (
         <div className="space-y-3">
-          {documents.map((doc) => (
-            <Card key={doc.id} className="p-4 hover:shadow-md transition">
-              <div className="flex items-start justify-between gap-4">
-                <div className="flex items-start gap-3 min-w-0">
-                  <div className="text-2xl">{getFileIcon(doc.mimeType)}</div>
-                  <div className="min-w-0">
-                    <h3 className="font-medium truncate">{doc.title}</h3>
-                    <div className="flex items-center gap-3 mt-1 text-xs text-muted-foreground">
-                      <span className="flex items-center gap-1">
-                        <Folder className="w-3 h-3" />
-                        {categoryLabel(doc.category)}
-                      </span>
-                      <span className="flex items-center gap-1">
-                        <Building2 className="w-3 h-3" />
-                        {scopeLabel(doc.buildingId, doc.unitId)}
-                      </span>
-                      <span className="flex items-center gap-1">
-                        <Calendar className="w-3 h-3" />
-                        {formatDate(doc.createdAt)}
-                      </span>
-                      <span>{formatFileSize(doc.size)}</span>
+          {documents.map((document) => {
+            const fileName = getSafeFileName(document);
+            const mimeType = getSafeMimeType(document);
+            const sizeLabel = getSafeSize(document);
+            const isOpening = openingDocumentId === document.id;
+            const actionLabel = isPreviewableMimeType(mimeType) ? 'Abrir' : 'Descargar';
+
+            return (
+              <Card key={document.id} className="p-4 transition hover:shadow-md">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex min-w-0 items-start gap-3">
+                    <div className="text-2xl">{getFileIcon(mimeType)}</div>
+                    <div className="min-w-0 space-y-1">
+                      <h3 className="truncate font-medium">{document.title}</h3>
+                      <p className="truncate text-sm text-muted-foreground">{fileName}</p>
+                      <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                        <span className="flex items-center gap-1">
+                          <Folder className="h-3 w-3" />
+                          {CATEGORY_LABELS[document.category] ?? document.category}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <Building2 className="h-3 w-3" />
+                          {getDocumentScopeLabel(document.buildingId ?? null, document.unitId ?? null)}
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <Calendar className="h-3 w-3" />
+                          {formatDate(document.createdAt)}
+                        </span>
+                      </div>
+                      <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                        <span>{mimeType}</span>
+                        <span>{sizeLabel}</span>
+                      </div>
                     </div>
                   </div>
+
+                  <button
+                    type="button"
+                    onClick={() => void handleOpenDocument(document)}
+                    disabled={isOpening}
+                    aria-label={`${actionLabel} ${document.title}`}
+                    className="inline-flex items-center gap-1 rounded bg-blue-50 px-3 py-1.5 text-sm text-blue-700 transition hover:bg-blue-100 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {isOpening ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+                    {actionLabel}
+                  </button>
                 </div>
-                <button
-                  onClick={() => handleDownload(doc)}
-                  type="button"
-                  aria-label={`Descargar ${doc.title}`}
-                  className="flex items-center gap-1 px-3 py-1.5 text-sm bg-blue-50 text-blue-700 rounded hover:bg-blue-100 transition"
-                >
-                  <Download className="w-4 h-4" />
-                  Descargar
-                </button>
-              </div>
-            </Card>
-          ))}
+              </Card>
+            );
+          })}
         </div>
       )}
     </div>

--- a/apps/web/features/buildings/services/documents.api.test.ts
+++ b/apps/web/features/buildings/services/documents.api.test.ts
@@ -1,0 +1,89 @@
+import { apiClient, apiClientWithResponse } from '@/shared/lib/http/client';
+import {
+  downloadDocumentContent,
+  downloadProtectedDocumentContent,
+  type DocumentCategory,
+} from './documents.api';
+
+jest.mock('@/shared/lib/http/client', () => ({
+  apiClient: jest.fn(),
+  apiClientWithResponse: jest.fn(),
+}));
+
+const mockedApiClient = jest.mocked(apiClient);
+const mockedApiClientWithResponse = jest.mocked(apiClientWithResponse);
+
+function createResponse(headers: Record<string, string | undefined>) {
+  return {
+    headers: {
+      get(name: string) {
+        return headers[name.toLowerCase()];
+      },
+    },
+  } as never;
+}
+
+describe('documents api', () => {
+  beforeEach(() => {
+    mockedApiClient.mockReset();
+    mockedApiClientWithResponse.mockReset();
+  });
+
+  it('downloads resident document content through the protected endpoint and parses the filename from Content-Disposition', async () => {
+    const blob = new Blob(['pdf'], { type: 'application/pdf' });
+    mockedApiClientWithResponse.mockResolvedValue({
+      data: blob,
+      response: createResponse({
+        'content-disposition': 'inline; filename="Acta Asamblea.pdf"',
+        'content-type': 'application/pdf',
+      }),
+    } as never);
+
+    const result = await downloadProtectedDocumentContent('tenant-1', 'document-1', 'fallback.pdf');
+
+    expect(mockedApiClientWithResponse).toHaveBeenCalledWith({
+      path: '/tenants/tenant-1/documents/document-1/content',
+      method: 'GET',
+      headers: { 'X-Tenant-Id': 'tenant-1' },
+      responseType: 'blob',
+    });
+    expect(result.blob).toBe(blob);
+    expect(result.fileName).toBe('Acta Asamblea.pdf');
+    expect(result.contentType).toBe('application/pdf');
+  });
+
+  it('falls back to the document original name when Content-Disposition is missing', async () => {
+    const blob = new Blob(['sheet'], { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' });
+    mockedApiClientWithResponse.mockResolvedValue({
+      data: blob,
+      response: createResponse({
+        'content-disposition': undefined,
+        'content-type': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      }),
+    } as never);
+
+    const result = await downloadProtectedDocumentContent('tenant-1', 'document-2', 'original-name.xlsx');
+
+    expect(result.fileName).toBe('original-name.xlsx');
+    expect(result.contentType).toBe('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+  });
+
+  it('includes RULES as a valid DocumentCategory matching the Prisma enum', () => {
+    const category: DocumentCategory = 'RULES';
+    expect(category).toBe('RULES');
+  });
+
+  it('keeps the legacy blob helper available for other resident flows', async () => {
+    const blob = new Blob(['pdf'], { type: 'application/pdf' });
+    mockedApiClientWithResponse.mockResolvedValue({
+      data: blob,
+      response: createResponse({
+        'content-disposition': 'attachment; filename="recibo.pdf"',
+      }),
+    } as never);
+
+    const result = await downloadDocumentContent('tenant-1', 'document-3');
+
+    expect(result).toBe(blob);
+  });
+});

--- a/apps/web/features/buildings/services/documents.api.ts
+++ b/apps/web/features/buildings/services/documents.api.ts
@@ -8,7 +8,7 @@
  * 3. POST /documents → create Document record with file metadata
  */
 
-import { apiClient } from '@/shared/lib/http/client';
+import { apiClient, apiClientWithResponse } from '@/shared/lib/http/client';
 
 const isDev = process.env.NODE_ENV === 'development';
 
@@ -62,6 +62,12 @@ export interface DownloadUrlResponse {
   expiresAt: string;
 }
 
+export interface ProtectedDocumentContent {
+  blob: Blob;
+  fileName: string;
+  contentType: string;
+}
+
 export interface CreateDocumentInput {
   title: string;
   category: DocumentCategory;
@@ -113,6 +119,33 @@ function getTenantHeaders(tenantId: string): Record<string, string> {
   return {
     'X-Tenant-Id': tenantId,
   };
+}
+
+function decodeContentDispositionValue(value: string): string {
+  try {
+    return decodeURIComponent(value.replace(/^"|"$/g, '').trim());
+  } catch {
+    return value.replace(/^"|"$/g, '').trim();
+  }
+}
+
+function parseContentDispositionFileName(contentDisposition: string | null): string | null {
+  if (!contentDisposition) return null;
+
+  const filenameStarMatch = contentDisposition.match(/filename\*\s*=\s*([^;]+)/i);
+  if (filenameStarMatch?.[1]) {
+    const rawValue = filenameStarMatch[1].trim();
+    const utf8Match = rawValue.match(/^UTF-8''(.+)$/i);
+    const candidate = utf8Match?.[1] ?? rawValue;
+    return decodeContentDispositionValue(candidate);
+  }
+
+  const filenameMatch = contentDisposition.match(/filename\s*=\s*([^;]+)/i);
+  if (filenameMatch?.[1]) {
+    return decodeContentDispositionValue(filenameMatch[1]);
+  }
+
+  return null;
 }
 
 // ============================================
@@ -374,25 +407,40 @@ export async function getDownloadUrl(
  * Download protected document content through the BuildingOS API.
  *
  * GET /documents/:id/content
- * response: Blob
+ * response: Blob + response headers
  */
-export async function downloadDocumentContent(
+export async function downloadProtectedDocumentContent(
   tenantId: string,
   documentId: string,
-): Promise<Blob> {
+  fallbackFileName?: string,
+): Promise<ProtectedDocumentContent> {
   const endpoint = `/tenants/${tenantId}/documents/${documentId}/content`;
   logRequest('GET', endpoint);
 
   try {
-    return await apiClient<Blob>({
+    const { data: blob, response } = await apiClientWithResponse<Blob>({
       path: endpoint,
       method: 'GET',
       headers: getTenantHeaders(tenantId),
       responseType: 'blob',
     });
+
+    const headerFileName = parseContentDispositionFileName(response.headers.get('content-disposition'));
+    const fileName = headerFileName ?? fallbackFileName ?? `document-${documentId}`;
+    const contentType = blob.type || response.headers.get('content-type') || 'application/octet-stream';
+
+    return { blob, fileName, contentType };
   } catch (error) {
     const message = `Failed to download document content: ${(error as Error).message}`;
     logError(endpoint, 500, message);
     throw error;
   }
+}
+
+export async function downloadDocumentContent(
+  tenantId: string,
+  documentId: string,
+): Promise<Blob> {
+  const { blob } = await downloadProtectedDocumentContent(tenantId, documentId);
+  return blob;
 }

--- a/apps/web/shared/lib/http/client.ts
+++ b/apps/web/shared/lib/http/client.ts
@@ -12,6 +12,11 @@ export interface HttpRequestConfig<TReq = never> {
   responseType?: 'json' | 'blob' | 'text' | 'arrayBuffer';
 }
 
+export interface HttpResponse<TRes> {
+  data: TRes;
+  response: Response;
+}
+
 export interface ErrorResponseData {
   code?: string;
   message?: string | string[];
@@ -99,6 +104,86 @@ async function readResponse<TRes>(
   }
 }
 
+async function performRequest(
+  path: string,
+  init: RequestInit,
+  method: string,
+): Promise<Response> {
+  const url = `${API_URL}${path}`;
+
+  try {
+    const response = await fetch(url, init);
+    captureResponseContext(response, method, path);
+    return response;
+  } catch (error) {
+    recordApiResponseContext({
+      requestId: undefined,
+      method,
+      path,
+      statusCode: 0,
+    });
+    throw error;
+  }
+}
+
+async function executeRequest<TRes, TReq = never>(
+  config: HttpRequestConfig<TReq>,
+): Promise<HttpResponse<TRes>> {
+  const { path, method = 'GET', body, headers: customHeaders, responseType = 'json' } = config;
+
+  const token = getCurrentImpersonationToken();
+  const hasBody = body !== undefined;
+  const shouldUseBinaryBody = hasBody && isBinaryBody(body);
+
+  const headers: Record<string, string> = {
+    ...customHeaders,
+  };
+
+  if (hasBody && !shouldUseBinaryBody && headers['Content-Type'] === undefined) {
+    headers['Content-Type'] = 'application/json';
+  }
+
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const init: RequestInit = {
+    method,
+    headers,
+    credentials: 'include',
+  };
+
+  if (hasBody && method !== 'GET') {
+    init.body = shouldUseBinaryBody ? (body as BodyInit) : JSON.stringify(body);
+  }
+
+  let response = await performRequest(path, init, method);
+
+  if (!response.ok && response.status === 401) {
+    const hasImpersonationToken = !!getCurrentImpersonationToken();
+
+    if (!hasImpersonationToken && !isAuthRoute(path)) {
+      try {
+        await ensureSharedRefreshPromise();
+      } catch {
+        throw new HttpError(401, 'Unauthorized', 'Sesión expirada. Vuelve a iniciar sesión.');
+      }
+
+      response = await performRequest(path, init, method);
+    }
+  }
+
+  if (!response.ok) {
+    const { message, data } = await parseErrorResponse(response);
+    throw new HttpError(response.status, response.statusText, message, data);
+  }
+
+  return {
+    data: await readResponse<TRes>(response, responseType),
+    response,
+  };
+}
+
 function isAuthRoute(path: string): boolean {
   return (
     path === '/auth/refresh' ||
@@ -173,83 +258,12 @@ function captureResponseContext(
 export async function apiClient<TRes, TReq = never>(
   config: HttpRequestConfig<TReq>,
 ): Promise<TRes> {
-  const { path, method = 'GET', body, headers: customHeaders, responseType = 'json' } = config;
+  const { data } = await executeRequest<TRes, TReq>(config);
+  return data;
+}
 
-  const url = `${API_URL}${path}`;
-  const token = getCurrentImpersonationToken();
-  const hasBody = body !== undefined;
-  const shouldUseBinaryBody = hasBody && isBinaryBody(body);
-
-  const headers: Record<string, string> = {
-    ...customHeaders,
-  };
-
-  if (hasBody && !shouldUseBinaryBody && headers['Content-Type'] === undefined) {
-    headers['Content-Type'] = 'application/json';
-  }
-
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
-  }
-
-  const init: RequestInit = {
-    method,
-    headers,
-    credentials: 'include',
-  };
-
-  if (hasBody && method !== 'GET') {
-    init.body = shouldUseBinaryBody ? (body as BodyInit) : JSON.stringify(body);
-  }
-
-  let response: Response;
-  try {
-    response = await fetch(url, init);
-  } catch (error) {
-    recordApiResponseContext({
-      requestId: undefined,
-      method,
-      path,
-      statusCode: 0,
-    });
-    throw error;
-  }
-  captureResponseContext(response, method, path);
-
-  if (!response.ok) {
-    // Centralized 401 handler: try refresh cookie once, then emit an auth-expired event.
-    if (response.status === 401) {
-      const hasImpersonationToken = !!getCurrentImpersonationToken();
-
-      if (!hasImpersonationToken && !isAuthRoute(path)) {
-        try {
-          await ensureSharedRefreshPromise();
-        } catch {
-          throw new HttpError(401, 'Unauthorized', 'Sesión expirada. Vuelve a iniciar sesión.');
-        }
-
-        const retryResponse = await fetch(url, init);
-        captureResponseContext(retryResponse, method, path);
-        if (retryResponse.ok) {
-          return readResponse<TRes>(retryResponse, responseType);
-        }
-
-        const retryError = await parseErrorResponse(retryResponse);
-        throw new HttpError(
-          retryResponse.status,
-          retryResponse.statusText,
-          retryError.message,
-          retryError.data,
-        );
-      }
-
-      const { message, data } = await parseErrorResponse(response);
-      throw new HttpError(response.status, response.statusText, message, data);
-    }
-
-    const { message, data } = await parseErrorResponse(response);
-    throw new HttpError(response.status, response.statusText, message, data);
-  }
-
-  return readResponse<TRes>(response, responseType);
+export async function apiClientWithResponse<TRes, TReq = never>(
+  config: HttpRequestConfig<TReq>,
+): Promise<HttpResponse<TRes>> {
+  return executeRequest<TRes, TReq>(config);
 }


### PR DESCRIPTION
## Resumen

Endurece el acceso y manejo de documentos en la pantalla del residente.

## Cambios

- corrige el contrato frontend para usar `document.file`;
- utiliza el endpoint protegido `/content`;
- evita exponer URLs presignadas de MinIO;
- abre PDF e imágenes mediante Blob URL;
- descarga otros formatos con el nombre correcto;
- maneja `Content-Disposition` y `Content-Type`;
- agrega fallback cuando el navegador bloquea la pestaña;
- evita solicitudes duplicadas;
- separa errores de listado y apertura;
- restaura `RULES` como categoría válida;
- agrega cobertura frontend focalizada.

## Validaciones

- TypeScript apps/web: PASS, 0 errores;
- pantalla de documentos residente: 9/9 tests PASS;
- servicio de documentos: 4/4 tests PASS;
- `git diff --check`: PASS;
- working tree limpia antes del push.

## Fuera de alcance

- soporte multiunidad;
- backend;
- Prisma, migraciones y seeds;
- Docker, VPS y producción.