### PR TITLE
fix(web): improve resident dark mode contrast

### DIFF
--- a/apps/web/app/(tenant)/[tenantId]/resident/announcements/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/announcements/page.tsx
@@ -10,6 +10,7 @@ import { useTenantId } from '@/features/tenancy/tenant.hooks';
 import { useResidentContext } from '@/features/resident/hooks/useResidentContext';
 import { BuildingIcon, Bell, CheckCircle2, Circle, Loader2, AlertCircle } from 'lucide-react';
 import Card from '@/shared/components/ui/Card';
+import Badge from '@/shared/components/ui/Badge';
 
 const ResidentAnnouncementsPage = () => {
   const tenantId = useTenantId();
@@ -174,12 +175,12 @@ const ResidentAnnouncementsPage = () => {
 
   if (error) {
     return (
-      <Card className="p-6 border-red-200 bg-red-50">
+      <Card className="p-6 border-red-200 bg-red-50 dark:border-red-900/60 dark:bg-red-950/40">
         <div className="flex items-start gap-3">
-          <AlertCircle className="text-red-600 mt-0.5" size={20} />
+          <AlertCircle className="text-red-600 dark:text-red-400 mt-0.5" size={20} />
           <div className="space-y-1">
-            <p className="font-medium text-red-800">No pudimos cargar los comunicados</p>
-            <p className="text-sm text-red-700">{error}</p>
+            <p className="font-medium text-red-800 dark:text-red-200">No pudimos cargar los comunicados</p>
+            <p className="text-sm text-red-700 dark:text-red-300">{error}</p>
           </div>
         </div>
         <button
@@ -208,13 +209,13 @@ const ResidentAnnouncementsPage = () => {
       </div>
 
       {markReadError && (
-        <Card className="p-4 mb-4 border-amber-200 bg-amber-50">
-          <p className="text-sm text-amber-800">{markReadError}</p>
-          <button
-            type="button"
-            onClick={() => setMarkReadError(null)}
-            className="mt-2 text-sm font-medium text-amber-800 hover:underline"
-          >
+      <Card className="p-4 mb-4 border-amber-200 bg-amber-50 dark:border-amber-900/60 dark:bg-amber-950/40">
+        <p className="text-sm text-amber-800 dark:text-amber-200">{markReadError}</p>
+        <button
+          type="button"
+          onClick={() => setMarkReadError(null)}
+          className="mt-2 text-sm font-medium text-amber-800 hover:underline dark:text-amber-200"
+        >
             Cerrar
           </button>
         </Card>
@@ -260,9 +261,7 @@ const ResidentAnnouncementsPage = () => {
                         <span>{formatDate(comm.publishedAt)}</span>
                       )}
                       {comm.priority === 'URGENT' && (
-                        <span className="px-2 py-0.5 bg-red-100 text-red-700 rounded text-xs font-medium">
-                          Urgente
-                        </span>
+                        <Badge variant="danger">Urgente</Badge>
                       )}
                       {comm.scopeType === 'BUILDING' && comm.buildingIds.length > 0 && (
                         <span className="flex items-center gap-1">

--- a/apps/web/app/(tenant)/[tenantId]/resident/documents/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/documents/page.tsx
@@ -19,6 +19,7 @@ import { useContextOptions } from '../../../../../features/context/useContextOpt
 import { useAuthSession } from '../../../../../features/auth/useAuthSession';
 import { useTenants } from '../../../../../features/tenants/tenants.hooks';
 import Card from '../../../../../shared/components/ui/Card';
+import Badge, { type BadgeVariant } from '../../../../../shared/components/ui/Badge';
 import Skeleton from '../../../../../shared/components/ui/Skeleton';
 import {
   Document,
@@ -56,11 +57,11 @@ const PAYMENT_STATUS_LABELS: Record<string, string> = {
   RECONCILED: 'Conciliado',
 };
 
-const PAYMENT_STATUS_STYLES: Record<string, string> = {
-  SUBMITTED: 'bg-yellow-100 text-yellow-800',
-  APPROVED: 'bg-green-100 text-green-800',
-  REJECTED: 'bg-red-100 text-red-800',
-  RECONCILED: 'bg-blue-100 text-blue-800',
+const PAYMENT_STATUS_VARIANTS: Record<string, BadgeVariant> = {
+  SUBMITTED: 'warning',
+  APPROVED: 'success',
+  REJECTED: 'danger',
+  RECONCILED: 'info',
 };
 
 function formatDate(dateValue: string): string {
@@ -430,12 +431,12 @@ export default function ResidentDocumentsPage() {
         </h1>
         <p className="mt-1 text-muted-foreground">{tenantName}</p>
 
-        <Card className="mt-6 border-yellow-300 bg-yellow-50 p-4">
+        <Card className="mt-6 border-yellow-300 bg-yellow-50 p-4 dark:border-yellow-900/60 dark:bg-yellow-950/40">
           <div className="flex items-center gap-2">
-            <AlertCircle className="text-yellow-600" size={20} />
+            <AlertCircle className="text-yellow-600 dark:text-yellow-400" size={20} />
             <div>
-              <p className="font-medium text-yellow-800">Sin unidad asignada</p>
-              <p className="text-sm text-yellow-700">Comunicate con la administración para que te asignen una unidad.</p>
+              <p className="font-medium text-yellow-800 dark:text-yellow-200">Sin unidad asignada</p>
+              <p className="text-sm text-yellow-700 dark:text-yellow-300">Comunicate con la administración para que te asignen una unidad.</p>
             </div>
           </div>
         </Card>
@@ -457,16 +458,16 @@ export default function ResidentDocumentsPage() {
       </div>
 
       {listErrorMessage && (
-        <Card className="border-red-200 bg-red-50 p-4">
+        <Card className="border-red-200 bg-red-50 p-4 dark:border-red-900/60 dark:bg-red-950/40">
           <div className="flex items-start gap-3">
-            <AlertCircle className="mt-0.5 text-red-600" size={20} />
+            <AlertCircle className="mt-0.5 text-red-600 dark:text-red-400" size={20} />
             <div className="space-y-1">
-              <p className="font-medium text-red-800">No pudimos cargar los documentos</p>
-              <p className="text-sm text-red-700">{listErrorMessage}</p>
+              <p className="font-medium text-red-800 dark:text-red-200">No pudimos cargar los documentos</p>
+              <p className="text-sm text-red-700 dark:text-red-300">{listErrorMessage}</p>
               <button
                 type="button"
                 onClick={() => void refetch()}
-                className="text-sm font-medium text-red-700 hover:underline"
+                className="text-sm font-medium text-red-700 hover:underline dark:text-red-300"
               >
                 Reintentar
               </button>
@@ -476,23 +477,23 @@ export default function ResidentDocumentsPage() {
       )}
 
       {openError && (
-        <Card className="border-red-200 bg-red-50 p-4">
+        <Card className="border-red-200 bg-red-50 p-4 dark:border-red-900/60 dark:bg-red-950/40">
           <div className="flex items-start gap-3">
-            <AlertCircle className="mt-0.5 text-red-600" size={20} />
+            <AlertCircle className="mt-0.5 text-red-600 dark:text-red-400" size={20} />
             <div className="space-y-1">
-              <p className="font-medium text-red-800">
+              <p className="font-medium text-red-800 dark:text-red-200">
                 {openErrorDocumentTitle
                   ? `No pudimos abrir "${openErrorDocumentTitle}"`
                   : 'No pudimos abrir el documento'}
               </p>
-              <p className="text-sm text-red-700">{openError}</p>
+              <p className="text-sm text-red-700 dark:text-red-300">{openError}</p>
               <button
                 type="button"
                 onClick={() => {
                   setOpenError(null);
                   setOpenErrorDocumentTitle(null);
                 }}
-                className="text-sm font-medium text-red-700 hover:underline"
+                className="text-sm font-medium text-red-700 hover:underline dark:text-red-300"
               >
                 Cerrar
               </button>
@@ -628,13 +629,9 @@ export default function ResidentDocumentsPage() {
                             {formatCurrency(document.payment.amount, document.payment.currency)}
                           </span>
                           {document.payment.status && (
-                            <span
-                              className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
-                                PAYMENT_STATUS_STYLES[document.payment.status] ?? 'bg-gray-100 text-gray-800'
-                              }`}
-                            >
+                            <Badge variant={PAYMENT_STATUS_VARIANTS[document.payment.status] ?? 'muted'}>
                               {PAYMENT_STATUS_LABELS[document.payment.status] ?? document.payment.status}
-                            </span>
+                            </Badge>
                           )}
                           {document.payment.period && (
                             <span className="text-muted-foreground">

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
@@ -813,4 +813,73 @@ describe('ResidentPaymentsPage', () => {
     expect(screen.getByText(/El archivo supera el máximo/)).toBeTruthy();
     expect(mockedSubmitPayment).not.toHaveBeenCalled();
   });
+
+  it('uses text-foreground for KPI values instead of text-gray-900', async () => {
+    mockedGetResidentLedger.mockResolvedValueOnce(
+      makeLedger({
+        charges: [
+          makeCharge({ dueDate: '2026-08-15', amount: 5000 }),
+        ],
+        totals: { balance: 5000, currency: 'ARS', totalCharges: 5000, totalPaid: 0, totalAllocated: 0 },
+      }),
+    );
+    mockedListPayments.mockResolvedValueOnce([
+      makePayment({ id: 'pay-last', amount: 3000, paidAt: '2026-07-20', status: PaymentStatus.APPROVED }),
+    ]);
+
+    const Wrapper = createWrapper();
+    const { container } = render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    await screen.findByText('Historial de pagos');
+
+    const kpiElements = container.querySelectorAll('.text-foreground');
+    expect(kpiElements.length).toBeGreaterThanOrEqual(2);
+
+    const gray900Elements = container.querySelectorAll('.text-gray-900');
+    expect(gray900Elements).toHaveLength(0);
+  });
+
+  it('does not use text-black in KPI elements', async () => {
+    mockedGetResidentLedger.mockResolvedValueOnce(makeLedger());
+    mockedListPayments.mockResolvedValueOnce([]);
+
+    const Wrapper = createWrapper();
+    const { container } = render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    await screen.findByText('Historial de pagos');
+
+    const blackElements = container.querySelectorAll('.text-black');
+    expect(blackElements).toHaveLength(0);
+  });
+
+  it('renders payment status badges with semantic variant classes', async () => {
+    mockedGetResidentLedger.mockResolvedValueOnce(makeLedger());
+    mockedListPayments.mockResolvedValueOnce([
+      makePayment({ id: 'pay-sub', status: PaymentStatus.SUBMITTED }),
+      makePayment({ id: 'pay-apr', status: PaymentStatus.APPROVED }),
+      makePayment({ id: 'pay-rej', status: PaymentStatus.REJECTED }),
+      makePayment({ id: 'pay-rec', status: PaymentStatus.RECONCILED }),
+    ]);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    await screen.findByText('Historial de pagos');
+
+    const submittedBadge = screen.getByText('Enviado');
+    expect(submittedBadge.className).toContain('bg-amber-100');
+    expect(submittedBadge.className).toContain('dark:bg-amber-950/40');
+
+    const approvedBadge = screen.getByText('Aprobado');
+    expect(approvedBadge.className).toContain('bg-green-100');
+    expect(approvedBadge.className).toContain('dark:bg-green-950/40');
+
+    const rejectedBadge = screen.getByText('Rechazado');
+    expect(rejectedBadge.className).toContain('bg-red-100');
+    expect(rejectedBadge.className).toContain('dark:bg-red-950/40');
+
+    const reconciledBadge = screen.getByText('Conciliado');
+    expect(reconciledBadge.className).toContain('bg-blue-100');
+    expect(reconciledBadge.className).toContain('dark:bg-blue-950/40');
+  });
 });

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
@@ -29,6 +29,7 @@ import Card from '@/shared/components/ui/Card';
 import Input from '@/shared/components/ui/Input';
 import Select from '@/shared/components/ui/Select';
 import Button from '@/shared/components/ui/Button';
+import Badge, { type BadgeVariant } from '@/shared/components/ui/Badge';
 import Skeleton from '@/shared/components/ui/Skeleton';
 import { formatCurrency, getLocaleForCurrency } from '@/shared/lib/format/money';
 
@@ -91,14 +92,14 @@ function paymentStatusLabel(status: string): string {
   return labels[status] ?? status;
 }
 
-function paymentStatusColor(status: string): string {
-  const colors: Record<string, string> = {
-    SUBMITTED: 'bg-yellow-100 text-yellow-700 border-yellow-200',
-    APPROVED: 'bg-green-100 text-green-700 border-green-200',
-    REJECTED: 'bg-red-100 text-red-700 border-red-200',
-    RECONCILED: 'bg-blue-100 text-blue-700 border-blue-200',
+function paymentStatusVariant(status: string): BadgeVariant {
+  const variants: Record<string, BadgeVariant> = {
+    SUBMITTED: 'warning',
+    APPROVED: 'success',
+    REJECTED: 'danger',
+    RECONCILED: 'info',
   };
-  return colors[status] ?? 'bg-muted text-muted-foreground border-border';
+  return variants[status] ?? 'muted';
 }
 
 interface PaymentFormData {
@@ -773,7 +774,7 @@ export const ResidentPaymentsPage = () => {
             <DollarSign className="text-blue-500 mt-0.5" size={22} />
             <div>
               <p className="text-sm font-medium text-muted-foreground">Próximo vencimiento</p>
-              <p className="text-2xl font-bold text-gray-900">
+              <p className="text-2xl font-bold text-foreground">
                 {nextDueCharge ? formatPaymentDisplayDate(nextDueCharge.dueDate) : '—'}
               </p>
               {nextDueCharge && (
@@ -790,7 +791,7 @@ export const ResidentPaymentsPage = () => {
             <CreditCard className="text-green-500 mt-0.5" size={22} />
             <div>
               <p className="text-sm font-medium text-muted-foreground">Último pago</p>
-              <p className="text-2xl font-bold text-gray-900">
+              <p className="text-2xl font-bold text-foreground">
                 {lastPayment ? formatCurrency(lastPayment.amount, lastPayment.currency, getLocaleForCurrency(lastPayment.currency)) : '—'}
               </p>
               {lastPayment && (
@@ -942,9 +943,9 @@ export const ResidentPaymentsPage = () => {
                         Ver recibo
                       </button>
                     ) : null}
-                    <span className={`px-2 py-1 rounded text-xs font-medium border whitespace-nowrap ${paymentStatusColor(payment.status)}`}>
+                    <Badge variant={paymentStatusVariant(payment.status)} className="whitespace-nowrap">
                       {paymentStatusLabel(payment.status)}
-                    </span>
+                    </Badge>
                   </div>
                 </div>
               );

--- a/apps/web/app/(tenant)/[tenantId]/resident/tickets/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/tickets/page.tsx
@@ -21,6 +21,7 @@ import { ticketCategoryLabel } from '../../../../../features/tickets/ticket-labe
 import { useTenants } from '../../../../../features/tenants/tenants.hooks';
 import { useAuthSession } from '../../../../../features/auth/useAuthSession';
 import Card from '../../../../../shared/components/ui/Card';
+import Badge, { type BadgeVariant } from '../../../../../shared/components/ui/Badge';
 import Skeleton from '../../../../../shared/components/ui/Skeleton';
 import { ticketDetailPath } from '../../../../../shared/lib/routes';
 
@@ -44,24 +45,24 @@ function priorityLabel(priority: Ticket['priority']): string {
   return labels[priority] ?? priority;
 }
 
-function priorityColor(priority: Ticket['priority']): string {
-  const colors: Record<Ticket['priority'], string> = {
-    LOW: 'bg-gray-100 text-gray-700',
-    MEDIUM: 'bg-blue-100 text-blue-700',
-    HIGH: 'bg-orange-100 text-orange-700',
-    URGENT: 'bg-red-100 text-red-700',
+function priorityVariant(priority: Ticket['priority']): BadgeVariant {
+  const variants: Record<Ticket['priority'], BadgeVariant> = {
+    LOW: 'muted',
+    MEDIUM: 'info',
+    HIGH: 'warning',
+    URGENT: 'danger',
   };
-  return colors[priority] ?? 'bg-gray-100 text-gray-700';
+  return variants[priority] ?? 'muted';
 }
 
 function statusColor(status: Ticket['status']): string {
   const colors: Record<Ticket['status'], string> = {
-    OPEN: 'text-orange-600',
-    IN_PROGRESS: 'text-blue-600',
-    RESOLVED: 'text-green-600',
-    CLOSED: 'text-gray-600',
+    OPEN: 'text-orange-600 dark:text-orange-400',
+    IN_PROGRESS: 'text-blue-600 dark:text-blue-400',
+    RESOLVED: 'text-green-600 dark:text-green-400',
+    CLOSED: 'text-gray-600 dark:text-gray-400',
   };
-  return colors[status] ?? 'text-gray-600';
+  return colors[status] ?? 'text-gray-600 dark:text-gray-400';
 }
 
 function formatDate(dateStr: string | undefined): string {
@@ -187,15 +188,15 @@ export default function ResidentTicketsPage() {
         </h1>
         <p className="text-muted-foreground mt-1">{tenantName}</p>
         
-        <Card className="p-4 mt-6 border-yellow-300 bg-yellow-50">
-          <div className="flex items-center gap-2">
-            <AlertCircle className="text-yellow-600" size={20} />
-            <div>
-              <p className="font-medium text-yellow-800">Sin unidad asignada</p>
-              <p className="text-sm text-yellow-700">Comunicate con la administración para que te asignen una unidad.</p>
-            </div>
+      <Card className="p-4 mt-6 border-yellow-300 bg-yellow-50 dark:border-yellow-900/60 dark:bg-yellow-950/40">
+        <div className="flex items-center gap-2">
+          <AlertCircle className="text-yellow-600 dark:text-yellow-400" size={20} />
+          <div>
+            <p className="font-medium text-yellow-800 dark:text-yellow-200">Sin unidad asignada</p>
+            <p className="text-sm text-yellow-700 dark:text-yellow-300">Comunicate con la administración para que te asignen una unidad.</p>
           </div>
-        </Card>
+        </div>
+      </Card>
       </div>
     );
   }
@@ -276,11 +277,11 @@ export default function ResidentTicketsPage() {
               </div>
             </div>
             {error && (
-              <p id="resident-ticket-error" className="text-red-600 text-sm" aria-live="polite">
+              <p id="resident-ticket-error" className="text-red-600 dark:text-red-400 text-sm" aria-live="polite">
                 {error}
               </p>
             )}
-            {success && <p className="text-green-600 text-sm" aria-live="polite">{success}</p>}
+            {success && <p className="text-green-600 dark:text-green-400 text-sm" aria-live="polite">{success}</p>}
             <div className="flex gap-2">
               <button
                 type="submit"
@@ -309,18 +310,18 @@ export default function ResidentTicketsPage() {
       )}
 
       {(ticketsError || ticketsErrorValue) && (
-        <Card className="p-4 mb-6 border-red-200 bg-red-50">
+        <Card className="p-4 mb-6 border-red-200 bg-red-50 dark:border-red-900/60 dark:bg-red-950/40">
           <div className="flex items-start gap-3">
-            <AlertCircle className="text-red-600 mt-0.5" size={20} />
+            <AlertCircle className="text-red-600 dark:text-red-400 mt-0.5" size={20} />
             <div className="space-y-1">
-              <p className="font-medium text-red-800">No pudimos cargar tus reclamos</p>
-              <p className="text-sm text-red-700">
+              <p className="font-medium text-red-800 dark:text-red-200">No pudimos cargar tus reclamos</p>
+              <p className="text-sm text-red-700 dark:text-red-300">
                 {ticketsErrorValue instanceof Error ? ticketsErrorValue.message : 'Intentá nuevamente en unos segundos.'}
               </p>
               <button
                 type="button"
                 onClick={() => refetch()}
-                className="text-sm font-medium text-red-700 hover:underline"
+                className="text-sm font-medium text-red-700 hover:underline dark:text-red-300"
               >
                 Reintentar
               </button>
@@ -356,9 +357,9 @@ export default function ResidentTicketsPage() {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-1">
                       <h3 className="font-medium truncate">{ticket.title}</h3>
-                      <span className={`px-2 py-0.5 rounded text-xs font-medium ${priorityColor(ticket.priority)}`}>
+                      <Badge variant={priorityVariant(ticket.priority)}>
                         {priorityLabel(ticket.priority)}
-                      </span>
+                      </Badge>
                     </div>
                     <p className="text-sm text-muted-foreground line-clamp-2">{ticket.description}</p>
                     <div className="flex items-center gap-4 mt-2 text-xs text-muted-foreground">

--- a/apps/web/app/(tenant)/[tenantId]/resident/unit/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/unit/page.tsx
@@ -7,8 +7,6 @@ import {
   User,
   Users,
   AlertCircle,
-  CheckCircle,
-  Loader2,
   Building2,
 } from 'lucide-react';
 import { useResidentContext } from '../../../../../features/resident/hooks/useResidentContext';
@@ -16,6 +14,7 @@ import { useContextOptions } from '../../../../../features/context/useContextOpt
 import { getUnit, type Unit } from '../../../../../features/units/units.api';
 import { useTenants } from '../../../../../features/tenants/tenants.hooks';
 import Card from '../../../../../shared/components/ui/Card';
+import Badge, { type BadgeVariant } from '../../../../../shared/components/ui/Badge';
 import Skeleton from '../../../../../shared/components/ui/Skeleton';
 
 function unitTypeLabel(type: Unit['unitType']): string {
@@ -39,13 +38,13 @@ function occupancyStatusLabel(status: Unit['occupancyStatus']): string {
   return labels[status] ?? status;
 }
 
-function occupancyStatusColor(status: Unit['occupancyStatus']): string {
-  const colors: Record<Unit['occupancyStatus'], string> = {
-    OCCUPIED: 'bg-green-100 text-green-700 border-green-200',
-    VACANT: 'bg-yellow-100 text-yellow-700 border-yellow-200',
-    UNKNOWN: 'bg-gray-100 text-gray-700 border-gray-200',
+function occupancyStatusVariant(status: Unit['occupancyStatus']): BadgeVariant {
+  const variants: Record<Unit['occupancyStatus'], BadgeVariant> = {
+    OCCUPIED: 'success',
+    VACANT: 'warning',
+    UNKNOWN: 'muted',
   };
-  return colors[status] ?? 'bg-gray-100 text-gray-700 border-gray-200';
+  return variants[status] ?? 'muted';
 }
 
 function roleLabel(role: 'OWNER' | 'RESIDENT'): string {
@@ -99,12 +98,12 @@ export default function ResidentUnitPage() {
         </h1>
         <p className="text-muted-foreground mt-1">{tenantName}</p>
 
-        <Card className="p-4 mt-6 border-yellow-300 bg-yellow-50">
+        <Card className="p-4 mt-6 border-yellow-300 bg-yellow-50 dark:border-yellow-900/60 dark:bg-yellow-950/40">
           <div className="flex items-center gap-2">
-            <AlertCircle className="text-yellow-600" size={20} />
+            <AlertCircle className="text-yellow-600 dark:text-yellow-400" size={20} />
             <div>
-              <p className="font-medium text-yellow-800">Sin unidad asignada</p>
-              <p className="text-sm text-yellow-700">Comunicate con la administración para que te asignen una unidad.</p>
+              <p className="font-medium text-yellow-800 dark:text-yellow-200">Sin unidad asignada</p>
+              <p className="text-sm text-yellow-700 dark:text-yellow-300">Comunicate con la administración para que te asignen una unidad.</p>
             </div>
           </div>
         </Card>
@@ -164,9 +163,9 @@ export default function ResidentUnitPage() {
           </div>
           <div>
             <p className="text-sm text-muted-foreground">Estado de ocupación</p>
-            <span className={`inline-block px-2 py-1 rounded text-sm font-medium border ${unit?.occupancyStatus ? occupancyStatusColor(unit.occupancyStatus) : ''}`}>
+            <Badge variant={unit?.occupancyStatus ? occupancyStatusVariant(unit.occupancyStatus) : 'muted'} className="text-sm">
               {unit?.occupancyStatus ? occupancyStatusLabel(unit.occupancyStatus) : '—'}
-            </span>
+            </Badge>
           </div>
           <div>
             <p className="text-sm text-muted-foreground">Categoría</p>
@@ -209,13 +208,13 @@ export default function ResidentUnitPage() {
                     )}
                   </div>
                 </div>
-                <span className={`px-2 py-1 rounded text-xs font-medium ${
-                  occupant.role === 'OWNER'
-                    ? 'bg-purple-100 text-purple-700'
-                    : 'bg-blue-100 text-blue-700'
-                }`}>
-                  {roleLabel(occupant.role)}
-                </span>
+                {occupant.role === 'OWNER' ? (
+                  <span className="px-2 py-1 rounded text-xs font-medium bg-purple-100 text-purple-700 dark:bg-purple-950/40 dark:text-purple-300">
+                    {roleLabel(occupant.role)}
+                  </span>
+                ) : (
+                  <Badge variant="info">{roleLabel(occupant.role)}</Badge>
+                )}
               </div>
             ))}
           </div>

--- a/apps/web/shared/components/ui/Badge.test.tsx
+++ b/apps/web/shared/components/ui/Badge.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import Badge from './Badge';
+
+describe('Badge', () => {
+  it('renders children text', () => {
+    render(<Badge>Active</Badge>);
+    expect(screen.getByText('Active')).toBeTruthy();
+  });
+
+  it('applies default variant classes', () => {
+    render(<Badge>Default</Badge>);
+    const badge = screen.getByText('Default');
+    expect(badge.className).toContain('bg-muted');
+    expect(badge.className).toContain('text-muted-foreground');
+  });
+
+  it('applies success variant classes', () => {
+    render(<Badge variant="success">Success</Badge>);
+    const badge = screen.getByText('Success');
+    expect(badge.className).toContain('bg-green-100');
+    expect(badge.className).toContain('text-green-800');
+    expect(badge.className).toContain('dark:bg-green-950/40');
+    expect(badge.className).toContain('dark:text-green-300');
+  });
+
+  it('applies warning variant classes', () => {
+    render(<Badge variant="warning">Warning</Badge>);
+    const badge = screen.getByText('Warning');
+    expect(badge.className).toContain('bg-amber-100');
+    expect(badge.className).toContain('text-amber-800');
+    expect(badge.className).toContain('dark:bg-amber-950/40');
+    expect(badge.className).toContain('dark:text-amber-300');
+  });
+
+  it('applies danger variant classes', () => {
+    render(<Badge variant="danger">Danger</Badge>);
+    const badge = screen.getByText('Danger');
+    expect(badge.className).toContain('bg-red-100');
+    expect(badge.className).toContain('text-red-800');
+    expect(badge.className).toContain('dark:bg-red-950/40');
+    expect(badge.className).toContain('dark:text-red-300');
+  });
+
+  it('applies info variant classes', () => {
+    render(<Badge variant="info">Info</Badge>);
+    const badge = screen.getByText('Info');
+    expect(badge.className).toContain('bg-blue-100');
+    expect(badge.className).toContain('text-blue-800');
+    expect(badge.className).toContain('dark:bg-blue-950/40');
+    expect(badge.className).toContain('dark:text-blue-300');
+  });
+
+  it('applies muted variant classes', () => {
+    render(<Badge variant="muted">Muted</Badge>);
+    const badge = screen.getByText('Muted');
+    expect(badge.className).toContain('bg-muted');
+    expect(badge.className).toContain('text-muted-foreground');
+  });
+
+  it('merges additional className without adding default variant classes', () => {
+    render(<Badge className="extra-class">Extra</Badge>);
+    const badge = screen.getByText('Extra');
+    expect(badge.className).toContain('extra-class');
+    expect(badge.className).toContain('inline-flex');
+    expect(badge.className).not.toContain('bg-muted');
+    expect(badge.className).not.toContain('text-muted-foreground');
+  });
+
+  it('does not add default variant classes when only className is provided (legacy behavior)', () => {
+    render(<Badge className="bg-purple-100 text-purple-700">Legacy</Badge>);
+    const badge = screen.getByText('Legacy');
+    expect(badge.className).toContain('bg-purple-100');
+    expect(badge.className).toContain('text-purple-700');
+    expect(badge.className).not.toContain('bg-muted');
+    expect(badge.className).not.toContain('text-muted-foreground');
+    expect(badge.className).not.toContain('border-border');
+  });
+
+  it('applies variant classes and merges className when both are provided', () => {
+    render(<Badge variant="info" className="whitespace-nowrap">Info</Badge>);
+    const badge = screen.getByText('Info');
+    expect(badge.className).toContain('bg-blue-100');
+    expect(badge.className).toContain('text-blue-800');
+    expect(badge.className).toContain('dark:bg-blue-950/40');
+    expect(badge.className).toContain('whitespace-nowrap');
+  });
+
+  it('renders as a span element', () => {
+    render(<Badge>Span</Badge>);
+    const badge = screen.getByText('Span');
+    expect(badge.tagName).toBe('SPAN');
+  });
+});

--- a/apps/web/shared/components/ui/Badge.tsx
+++ b/apps/web/shared/components/ui/Badge.tsx
@@ -1,6 +1,38 @@
- export default function Badge({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+export type BadgeVariant = 'default' | 'success' | 'warning' | 'danger' | 'info' | 'muted';
+
+const variantClasses: Record<BadgeVariant, string> = {
+  default: 'bg-muted text-muted-foreground border border-border',
+  success:
+    'bg-green-100 text-green-800 border border-green-200 dark:bg-green-950/40 dark:text-green-300 dark:border-green-900/60',
+  warning:
+    'bg-amber-100 text-amber-800 border border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-900/60',
+  danger:
+    'bg-red-100 text-red-800 border border-red-200 dark:bg-red-950/40 dark:text-red-300 dark:border-red-900/60',
+  info:
+    'bg-blue-100 text-blue-800 border border-blue-200 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-900/60',
+  muted: 'bg-muted text-muted-foreground border border-border',
+};
+
+interface BadgeProps {
+  children: React.ReactNode;
+  className?: string;
+  variant?: BadgeVariant;
+}
+
+export default function Badge({
+  children,
+  className = '',
+  variant,
+}: BadgeProps) {
+  const paletteClasses = variant
+    ? variantClasses[variant]
+    : className
+      ? ''
+      : variantClasses.default;
   return (
-    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${className || "bg-muted text-muted-foreground border border-border"}`}>
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${paletteClasses} ${className}`}
+    >
       {children}
     </span>
   );

--- a/apps/web/shared/components/ui/ErrorState.test.tsx
+++ b/apps/web/shared/components/ui/ErrorState.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ErrorState from './ErrorState';
+
+describe('ErrorState', () => {
+  it('renders the error message', () => {
+    render(<ErrorState message="Something failed" />);
+    expect(screen.getByText('Something failed')).toBeTruthy();
+  });
+
+  it('renders the title', () => {
+    render(<ErrorState message="Error" />);
+    expect(screen.getByText('Something went wrong')).toBeTruthy();
+  });
+
+  it('applies dark mode classes on the card container', () => {
+    const { container } = render(<ErrorState message="Error" />);
+    const card = container.querySelector('.dark\\:border-red-900\\/60');
+    expect(card).toBeTruthy();
+  });
+
+  it('applies dark mode classes on the icon', () => {
+    const { container } = render(<ErrorState message="Error" />);
+    const icon = container.querySelector('.dark\\:text-red-400');
+    expect(icon).toBeTruthy();
+  });
+
+  it('applies dark mode classes on the title', () => {
+    const { container } = render(<ErrorState message="Error" />);
+    const title = container.querySelector('.dark\\:text-red-100');
+    expect(title).toBeTruthy();
+  });
+
+  it('applies dark mode classes on the message', () => {
+    const { container } = render(<ErrorState message="Error" />);
+    const message = container.querySelector('.dark\\:text-red-200');
+    expect(message).toBeTruthy();
+  });
+
+  it('does not render retry button when onRetry is not provided', () => {
+    render(<ErrorState message="Error" />);
+    expect(screen.queryByRole('button', { name: /try again/i })).toBeNull();
+  });
+
+  it('renders retry button when onRetry is provided', () => {
+    const onRetry = jest.fn();
+    render(<ErrorState message="Error" onRetry={onRetry} />);
+    const button = screen.getByRole('button', { name: /try again/i });
+    expect(button).toBeTruthy();
+  });
+
+  it('calls onRetry when retry button is clicked', () => {
+    const onRetry = jest.fn();
+    render(<ErrorState message="Error" onRetry={onRetry} />);
+    const button = screen.getByRole('button', { name: /try again/i });
+    fireEvent.click(button);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows Retrying... text and disables button when isRetrying is true', () => {
+    const onRetry = jest.fn();
+    render(<ErrorState message="Error" onRetry={onRetry} isRetrying />);
+    const button = screen.getByRole('button', { name: /retrying/i });
+    expect(button).toBeTruthy();
+    expect(button.getAttribute('disabled')).not.toBeNull();
+  });
+});

--- a/apps/web/shared/components/ui/ErrorState.tsx
+++ b/apps/web/shared/components/ui/ErrorState.tsx
@@ -17,15 +17,15 @@ export default function ErrorState({
 }: ErrorStateProps) {
   return (
     <div className="flex items-center justify-center min-h-[200px]">
-      <Card className="w-full max-w-md border-red-200 bg-red-50">
+      <Card className="w-full max-w-md border-red-200 bg-red-50 dark:border-red-900/60 dark:bg-red-950/40">
         <div className="text-center">
           <div className="mb-4 flex justify-center">
-            <AlertCircle className="text-red-600" size={32} />
+            <AlertCircle className="text-red-600 dark:text-red-400" size={32} />
           </div>
-          <h3 className="text-lg font-semibold text-red-900 mb-2">
+          <h3 className="text-lg font-semibold text-red-900 dark:text-red-100 mb-2">
             Something went wrong
           </h3>
-          <p className="text-sm text-red-700 mb-6">{message}</p>
+          <p className="text-sm text-red-700 dark:text-red-200 mb-6">{message}</p>
           {onRetry && (
             <Button
               onClick={onRetry}


### PR DESCRIPTION
## Summary

- fixes low-contrast resident payment KPIs in dark mode;
- adds semantic, backward-compatible `Badge` variants;
- hardens shared `ErrorState` contrast;
- updates resident payments, documents, announcements, tickets, and unit surfaces for light/dark readability;
- preserves legacy `Badge className` behavior to avoid regressions outside the resident portal.

## Validation

- 41 focused tests passing;
- TypeScript clean;
- ESLint clean with `--max-warnings=0`;
- `apps/web` production build passing;
- `git diff --check` clean.

## Scope

- `apps/web` only;
- no API, Prisma, schema, migrations, or business-logic changes;
- no production deployment.

Closes #64