### PR TITLE
fix(resident): enable multi-unit context switching

### DIFF
--- a/apps/api/src/communications/communications-user.controller.spec.ts
+++ b/apps/api/src/communications/communications-user.controller.spec.ts
@@ -1,0 +1,222 @@
+import { BadRequestException } from '@nestjs/common';
+import { ResidentCommunicationsController } from './communications-user.controller';
+import { CommunicationsService } from './communications.service';
+import { CommunicationsValidators } from './communications.validators';
+import { ResidentAccessService } from '../resident-access/resident-access.service';
+import type { AuthenticatedRequest } from '../common/types/request.types';
+
+const tenantId = 'tenant-1';
+const userId = 'user-1';
+const buildingId = 'building-1';
+const unitId = 'unit-1';
+const communicationId = 'comm-1';
+
+function buildReq(
+  overrides: Partial<{ headers: Record<string, string>; user: Record<string, unknown> }> = {},
+): AuthenticatedRequest {
+  return {
+    headers: { 'x-tenant-id': tenantId, ...overrides.headers },
+    user: {
+      id: userId,
+      memberships: [{ tenantId, roles: ['RESIDENT'] }],
+      ...overrides.user,
+    },
+  } as unknown as AuthenticatedRequest;
+}
+
+describe('ResidentCommunicationsController', () => {
+  let service: { findForResidentV2: jest.Mock; markAsReadForResident: jest.Mock };
+  let validators: { validateCommunicationBelongsToTenant: jest.Mock };
+  let residentAccess: { assertUnitAccess: jest.Mock };
+  let controller: ResidentCommunicationsController;
+
+  beforeEach(() => {
+    service = {
+      findForResidentV2: jest.fn().mockResolvedValue({ items: [], nextCursor: undefined }),
+      markAsReadForResident: jest.fn().mockResolvedValue({ readAt: new Date() }),
+    };
+    validators = { validateCommunicationBelongsToTenant: jest.fn().mockResolvedValue(undefined) };
+    residentAccess = { assertUnitAccess: jest.fn().mockResolvedValue(undefined) };
+    controller = new ResidentCommunicationsController(
+      service as unknown as CommunicationsService,
+      validators as unknown as CommunicationsValidators,
+      residentAccess as unknown as ResidentAccessService,
+    );
+  });
+
+  describe('getResidentCommunications', () => {
+    it('uses X-Tenant-Id header and not the first membership', async () => {
+      const req = buildReq({
+        user: {
+          id: userId,
+          memberships: [
+            { tenantId: 'tenant-other', roles: ['RESIDENT'] },
+            { tenantId, roles: ['RESIDENT'] },
+          ],
+        },
+      });
+
+      await controller.getResidentCommunications(
+        { buildingId, unitId, limit: 10 },
+        req,
+      );
+
+      expect(service.findForResidentV2).toHaveBeenCalledWith(
+        tenantId,
+        userId,
+        buildingId,
+        unitId,
+        10,
+        undefined,
+      );
+    });
+
+    it('validates active occupancy via assertUnitAccess', async () => {
+      const req = buildReq();
+
+      await controller.getResidentCommunications(
+        { buildingId, unitId, limit: 10 },
+        req,
+      );
+
+      expect(residentAccess.assertUnitAccess).toHaveBeenCalledWith(
+        tenantId,
+        userId,
+        unitId,
+        buildingId,
+      );
+    });
+
+    it('passes tenantId, userId, buildingId, unitId, limit and cursor to service', async () => {
+      const req = buildReq();
+      const cursor = 'test-cursor';
+
+      await controller.getResidentCommunications(
+        { buildingId, unitId, limit: 5, cursor },
+        req,
+      );
+
+      expect(service.findForResidentV2).toHaveBeenCalledWith(
+        tenantId,
+        userId,
+        buildingId,
+        unitId,
+        5,
+        cursor,
+      );
+    });
+
+    it('rejects tenant without membership', async () => {
+      const req = buildReq({
+        headers: { 'x-tenant-id': 'tenant-unknown' },
+      });
+
+      await expect(
+        controller.getResidentCommunications({ buildingId, unitId, limit: 10 }, req),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects query without buildingId', async () => {
+      const req = buildReq();
+
+      await expect(
+        controller.getResidentCommunications({ unitId, limit: 10 }, req),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects query without unitId', async () => {
+      const req = buildReq();
+
+      await expect(
+        controller.getResidentCommunications({ buildingId, limit: 10 }, req),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('does not call service when assertUnitAccess fails', async () => {
+      residentAccess.assertUnitAccess.mockRejectedValue(
+        new BadRequestException('Unit not found or does not belong to you'),
+      );
+      const req = buildReq();
+
+      await expect(
+        controller.getResidentCommunications({ buildingId, unitId, limit: 10 }, req),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(service.findForResidentV2).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('markResidentAsRead', () => {
+    it('requires X-Tenant-Id header', async () => {
+      const req = buildReq({ headers: { 'x-tenant-id': undefined as unknown as string } });
+
+      await expect(
+        controller.markResidentAsRead(communicationId, req),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('selects the matching membership and not the first', async () => {
+      const req = buildReq({
+        user: {
+          id: userId,
+          memberships: [
+            { tenantId: 'tenant-other', roles: ['RESIDENT'] },
+            { tenantId, roles: ['RESIDENT'] },
+          ],
+        },
+      });
+
+      await controller.markResidentAsRead(communicationId, req);
+
+      expect(validators.validateCommunicationBelongsToTenant).toHaveBeenCalledWith(
+        tenantId,
+        communicationId,
+      );
+      expect(service.markAsReadForResident).toHaveBeenCalledWith(
+        tenantId,
+        userId,
+        communicationId,
+      );
+    });
+
+    it('uses the resolved tenantId for validation and marking', async () => {
+      const req = buildReq();
+
+      await controller.markResidentAsRead(communicationId, req);
+
+      expect(validators.validateCommunicationBelongsToTenant).toHaveBeenCalledWith(
+        tenantId,
+        communicationId,
+      );
+      expect(service.markAsReadForResident).toHaveBeenCalledWith(
+        tenantId,
+        userId,
+        communicationId,
+      );
+    });
+
+    it('rejects tenant without membership', async () => {
+      const req = buildReq({
+        headers: { 'x-tenant-id': 'tenant-unknown' },
+      });
+
+      await expect(
+        controller.markResidentAsRead(communicationId, req),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(validators.validateCommunicationBelongsToTenant).not.toHaveBeenCalled();
+      expect(service.markAsReadForResident).not.toHaveBeenCalled();
+    });
+
+    it('does not call service when header is missing', async () => {
+      const req = buildReq({ headers: { 'x-tenant-id': undefined as unknown as string } });
+
+      await expect(
+        controller.markResidentAsRead(communicationId, req),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(validators.validateCommunicationBelongsToTenant).not.toHaveBeenCalled();
+      expect(service.markAsReadForResident).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/communications/communications-user.controller.ts
+++ b/apps/api/src/communications/communications-user.controller.ts
@@ -24,6 +24,7 @@ import {
   ResidentCommunicationsQuerySchema,
 } from '@buildingos/contracts';
 import type { AuthenticatedRequest } from '../common/types/request.types';
+import { ResidentAccessService } from '../resident-access/resident-access.service';
 
 /**
  * CommunicationsUserController: Tenant-level and user-level Communications endpoints
@@ -540,6 +541,7 @@ export class ResidentCommunicationsController {
   constructor(
     private communicationsService: CommunicationsService,
     private validators: CommunicationsValidators,
+    private residentAccessService: ResidentAccessService,
   ) {}
 
   /**
@@ -547,6 +549,8 @@ export class ResidentCommunicationsController {
    * Resident inbox with cursor pagination
    *
    * Query params:
+   * - buildingId: required, active building context
+   * - unitId: required, active unit context
    * - limit: number (default 20, max 100)
    * - cursor: opaque cursor string (base64 encoded)
    *
@@ -554,16 +558,27 @@ export class ResidentCommunicationsController {
    *
    * Ordering: publishedAt DESC, id DESC (mapped to sentAt internally)
    *
-   * No permission required (authenticated users only)
+   * Security:
+   * 1. JwtAuthGuard: Requires valid JWT token
+   * 2. X-Tenant-Id header: Required, validated against user memberships
+   * 3. assertUnitAccess: Validates user has active occupancy for the unit
    */
   @Get('communications')
   async getResidentCommunications(
     @Query() rawQuery: Record<string, unknown>,
     @Request() req: AuthenticatedRequest,
   ): Promise<ResidentCommunicationListResponse> {
-    const userMemberships = req.user?.memberships;
-    if (!userMemberships || userMemberships.length === 0) {
-      throw new BadRequestException('User does not have a tenant membership');
+    const xTenantId = req.headers['x-tenant-id'] as string | undefined;
+    if (!xTenantId) {
+      throw new BadRequestException('X-Tenant-Id header is required');
+    }
+
+    const userMemberships = req.user?.memberships || [];
+    const membership = userMemberships.find((m) => m.tenantId === xTenantId);
+    if (!membership) {
+      throw new BadRequestException(
+        'User does not have membership in the specified tenant',
+      );
     }
 
     const parsedQuery = ResidentCommunicationsQuerySchema.safeParse(rawQuery);
@@ -574,13 +589,22 @@ export class ResidentCommunicationsController {
       });
     }
 
-    const { limit, cursor } = parsedQuery.data;
-    const tenantId = userMemberships[0]!.tenantId;
+    const { buildingId, unitId, limit, cursor } = parsedQuery.data;
+    const tenantId = xTenantId;
     const userId = req.user.id;
+
+    await this.residentAccessService.assertUnitAccess(
+      tenantId,
+      userId,
+      unitId,
+      buildingId,
+    );
 
     return await this.communicationsService.findForResidentV2(
       tenantId,
       userId,
+      buildingId,
+      unitId,
       limit,
       cursor,
     );
@@ -592,19 +616,29 @@ export class ResidentCommunicationsController {
    *
    * Returns: { readAt: Date | null }
    *
-   * No permission required (authenticated users only)
+   * Security:
+   * 1. JwtAuthGuard: Requires valid JWT token
+   * 2. X-Tenant-Id header: Required, validated against user memberships
    */
   @Post('communications/:communicationId/read')
   async markResidentAsRead(
     @Param('communicationId') communicationId: string,
     @Request() req: AuthenticatedRequest,
   ): Promise<{ readAt: Date | null }> {
-    const userMemberships = req.user?.memberships;
-    if (!userMemberships || userMemberships.length === 0) {
-      throw new BadRequestException('User does not have a tenant membership');
+    const xTenantId = req.headers['x-tenant-id'] as string | undefined;
+    if (!xTenantId) {
+      throw new BadRequestException('X-Tenant-Id header is required');
     }
 
-    const tenantId = userMemberships[0]!.tenantId;
+    const userMemberships = req.user?.memberships || [];
+    const membership = userMemberships.find((m) => m.tenantId === xTenantId);
+    if (!membership) {
+      throw new BadRequestException(
+        'User does not have membership in the specified tenant',
+      );
+    }
+
+    const tenantId = xTenantId;
     const userId = req.user.id;
 
     await this.validators.validateCommunicationBelongsToTenant(

--- a/apps/api/src/communications/communications.module.ts
+++ b/apps/api/src/communications/communications.module.ts
@@ -11,11 +11,12 @@ import { EmailBounceController } from './email/webhooks/email-bounce.controller'
 import { DeliveryTrackingService } from './email/delivery-tracking.service';
 import { resolveEmailDelivery } from './email/email-delivery.resolver';
 import { PushDeliveryService } from '../push/push-delivery.service';
+import { ResidentAccessModule } from '../resident-access/resident-access.module';
 
 const emailOptions = resolveEmailDelivery();
 
 @Module({
-  imports: [PrismaModule, AppConfigModule, EmailDeliveryModule.register(emailOptions)],
+  imports: [PrismaModule, AppConfigModule, EmailDeliveryModule.register(emailOptions), ResidentAccessModule],
   controllers: [
     CommunicationsController,
     CommunicationsUserController,

--- a/apps/api/src/communications/communications.service.spec.ts
+++ b/apps/api/src/communications/communications.service.spec.ts
@@ -340,3 +340,185 @@ function buildDeliveryResult(status: PushDeliveryResult['status']): PushDelivery
     skipped: status === 'skipped_disabled' ? true : undefined,
   };
 }
+
+const buildingId = 'building-1';
+const unitId = 'unit-1';
+const otherBuildingId = 'building-other';
+const otherUnitId = 'unit-other';
+
+interface ReceiptDelegateMock {
+  readonly findMany: jest.Mock;
+}
+
+interface PrismaResidentMock {
+  readonly communicationReceipt: ReceiptDelegateMock;
+}
+
+function buildTarget(targetType: string, targetId?: string) {
+  return { targetType, targetId: targetId ?? null };
+}
+
+function buildReceiptWithComm(
+  commId: string,
+  targets: Array<{ targetType: string; targetId?: string }>,
+  readAt: Date | null = null,
+) {
+  return {
+    id: `receipt-${commId}`,
+    tenantId,
+    userId: userOneId,
+    communicationId: commId,
+    readAt,
+    deliveredAt: null,
+    createdAt: new Date('2026-07-01T00:00:00.000Z'),
+    communication: {
+      id: commId,
+      tenantId,
+      buildingId: null,
+      title: `Communication ${commId}`,
+      body: `Body ${commId}`,
+      channel: 'IN_APP',
+      status: 'SENT',
+      priority: 'NORMAL',
+      scheduledAt: null,
+      sentAt: new Date('2026-07-01T00:00:00.000Z'),
+      createdByMembershipId: 'membership-1',
+      createdAt: new Date('2026-07-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+      deletedAt: null,
+      targets,
+    },
+  };
+}
+
+describe('CommunicationsService findForResidentV2 scope filtering', () => {
+  let prisma: PrismaResidentMock;
+  let service: CommunicationsService;
+
+  beforeEach(() => {
+    prisma = {
+      communicationReceipt: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+    };
+    service = new CommunicationsService(
+      prisma as unknown as PrismaService,
+      { validateCommunicationBelongsToTenant: jest.fn() } as unknown as CommunicationsValidators,
+      { isFeatureEnabled: jest.fn() } as unknown as ConfigService,
+      { sendToSubscription: jest.fn() } as unknown as PushDeliveryService,
+    );
+  });
+
+  it('allows ALL_TENANT communications regardless of buildingId/unitId', async () => {
+    prisma.communicationReceipt.findMany.mockResolvedValue([
+      buildReceiptWithComm('comm-1', [buildTarget('ALL_TENANT')]),
+    ]);
+
+    const result = await service.findForResidentV2(tenantId, userOneId, buildingId, unitId, 20);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]!.id).toBe('comm-1');
+    expect(prisma.communicationReceipt.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          communication: expect.objectContaining({
+            targets: expect.objectContaining({
+              some: expect.objectContaining({
+                OR: expect.arrayContaining([
+                  { targetType: 'ALL_TENANT' },
+                  { targetType: 'ROLE' },
+                  { targetType: 'BUILDING', targetId: buildingId },
+                  { targetType: 'UNIT', targetId: unitId },
+                ]),
+              }),
+            }),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('allows ROLE communications', async () => {
+    prisma.communicationReceipt.findMany.mockResolvedValue([
+      buildReceiptWithComm('comm-role', [buildTarget('ROLE', 'RESIDENT')]),
+    ]);
+
+    const result = await service.findForResidentV2(tenantId, userOneId, buildingId, unitId, 20);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]!.id).toBe('comm-role');
+  });
+
+  it('allows BUILDING communications matching the selected buildingId', async () => {
+    prisma.communicationReceipt.findMany.mockResolvedValue([
+      buildReceiptWithComm('comm-bld', [buildTarget('BUILDING', buildingId)]),
+    ]);
+
+    const result = await service.findForResidentV2(tenantId, userOneId, buildingId, unitId, 20);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]!.id).toBe('comm-bld');
+  });
+
+  it('allows UNIT communications matching the selected unitId', async () => {
+    prisma.communicationReceipt.findMany.mockResolvedValue([
+      buildReceiptWithComm('comm-unit', [buildTarget('UNIT', unitId)]),
+    ]);
+
+    const result = await service.findForResidentV2(tenantId, userOneId, buildingId, unitId, 20);
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]!.id).toBe('comm-unit');
+  });
+
+  it('excludes communications targeted exclusively to another building', async () => {
+    prisma.communicationReceipt.findMany.mockResolvedValue([]);
+
+    const result = await service.findForResidentV2(tenantId, userOneId, buildingId, unitId, 20);
+
+    expect(result.items).toHaveLength(0);
+
+    const callWhere = prisma.communicationReceipt.findMany.mock.calls[0][0].where;
+    const orConditions = callWhere.communication.targets.some.OR;
+    const buildingConditions = orConditions.filter(
+      (c: { targetType: string }) => c.targetType === 'BUILDING',
+    );
+    expect(buildingConditions).toEqual([{ targetType: 'BUILDING', targetId: buildingId }]);
+  });
+
+  it('excludes communications targeted exclusively to another unit', async () => {
+    prisma.communicationReceipt.findMany.mockResolvedValue([]);
+
+    const result = await service.findForResidentV2(tenantId, userOneId, buildingId, unitId, 20);
+
+    expect(result.items).toHaveLength(0);
+
+    const callWhere = prisma.communicationReceipt.findMany.mock.calls[0][0].where;
+    const orConditions = callWhere.communication.targets.some.OR;
+    const unitConditions = orConditions.filter(
+      (c: { targetType: string }) => c.targetType === 'UNIT',
+    );
+    expect(unitConditions).toEqual([{ targetType: 'UNIT', targetId: unitId }]);
+  });
+
+  it('does not include other buildingId or unitId in the scope filter OR', async () => {
+    prisma.communicationReceipt.findMany.mockResolvedValue([]);
+
+    await service.findForResidentV2(tenantId, userOneId, buildingId, unitId, 20);
+
+    const callWhere = prisma.communicationReceipt.findMany.mock.calls[0][0].where;
+    const orConditions = callWhere.communication.targets.some.OR;
+
+    const buildingConditions = orConditions.filter(
+      (c: { targetType: string }) => c.targetType === 'BUILDING',
+    );
+    expect(buildingConditions).toHaveLength(1);
+    expect(buildingConditions[0]).toEqual({ targetType: 'BUILDING', targetId: buildingId });
+
+    const unitConditions = orConditions.filter(
+      (c: { targetType: string }) => c.targetType === 'UNIT',
+    );
+    expect(unitConditions).toHaveLength(1);
+    expect(unitConditions[0]).toEqual({ targetType: 'UNIT', targetId: unitId });
+  });
+});

--- a/apps/api/src/communications/communications.service.ts
+++ b/apps/api/src/communications/communications.service.ts
@@ -1058,11 +1058,21 @@ export class CommunicationsService {
    *
    * Ordering: publishedAt DESC, id DESC (mapped to sentAt DESC, id DESC internally)
    *
+   * Filters by context:
+   * - ALL_TENANT: always visible
+   * - ROLE: visible (applies to user within tenant)
+   * - BUILDING: visible only when targetId matches buildingId
+   * - UNIT: visible only when targetId matches unitId
+   *
+   * Excludes communications targeted exclusively to another building or unit.
+   *
    * @returns ResidentCommunicationListResponse with typed items
    */
   async findForResidentV2(
     tenantId: string,
     userId: string,
+    buildingId: string,
+    unitId: string,
     limit: number = 20,
     cursor?: string,
   ): Promise<ResidentCommunicationListResponse> {
@@ -1084,6 +1094,16 @@ export class CommunicationsService {
       communication: {
         status: 'SENT',
         sentAt: { not: null },
+        targets: {
+          some: {
+            OR: [
+              { targetType: 'ALL_TENANT' },
+              { targetType: 'ROLE' },
+              { targetType: 'BUILDING', targetId: buildingId },
+              { targetType: 'UNIT', targetId: unitId },
+            ],
+          },
+        },
       },
     };
 

--- a/apps/api/src/context/context.service.spec.ts
+++ b/apps/api/src/context/context.service.spec.ts
@@ -1,0 +1,181 @@
+import { NotFoundException } from '@nestjs/common';
+import { ContextService } from './context.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuthorizeService } from '../rbac/authorize.service';
+import { ResidentAccessService } from '../resident-access/resident-access.service';
+
+describe('ContextService', () => {
+  const prisma = {
+    membership: {
+      findUnique: jest.fn(),
+    },
+    userContext: {
+      upsert: jest.fn(),
+      create: jest.fn(),
+    },
+    building: {
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+    },
+    unit: {
+      findFirst: jest.fn(),
+      findMany: jest.fn(),
+    },
+  } as unknown as PrismaService;
+
+  const authorize = {
+    authorize: jest.fn(),
+  } as unknown as AuthorizeService;
+
+  const residentAccess = {
+    shouldEnforce: jest.fn(),
+    resolveActiveResidentOccupancy: jest.fn(),
+    getActiveUnitIds: jest.fn(),
+    getActiveBuildingIds: jest.fn(),
+    assertUnitAccess: jest.fn(),
+    assertBuildingAccess: jest.fn(),
+  } as unknown as ResidentAccessService;
+
+  const service = new ContextService(prisma, authorize, residentAccess);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('falls back to the first active resident occupancy when the saved selection is stale', async () => {
+    jest.spyOn(prisma.membership, 'findUnique').mockResolvedValue({
+      id: 'membership-1',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      userContext: {
+        activeBuildingId: 'building-stale',
+        activeUnitId: 'unit-stale',
+      },
+      roles: [{ role: 'RESIDENT' }],
+    } as never);
+    jest.spyOn(residentAccess, 'shouldEnforce').mockReturnValue(true);
+    jest.spyOn(residentAccess, 'resolveActiveResidentOccupancy')
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        occupancyId: 'occupancy-1',
+        tenantId: 'tenant-1',
+        buildingId: 'building-1',
+        buildingName: 'Edificio A',
+        buildingAlias: 'A',
+        unitId: 'unit-1',
+        unitCode: 'A-01',
+        unitLabel: 'Unidad 1',
+        memberId: 'member-1',
+      });
+    jest.spyOn(prisma.userContext, 'upsert').mockResolvedValue({
+      tenantId: 'tenant-1',
+      activeBuildingId: 'building-1',
+      activeUnitId: 'unit-1',
+    } as never);
+
+    await expect(service.getContext('user-1', 'tenant-1')).resolves.toEqual({
+      tenantId: 'tenant-1',
+      activeBuildingId: 'building-1',
+      activeUnitId: 'unit-1',
+    });
+
+    expect(prisma.userContext.upsert).toHaveBeenCalledWith({
+      where: { membershipId: 'membership-1' },
+      update: {
+        tenantId: 'tenant-1',
+        activeBuildingId: 'building-1',
+        activeUnitId: 'unit-1',
+      },
+      create: {
+        tenantId: 'tenant-1',
+        membershipId: 'membership-1',
+        activeBuildingId: 'building-1',
+        activeUnitId: 'unit-1',
+      },
+    });
+  });
+
+  it('normalizes a resident building-only selection to the first active unit in that building', async () => {
+    jest.spyOn(prisma.membership, 'findUnique').mockResolvedValue({
+      id: 'membership-1',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      userContext: null,
+      roles: [{ role: 'RESIDENT' }],
+    } as never);
+    jest.spyOn(residentAccess, 'shouldEnforce').mockReturnValue(true);
+    jest.spyOn(residentAccess, 'resolveActiveResidentOccupancy').mockResolvedValue({
+      occupancyId: 'occupancy-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      buildingName: 'Edificio A',
+      buildingAlias: 'A',
+      unitId: 'unit-1',
+      unitCode: 'A-01',
+      unitLabel: 'Unidad 1',
+      memberId: 'member-1',
+    });
+    jest.spyOn(prisma.building, 'findFirst').mockResolvedValue({
+      id: 'building-1',
+      tenantId: 'tenant-1',
+      name: 'Edificio A',
+    } as never);
+    jest.spyOn(prisma.userContext, 'upsert').mockResolvedValue({
+      tenantId: 'tenant-1',
+      activeBuildingId: 'building-1',
+      activeUnitId: 'unit-1',
+    } as never);
+
+    await expect(service.setContext('user-1', 'tenant-1', 'building-1', null)).resolves.toEqual({
+      tenantId: 'tenant-1',
+      activeBuildingId: 'building-1',
+      activeUnitId: 'unit-1',
+    });
+
+    expect(residentAccess.resolveActiveResidentOccupancy).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      buildingId: 'building-1',
+    });
+  });
+
+  it('rejects a resident unit that is not authorized in the current tenant', async () => {
+    jest.spyOn(prisma.membership, 'findUnique').mockResolvedValue({
+      id: 'membership-1',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      userContext: null,
+      roles: [{ role: 'RESIDENT' }],
+    } as never);
+    jest.spyOn(residentAccess, 'shouldEnforce').mockReturnValue(true);
+    jest.spyOn(residentAccess, 'resolveActiveResidentOccupancy').mockResolvedValue(null);
+
+    await expect(service.setContext('user-1', 'tenant-1', null, 'unit-other')).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('keeps the resident context empty when there are no active occupancies', async () => {
+    jest.spyOn(prisma.membership, 'findUnique').mockResolvedValue({
+      id: 'membership-1',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      userContext: null,
+      roles: [{ role: 'RESIDENT' }],
+    } as never);
+    jest.spyOn(residentAccess, 'shouldEnforce').mockReturnValue(true);
+    jest.spyOn(residentAccess, 'resolveActiveResidentOccupancy').mockResolvedValue(null);
+    jest.spyOn(prisma.userContext, 'upsert').mockResolvedValue({
+      tenantId: 'tenant-1',
+      activeBuildingId: null,
+      activeUnitId: null,
+    } as never);
+
+    await expect(service.getContext('user-1', 'tenant-1')).resolves.toEqual({
+      tenantId: 'tenant-1',
+      activeBuildingId: null,
+      activeUnitId: null,
+    });
+  });
+});

--- a/apps/api/src/context/context.service.ts
+++ b/apps/api/src/context/context.service.ts
@@ -1,7 +1,10 @@
 import { Injectable, NotFoundException, ForbiddenException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuthorizeService } from '../rbac/authorize.service';
-import { ResidentAccessService } from '../resident-access/resident-access.service';
+import {
+  ResidentAccessService,
+  type ActiveResidentOccupancy,
+} from '../resident-access/resident-access.service';
 
 interface MembershipRoleShape {
   role: string;
@@ -36,17 +39,121 @@ export class ContextService {
     private readonly residentAccess: ResidentAccessService,
   ) {}
 
+  private async persistContext(
+    membershipId: string,
+    tenantId: string,
+    activeBuildingId: string | null,
+    activeUnitId: string | null,
+  ): Promise<UserContextData> {
+    const userContext = await this.prisma.userContext.upsert({
+      where: { membershipId },
+      update: {
+        tenantId,
+        activeBuildingId,
+        activeUnitId,
+      },
+      create: {
+        tenantId,
+        membershipId,
+        activeBuildingId,
+        activeUnitId,
+      },
+    });
+
+    return {
+      tenantId,
+      activeBuildingId: userContext.activeBuildingId,
+      activeUnitId: userContext.activeUnitId,
+    };
+  }
+
+  private async resolveResidentContextState(
+    tenantId: string,
+    userId: string,
+    currentContext?: { activeBuildingId?: string | null; activeUnitId?: string | null } | null,
+  ): Promise<ActiveResidentOccupancy | null> {
+    const activeBuildingId = currentContext?.activeBuildingId ?? null;
+    const activeUnitId = currentContext?.activeUnitId ?? null;
+
+    if (activeUnitId) {
+      const selectedOccupancy = await this.residentAccess.resolveActiveResidentOccupancy({
+        tenantId,
+        userId,
+        unitId: activeUnitId,
+      });
+
+      if (selectedOccupancy) {
+        return selectedOccupancy;
+      }
+    }
+
+    if (activeBuildingId) {
+      const selectedOccupancy = await this.residentAccess.resolveActiveResidentOccupancy({
+        tenantId,
+        userId,
+        buildingId: activeBuildingId,
+      });
+
+      if (selectedOccupancy) {
+        return selectedOccupancy;
+      }
+    }
+
+    return this.residentAccess.resolveActiveResidentOccupancy({
+      tenantId,
+      userId,
+    });
+  }
+
   /**
    * Get current context for user/tenant
    */
   async getContext(userId: string, tenantId: string): Promise<UserContextData> {
     const membership = await this.prisma.membership.findUnique({
       where: { userId_tenantId: { userId, tenantId } },
-      include: { userContext: true },
+      include: {
+        userContext: true,
+        roles: { where: { tenantId } },
+      },
     });
 
     if (!membership) {
       throw new NotFoundException('Membership not found');
+    }
+
+    const roles = membership.roles || [];
+    const isResident = this.residentAccess.shouldEnforce(roles.map((role) => role.role));
+
+    if (isResident) {
+      const resolvedOccupancy = await this.resolveResidentContextState(
+        tenantId,
+        userId,
+        membership.userContext,
+      );
+
+      const nextBuildingId = resolvedOccupancy?.buildingId ?? null;
+      const nextUnitId = resolvedOccupancy?.unitId ?? null;
+      const currentBuildingId = membership.userContext?.activeBuildingId ?? null;
+      const currentUnitId = membership.userContext?.activeUnitId ?? null;
+
+      if (
+        !membership.userContext ||
+        currentBuildingId !== nextBuildingId ||
+        currentUnitId !== nextUnitId
+      ) {
+        return this.persistContext(
+          membership.id,
+          tenantId,
+          nextBuildingId,
+          nextUnitId,
+        );
+      }
+
+      return {
+        tenantId,
+        activeBuildingId: currentBuildingId,
+        activeUnitId: currentUnitId,
+      };
     }
 
     // Auto-initialize if no context exists OR if context is empty (both null — never properly initialized)
@@ -110,6 +217,37 @@ export class ContextService {
     const rolesForCheck = membership.roles || [];
     const isResidentForBuildingCheck = this.residentAccess.shouldEnforce(rolesForCheck.map((role) => role.role));
 
+    if (isResidentForBuildingCheck) {
+      if (effectiveUnitId) {
+        const occupancy = await this.residentAccess.resolveActiveResidentOccupancy({
+          tenantId,
+          userId,
+          unitId: effectiveUnitId,
+          buildingId: effectiveBuildingId ?? undefined,
+        });
+
+        if (!occupancy) {
+          throw new NotFoundException('Unit not found or does not belong to you');
+        }
+
+        effectiveBuildingId = occupancy.buildingId;
+        effectiveUnitId = occupancy.unitId;
+      } else if (effectiveBuildingId) {
+        const occupancy = await this.residentAccess.resolveActiveResidentOccupancy({
+          tenantId,
+          userId,
+          buildingId: effectiveBuildingId,
+        });
+
+        if (!occupancy) {
+          throw new NotFoundException('Building not found or does not belong to this tenant');
+        }
+
+        effectiveBuildingId = occupancy.buildingId;
+        effectiveUnitId = occupancy.unitId;
+      }
+    }
+
     // Validate building if specified
     if (effectiveBuildingId) {
       const building = await this.prisma.building.findFirst({
@@ -167,27 +305,12 @@ export class ContextService {
       }
     }
 
-    // Upsert or update UserContext
-    const userContext = await this.prisma.userContext.upsert({
-      where: { membershipId: membership.id },
-      update: {
-        tenantId,
-        activeBuildingId: effectiveBuildingId,
-        activeUnitId: effectiveUnitId,
-      },
-      create: {
-        tenantId,
-        membershipId: membership.id,
-        activeBuildingId: effectiveBuildingId,
-        activeUnitId: effectiveUnitId,
-      },
-    });
-
-    return {
+    return this.persistContext(
+      membership.id,
       tenantId,
-      activeBuildingId: userContext.activeBuildingId,
-      activeUnitId: userContext.activeUnitId,
-    };
+      effectiveBuildingId,
+      effectiveUnitId,
+    );
   }
 
   /**
@@ -250,19 +373,27 @@ export class ContextService {
     if (isResident) {
       const buildingIds = await this.residentAccess.getActiveBuildingIds(tenantId, userId);
       if (buildingIds.length === 0) return [];
-      return this.prisma.building.findMany({
+      const buildings = await this.prisma.building.findMany({
         where: { tenantId, id: { in: buildingIds }, deletedAt: null },
         select: { id: true, name: true },
       });
+      return buildings.sort((a, b) =>
+        a.name.localeCompare(b.name, 'es', { numeric: true, sensitivity: 'base' }) ||
+        a.id.localeCompare(b.id, 'es', { numeric: true, sensitivity: 'base' }),
+      );
     }
 
     // Non-RESIDENT: check scope
     const hasTenantScope = roles.some((r: MembershipRoleShape) => r.scopeType === 'TENANT');
     if (hasTenantScope) {
-      return this.prisma.building.findMany({
+      const buildings = await this.prisma.building.findMany({
         where: { tenantId },
         select: { id: true, name: true },
       });
+      return buildings.sort((a, b) =>
+        a.name.localeCompare(b.name, 'es', { numeric: true, sensitivity: 'base' }) ||
+        a.id.localeCompare(b.id, 'es', { numeric: true, sensitivity: 'base' }),
+      );
     }
 
     const buildingScopedRoles = roles.filter((r: MembershipRoleShape) => r.scopeType === 'BUILDING');
@@ -271,10 +402,14 @@ export class ContextService {
       .filter((id: string | null) => id !== null);
 
     if (buildingIds.length > 0) {
-      return this.prisma.building.findMany({
+      const buildings = await this.prisma.building.findMany({
         where: { tenantId, id: { in: buildingIds } },
         select: { id: true, name: true },
       });
+      return buildings.sort((a, b) =>
+        a.name.localeCompare(b.name, 'es', { numeric: true, sensitivity: 'base' }) ||
+        a.id.localeCompare(b.id, 'es', { numeric: true, sensitivity: 'base' }),
+      );
     }
 
     return [];
@@ -302,18 +437,28 @@ export class ContextService {
     if (isResident) {
       const unitIds = await this.residentAccess.getActiveUnitIds(_tenantId, userId, buildingId);
       if (unitIds.length === 0) return [];
-      return this.prisma.unit.findMany({
+      const units = await this.prisma.unit.findMany({
         where: { tenantId: _tenantId, buildingId, id: { in: unitIds } },
         select: { id: true, code: true, label: true },
       });
+      return units.sort((a, b) =>
+        (a.code ?? '').localeCompare(b.code ?? '', 'es', { numeric: true, sensitivity: 'base' }) ||
+        (a.label ?? '').localeCompare(b.label ?? '', 'es', { numeric: true, sensitivity: 'base' }) ||
+        a.id.localeCompare(b.id, 'es', { numeric: true, sensitivity: 'base' }),
+      );
     }
 
     // If TENANT or BUILDING scoped: return all units in building
     if (hasTenantScope || hasBuildingScope) {
-      return this.prisma.unit.findMany({
+      const units = await this.prisma.unit.findMany({
         where: { tenantId: _tenantId, buildingId },
         select: { id: true, code: true, label: true },
       });
+      return units.sort((a, b) =>
+        (a.code ?? '').localeCompare(b.code ?? '', 'es', { numeric: true, sensitivity: 'base' }) ||
+        (a.label ?? '').localeCompare(b.label ?? '', 'es', { numeric: true, sensitivity: 'base' }) ||
+        a.id.localeCompare(b.id, 'es', { numeric: true, sensitivity: 'base' }),
+      );
     }
 
     // If only UNIT-scoped: return units in this building that user has scope for
@@ -323,7 +468,7 @@ export class ContextService {
         .map((r: MembershipRoleShape) => r.scopeUnitId)
         .filter((id): id is string => id !== null && id !== undefined);
 
-      return this.prisma.unit.findMany({
+      const units = await this.prisma.unit.findMany({
         where: {
           tenantId: _tenantId,
           buildingId,
@@ -331,6 +476,11 @@ export class ContextService {
         },
         select: { id: true, code: true, label: true },
       });
+      return units.sort((a, b) =>
+        (a.code ?? '').localeCompare(b.code ?? '', 'es', { numeric: true, sensitivity: 'base' }) ||
+        (a.label ?? '').localeCompare(b.label ?? '', 'es', { numeric: true, sensitivity: 'base' }) ||
+        a.id.localeCompare(b.id, 'es', { numeric: true, sensitivity: 'base' }),
+      );
     }
 
     return [];
@@ -353,6 +503,20 @@ export class ContextService {
         activeBuildingId: membership?.userContext?.activeBuildingId ?? null,
         activeUnitId: membership?.userContext?.activeUnitId ?? null,
       };
+    }
+
+    const roles = membership.roles || [];
+    const isResident = this.residentAccess.shouldEnforce(roles.map((role) => role.role));
+
+    if (isResident) {
+      const resolvedOccupancy = await this.resolveResidentContextState(tenantId, userId, null);
+
+      return this.persistContext(
+        membership.id,
+        tenantId,
+        resolvedOccupancy?.buildingId ?? null,
+        resolvedOccupancy?.unitId ?? null,
+      );
     }
 
     // Auto-select building if only one is accessible

--- a/apps/api/src/resident-access/resident-access.service.spec.ts
+++ b/apps/api/src/resident-access/resident-access.service.spec.ts
@@ -15,14 +15,86 @@ describe('ResidentAccessService', () => {
 
   it('returns every active unit for a resident with multiple authorized units', async () => {
     jest.spyOn(prisma.unitOccupant, 'findMany').mockResolvedValue([
-      { unitId: 'unit-1' },
-      { unitId: 'unit-2' },
+      {
+        id: 'occupancy-2',
+        memberId: 'member-1',
+        unitId: 'unit-2',
+        unit: {
+          id: 'unit-2',
+          code: 'B-02',
+          label: 'Unidad 2',
+          building: {
+            id: 'building-b',
+            name: 'Edificio B',
+            alias: 'B',
+          },
+        },
+      },
+      {
+        id: 'occupancy-1',
+        memberId: 'member-1',
+        unitId: 'unit-1',
+        unit: {
+          id: 'unit-1',
+          code: 'A-01',
+          label: 'Unidad 1',
+          building: {
+            id: 'building-a',
+            name: 'Edificio A',
+            alias: 'A',
+          },
+        },
+      },
     ] as never);
 
     await expect(service.getActiveUnitIds('tenant-1', 'user-1')).resolves.toEqual(['unit-1', 'unit-2']);
     expect(prisma.unitOccupant.findMany).toHaveBeenCalledWith(expect.objectContaining({
       where: expect.objectContaining({ tenantId: 'tenant-1', endDate: null }),
     }));
+  });
+
+  it('resolves the first active occupancy in a stable order', async () => {
+    jest.spyOn(prisma.unitOccupant, 'findMany').mockResolvedValue([
+      {
+        id: 'occupancy-2',
+        memberId: 'member-1',
+        unitId: 'unit-2',
+        unit: {
+          id: 'unit-2',
+          code: 'B-02',
+          label: 'Unidad 2',
+          building: {
+            id: 'building-b',
+            name: 'Edificio B',
+            alias: 'B',
+          },
+        },
+      },
+      {
+        id: 'occupancy-1',
+        memberId: 'member-1',
+        unitId: 'unit-1',
+        unit: {
+          id: 'unit-1',
+          code: 'A-01',
+          label: 'Unidad 1',
+          building: {
+            id: 'building-a',
+            name: 'Edificio A',
+            alias: 'A',
+          },
+        },
+      },
+    ] as never);
+
+    await expect(service.resolveActiveResidentOccupancy({
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+    })).resolves.toMatchObject({
+      tenantId: 'tenant-1',
+      buildingId: 'building-a',
+      unitId: 'unit-1',
+    });
   });
 
   it('denies a foreign unit because no active occupant row matches it', async () => {
@@ -33,12 +105,16 @@ describe('ResidentAccessService', () => {
   });
 
   it('denies an ended occupancy because authorization requires endDate to be null', async () => {
-    jest.spyOn(prisma.unitOccupant, 'findFirst').mockResolvedValue(null);
+    jest.spyOn(prisma.unitOccupant, 'findMany').mockResolvedValue([]);
 
     await expect(service.assertUnitAccess('tenant-1', 'former-resident', 'unit-1'))
       .rejects.toBeInstanceOf(NotFoundException);
-    expect(prisma.unitOccupant.findFirst).toHaveBeenCalledWith(expect.objectContaining({
-      where: expect.objectContaining({ endDate: null, unitId: 'unit-1' }),
+    expect(prisma.unitOccupant.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        endDate: null,
+        tenantId: 'tenant-1',
+        member: expect.objectContaining({ userId: 'former-resident' }),
+      }),
     }));
   });
 

--- a/apps/api/src/resident-access/resident-access.service.ts
+++ b/apps/api/src/resident-access/resident-access.service.ts
@@ -1,6 +1,18 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 
+export interface ActiveResidentOccupancy {
+  occupancyId: string;
+  tenantId: string;
+  buildingId: string;
+  buildingName: string;
+  buildingAlias: string;
+  unitId: string;
+  unitCode: string;
+  unitLabel: string | null;
+  memberId: string;
+}
+
 /**
  * Resolves the self-scope for a resident from the authenticated user only.
  * Historical UnitOccupant rows never grant current access.
@@ -22,7 +34,11 @@ export class ResidentAccessService {
     );
   }
 
-  async getActiveUnitIds(tenantId: string, userId: string, buildingId?: string): Promise<string[]> {
+  async listActiveOccupancies(
+    tenantId: string,
+    userId: string,
+    buildingId?: string,
+  ): Promise<ActiveResidentOccupancy[]> {
     const occupancies = await this.prisma.unitOccupant.findMany({
       where: {
         tenantId,
@@ -30,26 +46,74 @@ export class ResidentAccessService {
         member: { tenantId, userId, disabledAt: null },
         unit: { tenantId, ...(buildingId ? { buildingId } : {}) },
       },
-      select: { unitId: true },
-      distinct: ['unitId'],
+      select: {
+        id: true,
+        memberId: true,
+        unitId: true,
+        unit: {
+          select: {
+            id: true,
+            code: true,
+            label: true,
+            building: {
+              select: {
+                id: true,
+                name: true,
+                alias: true,
+              },
+            },
+          },
+        },
+      },
     });
 
+    const sorted = occupancies
+      .map((occupancy) => ({
+        occupancyId: occupancy.id,
+        tenantId,
+        buildingId: occupancy.unit.building.id,
+        buildingName: occupancy.unit.building.name,
+        buildingAlias: occupancy.unit.building.alias,
+        unitId: occupancy.unit.id,
+        unitCode: occupancy.unit.code,
+        unitLabel: occupancy.unit.label ?? null,
+        memberId: occupancy.memberId,
+      }))
+      .sort((a, b) =>
+        a.buildingAlias.localeCompare(b.buildingAlias, 'es', { numeric: true, sensitivity: 'base' }) ||
+        a.buildingName.localeCompare(b.buildingName, 'es', { numeric: true, sensitivity: 'base' }) ||
+        a.unitCode.localeCompare(b.unitCode, 'es', { numeric: true, sensitivity: 'base' }) ||
+        (a.unitLabel ?? '').localeCompare(b.unitLabel ?? '', 'es', { numeric: true, sensitivity: 'base' }) ||
+        a.unitId.localeCompare(b.unitId, 'es', { numeric: true, sensitivity: 'base' }),
+      );
+
+    return sorted;
+  }
+
+  async resolveActiveResidentOccupancy(params: {
+    tenantId: string;
+    userId: string;
+    unitId?: string;
+    buildingId?: string;
+  }): Promise<ActiveResidentOccupancy | null> {
+    const { tenantId, userId, unitId, buildingId } = params;
+    const occupancies = await this.listActiveOccupancies(tenantId, userId, buildingId);
+
+    if (unitId) {
+      return occupancies.find((occupancy) => occupancy.unitId === unitId) ?? null;
+    }
+
+    return occupancies[0] ?? null;
+  }
+
+  async getActiveUnitIds(tenantId: string, userId: string, buildingId?: string): Promise<string[]> {
+    const occupancies = await this.listActiveOccupancies(tenantId, userId, buildingId);
     return occupancies.map(({ unitId }) => unitId);
   }
 
   async getActiveBuildingIds(tenantId: string, userId: string): Promise<string[]> {
-    const occupancies = await this.prisma.unitOccupant.findMany({
-      where: {
-        tenantId,
-        endDate: null,
-        member: { tenantId, userId, disabledAt: null },
-        unit: { tenantId },
-      },
-      select: { unit: { select: { buildingId: true } } },
-      distinct: ['unitId'],
-    });
-
-    return [...new Set(occupancies.map(({ unit }) => unit.buildingId))];
+    const occupancies = await this.listActiveOccupancies(tenantId, userId);
+    return [...new Set(occupancies.map(({ buildingId: activeBuildingId }) => activeBuildingId))];
   }
 
   async assertUnitAccess(
@@ -58,15 +122,11 @@ export class ResidentAccessService {
     unitId: string,
     buildingId?: string,
   ): Promise<void> {
-    const occupancy = await this.prisma.unitOccupant.findFirst({
-      where: {
-        tenantId,
-        unitId,
-        endDate: null,
-        member: { tenantId, userId, disabledAt: null },
-        unit: { tenantId, ...(buildingId ? { buildingId } : {}) },
-      },
-      select: { id: true },
+    const occupancy = await this.resolveActiveResidentOccupancy({
+      tenantId,
+      userId,
+      unitId,
+      buildingId,
     });
 
     if (!occupancy) {
@@ -75,8 +135,13 @@ export class ResidentAccessService {
   }
 
   async assertBuildingAccess(tenantId: string, userId: string, buildingId: string): Promise<void> {
-    const unitIds = await this.getActiveUnitIds(tenantId, userId, buildingId);
-    if (unitIds.length === 0) {
+    const occupancy = await this.resolveActiveResidentOccupancy({
+      tenantId,
+      userId,
+      buildingId,
+    });
+
+    if (!occupancy) {
       throw new NotFoundException('Building not found or does not belong to you');
     }
   }

--- a/apps/web/app/(tenant)/[tenantId]/resident/announcements/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/announcements/page.test.tsx
@@ -1,0 +1,370 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import ResidentAnnouncementsPage from './page';
+import { useTenantId } from '@/features/tenancy/tenant.hooks';
+import { useResidentContext } from '@/features/resident/hooks/useResidentContext';
+import {
+  getResidentCommunications,
+  markResidentAsRead,
+  type ResidentCommunicationItem,
+} from '@/features/communications/services/communications.api';
+
+jest.mock('@/features/tenancy/tenant.hooks', () => ({
+  useTenantId: jest.fn(),
+}));
+
+jest.mock('@/features/resident/hooks/useResidentContext', () => ({
+  useResidentContext: jest.fn(),
+}));
+
+jest.mock('@/features/communications/services/communications.api', () => ({
+  getResidentCommunications: jest.fn(),
+  markResidentAsRead: jest.fn(),
+}));
+
+const mockedUseTenantId = jest.mocked(useTenantId);
+const mockedUseResidentContext = jest.mocked(useResidentContext);
+const mockedGetResidentCommunications = jest.mocked(getResidentCommunications);
+const mockedMarkResidentAsRead = jest.mocked(markResidentAsRead);
+
+function makeComm(overrides: Partial<ResidentCommunicationItem> = {}): ResidentCommunicationItem {
+  return {
+    id: 'comm-1',
+    title: 'Aviso importante',
+    body: 'Se realiza asamblea el viernes.',
+    priority: 'NORMAL',
+    scopeType: 'BUILDING',
+    buildingIds: ['building-1'],
+    createdAt: '2026-07-01T00:00:00.000Z',
+    publishedAt: '2026-07-01T00:00:00.000Z',
+    deliveryStatus: 'UNREAD',
+    readAt: null,
+    ...overrides,
+  };
+}
+
+describe('ResidentAnnouncementsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseTenantId.mockReturnValue('tenant-1');
+  });
+
+  it('does not query without complete context', async () => {
+    mockedUseResidentContext.mockReturnValue({
+      data: { tenantId: 'tenant-1', activeBuildingId: 'building-1', activeUnitId: null },
+      isLoading: false,
+    } as never);
+
+    render(<ResidentAnnouncementsPage />);
+
+    expect(mockedGetResidentCommunications).not.toHaveBeenCalled();
+    expect(screen.getByText(/Seleccioná un edificio y una unidad/)).toBeTruthy();
+  });
+
+  it('does not query when tenantId is missing', async () => {
+    mockedUseTenantId.mockReturnValue(null as unknown as string);
+    mockedUseResidentContext.mockReturnValue({
+      data: { tenantId: 'tenant-1', activeBuildingId: 'building-1', activeUnitId: 'unit-1' },
+      isLoading: false,
+    } as never);
+
+    render(<ResidentAnnouncementsPage />);
+
+    expect(mockedGetResidentCommunications).not.toHaveBeenCalled();
+  });
+
+  it('queries with tenantId, buildingId and unitId when context is complete', async () => {
+    mockedUseResidentContext.mockReturnValue({
+      data: { tenantId: 'tenant-1', activeBuildingId: 'building-1', activeUnitId: 'unit-1' },
+      isLoading: false,
+    } as never);
+    mockedGetResidentCommunications.mockResolvedValue({
+      items: [makeComm()],
+      nextCursor: undefined,
+    });
+
+    render(<ResidentAnnouncementsPage />);
+
+    await waitFor(() => {
+      expect(mockedGetResidentCommunications).toHaveBeenCalledWith(
+        'tenant-1',
+        'building-1',
+        'unit-1',
+        20,
+        undefined,
+      );
+    });
+
+    expect(screen.getByText('Aviso importante')).toBeTruthy();
+  });
+
+  it('re-queries when context changes and resets previous items', async () => {
+    mockedUseResidentContext.mockReturnValue({
+      data: { tenantId: 'tenant-1', activeBuildingId: 'building-1', activeUnitId: 'unit-1' },
+      isLoading: false,
+    } as never);
+    mockedGetResidentCommunications.mockResolvedValue({
+      items: [makeComm({ id: 'comm-old', title: 'Viejo edificio' })],
+      nextCursor: undefined,
+    });
+
+    const { rerender } = render(<ResidentAnnouncementsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Viejo edificio')).toBeTruthy();
+    });
+
+    mockedGetResidentCommunications.mockResolvedValue({
+      items: [makeComm({ id: 'comm-new', title: 'Nuevo edificio' })],
+      nextCursor: undefined,
+    });
+    mockedUseResidentContext.mockReturnValue({
+      data: { tenantId: 'tenant-1', activeBuildingId: 'building-2', activeUnitId: 'unit-2' },
+      isLoading: false,
+    } as never);
+
+    rerender(<ResidentAnnouncementsPage />);
+
+    await waitFor(() => {
+      expect(mockedGetResidentCommunications).toHaveBeenCalledWith(
+        'tenant-1',
+        'building-2',
+        'unit-2',
+        20,
+        undefined,
+      );
+    });
+
+    expect(screen.queryByText('Viejo edificio')).toBeNull();
+    expect(screen.getByText('Nuevo edificio')).toBeTruthy();
+  });
+
+  it('does not mix results from the previous unit', async () => {
+    mockedUseResidentContext.mockReturnValue({
+      data: { tenantId: 'tenant-1', activeBuildingId: 'building-1', activeUnitId: 'unit-1' },
+      isLoading: false,
+    } as never);
+    mockedGetResidentCommunications.mockResolvedValue({
+      items: [makeComm({ id: 'comm-1', title: 'Unidad 1' })],
+      nextCursor: undefined,
+    });
+
+    const { rerender } = render(<ResidentAnnouncementsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unidad 1')).toBeTruthy();
+    });
+
+    mockedGetResidentCommunications.mockResolvedValue({
+      items: [makeComm({ id: 'comm-2', title: 'Unidad 2' })],
+      nextCursor: undefined,
+    });
+    mockedUseResidentContext.mockReturnValue({
+      data: { tenantId: 'tenant-1', activeBuildingId: 'building-1', activeUnitId: 'unit-2' },
+      isLoading: false,
+    } as never);
+
+    rerender(<ResidentAnnouncementsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Unidad 2')).toBeTruthy();
+    });
+
+    expect(screen.queryByText('Unidad 1')).toBeNull();
+  });
+
+  it('load more uses the selected context', async () => {
+    mockedUseResidentContext.mockReturnValue({
+      data: { tenantId: 'tenant-1', activeBuildingId: 'building-1', activeUnitId: 'unit-1' },
+      isLoading: false,
+    } as never);
+    mockedGetResidentCommunications
+      .mockResolvedValueOnce({
+        items: [makeComm({ id: 'comm-1', title: 'First' })],
+        nextCursor: 'cursor-abc',
+      })
+      .mockResolvedValueOnce({
+        items: [makeComm({ id: 'comm-2', title: 'Second' })],
+        nextCursor: undefined,
+      });
+
+    render(<ResidentAnnouncementsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('First')).toBeTruthy();
+    });
+
+    const loadMoreBtn = screen.getByText('Ver más');
+    loadMoreBtn.click();
+
+    await waitFor(() => {
+      expect(mockedGetResidentCommunications).toHaveBeenCalledWith(
+        'tenant-1',
+        'building-1',
+        'unit-1',
+        20,
+        'cursor-abc',
+      );
+    });
+
+    expect(screen.getByText('Second')).toBeTruthy();
+  });
+
+  it('shows error state and retry works', async () => {
+    mockedUseResidentContext.mockReturnValue({
+      data: { tenantId: 'tenant-1', activeBuildingId: 'building-1', activeUnitId: 'unit-1' },
+      isLoading: false,
+    } as never);
+    mockedGetResidentCommunications.mockRejectedValueOnce(new Error('Network error'));
+
+    render(<ResidentAnnouncementsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No pudimos cargar los comunicados')).toBeTruthy();
+    });
+
+    mockedGetResidentCommunications.mockResolvedValue({
+      items: [makeComm()],
+      nextCursor: undefined,
+    });
+
+    screen.getByText('Reintentar').click();
+
+    await waitFor(() => {
+      expect(screen.getByText('Aviso importante')).toBeTruthy();
+    });
+  });
+
+  it('shows safe state when context is loading', () => {
+    mockedUseResidentContext.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    } as never);
+
+    const { container } = render(<ResidentAnnouncementsPage />);
+
+    expect(container.querySelector('.animate-spin')).toBeTruthy();
+  });
+
+  it('markResidentAsRead receives tenantId and communicationId', async () => {
+    mockedUseResidentContext.mockReturnValue({
+      data: { tenantId: 'tenant-1', activeBuildingId: 'building-1', activeUnitId: 'unit-1' },
+      isLoading: false,
+    } as never);
+    mockedGetResidentCommunications.mockResolvedValue({
+      items: [makeComm()],
+      nextCursor: undefined,
+    });
+    mockedMarkResidentAsRead.mockResolvedValue({ readAt: '2026-07-26T00:00:00.000Z' });
+
+    render(<ResidentAnnouncementsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Aviso importante')).toBeTruthy();
+    });
+
+    screen.getByText('Aviso importante').click();
+
+    await waitFor(() => {
+      expect(mockedMarkResidentAsRead).toHaveBeenCalledWith('tenant-1', 'comm-1');
+    });
+  });
+
+  it('shows error state for mark-as-read failure', async () => {
+    mockedUseResidentContext.mockReturnValue({
+      data: { tenantId: 'tenant-1', activeBuildingId: 'building-1', activeUnitId: 'unit-1' },
+      isLoading: false,
+    } as never);
+    mockedGetResidentCommunications.mockResolvedValue({
+      items: [makeComm()],
+      nextCursor: undefined,
+    });
+    mockedMarkResidentAsRead.mockRejectedValue(new Error('Mark read failed'));
+
+    render(<ResidentAnnouncementsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Aviso importante')).toBeTruthy();
+    });
+
+    screen.getByText('Aviso importante').click();
+
+    await waitFor(() => {
+      expect(screen.getByText('Mark read failed')).toBeTruthy();
+    });
+  });
+
+  it('does not repopulate screen with stale response after context change to incomplete', async () => {
+    mockedUseResidentContext.mockReturnValue({
+      data: { tenantId: 'tenant-1', activeBuildingId: 'building-1', activeUnitId: 'unit-1' },
+      isLoading: false,
+    } as never);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let resolveFirst!: (value: any) => void;
+    mockedGetResidentCommunications.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveFirst = resolve as never; }),
+    );
+
+    const { rerender } = render(<ResidentAnnouncementsPage />);
+
+    mockedUseResidentContext.mockReturnValue({
+      data: { tenantId: 'tenant-1', activeBuildingId: null, activeUnitId: null },
+      isLoading: false,
+    } as never);
+
+    rerender(<ResidentAnnouncementsPage />);
+
+    resolveFirst({
+      items: [makeComm({ id: 'stale-comm', title: 'Stale' })],
+      nextCursor: undefined,
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(screen.queryByText('Stale')).toBeNull();
+  });
+
+  it('does not apply stale mark-as-read result to new context', async () => {
+    mockedUseResidentContext.mockReturnValue({
+      data: { tenantId: 'tenant-1', activeBuildingId: 'building-1', activeUnitId: 'unit-1' },
+      isLoading: false,
+    } as never);
+    mockedGetResidentCommunications.mockResolvedValue({
+      items: [makeComm({ id: 'comm-1', title: 'Original' })],
+      nextCursor: undefined,
+    });
+
+    render(<ResidentAnnouncementsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Original')).toBeTruthy();
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let resolveMarkRead!: (value: any) => void;
+    mockedMarkResidentAsRead.mockImplementationOnce(
+      () => new Promise((resolve) => { resolveMarkRead = resolve as never; }),
+    );
+
+    screen.getByText('Original').click();
+
+    mockedUseResidentContext.mockReturnValue({
+      data: { tenantId: 'tenant-1', activeBuildingId: 'building-2', activeUnitId: 'unit-2' },
+      isLoading: false,
+    } as never);
+
+    resolveMarkRead({ readAt: '2026-07-26T00:00:00.000Z' });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const readIcons = screen.queryAllByText('Original');
+    readIcons.forEach((el) => {
+      expect(el.closest('button')?.querySelector('[data-testid="read-icon"]')).toBeNull();
+    });
+  });
+});

--- a/apps/web/app/(tenant)/[tenantId]/resident/announcements/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/announcements/page.tsx
@@ -1,62 +1,110 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import {
   getResidentCommunications,
   markResidentAsRead,
   type ResidentCommunicationItem,
 } from '@/features/communications/services/communications.api';
 import { useTenantId } from '@/features/tenancy/tenant.hooks';
+import { useResidentContext } from '@/features/resident/hooks/useResidentContext';
 import { BuildingIcon, Bell, CheckCircle2, Circle, Loader2, AlertCircle } from 'lucide-react';
 import Card from '@/shared/components/ui/Card';
 
 const ResidentAnnouncementsPage = () => {
   const tenantId = useTenantId();
+  const { data: context, isLoading: contextLoading } = useResidentContext(tenantId ?? null);
+  const buildingId = context?.activeBuildingId ?? null;
+  const unitId = context?.activeUnitId ?? null;
+
   const [communications, setCommunications] = useState<ResidentCommunicationItem[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [markReadError, setMarkReadError] = useState<string | null>(null);
   const [nextCursor, setNextCursor] = useState<string | undefined>();
   const [hasMore, setHasMore] = useState(false);
 
-  const fetchCommunications = useCallback(async (cursor?: string, isLoadMore = false) => {
-    if (!tenantId) return;
+  const contextKey = `${tenantId ?? ''}:${buildingId ?? ''}:${unitId ?? ''}`;
+  const contextKeyRef = useRef(contextKey);
+  const fetchIdRef = useRef(0);
+  const mountedRef = useRef(false);
 
-    try {
-      if (isLoadMore) {
-        setLoadingMore(true);
-      } else {
-        setLoading(true);
+  const fetchCommunications = useCallback(
+    async (cursor?: string, isLoadMore = false) => {
+      if (!tenantId || !buildingId || !unitId) return;
+
+      const currentFetchId = ++fetchIdRef.current;
+
+      try {
+        if (isLoadMore) {
+          setLoadingMore(true);
+        } else {
+          setLoading(true);
+        }
+        setError(null);
+
+        const response = await getResidentCommunications(tenantId, buildingId, unitId, 20, cursor);
+
+        if (currentFetchId !== fetchIdRef.current) return;
+
+        if (isLoadMore) {
+          setCommunications((prev) => [...prev, ...response.items]);
+        } else {
+          setCommunications(response.items);
+        }
+
+        setNextCursor(response.nextCursor);
+        setHasMore(!!response.nextCursor);
+      } catch (err) {
+        if (currentFetchId !== fetchIdRef.current) return;
+        setError(err instanceof Error ? err.message : 'Error al cargar comunicados');
+      } finally {
+        if (currentFetchId === fetchIdRef.current) {
+          setLoading(false);
+          setLoadingMore(false);
+        }
       }
-      setError(null);
+    },
+    [tenantId, buildingId, unitId],
+  );
 
-      const response = await getResidentCommunications(20, cursor);
-
-      if (isLoadMore) {
-        setCommunications((prev) => [...prev, ...response.items]);
-      } else {
-        setCommunications(response.items);
-      }
-
-      setNextCursor(response.nextCursor);
-      setHasMore(!!response.nextCursor);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Error al cargar comunicados');
-    } finally {
-      setLoading(false);
-      setLoadingMore(false);
-    }
-  }, [tenantId]);
+  const fetchCommunicationsRef = useRef(fetchCommunications);
 
   useEffect(() => {
-    fetchCommunications();
-  }, [fetchCommunications]);
+    fetchCommunicationsRef.current = fetchCommunications;
+  });
+
+  useEffect(() => {
+    if (!mountedRef.current) {
+      mountedRef.current = true;
+      if (tenantId && buildingId && unitId) {
+        fetchCommunicationsRef.current();
+      }
+      return;
+    }
+
+    if (contextKey !== contextKeyRef.current) {
+      contextKeyRef.current = contextKey;
+      fetchIdRef.current++;
+      setCommunications([]);
+      setNextCursor(undefined);
+      setHasMore(false);
+      setError(null);
+      setMarkReadError(null);
+      if (tenantId && buildingId && unitId) {
+        fetchCommunicationsRef.current();
+      }
+    }
+  }, [contextKey, tenantId, buildingId, unitId]);
 
   const handleMarkAsRead = async (communicationId: string) => {
+    if (!tenantId) return;
+    const snapshotKey = contextKey;
     try {
       setMarkReadError(null);
-      const result = await markResidentAsRead(communicationId);
+      const result = await markResidentAsRead(tenantId, communicationId);
+      if (snapshotKey !== contextKeyRef.current) return;
       setCommunications((prev) =>
         prev.map((c) =>
           c.id === communicationId
@@ -65,6 +113,7 @@ const ResidentAnnouncementsPage = () => {
         )
       );
     } catch (err) {
+      if (snapshotKey !== contextKeyRef.current) return;
       console.error('Failed to mark as read:', err);
       setMarkReadError(
         err instanceof Error
@@ -95,6 +144,25 @@ const ResidentAnnouncementsPage = () => {
       year: 'numeric',
     });
   };
+
+  if (contextLoading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!buildingId || !unitId) {
+    return (
+      <div className="text-center py-12">
+        <Bell className="w-12 h-12 mx-auto text-muted-foreground mb-4" />
+        <p className="text-muted-foreground">
+          Seleccioná un edificio y una unidad para ver los comunicados.
+        </p>
+      </div>
+    );
+  }
 
   if (loading) {
     return (

--- a/apps/web/app/(tenant)/[tenantId]/resident/dashboard/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/dashboard/page.tsx
@@ -81,6 +81,7 @@ const ResidentDashboardPage = () => {
   const tenantId = params.tenantId;
   const session = useAuthSession();
   const userName = session?.user?.name ?? '';
+  const userId = session?.user?.id ?? null;
 
   const { data: tenants } = useTenants();
   const tenantName = tenants?.find((t) => t.id === tenantId)?.name ?? tenantId;
@@ -124,9 +125,9 @@ const ResidentDashboardPage = () => {
     isError: ticketsError,
     error: ticketsErrorValue,
   } = useQuery<Ticket[]>({
-    queryKey: ['residentTickets', buildingId, unitId],
+    queryKey: ['residentTickets', tenantId, userId, buildingId, unitId],
     queryFn: () => getResidentTickets(buildingId!, unitId!, 3),
-    enabled: !!buildingId && !!unitId,
+    enabled: !!buildingId && !!unitId && !!userId,
     staleTime: 2 * 60 * 1000,
     gcTime: 5 * 60 * 1000,
     retry: 1,

--- a/apps/web/app/(tenant)/[tenantId]/resident/documents/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/documents/page.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import { useResidentContext } from '../../../../../features/resident/hooks/useResidentContext';
 import { useContextOptions } from '../../../../../features/context/useContextOptions';
+import { useAuthSession } from '../../../../../features/auth/useAuthSession';
 import { useTenants } from '../../../../../features/tenants/tenants.hooks';
 import Card from '../../../../../shared/components/ui/Card';
 import Skeleton from '../../../../../shared/components/ui/Skeleton';
@@ -171,6 +172,8 @@ function matchesSearch(doc: Document, query: string): boolean {
 export default function ResidentDocumentsPage() {
   const params = useParams<{ tenantId: string }>();
   const tenantId = params.tenantId;
+  const session = useAuthSession();
+  const userId = session?.user.id ?? null;
 
   const [openError, setOpenError] = useState<string | null>(null);
   const [openErrorDocumentTitle, setOpenErrorDocumentTitle] = useState<string | null>(null);
@@ -216,9 +219,9 @@ export default function ResidentDocumentsPage() {
     error: docsErrorValue,
     refetch,
   } = useQuery<Document[]>({
-    queryKey: ['residentDocuments', tenantId, buildingId, unitId],
+    queryKey: ['residentDocuments', tenantId, userId, buildingId, unitId],
     queryFn: () => listDocuments(tenantId!, { buildingId: buildingId ?? undefined, unitId: unitId ?? undefined }),
-    enabled: !!tenantId && !!buildingId && !!unitId,
+    enabled: !!tenantId && !!userId && !!buildingId && !!unitId,
     staleTime: 5 * 60 * 1000,
   });
 

--- a/apps/web/app/(tenant)/[tenantId]/resident/layout.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/layout.tsx
@@ -6,6 +6,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { useHasRole, useAuthSession } from '../../../../features/auth/useAuthSession';
 import { getSession } from '../../../../features/auth/session.storage';
 import { useBoStorageTick } from '../../../../shared/lib/storage/useBoStorage';
+import { ResidentContextSwitcher } from '../../../../features/resident/components/ResidentContextSwitcher';
 
 interface TenantParams { tenantId?: string; [key: string]: string | string[] | undefined; }
 
@@ -40,7 +41,14 @@ const ResidentLayout = ({ children }: ResidentLayoutProps) => {
     return () => window.clearTimeout(timer);
   }, [session, router, storageTick]);
 
-  return <>{children}</>;
+  return (
+    <div className="space-y-6">
+      {session && isResident && (
+        <ResidentContextSwitcher tenantId={tenantId} />
+      )}
+      {children}
+    </div>
+  );
 };
 
 export default ResidentLayout;

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
@@ -9,6 +9,7 @@ import { useParams } from 'next/navigation';
 import ResidentPaymentsPage from './page';
 import { useResidentContext } from '@/features/resident/hooks/useResidentContext';
 import { useContextOptions } from '@/features/context/useContextOptions';
+import { useAuthSession } from '@/features/auth/useAuthSession';
 import { useTenants } from '@/features/tenants/tenants.hooks';
 import { getResidentLedger } from '@/features/resident/api/resident-context.api';
 import { listPayments, submitPayment, PaymentMethod, PaymentStatus, ChargeStatus, ChargeType, type Payment } from '@/features/finance/services/finance.api';
@@ -24,6 +25,10 @@ jest.mock('@/features/resident/hooks/useResidentContext', () => ({
 
 jest.mock('@/features/context/useContextOptions', () => ({
   useContextOptions: jest.fn(),
+}));
+
+jest.mock('@/features/auth/useAuthSession', () => ({
+  useAuthSession: jest.fn(),
 }));
 
 jest.mock('@/features/tenants/tenants.hooks', () => ({
@@ -67,6 +72,7 @@ jest.mock('@/features/buildings/services/documents.api', () => ({
 const mockedUseParams = jest.mocked(useParams);
 const mockedUseResidentContext = jest.mocked(useResidentContext);
 const mockedUseContextOptions = jest.mocked(useContextOptions);
+const mockedUseAuthSession = jest.mocked(useAuthSession);
 const mockedUseTenants = jest.mocked(useTenants);
 const mockedGetResidentLedger = jest.mocked(getResidentLedger);
 const mockedListPayments = jest.mocked(listPayments);
@@ -169,6 +175,20 @@ describe('ResidentPaymentsPage', () => {
     jest.setSystemTime(new Date('2026-07-24T12:00:00.000Z'));
     jest.clearAllMocks();
     mockedUseParams.mockReturnValue({ tenantId: 'tenant-1' } as never);
+    mockedUseAuthSession.mockReturnValue({
+      user: {
+        id: 'resident-user-1',
+        email: 'resident@example.com',
+        name: 'Resident Test',
+      },
+      memberships: [
+        {
+          tenantId: 'tenant-1',
+          roles: ['RESIDENT'],
+        },
+      ],
+      activeTenantId: 'tenant-1',
+    } as never);
     mockedUseTenants.mockReturnValue({
       data: [{ id: 'tenant-1', name: 'Complejo Horizonte' }],
     } as never);

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
@@ -16,6 +16,7 @@ import {
 import { useResidentContext } from '@/features/resident/hooks/useResidentContext';
 import { useContextOptions } from '@/features/context/useContextOptions';
 import { getResidentLedger, type UnitLedger } from '@/features/resident/api/resident-context.api';
+import { useAuthSession } from '@/features/auth/useAuthSession';
 import { useTenants } from '@/features/tenants/tenants.hooks';
 import { listPayments, submitPayment, type Payment, PaymentMethod, ChargeStatus, PaymentStatus } from '@/features/finance/services/finance.api';
 import {
@@ -316,6 +317,8 @@ function PaymentConfirmDialog({
 export const ResidentPaymentsPage = () => {
   const params = useParams<{ tenantId: string }>();
   const tenantId = params.tenantId;
+  const session = useAuthSession();
+  const userId = session?.user.id ?? null;
 
   const { data: tenants } = useTenants();
   const tenantName = tenants?.find((t) => t.id === tenantId)?.name ?? tenantId;
@@ -347,7 +350,7 @@ export const ResidentPaymentsPage = () => {
     error: ledgerErrorValue,
     refetch: refetchLedger,
   } = useQuery<UnitLedger>({
-    queryKey: ['residentLedger', tenantId, unitId],
+    queryKey: ['residentLedger', tenantId, userId, unitId],
     queryFn: () => {
       if (!tenantId || !unitId) {
         throw new Error('Missing tenant or unit context for resident ledger');
@@ -365,14 +368,14 @@ export const ResidentPaymentsPage = () => {
     error: paymentsErrorValue,
     refetch: refetchPayments,
   } = useQuery<Payment[]>({
-    queryKey: ['residentPayments', buildingId, unitId],
+    queryKey: ['residentPayments', tenantId, userId, buildingId, unitId],
     queryFn: () => {
       if (!buildingId || !unitId) {
         throw new Error('Missing building or unit context for resident payments');
       }
       return listPayments(buildingId, undefined, unitId, 20);
     },
-    enabled: !!buildingId && !!unitId,
+    enabled: !!tenantId && !!userId && !!buildingId && !!unitId,
     staleTime: 5 * 60 * 1000,
   });
 

--- a/apps/web/app/(tenant)/[tenantId]/resident/tickets/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/tickets/page.tsx
@@ -116,7 +116,7 @@ export default function ResidentTicketsPage() {
     error: ticketsErrorValue,
     refetch,
   } = useQuery<Ticket[]>({
-    queryKey: ['residentTickets', userId, tenantId, buildingId, unitId],
+    queryKey: ['residentTickets', tenantId, userId, buildingId, unitId],
     queryFn: () => getResidentTickets(buildingId!, unitId!, 50),
     enabled: identityMatchesRoute && !!buildingId && !!unitId && !contextLoading,
     staleTime: 30_000,

--- a/apps/web/features/communications/services/communications.api.ts
+++ b/apps/web/features/communications/services/communications.api.ts
@@ -389,20 +389,26 @@ export interface CreateCommunicationV2Input {
 }
 
 export async function getResidentCommunications(
+  tenantId: string,
+  buildingId: string,
+  unitId: string,
   limit?: number,
   cursor?: string,
 ): Promise<ResidentCommunicationsResponse> {
   const params = new URLSearchParams();
+  params.append('buildingId', buildingId);
+  params.append('unitId', unitId);
   if (limit) params.append('limit', String(limit));
   if (cursor) params.append('cursor', cursor);
 
-  const endpoint = `/resident/communications${params.toString() ? '?' + params.toString() : ''}`;
+  const endpoint = `/resident/communications?${params.toString()}`;
   logRequest('GET', endpoint);
 
   try {
     return await apiClient<ResidentCommunicationsResponse>({
       path: endpoint,
       method: 'GET',
+      headers: { 'X-Tenant-Id': tenantId },
     });
   } catch (error) {
     const message = `Failed to get resident communications: ${(error as Error).message}`;
@@ -411,7 +417,10 @@ export async function getResidentCommunications(
   }
 }
 
-export async function markResidentAsRead(communicationId: string): Promise<{ readAt: string | null }> {
+export async function markResidentAsRead(
+  tenantId: string,
+  communicationId: string,
+): Promise<{ readAt: string | null }> {
   const endpoint = `/resident/communications/${communicationId}/read`;
   logRequest('POST', endpoint);
 
@@ -419,6 +428,7 @@ export async function markResidentAsRead(communicationId: string): Promise<{ rea
     return await apiClient<{ readAt: string | null }>({
       path: endpoint,
       method: 'POST',
+      headers: { 'X-Tenant-Id': tenantId },
     });
   } catch (error) {
     const message = `Failed to mark as read: ${(error as Error).message}`;

--- a/apps/web/features/context/components/ContextSelector.test.tsx
+++ b/apps/web/features/context/components/ContextSelector.test.tsx
@@ -1,0 +1,58 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ContextSelector } from './ContextSelector';
+import type { ContextOption, UserContext } from '../context.types';
+
+describe('ContextSelector', () => {
+  it('auto-selects the first unit when changing building with the resident mode enabled', async () => {
+    const context: UserContext = {
+      tenantId: 'tenant-1',
+      activeBuildingId: 'building-1',
+      activeUnitId: 'unit-1',
+    };
+
+    const options: ContextOption[] = [
+      { id: 'building-1', name: 'Edificio A' },
+      { id: 'building-2', name: 'Edificio B' },
+    ];
+
+    const unitsByBuilding = {
+      'building-1': [
+        { id: 'unit-1', label: 'A-01' },
+        { id: 'unit-2', label: 'A-02' },
+      ],
+      'building-2': [
+        { id: 'unit-3', label: 'B-01' },
+        { id: 'unit-4', label: 'B-02' },
+      ],
+    };
+
+    const onBuildingChange = jest.fn().mockResolvedValue(undefined);
+    const onUnitChange = jest.fn().mockResolvedValue(undefined);
+
+    render(
+      <ContextSelector
+        tenantId="tenant-1"
+        context={context}
+        options={options}
+        unitsByBuilding={unitsByBuilding}
+        onBuildingChange={onBuildingChange}
+        onUnitChange={onUnitChange}
+        autoSelectFirstUnitOnBuildingChange
+      />,
+    );
+
+    expect(screen.getByLabelText('Edificio')).toBeTruthy();
+    expect(screen.getByLabelText('Unidad')).toBeTruthy();
+    expect(screen.getByText('Todos los edificios')).toBeTruthy();
+    expect(screen.getByText('Todas las unidades')).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Edificio'), {
+      target: { value: 'building-2' },
+    });
+
+    await waitFor(() => {
+      expect(onBuildingChange).toHaveBeenCalledWith('building-2');
+      expect(onUnitChange).toHaveBeenCalledWith('building-2', 'unit-3');
+    });
+  });
+});

--- a/apps/web/features/context/components/ContextSelector.tsx
+++ b/apps/web/features/context/components/ContextSelector.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useState } from 'react';
-import { useContextManager } from '../useContext';
 import { UserContext, ContextOption } from '../context.types';
 
 interface ContextSelectorProps {
@@ -11,6 +10,9 @@ interface ContextSelectorProps {
   unitsByBuilding: Record<string, ContextOption[]>;
   onBuildingChange: (buildingId: string | null) => Promise<void>;
   onUnitChange: (buildingId: string | null, unitId: string | null) => Promise<void>;
+  autoSelectFirstUnitOnBuildingChange?: boolean;
+  allowAllBuildings?: boolean;
+  allowAllUnits?: boolean;
   isLoading?: boolean;
 }
 
@@ -30,10 +32,15 @@ export function ContextSelector({
   unitsByBuilding,
   onBuildingChange,
   onUnitChange,
+  autoSelectFirstUnitOnBuildingChange = false,
+  allowAllBuildings = true,
+  allowAllUnits = true,
   isLoading = false,
 }: ContextSelectorProps) {
   const [error, setError] = useState<string | null>(null);
   const [isChanging, setIsChanging] = useState(false);
+  const buildingSelectId = `context-building-select-${tenantId}`;
+  const unitSelectId = `context-unit-select-${tenantId}`;
 
   const handleBuildingChange = async (buildingId: string) => {
     setError(null);
@@ -42,12 +49,17 @@ export function ContextSelector({
     try {
       const effectiveBuildingId = buildingId === '' ? null : buildingId;
       await onBuildingChange(effectiveBuildingId);
-      // Auto-clear unit when changing building
-      if (context?.activeUnitId) {
+      if (autoSelectFirstUnitOnBuildingChange) {
+        const unitsForBuilding = effectiveBuildingId
+          ? unitsByBuilding[effectiveBuildingId] || []
+          : [];
+        const firstUnit = unitsForBuilding[0] ?? null;
+        await onUnitChange(effectiveBuildingId, firstUnit?.id ?? null);
+      } else if (context?.activeUnitId) {
         await onUnitChange(effectiveBuildingId, null);
       }
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to change building';
+      const message = err instanceof Error ? err.message : 'No se pudo cambiar el edificio';
       setError(message);
     } finally {
       setIsChanging(false);
@@ -62,7 +74,7 @@ export function ContextSelector({
       const effectiveUnitId = unitId === '' ? null : unitId;
       await onUnitChange(context?.activeBuildingId || null, effectiveUnitId);
     } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to change unit';
+      const message = err instanceof Error ? err.message : 'No se pudo cambiar la unidad';
       setError(message);
     } finally {
       setIsChanging(false);
@@ -71,7 +83,7 @@ export function ContextSelector({
 
   const currentBuilding =
     options.find((b) => b.id === context?.activeBuildingId)?.name ||
-    (context?.activeBuildingId ? 'Unknown Building' : 'All Buildings');
+    (context?.activeBuildingId ? 'Edificio no encontrado' : 'Todos los edificios');
 
   const currentUnit =
     context?.activeBuildingId &&
@@ -83,23 +95,34 @@ export function ContextSelector({
     : [];
 
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex flex-wrap items-end gap-3">
       {error && (
-        <div className="text-xs text-red-600 bg-red-50 px-2 py-1 rounded">
+        <div className="text-xs text-red-700 bg-red-50 px-2 py-1 rounded dark:bg-red-950/40 dark:text-red-200">
           {error}
         </div>
       )}
 
+      <div className="w-full text-xs text-muted-foreground">
+        Contexto actual:{' '}
+        <span className="font-medium text-foreground">
+          {currentBuilding}
+          {currentUnit ? ` · ${currentUnit}` : ''}
+        </span>
+      </div>
+
       {/* Building Selector */}
       <div className="flex flex-col gap-1">
-        <label className="text-xs font-medium text-gray-600">Building</label>
+        <label htmlFor={buildingSelectId} className="text-xs font-medium text-muted-foreground">
+          Edificio
+        </label>
         <select
+          id={buildingSelectId}
           value={context?.activeBuildingId || ''}
           onChange={(e) => handleBuildingChange(e.target.value)}
           disabled={isLoading || isChanging}
-          className="px-3 py-2 border rounded text-sm bg-white disabled:bg-gray-100"
+          className="px-3 py-2 border border-border rounded text-sm bg-background text-foreground disabled:bg-muted"
         >
-          <option value="">All Buildings</option>
+          {allowAllBuildings && <option value="">Todos los edificios</option>}
           {options.map((building) => (
             <option key={building.id} value={building.id}>
               {building.name}
@@ -111,14 +134,17 @@ export function ContextSelector({
       {/* Unit Selector (only show if building selected) */}
       {context?.activeBuildingId && (
         <div className="flex flex-col gap-1">
-          <label className="text-xs font-medium text-gray-600">Unit</label>
+          <label htmlFor={unitSelectId} className="text-xs font-medium text-muted-foreground">
+            Unidad
+          </label>
           <select
+            id={unitSelectId}
             value={context?.activeUnitId || ''}
             onChange={(e) => handleUnitChange(e.target.value)}
             disabled={isLoading || isChanging}
-            className="px-3 py-2 border rounded text-sm bg-white disabled:bg-gray-100"
+            className="px-3 py-2 border border-border rounded text-sm bg-background text-foreground disabled:bg-muted"
           >
-            <option value="">All Units</option>
+            {allowAllUnits && <option value="">Todas las unidades</option>}
             {unitsForActiveBuilding.map((unit) => (
               <option key={unit.id} value={unit.id}>
                 {unit.label || unit.code}
@@ -130,7 +156,7 @@ export function ContextSelector({
 
       {/* Status indicator */}
       {isChanging && (
-        <div className="text-xs text-gray-500">Updating context...</div>
+        <div className="text-xs text-muted-foreground">Actualizando contexto...</div>
       )}
     </div>
   );

--- a/apps/web/features/resident/components/ResidentContextSwitcher.test.tsx
+++ b/apps/web/features/resident/components/ResidentContextSwitcher.test.tsx
@@ -1,0 +1,116 @@
+import type { ReactNode } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useAuthSession } from '@/features/auth/useAuthSession';
+import { useContextManager } from '@/features/context/useContext';
+import { ResidentContextSwitcher } from './ResidentContextSwitcher';
+
+jest.mock('@/features/auth/useAuthSession', () => ({
+  useAuthSession: jest.fn(),
+}));
+
+jest.mock('@/features/context/useContext', () => ({
+  useContextManager: jest.fn(),
+}));
+
+const mockedUseAuthSession = jest.mocked(useAuthSession);
+const mockedUseContextManager = jest.mocked(useContextManager);
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('ResidentContextSwitcher', () => {
+  beforeEach(() => {
+    mockedUseAuthSession.mockReset();
+    mockedUseContextManager.mockReset();
+  });
+
+  it('shows a compact summary when only one resident occupancy is available', () => {
+    mockedUseAuthSession.mockReturnValue({
+      user: { id: 'user-1', email: 'resident@test.com', name: 'Resident' },
+      memberships: [],
+      activeTenantId: 'tenant-1',
+    });
+    mockedUseContextManager.mockReturnValue({
+      context: {
+        tenantId: 'tenant-1',
+        activeBuildingId: 'building-1',
+        activeUnitId: 'unit-1',
+      },
+      options: {
+        buildings: [{ id: 'building-1', name: 'Edificio A' }],
+        unitsByBuilding: {
+          'building-1': [{ id: 'unit-1', code: 'A-01', label: 'A-01' }],
+        },
+      },
+      loading: false,
+      error: null,
+      refetch: jest.fn(),
+      setActiveBuilding: jest.fn(),
+      setActiveUnit: jest.fn(),
+    });
+
+    render(
+      <ResidentContextSwitcher tenantId="tenant-1" />,
+      { wrapper: createWrapper(new QueryClient()) },
+    );
+
+    expect(screen.getByText('Contexto activo')).toBeTruthy();
+    expect(screen.getByText('Edificio A · A-01')).toBeTruthy();
+    expect(screen.queryByLabelText('Edificio')).toBeNull();
+  });
+
+  it('invalidates resident queries after changing the selected occupancy', async () => {
+    const queryClient = new QueryClient();
+    const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries');
+    const setActiveUnit = jest.fn().mockResolvedValue(undefined);
+
+    mockedUseAuthSession.mockReturnValue({
+      user: { id: 'user-1', email: 'resident@test.com', name: 'Resident' },
+      memberships: [],
+      activeTenantId: 'tenant-1',
+    });
+    mockedUseContextManager.mockReturnValue({
+      context: {
+        tenantId: 'tenant-1',
+        activeBuildingId: 'building-1',
+        activeUnitId: 'unit-1',
+      },
+      options: {
+        buildings: [
+          { id: 'building-1', name: 'Edificio A' },
+          { id: 'building-2', name: 'Edificio B' },
+        ],
+        unitsByBuilding: {
+          'building-1': [{ id: 'unit-1', code: 'A-01', label: 'A-01' }],
+          'building-2': [
+            { id: 'unit-2', code: 'B-01', label: 'B-01' },
+            { id: 'unit-3', code: 'B-02', label: 'B-02' },
+          ],
+        },
+      },
+      loading: false,
+      error: null,
+      refetch: jest.fn(),
+      setActiveBuilding: jest.fn(),
+      setActiveUnit,
+    });
+
+    render(
+      <ResidentContextSwitcher tenantId="tenant-1" />,
+      { wrapper: createWrapper(queryClient) },
+    );
+
+    fireEvent.change(screen.getByLabelText('Edificio'), {
+      target: { value: 'building-2' },
+    });
+
+    await waitFor(() => {
+      expect(setActiveUnit).toHaveBeenCalledWith('building-2', 'unit-2');
+      expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['residentContext', 'tenant-1', 'user-1'] });
+    });
+  });
+});

--- a/apps/web/features/resident/components/ResidentContextSwitcher.tsx
+++ b/apps/web/features/resident/components/ResidentContextSwitcher.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useCallback } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { AlertCircle, Building2, Home } from 'lucide-react';
+import { useAuthSession } from '@/features/auth/useAuthSession';
+import { useContextManager } from '@/features/context/useContext';
+import { ContextSelector } from '@/features/context/components/ContextSelector';
+import Card from '@/shared/components/ui/Card';
+import Skeleton from '@/shared/components/ui/Skeleton';
+
+interface ResidentContextSwitcherProps {
+  tenantId: string;
+}
+
+function countAccessibleUnits(unitsByBuilding: Record<string, { id: string }[]>): number {
+  return Object.values(unitsByBuilding).reduce((count, units) => count + units.length, 0);
+}
+
+export function ResidentContextSwitcher({ tenantId }: ResidentContextSwitcherProps) {
+  const queryClient = useQueryClient();
+  const session = useAuthSession();
+  const userId = session?.user.id ?? null;
+  const { context, options, loading, error, refetch, setActiveUnit } = useContextManager(tenantId);
+
+  const totalUnits = countAccessibleUnits(options?.unitsByBuilding ?? {});
+
+  const selectedBuilding = (() => {
+    if (!context?.activeBuildingId) return null;
+    return options?.buildings.find((building) => building.id === context.activeBuildingId) ?? null;
+  })();
+
+  const selectedUnit = (() => {
+    if (!context?.activeBuildingId || !context?.activeUnitId) return null;
+    return options?.unitsByBuilding[context.activeBuildingId]?.find((unit) => unit.id === context.activeUnitId) ?? null;
+  })();
+
+  const invalidateResidentQueries = useCallback(async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['residentContext', tenantId, userId] }),
+      queryClient.invalidateQueries({ queryKey: ['residentLedger', tenantId, userId] }),
+      queryClient.invalidateQueries({ queryKey: ['residentPayments', tenantId, userId] }),
+      queryClient.invalidateQueries({ queryKey: ['residentDocuments', tenantId, userId] }),
+      queryClient.invalidateQueries({ queryKey: ['residentTickets', tenantId, userId] }),
+      queryClient.invalidateQueries({ queryKey: ['residentCommunications', tenantId, userId] }),
+    ]);
+  }, [queryClient, tenantId, userId]);
+
+  const handleUnitChange = useCallback(
+    async (buildingId: string | null, unitId: string | null) => {
+      await setActiveUnit(buildingId, unitId);
+      await invalidateResidentQueries();
+    },
+    [invalidateResidentQueries, setActiveUnit],
+  );
+
+  if (loading && !context && !options) {
+    return (
+      <Card className="p-4">
+        <div className="space-y-3">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-10 w-full max-w-md" />
+        </div>
+      </Card>
+    );
+  }
+
+  if (error && !options) {
+    return (
+      <Card className="border-red-200 bg-red-50 p-4 dark:border-red-900/50 dark:bg-red-950/30">
+        <div className="flex items-start gap-3">
+          <AlertCircle className="mt-0.5 text-red-600 dark:text-red-300" size={20} />
+          <div className="space-y-1">
+            <p className="font-medium text-red-800 dark:text-red-100">No pudimos cargar tu contexto residente.</p>
+            <p className="text-sm text-red-700 dark:text-red-200">
+              {error}
+            </p>
+            <button
+              type="button"
+              onClick={() => void refetch()}
+              className="text-sm font-medium text-red-700 hover:underline dark:text-red-200"
+            >
+              Reintentar
+            </button>
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  if (totalUnits <= 1) {
+    return (
+      <Card className="p-4">
+        <div className="flex items-start gap-3">
+          <div className="rounded-lg bg-primary/10 p-2 text-primary">
+            <Home size={18} />
+          </div>
+          <div className="space-y-1">
+            <p className="text-sm font-semibold text-foreground">Contexto activo</p>
+            {context?.activeUnitId && selectedBuilding && selectedUnit ? (
+              <p className="text-sm text-muted-foreground">
+                {selectedBuilding.name} · {selectedUnit.label || selectedUnit.code}
+              </p>
+            ) : (
+              <p className="text-sm text-muted-foreground">Sin unidad activa autorizada.</p>
+            )}
+            <p className="text-xs text-muted-foreground">
+              {totalUnits === 1
+                ? 'Tu portal usa una única ocupación autorizada.'
+                : 'Si se autoriza una nueva ocupación, la vas a poder elegir desde acá.'}
+            </p>
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-4">
+      <div className="mb-3 flex items-start gap-3">
+        <div className="rounded-lg bg-primary/10 p-2 text-primary">
+          <Building2 size={18} />
+        </div>
+        <div className="space-y-1">
+          <p className="text-sm font-semibold text-foreground">Elegí tu unidad activa</p>
+          <p className="text-xs text-muted-foreground">
+            El portal residente usa siempre la ocupación seleccionada. Si cambiás de unidad, los datos se actualizan en toda la pantalla.
+          </p>
+        </div>
+      </div>
+
+      <ContextSelector
+        tenantId={tenantId}
+        context={context}
+        options={options?.buildings ?? []}
+        unitsByBuilding={options?.unitsByBuilding ?? {}}
+        onBuildingChange={async () => {}}
+        onUnitChange={handleUnitChange}
+        autoSelectFirstUnitOnBuildingChange
+        allowAllBuildings={false}
+        allowAllUnits={false}
+        isLoading={loading}
+      />
+    </Card>
+  );
+}

--- a/apps/web/features/resident/hooks/useResidentLedger.ts
+++ b/apps/web/features/resident/hooks/useResidentLedger.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
+import { useAuthSession } from '@/features/auth/useAuthSession';
 import { getResidentLedger, type UnitLedger } from '../api/resident-context.api';
 
 /**
@@ -11,10 +12,13 @@ export function useResidentLedger(
   tenantId: string | null | undefined,
   unitId: string | null | undefined,
 ) {
+  const session = useAuthSession();
+  const userId = session?.user.id ?? null;
+
   return useQuery<UnitLedger>({
-    queryKey: ['residentLedger', tenantId, unitId],
+    queryKey: ['residentLedger', tenantId, userId, unitId],
     queryFn: () => getResidentLedger(tenantId!, unitId!),
-    enabled: !!tenantId && !!unitId,
+    enabled: !!tenantId && !!unitId && !!userId,
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000,
     retry: 1,

--- a/packages/contracts/src/communications.ts
+++ b/packages/contracts/src/communications.ts
@@ -47,6 +47,8 @@ export const PublishCommunicationRequestSchema = z.object({
 export type PublishCommunicationRequest = z.infer<typeof PublishCommunicationRequestSchema>;
 
 export const ResidentCommunicationsQuerySchema = z.object({
+  buildingId: z.string().min(1),
+  unitId: z.string().min(1),
   limit: z.coerce.number().min(1).max(100).default(20),
   cursor: z.string().optional(),
 });


### PR DESCRIPTION
## Resumen

Implementa el contexto multiunidad para residentes con más de una ocupación activa.

Closes #53

## Cambios principales

- lista únicamente ocupaciones activas y autorizadas del residente;
- incorpora un selector de edificio/unidad en el portal residente;
- conserva la selección durante la navegación;
- aplica un fallback seguro cuando el contexto seleccionado deja de ser válido;
- revalida el tenant, usuario y ocupación en backend;
- incorpora el contexto seleccionado en dashboard, pagos, documentos, tickets y ledger;
- incluye tenant, usuario, edificio y unidad en las claves de caché relevantes;
- mantiene sin fricción el flujo de residentes con una sola ocupación;
- no utiliza `location.reload()`.

## Seguridad

- no confía en IDs enviados por el cliente sin validación;
- impide seleccionar ocupaciones ajenas o inactivas;
- no amplía permisos administrativos;
- no incorpora migraciones ni cambios de schema.

## Validaciones realizadas

### Backend

- `context.service.spec.ts`
- `resident-access.service.spec.ts`
- 2 suites / 9 tests aprobados
- build NestJS aprobado
- ESLint focalizado aprobado

### Frontend

- `ContextSelector.test.tsx`
- `ResidentContextSwitcher.test.tsx`
- 2 suites / 3 tests aprobados
- TypeScript aprobado
- ESLint focalizado aprobado
- build Next.js de producción aprobado

## Fuera de alcance

- perfil editable del residente;
- asistente del residente;
- configuración Web Push/VAPID;
- producción.
