### PR TITLE
fix(resident): align notification visibility and navigation

### DIFF
--- a/apps/api/src/notifications/notifications.service.spec.ts
+++ b/apps/api/src/notifications/notifications.service.spec.ts
@@ -5,14 +5,22 @@ import { EmailType } from '../email/email.types';
 import { PrismaService } from '../prisma/prisma.service';
 import { NotificationsService } from './notifications.service';
 
-describe('NotificationsService email delivery', () => {
+describe('NotificationsService', () => {
   const tenantId = 'tenant-123';
   const userId = 'user-123';
+  const otherTenantId = 'tenant-999';
+  const otherUserId = 'user-999';
   const userEmail = 'resident@example.com';
 
   let service: NotificationsService;
   let prismaService: {
-    notification: { create: jest.Mock };
+    notification: {
+      create: jest.Mock;
+      findFirst: jest.Mock;
+      findMany: jest.Mock;
+      updateMany: jest.Mock;
+      count: jest.Mock;
+    };
     membership: { findFirst: jest.Mock };
   };
   let auditService: { createLog: jest.Mock };
@@ -22,6 +30,10 @@ describe('NotificationsService email delivery', () => {
     prismaService = {
       notification: {
         create: jest.fn().mockResolvedValue({ id: 'notification-123' }),
+        findFirst: jest.fn(),
+        findMany: jest.fn().mockResolvedValue([]),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+        count: jest.fn().mockResolvedValue(0),
       },
       membership: {
         findFirst: jest.fn().mockResolvedValue({ user: { email: userEmail } }),
@@ -41,90 +53,476 @@ describe('NotificationsService email delivery', () => {
     );
   });
 
-  const createPaymentNotification = (type: NotificationType): Promise<void> =>
-    service.createNotification({
-      tenantId,
-      userId,
-      type,
-      title: 'Payment notification',
-      body: 'A payment event occurred.',
-      data: {
-        amount: '$120.00',
-        currency: 'USD',
-        buildingName: 'Main Tower',
-        unitLabel: 'A-101',
-        period: '2026-07',
-        dueDate: '2026-07-31',
-        rejectionReason: 'Unreadable receipt',
-      },
-      deliveryMethods: ['IN_APP', 'EMAIL'] as DeliveryMethod[],
-    });
-
-  it.each<NotificationType>([
-    'CHARGE_PUBLISHED',
-    'PAYMENT_RECEIVED',
-    'PAYMENT_REJECTED',
-    'PAYMENT_OVERDUE',
-    'PAYMENT_REMINDER',
-  ])('sends email for configured payment notification type %s', async (type) => {
-    await createPaymentNotification(type);
-
-    expect(emailService.sendEmail).toHaveBeenCalledTimes(1);
-    expect(emailService.sendEmail).toHaveBeenCalledWith(
-      expect.objectContaining({
-        to: userEmail,
+  describe('createNotification', () => {
+    it('persists notification with correct fields', async () => {
+      await service.createNotification({
         tenantId,
-      }),
-      EmailType.PAYMENT_SUBMITTED,
-    );
-  });
+        userId,
+        type: 'PAYMENT_RECEIVED',
+        title: 'Payment received',
+        body: 'Body',
+        data: { amount: 100 },
+        deliveryMethods: ['IN_APP'],
+      });
 
-  it('renders configured payment template variables before sending email', async () => {
-    await createPaymentNotification('PAYMENT_REJECTED');
-
-    expect(emailService.sendEmail).toHaveBeenCalledWith(
-      expect.objectContaining({
-        subject: 'Payment rejected',
-        textBody: 'Your payment of $120.00 USD has been rejected. Reason: Unreadable receipt',
-        htmlBody: expect.stringContaining('Unreadable receipt'),
-      }),
-      EmailType.PAYMENT_SUBMITTED,
-    );
-  });
-
-  it('does not send email when EMAIL delivery is not requested', async () => {
-    await service.createNotification({
-      tenantId,
-      userId,
-      type: 'PAYMENT_RECEIVED',
-      title: 'Payment received',
-      body: 'Payment was received.',
-      deliveryMethods: ['IN_APP'],
+      expect(prismaService.notification.create).toHaveBeenCalledWith({
+        data: {
+          tenantId,
+          userId,
+          type: 'PAYMENT_RECEIVED',
+          title: 'Payment received',
+          body: 'Body',
+          data: { amount: 100 },
+          deliveryMethods: ['IN_APP'],
+        },
+      });
     });
 
-    expect(prismaService.membership.findFirst).not.toHaveBeenCalled();
-    expect(emailService.sendEmail).not.toHaveBeenCalled();
-  });
+    it('does not throw on failure (fire-and-forget)', async () => {
+      prismaService.notification.create.mockRejectedValue(new Error('DB error'));
 
-  it('does not send email when notification type is not configured for email', async () => {
-    await service.createNotification({
-      tenantId,
-      userId,
-      type: 'DOCUMENT_SHARED',
-      title: 'Document shared',
-      body: 'A document was shared.',
-      deliveryMethods: ['EMAIL'],
+      await expect(
+        service.createNotification({
+          tenantId,
+          userId,
+          type: 'PAYMENT_RECEIVED',
+          title: 'Title',
+          body: 'Body',
+        })
+      ).resolves.toBeUndefined();
+
+      expect(auditService.createLog).not.toHaveBeenCalled();
     });
 
-    expect(prismaService.membership.findFirst).not.toHaveBeenCalled();
-    expect(emailService.sendEmail).not.toHaveBeenCalled();
+    it('creates audit log after persistence', async () => {
+      prismaService.notification.create.mockResolvedValue({ id: 'n-1' });
+
+      await service.createNotification({
+        tenantId,
+        userId,
+        type: 'TICKET_STATUS_CHANGED',
+        title: 'Title',
+        body: 'Body',
+      });
+
+      expect(auditService.createLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId,
+          action: 'NOTIFICATION_CREATED',
+          entityType: 'Notification',
+          entityId: 'n-1',
+        })
+      );
+    });
+
+    it('sends email when EMAIL delivery is requested and type is configured', async () => {
+      await service.createNotification({
+        tenantId,
+        userId,
+        type: 'PAYMENT_RECEIVED',
+        title: 'Payment',
+        body: 'Body',
+        deliveryMethods: ['EMAIL'],
+      });
+
+      expect(emailService.sendEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not send email when EMAIL delivery is not requested', async () => {
+      await service.createNotification({
+        tenantId,
+        userId,
+        type: 'PAYMENT_RECEIVED',
+        title: 'Payment',
+        body: 'Body',
+        deliveryMethods: ['IN_APP'],
+      });
+
+      expect(emailService.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('does not send email when notification type is not configured for email', async () => {
+      await service.createNotification({
+        tenantId,
+        userId,
+        type: 'DOCUMENT_SHARED',
+        title: 'Doc',
+        body: 'Body',
+        deliveryMethods: ['EMAIL'],
+      });
+
+      expect(emailService.sendEmail).not.toHaveBeenCalled();
+    });
+
+    it('does not send email when recipient email is missing', async () => {
+      prismaService.membership.findFirst.mockResolvedValue({ user: { email: null } });
+
+      await service.createNotification({
+        tenantId,
+        userId,
+        type: 'PAYMENT_RECEIVED',
+        title: 'Payment',
+        body: 'Body',
+        deliveryMethods: ['EMAIL'],
+      });
+
+      expect(emailService.sendEmail).not.toHaveBeenCalled();
+    });
   });
 
-  it('does not send email when recipient email is missing', async () => {
-    prismaService.membership.findFirst.mockResolvedValue({ user: { email: null } });
+  describe('HTML escaping in emails', () => {
+    it('escapes HTML entities in title and body', async () => {
+      await service.createNotification({
+        tenantId,
+        userId,
+        type: 'PAYMENT_RECEIVED',
+        title: '<script>alert("xss")</script>',
+        body: 'Body with <b>bold</b> and "quotes" and \'apostrophes\'',
+        data: { amount: '$120.00', currency: 'USD' },
+        deliveryMethods: ['EMAIL'],
+      });
 
-    await createPaymentNotification('PAYMENT_RECEIVED');
+      const emailCall = emailService.sendEmail.mock.calls[0];
+      const htmlBody = emailCall[0].htmlBody;
 
-    expect(emailService.sendEmail).not.toHaveBeenCalled();
+      expect(htmlBody).not.toContain('<script>');
+      expect(htmlBody).toContain('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
+    });
+
+    it('converts newlines to br after escaping', async () => {
+      await service.createNotification({
+        tenantId,
+        userId,
+        type: 'PAYMENT_RECEIVED',
+        title: 'Title\nSecond line',
+        body: 'Body',
+        data: { amount: '$120.00', currency: 'USD' },
+        deliveryMethods: ['EMAIL'],
+      });
+
+      const emailCall = emailService.sendEmail.mock.calls[0];
+      const htmlBody = emailCall[0].htmlBody;
+
+      expect(htmlBody).toContain('Title<br>Second line');
+    });
+
+    it('escapes ampersand first to avoid double-escaping', async () => {
+      await service.createNotification({
+        tenantId,
+        userId,
+        type: 'PAYMENT_RECEIVED',
+        title: 'A & B',
+        body: 'Test',
+        data: { amount: '$120.00', currency: 'USD' },
+        deliveryMethods: ['EMAIL'],
+      });
+
+      const emailCall = emailService.sendEmail.mock.calls[0];
+      const htmlBody = emailCall[0].htmlBody;
+
+      expect(htmlBody).toContain('A &amp; B');
+      expect(htmlBody).not.toContain('&amp;amp;');
+    });
+  });
+
+  describe('markAsRead', () => {
+    const notificationId = 'n-1';
+
+    beforeEach(() => {
+      prismaService.notification.findFirst.mockResolvedValue({
+        id: notificationId,
+        tenantId,
+        userId,
+        isRead: false,
+      });
+    });
+
+    it('marks notification as read with correct tenant+user scope', async () => {
+      prismaService.notification.updateMany.mockResolvedValue({ count: 1 });
+      prismaService.notification.findFirst
+        .mockResolvedValueOnce({
+          id: notificationId,
+          tenantId,
+          userId,
+          isRead: false,
+        })
+        .mockResolvedValueOnce({
+          id: notificationId,
+          tenantId,
+          userId,
+          isRead: true,
+          readAt: new Date(),
+        });
+
+      const result = await service.markAsRead(notificationId, tenantId, userId);
+
+      expect(prismaService.notification.updateMany).toHaveBeenCalledWith({
+        where: { id: notificationId, tenantId, userId, deletedAt: null },
+        data: { isRead: true, readAt: expect.any(Date) },
+      });
+      expect(result.isRead).toBe(true);
+    });
+
+    it('throws NotFoundException for other tenant', async () => {
+      prismaService.notification.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.markAsRead(notificationId, otherTenantId, userId)
+      ).rejects.toThrow('Notification not found');
+    });
+
+    it('throws NotFoundException for other user', async () => {
+      prismaService.notification.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.markAsRead(notificationId, tenantId, otherUserId)
+      ).rejects.toThrow('Notification not found');
+    });
+
+    it('throws NotFoundException when not found', async () => {
+      prismaService.notification.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.markAsRead('nonexistent', tenantId, userId)
+      ).rejects.toThrow('Notification not found');
+    });
+
+    it('creates audit log', async () => {
+      prismaService.notification.updateMany.mockResolvedValue({ count: 1 });
+      prismaService.notification.findFirst
+        .mockResolvedValueOnce({
+          id: notificationId,
+          tenantId,
+          userId,
+          isRead: false,
+        })
+        .mockResolvedValueOnce({
+          id: notificationId,
+          tenantId,
+          userId,
+          isRead: true,
+        });
+
+      await service.markAsRead(notificationId, tenantId, userId);
+
+      expect(auditService.createLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId,
+          action: 'NOTIFICATION_READ',
+          entityId: notificationId,
+          actorUserId: userId,
+        })
+      );
+    });
+  });
+
+  describe('markAllAsRead', () => {
+    it('returns count of updated notifications', async () => {
+      prismaService.notification.updateMany.mockResolvedValue({ count: 3 });
+
+      const result = await service.markAllAsRead(tenantId, userId);
+
+      expect(result.count).toBe(3);
+      expect(prismaService.notification.updateMany).toHaveBeenCalledWith({
+        where: { tenantId, userId, isRead: false, deletedAt: null },
+        data: { isRead: true, readAt: expect.any(Date) },
+      });
+    });
+
+    it('only updates unread notifications', async () => {
+      prismaService.notification.updateMany.mockResolvedValue({ count: 0 });
+
+      await service.markAllAsRead(tenantId, userId);
+
+      expect(prismaService.notification.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ isRead: false }),
+        })
+      );
+    });
+
+    it('returns 0 when no notifications to mark', async () => {
+      prismaService.notification.updateMany.mockResolvedValue({ count: 0 });
+
+      const result = await service.markAllAsRead(tenantId, userId);
+
+      expect(result.count).toBe(0);
+    });
+  });
+
+  describe('getUnreadCount', () => {
+    it('returns correct count for tenant+user', async () => {
+      prismaService.notification.count.mockResolvedValue(5);
+
+      const result = await service.getUnreadCount(tenantId, userId);
+
+      expect(result).toBe(5);
+      expect(prismaService.notification.count).toHaveBeenCalledWith({
+        where: { tenantId, userId, isRead: false, deletedAt: null },
+      });
+    });
+
+    it('returns 0 when no unread notifications', async () => {
+      prismaService.notification.count.mockResolvedValue(0);
+
+      const result = await service.getUnreadCount(tenantId, userId);
+
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('queryNotifications', () => {
+    const mockNotifications = [
+      { id: 'n-1', tenantId, userId, type: 'PAYMENT_RECEIVED', isRead: false, createdAt: new Date('2025-01-02') },
+      { id: 'n-2', tenantId, userId, type: 'TICKET_STATUS_CHANGED', isRead: true, createdAt: new Date('2025-01-01') },
+    ];
+
+    it('returns notifications and total for tenant+user', async () => {
+      prismaService.notification.findMany.mockResolvedValue(mockNotifications);
+      prismaService.notification.count.mockResolvedValue(2);
+
+      const result = await service.queryNotifications(tenantId, userId);
+
+      expect(result.notifications).toHaveLength(2);
+      expect(result.total).toBe(2);
+      expect(prismaService.notification.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { tenantId, userId, deletedAt: null },
+          orderBy: { createdAt: 'desc' },
+        })
+      );
+    });
+
+    it('applies isRead filter', async () => {
+      prismaService.notification.findMany.mockResolvedValue([mockNotifications[0]]);
+      prismaService.notification.count.mockResolvedValue(1);
+
+      await service.queryNotifications(tenantId, userId, { isRead: false });
+
+      expect(prismaService.notification.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ isRead: false }),
+        })
+      );
+    });
+
+    it('applies type filter', async () => {
+      prismaService.notification.findMany.mockResolvedValue([]);
+      prismaService.notification.count.mockResolvedValue(0);
+
+      await service.queryNotifications(tenantId, userId, { type: 'PAYMENT_RECEIVED' });
+
+      expect(prismaService.notification.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ type: 'PAYMENT_RECEIVED' }),
+        })
+      );
+    });
+
+    it('applies skip and take', async () => {
+      prismaService.notification.findMany.mockResolvedValue([]);
+      prismaService.notification.count.mockResolvedValue(0);
+
+      await service.queryNotifications(tenantId, userId, undefined, 10, 5);
+
+      expect(prismaService.notification.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          skip: 10,
+          take: 5,
+        })
+      );
+    });
+
+    it('caps take at 100', async () => {
+      prismaService.notification.findMany.mockResolvedValue([]);
+      prismaService.notification.count.mockResolvedValue(0);
+
+      await service.queryNotifications(tenantId, userId, undefined, 0, 200);
+
+      expect(prismaService.notification.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          take: 100,
+        })
+      );
+    });
+
+    it('orders by createdAt desc', async () => {
+      prismaService.notification.findMany.mockResolvedValue([]);
+      prismaService.notification.count.mockResolvedValue(0);
+
+      await service.queryNotifications(tenantId, userId);
+
+      expect(prismaService.notification.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderBy: { createdAt: 'desc' },
+        })
+      );
+    });
+  });
+
+  describe('deleteNotification', () => {
+    const notificationId = 'n-del';
+
+    it('soft deletes notification with correct scope', async () => {
+      prismaService.notification.findFirst.mockResolvedValue({
+        id: notificationId,
+        tenantId,
+        userId,
+        deletedAt: null,
+      });
+      prismaService.notification.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.deleteNotification(notificationId, tenantId, userId);
+
+      expect(prismaService.notification.updateMany).toHaveBeenCalledWith({
+        where: { id: notificationId, tenantId, userId, deletedAt: null },
+        data: { deletedAt: expect.any(Date) },
+      });
+    });
+
+    it('throws NotFoundException for other tenant', async () => {
+      prismaService.notification.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.deleteNotification(notificationId, otherTenantId, userId)
+      ).rejects.toThrow('Notification not found');
+    });
+
+    it('throws NotFoundException for other user', async () => {
+      prismaService.notification.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.deleteNotification(notificationId, tenantId, otherUserId)
+      ).rejects.toThrow('Notification not found');
+    });
+
+    it('throws NotFoundException for nonexistent notification', async () => {
+      prismaService.notification.findFirst.mockResolvedValue(null);
+
+      await expect(
+        service.deleteNotification('nonexistent', tenantId, userId)
+      ).rejects.toThrow('Notification not found');
+    });
+
+    it('creates audit log', async () => {
+      prismaService.notification.findFirst.mockResolvedValue({
+        id: notificationId,
+        tenantId,
+        userId,
+        deletedAt: null,
+      });
+      prismaService.notification.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.deleteNotification(notificationId, tenantId, userId);
+
+      expect(auditService.createLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId,
+          action: 'NOTIFICATION_DELETED',
+          entityId: notificationId,
+          actorUserId: userId,
+        })
+      );
+    });
   });
 });

