### PR TITLE
feat(resident): add self-service profile

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -37,6 +37,7 @@ import { ObservabilityModule } from './observability/observability.module';
 import { AssistantModule } from './assistant/assistant.module';
 import { LeadsModule } from './leads/leads.module';
 import { TenantMembersModule } from './tenant-members/tenant-members.module';
+import { ProfileModule } from './profile/profile.module';
 import { DashboardModule } from './dashboard/dashboard.module';
 import { PushController } from './push/push.controller';
 import { PushDeliveryService } from './push/push-delivery.service';
@@ -81,6 +82,7 @@ import { ReceiptsModule } from './receipts/receipts.module';
     AssistantModule,
     LeadsModule,
     TenantMembersModule,
+    ProfileModule,
     DashboardModule,
     ReceiptsModule,
   ],

--- a/apps/api/src/profile/dto/update-profile.dto.ts
+++ b/apps/api/src/profile/dto/update-profile.dto.ts
@@ -1,0 +1,34 @@
+import { Transform } from 'class-transformer';
+import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+
+function trimToNull(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const normalized = value.trim();
+  return normalized === '' ? null : normalized;
+}
+
+function trimString(value: unknown): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  return value.trim();
+}
+
+export class UpdateProfileDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(255)
+  @Transform(({ value }) => trimString(value), { toClassOnly: true })
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(30)
+  @Transform(({ value }) => trimToNull(value), { toClassOnly: true })
+  phone?: string | null;
+}

--- a/apps/api/src/profile/profile.controller.ts
+++ b/apps/api/src/profile/profile.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Get, Patch, Req, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import type { AuthenticatedRequest } from '../common/types/request.types';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+import { ProfileResponse, ProfileService } from './profile.service';
+
+@Controller('me/profile')
+@UseGuards(JwtAuthGuard)
+export class ProfileController {
+  constructor(private readonly profileService: ProfileService) {}
+
+  @Get()
+  getProfile(@Req() req: AuthenticatedRequest): Promise<ProfileResponse> {
+    return this.profileService.getMyProfile(req);
+  }
+
+  @Patch()
+  updateProfile(
+    @Req() req: AuthenticatedRequest,
+    @Body() dto: UpdateProfileDto,
+  ): Promise<ProfileResponse> {
+    return this.profileService.updateMyProfile(req, dto);
+  }
+}

--- a/apps/api/src/profile/profile.module.ts
+++ b/apps/api/src/profile/profile.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { PrismaModule } from '../prisma/prisma.module';
+import { ProfileController } from './profile.controller';
+import { ProfileService } from './profile.service';
+
+@Module({
+  imports: [PrismaModule],
+  controllers: [ProfileController],
+  providers: [ProfileService],
+})
+export class ProfileModule {}

