### PR TITLE
fix(web): make resident shell responsive

### DIFF
--- a/apps/web/features/context/components/ContextSelector.test.tsx
+++ b/apps/web/features/context/components/ContextSelector.test.tsx
@@ -55,4 +55,48 @@ describe('ContextSelector', () => {
       expect(onUnitChange).toHaveBeenCalledWith('building-2', 'unit-3');
     });
   });
+
+  it('keeps mobile controls contained and preserves callbacks with long labels', async () => {
+    const onBuildingChange = jest.fn().mockResolvedValue(undefined);
+    const onUnitChange = jest.fn().mockResolvedValue(undefined);
+    const longBuildingName = 'Edificio Residencial con una denominación muy larga para una pantalla móvil';
+
+    const { container } = render(
+      <ContextSelector
+        tenantId="tenant-1"
+        context={{ tenantId: 'tenant-1', activeBuildingId: 'building-1', activeUnitId: 'unit-1' }}
+        options={[{ id: 'building-1', name: longBuildingName }, { id: 'building-2', name: 'Edificio B' }]}
+        unitsByBuilding={{
+          'building-1': [{ id: 'unit-1', label: 'Unidad con una referencia extensa para móvil' }],
+          'building-2': [{ id: 'unit-2', label: 'B-01' }],
+        }}
+        onBuildingChange={onBuildingChange}
+        onUnitChange={onUnitChange}
+      />,
+    );
+
+    const root = container.firstElementChild;
+    const buildingSelect = screen.getByLabelText('Edificio');
+    const unitSelect = screen.getByLabelText('Unidad');
+
+    expect(root?.className).toContain('min-w-0');
+    expect(root?.className).toContain('sm:flex-row');
+    expect(buildingSelect.className).toContain('w-full');
+    expect(buildingSelect.className).toContain('min-h-11');
+    expect(unitSelect.className).toContain('w-full');
+    const longUnitLabel = 'Unidad con una referencia extensa para móvil';
+    const unitSummary = container.querySelector(`[title="${longUnitLabel}"]`);
+
+    expect(container.querySelector(`[title="${longBuildingName}"]`)?.getAttribute('title')).toBe(longBuildingName);
+    expect(unitSummary?.className).toContain('truncate');
+    expect(unitSummary?.className).toContain('min-w-0');
+    expect(unitSummary?.className).not.toContain('shrink-0');
+    expect(unitSummary?.textContent).toBe(longUnitLabel);
+
+    fireEvent.change(unitSelect, { target: { value: 'unit-1' } });
+
+    await waitFor(() => {
+      expect(onUnitChange).toHaveBeenCalledWith('building-1', 'unit-1');
+    });
+  });
 });