--- a/apps/api/src/notifications/notifications.service.ts
+++ b/apps/api/src/notifications/notifications.service.ts
@@ -311,13 +311,28 @@ export class NotificationsService {
   }
 
   /**
+   * Private: Escape HTML special characters to prevent injection
+   */
+  private escapeHtml(value: string): string {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  /**
    * Private: Wrap text body in HTML
    */
   private wrapHtmlBody(body: string, title: string): string {
+    const safeTitle = this.escapeHtml(title).replace(/\r?\n/g, '<br>');
+    const safeBody = this.escapeHtml(body).replace(/\r?\n/g, '<br>');
+
     return `
       <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #333;">
-        <h2 style="color: #1E3A8A; margin-bottom: 16px;">${title}</h2>
-        <p>${body}</p>
+        <h2 style="color: #1E3A8A; margin-bottom: 16px;">${safeTitle}</h2>
+        <p>${safeBody}</p>
         <p style="margin-top: 24px; color: #666; font-size: 12px;">
           This is an automated notification from BuildingOS. You can manage your notification preferences in your account settings.
         </p>

--- a/apps/web/app/(tenant)/[tenantId]/notifications/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/notifications/page.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, usePathname } from 'next/navigation';
 import NotificationsPage from './page';
 import * as notificationsHook from '@/features/notifications/useNotifications';
 import * as authHook from '@/features/auth/useAuthSession';
@@ -19,6 +19,7 @@ jest.mock('@/shared/components/ui', () => {
 jest.mock('next/navigation', () => ({
   useParams: jest.fn(),
   useRouter: jest.fn(),
+  usePathname: jest.fn(),
 }));
 
 jest.mock('@/features/notifications/useNotifications', () => ({
@@ -31,6 +32,7 @@ jest.mock('@/features/auth/useAuthSession', () => ({
 
 const mockedUseParams = jest.mocked(useParams);
 const mockedUseRouter = jest.mocked(useRouter);
+const mockedUsePathname = jest.mocked(usePathname);
 const mockedUseNotifications = jest.mocked(notificationsHook.useNotifications);
 const mockedUseAuthSession = jest.mocked(authHook.useAuthSession);
 
@@ -45,6 +47,7 @@ describe('NotificationsPage', () => {
     jest.clearAllMocks();
     mockedUseParams.mockReturnValue({ tenantId: 'tenant-1' } as never);
     mockedUseRouter.mockReturnValue({ push, replace: jest.fn(), back: jest.fn(), prefetch: jest.fn(), refresh: jest.fn() } as never);
+    mockedUsePathname.mockReturnValue('/tenant-1/notifications' as never);
     mockedUseAuthSession.mockReturnValue({
       activeTenantId: 'tenant-1',
       memberships: [{ tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] }],
@@ -225,6 +228,123 @@ describe('NotificationsPage', () => {
     await waitFor(() => {
       expect(screen.getByText('Alerta')).toBeTruthy();
       expect(push).not.toHaveBeenCalled();
+    });
+  });
+
+  it('detects resident portal context from pathname', async () => {
+    mockedUsePathname.mockReturnValue('/tenant-1/resident/notifications' as never);
+    mockedUseAuthSession.mockReturnValue({
+      activeTenantId: 'tenant-1',
+      memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] }],
+      user: { id: 'user-1', email: 'user@test.com', name: 'User' },
+    } as never);
+    mockedUseNotifications.mockReturnValue({
+      notifications: [
+        {
+          id: 'n-payment',
+          tenantId: 'tenant-1',
+          userId: 'user-1',
+          type: 'PAYMENT_RECEIVED',
+          title: 'Pago recibido',
+          body: 'Tu pago fue procesado',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+      total: 1,
+      unreadCount: 1,
+      loading: false,
+      error: null,
+      fetch,
+      markAsRead,
+      markAllAsRead,
+      deleteNotification,
+    } as never);
+
+    render(<NotificationsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /abrir/i }));
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith('/tenant-1/resident/payments');
+    });
+  });
+
+  it('detects admin portal context from pathname', async () => {
+    mockedUsePathname.mockReturnValue('/tenant-1/notifications' as never);
+    mockedUseAuthSession.mockReturnValue({
+      activeTenantId: 'tenant-1',
+      memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] }],
+      user: { id: 'user-1', email: 'user@test.com', name: 'User' },
+    } as never);
+    mockedUseNotifications.mockReturnValue({
+      notifications: [
+        {
+          id: 'n-payment',
+          tenantId: 'tenant-1',
+          userId: 'user-1',
+          type: 'PAYMENT_RECEIVED',
+          title: 'Pago recibido',
+          body: 'Tu pago fue procesado',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+      total: 1,
+      unreadCount: 1,
+      loading: false,
+      error: null,
+      fetch,
+      markAsRead,
+      markAllAsRead,
+      deleteNotification,
+    } as never);
+
+    render(<NotificationsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /abrir/i }));
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith('/tenant-1/finanzas?tab=payments');
+    });
+  });
+
+  it('SUPPORT_TICKET_STATUS_CHANGED routes to support page', async () => {
+    mockedUseNotifications.mockReturnValue({
+      notifications: [
+        {
+          id: 'n-support',
+          tenantId: 'tenant-1',
+          userId: 'user-1',
+          type: 'SUPPORT_TICKET_STATUS_CHANGED',
+          title: 'Estado de solicitud',
+          body: 'Tu solicitud fue actualizada',
+          data: { ticketId: 'support-42' },
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+      total: 1,
+      unreadCount: 1,
+      loading: false,
+      error: null,
+      fetch,
+      markAsRead,
+      markAllAsRead,
+      deleteNotification,
+    } as never);
+
+    render(<NotificationsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /abrir/i }));
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith('/tenant-1/support');
     });
   });
 });

--- a/apps/web/app/(tenant)/[tenantId]/notifications/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/notifications/page.test.tsx
@@ -86,4 +86,145 @@ describe('NotificationsPage', () => {
       expect(push).toHaveBeenCalledWith('/tenant-1/tickets/ticket-1');
     });
   });
+
+  it('uses shared resolver for routing', async () => {
+    render(<NotificationsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /abrir/i }));
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith('/tenant-1/tickets/ticket-1');
+    });
+  });
+
+  it('shows feedback when notification has no valid route', async () => {
+    mockedUseNotifications.mockReturnValue({
+      notifications: [
+        {
+          id: 'n-no-route',
+          tenantId: 'tenant-1',
+          userId: 'admin-1',
+          type: 'CUSTOM_EVENT',
+          title: 'Sin ruta',
+          body: 'No tiene ruta',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+      total: 1,
+      unreadCount: 1,
+      loading: false,
+      error: null,
+      fetch,
+      markAsRead,
+      markAllAsRead,
+      deleteNotification,
+    } as never);
+
+    render(<NotificationsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /abrir/i }));
+
+    await waitFor(() => {
+      expect(markAsRead).toHaveBeenCalledWith('n-no-route');
+      expect(push).not.toHaveBeenCalled();
+    });
+  });
+
+  it('does not navigate when resolveNotificationPath returns null', async () => {
+    mockedUseNotifications.mockReturnValue({
+      notifications: [
+        {
+          id: 'n-unknown',
+          tenantId: 'tenant-1',
+          userId: 'admin-1',
+          type: 'UNKNOWN_TYPE',
+          title: 'Desconocido',
+          body: 'Tipo no reconocido',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+      total: 1,
+      unreadCount: 1,
+      loading: false,
+      error: null,
+      fetch,
+      markAsRead,
+      markAllAsRead,
+      deleteNotification,
+    } as never);
+
+    render(<NotificationsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /abrir/i }));
+
+    await waitFor(() => {
+      expect(push).not.toHaveBeenCalled();
+    });
+  });
+
+  it('delete notification calls the API correctly', async () => {
+    render(<NotificationsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+
+    await waitFor(() => {
+      expect(deleteNotification).toHaveBeenCalledWith('n1');
+    });
+  });
+
+  it('markAllAsRead calls the API correctly', async () => {
+    render(<NotificationsPage />);
+
+    fireEvent.click(screen.getByText(/Mark All Read/i));
+
+    await waitFor(() => {
+      expect(markAllAsRead).toHaveBeenCalled();
+    });
+  });
+
+  it('notification remains visible after failed navigation', async () => {
+    mockedUseNotifications.mockReturnValue({
+      notifications: [
+        {
+          id: 'n-visible',
+          tenantId: 'tenant-1',
+          userId: 'admin-1',
+          type: 'SYSTEM_ALERT',
+          title: 'Alerta',
+          body: 'Algo pasó',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+      total: 1,
+      unreadCount: 1,
+      loading: false,
+      error: null,
+      fetch,
+      markAsRead,
+      markAllAsRead,
+      deleteNotification,
+    } as never);
+
+    render(<NotificationsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Alerta')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /abrir/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Alerta')).toBeTruthy();
+      expect(push).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/web/app/(tenant)/[tenantId]/notifications/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/notifications/page.tsx
@@ -85,6 +85,8 @@ const NotificationsPage = () => {
       const targetPath = resolveNotificationPath(notification, tenantId, roleContext);
       if (targetPath) {
         router.push(targetPath);
+      } else {
+        toast('Esta notificación no tiene una acción disponible', 'info');
       }
     } catch (err) {
       toast(err instanceof Error ? err.message : t('notifications.markReadError'), 'error');

--- a/apps/web/app/(tenant)/[tenantId]/notifications/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/notifications/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState, useEffect } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, usePathname } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import { useNotifications } from '@/features/notifications/useNotifications';
 import {
@@ -21,6 +21,7 @@ import type { Notification } from '@/features/notifications/notifications.api';
 
 const NotificationsPage = () => {
   const params = useParams();
+  const pathname = usePathname();
   const router = useRouter();
   const tenantId = params.tenantId as string;
   const session = useAuthSession();
@@ -36,12 +37,14 @@ const NotificationsPage = () => {
     () => session?.memberships?.find((membership) => membership.tenantId === tenantId),
     [session, tenantId],
   );
+  const portalContext: 'resident' | 'admin' = pathname?.includes('/resident/') ? 'resident' : 'admin';
   const roleContext = useMemo(
     () => ({
       isAdmin: activeMembership?.roles?.some((role) => ['TENANT_OWNER', 'TENANT_ADMIN', 'OPERATOR', 'SUPER_ADMIN'].includes(role)) ?? false,
       isResident: activeMembership?.roles?.includes('RESIDENT') ?? false,
+      portalContext,
     }),
-    [activeMembership],
+    [activeMembership, portalContext],
   );
 
   // Fetch notifications on mount and when filters change

--- a/apps/web/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/shared/components/layout/Topbar.test.tsx
@@ -43,6 +43,7 @@ jest.mock('@/features/notifications/components/PushPermissionControl', () => ({
 jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
   useParams: () => ({ tenantId: 'tenant-1' }),
+  usePathname: () => '/tenant-1/dashboard',
 }));
 
 const mockGetUnreadCount = jest.mocked(notificationsApi.getUnreadCount);
@@ -702,5 +703,127 @@ describe('PaymentNotificationBell', () => {
     });
 
     invalidateSpy.mockRestore();
+  });
+
+  it('SUPPORT_TICKET_STATUS_CHANGED navigates to support page', async () => {
+    const mockPush = jest.fn();
+    jest.requireMock('next/navigation').useRouter = () => ({ push: mockPush, replace: jest.fn() });
+
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n-support',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'SUPPORT_TICKET_STATUS_CHANGED',
+          title: 'Estado de solicitud',
+          body: 'Tu solicitud fue actualizada',
+          data: { ticketId: 'support-42' },
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Estado de solicitud')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('Estado de solicitud'));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/tenant-1/support');
+    });
+  });
+
+  it('mixed role user in resident portal navigates to resident payment route', async () => {
+    const mockPush = jest.fn();
+    jest.requireMock('next/navigation').useRouter = () => ({ push: mockPush, replace: jest.fn() });
+    jest.requireMock('next/navigation').usePathname = () => '/tenant-1/resident/dashboard';
+
+    mockGetSession.mockReturnValue({
+      user: { id: 'admin-1', email: 'admin@test.com', name: 'Admin User' },
+      memberships: [{ tenantId: TENANT_ID, roles: ['RESIDENT', 'TENANT_ADMIN'] }],
+      activeTenantId: TENANT_ID,
+    });
+
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n-payment',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'PAYMENT_RECEIVED',
+          title: 'Pago recibido',
+          body: 'Tu pago fue procesado',
+          data: { paymentId: 'pay-1' },
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Pago recibido')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('Pago recibido'));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/tenant-1/resident/payments');
+    });
+  });
+
+  it('mixed role user in admin portal navigates to admin payment route', async () => {
+    const mockPush = jest.fn();
+    jest.requireMock('next/navigation').useRouter = () => ({ push: mockPush, replace: jest.fn() });
+    jest.requireMock('next/navigation').usePathname = () => '/tenant-1/dashboard';
+
+    mockGetSession.mockReturnValue({
+      user: { id: 'admin-1', email: 'admin@test.com', name: 'Admin User' },
+      memberships: [{ tenantId: TENANT_ID, roles: ['RESIDENT', 'TENANT_ADMIN'] }],
+      activeTenantId: TENANT_ID,
+    });
+
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n-payment',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'PAYMENT_RECEIVED',
+          title: 'Pago recibido',
+          body: 'Tu pago fue procesado',
+          data: { paymentId: 'pay-1' },
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Pago recibido')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('Pago recibido'));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/tenant-1/finanzas?tab=payments');
+    });
   });
 });

--- a/apps/web/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/shared/components/layout/Topbar.test.tsx
@@ -353,4 +353,354 @@ describe('PaymentNotificationBell', () => {
       expect(screen.getByText(/1 pago pendiente por revisar/)).toBeTruthy();
     });
   });
+
+  it('resident sees DOCUMENT_SHARED notification in dropdown', async () => {
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n-doc',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'DOCUMENT_SHARED',
+          title: 'Documento compartido',
+          body: 'Te compartieron un documento',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Documento compartido')).toBeTruthy();
+    });
+  });
+
+  it('resident sees OCCUPANT_ASSIGNED notification in dropdown', async () => {
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n-occ',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'OCCUPANT_ASSIGNED',
+          title: 'Asignado a unidad',
+          body: 'Fuiste asignado a una unidad',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Asignado a unidad')).toBeTruthy();
+    });
+  });
+
+  it('resident sees CHARGE_PUBLISHED notification in dropdown', async () => {
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n-charge',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'CHARGE_PUBLISHED',
+          title: 'Nuevo cargo',
+          body: 'Se publicó un cargo',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Nuevo cargo')).toBeTruthy();
+    });
+  });
+
+  it('resident sees PAYMENT_REMINDER notification in dropdown', async () => {
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n-remind',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'PAYMENT_REMINDER',
+          title: 'Recordatorio de pago',
+          body: 'Tu pago vence pronto',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Recordatorio de pago')).toBeTruthy();
+    });
+  });
+
+  it('resident sees PAYMENT_OVERDUE notification in dropdown', async () => {
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n-overdue',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'PAYMENT_OVERDUE',
+          title: 'Pago vencido',
+          body: 'Tu pago está vencido',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Pago vencido')).toBeTruthy();
+    });
+  });
+
+  it('resident sees SUPPORT_TICKET_STATUS_CHANGED when they are the recipient', async () => {
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n-support',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'SUPPORT_TICKET_STATUS_CHANGED',
+          title: 'Estado de solicitud',
+          body: 'Tu solicitud fue actualizada',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Estado de solicitud')).toBeTruthy();
+    });
+  });
+
+  it('unknown notification type remains visible in dropdown', async () => {
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n-unknown',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'CUSTOM_EVENT',
+          title: 'Evento custom',
+          body: 'Algo nuevo',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Evento custom')).toBeTruthy();
+    });
+  });
+
+  it('unknown notification type without valid route does not navigate to payments', async () => {
+    const mockPush = jest.fn();
+    jest.requireMock('next/navigation').useRouter = () => ({ push: mockPush, replace: jest.fn() });
+
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n-unknown',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'CUSTOM_EVENT',
+          title: 'Evento custom',
+          body: 'Algo nuevo',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Evento custom')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('Evento custom'));
+
+    await waitFor(() => {
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+  });
+
+  it('badge preserves backend unreadCount without recalculation', async () => {
+    mockGetUnreadCount.mockResolvedValue(5);
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n1',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'DOCUMENT_SHARED',
+          title: 'Doc',
+          body: 'Body',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+        {
+          id: 'n2',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'CUSTOM_TYPE',
+          title: 'Custom',
+          body: 'Body',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 2,
+    });
+
+    renderBell();
+
+    await waitFor(() => {
+      expect(screen.getByText('5')).toBeTruthy();
+    });
+  });
+
+  it('markAsRead invalidates both notification queries', async () => {
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n1',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'TICKET_STATUS_CHANGED',
+          title: 'Ticket update',
+          body: 'Body',
+          data: { ticketId: 't-1' },
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    const { queryClient } = renderBell();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Ticket update')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('Ticket update'));
+
+    await waitFor(() => {
+      expect(mockMarkAsRead).toHaveBeenCalledWith(TENANT_ID, 'n1');
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['notificationUnreadCount', TENANT_ID] })
+      );
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['notificationList', TENANT_ID] })
+      );
+    });
+
+    invalidateSpy.mockRestore();
+  });
+
+  it('markAllAsRead invalidates both notification queries', async () => {
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n1',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'TICKET_COMMENT_ADDED',
+          title: 'Test',
+          body: 'Body',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    const { queryClient } = renderBell();
+    const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Test')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('Marcar todas como leídas'));
+
+    await waitFor(() => {
+      expect(mockMarkAllAsRead).toHaveBeenCalledWith(TENANT_ID);
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['notificationUnreadCount', TENANT_ID] })
+      );
+      expect(invalidateSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ queryKey: ['notificationList', TENANT_ID] })
+      );
+    });
+
+    invalidateSpy.mockRestore();
+  });
 });

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter, useParams } from 'next/navigation';
+import { useRouter, useParams, usePathname } from 'next/navigation';
 import { getSession, setSession, setLastTenant, clearAuth } from '../../../features/auth/session.storage';
 import { clearAllImpersonationData } from '@/features/impersonation/impersonation.storage';
 import { useTenants } from '../../../features/tenants/tenants.hooks';
@@ -24,6 +24,7 @@ const POLL_INTERVAL = 30_000;
 export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
   const queryClient = useQueryClient();
   const router = useRouter();
+  const pathname = usePathname();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -31,9 +32,12 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
   const session = getSession();
   const activeMembership = session?.memberships?.find((membership: Membership) => membership.tenantId === tenantId);
   const isAdmin = activeMembership?.roles?.some((candidateRole) => ADMIN_ROLES.has(candidateRole)) ?? false;
+  const isResident = activeMembership?.roles?.includes('RESIDENT') ?? false;
+  const portalContext: 'resident' | 'admin' = pathname?.includes('/resident/') ? 'resident' : 'admin';
   const roleContext = {
     isAdmin,
-    isResident: activeMembership?.roles?.includes('RESIDENT') ?? false,
+    isResident,
+    portalContext,
   };
   const hasSession = Boolean(session);
 
@@ -166,6 +170,8 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
         return <CreditCard className="w-4 h-4 text-blue-600" />;
       case 'ticket':
         return <MessageSquare className="w-4 h-4 text-blue-600" />;
+      case 'support':
+        return <MessageSquare className="w-4 h-4 text-purple-600" />;
       case 'document':
         return <FileText className="w-4 h-4 text-yellow-600" />;
       case 'unit':

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -7,7 +7,7 @@ import { useTenants } from '../../../features/tenants/tenants.hooks';
 import type { TenantSummary } from '../../../features/tenants/tenants.service';
 import type { Membership } from '../../../features/auth/auth.types';
 import Select from '../ui/Select';
-import { Bell, CreditCard, X, Clock, CheckCircle, XCircle, MessageSquare } from 'lucide-react';
+import { Bell, CreditCard, X, Clock, CheckCircle, XCircle, MessageSquare, FileText, Home } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useEffect, useRef } from 'react';
 import { listNotifications, markAsRead, markAllAsRead, getUnreadCount, type Notification } from '@/features/notifications/notifications.api';
@@ -15,14 +15,8 @@ import { formatCurrency } from '@/shared/lib/format/money';
 import { listPendingPayments, PaymentStatus } from '@/features/finance/services/finance.api';
 import { PushPermissionControl } from '@/features/notifications/components/PushPermissionControl';
 import { resolveNotificationPath } from '@/shared/lib/notification-routes';
+import { getNotificationCategory } from '@/shared/lib/notification-types';
 
-const TICKET_TYPES = new Set([
-  'TICKET_STATUS_CHANGED',
-  'TICKET_COMMENT_ADDED',
-  'TICKET_CREATED',
-  'SUPPORT_TICKET_CREATED',
-  'URGENT_TICKET_UNASSIGNED',
-]);
 const ADMIN_ROLES = new Set(['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR', 'SUPER_ADMIN']);
 
 const POLL_INTERVAL = 30_000;
@@ -94,25 +88,18 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
     },
   });
 
-  // 5. Filter notifications for display
+  // 5. Notifications for display
+  // Residents see ALL notifications returned by the backend.
+  // Admins filter to payment submissions and ticket types only.
   const allNotifs = notificationResult?.notifications ?? [];
 
-  let filteredNotifications: Notification[] = [];
-  if (isAdmin) {
-    filteredNotifications = allNotifs.filter((n: Notification) =>
-      (n.type === 'BUILDING_ALERT' && n.data?.event === 'PAYMENT_SUBMITTED') ||
-      n.data?.paymentId ||
-      TICKET_TYPES.has(n.type)
-    );
-  } else {
-    filteredNotifications = allNotifs.filter((n: Notification) =>
-      n.type === 'PAYMENT_RECEIVED' ||
-      n.type === 'PAYMENT_REJECTED' ||
-      n.data?.event === 'PAYMENT_APPROVED' ||
-      n.data?.event === 'PAYMENT_REJECTED' ||
-      TICKET_TYPES.has(n.type)
-    );
-  }
+  const filteredNotifications: Notification[] = isAdmin
+    ? allNotifs.filter((n: Notification) =>
+        (n.type === 'BUILDING_ALERT' && n.data?.event === 'PAYMENT_SUBMITTED') ||
+        n.data?.paymentId ||
+        getNotificationCategory(n.type) === 'ticket'
+      )
+    : allNotifs;
 
   // Badge: pending payments (admin) + unread notifications
   const badgeCount = isAdmin ? pendingCount + unreadCount : unreadCount;
@@ -158,10 +145,6 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
     const targetPath = resolveNotificationPath(notification, tenantId, roleContext);
     if (targetPath) {
       router.push(targetPath);
-    } else if (isAdmin) {
-      router.push(`/${tenantId}/finanzas?tab=payments`);
-    } else {
-      router.push(`/${tenantId}/resident/payments`);
     }
     setIsOpen(false);
   };
@@ -171,19 +154,28 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
   };
 
   const getNotificationIcon = (notification: Notification) => {
-    if (notification.type === 'PAYMENT_RECEIVED' || notification.data?.event === 'PAYMENT_APPROVED') {
-      return <CheckCircle className="w-4 h-4 text-green-600" />;
+    const category = getNotificationCategory(notification.type);
+    switch (category) {
+      case 'payment':
+        if (notification.type === 'PAYMENT_RECEIVED' || notification.data?.event === 'PAYMENT_APPROVED') {
+          return <CheckCircle className="w-4 h-4 text-green-600" />;
+        }
+        if (notification.type === 'PAYMENT_REJECTED' || notification.data?.event === 'PAYMENT_REJECTED') {
+          return <XCircle className="w-4 h-4 text-red-600" />;
+        }
+        return <CreditCard className="w-4 h-4 text-blue-600" />;
+      case 'ticket':
+        return <MessageSquare className="w-4 h-4 text-blue-600" />;
+      case 'document':
+        return <FileText className="w-4 h-4 text-yellow-600" />;
+      case 'unit':
+        return <Home className="w-4 h-4 text-cyan-600" />;
+      default:
+        if (notification.type === 'BUILDING_ALERT') {
+          return <Clock className="w-4 h-4 text-amber-600" />;
+        }
+        return <Bell className="w-4 h-4 text-gray-600" />;
     }
-    if (notification.type === 'PAYMENT_REJECTED' || notification.data?.event === 'PAYMENT_REJECTED') {
-      return <XCircle className="w-4 h-4 text-red-600" />;
-    }
-    if (notification.type === 'BUILDING_ALERT') {
-      return <Clock className="w-4 h-4 text-amber-600" />;
-    }
-    if (TICKET_TYPES.has(notification.type)) {
-      return <MessageSquare className="w-4 h-4 text-blue-600" />;
-    }
-    return <CreditCard className="w-4 h-4 text-blue-600" />;
   };
 
   return (

--- a/apps/web/shared/lib/notification-routes.test.ts
+++ b/apps/web/shared/lib/notification-routes.test.ts
@@ -1,0 +1,278 @@
+import { resolveNotificationPath, type NotificationRoleContext } from './notification-routes';
+import type { Notification } from '@/features/notifications/notifications.api';
+
+const TENANT_ID = 'tenant-1';
+
+const adminContext: NotificationRoleContext = { isAdmin: true, isResident: false };
+const residentContext: NotificationRoleContext = { isAdmin: false, isResident: true };
+
+function makeNotification(overrides: Partial<Notification> & { type: string }): Notification {
+  return {
+    id: 'n1',
+    tenantId: TENANT_ID,
+    userId: 'user-1',
+    title: 'Test',
+    body: 'Body',
+    data: {},
+    deliveryMethods: ['IN_APP'],
+    isRead: false,
+    createdAt: '2025-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('resolveNotificationPath', () => {
+  describe('ticket types', () => {
+    it('resolves TICKET_STATUS_CHANGED with ticketId to detail path', () => {
+      const n = makeNotification({
+        type: 'TICKET_STATUS_CHANGED',
+        data: { ticketId: 'ticket-42', buildingId: 'b-1' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBe(
+        `/${TENANT_ID}/tickets/ticket-42`
+      );
+    });
+
+    it('resolves TICKET_COMMENT_ADDED without ticketId to resident tickets list', () => {
+      const n = makeNotification({ type: 'TICKET_COMMENT_ADDED', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBe(
+        `/${TENANT_ID}/resident/tickets`
+      );
+    });
+
+    it('resolves SUPPORT_TICKET_STATUS_CHANGED without ticketId to resident tickets list', () => {
+      const n = makeNotification({ type: 'SUPPORT_TICKET_STATUS_CHANGED', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBe(
+        `/${TENANT_ID}/resident/tickets`
+      );
+    });
+
+    it('resolves ticket type without ticketId for admin to building tickets', () => {
+      const n = makeNotification({
+        type: 'TICKET_STATUS_CHANGED',
+        data: { buildingId: 'b-1' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, adminContext)).toBe(
+        `/${TENANT_ID}/buildings/b-1/tickets`
+      );
+    });
+
+    it('resolves ticket type without ticketId for admin without buildingId to tenant tickets', () => {
+      const n = makeNotification({ type: 'TICKET_STATUS_CHANGED', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, adminContext)).toBe(
+        `/${TENANT_ID}/tickets`
+      );
+    });
+
+    it('does not treat unknown type with ticketId as ticket', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { ticketId: 'ticket-42' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+  });
+
+  describe('payment types', () => {
+    it.each([
+      'PAYMENT_RECEIVED',
+      'PAYMENT_REJECTED',
+      'PAYMENT_REMINDER',
+      'PAYMENT_OVERDUE',
+      'CHARGE_PUBLISHED',
+    ])('resolves %s for resident to resident/payments', (type) => {
+      const n = makeNotification({ type, data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBe(
+        `/${TENANT_ID}/resident/payments`
+      );
+    });
+
+    it.each([
+      'PAYMENT_RECEIVED',
+      'PAYMENT_REJECTED',
+      'PAYMENT_REMINDER',
+      'PAYMENT_OVERDUE',
+      'CHARGE_PUBLISHED',
+    ])('resolves %s for admin to finanzas', (type) => {
+      const n = makeNotification({ type, data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, adminContext)).toBe(
+        `/${TENANT_ID}/finanzas?tab=payments`
+      );
+    });
+  });
+
+  describe('document types', () => {
+    it('resolves DOCUMENT_SHARED for resident to resident/documents', () => {
+      const n = makeNotification({ type: 'DOCUMENT_SHARED', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBe(
+        `/${TENANT_ID}/resident/documents`
+      );
+    });
+
+    it('resolves DOCUMENT_SHARED for admin with buildingId to building documents', () => {
+      const n = makeNotification({
+        type: 'DOCUMENT_SHARED',
+        data: { buildingId: 'b-1' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, adminContext)).toBe(
+        `/${TENANT_ID}/buildings/b-1/documents`
+      );
+    });
+
+    it('resolves DOCUMENT_SHARED for admin without buildingId to buildings list', () => {
+      const n = makeNotification({ type: 'DOCUMENT_SHARED', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, adminContext)).toBe(
+        `/${TENANT_ID}/buildings`
+      );
+    });
+  });
+
+  describe('unit types', () => {
+    it('resolves OCCUPANT_ASSIGNED for resident to resident/unit', () => {
+      const n = makeNotification({ type: 'OCCUPANT_ASSIGNED', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBe(
+        `/${TENANT_ID}/resident/unit`
+      );
+    });
+
+    it('resolves OCCUPANT_ASSIGNED for admin with buildingId to building units', () => {
+      const n = makeNotification({
+        type: 'OCCUPANT_ASSIGNED',
+        data: { buildingId: 'b-1' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, adminContext)).toBe(
+        `/${TENANT_ID}/buildings/b-1/units`
+      );
+    });
+
+    it('resolves OCCUPANT_ASSIGNED for admin without buildingId to buildings list', () => {
+      const n = makeNotification({ type: 'OCCUPANT_ASSIGNED', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, adminContext)).toBe(
+        `/${TENANT_ID}/buildings`
+      );
+    });
+  });
+
+  describe('fallback URL validation', () => {
+    it('accepts safe resident path as fallback', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: `/${TENANT_ID}/resident/dashboard` },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBe(
+        `/${TENANT_ID}/resident/dashboard`
+      );
+    });
+
+    it('rejects external protocol', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: 'https://evil.com/phish' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+
+    it('rejects javascript: protocol', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: 'javascript:alert(1)' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+
+    it('rejects data: protocol', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: 'data:text/html,<script>alert(1)</script>' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+
+    it('rejects double slash', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: '//evil.com' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+
+    it('rejects traversal', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: `/${TENANT_ID}/resident/../admin` },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+
+    it('rejects encoded traversal', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: `/${TENANT_ID}/resident/%2e%2e/admin` },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+
+    it('rejects backslash', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: `/${TENANT_ID}\\admin` },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+
+    it('rejects different tenant', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: '/other-tenant/resident/dashboard' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+
+    it('rejects admin path for resident', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: `/${TENANT_ID}/finanzas` },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+
+    it('accepts safe admin path for admin', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: `/${TENANT_ID}/inbox` },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, adminContext)).toBe(
+        `/${TENANT_ID}/inbox`
+      );
+    });
+
+    it('rejects admin-only paths for admin (finanzas is already handled by payment types)', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: `/${TENANT_ID}/super-admin` },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, adminContext)).toBeNull();
+    });
+
+    it('returns null for non-string url', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: 123 as unknown as string },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+
+    it('returns null for non-slash url', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: 'relative-path' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+
+    it('returns null for unknown type without valid fallback', () => {
+      const n = makeNotification({ type: 'UNKNOWN_TYPE', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+  });
+});

--- a/apps/web/shared/lib/notification-routes.test.ts
+++ b/apps/web/shared/lib/notification-routes.test.ts
@@ -5,6 +5,8 @@ const TENANT_ID = 'tenant-1';
 
 const adminContext: NotificationRoleContext = { isAdmin: true, isResident: false };
 const residentContext: NotificationRoleContext = { isAdmin: false, isResident: true };
+const mixedResidentPortal: NotificationRoleContext = { isAdmin: true, isResident: true, portalContext: 'resident' };
+const mixedAdminPortal: NotificationRoleContext = { isAdmin: true, isResident: true, portalContext: 'admin' };
 
 function makeNotification(overrides: Partial<Notification> & { type: string }): Notification {
   return {
@@ -40,10 +42,10 @@ describe('resolveNotificationPath', () => {
       );
     });
 
-    it('resolves SUPPORT_TICKET_STATUS_CHANGED without ticketId to resident tickets list', () => {
+    it('resolves SUPPORT_TICKET_STATUS_CHANGED to support page', () => {
       const n = makeNotification({ type: 'SUPPORT_TICKET_STATUS_CHANGED', data: {} });
       expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBe(
-        `/${TENANT_ID}/resident/tickets`
+        `/${TENANT_ID}/support`
       );
     });
 
@@ -70,6 +72,42 @@ describe('resolveNotificationPath', () => {
         data: { ticketId: 'ticket-42' },
       });
       expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+  });
+
+  describe('support ticket types', () => {
+    it('resolves SUPPORT_TICKET_STATUS_CHANGED to support page regardless of ticketId', () => {
+      const n = makeNotification({
+        type: 'SUPPORT_TICKET_STATUS_CHANGED',
+        data: { ticketId: 'support-42' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBe(
+        `/${TENANT_ID}/support`
+      );
+    });
+
+    it('resolves SUPPORT_TICKET_CREATED to support page', () => {
+      const n = makeNotification({ type: 'SUPPORT_TICKET_CREATED', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBe(
+        `/${TENANT_ID}/support`
+      );
+    });
+
+    it('resolves SUPPORT_TICKET_STATUS_CHANGED for admin to support page', () => {
+      const n = makeNotification({ type: 'SUPPORT_TICKET_STATUS_CHANGED', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, adminContext)).toBe(
+        `/${TENANT_ID}/support`
+      );
+    });
+
+    it('does not use ticketDetailPath for support ticket types', () => {
+      const n = makeNotification({
+        type: 'SUPPORT_TICKET_STATUS_CHANGED',
+        data: { ticketId: 'support-42', buildingId: 'b-1' },
+      });
+      const path = resolveNotificationPath(n, TENANT_ID, adminContext);
+      expect(path).toBe(`/${TENANT_ID}/support`);
+      expect(path).not.toContain('/tickets/');
     });
   });
 
@@ -273,6 +311,92 @@ describe('resolveNotificationPath', () => {
     it('returns null for unknown type without valid fallback', () => {
       const n = makeNotification({ type: 'UNKNOWN_TYPE', data: {} });
       expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+  });
+
+  describe('portalContext for mixed roles', () => {
+    it('resolves payment to resident path when portalContext is resident', () => {
+      const n = makeNotification({ type: 'PAYMENT_RECEIVED', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, mixedResidentPortal)).toBe(
+        `/${TENANT_ID}/resident/payments`
+      );
+    });
+
+    it('resolves payment to admin path when portalContext is admin', () => {
+      const n = makeNotification({ type: 'PAYMENT_RECEIVED', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, mixedAdminPortal)).toBe(
+        `/${TENANT_ID}/finanzas?tab=payments`
+      );
+    });
+
+    it('resolves document to resident path when portalContext is resident', () => {
+      const n = makeNotification({ type: 'DOCUMENT_SHARED', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, mixedResidentPortal)).toBe(
+        `/${TENANT_ID}/resident/documents`
+      );
+    });
+
+    it('resolves document to admin path when portalContext is admin', () => {
+      const n = makeNotification({ type: 'DOCUMENT_SHARED', data: { buildingId: 'b-1' } });
+      expect(resolveNotificationPath(n, TENANT_ID, mixedAdminPortal)).toBe(
+        `/${TENANT_ID}/buildings/b-1/documents`
+      );
+    });
+
+    it('resolves unit to resident path when portalContext is resident', () => {
+      const n = makeNotification({ type: 'OCCUPANT_ASSIGNED', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, mixedResidentPortal)).toBe(
+        `/${TENANT_ID}/resident/unit`
+      );
+    });
+
+    it('resolves unit to admin path when portalContext is admin', () => {
+      const n = makeNotification({ type: 'OCCUPANT_ASSIGNED', data: { buildingId: 'b-1' } });
+      expect(resolveNotificationPath(n, TENANT_ID, mixedAdminPortal)).toBe(
+        `/${TENANT_ID}/buildings/b-1/units`
+      );
+    });
+
+    it('resolves ticket to resident path when portalContext is resident', () => {
+      const n = makeNotification({ type: 'TICKET_COMMENT_ADDED', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, mixedResidentPortal)).toBe(
+        `/${TENANT_ID}/resident/tickets`
+      );
+    });
+
+    it('resolves ticket to admin path when portalContext is admin', () => {
+      const n = makeNotification({ type: 'TICKET_STATUS_CHANGED', data: { buildingId: 'b-1' } });
+      expect(resolveNotificationPath(n, TENANT_ID, mixedAdminPortal)).toBe(
+        `/${TENANT_ID}/buildings/b-1/tickets`
+      );
+    });
+
+    it('resolves fallback URL to resident path when portalContext is resident', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: `/${TENANT_ID}/resident/dashboard` },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, mixedResidentPortal)).toBe(
+        `/${TENANT_ID}/resident/dashboard`
+      );
+    });
+
+    it('rejects resident fallback URL when portalContext is admin', () => {
+      const n = makeNotification({
+        type: 'SYSTEM_ALERT',
+        data: { url: `/${TENANT_ID}/resident/dashboard` },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, mixedAdminPortal)).toBeNull();
+    });
+
+    it('resolves support ticket to support page regardless of portalContext', () => {
+      const n = makeNotification({ type: 'SUPPORT_TICKET_STATUS_CHANGED', data: {} });
+      expect(resolveNotificationPath(n, TENANT_ID, mixedResidentPortal)).toBe(
+        `/${TENANT_ID}/support`
+      );
+      expect(resolveNotificationPath(n, TENANT_ID, mixedAdminPortal)).toBe(
+        `/${TENANT_ID}/support`
+      );
     });
   });
 });

--- a/apps/web/shared/lib/notification-routes.ts
+++ b/apps/web/shared/lib/notification-routes.ts
@@ -5,6 +5,7 @@ import {
 } from './routes';
 import {
   TICKET_NOTIFICATION_TYPES,
+  SUPPORT_TICKET_NOTIFICATION_TYPES,
   PAYMENT_NOTIFICATION_TYPES,
   DOCUMENT_NOTIFICATION_TYPES,
   UNIT_NOTIFICATION_TYPES,
@@ -14,6 +15,7 @@ import type { Notification } from '@/features/notifications/notifications.api';
 export interface NotificationRoleContext {
   readonly isAdmin: boolean;
   readonly isResident: boolean;
+  readonly portalContext?: 'resident' | 'admin';
 }
 
 const ADMIN_PATH_SEGMENTS = [
@@ -68,6 +70,7 @@ function isSafeResidentPath(path: string, tenantId: string): boolean {
 
 function isSafeAdminPath(path: string, tenantId: string): boolean {
   if (!path.startsWith(`/${tenantId}/`)) return false;
+  if (path.startsWith(`/${tenantId}/resident/`)) return false;
   if (isAdminPath(path, tenantId)) return false;
 
   const decoded = decodeSafe(path);
@@ -83,8 +86,20 @@ function isTicketType(type: string): boolean {
   return (TICKET_NOTIFICATION_TYPES as readonly string[]).includes(type);
 }
 
+function isSupportTicketType(type: string): boolean {
+  return (SUPPORT_TICKET_NOTIFICATION_TYPES as readonly string[]).includes(type);
+}
+
 function isPaymentType(type: string): boolean {
   return (PAYMENT_NOTIFICATION_TYPES as readonly string[]).includes(type);
+}
+
+function isResidentContext(ctx: NotificationRoleContext): boolean {
+  return ctx.portalContext === 'resident' || (!ctx.portalContext && ctx.isResident && !ctx.isAdmin);
+}
+
+function isAdminContext(ctx: NotificationRoleContext): boolean {
+  return ctx.portalContext === 'admin' || (!ctx.portalContext && ctx.isAdmin);
 }
 
 export function resolveNotificationPath(
@@ -95,33 +110,38 @@ export function resolveNotificationPath(
   const { type, data } = notification;
   const ticketId = data?.ticketId;
 
-  // 1. Ticket types: first confirm type, then use ticketId if available
+  // 1. Support ticket types — route to support module, not building tickets
+  if (isSupportTicketType(type)) {
+    return `/${tenantId}/support`;
+  }
+
+  // 2. Building ticket types: first confirm type, then use ticketId if available
   if (isTicketType(type)) {
     if (ticketId && typeof ticketId === 'string') {
       return ticketDetailPath(tenantId, ticketId);
     }
-    if (roleContext.isAdmin) {
+    if (isAdminContext(roleContext)) {
       const buildingId = data?.buildingId;
       return buildingId
         ? buildingTickets(tenantId, buildingId)
         : `/${tenantId}/tickets`;
     }
-    if (roleContext.isResident) {
+    if (isResidentContext(roleContext)) {
       return residentTicketsPath(tenantId);
     }
     return `/${tenantId}/tickets`;
   }
 
-  // 2. Payment types
+  // 3. Payment types
   if (isPaymentType(type)) {
-    return roleContext.isAdmin
+    return isAdminContext(roleContext)
       ? `/${tenantId}/finanzas?tab=payments`
       : `/${tenantId}/resident/payments`;
   }
 
-  // 3. Document types
+  // 4. Document types
   if ((DOCUMENT_NOTIFICATION_TYPES as readonly string[]).includes(type)) {
-    if (roleContext.isAdmin) {
+    if (isAdminContext(roleContext)) {
       const buildingId = data?.buildingId;
       return buildingId
         ? `/${tenantId}/buildings/${buildingId}/documents`
@@ -130,9 +150,9 @@ export function resolveNotificationPath(
     return `/${tenantId}/resident/documents`;
   }
 
-  // 4. Unit types
+  // 5. Unit types
   if ((UNIT_NOTIFICATION_TYPES as readonly string[]).includes(type)) {
-    if (roleContext.isAdmin) {
+    if (isAdminContext(roleContext)) {
       const buildingId = data?.buildingId;
       return buildingId
         ? `/${tenantId}/buildings/${buildingId}/units`
@@ -141,17 +161,17 @@ export function resolveNotificationPath(
     return `/${tenantId}/resident/unit`;
   }
 
-  // 5. Fallback URL — strict validation only for known types
+  // 6. Fallback URL — strict validation only for known types
   const fallbackUrl = data?.url;
   if (typeof fallbackUrl !== 'string' || !fallbackUrl.startsWith('/')) {
     return null;
   }
 
-  if (roleContext.isResident && isSafeResidentPath(fallbackUrl, tenantId)) {
+  if (isResidentContext(roleContext) && isSafeResidentPath(fallbackUrl, tenantId)) {
     return fallbackUrl;
   }
 
-  if (roleContext.isAdmin && isSafeAdminPath(fallbackUrl, tenantId)) {
+  if (isAdminContext(roleContext) && isSafeAdminPath(fallbackUrl, tenantId)) {
     return fallbackUrl;
   }
 

--- a/apps/web/shared/lib/notification-routes.ts
+++ b/apps/web/shared/lib/notification-routes.ts
@@ -1,4 +1,14 @@
-import { buildingTickets, residentTicketsPath, ticketDetailPath } from './routes';
+import {
+  ticketDetailPath,
+  residentTicketsPath,
+  buildingTickets,
+} from './routes';
+import {
+  TICKET_NOTIFICATION_TYPES,
+  PAYMENT_NOTIFICATION_TYPES,
+  DOCUMENT_NOTIFICATION_TYPES,
+  UNIT_NOTIFICATION_TYPES,
+} from './notification-types';
 import type { Notification } from '@/features/notifications/notifications.api';
 
 export interface NotificationRoleContext {
@@ -6,8 +16,75 @@ export interface NotificationRoleContext {
   readonly isResident: boolean;
 }
 
-function isInternalPath(path: string | undefined): path is string {
-  return Boolean(path && path.startsWith('/'));
+const ADMIN_PATH_SEGMENTS = [
+  '/finanzas',
+  '/finance',
+  '/buildings',
+  '/super-admin',
+  '/admin',
+  '/settings',
+  '/reports',
+  '/communications',
+  '/support',
+];
+
+function hasProtocol(value: string): boolean {
+  return /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(value);
+}
+
+function decodeSafe(value: string): string | null {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+}
+
+function hasTraversalOrSlash(value: string): boolean {
+  return value.includes('..') || value.includes('\\');
+}
+
+function hasDoubleSlash(value: string): boolean {
+  return value.startsWith('//');
+}
+
+function isAdminPath(path: string, tenantId: string): boolean {
+  return ADMIN_PATH_SEGMENTS.some((seg) =>
+    path.startsWith(`/${tenantId}${seg}`)
+  );
+}
+
+function isSafeResidentPath(path: string, tenantId: string): boolean {
+  if (!path.startsWith(`/${tenantId}/resident/`)) return false;
+
+  const decoded = decodeSafe(path);
+  if (decoded === null) return false;
+  if (hasProtocol(decoded)) return false;
+  if (hasDoubleSlash(decoded)) return false;
+  if (hasTraversalOrSlash(decoded)) return false;
+
+  return true;
+}
+
+function isSafeAdminPath(path: string, tenantId: string): boolean {
+  if (!path.startsWith(`/${tenantId}/`)) return false;
+  if (isAdminPath(path, tenantId)) return false;
+
+  const decoded = decodeSafe(path);
+  if (decoded === null) return false;
+  if (hasProtocol(decoded)) return false;
+  if (hasDoubleSlash(decoded)) return false;
+  if (hasTraversalOrSlash(decoded)) return false;
+
+  return true;
+}
+
+function isTicketType(type: string): boolean {
+  return (TICKET_NOTIFICATION_TYPES as readonly string[]).includes(type);
+}
+
+function isPaymentType(type: string): boolean {
+  return (PAYMENT_NOTIFICATION_TYPES as readonly string[]).includes(type);
 }
 
 export function resolveNotificationPath(
@@ -15,40 +92,66 @@ export function resolveNotificationPath(
   tenantId: string,
   roleContext: NotificationRoleContext,
 ): string | null {
-  const ticketId = notification.data?.ticketId;
-  if (ticketId) {
-    return ticketDetailPath(tenantId, ticketId);
-  }
+  const { type, data } = notification;
+  const ticketId = data?.ticketId;
 
-  const ticketRelatedTypes = new Set([
-    'TICKET_STATUS_CHANGED',
-    'TICKET_COMMENT_ADDED',
-    'TICKET_CREATED',
-    'TICKET_ASSIGNED',
-    'URGENT_TICKET_UNASSIGNED',
-  ]);
-
-  if (ticketRelatedTypes.has(notification.type)) {
-    if (roleContext.isAdmin) {
-      const buildingId = notification.data?.buildingId;
-      return buildingId ? buildingTickets(tenantId, buildingId) : `/${tenantId}/tickets`;
+  // 1. Ticket types: first confirm type, then use ticketId if available
+  if (isTicketType(type)) {
+    if (ticketId && typeof ticketId === 'string') {
+      return ticketDetailPath(tenantId, ticketId);
     }
-
+    if (roleContext.isAdmin) {
+      const buildingId = data?.buildingId;
+      return buildingId
+        ? buildingTickets(tenantId, buildingId)
+        : `/${tenantId}/tickets`;
+    }
     if (roleContext.isResident) {
       return residentTicketsPath(tenantId);
     }
-
     return `/${tenantId}/tickets`;
   }
 
-  if (notification.type === 'PAYMENT_RECEIVED' || notification.type === 'PAYMENT_REJECTED') {
+  // 2. Payment types
+  if (isPaymentType(type)) {
     return roleContext.isAdmin
       ? `/${tenantId}/finanzas?tab=payments`
       : `/${tenantId}/resident/payments`;
   }
 
-  const fallbackUrl = notification.data?.url;
-  if (isInternalPath(fallbackUrl)) {
+  // 3. Document types
+  if ((DOCUMENT_NOTIFICATION_TYPES as readonly string[]).includes(type)) {
+    if (roleContext.isAdmin) {
+      const buildingId = data?.buildingId;
+      return buildingId
+        ? `/${tenantId}/buildings/${buildingId}/documents`
+        : `/${tenantId}/buildings`;
+    }
+    return `/${tenantId}/resident/documents`;
+  }
+
+  // 4. Unit types
+  if ((UNIT_NOTIFICATION_TYPES as readonly string[]).includes(type)) {
+    if (roleContext.isAdmin) {
+      const buildingId = data?.buildingId;
+      return buildingId
+        ? `/${tenantId}/buildings/${buildingId}/units`
+        : `/${tenantId}/buildings`;
+    }
+    return `/${tenantId}/resident/unit`;
+  }
+
+  // 5. Fallback URL — strict validation only for known types
+  const fallbackUrl = data?.url;
+  if (typeof fallbackUrl !== 'string' || !fallbackUrl.startsWith('/')) {
+    return null;
+  }
+
+  if (roleContext.isResident && isSafeResidentPath(fallbackUrl, tenantId)) {
+    return fallbackUrl;
+  }
+
+  if (roleContext.isAdmin && isSafeAdminPath(fallbackUrl, tenantId)) {
     return fallbackUrl;
   }
 

--- a/apps/web/shared/lib/notification-types.ts
+++ b/apps/web/shared/lib/notification-types.ts
@@ -3,15 +3,22 @@ import type { Notification } from '@/features/notifications/notifications.api';
 type FrontendNotificationType = Notification['type'];
 
 /**
- * Ticket-related notification types.
- * Used for icon classification and navigation routing.
+ * Building ticket notification types (module: /tickets).
+ * These use ticketDetailPath or buildingTickets routing.
  */
 export const TICKET_NOTIFICATION_TYPES: readonly FrontendNotificationType[] = [
   'TICKET_STATUS_CHANGED',
   'TICKET_COMMENT_ADDED',
+  'URGENT_TICKET_UNASSIGNED',
+] as const;
+
+/**
+ * Support ticket notification types (module: /support).
+ * These route to the support page, not building tickets.
+ */
+export const SUPPORT_TICKET_NOTIFICATION_TYPES: readonly FrontendNotificationType[] = [
   'SUPPORT_TICKET_CREATED',
   'SUPPORT_TICKET_STATUS_CHANGED',
-  'URGENT_TICKET_UNASSIGNED',
 ] as const;
 
 /**
@@ -44,11 +51,13 @@ export const UNIT_NOTIFICATION_TYPES: readonly FrontendNotificationType[] = [
  */
 export function getNotificationCategory(type: FrontendNotificationType):
   | 'ticket'
+  | 'support'
   | 'payment'
   | 'document'
   | 'unit'
   | 'other' {
   if ((TICKET_NOTIFICATION_TYPES as readonly string[]).includes(type)) return 'ticket';
+  if ((SUPPORT_TICKET_NOTIFICATION_TYPES as readonly string[]).includes(type)) return 'support';
   if ((PAYMENT_NOTIFICATION_TYPES as readonly string[]).includes(type)) return 'payment';
   if ((DOCUMENT_NOTIFICATION_TYPES as readonly string[]).includes(type)) return 'document';
   if ((UNIT_NOTIFICATION_TYPES as readonly string[]).includes(type)) return 'unit';

--- a/apps/web/shared/lib/notification-types.ts
+++ b/apps/web/shared/lib/notification-types.ts
@@ -1,0 +1,56 @@
+import type { Notification } from '@/features/notifications/notifications.api';
+
+type FrontendNotificationType = Notification['type'];
+
+/**
+ * Ticket-related notification types.
+ * Used for icon classification and navigation routing.
+ */
+export const TICKET_NOTIFICATION_TYPES: readonly FrontendNotificationType[] = [
+  'TICKET_STATUS_CHANGED',
+  'TICKET_COMMENT_ADDED',
+  'SUPPORT_TICKET_CREATED',
+  'SUPPORT_TICKET_STATUS_CHANGED',
+  'URGENT_TICKET_UNASSIGNED',
+] as const;
+
+/**
+ * Payment and charge notification types.
+ */
+export const PAYMENT_NOTIFICATION_TYPES: readonly FrontendNotificationType[] = [
+  'PAYMENT_RECEIVED',
+  'PAYMENT_REJECTED',
+  'PAYMENT_REMINDER',
+  'PAYMENT_OVERDUE',
+  'CHARGE_PUBLISHED',
+] as const;
+
+/**
+ * Document notification types.
+ */
+export const DOCUMENT_NOTIFICATION_TYPES: readonly FrontendNotificationType[] = [
+  'DOCUMENT_SHARED',
+] as const;
+
+/**
+ * Unit assignment notification types.
+ */
+export const UNIT_NOTIFICATION_TYPES: readonly FrontendNotificationType[] = [
+  'OCCUPANT_ASSIGNED',
+] as const;
+
+/**
+ * Returns the category of a notification type for icon and navigation classification.
+ */
+export function getNotificationCategory(type: FrontendNotificationType):
+  | 'ticket'
+  | 'payment'
+  | 'document'
+  | 'unit'
+  | 'other' {
+  if ((TICKET_NOTIFICATION_TYPES as readonly string[]).includes(type)) return 'ticket';
+  if ((PAYMENT_NOTIFICATION_TYPES as readonly string[]).includes(type)) return 'payment';
+  if ((DOCUMENT_NOTIFICATION_TYPES as readonly string[]).includes(type)) return 'document';
+  if ((UNIT_NOTIFICATION_TYPES as readonly string[]).includes(type)) return 'unit';
+  return 'other';
+}


### PR DESCRIPTION
## Summary

Closes #61.

Aligns resident notification visibility, navigation and email rendering.

## Changes

- centralizes notification type classification in the frontend;
- keeps the badge based on the backend unread count;
- displays all notifications returned for residents instead of hiding valid types;
- adds resident routes for tickets, payments, charges, reminders, documents and unit assignment;
- validates fallback URLs against cross-tenant, cross-scope, protocol and traversal risks;
- removes the generic navigation fallback to resident payments;
- adds accessible feedback when a notification has no safe action;
- escapes dynamic title and body content in notification email HTML;
- adds backend tenant/user isolation tests;
- expands frontend visibility, routing and action tests.

## Validation

- Notifications backend tests: 31 passed
- Topbar frontend tests: 27 passed
- Notification routes tests: 37 passed
- Notifications page tests: 7 passed
- API TypeScript: passed
- Web TypeScript: passed
- API ESLint: passed
- Web ESLint: passed
- git diff --check: passed

## Scope

No schema, migrations, seeds, Docker, push infrastructure, staging, production or Phase 6 changes.