--- a/apps/api/src/profile/profile.service.spec.ts
+++ b/apps/api/src/profile/profile.service.spec.ts
@@ -1,0 +1,537 @@
+import { BadRequestException, ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { AuditAction, MemberStatus, Role } from '@prisma/client';
+import { AuditService } from '../audit/audit.service';
+import { PrismaService } from '../prisma/prisma.service';
+import type { AuthenticatedRequest } from '../common/types/request.types';
+import { ProfileService } from './profile.service';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+
+describe('ProfileService', () => {
+  let service: ProfileService;
+  let prisma: {
+    tenantMember: {
+      findFirst: jest.Mock;
+      update: jest.Mock;
+    };
+  };
+  let auditService: {
+    createLog: jest.Mock;
+  };
+
+  const now = new Date('2026-07-27T12:00:00.000Z');
+  const authEmail = 'resident.auth@example.com';
+  const tenantMemberEmail = 'tenant.member@example.com';
+
+  const baseMember = {
+    id: 'member-1',
+    tenantId: 'tenant-1',
+    userId: 'user-1',
+    disabledAt: null,
+    name: 'Resident One',
+    email: tenantMemberEmail,
+    phone: '+584141234567',
+    role: Role.RESIDENT,
+    status: MemberStatus.ACTIVE,
+    createdAt: now,
+    updatedAt: now,
+  } as const;
+
+  const residentMembership = {
+    id: 'membership-1',
+    tenantId: 'tenant-1',
+    roles: [Role.RESIDENT],
+  };
+
+  const makeRequest = (overrides: Partial<AuthenticatedRequest> = {}): AuthenticatedRequest => ({
+    headers: {},
+    user: {
+      id: 'user-1',
+      email: 'resident.auth@example.com',
+      name: 'Resident One',
+      memberships: [residentMembership],
+    },
+    tenantId: 'tenant-1',
+    ...overrides,
+  } as AuthenticatedRequest);
+
+  beforeEach(async () => {
+    prisma = {
+      tenantMember: {
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+    };
+    auditService = {
+      createLog: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ProfileService,
+        {
+          provide: PrismaService,
+          useValue: prisma,
+        },
+        {
+          provide: AuditService,
+          useValue: auditService,
+        },
+      ],
+    }).compile();
+
+    service = module.get(ProfileService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the authenticated tenant member profile without leaking private fields', async () => {
+    prisma.tenantMember.findFirst.mockResolvedValue(baseMember);
+
+    const profile = await service.getMyProfile(makeRequest());
+
+    expect(prisma.tenantMember.findFirst).toHaveBeenCalledWith({
+      where: {
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        disabledAt: null,
+      },
+      select: {
+        id: true,
+        tenantId: true,
+        userId: true,
+        disabledAt: true,
+        name: true,
+        phone: true,
+        role: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    expect(profile).toEqual({
+      id: 'member-1',
+      tenantId: 'tenant-1',
+      name: 'Resident One',
+      email: 'resident.auth@example.com',
+      phone: '+584141234567',
+      role: Role.RESIDENT,
+      status: MemberStatus.ACTIVE,
+      createdAt: now,
+      updatedAt: now,
+    });
+    expect(profile).not.toHaveProperty('userId');
+    expect(profile).not.toHaveProperty('disabledAt');
+    expect(profile).not.toHaveProperty('notes');
+  });
+
+  it('throws when tenant context is missing', async () => {
+    await expect(
+      service.getMyProfile(makeRequest({ tenantId: undefined, headers: {} })),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('throws when the authenticated user has no tenant member record', async () => {
+    prisma.tenantMember.findFirst.mockResolvedValue(null);
+
+    await expect(service.getMyProfile(makeRequest())).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('throws when the authenticated user email is missing', async () => {
+    await expect(
+      service.getMyProfile(
+        makeRequest({
+          user: {
+            id: 'user-1',
+            email: '',
+            name: 'Resident One',
+            memberships: [residentMembership],
+          },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(prisma.tenantMember.findFirst).not.toHaveBeenCalled();
+    expect(auditService.createLog).not.toHaveBeenCalled();
+  });
+
+  it('allows access when the requested tenant has a resident membership', async () => {
+    prisma.tenantMember.findFirst.mockResolvedValue(baseMember);
+
+    await service.getMyProfile(makeRequest());
+
+    expect(prisma.tenantMember.findFirst).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows access when the tenant membership includes resident plus admin roles', async () => {
+    prisma.tenantMember.findFirst.mockResolvedValue(baseMember);
+
+    const profile = await service.getMyProfile(
+      makeRequest({
+        user: {
+          id: 'user-1',
+          email: 'resident.auth@example.com',
+          name: 'Resident One',
+          memberships: [
+            {
+              id: 'membership-1',
+              tenantId: 'tenant-1',
+              roles: [Role.RESIDENT, Role.TENANT_ADMIN],
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(profile.id).toBe('member-1');
+  });
+
+  it('rejects when the membership belongs to another tenant', async () => {
+    await expect(
+      service.getMyProfile(
+        makeRequest({
+          tenantId: 'tenant-2',
+          user: {
+            id: 'user-1',
+            email: 'resident.auth@example.com',
+            name: 'Resident One',
+            memberships: [
+              {
+                id: 'membership-1',
+                tenantId: 'tenant-1',
+                roles: [Role.RESIDENT],
+              },
+            ],
+          },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(prisma.tenantMember.findFirst).not.toHaveBeenCalled();
+    expect(auditService.createLog).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the user has no membership records', async () => {
+    await expect(
+      service.getMyProfile(
+        makeRequest({
+          user: {
+            id: 'user-1',
+            email: 'resident.auth@example.com',
+            name: 'Resident One',
+            memberships: [],
+          },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(prisma.tenantMember.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the tenant membership does not include resident', async () => {
+    await expect(
+      service.getMyProfile(
+        makeRequest({
+          user: {
+            id: 'user-1',
+            email: 'resident.auth@example.com',
+            name: 'Resident One',
+            memberships: [
+              {
+                id: 'membership-1',
+                tenantId: 'tenant-1',
+                roles: [Role.TENANT_ADMIN],
+              },
+            ],
+          },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(prisma.tenantMember.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('updates only name and phone, normalizes trimmed values, and writes a safe audit log', async () => {
+    prisma.tenantMember.findFirst
+      .mockResolvedValueOnce(baseMember)
+      .mockResolvedValueOnce(null);
+    prisma.tenantMember.update.mockResolvedValue({
+      ...baseMember,
+      name: 'Resident Prime',
+      phone: '+584141111111',
+      updatedAt: new Date('2026-07-27T12:30:00.000Z'),
+    });
+
+    const profile = await service.updateMyProfile(makeRequest(), {
+      name: '  Resident Prime  ',
+      phone: ' +584141111111 ',
+    } as UpdateProfileDto);
+
+    expect(prisma.tenantMember.findFirst).toHaveBeenNthCalledWith(1, {
+      where: {
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        disabledAt: null,
+      },
+      select: {
+        id: true,
+        tenantId: true,
+        userId: true,
+        disabledAt: true,
+        name: true,
+        phone: true,
+        role: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    expect(prisma.tenantMember.findFirst).toHaveBeenNthCalledWith(2, {
+      where: {
+        tenantId: 'tenant-1',
+        phone: '+584141111111',
+        id: { not: 'member-1' },
+      },
+      select: { id: true },
+    });
+    expect(prisma.tenantMember.update).toHaveBeenCalledWith({
+      where: { id: 'member-1' },
+      data: {
+        name: 'Resident Prime',
+        phone: '+584141111111',
+      },
+      select: {
+        id: true,
+        tenantId: true,
+        userId: true,
+        disabledAt: true,
+        name: true,
+        phone: true,
+        role: true,
+        status: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    expect(auditService.createLog).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      actorUserId: 'user-1',
+      action: AuditAction.TENANT_MEMBER_UPDATE,
+      entityType: 'TenantMember',
+      entityId: 'member-1',
+      metadata: {
+        changedFields: ['name', 'phone'],
+      },
+    });
+    expect(profile).toEqual({
+      id: 'member-1',
+      tenantId: 'tenant-1',
+      name: 'Resident Prime',
+      email: 'resident.auth@example.com',
+      phone: '+584141111111',
+      role: Role.RESIDENT,
+      status: MemberStatus.ACTIVE,
+      createdAt: now,
+      updatedAt: new Date('2026-07-27T12:30:00.000Z'),
+    });
+  });
+
+  it('allows updating when the tenant membership includes mixed resident roles', async () => {
+    prisma.tenantMember.findFirst
+      .mockResolvedValueOnce(baseMember)
+      .mockResolvedValueOnce(null);
+    prisma.tenantMember.update.mockResolvedValue({
+      ...baseMember,
+      name: 'Resident Prime',
+      updatedAt: new Date('2026-07-27T12:30:00.000Z'),
+    });
+
+    await service.updateMyProfile(
+      makeRequest({
+        user: {
+          id: 'user-1',
+          email: 'resident.auth@example.com',
+          name: 'Resident One',
+          memberships: [
+            {
+              id: 'membership-1',
+              tenantId: 'tenant-1',
+              roles: [Role.RESIDENT, Role.OPERATOR],
+            },
+          ],
+        },
+      }),
+      {
+        name: 'Resident Prime',
+      } as UpdateProfileDto,
+    );
+
+    expect(prisma.tenantMember.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('normalizes an empty phone string to null and keeps private fields hidden', async () => {
+    prisma.tenantMember.findFirst.mockResolvedValue(baseMember);
+    prisma.tenantMember.update.mockResolvedValue({
+      ...baseMember,
+      phone: null,
+      updatedAt: new Date('2026-07-27T12:45:00.000Z'),
+    });
+
+    const profile = await service.updateMyProfile(makeRequest(), {
+      phone: '',
+    } as UpdateProfileDto);
+
+    expect(prisma.tenantMember.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: {
+          phone: null,
+        },
+      }),
+    );
+    expect(profile.phone).toBeNull();
+    expect(profile).not.toHaveProperty('userId');
+  });
+
+  it('returns the authenticated email on update even when the tenant member email differs', async () => {
+    prisma.tenantMember.findFirst.mockResolvedValue(baseMember);
+    prisma.tenantMember.update.mockResolvedValue({
+      ...baseMember,
+      name: 'Resident Prime',
+      updatedAt: new Date('2026-07-27T12:45:00.000Z'),
+    });
+
+    const profile = await service.updateMyProfile(makeRequest(), {
+      name: 'Resident Prime',
+    } as UpdateProfileDto);
+
+    expect(profile.email).toBe(authEmail);
+    expect(profile.email).not.toBe(tenantMemberEmail);
+  });
+
+  it('returns the current profile without updating when no effective changes are provided', async () => {
+    prisma.tenantMember.findFirst.mockResolvedValue(baseMember);
+
+    const profile = await service.updateMyProfile(makeRequest(), {
+      name: 'Resident One',
+      phone: '+584141234567',
+    } as UpdateProfileDto);
+
+    expect(prisma.tenantMember.update).not.toHaveBeenCalled();
+    expect(auditService.createLog).not.toHaveBeenCalled();
+    expect(profile).toEqual({
+      id: 'member-1',
+      tenantId: 'tenant-1',
+      name: 'Resident One',
+      email: 'resident.auth@example.com',
+      phone: '+584141234567',
+      role: Role.RESIDENT,
+      status: MemberStatus.ACTIVE,
+      createdAt: now,
+      updatedAt: now,
+    });
+  });
+
+  it('rejects duplicate phones inside the same tenant', async () => {
+    prisma.tenantMember.findFirst
+      .mockResolvedValueOnce(baseMember)
+      .mockResolvedValueOnce({ id: 'member-2' });
+
+    await expect(
+      service.updateMyProfile(makeRequest(), {
+        phone: '+584141999999',
+      } as UpdateProfileDto),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(prisma.tenantMember.update).not.toHaveBeenCalled();
+    expect(auditService.createLog).not.toHaveBeenCalled();
+  });
+
+  it('rejects update attempts when membership validation fails before tenant member lookup', async () => {
+    await expect(
+      service.updateMyProfile(
+        makeRequest({
+          user: {
+            id: 'user-1',
+            email: 'resident.auth@example.com',
+            name: 'Resident One',
+            memberships: [
+              {
+                id: 'membership-1',
+                tenantId: 'tenant-1',
+                roles: [Role.OPERATOR],
+              },
+            ],
+          },
+        }),
+        {
+          name: 'Resident Prime',
+        } as UpdateProfileDto,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(prisma.tenantMember.findFirst).not.toHaveBeenCalled();
+    expect(prisma.tenantMember.update).not.toHaveBeenCalled();
+    expect(auditService.createLog).not.toHaveBeenCalled();
+  });
+
+  it('rejects reading tenant B when authenticated membership belongs to tenant A', async () => {
+    await expect(
+      service.getMyProfile(
+        makeRequest({
+          tenantId: 'tenant-b',
+          user: {
+            id: 'user-1',
+            email: 'resident.auth@example.com',
+            name: 'Resident One',
+            memberships: [
+              {
+                id: 'membership-1',
+                tenantId: 'tenant-a',
+                roles: [Role.RESIDENT],
+              },
+            ],
+          },
+        }),
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(prisma.tenantMember.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('rejects updating tenant B when authenticated membership belongs to tenant A', async () => {
+    await expect(
+      service.updateMyProfile(
+        makeRequest({
+          tenantId: 'tenant-b',
+          user: {
+            id: 'user-1',
+            email: 'resident.auth@example.com',
+            name: 'Resident One',
+            memberships: [
+              {
+                id: 'membership-1',
+                tenantId: 'tenant-a',
+                roles: [Role.RESIDENT],
+              },
+            ],
+          },
+        }),
+        {
+          name: 'Resident Prime',
+        } as UpdateProfileDto,
+      ),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+
+    expect(prisma.tenantMember.findFirst).not.toHaveBeenCalled();
+    expect(prisma.tenantMember.update).not.toHaveBeenCalled();
+    expect(auditService.createLog).not.toHaveBeenCalled();
+  });
+
+  it('does not expose disabled members as the active profile', async () => {
+    prisma.tenantMember.findFirst.mockResolvedValue(null);
+
+    await expect(service.getMyProfile(makeRequest())).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/apps/api/src/profile/profile.service.ts
+++ b/apps/api/src/profile/profile.service.ts
@@ -1,0 +1,208 @@
+import { BadRequestException, ConflictException, ForbiddenException, Injectable, NotFoundException } from '@nestjs/common';
+import { AuditAction, MemberStatus, Prisma, Role } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import type { AuthenticatedMembership, AuthenticatedRequest } from '../common/types/request.types';
+import { UpdateProfileDto } from './dto/update-profile.dto';
+
+const tenantMemberProfileSelect = Prisma.validator<Prisma.TenantMemberDefaultArgs>()({
+  select: {
+    id: true,
+    tenantId: true,
+    userId: true,
+    disabledAt: true,
+    name: true,
+    phone: true,
+    role: true,
+    status: true,
+    createdAt: true,
+    updatedAt: true,
+  },
+});
+
+type TenantMemberProfileRecord = Prisma.TenantMemberGetPayload<typeof tenantMemberProfileSelect>;
+
+export interface ProfileResponse {
+  readonly id: string;
+  readonly tenantId: string;
+  readonly name: string;
+  readonly email: string | null;
+  readonly phone: string | null;
+  readonly role: Role;
+  readonly status: MemberStatus;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+@Injectable()
+export class ProfileService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auditService: AuditService,
+  ) {}
+
+  async getMyProfile(req: AuthenticatedRequest): Promise<ProfileResponse> {
+    const tenantId = this.resolveTenantId(req);
+    const userId = this.resolveUserId(req);
+    const email = this.resolveUserEmail(req);
+    this.assertResidentMembership(req, tenantId);
+
+    const member = await this.findTenantMember(tenantId, userId);
+    if (!member) {
+      throw new NotFoundException('Tenant member not found');
+    }
+
+    return this.toProfileResponse(member, email);
+  }
+
+  async updateMyProfile(
+    req: AuthenticatedRequest,
+    dto: UpdateProfileDto,
+  ): Promise<ProfileResponse> {
+    const tenantId = this.resolveTenantId(req);
+    const userId = this.resolveUserId(req);
+    const email = this.resolveUserEmail(req);
+    this.assertResidentMembership(req, tenantId);
+
+    const member = await this.findTenantMember(tenantId, userId);
+    if (!member) {
+      throw new NotFoundException('Tenant member not found');
+    }
+
+    const normalizedName = dto.name === undefined ? undefined : dto.name.trim();
+    const normalizedPhone =
+      dto.phone === undefined
+        ? undefined
+        : typeof dto.phone === 'string'
+          ? dto.phone.trim() === ''
+            ? null
+            : dto.phone.trim()
+          : dto.phone;
+
+    const updateData: Prisma.TenantMemberUpdateInput = {};
+
+    if (normalizedName !== undefined && normalizedName !== member.name) {
+      updateData.name = normalizedName;
+    }
+
+    if (normalizedPhone !== undefined && normalizedPhone !== member.phone) {
+      if (normalizedPhone !== null) {
+        const duplicatePhone = await this.prisma.tenantMember.findFirst({
+          where: {
+            tenantId,
+            phone: normalizedPhone,
+            id: { not: member.id },
+          },
+          select: { id: true },
+        });
+
+        if (duplicatePhone) {
+          throw new ConflictException('Phone already in use in this tenant');
+        }
+      }
+
+      updateData.phone = normalizedPhone;
+    }
+
+    if (Object.keys(updateData).length === 0) {
+      return this.toProfileResponse(member, email);
+    }
+
+    const updatedMember = await this.prisma.tenantMember.update({
+      where: { id: member.id },
+      data: updateData,
+      ...tenantMemberProfileSelect,
+    });
+
+    await this.auditService.createLog({
+      tenantId,
+      actorUserId: userId,
+      action: AuditAction.TENANT_MEMBER_UPDATE,
+      entityType: 'TenantMember',
+      entityId: member.id,
+      metadata: {
+        changedFields: Object.keys(updateData),
+      },
+    });
+
+    return this.toProfileResponse(updatedMember, email);
+  }
+
+  private async findTenantMember(
+    tenantId: string,
+    userId: string,
+  ): Promise<TenantMemberProfileRecord | null> {
+    return this.prisma.tenantMember.findFirst({
+      where: {
+        tenantId,
+        userId,
+        disabledAt: null,
+      },
+      ...tenantMemberProfileSelect,
+    });
+  }
+
+  private resolveTenantId(req: AuthenticatedRequest): string {
+    const tenantId = req.tenantId?.trim() ?? this.getTenantIdFromHeader(req);
+
+    if (!tenantId) {
+      throw new BadRequestException('tenantId is required');
+    }
+
+    return tenantId;
+  }
+
+  private getTenantIdFromHeader(req: AuthenticatedRequest): string | undefined {
+    const headerTenantId = req.headers['x-tenant-id'];
+    return typeof headerTenantId === 'string' ? headerTenantId.trim() : undefined;
+  }
+
+  private resolveUserId(req: AuthenticatedRequest): string {
+    const userId = req.user?.id?.trim();
+
+    if (!userId) {
+      throw new BadRequestException('userId is required');
+    }
+
+    return userId;
+  }
+
+  private resolveUserEmail(req: AuthenticatedRequest): string {
+    const email = req.user?.email?.trim();
+
+    if (!email) {
+      throw new BadRequestException('user email is required');
+    }
+
+    return email;
+  }
+
+  private assertResidentMembership(
+    req: AuthenticatedRequest,
+    tenantId: string,
+  ): AuthenticatedMembership {
+    const membership = (req.user?.memberships ?? []).find((entry) => {
+      return entry.tenantId.trim() === tenantId && (entry.roles ?? []).includes(Role.RESIDENT);
+    });
+
+    if (!membership) {
+      throw new ForbiddenException('Resident membership required');
+    }
+
+    return membership;
+  }
+
+  private toProfileResponse(member: TenantMemberProfileRecord, email: string): ProfileResponse {
+    return {
+      id: member.id,
+      tenantId: member.tenantId,
+      name: member.name,
+      email,
+      phone: member.phone,
+      role: member.role,
+      status: member.status,
+      createdAt: member.createdAt,
+      updatedAt: member.updatedAt,
+    };
+  }
+}

--- a/apps/web/app/(tenant)/[tenantId]/resident/profile/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/profile/page.test.tsx
@@ -1,0 +1,526 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useParams } from 'next/navigation';
+import ResidentProfilePage from './page';
+import type {
+  ResidentProfile,
+  UpdateResidentProfileInput,
+} from '@/features/resident/profile/resident-profile.api';
+import { useResidentProfile } from '@/features/resident/profile/useResidentProfile';
+import { useRefreshSession } from '@/features/auth/useRefreshSession';
+import { useTenants } from '@/features/tenants/tenants.hooks';
+
+const toast = jest.fn();
+
+jest.mock('@/shared/components/ui', () => {
+  const actual = jest.requireActual('@/shared/components/ui');
+  return {
+    ...actual,
+    useToast: () => ({ toast }),
+  };
+});
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+}));
+
+jest.mock('@/features/resident/profile/useResidentProfile', () => ({
+  useResidentProfile: jest.fn(),
+}));
+
+jest.mock('@/features/auth/useRefreshSession', () => ({
+  useRefreshSession: jest.fn(),
+}));
+
+jest.mock('@/features/tenants/tenants.hooks', () => ({
+  useTenants: jest.fn(),
+}));
+
+const mockedUseParams = jest.mocked(useParams);
+const mockedUseResidentProfile = jest.mocked(useResidentProfile);
+const mockedUseRefreshSession = jest.mocked(useRefreshSession);
+const mockedUseTenants = jest.mocked(useTenants);
+
+interface ResidentProfileHookState {
+  profileQuery: {
+    data: ResidentProfile;
+    isPending: boolean;
+    isError: boolean;
+    error: Error | null;
+    refetch: jest.Mock;
+  };
+  updateProfile: {
+    mutateAsync: jest.Mock<Promise<ResidentProfile>, [UpdateResidentProfileInput]>;
+    isPending: boolean;
+  };
+  canAccessProfile: boolean;
+  hasResidentMembership: boolean;
+  userId: string;
+}
+
+interface ResidentProfileTestOverrides {
+  profile?: Partial<ResidentProfile>;
+  canAccessProfile?: boolean;
+  hasResidentMembership?: boolean;
+  userId?: string;
+}
+
+function createProfile(overrides: Partial<ResidentProfile> = {}) {
+  return {
+    id: 'member-1',
+    tenantId: 'tenant-1',
+    name: 'Resident One',
+    email: 'resident@test.com',
+    phone: '+584141111111',
+    role: 'RESIDENT',
+    status: 'ACTIVE',
+    createdAt: '2026-07-27T00:00:00.000Z',
+    updatedAt: '2026-07-27T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function createProfileState(overrides: ResidentProfileTestOverrides = {}): ResidentProfileHookState {
+  return {
+    profileQuery: {
+      data: createProfile(overrides.profile ?? {}),
+      isPending: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    },
+    updateProfile: {
+      mutateAsync: jest.fn().mockResolvedValue(
+        createProfile({
+          name: 'Resident Prime',
+          phone: '+584141111222',
+          updatedAt: '2026-07-27T01:00:00.000Z',
+          ...(overrides.profile ?? {}),
+        }),
+      ),
+      isPending: false,
+    },
+    canAccessProfile: overrides.canAccessProfile ?? true,
+    hasResidentMembership: overrides.hasResidentMembership ?? true,
+    userId: overrides.userId ?? 'user-1',
+  };
+}
+
+function setResidentProfileHook(overrides: ResidentProfileTestOverrides = {}): ResidentProfileHookState {
+  const state = createProfileState(overrides);
+  mockedUseResidentProfile.mockReturnValue(state as never);
+  return state;
+}
+
+describe('ResidentProfilePage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseParams.mockReturnValue({ tenantId: 'tenant-1' } as never);
+    mockedUseTenants.mockReturnValue({
+      data: [{ id: 'tenant-1', name: 'Horizonte' }],
+    } as never);
+  });
+
+  it('renders the profile without internal identifiers and keeps the email read only', async () => {
+    setResidentProfileHook();
+
+    render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Mi perfil')).toBeTruthy();
+    });
+
+    expect(screen.getAllByText('Horizonte').length).toBeGreaterThan(0);
+    expect(screen.getByText('Administración')).toBeTruthy();
+    expect(screen.queryByText('user-1')).toBeNull();
+    expect(screen.queryByText('tenant-1')).toBeNull();
+
+    const email = screen.getByLabelText('Correo de acceso');
+    expect(email.getAttribute('id')).toBe('resident-profile-email');
+    expect(email.hasAttribute('readonly')).toBe(true);
+    expect(email.getAttribute('aria-describedby')).toBe('resident-profile-email-help');
+    expect(screen.getByText('El correo de acceso no puede modificarse desde este perfil.')).toBeTruthy();
+  });
+
+  it('uses a neutral administration label when the tenant name is not loaded yet', async () => {
+    mockedUseTenants.mockReturnValue({
+      data: undefined,
+    } as never);
+    setResidentProfileHook();
+
+    render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Resident One')).toBeTruthy();
+    });
+
+    expect(screen.getAllByText('Administración actual').length).toBeGreaterThan(0);
+    expect(screen.queryByText('tenant-1')).toBeNull();
+  });
+
+  it('keeps access when activeTenantId points elsewhere but the membership is resident', async () => {
+    setResidentProfileHook();
+
+    render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Resident One')).toBeTruthy();
+    });
+
+    expect(screen.queryByText('Perfil no disponible')).toBeNull();
+  });
+
+  it('shows a neutral access message when the membership exists but the profile cannot be loaded', async () => {
+    setResidentProfileHook({
+      canAccessProfile: false,
+      hasResidentMembership: true,
+    });
+
+    render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Perfil no disponible')).toBeTruthy();
+    });
+
+    expect(screen.getByText('No pudimos identificar tu sesión para cargar este perfil.')).toBeTruthy();
+    expect(screen.queryByText('Cambiá al tenant activo correcto para ver tu perfil residente.')).toBeNull();
+  });
+
+  it.each([
+    ['empty name', '', 'El nombre es obligatorio.'],
+    ['single character name', 'A', 'El nombre debe tener al menos 2 caracteres.'],
+    [
+      'long name',
+      'a'.repeat(256),
+      'El nombre no puede superar los 255 caracteres.',
+    ],
+  ])('marks %s as invalid and disables save', async (_label, name, message) => {
+    const { updateProfile } = setResidentProfileHook();
+
+    render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Resident One')).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: name } });
+    fireEvent.blur(screen.getByLabelText('Nombre'));
+
+    expect(screen.getByText(message)).toBeTruthy();
+    expect(screen.getByLabelText('Nombre').getAttribute('aria-invalid')).toBe('true');
+    expect((screen.getByRole('button', { name: 'Guardar cambios' }) as HTMLButtonElement).disabled).toBe(true);
+    expect(updateProfile.mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('marks an overlong phone number as invalid and blocks submission', async () => {
+    const { updateProfile } = setResidentProfileHook();
+
+    render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Resident One')).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText('Teléfono'), { target: { value: '1'.repeat(31) } });
+    fireEvent.blur(screen.getByLabelText('Teléfono'));
+
+    expect(screen.getByText('El teléfono no puede superar los 30 caracteres.')).toBeTruthy();
+    expect(screen.getByLabelText('Teléfono').getAttribute('aria-invalid')).toBe('true');
+    expect((screen.getByRole('button', { name: 'Guardar cambios' }) as HTMLButtonElement).disabled).toBe(true);
+    expect(updateProfile.mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      title: 'sends only the modified name',
+      mutate: async (updateProfile: ReturnType<typeof createProfileState>['updateProfile']) => {
+        updateProfile.mutateAsync.mockResolvedValueOnce(
+          createProfile({ name: 'Resident Prime', phone: '+584141111111', updatedAt: '2026-07-27T01:00:00.000Z' }),
+        );
+      },
+      change: () => fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Resident Prime' } }),
+      expected: { name: 'Resident Prime' },
+    },
+    {
+      title: 'sends only the modified phone',
+      mutate: async (updateProfile: ReturnType<typeof createProfileState>['updateProfile']) => {
+        updateProfile.mutateAsync.mockResolvedValueOnce(
+          createProfile({ name: 'Resident One', phone: '+584141222222', updatedAt: '2026-07-27T01:00:00.000Z' }),
+        );
+      },
+      change: () => fireEvent.change(screen.getByLabelText('Teléfono'), { target: { value: '+584141222222' } }),
+      expected: { phone: '+584141222222' },
+    },
+    {
+      title: 'clears the phone by sending null',
+      mutate: async (updateProfile: ReturnType<typeof createProfileState>['updateProfile']) => {
+        updateProfile.mutateAsync.mockResolvedValueOnce(
+          createProfile({ name: 'Resident One', phone: null, updatedAt: '2026-07-27T01:00:00.000Z' }),
+        );
+      },
+      change: () => fireEvent.change(screen.getByLabelText('Teléfono'), { target: { value: '   ' } }),
+      expected: { phone: null },
+    },
+  ])('$title', async ({ mutate, change, expected }) => {
+    const state = setResidentProfileHook();
+    await mutate(state.updateProfile);
+
+    render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Resident One')).toBeTruthy();
+    });
+
+    change();
+    fireEvent.click(screen.getByRole('button', { name: 'Guardar cambios' }));
+
+    await waitFor(() => {
+      expect(state.updateProfile.mutateAsync).toHaveBeenCalledWith(expected);
+      expect(toast).toHaveBeenCalledWith('Perfil actualizado correctamente', 'success');
+    });
+  });
+
+  it('does not enable save or submit when the name only changes by surrounding spaces', async () => {
+    const { updateProfile } = setResidentProfileHook();
+
+    render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Resident One')).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: '  Resident One  ' } });
+
+    const saveButton = screen.getByRole('button', { name: 'Guardar cambios' }) as HTMLButtonElement;
+    expect(saveButton.disabled).toBe(true);
+
+    const form = saveButton.closest('form');
+    expect(form).not.toBeNull();
+    if (form) {
+      fireEvent.submit(form);
+    }
+
+    expect(updateProfile.mutateAsync).not.toHaveBeenCalled();
+    expect(toast).not.toHaveBeenCalledWith('Perfil actualizado correctamente', 'success');
+  });
+
+  it('does not lose local edits when the same profile refetches with a new payload', async () => {
+    setResidentProfileHook();
+
+    const { rerender } = render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Resident One')).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Resident Draft' } });
+
+    mockedUseResidentProfile.mockReturnValue(
+      createProfileState({
+        profile: {
+          name: 'Resident Refetched',
+          updatedAt: '2026-07-27T02:00:00.000Z',
+        },
+      }) as never,
+    );
+
+    rerender(<ResidentProfilePage />);
+
+    expect(screen.getByDisplayValue('Resident Draft')).toBeTruthy();
+  });
+
+  it('syncs the clean form when the same profile refetches with fresh server data', async () => {
+    setResidentProfileHook();
+
+    const { rerender } = render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Resident One')).toBeTruthy();
+    });
+
+    mockedUseResidentProfile.mockReturnValue(
+      createProfileState({
+        profile: {
+          name: 'Resident Fresh',
+          phone: '+584141999999',
+        },
+      }) as never,
+    );
+
+    rerender(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Resident Fresh')).toBeTruthy();
+      expect(screen.getByDisplayValue('+584141999999')).toBeTruthy();
+    });
+  });
+
+  it('reinitializes the form when tenantId changes', async () => {
+    setResidentProfileHook();
+
+    const { rerender } = render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Resident One')).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Resident Draft' } });
+
+    mockedUseParams.mockReturnValue({ tenantId: 'tenant-2' } as never);
+    mockedUseTenants.mockReturnValue({
+      data: [{ id: 'tenant-2', name: 'Aurora' }],
+    } as never);
+    mockedUseResidentProfile.mockReturnValue(
+      createProfileState({
+        profile: {
+          id: 'member-2',
+          tenantId: 'tenant-2',
+          name: 'Resident Two',
+          email: 'resident2@test.com',
+          phone: '+584141222222',
+        },
+        userId: 'user-2',
+      }) as never,
+    );
+
+    rerender(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Resident Two')).toBeTruthy();
+    });
+    expect(screen.getAllByText('Aurora').length).toBeGreaterThan(0);
+  });
+
+  it('reinitializes the form when userId changes', async () => {
+    setResidentProfileHook();
+
+    const { rerender } = render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Resident One')).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Resident Draft' } });
+
+    mockedUseResidentProfile.mockReturnValue(
+      createProfileState({
+        profile: {
+          id: 'member-3',
+          tenantId: 'tenant-1',
+          name: 'Resident Three',
+          email: 'resident3@test.com',
+          phone: '+584141333333',
+        },
+        userId: 'user-3',
+      }) as never,
+    );
+
+    rerender(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Resident Three')).toBeTruthy();
+    });
+  });
+
+  it('adopts the saved profile as the new baseline and discard restores it', async () => {
+    const state = setResidentProfileHook();
+    state.updateProfile.mutateAsync.mockResolvedValueOnce(
+      createProfile({
+        name: 'Resident Prime',
+        phone: '+584141222222',
+        updatedAt: '2026-07-27T01:00:00.000Z',
+      }),
+    );
+
+    render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Resident One')).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Resident Prime' } });
+    fireEvent.change(screen.getByLabelText('Teléfono'), { target: { value: '+584141222222' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Guardar cambios' }));
+
+    await waitFor(() => {
+      expect(toast).toHaveBeenCalledWith('Perfil actualizado correctamente', 'success');
+      expect(screen.getByDisplayValue('Resident Prime')).toBeTruthy();
+      expect(screen.getByDisplayValue('+584141222222')).toBeTruthy();
+    });
+
+    fireEvent.change(screen.getByLabelText('Nombre'), { target: { value: 'Resident Temp' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Descartar' }));
+
+    expect(screen.getByDisplayValue('Resident Prime')).toBeTruthy();
+    expect(screen.getByDisplayValue('+584141222222')).toBeTruthy();
+  });
+
+  it.each([
+    ['RESIDENT', 'Residente'],
+    ['TENANT_ADMIN', 'Administrador'],
+    ['TENANT_OWNER', 'Propietario'],
+    ['OPERATOR', 'Operador'],
+  ])('translates role %s as %s', async (role, expected) => {
+    mockedUseResidentProfile.mockReturnValue(
+      createProfileState({
+        profile: {
+          role,
+        },
+      }) as never,
+    );
+
+    render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(expected)).toBeTruthy();
+    });
+  });
+
+  it.each([
+    ['ACTIVE', 'Activo'],
+    ['PENDING_INVITE', 'Invitación pendiente'],
+    ['DRAFT', 'Borrador'],
+    ['DISABLED', 'Deshabilitado'],
+  ])('translates status %s as %s', async (status, expected) => {
+    mockedUseResidentProfile.mockReturnValue(
+      createProfileState({
+        profile: {
+          status,
+        },
+      }) as never,
+    );
+
+    render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(expected)).toBeTruthy();
+    });
+  });
+
+  it('does not call useRefreshSession and keeps the session user immutable', async () => {
+    const session = {
+      user: { id: 'user-1', email: 'resident@test.com', name: 'Resident' },
+      memberships: [
+        {
+          tenantId: 'tenant-1',
+          roles: ['RESIDENT'],
+        },
+      ],
+      activeTenantId: 'tenant-2',
+    };
+
+    mockedUseResidentProfile.mockReturnValue(createProfileState() as never);
+
+    render(<ResidentProfilePage />);
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Resident One')).toBeTruthy();
+    });
+
+    expect(session.user.name).toBe('Resident');
+    expect(mockedUseRefreshSession).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/(tenant)/[tenantId]/resident/profile/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/profile/page.tsx
@@ -1,0 +1,407 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
+import { useParams } from 'next/navigation';
+import {
+  AlertCircle,
+  Building2,
+  Loader2,
+  RotateCcw,
+  Save,
+  ShieldCheck,
+  UserRound,
+} from 'lucide-react';
+import { Badge, Button, Card, Input, Skeleton, useToast } from '@/shared/components/ui';
+import { useTenants } from '@/features/tenants/tenants.hooks';
+import { useResidentProfile } from '@/features/resident/profile/useResidentProfile';
+import type { ResidentProfile, UpdateResidentProfileInput } from '@/features/resident/profile/resident-profile.api';
+
+interface ProfileSnapshot {
+  readonly name: string;
+  readonly phone: string;
+}
+
+interface ResidentProfileFormProps {
+  readonly profile: ResidentProfile;
+  readonly tenantName: string;
+  readonly toast: ReturnType<typeof useToast>['toast'];
+  readonly updateProfile: ReturnType<typeof useResidentProfile>['updateProfile'];
+}
+
+function snapshotFromProfile(profile: ResidentProfile): ProfileSnapshot {
+  return {
+    name: profile.name ?? '',
+    phone: profile.phone ?? '',
+  };
+}
+
+function normalizeName(value: string): string {
+  return value.trim();
+}
+
+function normalizePhone(value: string): string | null {
+  const trimmed = value.trim();
+  return trimmed === '' ? null : trimmed;
+}
+
+function validateName(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return 'El nombre es obligatorio.';
+  }
+  if (trimmed.length < 2) {
+    return 'El nombre debe tener al menos 2 caracteres.';
+  }
+  if (trimmed.length > 255) {
+    return 'El nombre no puede superar los 255 caracteres.';
+  }
+  return null;
+}
+
+function validatePhone(value: string): string | null {
+  const trimmed = value.trim();
+  if (trimmed.length > 30) {
+    return 'El teléfono no puede superar los 30 caracteres.';
+  }
+  return null;
+}
+
+function formatRole(role: string): string {
+  const labels: Record<string, string> = {
+    RESIDENT: 'Residente',
+    TENANT_ADMIN: 'Administrador',
+    TENANT_OWNER: 'Propietario',
+    OPERATOR: 'Operador',
+  };
+  return labels[role.trim().toUpperCase()] ?? role;
+}
+
+function formatStatus(status: string): string {
+  const labels: Record<string, string> = {
+    ACTIVE: 'Activo',
+    PENDING_INVITE: 'Invitación pendiente',
+    DRAFT: 'Borrador',
+    DISABLED: 'Deshabilitado',
+  };
+  return labels[status.trim().toUpperCase()] ?? status;
+}
+
+function ResidentProfileForm({
+  profile,
+  tenantName,
+  toast,
+  updateProfile,
+}: ResidentProfileFormProps) {
+  const [baseline, setBaseline] = useState<ProfileSnapshot>(() => snapshotFromProfile(profile));
+  const [form, setForm] = useState<ProfileSnapshot>(() => snapshotFromProfile(profile));
+  const [touched, setTouched] = useState({ name: false, phone: false });
+  const [attemptedSubmit, setAttemptedSubmit] = useState(false);
+  const lastServerSnapshotRef = useRef<ProfileSnapshot>(snapshotFromProfile(profile));
+
+  useEffect(() => {
+    if (normalizeName(form.name) !== normalizeName(baseline.name) || normalizePhone(form.phone) !== normalizePhone(baseline.phone)) {
+      return;
+    }
+
+    const nextSnapshot = snapshotFromProfile(profile);
+    if (
+      nextSnapshot.name === lastServerSnapshotRef.current.name &&
+      nextSnapshot.phone === lastServerSnapshotRef.current.phone
+    ) {
+      return;
+    }
+
+    lastServerSnapshotRef.current = nextSnapshot;
+    setBaseline(nextSnapshot);
+    setForm(nextSnapshot);
+    setTouched({ name: false, phone: false });
+    setAttemptedSubmit(false);
+  }, [baseline.name, baseline.phone, form.name, form.phone, profile.id, profile.name, profile.phone, profile.tenantId]);
+
+  const nameError = validateName(form.name);
+  const phoneError = validatePhone(form.phone);
+  const dirty =
+    normalizeName(form.name) !== normalizeName(baseline.name) ||
+    normalizePhone(form.phone) !== normalizePhone(baseline.phone);
+
+  const showNameError = attemptedSubmit || touched.name;
+  const showPhoneError = attemptedSubmit || touched.phone;
+
+  const handleDiscard = () => {
+    setForm(baseline);
+    setTouched({ name: false, phone: false });
+    setAttemptedSubmit(false);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setTouched({ name: true, phone: true });
+    setAttemptedSubmit(true);
+
+    if (nameError || phoneError) {
+      return;
+    }
+
+    const payload: UpdateResidentProfileInput = {};
+    const nextName = normalizeName(form.name);
+    if (nextName !== normalizeName(baseline.name)) {
+      payload.name = nextName;
+    }
+
+    const nextPhone = normalizePhone(form.phone);
+    if (nextPhone !== normalizePhone(baseline.phone)) {
+      payload.phone = nextPhone;
+    }
+
+    if (Object.keys(payload).length === 0) {
+      return;
+    }
+
+    try {
+      const updatedProfile = await updateProfile.mutateAsync(payload);
+      const nextSnapshot = snapshotFromProfile(updatedProfile);
+      setBaseline(nextSnapshot);
+      setForm(nextSnapshot);
+      setTouched({ name: false, phone: false });
+      setAttemptedSubmit(false);
+      toast('Perfil actualizado correctamente', 'success');
+    } catch (error) {
+      toast(
+        error instanceof Error ? error.message : 'No pudimos guardar los cambios.',
+        'error',
+      );
+    }
+  };
+
+  const canSave = dirty && !nameError && !phoneError && !updateProfile.isPending;
+
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-6 p-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-foreground">Mi perfil</h1>
+        <p className="mt-1 text-sm text-muted-foreground">{tenantName}</p>
+      </div>
+
+      <Card>
+        <div className="flex items-center gap-3 border-b border-border pb-4">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <UserRound size={20} />
+          </div>
+          <div>
+            <p className="text-sm font-medium text-foreground">Datos de tu membresía</p>
+            <p className="text-xs text-muted-foreground">Solo podés editar tu nombre y teléfono</p>
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-4 md:grid-cols-2">
+          <div className="space-y-1">
+            <p className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <Building2 size={16} />
+              Administración
+            </p>
+            <p className="text-sm font-medium text-foreground">{tenantName}</p>
+          </div>
+
+          <div className="space-y-1">
+            <p className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <ShieldCheck size={16} />
+              Rol
+            </p>
+            <Badge variant="info">{formatRole(profile.role)}</Badge>
+          </div>
+
+          <div className="space-y-1">
+            <p className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+              <ShieldCheck size={16} />
+              Estado
+            </p>
+            <Badge variant={profile.status.toUpperCase() === 'ACTIVE' ? 'success' : 'muted'}>
+              {formatStatus(profile.status)}
+            </Badge>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <form className="space-y-5" onSubmit={handleSubmit} noValidate>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <label htmlFor="resident-profile-name" className="block text-sm font-medium text-foreground">
+                Nombre
+              </label>
+              <Input
+                id="resident-profile-name"
+                value={form.name}
+                onChange={(event) => setForm((current) => ({ ...current, name: event.target.value }))}
+                onBlur={() => setTouched((current) => ({ ...current, name: true }))}
+                placeholder="Tu nombre"
+                autoComplete="name"
+                aria-invalid={Boolean(showNameError && nameError)}
+                aria-describedby={showNameError && nameError ? 'resident-profile-name-error' : undefined}
+              />
+              {showNameError && nameError && (
+                <p id="resident-profile-name-error" className="text-sm text-red-600 dark:text-red-400">
+                  {nameError}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <label htmlFor="resident-profile-phone" className="block text-sm font-medium text-foreground">
+                Teléfono
+              </label>
+              <Input
+                id="resident-profile-phone"
+                value={form.phone}
+                onChange={(event) => setForm((current) => ({ ...current, phone: event.target.value }))}
+                onBlur={() => setTouched((current) => ({ ...current, phone: true }))}
+                placeholder="Opcional"
+                autoComplete="tel"
+                aria-invalid={Boolean(showPhoneError && phoneError)}
+                aria-describedby={showPhoneError && phoneError ? 'resident-profile-phone-error' : undefined}
+              />
+              {showPhoneError && phoneError && (
+                <p id="resident-profile-phone-error" className="text-sm text-red-600 dark:text-red-400">
+                  {phoneError}
+                </p>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label htmlFor="resident-profile-email" className="block text-sm font-medium text-foreground">
+              Correo de acceso
+            </label>
+            <Input
+              id="resident-profile-email"
+              readOnly
+              value={profile.email ?? ''}
+              aria-describedby="resident-profile-email-help"
+            />
+            <p id="resident-profile-email-help" className="text-sm text-muted-foreground">
+              El correo de acceso no puede modificarse desde este perfil.
+            </p>
+          </div>
+
+          <div className="flex flex-wrap gap-3 border-t border-border pt-4">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleDiscard}
+              disabled={!dirty || updateProfile.isPending}
+            >
+              <RotateCcw size={16} className="mr-2" />
+              Descartar
+            </Button>
+            <Button type="submit" disabled={!canSave}>
+              {updateProfile.isPending ? (
+                <>
+                  <Loader2 size={16} className="mr-2 animate-spin" />
+                  Guardando...
+                </>
+              ) : (
+                <>
+                  <Save size={16} className="mr-2" />
+                  Guardar cambios
+                </>
+              )}
+            </Button>
+          </div>
+        </form>
+      </Card>
+    </div>
+  );
+}
+
+export default function ResidentProfilePage() {
+  const params = useParams<{ tenantId: string }>();
+  const tenantId = params?.tenantId ?? null;
+  const { toast } = useToast();
+  const { data: tenants } = useTenants();
+  const tenantName = useMemo(
+    () => (tenantId ? tenants?.find((tenant) => tenant.id === tenantId)?.name ?? 'Administración actual' : 'Administración actual'),
+    [tenantId, tenants],
+  );
+  const { profileQuery, updateProfile, canAccessProfile, hasResidentMembership, userId } = useResidentProfile(tenantId);
+  const profile = profileQuery.data;
+
+  if (!canAccessProfile) {
+    return (
+      <div className="mx-auto flex max-w-3xl flex-col gap-6 p-6">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Mi perfil</h1>
+          <p className="mt-1 text-sm text-muted-foreground">{tenantName}</p>
+        </div>
+
+        <Card className="border-amber-200 bg-amber-50 dark:border-amber-900/60 dark:bg-amber-950/40">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="mt-0.5 text-amber-600 dark:text-amber-300" size={20} />
+            <div className="space-y-1">
+              <p className="font-medium text-amber-900 dark:text-amber-100">Perfil no disponible</p>
+              <p className="text-sm text-amber-800 dark:text-amber-200">
+                {hasResidentMembership
+                  ? 'No pudimos identificar tu sesión para cargar este perfil.'
+                  : 'Necesitás una membresía residente activa para acceder a tu perfil.'}
+              </p>
+            </div>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  if (profileQuery.isPending) {
+    return (
+      <div className="mx-auto flex max-w-3xl flex-col gap-6 p-6">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-5 w-64" />
+        <Skeleton className="h-72 w-full rounded-xl" />
+      </div>
+    );
+  }
+
+  if (profileQuery.isError) {
+    return (
+      <div className="mx-auto flex max-w-3xl flex-col gap-6 p-6">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Mi perfil</h1>
+          <p className="mt-1 text-sm text-muted-foreground">{tenantName}</p>
+        </div>
+
+        <Card className="border-red-200 bg-red-50 dark:border-red-900/60 dark:bg-red-950/40">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="mt-0.5 text-red-600 dark:text-red-300" size={20} />
+            <div className="space-y-1">
+              <p className="font-medium text-red-900 dark:text-red-100">No pudimos cargar tu perfil</p>
+              <p className="text-sm text-red-800 dark:text-red-200">
+                {profileQuery.error instanceof Error ? profileQuery.error.message : 'Reintentalo en unos segundos.'}
+              </p>
+              <Button
+                type="button"
+                variant="secondary"
+                className="mt-3"
+                onClick={() => void profileQuery.refetch()}
+              >
+                Reintentar
+              </Button>
+            </div>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!profile) {
+    return null;
+  }
+
+  return (
+    <ResidentProfileForm
+      key={`${profile.id}:${profile.tenantId}:${userId ?? ''}`}
+      profile={profile}
+      tenantName={tenantName}
+      toast={toast}
+      updateProfile={updateProfile}
+    />
+  );
+}

--- a/apps/web/features/resident/profile/resident-profile.api.test.ts
+++ b/apps/web/features/resident/profile/resident-profile.api.test.ts
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { apiClient } from '@/shared/lib/http/client';
+import { getResidentProfile, updateResidentProfile } from './resident-profile.api';
+
+jest.mock('@/shared/lib/http/client', () => ({
+  apiClient: jest.fn(),
+}));
+
+const mockedApiClient = jest.mocked(apiClient);
+
+describe('resident-profile.api', () => {
+  beforeEach(() => {
+    mockedApiClient.mockReset();
+  });
+
+  it('calls GET /me/profile with X-Tenant-Id', async () => {
+    mockedApiClient.mockResolvedValue({
+      id: 'member-1',
+      tenantId: 'tenant-1',
+      name: 'Resident One',
+      email: 'resident@test.com',
+      phone: null,
+      role: 'RESIDENT',
+      status: 'ACTIVE',
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    } as never);
+
+    await getResidentProfile('tenant-1');
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/me/profile',
+      method: 'GET',
+      headers: { 'X-Tenant-Id': 'tenant-1' },
+    });
+  });
+
+  it('calls PATCH /me/profile with only the provided body and X-Tenant-Id', async () => {
+    mockedApiClient.mockResolvedValue({
+      id: 'member-1',
+      tenantId: 'tenant-1',
+      name: 'Resident Prime',
+      email: 'resident@test.com',
+      phone: '+584141111111',
+      role: 'RESIDENT',
+      status: 'ACTIVE',
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    } as never);
+
+    const input = { name: 'Resident Prime', phone: '+584141111111' };
+
+    await updateResidentProfile('tenant-1', input);
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/me/profile',
+      method: 'PATCH',
+      body: input,
+      headers: { 'X-Tenant-Id': 'tenant-1' },
+    });
+  });
+});

--- a/apps/web/features/resident/profile/resident-profile.api.ts
+++ b/apps/web/features/resident/profile/resident-profile.api.ts
@@ -1,0 +1,48 @@
+import { apiClient } from '@/shared/lib/http/client';
+
+export interface ResidentProfile {
+  id: string;
+  tenantId: string;
+  name: string;
+  email: string | null;
+  phone: string | null;
+  role: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdateResidentProfileInput {
+  name?: string;
+  phone?: string | null;
+}
+
+function getTenantHeaders(tenantId: string): Record<string, string> {
+  if (!tenantId || tenantId.trim() === '') {
+    throw new Error('tenantId is required');
+  }
+
+  return {
+    'X-Tenant-Id': tenantId,
+  };
+}
+
+export async function getResidentProfile(tenantId: string): Promise<ResidentProfile> {
+  return apiClient<ResidentProfile>({
+    path: '/me/profile',
+    method: 'GET',
+    headers: getTenantHeaders(tenantId),
+  });
+}
+
+export async function updateResidentProfile(
+  tenantId: string,
+  input: UpdateResidentProfileInput,
+): Promise<ResidentProfile> {
+  return apiClient<ResidentProfile, UpdateResidentProfileInput>({
+    path: '/me/profile',
+    method: 'PATCH',
+    body: input,
+    headers: getTenantHeaders(tenantId),
+  });
+}

--- a/apps/web/features/resident/profile/useResidentProfile.test.tsx
+++ b/apps/web/features/resident/profile/useResidentProfile.test.tsx
@@ -1,0 +1,340 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useAuthSession } from '@/features/auth/useAuthSession';
+import { useRefreshSession } from '@/features/auth/useRefreshSession';
+import { getResidentProfile, updateResidentProfile } from './resident-profile.api';
+import { residentProfileKeys, useResidentProfile } from './useResidentProfile';
+
+type MockSession = NonNullable<ReturnType<typeof useAuthSession>>;
+
+jest.mock('@/features/auth/useAuthSession', () => ({
+  useAuthSession: jest.fn(),
+}));
+
+jest.mock('@/features/auth/useRefreshSession', () => ({
+  useRefreshSession: jest.fn(),
+}));
+
+jest.mock('./resident-profile.api', () => ({
+  getResidentProfile: jest.fn(),
+  updateResidentProfile: jest.fn(),
+}));
+
+const mockedUseAuthSession = jest.mocked(useAuthSession);
+const mockedUseRefreshSession = jest.mocked(useRefreshSession);
+const mockedGetResidentProfile = jest.mocked(getResidentProfile);
+const mockedUpdateResidentProfile = jest.mocked(updateResidentProfile);
+
+function makeSession(overrides: Partial<MockSession> = {}): MockSession {
+  return {
+    user: { id: 'user-1', email: 'resident@test.com', name: 'Resident' },
+    memberships: [
+      {
+        tenantId: 'tenant-1',
+        roles: ['RESIDENT'],
+      },
+    ],
+    activeTenantId: 'tenant-2',
+    ...overrides,
+  } as MockSession;
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+
+  return { Wrapper, queryClient };
+}
+
+describe('useResidentProfile', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not query without tenantId', () => {
+    mockedUseAuthSession.mockReturnValue(makeSession() as never);
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useResidentProfile(null), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.canAccessProfile).toBe(false);
+    expect(result.current.profileQuery.fetchStatus).toBe('idle');
+    expect(mockedGetResidentProfile).not.toHaveBeenCalled();
+  });
+
+  it('does not query without userId', () => {
+    mockedUseAuthSession.mockReturnValue(
+      makeSession({ user: { id: '', email: 'resident@test.com', name: 'Resident' } }) as never,
+    );
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useResidentProfile('tenant-1'), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.canAccessProfile).toBe(false);
+    expect(result.current.profileQuery.fetchStatus).toBe('idle');
+    expect(mockedGetResidentProfile).not.toHaveBeenCalled();
+  });
+
+  it('allows access when the tenant membership contains RESIDENT even if activeTenantId points elsewhere', async () => {
+    mockedUseAuthSession.mockReturnValue(makeSession() as never);
+    mockedGetResidentProfile.mockResolvedValue({
+      id: 'member-1',
+      tenantId: 'tenant-1',
+      name: 'Resident One',
+      email: 'resident@test.com',
+      phone: null,
+      role: 'RESIDENT',
+      status: 'ACTIVE',
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    } as never);
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useResidentProfile('tenant-1'), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(mockedGetResidentProfile).toHaveBeenCalledTimes(1);
+    });
+
+    expect(result.current.canAccessProfile).toBe(true);
+    expect(result.current.hasResidentMembership).toBe(true);
+  });
+
+  it('allows access with mixed roles that include RESIDENT', async () => {
+    mockedUseAuthSession.mockReturnValue(
+      makeSession({
+        memberships: [
+          {
+            tenantId: 'tenant-1',
+            roles: ['RESIDENT', 'TENANT_ADMIN'],
+          },
+        ],
+      }) as never,
+    );
+    mockedGetResidentProfile.mockResolvedValue({
+      id: 'member-1',
+      tenantId: 'tenant-1',
+      name: 'Resident Prime',
+      email: 'resident@test.com',
+      phone: null,
+      role: 'RESIDENT',
+      status: 'ACTIVE',
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    } as never);
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useResidentProfile('tenant-1'), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(mockedGetResidentProfile).toHaveBeenCalledTimes(1);
+    });
+
+    expect(result.current.canAccessProfile).toBe(true);
+    expect(result.current.hasResidentMembership).toBe(true);
+  });
+
+  it('does not query when the membership belongs to another tenant', () => {
+    mockedUseAuthSession.mockReturnValue(
+      makeSession({
+        memberships: [
+          {
+            tenantId: 'tenant-2',
+            roles: ['RESIDENT'],
+          },
+        ],
+      }) as never,
+    );
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useResidentProfile('tenant-1'), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.canAccessProfile).toBe(false);
+    expect(result.current.profileQuery.fetchStatus).toBe('idle');
+    expect(mockedGetResidentProfile).not.toHaveBeenCalled();
+  });
+
+  it('does not query when the tenant membership does not include RESIDENT', () => {
+    mockedUseAuthSession.mockReturnValue(
+      makeSession({
+        memberships: [
+          {
+            tenantId: 'tenant-1',
+            roles: ['TENANT_ADMIN'],
+          },
+        ],
+      }) as never,
+    );
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useResidentProfile('tenant-1'), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.canAccessProfile).toBe(false);
+    expect(result.current.profileQuery.fetchStatus).toBe('idle');
+    expect(mockedGetResidentProfile).not.toHaveBeenCalled();
+  });
+
+  it('exposes a query key that includes tenantId and userId', () => {
+    mockedUseAuthSession.mockReturnValue(makeSession() as never);
+
+    const { Wrapper } = createWrapper();
+    const { result } = renderHook(() => useResidentProfile('tenant-1'), {
+      wrapper: Wrapper,
+    });
+
+    expect(result.current.queryKey).toEqual(residentProfileKeys.profile('tenant-1', 'user-1'));
+  });
+
+  it('refetches when the authenticated user changes inside the same tenant', async () => {
+    mockedUseAuthSession.mockReturnValue(
+      makeSession({
+        user: { id: 'user-1', email: 'resident1@test.com', name: 'Resident 1' },
+      }) as never,
+    );
+    mockedGetResidentProfile
+      .mockResolvedValueOnce({
+        id: 'member-1',
+        tenantId: 'tenant-1',
+        name: 'Resident One',
+        email: 'resident1@test.com',
+        phone: null,
+        role: 'RESIDENT',
+        status: 'ACTIVE',
+        createdAt: '2026-07-27T00:00:00.000Z',
+        updatedAt: '2026-07-27T00:00:00.000Z',
+      } as never)
+      .mockResolvedValueOnce({
+        id: 'member-2',
+        tenantId: 'tenant-1',
+        name: 'Resident Two',
+        email: 'resident2@test.com',
+        phone: null,
+        role: 'RESIDENT',
+        status: 'ACTIVE',
+        createdAt: '2026-07-27T00:00:00.000Z',
+        updatedAt: '2026-07-27T00:00:00.000Z',
+      } as never);
+
+    const { Wrapper } = createWrapper();
+    const { result, rerender } = renderHook(
+      ({ tenantId }: { tenantId: string | null }) => useResidentProfile(tenantId),
+      {
+        wrapper: Wrapper,
+        initialProps: { tenantId: 'tenant-1' },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.profileQuery.data?.name).toBe('Resident One');
+    });
+
+    mockedUseAuthSession.mockReturnValue(
+      makeSession({
+        user: { id: 'user-2', email: 'resident2@test.com', name: 'Resident 2' },
+      }) as never,
+    );
+
+    rerender({ tenantId: 'tenant-1' });
+
+    await waitFor(() => {
+      expect(result.current.profileQuery.data?.name).toBe('Resident Two');
+    });
+
+    expect(mockedGetResidentProfile).toHaveBeenCalledTimes(2);
+  });
+
+  it('updates only the matching resident profile cache entry and does not mutate the session user', async () => {
+    const session = makeSession();
+    mockedUseAuthSession.mockReturnValue(session as never);
+    mockedGetResidentProfile.mockResolvedValue({
+      id: 'member-1',
+      tenantId: 'tenant-1',
+      name: 'Resident One',
+      email: 'resident@test.com',
+      phone: null,
+      role: 'RESIDENT',
+      status: 'ACTIVE',
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    } as never);
+    mockedUpdateResidentProfile.mockResolvedValue({
+      id: 'member-1',
+      tenantId: 'tenant-1',
+      name: 'Resident Prime',
+      email: 'resident@test.com',
+      phone: '+584141111111',
+      role: 'RESIDENT',
+      status: 'ACTIVE',
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T01:00:00.000Z',
+    } as never);
+
+    const { Wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(residentProfileKeys.profile('tenant-1', 'user-1'), {
+      id: 'cached-member-1',
+      tenantId: 'tenant-1',
+      name: 'Resident One',
+      email: 'resident@test.com',
+      phone: null,
+      role: 'RESIDENT',
+      status: 'ACTIVE',
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    });
+    queryClient.setQueryData(residentProfileKeys.profile('tenant-1', 'user-2'), {
+      id: 'cached-member-2',
+      tenantId: 'tenant-1',
+      name: 'Resident Other',
+      email: 'resident2@test.com',
+      phone: null,
+      role: 'RESIDENT',
+      status: 'ACTIVE',
+      createdAt: '2026-07-27T00:00:00.000Z',
+      updatedAt: '2026-07-27T00:00:00.000Z',
+    });
+
+    const { result } = renderHook(() => useResidentProfile('tenant-1'), {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.profileQuery.data?.name).toBe('Resident One');
+    });
+
+    await act(async () => {
+      await result.current.updateProfile.mutateAsync({ name: 'Resident Prime' });
+    });
+
+    expect(mockedUpdateResidentProfile).toHaveBeenCalledWith('tenant-1', { name: 'Resident Prime' });
+    expect(queryClient.getQueryData(residentProfileKeys.profile('tenant-1', 'user-1'))).toMatchObject({
+      name: 'Resident Prime',
+      phone: '+584141111111',
+    });
+    expect(queryClient.getQueryData(residentProfileKeys.profile('tenant-1', 'user-2'))).toMatchObject({
+      name: 'Resident Other',
+    });
+    expect(session.user.name).toBe('Resident');
+    expect(mockedUseRefreshSession).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/features/resident/profile/useResidentProfile.ts
+++ b/apps/web/features/resident/profile/useResidentProfile.ts
@@ -1,0 +1,75 @@
+'use client';
+
+import { useMemo } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAuthSession } from '@/features/auth/useAuthSession';
+import {
+  getResidentProfile,
+  updateResidentProfile,
+  type ResidentProfile,
+  type UpdateResidentProfileInput,
+} from './resident-profile.api';
+
+export const residentProfileKeys = {
+  profile: (tenantId: string | null | undefined, userId: string | null | undefined) =>
+    ['residentProfile', tenantId ?? null, userId ?? null] as const,
+};
+
+export interface UseResidentProfileResult {
+  profileQuery: ReturnType<typeof useQuery<ResidentProfile>>;
+  updateProfile: ReturnType<typeof useMutation<ResidentProfile, Error, UpdateResidentProfileInput>>;
+  queryKey: readonly [string, string | null, string | null];
+  hasResidentMembership: boolean;
+  canAccessProfile: boolean;
+  tenantId: string | null;
+  userId: string | null;
+}
+
+export function useResidentProfile(tenantId: string | null | undefined): UseResidentProfileResult {
+  const session = useAuthSession();
+  const queryClient = useQueryClient();
+  const userId = session?.user.id ?? null;
+
+  const residentMembership = useMemo(() => {
+    if (!tenantId || !session) {
+      return null;
+    }
+
+    return (
+      session.memberships.find(
+        (membership) => membership.tenantId === tenantId && membership.roles.includes('RESIDENT'),
+      ) ?? null
+    );
+  }, [session, tenantId]);
+
+  const canAccessProfile = Boolean(tenantId && userId && residentMembership);
+  const queryKey = residentProfileKeys.profile(tenantId, userId);
+
+  const profileQuery = useQuery<ResidentProfile>({
+    queryKey,
+    queryFn: () => getResidentProfile(tenantId!),
+    enabled: canAccessProfile,
+    staleTime: 2 * 60 * 1000,
+    gcTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+
+  const updateProfile = useMutation<ResidentProfile, Error, UpdateResidentProfileInput>({
+    mutationFn: (input) => updateResidentProfile(tenantId!, input),
+    onSuccess: (updatedProfile) => {
+      if (tenantId && userId) {
+        queryClient.setQueryData(residentProfileKeys.profile(tenantId, userId), updatedProfile);
+      }
+    },
+  });
+
+  return {
+    profileQuery,
+    updateProfile,
+    queryKey,
+    hasResidentMembership: residentMembership !== null,
+    canAccessProfile,
+    tenantId: tenantId ?? null,
+    userId,
+  };
+}

--- a/apps/web/i18n/es-419.json
+++ b/apps/web/i18n/es-419.json
@@ -111,7 +111,8 @@
     "support": "Soporte",
     "inbox": "Bandeja de entrada",
     "reports": "Reportes",
-    "myUnit": "Mi unidad"
+    "myUnit": "Mi unidad",
+    "myProfile": "Mi perfil"
   },
 
   "sidebar": {

--- a/apps/web/shared/components/layout/Sidebar.test.tsx
+++ b/apps/web/shared/components/layout/Sidebar.test.tsx
@@ -37,6 +37,7 @@ jest.mock("@/i18n", () => ({
   t: (key: string) => ({
     "common.condominium": "Condominio",
     "navigation.dashboard": "Panel",
+    "navigation.myProfile": "Mi perfil",
     "navigation.payments": "Pagos",
     "navigation.communications": "Comunicados",
     "navigation.tickets": "Solicitudes",
@@ -70,6 +71,14 @@ describe("Sidebar", () => {
       expect(link.className).toContain("min-h-11");
       expect(link.className).toContain("items-center");
     });
+  });
+
+  it("keeps Mi perfil active on the resident profile route", () => {
+    pathname = "/tenant-1/resident/profile";
+
+    render(<Sidebar variant="drawer" />);
+
+    expect(screen.getByRole("link", { name: "Mi perfil" }).className).toContain("bg-primary");
   });
 
   it("keeps Solicitudes active for the canonical resident ticket detail route", () => {

--- a/apps/web/shared/components/layout/Sidebar.tsx
+++ b/apps/web/shared/components/layout/Sidebar.tsx
@@ -94,6 +94,7 @@ export const Sidebar = ({ className, footer, id, onNavigate, variant = "desktop"
 
         {isResident ? (
           <>
+            {navItem(`/${tenantId}/resident/profile`, t("navigation.myProfile"))}
             {navItem(`/${tenantId}/resident/payments`, t("navigation.payments"))}
             {navItem(`/${tenantId}/resident/announcements`, t("navigation.communications"))}
             {navItem(`/${tenantId}/resident/tickets`, t("navigation.tickets"))}


### PR DESCRIPTION
## Resumen
- agrega GET y PATCH /me/profile con aislamiento por tenant y usuario autenticado
- permite al residente actualizar nombre y teléfono
- muestra el correo autenticado como solo lectura
- agrega la página Mi perfil y su enlace en la navegación residente
- aísla la caché por tenantId y userId

## Validaciones
- API: 17 tests PASS
- Web: 41 tests PASS
- TypeScript web: PASS
- Build API: PASS
- Build web: PASS
- git diff --check: PASS

## Fuera de alcance
- sin cambios en Prisma ni migraciones
- sin cambios en ResidentContextSwitcher ni etapa 6
- sin cambios en el asistente residente