--- a/apps/web/features/context/components/ContextSelector.tsx
+++ b/apps/web/features/context/components/ContextSelector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { UserContext, ContextOption } from '../context.types';
 
 interface ContextSelectorProps {
@@ -95,23 +95,30 @@ export function ContextSelector({
     : [];
 
   return (
-    <div className="flex flex-wrap items-end gap-3">
+    <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end">
       {error && (
-        <div className="text-xs text-red-700 bg-red-50 px-2 py-1 rounded dark:bg-red-950/40 dark:text-red-200">
+        <div className="w-full min-w-0 rounded bg-red-50 px-2 py-1 text-xs text-red-700 dark:bg-red-950/40 dark:text-red-200">
           {error}
         </div>
       )}
 
-      <div className="w-full text-xs text-muted-foreground">
+      <div className="w-full min-w-0 text-xs text-muted-foreground">
         Contexto actual:{' '}
-        <span className="font-medium text-foreground">
-          {currentBuilding}
-          {currentUnit ? ` · ${currentUnit}` : ''}
+        <span className="inline-flex max-w-full min-w-0 align-bottom font-medium text-foreground">
+          <span className="min-w-0 flex-1 truncate" title={currentBuilding}>{currentBuilding}</span>
+          {currentUnit && (
+            <>
+              <span className="shrink-0" aria-hidden="true"> · </span>
+              <span className="min-w-0 max-w-[min(16rem,calc(100vw-8rem))] truncate" title={currentUnit}>
+                {currentUnit}
+              </span>
+            </>
+          )}
         </span>
       </div>
 
       {/* Building Selector */}
-      <div className="flex flex-col gap-1">
+      <div className="flex w-full min-w-0 flex-col gap-1 sm:w-56">
         <label htmlFor={buildingSelectId} className="text-xs font-medium text-muted-foreground">
           Edificio
         </label>
@@ -120,7 +127,7 @@ export function ContextSelector({
           value={context?.activeBuildingId || ''}
           onChange={(e) => handleBuildingChange(e.target.value)}
           disabled={isLoading || isChanging}
-          className="px-3 py-2 border border-border rounded text-sm bg-background text-foreground disabled:bg-muted"
+          className="min-h-11 w-full min-w-0 max-w-full rounded border border-border bg-background px-3 py-2 text-sm text-foreground disabled:bg-muted"
         >
           {allowAllBuildings && <option value="">Todos los edificios</option>}
           {options.map((building) => (
@@ -133,7 +140,7 @@ export function ContextSelector({
 
       {/* Unit Selector (only show if building selected) */}
       {context?.activeBuildingId && (
-        <div className="flex flex-col gap-1">
+        <div className="flex w-full min-w-0 flex-col gap-1 sm:w-56">
           <label htmlFor={unitSelectId} className="text-xs font-medium text-muted-foreground">
             Unidad
           </label>
@@ -142,7 +149,7 @@ export function ContextSelector({
             value={context?.activeUnitId || ''}
             onChange={(e) => handleUnitChange(e.target.value)}
             disabled={isLoading || isChanging}
-            className="px-3 py-2 border border-border rounded text-sm bg-background text-foreground disabled:bg-muted"
+            className="min-h-11 w-full min-w-0 max-w-full rounded border border-border bg-background px-3 py-2 text-sm text-foreground disabled:bg-muted"
           >
             {allowAllUnits && <option value="">Todas las unidades</option>}
             {unitsForActiveBuilding.map((unit) => (
@@ -156,7 +163,7 @@ export function ContextSelector({
 
       {/* Status indicator */}
       {isChanging && (
-        <div className="text-xs text-muted-foreground">Actualizando contexto...</div>
+        <div className="w-full min-w-0 text-xs text-muted-foreground sm:w-auto">Actualizando contexto...</div>
       )}
     </div>
   );

--- a/apps/web/features/notifications/components/PushPermissionControl.test.tsx
+++ b/apps/web/features/notifications/components/PushPermissionControl.test.tsx
@@ -12,6 +12,7 @@ import {
   unsubscribeFromWebPush,
 } from '../push-subscription.api';
 import { PushPermissionControl } from './PushPermissionControl';
+import { PushPermissionProvider } from './PushPermissionProvider';
 
 jest.mock('../push-subscription.api', () => ({
   getExistingPushSubscription: jest.fn(),
@@ -34,6 +35,18 @@ const mockedGetVapidPublicKey = jest.mocked(getVapidPublicKey);
 const mockedIsWebPushSupported = jest.mocked(isWebPushSupported);
 const mockedSubscribeToWebPush = jest.mocked(subscribeToWebPush);
 const mockedUnsubscribeFromWebPush = jest.mocked(unsubscribeFromWebPush);
+let mockRequestPermission: jest.Mock;
+
+function renderSharedControls(tenantId = 'tenant-active') {
+  return render(
+    <PushPermissionProvider key={tenantId} tenantId={tenantId}>
+      <div>
+        <PushPermissionControl />
+        <PushPermissionControl />
+      </div>
+    </PushPermissionProvider>,
+  );
+}
 
 describe('PushPermissionControl', () => {
   beforeEach(() => {
@@ -49,10 +62,11 @@ describe('PushPermissionControl', () => {
       endpoint: 'https://fcm.googleapis.com/fcm/send/subscription-1',
       unsubscribed: true,
     });
+    mockRequestPermission = jest.fn();
     Object.defineProperty(window, 'Notification', {
       value: {
         permission: 'default',
-        requestPermission: jest.fn(),
+        requestPermission: mockRequestPermission,
       },
       configurable: true,
     });
@@ -62,76 +76,90 @@ describe('PushPermissionControl', () => {
     Reflect.deleteProperty(window, 'Notification');
   });
 
-  it('checks status on mount without triggering browser permission or subscription', async () => {
-    render(<PushPermissionControl tenantId="tenant-active" />);
+  it('loads push status once for the shared tenant state', async () => {
+    renderSharedControls();
+
+    await waitFor(() => {
+      expect(mockedGetExistingPushSubscription).toHaveBeenCalledTimes(1);
+    });
+    expect(mockRequestPermission).not.toHaveBeenCalled();
+    expect(mockedSubscribeToWebPush).toHaveBeenCalledTimes(0);
+    expect(mockedUnsubscribeFromWebPush).toHaveBeenCalledTimes(0);
+    expect(screen.getAllByRole('button', { name: 'Activar alertas' })).toHaveLength(2);
+  });
+
+  it('shares activation and deactivation across both presentations without duplicating calls', async () => {
+    renderSharedControls();
 
     await waitFor(() => {
       expect(mockedGetExistingPushSubscription).toHaveBeenCalledTimes(1);
     });
 
-    const notification = window.Notification as unknown as {
-      readonly requestPermission: jest.Mock<Promise<NotificationPermission>, []>;
-    };
-    expect(notification.requestPermission).not.toHaveBeenCalled();
-    expect(mockedSubscribeToWebPush).not.toHaveBeenCalled();
-  });
-
-  it('passes active tenant context when enabling push notifications from the button', async () => {
-    render(<PushPermissionControl tenantId="tenant-active" />);
-
-    const button = await screen.findByRole('button', { name: 'Activar alertas' });
-    fireEvent.click(button);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Activar alertas' })[0]);
 
     await waitFor(() => {
+      expect(mockedSubscribeToWebPush).toHaveBeenCalledTimes(1);
       expect(mockedSubscribeToWebPush).toHaveBeenCalledWith('tenant-active');
+      expect(screen.getAllByRole('button', { name: 'Desactivar alertas' })).toHaveLength(2);
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Desactivar alertas' })[1]);
+
+    await waitFor(() => {
+      expect(mockedUnsubscribeFromWebPush).toHaveBeenCalledTimes(1);
+      expect(mockedUnsubscribeFromWebPush).toHaveBeenCalledWith('tenant-active');
+      expect(screen.getAllByRole('button', { name: 'Activar alertas' })).toHaveLength(2);
     });
   });
 
   it('does not treat an existing browser subscription as active tenant registration', async () => {
     mockedGetExistingPushSubscription.mockResolvedValue({} as PushSubscription);
 
-    render(<PushPermissionControl tenantId="tenant-active" />);
-
-    const button = await screen.findByRole('button', { name: 'Activar alertas' });
-    fireEvent.click(button);
+    renderSharedControls();
 
     await waitFor(() => {
-      expect(mockedSubscribeToWebPush).toHaveBeenCalledWith('tenant-active');
+      expect(mockedGetExistingPushSubscription).toHaveBeenCalledTimes(1);
     });
-    expect(mockedUnsubscribeFromWebPush).not.toHaveBeenCalled();
-  });
 
-  it('passes active tenant context when disabling after this tenant was enabled', async () => {
-    mockedGetExistingPushSubscription.mockResolvedValue({} as PushSubscription);
-
-    render(<PushPermissionControl tenantId="tenant-active" />);
-
-    fireEvent.click(await screen.findByRole('button', { name: 'Activar alertas' }));
-    const disableButton = await screen.findByRole('button', { name: 'Desactivar alertas' });
-
-    fireEvent.click(disableButton);
+    expect(screen.getAllByRole('button', { name: 'Activar alertas' })).toHaveLength(2);
+    fireEvent.click(screen.getAllByRole('button', { name: 'Activar alertas' })[0]);
 
     await waitFor(() => {
-      expect(mockedUnsubscribeFromWebPush).toHaveBeenCalledWith('tenant-active');
+      expect(mockedSubscribeToWebPush).toHaveBeenCalledTimes(1);
+      expect(mockedUnsubscribeFromWebPush).toHaveBeenCalledTimes(0);
     });
   });
 
-  it('does not show full disable success when local browser unsubscribe is incomplete', async () => {
-    mockedGetExistingPushSubscription.mockResolvedValue({} as PushSubscription);
-    mockedUnsubscribeFromWebPush.mockResolvedValue({
-      endpoint: 'https://fcm.googleapis.com/fcm/send/subscription-1',
-      unsubscribed: false,
+  it('reinitializes the controller when the tenant changes', async () => {
+    const { rerender } = render(
+      <PushPermissionProvider key="tenant-a" tenantId="tenant-a">
+        <PushPermissionControl />
+      </PushPermissionProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockedGetExistingPushSubscription).toHaveBeenCalledTimes(1);
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Activar alertas' }));
+
+    await waitFor(() => {
+      expect(mockedSubscribeToWebPush).toHaveBeenCalledWith('tenant-a');
+      expect(screen.getByRole('button', { name: 'Desactivar alertas' })).toBeTruthy();
     });
 
-    render(<PushPermissionControl tenantId="tenant-active" />);
+    mockedSubscribeToWebPush.mockClear();
+    mockedGetExistingPushSubscription.mockClear();
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Activar alertas' }));
-    fireEvent.click(await screen.findByRole('button', { name: 'Desactivar alertas' }));
+    rerender(
+      <PushPermissionProvider key="tenant-b" tenantId="tenant-b">
+        <PushPermissionControl />
+      </PushPermissionProvider>,
+    );
 
-    expect(
-      await screen.findByText('Desactivamos el registro, pero el navegador no confirmó la baja local.'),
-    ).toBeTruthy();
-    expect(screen.queryByText('Alertas push desactivadas en este dispositivo.')).toBeNull();
+    await waitFor(() => {
+      expect(mockedGetExistingPushSubscription).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole('button', { name: 'Activar alertas' })).toBeTruthy();
+    });
   });
 
   it('keeps the enable action available and recovers when refresh fails on mount', async () => {
@@ -139,21 +167,21 @@ describe('PushPermissionControl', () => {
       .mockRejectedValueOnce(new Error('Service worker lookup failed'))
       .mockResolvedValue(null);
 
-    render(<PushPermissionControl tenantId="tenant-active" />);
+    renderSharedControls();
 
-    const button = await screen.findByRole('button', { name: 'Activar alertas' });
+    const button = (await screen.findAllByRole('button', { name: 'Activar alertas' }))[0];
     await waitFor(() => {
       expect(button).toHaveProperty('disabled', false);
     });
 
-    expect(screen.getByText('No pudimos revisar el estado de alertas push.')).toBeTruthy();
+    expect(screen.getAllByText('No pudimos revisar el estado de alertas push.')[0]).toBeTruthy();
 
     fireEvent.click(button);
 
     await waitFor(() => {
-      expect(mockedSubscribeToWebPush).toHaveBeenCalledWith('tenant-active');
+      expect(mockedSubscribeToWebPush).toHaveBeenCalledTimes(1);
     });
-    expect(await screen.findByText('Alertas push activadas en este dispositivo.')).toBeTruthy();
+    expect(await screen.findAllByText('Alertas push activadas en este dispositivo.')).toHaveLength(2);
   });
 
   it('shows safe copy when the browser does not provide subscription keys', async () => {
@@ -161,12 +189,71 @@ describe('PushPermissionControl', () => {
       new PushSubscriptionError('missing-subscription-keys', 'The browser did not provide push subscription keys.'),
     );
 
-    render(<PushPermissionControl tenantId="tenant-active" />);
+    render(
+      <PushPermissionProvider tenantId="tenant-active">
+        <PushPermissionControl />
+      </PushPermissionProvider>,
+    );
 
-    fireEvent.click(await screen.findByRole('button', { name: 'Activar alertas' }));
+    const button = await screen.findByRole('button', { name: 'Activar alertas' });
+    await waitFor(() => {
+      expect(mockedGetExistingPushSubscription).toHaveBeenCalledTimes(1);
+      expect(button).toHaveProperty('disabled', false);
+    });
+
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(mockedSubscribeToWebPush).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(screen.getByText('No pudimos activar alertas porque el navegador no entregó las claves necesarias.')).toBeTruthy();
+    });
+  });
+
+  it('renders the action button with the mobile touch target height', async () => {
+    renderSharedControls();
+
+    await waitFor(() => {
+      expect(mockedGetExistingPushSubscription).toHaveBeenCalledTimes(1);
+    });
+
+    expect(screen.getAllByRole('button', { name: 'Activar alertas' })[0]?.className).toContain('min-h-11');
+  });
+
+  it('shows the explicit local unsubscribe warning when the browser keeps the local record', async () => {
+    render(
+      <PushPermissionProvider tenantId="tenant-active">
+        <PushPermissionControl />
+      </PushPermissionProvider>,
+    );
+
+    const activateButton = await screen.findByRole('button', { name: 'Activar alertas' });
+    await waitFor(() => {
+      expect(mockedGetExistingPushSubscription).toHaveBeenCalledTimes(1);
+      expect(activateButton).toHaveProperty('disabled', false);
+    });
+
+    fireEvent.click(activateButton);
+
+    await waitFor(() => {
+      expect(mockedSubscribeToWebPush).toHaveBeenCalledWith('tenant-active');
+    });
+
+    mockedUnsubscribeFromWebPush.mockResolvedValueOnce({
+      endpoint: 'https://fcm.googleapis.com/fcm/send/subscription-1',
+      unsubscribed: false,
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Desactivar alertas' }));
+
+    await waitFor(() => {
+      expect(mockedUnsubscribeFromWebPush).toHaveBeenCalledWith('tenant-active');
+    });
 
     expect(
-      await screen.findByText('No pudimos activar alertas porque el navegador no entregó las claves necesarias.'),
+      await screen.findByText('Desactivamos el registro, pero el navegador no confirmó la baja local.'),
     ).toBeTruthy();
+    expect(screen.queryByText('Alertas push desactivadas en este dispositivo.')).toBeNull();
   });
 });

--- a/apps/web/features/notifications/components/PushPermissionControl.tsx
+++ b/apps/web/features/notifications/components/PushPermissionControl.tsx
@@ -1,123 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
 import { BellOff, BellRing } from 'lucide-react';
-import {
-  getExistingPushSubscription,
-  getVapidPublicKey,
-  isWebPushSupported,
-  PushSubscriptionError,
-  subscribeToWebPush,
-  unsubscribeFromWebPush,
-} from '../push-subscription.api';
+import { usePushPermission } from './PushPermissionProvider';
 
-type PermissionState = NotificationPermission | 'unsupported';
-
-interface PushStatus {
-  browserSubscribed: boolean;
-  configured: boolean;
-  permission: PermissionState;
-  subscribed: boolean;
-  supported: boolean;
-}
-
-interface PushPermissionControlProps {
-  tenantId: string;
-}
-
-const initialStatus: PushStatus = {
-  browserSubscribed: false,
-  configured: false,
-  permission: 'default',
-  subscribed: false,
-  supported: false,
-};
-
-export function PushPermissionControl({ tenantId }: PushPermissionControlProps) {
-  const [status, setStatus] = useState<PushStatus>(initialStatus);
-  const [isBusy, setIsBusy] = useState(false);
-  const [message, setMessage] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  const refreshStatus = useCallback(async (activeTenantSubscribed?: boolean) => {
-    const supported = isWebPushSupported();
-    const configured = Boolean(getVapidPublicKey());
-
-    if (!supported) {
-      setStatus({
-        browserSubscribed: false,
-        configured,
-        permission: 'unsupported',
-        subscribed: false,
-        supported,
-      });
-      return;
-    }
-
-    const baseStatus = {
-      configured,
-      permission: Notification.permission,
-      supported,
-    } satisfies Pick<PushStatus, 'configured' | 'permission' | 'supported'>;
-
-    setStatus((current) => ({
-      ...current,
-      ...baseStatus,
-      subscribed: activeTenantSubscribed ?? current.subscribed,
-    }));
-
-    const subscription = await getExistingPushSubscription();
-    setStatus((current) => ({
-      ...current,
-      ...baseStatus,
-      browserSubscribed: Boolean(subscription),
-      subscribed: activeTenantSubscribed ?? current.subscribed,
-    }));
-  }, []);
-
-  useEffect(() => {
-    refreshStatus().catch(() => {
-      setError('No pudimos revisar el estado de alertas push.');
-    });
-  }, [refreshStatus]);
-
-  const handleEnable = async () => {
-    setIsBusy(true);
-    setError(null);
-    setMessage(null);
-
-    try {
-      await subscribeToWebPush(tenantId);
-      setMessage('Alertas push activadas en este dispositivo.');
-      await refreshStatus(true);
-    } catch (caught) {
-      setError(getUserFacingError(caught));
-      await refreshStatus().catch(() => undefined);
-    } finally {
-      setIsBusy(false);
-    }
-  };
-
-  const handleDisable = async () => {
-    setIsBusy(true);
-    setError(null);
-    setMessage(null);
-
-    try {
-      const result = await unsubscribeFromWebPush(tenantId);
-      if (result.unsubscribed) {
-        setMessage('Alertas push desactivadas en este dispositivo.');
-      } else {
-        setError(getIncompleteUnsubscribeMessage(result.endpoint));
-      }
-      await refreshStatus(false);
-    } catch (caught) {
-      setError(getUserFacingError(caught));
-      await refreshStatus().catch(() => undefined);
-    } finally {
-      setIsBusy(false);
-    }
-  };
+export function PushPermissionControl() {
+  const { error, handleDisable, handleEnable, isBusy, message, status } = usePushPermission();
 
   const disabledReason = getDisabledReason(status);
   const isDisabled = isBusy || Boolean(disabledReason);
@@ -138,7 +25,7 @@ export function PushPermissionControl({ tenantId }: PushPermissionControlProps) 
       </div>
       <button
         type="button"
-        className="whitespace-nowrap rounded-md bg-primary px-2 py-1 text-xs font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+        className="inline-flex min-h-11 items-center justify-center whitespace-nowrap rounded-md bg-primary px-2 py-1 text-xs font-medium text-primary-foreground transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
         onClick={status.subscribed ? handleDisable : handleEnable}
         disabled={isDisabled}
         title={disabledReason ?? actionLabel}
@@ -149,7 +36,12 @@ export function PushPermissionControl({ tenantId }: PushPermissionControlProps) 
   );
 }
 
-function getStatusLabel(status: PushStatus): string {
+function getStatusLabel(status: {
+  readonly configured: boolean;
+  readonly permission: NotificationPermission | 'unsupported';
+  readonly subscribed: boolean;
+  readonly supported: boolean;
+}): string {
   if (!status.supported) {
     return 'Alertas no compatibles';
   }
@@ -165,7 +57,11 @@ function getStatusLabel(status: PushStatus): string {
   return 'Alertas push disponibles';
 }
 
-function getDisabledReason(status: PushStatus): string | null {
+function getDisabledReason(status: {
+  readonly configured: boolean;
+  readonly permission: NotificationPermission | 'unsupported';
+  readonly supported: boolean;
+}): string | null {
   if (!status.supported) {
     return 'Este navegador no permite alertas push.';
   }
@@ -176,34 +72,4 @@ function getDisabledReason(status: PushStatus): string | null {
     return 'El permiso está bloqueado en el navegador.';
   }
   return null;
-}
-
-function getUserFacingError(caught: unknown): string {
-  if (caught instanceof PushSubscriptionError) {
-    if (caught.code === 'permission-denied') {
-      return 'No activamos alertas porque el permiso no fue concedido.';
-    }
-    if (caught.code === 'missing-public-key') {
-      return 'Falta configurar la clave pública VAPID.';
-    }
-    if (caught.code === 'missing-tenant') {
-      return 'Falta el contexto del consorcio activo.';
-    }
-    if (caught.code === 'missing-subscription-keys') {
-      return 'No pudimos activar alertas porque el navegador no entregó las claves necesarias.';
-    }
-    if (caught.code === 'unsupported') {
-      return 'Este navegador no permite alertas push.';
-    }
-  }
-
-  return 'No pudimos actualizar las alertas push.';
-}
-
-function getIncompleteUnsubscribeMessage(endpoint: string | null): string {
-  if (!endpoint) {
-    return 'No encontramos una suscripción push local para desactivar.';
-  }
-
-  return 'Desactivamos el registro, pero el navegador no confirmó la baja local.';
 }

--- a/apps/web/features/notifications/components/PushPermissionProvider.tsx
+++ b/apps/web/features/notifications/components/PushPermissionProvider.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import {
+  getExistingPushSubscription,
+  getVapidPublicKey,
+  isWebPushSupported,
+  PushSubscriptionError,
+  subscribeToWebPush,
+  unsubscribeFromWebPush,
+} from '../push-subscription.api';
+
+type PermissionState = NotificationPermission | 'unsupported';
+
+interface PushStatus {
+  browserSubscribed: boolean;
+  configured: boolean;
+  permission: PermissionState;
+  subscribed: boolean;
+  supported: boolean;
+}
+
+interface PushPermissionContextValue {
+  readonly error: string | null;
+  readonly handleDisable: () => Promise<void>;
+  readonly handleEnable: () => Promise<void>;
+  readonly isBusy: boolean;
+  readonly message: string | null;
+  readonly refreshStatus: (activeTenantSubscribed?: boolean) => Promise<void>;
+  readonly status: PushStatus;
+}
+
+const initialStatus: PushStatus = {
+  browserSubscribed: false,
+  configured: false,
+  permission: 'default',
+  subscribed: false,
+  supported: false,
+};
+
+const PushPermissionContext = createContext<PushPermissionContextValue | null>(null);
+
+interface PushPermissionProviderProps {
+  readonly children: ReactNode;
+  readonly tenantId: string;
+}
+
+export function PushPermissionProvider({ children, tenantId }: PushPermissionProviderProps) {
+  const [status, setStatus] = useState<PushStatus>(initialStatus);
+  const [isBusy, setIsBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshStatus = useCallback(async (activeTenantSubscribed?: boolean) => {
+    const supported = isWebPushSupported();
+    const configured = Boolean(getVapidPublicKey());
+
+    if (!supported) {
+      setStatus({
+        browserSubscribed: false,
+        configured,
+        permission: 'unsupported',
+        subscribed: false,
+        supported,
+      });
+      return;
+    }
+
+    const baseStatus = {
+      configured,
+      permission: Notification.permission,
+      supported,
+    } satisfies Pick<PushStatus, 'configured' | 'permission' | 'supported'>;
+
+    setStatus((current) => ({
+      ...current,
+      ...baseStatus,
+      subscribed: activeTenantSubscribed ?? current.subscribed,
+    }));
+
+    const subscription = await getExistingPushSubscription();
+    setStatus((current) => ({
+      ...current,
+      ...baseStatus,
+      browserSubscribed: Boolean(subscription),
+      subscribed: activeTenantSubscribed ?? current.subscribed,
+    }));
+  }, []);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      refreshStatus().catch(() => {
+        setError('No pudimos revisar el estado de alertas push.');
+      });
+    }, 0);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [refreshStatus, tenantId]);
+
+  const handleEnable = useCallback(async () => {
+    setIsBusy(true);
+    setError(null);
+    setMessage(null);
+
+    try {
+      await subscribeToWebPush(tenantId);
+      setMessage('Alertas push activadas en este dispositivo.');
+      await refreshStatus(true);
+    } catch (caught) {
+      setError(getUserFacingError(caught));
+      await refreshStatus().catch(() => undefined);
+    } finally {
+      setIsBusy(false);
+    }
+  }, [refreshStatus, tenantId]);
+
+  const handleDisable = useCallback(async () => {
+    setIsBusy(true);
+    setError(null);
+    setMessage(null);
+
+    try {
+      const result = await unsubscribeFromWebPush(tenantId);
+      if (result.unsubscribed) {
+        setMessage('Alertas push desactivadas en este dispositivo.');
+      } else {
+        setError(getIncompleteUnsubscribeMessage(result.endpoint));
+      }
+      await refreshStatus(false);
+    } catch (caught) {
+      setError(getUserFacingError(caught));
+      await refreshStatus().catch(() => undefined);
+    } finally {
+      setIsBusy(false);
+    }
+  }, [refreshStatus, tenantId]);
+
+  const value = useMemo<PushPermissionContextValue>(
+    () => ({
+      error,
+      handleDisable,
+      handleEnable,
+      isBusy,
+      message,
+      refreshStatus,
+      status,
+    }),
+    [error, handleDisable, handleEnable, isBusy, message, refreshStatus, status],
+  );
+
+  return <PushPermissionContext.Provider value={value}>{children}</PushPermissionContext.Provider>;
+}
+
+export function usePushPermission() {
+  const context = useContext(PushPermissionContext);
+
+  if (!context) {
+    throw new Error('usePushPermission must be used within a PushPermissionProvider');
+  }
+
+  return context;
+}
+
+function getUserFacingError(caught: unknown): string {
+  if (caught instanceof PushSubscriptionError) {
+    if (caught.code === 'permission-denied') {
+      return 'No activamos alertas porque el permiso no fue concedido.';
+    }
+    if (caught.code === 'missing-public-key') {
+      return 'Falta configurar la clave pública VAPID.';
+    }
+    if (caught.code === 'missing-tenant') {
+      return 'Falta el contexto del consorcio activo.';
+    }
+    if (caught.code === 'missing-subscription-keys') {
+      return 'No pudimos activar alertas porque el navegador no entregó las claves necesarias.';
+    }
+    if (caught.code === 'unsupported') {
+      return 'Este navegador no permite alertas push.';
+    }
+  }
+
+  return 'No pudimos actualizar las alertas push.';
+}
+
+function getIncompleteUnsubscribeMessage(endpoint: string | null): string {
+  if (!endpoint) {
+    return 'No encontramos una suscripción push local para desactivar.';
+  }
+
+  return 'Desactivamos el registro, pero el navegador no confirmó la baja local.';
+}

--- a/apps/web/features/resident/components/ResidentContextSwitcher.test.tsx
+++ b/apps/web/features/resident/components/ResidentContextSwitcher.test.tsx
@@ -59,7 +59,8 @@ describe('ResidentContextSwitcher', () => {
     );
 
     expect(screen.getByText('Contexto activo')).toBeTruthy();
-    expect(screen.getByText('Edificio A · A-01')).toBeTruthy();
+    expect(screen.getByText('Edificio A')).toBeTruthy();
+    expect(screen.getByText('A-01')).toBeTruthy();
     expect(screen.queryByLabelText('Edificio')).toBeNull();
   });
 
@@ -112,5 +113,47 @@ describe('ResidentContextSwitcher', () => {
       expect(setActiveUnit).toHaveBeenCalledWith('building-2', 'unit-2');
       expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['residentContext', 'tenant-1', 'user-1'] });
     });
+  });
+
+  it('contains a long building name while keeping the selected unit visible', () => {
+    const longBuildingName = 'Complejo Residencial con un nombre largo que no debe ampliar el viewport móvil';
+    mockedUseAuthSession.mockReturnValue({
+      user: { id: 'user-1', email: 'resident@test.com', name: 'Resident' },
+      memberships: [],
+      activeTenantId: 'tenant-1',
+    });
+    mockedUseContextManager.mockReturnValue({
+      context: { tenantId: 'tenant-1', activeBuildingId: 'building-1', activeUnitId: 'unit-1' },
+      options: {
+        buildings: [{ id: 'building-1', name: longBuildingName }],
+        unitsByBuilding: {
+          'building-1': [{
+            id: 'unit-1',
+            code: 'A-01',
+            label: 'Unidad con una referencia extensa para una pantalla móvil',
+          }],
+        },
+      },
+      loading: false,
+      error: null,
+      refetch: jest.fn(),
+      setActiveBuilding: jest.fn(),
+      setActiveUnit: jest.fn(),
+    });
+
+    const { container } = render(
+      <ResidentContextSwitcher tenantId="tenant-1" />,
+      { wrapper: createWrapper(new QueryClient()) },
+    );
+
+    const longUnitLabel = 'Unidad con una referencia extensa para una pantalla móvil';
+    const unitSummary = container.querySelector(`[title="${longUnitLabel}"]`);
+
+    expect(container.querySelector(`[title="${longBuildingName}"]`)?.getAttribute('title')).toBe(longBuildingName);
+    expect(unitSummary?.className).toContain('truncate');
+    expect(unitSummary?.className).toContain('min-w-0');
+    expect(unitSummary?.className).not.toContain('shrink-0');
+    expect(screen.getByText(longUnitLabel)).toBeTruthy();
+    expect(container.querySelector('[class*="min-w-0"]')).toBeTruthy();
   });
 });

--- a/apps/web/features/resident/components/ResidentContextSwitcher.tsx
+++ b/apps/web/features/resident/components/ResidentContextSwitcher.tsx
@@ -56,8 +56,8 @@ export function ResidentContextSwitcher({ tenantId }: ResidentContextSwitcherPro
 
   if (loading && !context && !options) {
     return (
-      <Card className="p-4">
-        <div className="space-y-3">
+      <Card className="w-full min-w-0 p-4">
+        <div className="min-w-0 space-y-3">
           <Skeleton className="h-4 w-40" />
           <Skeleton className="h-10 w-full max-w-md" />
         </div>
@@ -67,10 +67,10 @@ export function ResidentContextSwitcher({ tenantId }: ResidentContextSwitcherPro
 
   if (error && !options) {
     return (
-      <Card className="border-red-200 bg-red-50 p-4 dark:border-red-900/50 dark:bg-red-950/30">
-        <div className="flex items-start gap-3">
-          <AlertCircle className="mt-0.5 text-red-600 dark:text-red-300" size={20} />
-          <div className="space-y-1">
+      <Card className="w-full min-w-0 border-red-200 bg-red-50 p-4 dark:border-red-900/50 dark:bg-red-950/30">
+        <div className="flex min-w-0 items-start gap-3">
+          <AlertCircle className="mt-0.5 shrink-0 text-red-600 dark:text-red-300" size={20} />
+          <div className="min-w-0 space-y-1">
             <p className="font-medium text-red-800 dark:text-red-100">No pudimos cargar tu contexto residente.</p>
             <p className="text-sm text-red-700 dark:text-red-200">
               {error}
@@ -90,16 +90,23 @@ export function ResidentContextSwitcher({ tenantId }: ResidentContextSwitcherPro
 
   if (totalUnits <= 1) {
     return (
-      <Card className="p-4">
-        <div className="flex items-start gap-3">
-          <div className="rounded-lg bg-primary/10 p-2 text-primary">
+      <Card className="w-full min-w-0 p-4">
+        <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start">
+          <div className="w-fit shrink-0 rounded-lg bg-primary/10 p-2 text-primary">
             <Home size={18} />
           </div>
-          <div className="space-y-1">
+          <div className="min-w-0 space-y-1">
             <p className="text-sm font-semibold text-foreground">Contexto activo</p>
             {context?.activeUnitId && selectedBuilding && selectedUnit ? (
-              <p className="text-sm text-muted-foreground">
-                {selectedBuilding.name} · {selectedUnit.label || selectedUnit.code}
+              <p className="flex min-w-0 items-center gap-1 text-sm text-muted-foreground">
+                <span className="min-w-0 flex-1 truncate" title={selectedBuilding.name}>{selectedBuilding.name}</span>
+                <span className="shrink-0" aria-hidden="true">·</span>
+                <span
+                  className="min-w-0 max-w-[min(16rem,calc(100vw-8rem))] truncate"
+                  title={selectedUnit.label || selectedUnit.code}
+                >
+                  {selectedUnit.label || selectedUnit.code}
+                </span>
               </p>
             ) : (
               <p className="text-sm text-muted-foreground">Sin unidad activa autorizada.</p>
@@ -116,12 +123,12 @@ export function ResidentContextSwitcher({ tenantId }: ResidentContextSwitcherPro
   }
 
   return (
-    <Card className="p-4">
-      <div className="mb-3 flex items-start gap-3">
-        <div className="rounded-lg bg-primary/10 p-2 text-primary">
+    <Card className="w-full min-w-0 p-4">
+      <div className="mb-3 flex min-w-0 flex-col gap-3 sm:flex-row sm:items-start">
+        <div className="w-fit shrink-0 rounded-lg bg-primary/10 p-2 text-primary">
           <Building2 size={18} />
         </div>
-        <div className="space-y-1">
+        <div className="min-w-0 space-y-1">
           <p className="text-sm font-semibold text-foreground">Elegí tu unidad activa</p>
           <p className="text-xs text-muted-foreground">
             El portal residente usa siempre la ocupación seleccionada. Si cambiás de unidad, los datos se actualizan en toda la pantalla.

--- a/apps/web/shared/components/assistant/AssistantWidget.test.tsx
+++ b/apps/web/shared/components/assistant/AssistantWidget.test.tsx
@@ -96,6 +96,51 @@ describe('AssistantWidget responsive panel', () => {
     });
   });
 
+  it('suspends Escape handling without resetting state and resumes it without stealing focus', async () => {
+    const { rerender } = render(
+      <>
+        <button type="button">Fuera</button>
+        <AssistantWidget context={context} suspendEscapeHandling />
+      </>,
+    );
+
+    const trigger = screen.getByRole('button', { name: 'Abrir asistente' });
+    const outsideButton = screen.getByRole('button', { name: 'Fuera' });
+
+    fireEvent.click(trigger);
+    fireEvent.change(screen.getByLabelText('Escribí tu pregunta'), { target: { value: 'Necesito ayuda' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Enviar mensaje' }));
+
+    await waitFor(() => {
+      expect(mockChatV2).toHaveBeenCalledWith('tenant-1', expect.objectContaining({ message: 'Necesito ayuda' }));
+      expect(screen.getByText('Necesito ayuda')).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText('Escribí tu pregunta'), { target: { value: 'Borrador' } });
+    outsideButton.focus();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(screen.getByRole('button', { name: 'Cerrar asistente' }).getAttribute('aria-expanded')).toBe('true');
+    expect((screen.getByLabelText('Escribí tu pregunta') as HTMLTextAreaElement).value).toBe('Borrador');
+    expect(screen.getByText('Necesito ayuda')).toBeTruthy();
+
+    rerender(
+      <>
+        <button type="button">Fuera</button>
+        <AssistantWidget context={context} suspendEscapeHandling={false} />
+      </>,
+    );
+
+    expect(document.activeElement).toBe(outsideButton);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => {
+      expect(screen.queryByRole('region', { name: 'Asistente AI' })).toBeNull();
+      expect(screen.getByRole('button', { name: 'Abrir asistente' }).getAttribute('aria-expanded')).toBe('false');
+      expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Abrir asistente' }));
+    });
+  });
+
   it('keeps close and message submission controls operational', async () => {
     render(<AssistantWidget context={context} />);
     const trigger = screen.getByRole('button', { name: 'Abrir asistente' });

--- a/apps/web/shared/components/assistant/AssistantWidget.test.tsx
+++ b/apps/web/shared/components/assistant/AssistantWidget.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { AssistantWidget } from './AssistantWidget';
+import { assistantApi } from '@/features/assistant/services/assistant.api';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  useParams: () => ({ tenantId: 'tenant-1' }),
+}));
+
+jest.mock('@/features/assistant/services/assistant.api', () => ({
+  assistantApi: { chatV2: jest.fn() },
+  AssistantApiError: class AssistantApiError extends Error {},
+}));
+
+jest.mock('./assistant-analytics', () => ({
+  createActionClickEvent: jest.fn(),
+  trackAssistantActionClick: jest.fn(),
+  getOrCreateSessionId: () => 'session-1',
+}));
+
+jest.mock('./renderers', () => ({
+  AssistantResponseRenderer: () => null,
+}));
+
+const mockChatV2 = jest.mocked(assistantApi.chatV2);
+
+const context = {
+  appId: 'buildingos',
+  tenantId: 'tenant-1',
+  userId: 'user-1',
+  role: 'RESIDENT',
+  route: '/tenant-1/resident/dashboard',
+  currentModule: 'Panel',
+};
+
+describe('AssistantWidget responsive panel', () => {
+  beforeAll(() => {
+    Element.prototype.scrollIntoView = jest.fn();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockChatV2.mockResolvedValue({
+      type: 'text',
+      title: 'Respuesta',
+      summary: 'Respuesta',
+      actions: [],
+      meta: { intent: 'help', confidence: 1, tenantScoped: true },
+    });
+  });
+
+  it('uses a viewport-contained mobile panel and retains a bounded desktop size', () => {
+    render(<AssistantWidget context={context} />);
+
+    const trigger = screen.getByRole('button', { name: 'Abrir asistente' });
+    const triggerClasses = trigger.className.split(' ');
+    fireEvent.click(trigger);
+
+    const panel = screen.getByRole('region', { name: 'Asistente AI' });
+    const classes = panel.className.split(' ');
+
+    expect(classes).toContain('inset-x-2');
+    expect(classes).toContain('max-h-[calc(100dvh-env(safe-area-inset-top)-5rem)]');
+    expect(classes).toContain('sm:w-96');
+    expect(classes).not.toContain('w-96');
+    expect(triggerClasses).not.toContain('inset-x-2');
+    expect(triggerClasses).toContain('right-2');
+    expect(triggerClasses).toContain('min-h-11');
+    expect(triggerClasses).not.toContain('w-full');
+    expect(screen.getByLabelText('Escribí tu pregunta')).toBe(document.activeElement);
+  });
+
+  it('keeps the LLM control touch-sized and closes with Escape while restoring trigger focus', async () => {
+    render(<AssistantWidget context={context} />);
+    const trigger = screen.getByRole('button', { name: 'Abrir asistente' });
+
+    fireEvent.click(trigger);
+
+    const llmLabel = screen.getByText('Usar generación avanzada (LLM)').closest('label');
+    const llmCheckbox = screen.getByRole('checkbox');
+    expect(llmLabel?.className).toContain('min-h-11');
+    expect((llmCheckbox as HTMLInputElement).checked).toBe(false);
+
+    fireEvent.click(llmCheckbox);
+    expect((llmCheckbox as HTMLInputElement).checked).toBe(true);
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => {
+      expect(screen.queryByRole('region', { name: 'Asistente AI' })).toBeNull();
+      expect(trigger.getAttribute('aria-expanded')).toBe('false');
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  it('keeps close and message submission controls operational', async () => {
+    render(<AssistantWidget context={context} />);
+    const trigger = screen.getByRole('button', { name: 'Abrir asistente' });
+
+    fireEvent.click(trigger);
+    fireEvent.change(screen.getByLabelText('Escribí tu pregunta'), { target: { value: 'Necesito ayuda' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Enviar mensaje' }));
+
+    await waitFor(() => {
+      expect(mockChatV2).toHaveBeenCalledWith('tenant-1', expect.objectContaining({ message: 'Necesito ayuda' }));
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Minimizar asistente' }));
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+});

--- a/apps/web/shared/components/assistant/AssistantWidget.tsx
+++ b/apps/web/shared/components/assistant/AssistantWidget.tsx
@@ -11,12 +11,14 @@ export interface AssistantWidgetProps {
   context: AssistantContext;
   defaultUseLlm?: boolean;
   className?: string;
+  suspendEscapeHandling?: boolean;
 }
 
 export function AssistantWidget({ 
   context, 
   defaultUseLlm = false,
-  className = '' 
+  className = '',
+  suspendEscapeHandling = false,
 }: AssistantWidgetProps) {
   const params = useParams();
   const [isOpen, setIsOpen] = useState(false);
@@ -51,6 +53,11 @@ export function AssistantWidget({
     if (!isOpen) return;
 
     inputRef.current?.focus();
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen || suspendEscapeHandling) return;
+
     const handleEscape = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         closeAssistant();
@@ -59,7 +66,7 @@ export function AssistantWidget({
 
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);
-  }, [closeAssistant, isOpen]);
+  }, [closeAssistant, isOpen, suspendEscapeHandling]);
 
   const [conversationId] = useState(() => `conv-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`);
 

--- a/apps/web/shared/components/assistant/AssistantWidget.tsx
+++ b/apps/web/shared/components/assistant/AssistantWidget.tsx
@@ -1,12 +1,10 @@
 'use client';
 
-import { useState, useRef, useEffect } from 'react';
-import { useRouter, useParams } from 'next/navigation';
-import { Send, Bot, Sparkles, X, Minimize2, ArrowRight, ExternalLink } from 'lucide-react';
-import type { AssistantMessage, AssistantAction, AssistantContext } from './useAssistant';
-import { getAssistantActionPath } from './action-route-map';
-import { createActionClickEvent, trackAssistantActionClick, getOrCreateSessionId } from './assistant-analytics';
-import { assistantApi, AssistantApiError, StructuredResponse } from '@/features/assistant/services/assistant.api';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { Send, Bot, Sparkles, X, Minimize2 } from 'lucide-react';
+import type { AssistantMessage, AssistantContext } from './useAssistant';
+import { assistantApi, AssistantApiError } from '@/features/assistant/services/assistant.api';
 import { AssistantResponseRenderer } from './renderers';
 
 export interface AssistantWidgetProps {
@@ -20,7 +18,6 @@ export function AssistantWidget({
   defaultUseLlm = false,
   className = '' 
 }: AssistantWidgetProps) {
-  const router = useRouter();
   const params = useParams();
   const [isOpen, setIsOpen] = useState(false);
   const [input, setInput] = useState('');
@@ -31,18 +28,38 @@ export function AssistantWidget({
   
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const toggleButtonRef = useRef<HTMLButtonElement>(null);
 
   const tenantId = params?.tenantId as string | undefined || context.tenantId;
   
-  const [sessionId] = useState(() => getOrCreateSessionId());
-
-  const scrollToBottom = () => {
+  const scrollToBottom = useCallback(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  };
+  }, []);
 
   useEffect(() => {
     scrollToBottom();
-  }, [messages]);
+  }, [messages, scrollToBottom]);
+
+  const closeAssistant = useCallback((restoreFocus = true) => {
+    setIsOpen(false);
+    if (restoreFocus) {
+      requestAnimationFrame(() => toggleButtonRef.current?.focus());
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    inputRef.current?.focus();
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        closeAssistant();
+      }
+    };
+
+    document.addEventListener('keydown', handleEscape);
+    return () => document.removeEventListener('keydown', handleEscape);
+  }, [closeAssistant, isOpen]);
 
   const [conversationId] = useState(() => `conv-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`);
 
@@ -150,38 +167,17 @@ export function AssistantWidget({
     setError(null);
   };
 
-  const handleActionClick = (action: AssistantAction, messageId: string, actionIndex: number, totalActions: number) => {
-    const path = getAssistantActionPath(action.key, tenantId);
-    const isMapped = path !== null;
-
-    const event = createActionClickEvent({
-      actionKey: action.key,
-      actionLabel: action.label,
-      tenantId,
-      currentRoute: context.route,
-      currentModule: context.currentModule,
-      targetPath: path,
-      isMapped,
-      sessionId,
-      messageId,
-      actionIndex,
-      totalActions,
-    });
-
-    trackAssistantActionClick(event);
-
-    if (path) {
-      router.push(path);
-    }
-  };
-
   return (
     <>
       {/* Toggle Button - Floating */}
       <button
-        onClick={() => setIsOpen(!isOpen)}
-        className={`fixed bottom-4 right-4 z-50 flex items-center gap-2 px-4 py-3 bg-blue-600 text-white rounded-full shadow-lg hover:bg-blue-700 transition-colors ${className}`}
+        ref={toggleButtonRef}
+        type="button"
+        onClick={() => (isOpen ? closeAssistant(false) : setIsOpen(true))}
+        className={`fixed right-2 bottom-[max(0.5rem,env(safe-area-inset-bottom))] z-50 flex min-h-11 max-w-[calc(100vw-1rem)] items-center justify-center gap-2 rounded-full bg-primary px-4 py-3 text-primary-foreground shadow-lg transition hover:opacity-90 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 sm:bottom-4 sm:right-4 sm:w-auto ${className}`}
         aria-label={isOpen ? 'Cerrar asistente' : 'Abrir asistente'}
+        aria-expanded={isOpen}
+        aria-controls="assistant-panel"
       >
         {isOpen ? <Minimize2 size={20} /> : <Bot size={20} />}
         {!isOpen && <span className="font-medium">Asistente</span>}
@@ -189,28 +185,37 @@ export function AssistantWidget({
 
       {/* Panel */}
       {isOpen && (
-        <div className="fixed bottom-20 right-4 w-96 h-[500px] bg-white dark:bg-gray-900 rounded-xl shadow-2xl border border-gray-200 dark:border-gray-700 flex flex-col z-50">
+        <div
+          id="assistant-panel"
+          role="region"
+          aria-label="Asistente AI"
+          className="fixed inset-x-2 bottom-[calc(env(safe-area-inset-bottom)+3.5rem)] z-50 flex max-h-[calc(100dvh-env(safe-area-inset-top)-5rem)] min-h-0 flex-col overflow-hidden rounded-xl border border-border bg-card text-card-foreground shadow-2xl sm:inset-x-auto sm:bottom-20 sm:right-4 sm:h-[min(500px,calc(100dvh-6rem))] sm:w-96"
+        >
           {/* Header */}
-          <div className="flex items-center justify-between p-4 border-b border-gray-200 dark:border-gray-700">
-            <div className="flex items-center gap-2">
+          <div className="flex shrink-0 items-center justify-between border-b border-border p-4">
+            <div className="flex min-w-0 items-center gap-2">
               <Bot size={24} className="text-blue-600" />
-              <div>
-                <h3 className="font-semibold text-gray-900 dark:text-white">Asistente AI</h3>
-                <p className="text-xs text-gray-500 dark:text-gray-400">{context.role} • {context.currentModule || context.route}</p>
+              <div className="min-w-0">
+                <h3 className="truncate font-semibold">Asistente AI</h3>
+                <p className="truncate text-xs text-muted-foreground">{context.role} • {context.currentModule || context.route}</p>
               </div>
             </div>
             <div className="flex items-center gap-2">
               <button
+                type="button"
                 onClick={clearChat}
-                className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
+                className="inline-flex size-11 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                 title="Limpiar chat"
+                aria-label="Limpiar chat"
               >
                 <X size={18} />
               </button>
               <button
-                onClick={() => setIsOpen(false)}
-                className="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
+                type="button"
+                onClick={() => closeAssistant()}
+                className="inline-flex size-11 items-center justify-center rounded-lg text-muted-foreground hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                 title="Minimizar"
+                aria-label="Minimizar asistente"
               >
                 <Minimize2 size={18} />
               </button>
@@ -218,8 +223,8 @@ export function AssistantWidget({
           </div>
 
           {/* LLM Toggle */}
-          <div className="px-4 py-2 bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
-            <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300 cursor-pointer">
+          <div className="shrink-0 border-b border-border bg-muted/50 px-4 py-2">
+            <label className="flex min-h-11 min-w-0 items-center gap-2 text-sm text-muted-foreground">
               <input
                 type="checkbox"
                 checked={useLlm}
@@ -232,7 +237,7 @@ export function AssistantWidget({
           </div>
 
           {/* Messages */}
-          <div className="flex-1 overflow-y-auto p-4 space-y-4">
+          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
             {messages.length === 0 && (
               <div className="text-center text-gray-500 dark:text-gray-400 py-8">
                 <Bot size={40} className="mx-auto mb-2 opacity-50" />
@@ -265,7 +270,7 @@ export function AssistantWidget({
                       }}
                     />
                   ) : (
-                    <p className="text-sm whitespace-pre-wrap">{msg.content}</p>
+                    <p className="break-words text-sm whitespace-pre-wrap">{msg.content}</p>
                   )}
                   
                   {msg.role === 'assistant' && msg.llmUsed !== undefined && (
@@ -317,21 +322,24 @@ export function AssistantWidget({
           </div>
 
           {/* Input */}
-          <div className="p-4 border-t border-gray-200 dark:border-gray-700">
-            <div className="flex gap-2">
+          <div className="shrink-0 border-t border-border p-4 pb-[max(1rem,env(safe-area-inset-bottom))]">
+            <div className="flex min-w-0 gap-2">
               <textarea
                 ref={inputRef}
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder="Escribí tu pregunta..."
-                className="flex-1 min-h-[40px] max-h-[120px] resize-none rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-800 dark:text-white"
+                className="min-h-11 min-w-0 flex-1 resize-none rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
                 disabled={isLoading}
+                aria-label="Escribí tu pregunta"
               />
               <button
+                type="button"
                 onClick={sendMessage}
                 disabled={!input.trim() || isLoading}
-                className="p-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="inline-flex size-11 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+                aria-label="Enviar mensaje"
               >
                 <Send size={20} />
               </button>

--- a/apps/web/shared/components/layout/AppShell.push-permission.integration.test.tsx
+++ b/apps/web/shared/components/layout/AppShell.push-permission.integration.test.tsx
@@ -1,0 +1,285 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import AppShell from './AppShell';
+import * as notificationsApi from '@/features/notifications/notifications.api';
+import * as pushSubscriptionApi from '@/features/notifications/push-subscription.api';
+import * as financeApi from '@/features/finance/services/finance.api';
+import * as sessionModule from '@/features/auth/session.storage';
+
+let mockTenantData: Array<{ id: string; name: string; type: 'EDIFICIO_AUTOGESTION' }> = [];
+let mockTenantId = 'tenant-1';
+let mockPathname = '/tenant-1/dashboard';
+
+jest.mock('next/navigation', () => ({
+  useParams: () => ({ tenantId: mockTenantId }),
+  usePathname: () => mockPathname,
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+}));
+
+jest.mock('@/features/tenants/tenants.hooks', () => ({
+  useTenants: () => ({ data: mockTenantData, isLoading: false, error: null }),
+}));
+
+jest.mock('@/features/auth/useAuthSession', () => ({
+  useIsSuperAdmin: () => false,
+  useHasRole: (role: string) => role === 'RESIDENT',
+}));
+
+jest.mock('@/features/impersonation/useImpersonation', () => ({
+  useImpersonation: () => ({ isImpersonating: false }),
+}));
+
+jest.mock('@/features/impersonation/ImpersonationBanner', () => ({
+  ImpersonationBanner: () => null,
+}));
+
+jest.mock('@/shared/components/assistant', () => ({
+  AssistantWidget: () => <div data-testid="assistant-widget" data-open="false" />,
+  useAssistantContext: () => ({}),
+}));
+
+jest.mock('./Sidebar', () => ({
+  __esModule: true,
+  default: ({ id, footer }: { id?: string; footer?: ReactNode }) => (
+    <aside id={id} data-testid="sidebar-shell">
+      {footer}
+    </aside>
+  ),
+}));
+
+jest.mock('@/features/notifications/notifications.api', () => ({
+  listNotifications: jest.fn(),
+  getUnreadCount: jest.fn(),
+  markAsRead: jest.fn(),
+  markAllAsRead: jest.fn(),
+  deleteNotification: jest.fn(),
+}));
+
+jest.mock('@/features/notifications/push-subscription.api', () => ({
+  getExistingPushSubscription: jest.fn(),
+  getVapidPublicKey: jest.fn(),
+  isWebPushSupported: jest.fn(),
+  subscribeToWebPush: jest.fn(),
+  unsubscribeFromWebPush: jest.fn(),
+  PushSubscriptionError: class PushSubscriptionError extends Error {
+    constructor(
+      public readonly code: string,
+      message: string,
+    ) {
+      super(message);
+    }
+  },
+}));
+
+jest.mock('@/features/finance/services/finance.api', () => ({
+  listPendingPayments: jest.fn(),
+  PaymentStatus: { SUBMITTED: 'SUBMITTED' },
+}));
+
+jest.mock('@/features/auth/session.storage', () => ({
+  getSession: jest.fn(),
+  setSession: jest.fn(),
+  setLastTenant: jest.fn(),
+  clearAuth: jest.fn(),
+}));
+
+jest.mock('@/features/impersonation/impersonation.storage', () => ({
+  clearAllImpersonationData: jest.fn(),
+}));
+
+const mockGetUnreadCount = jest.mocked(notificationsApi.getUnreadCount);
+const mockListNotifications = jest.mocked(notificationsApi.listNotifications);
+const mockMarkAsRead = jest.mocked(notificationsApi.markAsRead);
+const mockGetExistingPushSubscription = jest.mocked(pushSubscriptionApi.getExistingPushSubscription);
+const mockGetVapidPublicKey = jest.mocked(pushSubscriptionApi.getVapidPublicKey);
+const mockIsWebPushSupported = jest.mocked(pushSubscriptionApi.isWebPushSupported);
+const mockSubscribeToWebPush = jest.mocked(pushSubscriptionApi.subscribeToWebPush);
+const mockUnsubscribeFromWebPush = jest.mocked(pushSubscriptionApi.unsubscribeFromWebPush);
+const mockListPendingPayments = jest.mocked(financeApi.listPendingPayments);
+const mockGetSession = jest.mocked(sessionModule.getSession);
+
+function renderShell() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+  return {
+    queryClient,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <AppShell>Contenido</AppShell>
+      </QueryClientProvider>,
+    ),
+  };
+}
+
+describe('AppShell push permission integration', () => {
+  beforeEach(() => {
+    mockTenantData = [{ id: 'tenant-1', name: 'Tenant 1', type: 'EDIFICIO_AUTOGESTION' }];
+    mockTenantId = 'tenant-1';
+    mockPathname = '/tenant-1/dashboard';
+    jest.clearAllMocks();
+
+    mockGetSession.mockReturnValue({
+      user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
+      memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT'] }],
+      activeTenantId: 'tenant-1',
+    });
+    mockGetUnreadCount.mockResolvedValue(0);
+    mockListNotifications.mockResolvedValue({ notifications: [], total: 0 });
+    mockListPendingPayments.mockResolvedValue([]);
+    mockMarkAsRead.mockResolvedValue({ id: 'n1', isRead: true } as Awaited<ReturnType<typeof notificationsApi.markAsRead>>);
+    mockIsWebPushSupported.mockReturnValue(true);
+    mockGetVapidPublicKey.mockReturnValue('public-key');
+    mockGetExistingPushSubscription.mockResolvedValue(null);
+    mockSubscribeToWebPush.mockResolvedValue({
+      endpoint: 'https://fcm.googleapis.com/fcm/send/subscription-1',
+      subscription: {} as PushSubscription,
+    });
+    mockUnsubscribeFromWebPush.mockResolvedValue({
+      endpoint: 'https://fcm.googleapis.com/fcm/send/subscription-1',
+      unsubscribed: true,
+    });
+    Object.defineProperty(window, 'Notification', {
+      value: {
+        permission: 'default',
+        requestPermission: jest.fn(),
+      },
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(window, 'Notification');
+  });
+
+  it('shares one push state across the desktop and drawer presentations inside AppShell', async () => {
+    renderShell();
+
+    await waitFor(() => {
+      expect(mockGetUnreadCount).toHaveBeenCalledTimes(1);
+      expect(mockGetExistingPushSubscription).toHaveBeenCalledTimes(1);
+    });
+
+    const desktopControl = screen.getByRole('button', { name: 'Activar alertas' });
+    fireEvent.click(desktopControl);
+
+    await waitFor(() => {
+      expect(mockSubscribeToWebPush).toHaveBeenCalledTimes(1);
+      expect(screen.getAllByRole('button', { name: 'Desactivar alertas' })).toHaveLength(1);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Abrir menú de navegación' }));
+    const drawer = screen.getByRole('dialog', { name: 'Navegación principal' });
+    const drawerControl = within(drawer).getByRole('button', { name: 'Desactivar alertas' });
+    expect(drawerControl).toBeTruthy();
+    expect(screen.getAllByRole('button', { name: 'Desactivar alertas' })).toHaveLength(2);
+
+    fireEvent.click(drawerControl);
+
+    await waitFor(() => {
+      expect(mockUnsubscribeFromWebPush).toHaveBeenCalledTimes(1);
+      expect(screen.getAllByRole('button', { name: 'Activar alertas' })).toHaveLength(2);
+    });
+  });
+
+  it('reinitializes the shared push controller when the tenant changes', async () => {
+    const { rerender, queryClient } = renderShell();
+
+    await waitFor(() => {
+      expect(mockGetUnreadCount).toHaveBeenCalledTimes(1);
+    });
+
+    const desktopControl = screen.getByRole('button', { name: 'Activar alertas' });
+    await waitFor(() => {
+      expect(desktopControl).toHaveProperty('disabled', false);
+    });
+    fireEvent.click(desktopControl);
+
+    await waitFor(() => {
+      expect(mockSubscribeToWebPush).toHaveBeenCalledTimes(1);
+      expect(mockSubscribeToWebPush).toHaveBeenCalledWith('tenant-1');
+      expect(screen.getByRole('button', { name: 'Desactivar alertas' })).toBeTruthy();
+    });
+
+    mockSubscribeToWebPush.mockClear();
+    mockGetExistingPushSubscription.mockClear();
+
+    mockTenantId = 'tenant-2';
+    mockTenantData = [{ id: 'tenant-2', name: 'Tenant 2', type: 'EDIFICIO_AUTOGESTION' }];
+    mockGetSession.mockReturnValue({
+      user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
+      memberships: [{ tenantId: 'tenant-2', roles: ['RESIDENT'] }],
+      activeTenantId: 'tenant-2',
+    });
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <AppShell>Contenido</AppShell>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockGetUnreadCount).toHaveBeenCalledTimes(2);
+      expect(mockGetExistingPushSubscription).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole('button', { name: 'Activar alertas' })).toBeTruthy();
+    });
+  });
+
+  it('keeps the tenant push state when the drawer is closed and reopened', async () => {
+    renderShell();
+
+    await waitFor(() => {
+      expect(mockGetUnreadCount).toHaveBeenCalledTimes(1);
+      expect(mockGetExistingPushSubscription).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Abrir menú de navegación' }));
+    const drawer = screen.getByRole('dialog', { name: 'Navegación principal' });
+    await waitFor(() => {
+      expect(within(drawer).getByRole('button', { name: 'Activar alertas' })).toHaveProperty('disabled', false);
+    });
+    fireEvent.click(within(drawer).getByRole('button', { name: 'Activar alertas' }));
+
+    await waitFor(() => {
+      expect(mockSubscribeToWebPush).toHaveBeenCalledTimes(1);
+      expect(mockSubscribeToWebPush).toHaveBeenCalledWith('tenant-1');
+      expect(within(drawer).getByRole('button', { name: 'Desactivar alertas' })).toBeTruthy();
+    });
+
+    mockSubscribeToWebPush.mockClear();
+    mockGetExistingPushSubscription.mockClear();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cerrar menú' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Abrir menú de navegación' }));
+
+    const reopenedDrawer = screen.getByRole('dialog', { name: 'Navegación principal' });
+    expect(within(reopenedDrawer).getByRole('button', { name: 'Desactivar alertas' })).toBeTruthy();
+    expect(mockSubscribeToWebPush).toHaveBeenCalledTimes(0);
+    expect(mockGetExistingPushSubscription).toHaveBeenCalledTimes(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cerrar menú' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Abrir menú de navegación' }));
+
+    const reopenedAgainDrawer = screen.getByRole('dialog', { name: 'Navegación principal' });
+    expect(within(reopenedAgainDrawer).getByRole('button', { name: 'Desactivar alertas' })).toBeTruthy();
+    expect(mockSubscribeToWebPush).toHaveBeenCalledTimes(0);
+    expect(mockGetExistingPushSubscription).toHaveBeenCalledTimes(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cerrar menú' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Desactivar alertas' }));
+
+    await waitFor(() => {
+      expect(mockUnsubscribeFromWebPush).toHaveBeenCalledTimes(1);
+      expect(mockUnsubscribeFromWebPush).toHaveBeenCalledWith('tenant-1');
+      expect(screen.getByRole('button', { name: 'Activar alertas' })).toHaveProperty('disabled', false);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Abrir menú de navegación' }));
+    const activateDrawer = screen.getByRole('dialog', { name: 'Navegación principal' });
+    expect(within(activateDrawer).getByRole('button', { name: 'Activar alertas' })).toBeTruthy();
+  });
+});

--- a/apps/web/shared/components/layout/AppShell.test.tsx
+++ b/apps/web/shared/components/layout/AppShell.test.tsx
@@ -2,24 +2,27 @@
  * @jest-environment jsdom
  */
 
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import AppShell from "./AppShell";
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import type { ReactNode, RefObject } from 'react';
+import AppShell from './AppShell';
 
-jest.mock("next/navigation", () => ({
-  useParams: () => ({ tenantId: "tenant-1" }),
-  usePathname: () => "/tenant-1/resident/dashboard",
+jest.mock('next/navigation', () => ({
+  useParams: () => ({ tenantId: 'tenant-1' }),
+  usePathname: () => '/tenant-1/resident/dashboard',
 }));
 
-jest.mock("./Sidebar", () => ({
+jest.mock('./Sidebar', () => ({
   __esModule: true,
-  default: ({ id, onNavigate }: { id?: string; onNavigate?: () => void }) => (
+  default: ({ id, onNavigate, footer }: { id?: string; onNavigate?: () => void; footer?: ReactNode }) => (
     <aside id={id}>
       {onNavigate && <button type="button" onClick={onNavigate}>Ir a pagos</button>}
+      {footer}
     </aside>
   ),
 }));
 
-jest.mock("./Topbar", () => ({
+jest.mock('./Topbar', () => ({
   __esModule: true,
   default: ({
     isMobileMenuOpen,
@@ -27,7 +30,7 @@ jest.mock("./Topbar", () => ({
     onMobileMenuToggle,
   }: {
     isMobileMenuOpen: boolean;
-    menuButtonRef: React.RefObject<HTMLButtonElement | null>;
+    menuButtonRef: RefObject<HTMLButtonElement | null>;
     onMobileMenuToggle: () => void;
   }) => (
     <button
@@ -43,84 +46,193 @@ jest.mock("./Topbar", () => ({
   ),
 }));
 
-jest.mock("../../../features/impersonation/ImpersonationBanner", () => ({
+jest.mock('../../../features/impersonation/ImpersonationBanner', () => ({
   ImpersonationBanner: () => null,
 }));
 
-jest.mock("@/shared/components/assistant", () => ({
-  AssistantWidget: () => <button type="button">Asistente disponible</button>,
-  useAssistantContext: () => ({}),
+jest.mock('@/features/notifications/push-subscription.api', () => ({
+  getExistingPushSubscription: jest.fn(),
+  getVapidPublicKey: jest.fn(),
+  isWebPushSupported: jest.fn(),
+  subscribeToWebPush: jest.fn(),
+  unsubscribeFromWebPush: jest.fn(),
+  PushSubscriptionError: class PushSubscriptionError extends Error {
+    constructor(
+      public readonly code: string,
+      message: string,
+    ) {
+      super(message);
+    }
+  },
 }));
 
-jest.mock("@/features/notifications/components/PushPermissionControl", () => ({
+jest.mock('@/shared/components/assistant', () => {
+  return {
+    AssistantWidget: ({ suspendEscapeHandling = false }: { readonly suspendEscapeHandling?: boolean }) => {
+      const [isOpen, setIsOpen] = React.useState(false);
+      const [input, setInput] = React.useState('');
+      const [messages, setMessages] = React.useState<string[]>([]);
+      const toggleButtonRef = React.useRef<HTMLButtonElement>(null);
+      const inputRef = React.useRef<HTMLTextAreaElement>(null);
+
+      React.useEffect(() => {
+        if (!isOpen) return;
+        inputRef.current?.focus();
+      }, [isOpen]);
+
+      React.useEffect(() => {
+        if (!isOpen || suspendEscapeHandling) return;
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+          if (event.key === 'Escape') {
+            setIsOpen(false);
+            requestAnimationFrame(() => toggleButtonRef.current?.focus());
+          }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+      }, [isOpen, suspendEscapeHandling]);
+
+      return (
+        <div
+          data-testid="assistant-widget"
+          data-input={input}
+          data-message-count={messages.length}
+          data-open={isOpen}
+        >
+          <button
+            ref={toggleButtonRef}
+            type="button"
+            aria-label={isOpen ? 'Cerrar asistente' : 'Abrir asistente'}
+            aria-expanded={isOpen}
+            onClick={() => setIsOpen((open: boolean) => !open)}
+          >
+            {isOpen ? 'Cerrar' : 'Abrir'}
+          </button>
+          {isOpen && (
+            <div role="region" aria-label="Asistente AI">
+              <textarea
+                ref={inputRef}
+                aria-label="Escribí tu pregunta"
+                value={input}
+                onChange={(event) => setInput(event.target.value)}
+              />
+              <button
+                type="button"
+                aria-label="Enviar mensaje"
+                onClick={() => {
+                  if (!input.trim()) return;
+                  setMessages((current: string[]) => [...current, input.trim()]);
+                  setInput('');
+                }}
+              >
+                Enviar mensaje
+              </button>
+              <button
+                type="button"
+                aria-label="Minimizar asistente"
+                onClick={() => {
+                  setIsOpen(false);
+                  requestAnimationFrame(() => toggleButtonRef.current?.focus());
+                }}
+              >
+                Minimizar
+              </button>
+            </div>
+          )}
+        </div>
+      );
+    },
+    useAssistantContext: () => ({}),
+  };
+});
+
+jest.mock('@/features/notifications/components/PushPermissionControl', () => ({
   PushPermissionControl: () => null,
 }));
 
 const openDrawer = () => {
-  const trigger = screen.getByRole("button", { name: "Abrir menú de navegación" });
+  const trigger = screen.getByRole('button', { name: 'Abrir menú de navegación' });
   fireEvent.click(trigger);
   return trigger;
 };
 
-describe("AppShell mobile drawer", () => {
+const openAssistant = () => {
+  const trigger = screen.getByRole('button', { name: 'Abrir asistente' });
+  fireEvent.click(trigger);
+  return trigger;
+};
+
+describe('AppShell mobile drawer', () => {
   beforeEach(() => {
-    document.body.style.overflow = "";
+    document.body.style.overflow = '';
   });
 
-  it("moves focus into the drawer and traps Tab in both directions", () => {
+  it('mounts the drawer only when opened and unmounts it again on close', () => {
+    render(<AppShell>Contenido</AppShell>);
+
+    expect(screen.queryByTestId('mobile-navigation-drawer')).toBeNull();
+
+    openDrawer();
+
+    const drawer = screen.getByTestId('mobile-navigation-drawer');
+    expect(drawer).toBeTruthy();
+    expect(screen.getByRole('dialog', { name: 'Navegación principal' })).toBeTruthy();
+    expect(document.body.style.overflow).toBe('hidden');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cerrar menú' }));
+
+    expect(screen.queryByTestId('mobile-navigation-drawer')).toBeNull();
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  it('moves focus into the drawer and traps Tab in both directions', () => {
     render(<AppShell>Contenido</AppShell>);
     openDrawer();
 
-    const closeButton = screen.getByRole("button", { name: "Cerrar menú" });
-    const lastControl = screen.getByRole("button", { name: "Ir a pagos" });
+    const closeButton = screen.getByRole('button', { name: 'Cerrar menú' });
+    const lastControl = screen.getByRole('button', { name: 'Ir a pagos' });
 
     expect(document.activeElement).toBe(closeButton);
 
     lastControl.focus();
-    fireEvent.keyDown(document, { key: "Tab" });
+    fireEvent.keyDown(document, { key: 'Tab' });
     expect(document.activeElement).toBe(closeButton);
 
     closeButton.focus();
-    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
     expect(document.activeElement).toBe(lastControl);
   });
 
-
-  it("recalculates focusable drawer controls on every Tab event", () => {
+  it('recalculates focusable drawer controls on every Tab event', () => {
     render(<AppShell>Contenido</AppShell>);
     openDrawer();
 
-    const drawer = screen.getByRole("dialog", { name: "Navegación principal" });
-    const closeButton = screen.getByRole("button", { name: "Cerrar menú" });
-    const existingLastControl = screen.getByRole("button", { name: "Ir a pagos" });
-    const dynamicControl = document.createElement("button");
-    dynamicControl.type = "button";
-    dynamicControl.textContent = "Control dinámico";
-    dynamicControl.disabled = true;
+    const drawer = screen.getByRole('dialog', { name: 'Navegación principal' });
+    const closeButton = screen.getByRole('button', { name: 'Cerrar menú' });
+    const dynamicControl = document.createElement('button');
+    dynamicControl.type = 'button';
+    dynamicControl.textContent = 'Control dinámico';
     drawer.appendChild(dynamicControl);
 
-    existingLastControl.focus();
-    fireEvent.keyDown(document, { key: "Tab" });
-    expect(document.activeElement).toBe(closeButton);
-
-    dynamicControl.disabled = false;
     dynamicControl.focus();
-    fireEvent.keyDown(document, { key: "Tab" });
+    fireEvent.keyDown(document, { key: 'Tab' });
     expect(document.activeElement).toBe(closeButton);
 
     closeButton.focus();
-    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    fireEvent.keyDown(document, { key: 'Tab', shiftKey: true });
     expect(document.activeElement).toBe(dynamicControl);
   });
 
-  it("closes the drawer and restores scroll when the desktop breakpoint becomes active", async () => {
+  it('closes the drawer and restores scroll when the desktop breakpoint becomes active', async () => {
     let changeListener: ((event: MediaQueryListEvent) => void) | undefined;
     const addEventListener = jest.fn((event: string, listener: (event: MediaQueryListEvent) => void) => {
-      if (event === "change") changeListener = listener;
+      if (event === 'change') changeListener = listener;
     });
     const removeEventListener = jest.fn();
     const originalMatchMedia = window.matchMedia;
-    Object.defineProperty(window, "matchMedia", {
+    Object.defineProperty(window, 'matchMedia', {
       configurable: true,
       value: jest.fn(() => ({
         matches: false,
@@ -132,29 +244,29 @@ describe("AppShell mobile drawer", () => {
     try {
       render(<AppShell>Contenido</AppShell>);
       const trigger = openDrawer();
-      const triggerFocus = jest.spyOn(trigger, "focus");
+      const triggerFocus = jest.spyOn(trigger, 'focus');
       triggerFocus.mockClear();
 
-      expect(document.body.style.overflow).toBe("hidden");
+      expect(document.body.style.overflow).toBe('hidden');
       act(() => {
         changeListener?.({ matches: true } as MediaQueryListEvent);
       });
 
       await waitFor(() => {
-        expect(screen.queryByTestId("mobile-navigation-drawer")).toBeNull();
-        expect(trigger.getAttribute("aria-expanded")).toBe("false");
-        expect(document.body.style.overflow).toBe("");
+        expect(screen.queryByTestId('mobile-navigation-drawer')).toBeNull();
+        expect(trigger.getAttribute('aria-expanded')).toBe('false');
+        expect(document.body.style.overflow).toBe('');
       });
       expect(triggerFocus).not.toHaveBeenCalled();
     } finally {
-      Object.defineProperty(window, "matchMedia", { configurable: true, value: originalMatchMedia });
+      Object.defineProperty(window, 'matchMedia', { configurable: true, value: originalMatchMedia });
     }
   });
 
-  it("removes the desktop breakpoint listener on unmount", () => {
+  it('removes the desktop breakpoint listener on unmount', () => {
     const removeEventListener = jest.fn();
     const originalMatchMedia = window.matchMedia;
-    Object.defineProperty(window, "matchMedia", {
+    Object.defineProperty(window, 'matchMedia', {
       configurable: true,
       value: jest.fn(() => ({
         matches: false,
@@ -166,85 +278,117 @@ describe("AppShell mobile drawer", () => {
     try {
       const { unmount } = render(<AppShell>Contenido</AppShell>);
       unmount();
-      expect(removeEventListener).toHaveBeenCalledWith("change", expect.any(Function));
+      expect(removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
     } finally {
-      Object.defineProperty(window, "matchMedia", { configurable: true, value: originalMatchMedia });
+      Object.defineProperty(window, 'matchMedia', { configurable: true, value: originalMatchMedia });
     }
   });
 
-  it("suppresses the assistant surface without unmounting it while the drawer is open", () => {
+  it('suppresses the assistant surface without unmounting it while the drawer is open', () => {
     render(<AppShell>Contenido</AppShell>);
-    const assistantSurface = screen.getByTestId("assistant-shell-surface");
+    const assistantSurface = screen.getByTestId('assistant-shell-surface');
+    const assistantWidget = screen.getByTestId('assistant-widget');
 
-    expect(assistantSurface.getAttribute("aria-hidden")).toBe("false");
-    expect(assistantSurface.querySelector("button")).toBeTruthy();
+    expect(assistantSurface.getAttribute('aria-hidden')).toBe('false');
+    expect(assistantWidget.getAttribute('data-open')).toBe('false');
 
     openDrawer();
-    expect(assistantSurface.getAttribute("aria-hidden")).toBe("true");
-    expect(assistantSurface.className).toContain("invisible");
-    expect(assistantSurface.className).toContain("pointer-events-none");
-    expect(assistantSurface.querySelector("button")).toBeTruthy();
+    expect(assistantSurface.getAttribute('aria-hidden')).toBe('true');
+    expect(assistantSurface.className).toContain('invisible');
+    expect(assistantSurface.className).toContain('pointer-events-none');
 
-    fireEvent.keyDown(document, { key: "Escape" });
-    expect(assistantSurface.getAttribute("aria-hidden")).toBe("false");
+    fireEvent.click(screen.getByRole('button', { name: 'Cerrar menú' }));
+    expect(assistantSurface.getAttribute('aria-hidden')).toBe('false');
   });
 
-  it("locks body scroll and restores trigger focus after Escape", async () => {
+  it('locks body scroll and restores trigger focus after Escape', async () => {
     render(<AppShell>Contenido</AppShell>);
     const trigger = openDrawer();
 
-    expect(document.body.style.overflow).toBe("hidden");
+    expect(document.body.style.overflow).toBe('hidden');
 
-    fireEvent.keyDown(document, { key: "Escape" });
+    fireEvent.keyDown(document, { key: 'Escape' });
 
-    expect(screen.queryByTestId("mobile-navigation-drawer")).toBeNull();
-    expect(document.body.style.overflow).toBe("");
+    expect(screen.queryByTestId('mobile-navigation-drawer')).toBeNull();
+    expect(document.body.style.overflow).toBe('');
     await waitFor(() => expect(document.activeElement).toBe(trigger));
   });
 
-  it("returns focus to the trigger after closing from the overlay or close button", async () => {
+  it('returns focus to the trigger after closing from the overlay or close button', async () => {
     render(<AppShell>Contenido</AppShell>);
     const trigger = openDrawer();
 
-    fireEvent.click(screen.getByRole("button", { name: "Cerrar menú de navegación" }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cerrar menú de navegación' }));
     await waitFor(() => expect(document.activeElement).toBe(trigger));
 
     fireEvent.click(trigger);
-    fireEvent.click(screen.getByRole("button", { name: "Cerrar menú" }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cerrar menú' }));
     await waitFor(() => expect(document.activeElement).toBe(trigger));
   });
 
-  it("closes after navigation without returning focus to the previous page trigger", () => {
+  it('closes after navigation without returning focus to the previous page trigger', () => {
     render(<AppShell>Contenido</AppShell>);
     const trigger = openDrawer();
 
-    fireEvent.click(screen.getByRole("button", { name: "Ir a pagos" }));
+    fireEvent.click(screen.getByRole('button', { name: 'Ir a pagos' }));
 
-    expect(screen.queryByTestId("mobile-navigation-drawer")).toBeNull();
+    expect(screen.queryByTestId('mobile-navigation-drawer')).toBeNull();
     expect(document.activeElement).not.toBe(trigger);
   });
 
-  it("restores the previous body overflow when unmounted while open", () => {
-    document.body.style.overflow = "scroll";
+  it('restores the previous body overflow when unmounted while open', () => {
+    document.body.style.overflow = 'scroll';
     const { unmount } = render(<AppShell>Contenido</AppShell>);
 
     openDrawer();
-    expect(document.body.style.overflow).toBe("hidden");
+    expect(document.body.style.overflow).toBe('hidden');
 
     unmount();
-    expect(document.body.style.overflow).toBe("scroll");
+    expect(document.body.style.overflow).toBe('scroll');
   });
 
-  it("keeps horizontal scrolling on exactly the content layer", () => {
+  it('keeps horizontal scrolling on exactly the content layer', () => {
     const { container } = render(<AppShell>Contenido</AppShell>);
     const root = container.firstElementChild;
-    const main = container.querySelector("main");
-    const horizontalScrollLayers = container.querySelectorAll(".overflow-x-auto");
+    const main = container.querySelector('main');
+    const horizontalScrollLayers = container.querySelectorAll('.overflow-x-auto');
 
-    expect(root?.className).toContain("min-h-dvh");
-    expect(root?.className).not.toContain("min-h-screen");
-    expect(main?.className).toContain("min-w-0");
+    expect(root?.className).toContain('min-h-dvh');
+    expect(root?.className).not.toContain('min-h-screen');
+    expect(main?.className).toContain('min-w-0');
     expect(horizontalScrollLayers).toHaveLength(1);
-    expect(horizontalScrollLayers[0]?.className).toContain("min-w-0");
+    expect(horizontalScrollLayers[0]?.className).toContain('min-w-0');
+  });
+
+  it('keeps the assistant open while the drawer is open and only closes it after a second Escape', async () => {
+    render(<AppShell>Contenido</AppShell>);
+    const assistantTrigger = openAssistant();
+
+    fireEvent.change(screen.getByLabelText('Escribí tu pregunta'), { target: { value: 'Mensaje persistente' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Enviar mensaje' }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assistant-widget').getAttribute('data-open')).toBe('true');
+      expect(screen.getByTestId('assistant-widget').getAttribute('data-message-count')).toBe('1');
+    });
+
+    const drawerTrigger = openDrawer();
+    expect(screen.getByTestId('assistant-shell-surface').getAttribute('aria-hidden')).toBe('true');
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('mobile-navigation-drawer')).toBeNull();
+      expect(document.activeElement).toBe(drawerTrigger);
+      expect(screen.getByTestId('assistant-widget').getAttribute('data-open')).toBe('true');
+      expect(screen.getByTestId('assistant-widget').getAttribute('data-message-count')).toBe('1');
+    });
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('assistant-widget').getAttribute('data-open')).toBe('false');
+      expect(screen.getByRole('button', { name: 'Abrir asistente' })).toBe(assistantTrigger);
+    });
   });
 });

--- a/apps/web/shared/components/layout/AppShell.test.tsx
+++ b/apps/web/shared/components/layout/AppShell.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import AppShell from "./AppShell";
 
 jest.mock("next/navigation", () => ({
@@ -48,7 +48,7 @@ jest.mock("../../../features/impersonation/ImpersonationBanner", () => ({
 }));
 
 jest.mock("@/shared/components/assistant", () => ({
-  AssistantWidget: () => null,
+  AssistantWidget: () => <button type="button">Asistente disponible</button>,
   useAssistantContext: () => ({}),
 }));
 
@@ -83,6 +83,110 @@ describe("AppShell mobile drawer", () => {
     closeButton.focus();
     fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
     expect(document.activeElement).toBe(lastControl);
+  });
+
+
+  it("recalculates focusable drawer controls on every Tab event", () => {
+    render(<AppShell>Contenido</AppShell>);
+    openDrawer();
+
+    const drawer = screen.getByRole("dialog", { name: "Navegación principal" });
+    const closeButton = screen.getByRole("button", { name: "Cerrar menú" });
+    const existingLastControl = screen.getByRole("button", { name: "Ir a pagos" });
+    const dynamicControl = document.createElement("button");
+    dynamicControl.type = "button";
+    dynamicControl.textContent = "Control dinámico";
+    dynamicControl.disabled = true;
+    drawer.appendChild(dynamicControl);
+
+    existingLastControl.focus();
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(document.activeElement).toBe(closeButton);
+
+    dynamicControl.disabled = false;
+    dynamicControl.focus();
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(document.activeElement).toBe(closeButton);
+
+    closeButton.focus();
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(dynamicControl);
+  });
+
+  it("closes the drawer and restores scroll when the desktop breakpoint becomes active", async () => {
+    let changeListener: ((event: MediaQueryListEvent) => void) | undefined;
+    const addEventListener = jest.fn((event: string, listener: (event: MediaQueryListEvent) => void) => {
+      if (event === "change") changeListener = listener;
+    });
+    const removeEventListener = jest.fn();
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: jest.fn(() => ({
+        matches: false,
+        addEventListener,
+        removeEventListener,
+      })),
+    });
+
+    try {
+      render(<AppShell>Contenido</AppShell>);
+      const trigger = openDrawer();
+      const triggerFocus = jest.spyOn(trigger, "focus");
+      triggerFocus.mockClear();
+
+      expect(document.body.style.overflow).toBe("hidden");
+      act(() => {
+        changeListener?.({ matches: true } as MediaQueryListEvent);
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTestId("mobile-navigation-drawer")).toBeNull();
+        expect(trigger.getAttribute("aria-expanded")).toBe("false");
+        expect(document.body.style.overflow).toBe("");
+      });
+      expect(triggerFocus).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, "matchMedia", { configurable: true, value: originalMatchMedia });
+    }
+  });
+
+  it("removes the desktop breakpoint listener on unmount", () => {
+    const removeEventListener = jest.fn();
+    const originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: jest.fn(() => ({
+        matches: false,
+        addEventListener: jest.fn(),
+        removeEventListener,
+      })),
+    });
+
+    try {
+      const { unmount } = render(<AppShell>Contenido</AppShell>);
+      unmount();
+      expect(removeEventListener).toHaveBeenCalledWith("change", expect.any(Function));
+    } finally {
+      Object.defineProperty(window, "matchMedia", { configurable: true, value: originalMatchMedia });
+    }
+  });
+
+  it("suppresses the assistant surface without unmounting it while the drawer is open", () => {
+    render(<AppShell>Contenido</AppShell>);
+    const assistantSurface = screen.getByTestId("assistant-shell-surface");
+
+    expect(assistantSurface.getAttribute("aria-hidden")).toBe("false");
+    expect(assistantSurface.querySelector("button")).toBeTruthy();
+
+    openDrawer();
+    expect(assistantSurface.getAttribute("aria-hidden")).toBe("true");
+    expect(assistantSurface.className).toContain("invisible");
+    expect(assistantSurface.className).toContain("pointer-events-none");
+    expect(assistantSurface.querySelector("button")).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(assistantSurface.getAttribute("aria-hidden")).toBe("false");
   });
 
   it("locks body scroll and restores trigger focus after Escape", async () => {

--- a/apps/web/shared/components/layout/AppShell.test.tsx
+++ b/apps/web/shared/components/layout/AppShell.test.tsx
@@ -1,0 +1,146 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import AppShell from "./AppShell";
+
+jest.mock("next/navigation", () => ({
+  useParams: () => ({ tenantId: "tenant-1" }),
+  usePathname: () => "/tenant-1/resident/dashboard",
+}));
+
+jest.mock("./Sidebar", () => ({
+  __esModule: true,
+  default: ({ id, onNavigate }: { id?: string; onNavigate?: () => void }) => (
+    <aside id={id}>
+      {onNavigate && <button type="button" onClick={onNavigate}>Ir a pagos</button>}
+    </aside>
+  ),
+}));
+
+jest.mock("./Topbar", () => ({
+  __esModule: true,
+  default: ({
+    isMobileMenuOpen,
+    menuButtonRef,
+    onMobileMenuToggle,
+  }: {
+    isMobileMenuOpen: boolean;
+    menuButtonRef: React.RefObject<HTMLButtonElement | null>;
+    onMobileMenuToggle: () => void;
+  }) => (
+    <button
+      ref={menuButtonRef}
+      type="button"
+      aria-label="Abrir menú de navegación"
+      aria-controls="mobile-navigation"
+      aria-expanded={isMobileMenuOpen}
+      onClick={onMobileMenuToggle}
+    >
+      Menú
+    </button>
+  ),
+}));
+
+jest.mock("../../../features/impersonation/ImpersonationBanner", () => ({
+  ImpersonationBanner: () => null,
+}));
+
+jest.mock("@/shared/components/assistant", () => ({
+  AssistantWidget: () => null,
+  useAssistantContext: () => ({}),
+}));
+
+jest.mock("@/features/notifications/components/PushPermissionControl", () => ({
+  PushPermissionControl: () => null,
+}));
+
+const openDrawer = () => {
+  const trigger = screen.getByRole("button", { name: "Abrir menú de navegación" });
+  fireEvent.click(trigger);
+  return trigger;
+};
+
+describe("AppShell mobile drawer", () => {
+  beforeEach(() => {
+    document.body.style.overflow = "";
+  });
+
+  it("moves focus into the drawer and traps Tab in both directions", () => {
+    render(<AppShell>Contenido</AppShell>);
+    openDrawer();
+
+    const closeButton = screen.getByRole("button", { name: "Cerrar menú" });
+    const lastControl = screen.getByRole("button", { name: "Ir a pagos" });
+
+    expect(document.activeElement).toBe(closeButton);
+
+    lastControl.focus();
+    fireEvent.keyDown(document, { key: "Tab" });
+    expect(document.activeElement).toBe(closeButton);
+
+    closeButton.focus();
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(lastControl);
+  });
+
+  it("locks body scroll and restores trigger focus after Escape", async () => {
+    render(<AppShell>Contenido</AppShell>);
+    const trigger = openDrawer();
+
+    expect(document.body.style.overflow).toBe("hidden");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(screen.queryByTestId("mobile-navigation-drawer")).toBeNull();
+    expect(document.body.style.overflow).toBe("");
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+
+  it("returns focus to the trigger after closing from the overlay or close button", async () => {
+    render(<AppShell>Contenido</AppShell>);
+    const trigger = openDrawer();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cerrar menú de navegación" }));
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+
+    fireEvent.click(trigger);
+    fireEvent.click(screen.getByRole("button", { name: "Cerrar menú" }));
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+
+  it("closes after navigation without returning focus to the previous page trigger", () => {
+    render(<AppShell>Contenido</AppShell>);
+    const trigger = openDrawer();
+
+    fireEvent.click(screen.getByRole("button", { name: "Ir a pagos" }));
+
+    expect(screen.queryByTestId("mobile-navigation-drawer")).toBeNull();
+    expect(document.activeElement).not.toBe(trigger);
+  });
+
+  it("restores the previous body overflow when unmounted while open", () => {
+    document.body.style.overflow = "scroll";
+    const { unmount } = render(<AppShell>Contenido</AppShell>);
+
+    openDrawer();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    unmount();
+    expect(document.body.style.overflow).toBe("scroll");
+  });
+
+  it("keeps horizontal scrolling on exactly the content layer", () => {
+    const { container } = render(<AppShell>Contenido</AppShell>);
+    const root = container.firstElementChild;
+    const main = container.querySelector("main");
+    const horizontalScrollLayers = container.querySelectorAll(".overflow-x-auto");
+
+    expect(root?.className).toContain("min-h-dvh");
+    expect(root?.className).not.toContain("min-h-screen");
+    expect(main?.className).toContain("min-w-0");
+    expect(horizontalScrollLayers).toHaveLength(1);
+    expect(horizontalScrollLayers[0]?.className).toContain("min-w-0");
+  });
+});

--- a/apps/web/shared/components/layout/AppShell.tsx
+++ b/apps/web/shared/components/layout/AppShell.tsx
@@ -9,9 +9,17 @@ import { ImpersonationBanner } from "../../../features/impersonation/Impersonati
 import { AssistantWidget, useAssistantContext } from "@/shared/components/assistant";
 import { PushPermissionControl } from "@/features/notifications/components/PushPermissionControl";
 
-function AssistantWrapper() {
+function AssistantWrapper({ isDrawerOpen }: { readonly isDrawerOpen: boolean }) {
   const context = useAssistantContext();
-  return <AssistantWidget context={context} defaultUseLlm={false} />;
+  return (
+    <div
+      data-testid="assistant-shell-surface"
+      aria-hidden={isDrawerOpen}
+      className={isDrawerOpen ? "invisible pointer-events-none" : undefined}
+    >
+      <AssistantWidget context={context} defaultUseLlm={false} />
+    </div>
+  );
 }
 
 function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
@@ -47,9 +55,6 @@ export default function AppShell({ children }: { readonly children: ReactNode })
     if (!isDrawerOpen) return;
 
     const previousOverflow = document.body.style.overflow;
-    const focusableElements = getFocusableElements(drawerPanelRef.current);
-    const firstFocusableElement = focusableElements[0];
-    const lastFocusableElement = focusableElements.at(-1);
 
     drawerCloseButtonRef.current?.focus();
     document.body.style.overflow = "hidden";
@@ -60,7 +65,12 @@ export default function AppShell({ children }: { readonly children: ReactNode })
         return;
       }
 
-      if (event.key !== "Tab" || !firstFocusableElement || !lastFocusableElement) return;
+      if (event.key !== "Tab") return;
+
+      const focusableElements = getFocusableElements(drawerPanelRef.current);
+      const firstFocusableElement = focusableElements[0];
+      const lastFocusableElement = focusableElements.at(-1);
+      if (!firstFocusableElement || !lastFocusableElement) return;
 
       const activeElement = document.activeElement;
       const isFocusInsideDrawer = drawerPanelRef.current?.contains(activeElement);
@@ -85,6 +95,20 @@ export default function AppShell({ children }: { readonly children: ReactNode })
       document.removeEventListener("keydown", handleKeyDown);
     };
   }, [closeDrawer, isDrawerOpen]);
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+
+    const desktopMediaQuery = window.matchMedia("(min-width: 1024px)");
+    const handleBreakpointChange = (event: MediaQueryListEvent) => {
+      if (event.matches) {
+        closeDrawer(false);
+      }
+    };
+
+    desktopMediaQuery.addEventListener("change", handleBreakpointChange);
+    return () => desktopMediaQuery.removeEventListener("change", handleBreakpointChange);
+  }, [closeDrawer]);
 
   return (
     <div className="flex min-h-dvh bg-background text-foreground">
@@ -142,7 +166,7 @@ export default function AppShell({ children }: { readonly children: ReactNode })
           </div>
         </div>
       )}
-      <AssistantWrapper />
+      <AssistantWrapper isDrawerOpen={isDrawerOpen} />
     </div>
   );
 }

--- a/apps/web/shared/components/layout/AppShell.tsx
+++ b/apps/web/shared/components/layout/AppShell.tsx
@@ -8,6 +8,7 @@ import Topbar from "./Topbar";
 import { ImpersonationBanner } from "../../../features/impersonation/ImpersonationBanner";
 import { AssistantWidget, useAssistantContext } from "@/shared/components/assistant";
 import { PushPermissionControl } from "@/features/notifications/components/PushPermissionControl";
+import { PushPermissionProvider } from "@/features/notifications/components/PushPermissionProvider";
 
 function AssistantWrapper({ isDrawerOpen }: { readonly isDrawerOpen: boolean }) {
   const context = useAssistantContext();
@@ -17,7 +18,7 @@ function AssistantWrapper({ isDrawerOpen }: { readonly isDrawerOpen: boolean }) 
       aria-hidden={isDrawerOpen}
       className={isDrawerOpen ? "invisible pointer-events-none" : undefined}
     >
-      <AssistantWidget context={context} defaultUseLlm={false} />
+      <AssistantWidget context={context} defaultUseLlm={false} suspendEscapeHandling={isDrawerOpen} />
     </div>
   );
 }
@@ -113,60 +114,66 @@ export default function AppShell({ children }: { readonly children: ReactNode })
   return (
     <div className="flex min-h-dvh bg-background text-foreground">
       <Sidebar />
-      <div className="flex min-w-0 flex-1 flex-col">
-        <ImpersonationBanner />
-        <Topbar
-          isMobileMenuOpen={isDrawerOpen}
-          menuButtonRef={menuButtonRef}
-          onMobileMenuToggle={toggleDrawer}
-        />
-        <main className="min-w-0 flex-1 p-3 sm:p-4 lg:p-6">
-          <div className="mx-auto w-full max-w-6xl">
-            <div className="overflow-hidden rounded-xl border border-border bg-card text-card-foreground shadow-sm">
-              <div className="min-w-0 overflow-x-auto p-3 sm:p-4 lg:p-6">{children}</div>
-            </div>
-          </div>
-        </main>
-      </div>
-
-      {isDrawerOpen && (
-        <div className="fixed inset-0 z-40 lg:hidden" data-testid="mobile-navigation-drawer">
-          <button
-            type="button"
-            aria-label="Cerrar menú de navegación"
-            className="absolute inset-0 bg-black/50"
-            onClick={() => closeDrawer()}
+      <PushPermissionProvider key={tenantId ?? "tenant-unavailable"} tenantId={tenantId ?? ""}>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <ImpersonationBanner />
+          <Topbar
+            isMobileMenuOpen={isDrawerOpen}
+            menuButtonRef={menuButtonRef}
+            onMobileMenuToggle={toggleDrawer}
           />
-          <div
-            ref={drawerPanelRef}
-            role="dialog"
-            aria-modal="true"
-            aria-label="Navegación principal"
-            className="relative z-10 flex h-full w-[min(20rem,calc(100vw-2rem))] flex-col overflow-y-auto border-r border-border bg-card pb-[max(1rem,env(safe-area-inset-bottom))] pt-[max(1rem,env(safe-area-inset-top))] text-card-foreground shadow-xl"
-          >
-            <div className="flex items-center justify-between px-4 pb-2">
-              <span className="font-semibold">BuildingOS</span>
-              <button
-                ref={drawerCloseButtonRef}
-                type="button"
-                aria-label="Cerrar menú"
-                className="inline-flex size-11 items-center justify-center rounded-md hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring"
-                onClick={() => closeDrawer()}
-              >
-                <X className="size-5" aria-hidden="true" />
-              </button>
+          <main className="min-w-0 flex-1 p-3 sm:p-4 lg:p-6">
+            <div className="mx-auto w-full max-w-6xl">
+              <div className="overflow-hidden rounded-xl border border-border bg-card text-card-foreground shadow-sm">
+                <div className="min-w-0 overflow-x-auto p-3 sm:p-4 lg:p-6">{children}</div>
+              </div>
             </div>
-            <Sidebar
-              id="mobile-navigation"
-              variant="drawer"
-              className="min-h-0 w-full flex-1 border-0"
-              onNavigate={() => closeDrawer(false)}
-              footer={tenantId ? <div className="border-t border-border p-4"><PushPermissionControl tenantId={tenantId} /></div> : null}
-            />
-          </div>
+          </main>
         </div>
-      )}
-      <AssistantWrapper isDrawerOpen={isDrawerOpen} />
+
+        {isDrawerOpen && (
+          <div className="fixed inset-0 z-40 lg:hidden" data-testid="mobile-navigation-drawer">
+            <button
+              type="button"
+              aria-label="Cerrar menú de navegación"
+              className="absolute inset-0 bg-black/50"
+              onClick={() => closeDrawer()}
+            />
+            <div
+              ref={drawerPanelRef}
+              role="dialog"
+              aria-modal="true"
+              aria-label="Navegación principal"
+              className="relative z-10 flex h-full w-[min(20rem,calc(100vw-2rem))] flex-col overflow-y-auto border-r border-border bg-card pb-[max(1rem,env(safe-area-inset-bottom))] pt-[max(1rem,env(safe-area-inset-top))] text-card-foreground shadow-xl"
+            >
+              <div className="flex items-center justify-between px-4 pb-2">
+                <span className="font-semibold">BuildingOS</span>
+                <button
+                  ref={drawerCloseButtonRef}
+                  type="button"
+                  aria-label="Cerrar menú"
+                  className="inline-flex size-11 items-center justify-center rounded-md hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring"
+                  onClick={() => closeDrawer()}
+                >
+                  <X className="size-5" aria-hidden="true" />
+                </button>
+              </div>
+              <Sidebar
+                id="mobile-navigation"
+                variant="drawer"
+                className="min-h-0 w-full flex-1 border-0"
+                onNavigate={() => closeDrawer(false)}
+                footer={tenantId ? (
+                  <div className="border-t border-border p-4">
+                    <PushPermissionControl />
+                  </div>
+                ) : null}
+              />
+            </div>
+          </div>
+        )}
+        <AssistantWrapper isDrawerOpen={isDrawerOpen} />
+      </PushPermissionProvider>
     </div>
   );
 }

--- a/apps/web/shared/components/layout/AppShell.tsx
+++ b/apps/web/shared/components/layout/AppShell.tsx
@@ -1,31 +1,147 @@
 "use client";
 
-import { ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { useParams } from "next/navigation";
+import { X } from "lucide-react";
 import Sidebar from "./Sidebar";
 import Topbar from "./Topbar";
 import { ImpersonationBanner } from "../../../features/impersonation/ImpersonationBanner";
 import { AssistantWidget, useAssistantContext } from "@/shared/components/assistant";
+import { PushPermissionControl } from "@/features/notifications/components/PushPermissionControl";
 
 function AssistantWrapper() {
   const context = useAssistantContext();
   return <AssistantWidget context={context} defaultUseLlm={false} />;
 }
 
-export default function AppShell({ children }: { children: ReactNode }) {
+function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return [];
+
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(
+      'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])',
+    ),
+  ).filter((element) => element.tabIndex >= 0);
+}
+
+export default function AppShell({ children }: { readonly children: ReactNode }) {
+  const params = useParams();
+  const tenantId = params?.tenantId as string | undefined;
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const drawerPanelRef = useRef<HTMLDivElement>(null);
+  const drawerCloseButtonRef = useRef<HTMLButtonElement>(null);
+
+  const closeDrawer = useCallback((restoreFocus = true) => {
+    setIsDrawerOpen(false);
+    if (restoreFocus) {
+      requestAnimationFrame(() => menuButtonRef.current?.focus());
+    }
+  }, []);
+
+  const toggleDrawer = useCallback(() => {
+    setIsDrawerOpen((open) => !open);
+  }, []);
+
+  useEffect(() => {
+    if (!isDrawerOpen) return;
+
+    const previousOverflow = document.body.style.overflow;
+    const focusableElements = getFocusableElements(drawerPanelRef.current);
+    const firstFocusableElement = focusableElements[0];
+    const lastFocusableElement = focusableElements.at(-1);
+
+    drawerCloseButtonRef.current?.focus();
+    document.body.style.overflow = "hidden";
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeDrawer();
+        return;
+      }
+
+      if (event.key !== "Tab" || !firstFocusableElement || !lastFocusableElement) return;
+
+      const activeElement = document.activeElement;
+      const isFocusInsideDrawer = drawerPanelRef.current?.contains(activeElement);
+      if (!isFocusInsideDrawer) {
+        event.preventDefault();
+        firstFocusableElement.focus();
+        return;
+      }
+
+      if (event.shiftKey && activeElement === firstFocusableElement) {
+        event.preventDefault();
+        lastFocusableElement.focus();
+      } else if (!event.shiftKey && activeElement === lastFocusableElement) {
+        event.preventDefault();
+        firstFocusableElement.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [closeDrawer, isDrawerOpen]);
+
   return (
-    <div className="min-h-screen bg-background text-foreground flex">
+    <div className="flex min-h-dvh bg-background text-foreground">
       <Sidebar />
-      <div className="flex-1 flex flex-col overflow-hidden">
+      <div className="flex min-w-0 flex-1 flex-col">
         <ImpersonationBanner />
-        <Topbar />
-        <main className="p-6 overflow-x-auto">
+        <Topbar
+          isMobileMenuOpen={isDrawerOpen}
+          menuButtonRef={menuButtonRef}
+          onMobileMenuToggle={toggleDrawer}
+        />
+        <main className="min-w-0 flex-1 p-3 sm:p-4 lg:p-6">
           <div className="mx-auto w-full max-w-6xl">
-            <div className="rounded-xl border border-border bg-card text-card-foreground shadow-sm overflow-hidden">
-              <div className="p-6 overflow-x-auto">{children}</div>
+            <div className="overflow-hidden rounded-xl border border-border bg-card text-card-foreground shadow-sm">
+              <div className="min-w-0 overflow-x-auto p-3 sm:p-4 lg:p-6">{children}</div>
             </div>
           </div>
         </main>
       </div>
+
+      {isDrawerOpen && (
+        <div className="fixed inset-0 z-40 lg:hidden" data-testid="mobile-navigation-drawer">
+          <button
+            type="button"
+            aria-label="Cerrar menú de navegación"
+            className="absolute inset-0 bg-black/50"
+            onClick={() => closeDrawer()}
+          />
+          <div
+            ref={drawerPanelRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Navegación principal"
+            className="relative z-10 flex h-full w-[min(20rem,calc(100vw-2rem))] flex-col overflow-y-auto border-r border-border bg-card pb-[max(1rem,env(safe-area-inset-bottom))] pt-[max(1rem,env(safe-area-inset-top))] text-card-foreground shadow-xl"
+          >
+            <div className="flex items-center justify-between px-4 pb-2">
+              <span className="font-semibold">BuildingOS</span>
+              <button
+                ref={drawerCloseButtonRef}
+                type="button"
+                aria-label="Cerrar menú"
+                className="inline-flex size-11 items-center justify-center rounded-md hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring"
+                onClick={() => closeDrawer()}
+              >
+                <X className="size-5" aria-hidden="true" />
+              </button>
+            </div>
+            <Sidebar
+              id="mobile-navigation"
+              variant="drawer"
+              className="min-h-0 w-full flex-1 border-0"
+              onNavigate={() => closeDrawer(false)}
+              footer={tenantId ? <div className="border-t border-border p-4"><PushPermissionControl tenantId={tenantId} /></div> : null}
+            />
+          </div>
+        </div>
+      )}
       <AssistantWrapper />
     </div>
   );

--- a/apps/web/shared/components/layout/Sidebar.test.tsx
+++ b/apps/web/shared/components/layout/Sidebar.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import { Sidebar } from "./Sidebar";
+
+let pathname = "/tenant-1/tickets/ticket-1";
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => <a href={href} {...props}>{children}</a>,
+}));
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => pathname,
+}));
+
+jest.mock("../../../features/tenancy/tenant.hooks", () => ({
+  useTenantId: () => "tenant-1",
+}));
+
+jest.mock("../../../features/auth/useAuthSession", () => ({
+  useIsSuperAdmin: () => false,
+  useHasRole: (role: string) => role === "RESIDENT",
+}));
+
+jest.mock("../../../features/impersonation/useImpersonation", () => ({
+  useImpersonation: () => ({ isImpersonating: false }),
+}));
+
+jest.mock("../../../features/tenants/tenants.hooks", () => ({
+  useTenants: () => ({ data: [{ id: "tenant-1", name: "Horizonte" }] }),
+}));
+
+jest.mock("@/i18n", () => ({
+  t: (key: string) => ({
+    "common.condominium": "Condominio",
+    "navigation.dashboard": "Panel",
+    "navigation.payments": "Pagos",
+    "navigation.communications": "Comunicados",
+    "navigation.tickets": "Solicitudes",
+    "navigation.myUnit": "Mi unidad",
+    "navigation.documents": "Documentos",
+  })[key] ?? key,
+}));
+
+describe("Sidebar", () => {
+  beforeEach(() => {
+    pathname = "/tenant-1/tickets/ticket-1";
+  });
+
+  it("uses desktop-only structural classes and desktop link density by default", () => {
+    const { container } = render(<Sidebar />);
+    const aside = container.querySelector("aside");
+
+    expect(aside?.className).toContain("hidden");
+    expect(aside?.className).toContain("w-64");
+    expect(aside?.className).toContain("lg:block");
+    expect(screen.getByRole("link", { name: "Solicitudes" }).className).not.toContain("min-h-11");
+  });
+
+  it("uses visible touch-sized links without a fixed desktop width in the drawer variant", () => {
+    const { container } = render(<Sidebar variant="drawer" />);
+    const aside = container.querySelector("aside");
+
+    expect(aside?.className).toContain("block");
+    expect(aside?.className).not.toContain("w-64");
+    screen.getAllByRole("link").forEach((link) => {
+      expect(link.className).toContain("min-h-11");
+      expect(link.className).toContain("items-center");
+    });
+  });
+
+  it("keeps Solicitudes active for the canonical resident ticket detail route", () => {
+    render(<Sidebar variant="drawer" />);
+
+    expect(screen.getByRole("link", { name: "Solicitudes" }).className).toContain("bg-primary");
+  });
+});

--- a/apps/web/shared/components/layout/Sidebar.tsx
+++ b/apps/web/shared/components/layout/Sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { ReactNode } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { routes } from "../../../shared/lib/routes";
@@ -10,81 +11,113 @@ import { useTenants } from "../../../features/tenants/tenants.hooks";
 import { t } from "@/i18n";
 
 interface NavItemProps {
-  href: string;
-  label: string;
+  readonly href: string;
+  readonly label: string;
+  readonly isActive: boolean;
+  readonly onNavigate?: () => void;
+  readonly variant: "desktop" | "drawer";
 }
 
-const NavItem = ({ href, label }: NavItemProps) => {
-  const pathname = usePathname();
-  const isActive = pathname === href;
+interface SidebarProps {
+  readonly className?: string;
+  readonly footer?: ReactNode;
+  readonly id?: string;
+  readonly onNavigate?: () => void;
+  readonly variant?: "desktop" | "drawer";
+}
 
-  return (
-    <Link
-      href={href}
-      className={[
-        "px-3 py-2 rounded-md text-sm transition-colors",
-        "hover:bg-muted",
-        isActive
-          ? "bg-primary text-primary-foreground"
-          : "text-foreground",
-      ].join(" ")}
-    >
-      {label}
-    </Link>
-  );
-};
+const NavItem = ({ href, label, isActive, onNavigate, variant }: NavItemProps) => (
+  <Link
+    href={href}
+    onClick={onNavigate}
+    className={[
+      variant === "drawer"
+        ? "flex min-h-11 items-center rounded-md px-3 text-sm transition-colors"
+        : "rounded-md px-3 py-2 text-sm transition-colors",
+      "hover:bg-muted",
+      isActive ? "bg-primary text-primary-foreground" : "text-foreground",
+    ].join(" ")}
+  >
+    {label}
+  </Link>
+);
 
-export const Sidebar = () => {
+export const Sidebar = ({ className, footer, id, onNavigate, variant = "desktop" }: SidebarProps) => {
   const tenantId = useTenantId();
+  const pathname = usePathname();
   const { data: tenants } = useTenants();
-  const tenantName = tenants?.find(t => t.id === tenantId)?.name;
+  const tenantName = tenants?.find((tenant) => tenant.id === tenantId)?.name;
   const isSuperAdmin = useIsSuperAdmin();
   const isResident = useHasRole("RESIDENT");
   const { isImpersonating } = useImpersonation();
 
   if ((isSuperAdmin && !isImpersonating) || !tenantId) return null;
 
+  const isActive = (href: string) =>
+    pathname === href || (
+      isResident &&
+      href === `/${tenantId}/resident/tickets` &&
+      pathname.startsWith(`/${tenantId}/tickets/`)
+    );
+
+  const navItem = (href: string, label: string) => (
+    <NavItem
+      key={href}
+      href={href}
+      label={label}
+      isActive={isActive(href)}
+      onNavigate={onNavigate}
+      variant={variant}
+    />
+  );
+
   return (
-    <aside className="w-64 border-r border-border bg-card text-card-foreground">
+    <aside
+      id={id}
+      className={className ?? (
+        variant === "drawer"
+          ? "block min-h-0 w-full flex-1 border-r border-border bg-card text-card-foreground"
+          : "hidden w-64 border-r border-border bg-card text-card-foreground lg:block"
+      )}
+    >
       <div className="p-4">
-        <div className="font-semibold text-base">BuildingOS</div>
+        <div className="text-base font-semibold">BuildingOS</div>
         {tenantName && (
           <div className="mt-1 text-xs text-muted-foreground">
-            {t('common.condominium')}: <span className="font-medium text-foreground">{tenantName}</span>
+            {t("common.condominium")}: <span className="font-medium text-foreground">{tenantName}</span>
           </div>
         )}
       </div>
 
       <nav className="flex flex-col gap-1 px-2 pb-4">
-        <NavItem href={routes.tenantDashboard(tenantId)} label={t('navigation.dashboard')} />
+        {navItem(routes.tenantDashboard(tenantId), t("navigation.dashboard"))}
 
         {isResident ? (
           <>
-            <NavItem href={`/${tenantId}/resident/payments`} label={t('navigation.payments')} />
-            <NavItem href={`/${tenantId}/resident/announcements`} label={t('navigation.communications')} />
-            <NavItem href={`/${tenantId}/resident/tickets`} label={t('navigation.tickets')} />
-            <NavItem href={`/${tenantId}/resident/unit`} label={t('navigation.myUnit')} />
-            <NavItem href={`/${tenantId}/resident/documents`} label={t('navigation.documents')} />
+            {navItem(`/${tenantId}/resident/payments`, t("navigation.payments"))}
+            {navItem(`/${tenantId}/resident/announcements`, t("navigation.communications"))}
+            {navItem(`/${tenantId}/resident/tickets`, t("navigation.tickets"))}
+            {navItem(`/${tenantId}/resident/unit`, t("navigation.myUnit"))}
+            {navItem(`/${tenantId}/resident/documents`, t("navigation.documents"))}
           </>
         ) : (
           <>
-            <NavItem href={routes.buildingsList(tenantId)} label={t('navigation.buildings')} />
-            <NavItem href={`/${tenantId}/units`} label={t('navigation.units')} />
-            <NavItem href={`/${tenantId}/finanzas`} label={t('navigation.finanzas')} />
-            <NavItem href={`/${tenantId}/finance/categories`} label={t('navigation.rubros')} />
-            <NavItem href={routes.tenantReports(tenantId)} label={t('navigation.reports')} />
-
-
-            <div className="mt-3 px-3 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
-              {t('navigation.settings')}
+            {navItem(routes.buildingsList(tenantId), t("navigation.buildings"))}
+            {navItem(`/${tenantId}/units`, t("navigation.units"))}
+            {navItem(`/${tenantId}/finanzas`, t("navigation.finanzas"))}
+            {navItem(`/${tenantId}/finance/categories`, t("navigation.rubros"))}
+            {navItem(routes.tenantReports(tenantId), t("navigation.reports"))}
+            <div className="mt-3 px-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {t("navigation.settings")}
             </div>
-            <NavItem href={`/${tenantId}/settings/general`} label={t('settings.general')} />
-            <NavItem href={routes.onboardingImport(tenantId)} label="Onboarding import" />
-            <NavItem href={`/${tenantId}/settings/members`} label={t('navigation.residents')} />
-            <NavItem href={`/${tenantId}/settings/team`} label={t('sidebar.team')} />
+            {navItem(`/${tenantId}/settings/general`, t("settings.general"))}
+            {navItem(routes.onboardingImport(tenantId), "Onboarding import")}
+            {navItem(`/${tenantId}/settings/members`, t("navigation.residents"))}
+            {navItem(`/${tenantId}/settings/team`, t("sidebar.team"))}
           </>
         )}
       </nav>
+      {footer}
     </aside>
   );
 };

--- a/apps/web/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/shared/components/layout/Topbar.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as notificationsApi from '@/features/notifications/notifications.api';
 import * as financeApi from '@/features/finance/services/finance.api';
@@ -974,5 +975,87 @@ describe('Topbar responsive tenant selector', () => {
 
     expect(document.getElementById('tenant-select-mobile')).toBeNull();
     expect(document.getElementById('tenant-select-desktop')).toBeNull();
+  });
+});
+
+
+function MobileMenuHarness() {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+
+  return (
+    <Topbar
+      isMobileMenuOpen={isMobileMenuOpen}
+      onMobileMenuToggle={() => setIsMobileMenuOpen((open) => !open)}
+    />
+  );
+}
+
+describe('PaymentNotificationBell drawer coordination', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTenantData = [];
+    mockGetSession.mockReturnValue({
+      user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
+      memberships: [{ tenantId: TENANT_ID, roles: ['RESIDENT'] }],
+      activeTenantId: TENANT_ID,
+    });
+    mockGetUnreadCount.mockResolvedValue(0);
+    mockListNotifications.mockResolvedValue({ notifications: [], total: 0 });
+    mockListPendingPayments.mockResolvedValue([]);
+    jest.requireMock('next/navigation').useRouter = () => ({ push: jest.fn(), replace: jest.fn() });
+  });
+
+  it('closes an open notification dropdown when mobile-menu state changes programmatically', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { rerender } = render(
+      <QueryClientProvider client={queryClient}>
+        <Topbar isMobileMenuOpen={false} />
+      </QueryClientProvider>,
+    );
+    const notificationButton = screen.getByRole('button', { name: /notificaciones/i });
+
+    fireEvent.click(notificationButton);
+    await waitFor(() => expect(screen.getByRole('menu')).toBeTruthy());
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <Topbar isMobileMenuOpen />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).toBeNull();
+      expect(notificationButton.getAttribute('aria-expanded')).toBe('false');
+    });
+
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <Topbar isMobileMenuOpen={false} />
+      </QueryClientProvider>,
+    );
+    expect(screen.queryByRole('menu')).toBeNull();
+
+    fireEvent.click(notificationButton);
+    await waitFor(() => expect(screen.getByRole('menu')).toBeTruthy());
+  });
+
+  it('closes notifications through the hamburger interaction without requiring mousedown', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MobileMenuHarness />
+      </QueryClientProvider>,
+    );
+
+    const notificationButton = screen.getByRole('button', { name: /notificaciones/i });
+    fireEvent.click(notificationButton);
+    await waitFor(() => expect(screen.getByRole('menu')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: 'Abrir menú de navegación' }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).toBeNull();
+      expect(notificationButton.getAttribute('aria-expanded')).toBe('false');
+    });
   });
 });

--- a/apps/web/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/shared/components/layout/Topbar.test.tsx
@@ -8,6 +8,8 @@ import * as notificationsApi from '@/features/notifications/notifications.api';
 import * as financeApi from '@/features/finance/services/finance.api';
 import * as sessionModule from '@/features/auth/session.storage';
 
+let mockTenantData: Array<{ id: string; name: string; type: 'EDIFICIO_AUTOGESTION' }> = [];
+
 jest.mock('@/features/notifications/notifications.api', () => ({
   listNotifications: jest.fn(),
   getUnreadCount: jest.fn(),
@@ -33,7 +35,7 @@ jest.mock('@/features/impersonation/impersonation.storage', () => ({
 }));
 
 jest.mock('@/features/tenants/tenants.hooks', () => ({
-  useTenants: () => ({ data: [], isLoading: false, error: null }),
+  useTenants: () => ({ data: mockTenantData, isLoading: false, error: null }),
 }));
 
 jest.mock('@/features/notifications/components/PushPermissionControl', () => ({
@@ -52,6 +54,8 @@ const mockMarkAsRead = jest.mocked(notificationsApi.markAsRead);
 const mockMarkAllAsRead = jest.mocked(notificationsApi.markAllAsRead);
 const mockListPendingPayments = jest.mocked(financeApi.listPendingPayments);
 const mockGetSession = jest.mocked(sessionModule.getSession);
+const mockSetSession = jest.mocked(sessionModule.setSession);
+const mockSetLastTenant = jest.mocked(sessionModule.setLastTenant);
 
 const TENANT_ID = 'tenant-1';
 
@@ -887,5 +891,88 @@ describe('PaymentNotificationBell responsive dropdown', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Cerrar notificaciones' }));
     await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+});
+
+
+describe('Topbar responsive tenant selector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTenantData = [];
+    jest.requireMock('next/navigation').useRouter = () => ({ push: jest.fn(), replace: jest.fn() });
+  });
+
+  it('renders distinct mobile and desktop selectors for multiple tenant memberships', () => {
+    const longTenantName = 'Complejo Residencial con una denominación extensa que debe permanecer contenida';
+    mockTenantData = [
+      { id: 'tenant-1', name: longTenantName, type: 'EDIFICIO_AUTOGESTION' },
+      { id: 'tenant-2', name: 'Edificio B', type: 'EDIFICIO_AUTOGESTION' },
+    ];
+    mockGetSession.mockReturnValue({
+      user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
+      memberships: [
+        { tenantId: 'tenant-1', roles: ['RESIDENT'] },
+        { tenantId: 'tenant-2', roles: ['RESIDENT'] },
+      ],
+      activeTenantId: 'tenant-1',
+    });
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(<QueryClientProvider client={queryClient}><Topbar /></QueryClientProvider>);
+
+    const mobileSelect = document.getElementById('tenant-select-mobile') as HTMLSelectElement;
+    const desktopSelect = document.getElementById('tenant-select-desktop') as HTMLSelectElement;
+
+    expect(mobileSelect).toBeTruthy();
+    expect(desktopSelect).toBeTruthy();
+    expect(mobileSelect.className).toContain('min-h-11');
+    expect(mobileSelect.className).toContain('min-w-0');
+    expect(mobileSelect.parentElement?.className).toContain('lg:hidden');
+    expect(desktopSelect.parentElement?.className).toContain('hidden');
+    expect(desktopSelect.parentElement?.className).toContain('lg:flex');
+    expect(mobileSelect.id).not.toBe(desktopSelect.id);
+    expect(mobileSelect.className).toContain('flex-1');
+    expect(mobileSelect.options[0]?.text).toBe(longTenantName);
+  });
+
+  it('uses the existing tenant change logic from the mobile selector', async () => {
+    const replace = jest.fn();
+    jest.requireMock('next/navigation').useRouter = () => ({ push: jest.fn(), replace });
+    const session: NonNullable<ReturnType<typeof sessionModule.getSession>> = {
+      user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
+      memberships: [
+        { tenantId: 'tenant-1', roles: ['RESIDENT'] },
+        { tenantId: 'tenant-2', roles: ['RESIDENT'] },
+      ],
+      activeTenantId: 'tenant-1',
+    };
+    mockGetSession.mockReturnValue(session);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(<QueryClientProvider client={queryClient}><Topbar /></QueryClientProvider>);
+
+    fireEvent.change(document.getElementById('tenant-select-mobile') as HTMLSelectElement, {
+      target: { value: 'tenant-2' },
+    });
+
+    await waitFor(() => {
+      expect(mockSetSession).toHaveBeenCalledWith({ ...session, activeTenantId: 'tenant-2' });
+      expect(mockSetLastTenant).toHaveBeenCalledWith('tenant-2');
+      expect(replace).toHaveBeenCalledWith('/tenant-2/dashboard');
+    });
+  });
+
+  it('does not render either selector for a single tenant membership', () => {
+    mockGetSession.mockReturnValue({
+      user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
+      memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT'] }],
+      activeTenantId: 'tenant-1',
+    });
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(<QueryClientProvider client={queryClient}><Topbar /></QueryClientProvider>);
+
+    expect(document.getElementById('tenant-select-mobile')).toBeNull();
+    expect(document.getElementById('tenant-select-desktop')).toBeNull();
   });
 });

--- a/apps/web/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/shared/components/layout/Topbar.test.tsx
@@ -56,10 +56,16 @@ const mockGetSession = jest.mocked(sessionModule.getSession);
 const TENANT_ID = 'tenant-1';
 
 let PaymentNotificationBell: React.ComponentType<{ tenantId: string }>;
+let Topbar: React.ComponentType<{
+  isMobileMenuOpen?: boolean;
+  menuButtonRef?: React.RefObject<HTMLButtonElement | null>;
+  onMobileMenuToggle?: () => void;
+}>;
 
 beforeAll(async () => {
   const mod = await import('@/shared/components/layout/Topbar');
   PaymentNotificationBell = mod.PaymentNotificationBell;
+  Topbar = mod.default;
 });
 
 function renderBell(tenantId = TENANT_ID) {
@@ -825,5 +831,27 @@ describe('PaymentNotificationBell', () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/tenant-1/finanzas?tab=payments');
     });
+  });
+});
+
+
+describe("Topbar mobile menu trigger", () => {
+  it("exposes the mobile navigation trigger with its expanded state", () => {
+    const toggle = jest.fn();
+    const buttonRef = { current: null } as React.RefObject<HTMLButtonElement | null>;
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Topbar isMobileMenuOpen={false} menuButtonRef={buttonRef} onMobileMenuToggle={toggle} />
+      </QueryClientProvider>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Abrir menú de navegación" });
+    expect(trigger.getAttribute("aria-controls")).toBe("mobile-navigation");
+    expect(trigger.getAttribute("aria-expanded")).toBe("false");
+
+    fireEvent.click(trigger);
+    expect(toggle).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/shared/components/layout/Topbar.test.tsx
@@ -855,3 +855,37 @@ describe("Topbar mobile menu trigger", () => {
     expect(toggle).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('PaymentNotificationBell responsive dropdown', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetSession.mockReturnValue({
+      user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
+      memberships: [{ tenantId: TENANT_ID, roles: ['RESIDENT'] }],
+      activeTenantId: TENANT_ID,
+    });
+    mockGetUnreadCount.mockResolvedValue(0);
+    mockListNotifications.mockResolvedValue({ notifications: [], total: 0 });
+    mockListPendingPayments.mockResolvedValue([]);
+  });
+
+  it('keeps the mobile dropdown inside the viewport and restores focus after closing', async () => {
+    renderBell();
+    const trigger = screen.getByRole('button', { name: /notificaciones/i });
+
+    fireEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByRole('menu')).toBeTruthy();
+    });
+
+    const dropdown = screen.getByRole('menu');
+    expect(dropdown.className).toContain('fixed');
+    expect(dropdown.className).toContain('inset-x-2');
+    expect(dropdown.className).toContain('max-h-[calc(100dvh-env(safe-area-inset-top)-4.5rem)]');
+    expect(dropdown.className).toContain('lg:absolute');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Cerrar notificaciones' }));
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+});

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -420,15 +420,16 @@ export default function Topbar({
   const canSelectTenant = session.memberships.length > 1;
 
   // Fallback si no hay tenants cargados: mostrar por ID
-  const fallbackTenants: TenantSummary[] = tenants || session.memberships.map((membership: Membership) => ({
+  const fallbackTenants: TenantSummary[] = tenants?.length ? tenants : session.memberships.map((membership: Membership) => ({
     id: membership.tenantId,
     name: membership.tenantId,
     type: 'EDIFICIO_AUTOGESTION' as const,
   }));
 
   return (
-    <header className="flex min-h-14 items-center justify-between gap-2 border-b border-border bg-card px-3 text-card-foreground sm:px-4">
-      <div className="flex min-w-0 items-center gap-2 sm:gap-4">
+    <header className="border-b border-border bg-card text-card-foreground">
+      <div className="flex min-h-14 items-center justify-between gap-2 px-3 sm:px-4">
+        <div className="flex min-w-0 items-center gap-2 sm:gap-4">
         {onMobileMenuToggle && (
           <button
             ref={menuButtonRef}
@@ -445,15 +446,15 @@ export default function Topbar({
         <div className="truncate text-sm font-semibold">BuildingOS</div>
 
         {canSelectTenant ? (
-          <div className="hidden items-center gap-2 lg:flex">
-            <label htmlFor="tenant-select" className="text-xs text-muted-foreground">
+          <div className="hidden min-w-0 items-center gap-2 lg:flex">
+            <label htmlFor="tenant-select-desktop" className="text-xs text-muted-foreground">
               {isLoading ? 'Cargando...' : 'Edificio:'}
             </label>
             <Select
-              id="tenant-select"
+              id="tenant-select-desktop"
               value={activeTenantId}
               onChange={(e) => handleTenantChange(e.target.value)}
-              className="text-xs"
+              className="min-h-11 min-w-0 text-xs"
               disabled={isLoading}
             >
               {fallbackTenants.map((tenant) => (
@@ -475,7 +476,7 @@ export default function Topbar({
         )}
       </div>
 
-      <div className="flex shrink-0 items-center gap-1 sm:gap-3">
+        <div className="flex shrink-0 items-center gap-1 sm:gap-3">
         {urlTenantId && <div className="hidden lg:block"><PushPermissionControl tenantId={urlTenantId} /></div>}
         {urlTenantId && <PaymentNotificationBell tenantId={urlTenantId} />}
         <span className="hidden items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium lg:inline-flex">
@@ -488,7 +489,34 @@ export default function Topbar({
         >
           Cerrar sesión
         </button>
+        </div>
       </div>
+
+      {canSelectTenant && (
+        <div className="flex min-w-0 items-center gap-2 border-t border-border px-3 py-2 lg:hidden sm:px-4">
+          <label htmlFor="tenant-select-mobile" className="shrink-0 text-xs text-muted-foreground">
+            {isLoading ? 'Cargando...' : 'Edificio:'}
+          </label>
+          <Select
+            id="tenant-select-mobile"
+            value={activeTenantId}
+            onChange={(e) => handleTenantChange(e.target.value)}
+            className="min-h-11 min-w-0 flex-1 truncate text-xs"
+            disabled={isLoading}
+          >
+            {fallbackTenants.map((tenant) => (
+              <option key={tenant.id} value={tenant.id}>
+                {tenant.name}
+              </option>
+            ))}
+          </Select>
+          {error && (
+            <span className="shrink-0 text-xs text-red-500" title="Error al cargar tenants">
+              ⚠️
+            </span>
+          )}
+        </div>
+      )}
     </header>
   );
 }

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -498,7 +498,7 @@ export default function Topbar({
       </div>
 
         <div className="flex shrink-0 items-center gap-1 sm:gap-3">
-        {urlTenantId && <div className="hidden lg:block"><PushPermissionControl tenantId={urlTenantId} /></div>}
+        {urlTenantId && <div className="hidden lg:block"><PushPermissionControl /></div>}
         {urlTenantId && <PaymentNotificationBell tenantId={urlTenantId} isMobileMenuOpen={isMobileMenuOpen} />}
         <span className="hidden items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium lg:inline-flex">
           {roleLabel}

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -9,7 +9,7 @@ import type { Membership } from '../../../features/auth/auth.types';
 import Select from '../ui/Select';
 import { Bell, CreditCard, X, Clock, CheckCircle, XCircle, MessageSquare, FileText, Home, Menu } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useState, useEffect, useRef, type RefObject } from 'react';
+import { useCallback, useState, useEffect, useLayoutEffect, useRef, type RefObject } from 'react';
 import { listNotifications, markAsRead, markAllAsRead, getUnreadCount, type Notification } from '@/features/notifications/notifications.api';
 import { formatCurrency } from '@/shared/lib/format/money';
 import { listPendingPayments, PaymentStatus } from '@/features/finance/services/finance.api';
@@ -21,7 +21,13 @@ const ADMIN_ROLES = new Set(['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR', 'SUPER_
 
 const POLL_INTERVAL = 30_000;
 
-export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
+export function PaymentNotificationBell({
+  tenantId,
+  isMobileMenuOpen = false,
+}: {
+  readonly tenantId: string;
+  readonly isMobileMenuOpen?: boolean;
+}) {
   const queryClient = useQueryClient();
   const router = useRouter();
   const pathname = usePathname();
@@ -114,6 +120,21 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
       requestAnimationFrame(() => buttonRef.current?.focus());
     }
   }, []);
+
+  useLayoutEffect(() => {
+    if (!isMobileMenuOpen || !isOpen) return;
+
+    let isCurrentEffect = true;
+    queueMicrotask(() => {
+      if (isCurrentEffect) {
+        closeDropdown(false);
+      }
+    });
+
+    return () => {
+      isCurrentEffect = false;
+    };
+  }, [closeDropdown, isMobileMenuOpen, isOpen]);
 
   // 6. Close on click outside
   useEffect(() => {
@@ -478,7 +499,7 @@ export default function Topbar({
 
         <div className="flex shrink-0 items-center gap-1 sm:gap-3">
         {urlTenantId && <div className="hidden lg:block"><PushPermissionControl tenantId={urlTenantId} /></div>}
-        {urlTenantId && <PaymentNotificationBell tenantId={urlTenantId} />}
+        {urlTenantId && <PaymentNotificationBell tenantId={urlTenantId} isMobileMenuOpen={isMobileMenuOpen} />}
         <span className="hidden items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium lg:inline-flex">
           {roleLabel}
         </span>

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -7,9 +7,9 @@ import { useTenants } from '../../../features/tenants/tenants.hooks';
 import type { TenantSummary } from '../../../features/tenants/tenants.service';
 import type { Membership } from '../../../features/auth/auth.types';
 import Select from '../ui/Select';
-import { Bell, CreditCard, X, Clock, CheckCircle, XCircle, MessageSquare, FileText, Home } from 'lucide-react';
+import { Bell, CreditCard, X, Clock, CheckCircle, XCircle, MessageSquare, FileText, Home, Menu } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, type RefObject } from 'react';
 import { listNotifications, markAsRead, markAllAsRead, getUnreadCount, type Notification } from '@/features/notifications/notifications.api';
 import { formatCurrency } from '@/shared/lib/format/money';
 import { listPendingPayments, PaymentStatus } from '@/features/finance/services/finance.api';
@@ -189,7 +189,7 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
       <button
         ref={buttonRef}
         onClick={handleToggle}
-        className="relative p-2 rounded-lg hover:bg-muted transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+        className="relative inline-flex size-11 items-center justify-center rounded-lg hover:bg-muted transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
         title="Notificaciones"
         aria-label={`Notificaciones${badgeCount > 0 ? `, ${badgeCount} sin leer` : ''}`}
         aria-expanded={isOpen}
@@ -207,7 +207,7 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
         <div
           id="notification-dropdown"
           role="menu"
-          className="absolute right-0 top-full mt-2 w-80 bg-card border rounded-lg shadow-lg z-50 overflow-hidden"
+          className="fixed inset-x-3 top-[calc(env(safe-area-inset-top)+3.5rem)] z-50 max-h-[calc(100dvh-5rem)] overflow-hidden rounded-lg border bg-card shadow-lg sm:inset-x-auto sm:right-3 sm:w-80 lg:absolute lg:right-0 lg:top-full lg:mt-2 lg:w-80"
         >
           <div className="flex items-center justify-between p-3 border-b">
             <span className="font-semibold">Notificaciones</span>
@@ -337,7 +337,17 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
   );
 }
 
-export default function Topbar() {
+interface TopbarProps {
+  readonly isMobileMenuOpen?: boolean;
+  readonly menuButtonRef?: RefObject<HTMLButtonElement | null>;
+  readonly onMobileMenuToggle?: () => void;
+}
+
+export default function Topbar({
+  isMobileMenuOpen = false,
+  menuButtonRef,
+  onMobileMenuToggle,
+}: TopbarProps) {
   const router = useRouter();
   const params = useParams();
   const urlTenantId = params?.tenantId as string | undefined;
@@ -410,12 +420,25 @@ export default function Topbar() {
   }));
 
   return (
-    <header className="h-14 border-b border-border bg-card text-card-foreground flex items-center justify-between px-4">
-      <div className="flex items-center gap-4">
-        <div className="text-sm font-semibold">BuildingOS</div>
+    <header className="flex min-h-14 items-center justify-between gap-2 border-b border-border bg-card px-3 text-card-foreground sm:px-4">
+      <div className="flex min-w-0 items-center gap-2 sm:gap-4">
+        {onMobileMenuToggle && (
+          <button
+            ref={menuButtonRef}
+            type="button"
+            className="inline-flex size-11 shrink-0 items-center justify-center rounded-md hover:bg-muted focus:outline-none focus:ring-2 focus:ring-ring lg:hidden"
+            onClick={onMobileMenuToggle}
+            aria-label="Abrir menú de navegación"
+            aria-expanded={isMobileMenuOpen}
+            aria-controls="mobile-navigation"
+          >
+            <Menu className="size-5" aria-hidden="true" />
+          </button>
+        )}
+        <div className="truncate text-sm font-semibold">BuildingOS</div>
 
         {canSelectTenant ? (
-          <div className="flex items-center gap-2">
+          <div className="hidden items-center gap-2 lg:flex">
             <label htmlFor="tenant-select" className="text-xs text-muted-foreground">
               {isLoading ? 'Cargando...' : 'Edificio:'}
             </label>
@@ -439,21 +462,21 @@ export default function Topbar() {
             )}
           </div>
         ) : (
-          <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium">
+          <span className="hidden items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium lg:inline-flex">
             {activeTenantName}
           </span>
         )}
       </div>
 
-      <div className="flex items-center gap-3">
-        {urlTenantId && <PushPermissionControl tenantId={urlTenantId} />}
+      <div className="flex shrink-0 items-center gap-1 sm:gap-3">
+        {urlTenantId && <div className="hidden lg:block"><PushPermissionControl tenantId={urlTenantId} /></div>}
         {urlTenantId && <PaymentNotificationBell tenantId={urlTenantId} />}
-        <span className="inline-flex items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium">
+        <span className="hidden items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium lg:inline-flex">
           {roleLabel}
         </span>
 
         <button
-          className="inline-flex items-center justify-center rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground hover:opacity-90 transition"
+          className="inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition hover:opacity-90"
           onClick={handleLogout}
         >
           Cerrar sesión

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -9,7 +9,7 @@ import type { Membership } from '../../../features/auth/auth.types';
 import Select from '../ui/Select';
 import { Bell, CreditCard, X, Clock, CheckCircle, XCircle, MessageSquare, FileText, Home, Menu } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useState, useEffect, useRef, type RefObject } from 'react';
+import { useCallback, useState, useEffect, useRef, type RefObject } from 'react';
 import { listNotifications, markAsRead, markAllAsRead, getUnreadCount, type Notification } from '@/features/notifications/notifications.api';
 import { formatCurrency } from '@/shared/lib/format/money';
 import { listPendingPayments, PaymentStatus } from '@/features/finance/services/finance.api';
@@ -108,6 +108,13 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
   // Badge: pending payments (admin) + unread notifications
   const badgeCount = isAdmin ? pendingCount + unreadCount : unreadCount;
 
+  const closeDropdown = useCallback((restoreFocus = false) => {
+    setIsOpen(false);
+    if (restoreFocus) {
+      requestAnimationFrame(() => buttonRef.current?.focus());
+    }
+  }, []);
+
   // 6. Close on click outside
   useEffect(() => {
     if (!isOpen) return;
@@ -118,25 +125,24 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
         buttonRef.current &&
         !buttonRef.current.contains(event.target as Node)
       ) {
-        setIsOpen(false);
+        closeDropdown();
       }
     }
     document.addEventListener('mousedown', handleClickOutside);
     return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [isOpen]);
+  }, [closeDropdown, isOpen]);
 
   // 7. Close on Escape
   useEffect(() => {
     if (!isOpen) return;
     function handleEscape(event: KeyboardEvent) {
       if (event.key === 'Escape') {
-        setIsOpen(false);
-        buttonRef.current?.focus();
+        closeDropdown(true);
       }
     }
     document.addEventListener('keydown', handleEscape);
     return () => document.removeEventListener('keydown', handleEscape);
-  }, [isOpen]);
+  }, [closeDropdown, isOpen]);
 
   // 8. Handlers
   const handleToggle = () => setIsOpen((prev) => !prev);
@@ -150,7 +156,7 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
     if (targetPath) {
       router.push(targetPath);
     }
-    setIsOpen(false);
+    closeDropdown(false);
   };
 
   const handleMarkAllRead = () => {
@@ -207,20 +213,21 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
         <div
           id="notification-dropdown"
           role="menu"
-          className="fixed inset-x-3 top-[calc(env(safe-area-inset-top)+3.5rem)] z-50 max-h-[calc(100dvh-5rem)] overflow-hidden rounded-lg border bg-card shadow-lg sm:inset-x-auto sm:right-3 sm:w-80 lg:absolute lg:right-0 lg:top-full lg:mt-2 lg:w-80"
+          className="fixed inset-x-2 top-[calc(env(safe-area-inset-top)+3.5rem)] z-50 flex max-h-[calc(100dvh-env(safe-area-inset-top)-4.5rem)] flex-col overflow-hidden rounded-lg border border-border bg-card text-card-foreground shadow-lg sm:inset-x-auto sm:right-3 sm:w-80 lg:absolute lg:right-0 lg:top-full lg:mt-2 lg:w-80"
         >
-          <div className="flex items-center justify-between p-3 border-b">
+          <div className="flex shrink-0 items-center justify-between border-b border-border p-3">
             <span className="font-semibold">Notificaciones</span>
             <button
-              onClick={() => setIsOpen(false)}
-              className="text-muted-foreground hover:text-foreground"
+              type="button"
+              onClick={() => closeDropdown(true)}
+              className="inline-flex size-11 items-center justify-center rounded-md text-muted-foreground hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
               aria-label="Cerrar notificaciones"
             >
               <X className="w-4 h-4" />
             </button>
           </div>
 
-          <div className="max-h-96 overflow-y-auto">
+          <div className="min-h-0 flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]">
             {listLoading && (
               <div className="p-4 text-center text-muted-foreground text-sm">
                 Cargando notificaciones…
@@ -258,9 +265,9 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
                 <button
                   onClick={() => {
                     router.push(`/${tenantId}/finanzas?tab=payments`);
-                    setIsOpen(false);
+                    closeDropdown(false);
                   }}
-                  className="w-full py-2 px-4 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors"
+                  className="min-h-11 w-full rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:opacity-90"
                 >
                   Revisar pagos →
                 </button>
@@ -274,7 +281,7 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
                     key={notification.id}
                     role="menuitem"
                     onClick={() => handleNotificationClick(notification)}
-                    className={`w-full text-left p-3 border-b hover:bg-muted/50 transition-colors ${
+                    className={`min-h-11 w-full text-left p-3 border-b border-border hover:bg-muted/50 transition-colors ${
                       !notification.isRead ? 'bg-blue-50/50 dark:bg-blue-950/30' : ''
                     }`}
                   >
@@ -310,12 +317,12 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
           </div>
 
           {(filteredNotifications.length > 0 || pendingCount > 0) && (
-            <div className="p-2 border-t bg-muted/30">
+            <div className="shrink-0 border-t border-border bg-muted/30 p-2 pb-[max(0.5rem,env(safe-area-inset-bottom))]">
               {filteredNotifications.length > 0 && (
                 <button
                   onClick={handleMarkAllRead}
                   disabled={markAllReadMutation.isPending}
-                  className="w-full text-xs text-blue-600 hover:text-blue-800 font-medium disabled:opacity-50"
+                  className="min-h-11 w-full text-xs font-medium text-primary hover:opacity-80 disabled:opacity-50"
                 >
                   {markAllReadMutation.isPending ? 'Marcando…' : 'Marcar todas como leídas'}
                 </button>
@@ -323,9 +330,9 @@ export function PaymentNotificationBell({ tenantId }: { tenantId: string }) {
               <button
                 onClick={() => {
                   router.push(isAdmin ? `/${tenantId}/finanzas?tab=payments` : `/${tenantId}/resident/payments`);
-                  setIsOpen(false);
+                  closeDropdown(false);
                 }}
-                className="w-full text-xs text-muted-foreground hover:text-foreground mt-1"
+                className="mt-1 min-h-11 w-full text-xs text-muted-foreground hover:text-foreground"
               >
                 Ver pagos →
               </button>


### PR DESCRIPTION
## Resumen

Implementa el Lote 1 de la Fase 6.2 para hacer responsive el shell del portal RESIDENT.

Incluye:

- `AppShell` mobile-first con `min-h-dvh`, `min-w-0`, padding progresivo y un único contenedor `overflow-x-auto` controlado;
- Sidebar visible en desktop y drawer móvil accesible;
- cierre del drawer por botón, overlay, Escape y navegación;
- focus trap, restauración de foco y bloqueo/restauración del scroll del `body`;
- navegación activa correcta para la familia de rutas de solicitudes, incluido el detalle canónico;
- Topbar móvil con controles esenciales y secundarios fuera de la fila principal;
- `ResidentContextSwitcher` y `ContextSelector` adaptados a móvil y textos largos;
- dropdown de notificaciones contenido dentro del viewport con `dvh` y safe-area;
- `AssistantWidget` responsive con panel móvil, activador compacto, safe-area y cierre por Escape;
- targets táctiles principales cercanos a 44 px;
- pruebas focalizadas de shell, navegación, contexto, notificaciones y asistente.

## Alcance

Este PR cubre únicamente el Lote 1 del issue #66.

No modifica:

- páginas funcionales del portal RESIDENT;
- dashboard;
- pagos;
- documentos;
- comunicados;
- tickets;
- Mi unidad;
- API, Prisma, schema, migraciones o datos;
- permisos, tenant/building/unit scope ni lógica de negocio.

## Validaciones ejecutadas

- Tests focalizados de layout/contexto/asistente/topbar: PASS
- TypeScript: PASS
- ESLint focalizado: PASS
- Build web: PASS
- `git diff --check`: PASS

## Riesgos controlados

- Los componentes compartidos mantienen comportamiento desktop desde `lg`/`sm` según corresponda.
- El dropdown sigue siendo `absolute` en desktop y `fixed` solo en móvil.
- La navegación reutiliza una sola definición de menú.
- El panel del asistente puede ocupar el ancho móvil, pero su activador permanece compacto.

## Validación pendiente

- CI del PR.
- Deploy a staging.
- Smoke visual real en 320×568, 360×800, 390×844, 430×932, 768×1024, 1024×768 y 1440×900, en light/dark.

Closes parte del alcance de #66; el issue debe permanecer abierto para los Lotes 2–6.