### PR TITLE
fix(notifications): route transactional alerts by portal context

### DIFF
--- a/apps/api/src/common/portal-context.spec.ts
+++ b/apps/api/src/common/portal-context.spec.ts
@@ -1,0 +1,63 @@
+import { normalizePortalContextHeader, resolveNotificationPortalContext } from './portal-context';
+
+describe('normalizePortalContextHeader', () => {
+  it('returns resident for resident', () => {
+    expect(normalizePortalContextHeader('resident')).toBe('resident');
+  });
+
+  it('returns admin for admin', () => {
+    expect(normalizePortalContextHeader('admin')).toBe('admin');
+  });
+
+  it('returns undefined for undefined', () => {
+    expect(normalizePortalContextHeader(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for invalid values', () => {
+    expect(normalizePortalContextHeader('resident ')).toBeUndefined();
+    expect(normalizePortalContextHeader('ADMIN')).toBeUndefined();
+    expect(normalizePortalContextHeader('')).toBeUndefined();
+  });
+});
+
+describe('resolveNotificationPortalContext', () => {
+  it('returns resident for a pure resident without header', () => {
+    expect(resolveNotificationPortalContext(['RESIDENT'])).toBe('resident');
+  });
+
+  it('returns resident for a pure resident with a falsified admin header', () => {
+    expect(resolveNotificationPortalContext(['RESIDENT'], 'admin')).toBe('resident');
+  });
+
+  it('returns admin for a pure tenant admin with a falsified resident header', () => {
+    expect(resolveNotificationPortalContext(['TENANT_ADMIN'], 'resident')).toBe('admin');
+  });
+
+  it('returns admin for a pure super admin with a falsified resident header', () => {
+    expect(resolveNotificationPortalContext(['SUPER_ADMIN'], 'resident')).toBe('admin');
+  });
+
+  it('returns resident for resident plus tenant admin when header is resident', () => {
+    expect(resolveNotificationPortalContext(['RESIDENT', 'TENANT_ADMIN'], 'resident')).toBe('resident');
+  });
+
+  it('returns admin for resident plus tenant admin without header', () => {
+    expect(resolveNotificationPortalContext(['RESIDENT', 'TENANT_ADMIN'])).toBe('admin');
+  });
+
+  it('returns resident for resident plus operator when header is resident', () => {
+    expect(resolveNotificationPortalContext(['RESIDENT', 'OPERATOR'], 'resident')).toBe('resident');
+  });
+
+  it('returns admin for resident plus tenant owner when header is admin', () => {
+    expect(resolveNotificationPortalContext(['RESIDENT', 'TENANT_OWNER'], 'admin')).toBe('admin');
+  });
+
+  it('returns resident for resident plus super admin when header is resident', () => {
+    expect(resolveNotificationPortalContext(['RESIDENT', 'SUPER_ADMIN'], 'resident')).toBe('resident');
+  });
+
+  it('returns admin for resident plus super admin without header', () => {
+    expect(resolveNotificationPortalContext(['RESIDENT', 'SUPER_ADMIN'])).toBe('admin');
+  });
+});

--- a/apps/api/src/common/portal-context.ts
+++ b/apps/api/src/common/portal-context.ts
@@ -1,0 +1,31 @@
+import type { PortalContext } from './types/request.types';
+
+const PRIVILEGED_ROLES = ['SUPER_ADMIN', 'TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR'] as const;
+
+export function normalizePortalContextHeader(
+  value: string | undefined | null,
+): PortalContext | undefined {
+  if (value === 'resident' || value === 'admin') {
+    return value;
+  }
+
+  return undefined;
+}
+
+export function resolveNotificationPortalContext(
+  userRoles: readonly string[],
+  portalContext?: PortalContext,
+): PortalContext {
+  const hasResidentRole = userRoles.includes('RESIDENT');
+  const hasPrivilegedRole = userRoles.some((role) => PRIVILEGED_ROLES.includes(role as typeof PRIVILEGED_ROLES[number]));
+
+  if (hasResidentRole && !hasPrivilegedRole) {
+    return 'resident';
+  }
+
+  if (!hasResidentRole) {
+    return 'admin';
+  }
+
+  return portalContext === 'resident' ? 'resident' : 'admin';
+}

--- a/apps/api/src/common/types/request.types.ts
+++ b/apps/api/src/common/types/request.types.ts
@@ -1,6 +1,8 @@
 import { Request } from 'express';
 import type { Role, ScopedRole } from '@buildingos/contracts';
 
+export type PortalContext = 'resident' | 'admin';
+
 export interface AuthenticatedMembership {
   id?: string;
   tenantId: string;

--- a/apps/api/src/documents/documents.service.spec.ts
+++ b/apps/api/src/documents/documents.service.spec.ts
@@ -231,6 +231,80 @@ describe('DocumentsService', () => {
     expect(result.file.objectKey).toContain('expensas..julio.pdf');
   });
 
+  it('notifies admins instead of the uploading resident for payment proofs', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    prisma.file.create.mockResolvedValueOnce({ id: 'file-proof' } as never);
+    prisma.document.create.mockResolvedValueOnce({
+      id: 'document-proof',
+      tenantId: 'tenant-1',
+      title: 'Pago de julio',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      createdByMembership: { user: { id: 'resident-1', name: 'Resident' } },
+      file: { bucket: DEFAULT_BUCKET, objectKey: 'tenant-tenant-1/payment-proofs/proof.pdf' },
+    } as never);
+    await service.createDocument('tenant-1', 'membership-1', {
+      title: 'Pago de julio',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      file: {
+        ...uploadFile,
+        objectKey: 'tenant-tenant-1/payment-proofs/proof.pdf',
+      },
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    });
+
+    expect(prisma.unitOccupant.findMany).not.toHaveBeenCalled();
+    expect(notifications.createNotification).not.toHaveBeenCalled();
+  });
+
+  it('excludes the uploading resident from general resident document notifications', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    prisma.file.create.mockResolvedValueOnce({ id: 'file-doc' } as never);
+    prisma.document.create.mockResolvedValueOnce({
+      id: 'document-general',
+      tenantId: 'tenant-1',
+      title: 'Reglamento',
+      category: 'OTHER',
+      visibility: 'RESIDENTS',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      createdByMembership: { user: { id: 'resident-1', name: 'Resident' } },
+      file: { bucket: DEFAULT_BUCKET, objectKey: 'tenant-tenant-1/documents/reglamento.pdf' },
+    } as never);
+    prisma.unitOccupant.findMany.mockResolvedValueOnce([
+      { member: { user: { id: 'resident-1' } } },
+      { member: { user: { id: 'resident-2' } } },
+    ] as never);
+
+    await service.createDocument('tenant-1', 'membership-1', {
+      title: 'Reglamento',
+      category: 'OTHER',
+      visibility: 'RESIDENTS',
+      file: {
+        ...uploadFile,
+        objectKey: 'tenant-tenant-1/documents/reglamento.pdf',
+      },
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    });
+
+    expect(notifications.createNotification).toHaveBeenCalledTimes(1);
+    expect(notifications.createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      userId: 'resident-2',
+      type: 'DOCUMENT_SHARED',
+    }));
+    expect(notifications.createNotification).not.toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'resident-1',
+    }));
+  });
+
   it('rejects empty uploads before creating the document record', async () => {
     minio.objectExists.mockResolvedValue(true);
     minio.statObject.mockResolvedValue({ size: 0 } as never);

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -293,8 +293,8 @@ export class DocumentsService {
       throw new BadRequestException('Failed to persist document metadata');
     }
 
-    // [PHASE 2 QUICK #6] Send DOCUMENT_SHARED notification if visibility=RESIDENTS
-    void this.sendDocumentSharedNotification(tenantId, document, dto);
+    // [PHASE 2 QUICK #6] Send transactional notification after document creation
+    void this.sendDocumentSharedNotification(tenantId, document, uploadPurpose);
 
     // [PHASE 2 QUICK #7] Audit: DOCUMENT_CREATE
     void this.auditService.createLog({
@@ -1088,68 +1088,68 @@ export class DocumentsService {
   private async sendDocumentSharedNotification(
     tenantId: string,
     document: DocumentNotificationTarget,
-    dto: CreateDocumentDto,
+    uploadPurpose: DocumentUploadPurpose,
   ): Promise<void> {
     try {
-      // Only notify for RESIDENTS visibility
+      const actorUserId = document.createdByMembership?.user?.id ?? null;
+
+      if (uploadPurpose === DocumentUploadPurpose.PAYMENT_PROOF) return;
+
+      // Only notify for RESIDENTS visibility on general documents
       if (document.visibility !== 'RESIDENTS') return;
 
-      let recipientUnitOccupants: UnitOccupantNotificationRecipient[] = [];
-
-      if (document.unitId) {
-        // Unit-scoped: notify occupants of that unit
-        recipientUnitOccupants = await this.prisma.unitOccupant.findMany({
-          where: {
-            tenantId,
-            unitId: document.unitId,
-            endDate: null, // Active only
-          },
-          include: {
-            member: { select: { user: { select: { id: true } } } },
-          },
-        });
-      } else if (document.buildingId) {
-        // Building-scoped: notify all occupants in that building
-        recipientUnitOccupants = await this.prisma.unitOccupant.findMany({
-          where: {
-            tenantId,
-            unit: { buildingId: document.buildingId },
-            endDate: null, // Active only
-          },
-          include: {
-            member: { select: { user: { select: { id: true } } } },
-          },
-        });
-      } else {
-        // Tenant-wide: notify all occupants
-        recipientUnitOccupants = await this.prisma.unitOccupant.findMany({
-          where: {
-            tenantId,
-            endDate: null, // Active only
-          },
-          include: {
-            member: { select: { user: { select: { id: true } } } },
-          },
-        });
-      }
-
-      // Send notification to each occupant
-      for (const occupant of recipientUnitOccupants) {
-        if (occupant.member?.user?.id) {
-          await this.notificationsService.createNotification({
-            tenantId,
-            userId: occupant.member.user.id,
-            type: 'DOCUMENT_SHARED',
-            title: 'Documento compartido contigo',
-            body: `Se ha compartido el documento "${document.title}" (${document.category}). Puedes descargarlo desde la sección Documentos.`,
-            data: {
-              documentId: document.id,
-              documentTitle: document.title,
-              documentCategory: document.category,
+      const recipientUnitOccupants: UnitOccupantNotificationRecipient[] = document.unitId
+        ? await this.prisma.unitOccupant.findMany({
+            where: {
+              tenantId,
+              unitId: document.unitId,
+              endDate: null, // Active only
             },
-            deliveryMethods: ['IN_APP', 'EMAIL'],
-          });
-        }
+            include: {
+              member: { select: { user: { select: { id: true } } } },
+            },
+          })
+        : document.buildingId
+          ? await this.prisma.unitOccupant.findMany({
+              where: {
+                tenantId,
+                unit: { buildingId: document.buildingId },
+                endDate: null, // Active only
+              },
+              include: {
+                member: { select: { user: { select: { id: true } } } },
+              },
+            })
+          : await this.prisma.unitOccupant.findMany({
+              where: {
+                tenantId,
+                endDate: null, // Active only
+              },
+              include: {
+                member: { select: { user: { select: { id: true } } } },
+              },
+            });
+
+      const recipientIds = new Set(
+        recipientUnitOccupants
+          .map((occupant) => occupant.member?.user?.id)
+          .filter((userId): userId is string => !!userId && userId !== actorUserId),
+      );
+
+      for (const userId of recipientIds) {
+        await this.notificationsService.createNotification({
+          tenantId,
+          userId,
+          type: 'DOCUMENT_SHARED',
+          title: 'Documento compartido contigo',
+          body: `Se ha compartido el documento "${document.title}" (${document.category}). Puedes descargarlo desde la sección Documentos.`,
+          data: {
+            documentId: document.id,
+            documentTitle: document.title,
+            documentCategory: document.category,
+          },
+          deliveryMethods: ['IN_APP', 'EMAIL'],
+        });
       }
     } catch (error) {
       // Fire-and-forget: log but never fail
@@ -1159,4 +1159,5 @@ export class DocumentsService {
       );
     }
   }
+
 }

--- a/apps/api/src/finanzas/finanzas.controller.ts
+++ b/apps/api/src/finanzas/finanzas.controller.ts
@@ -9,6 +9,7 @@ import {
   Query,
   UseGuards,
   Request,
+  Headers,
   ForbiddenException,
   BadRequestException,
 } from '@nestjs/common';
@@ -19,6 +20,7 @@ import { BuildingAccessGuard } from '../tenancy/building-access.guard';
 import { FinanzasService } from './finanzas.service';
 import { ExpenseImportService } from './expense-import.service';
 import { AuthenticatedRequest } from '../common/types/request.types';
+import { normalizePortalContextHeader } from '../common/portal-context';
 import {
   CreateChargeDto,
   UpdateChargeDto,
@@ -230,6 +232,7 @@ export class FinanzasController {
     @Param() params: CreatePaymentParamDto,
     @Body() dto: SubmitPaymentDto,
     @Request() req: AuthenticatedRequest,
+    @Headers('x-portal-context') portalContext?: string,
   ): Promise<PaymentDetailDto> {
     const tenantId = req.tenantId!;
     const userId = req.user.id;
@@ -240,6 +243,7 @@ export class FinanzasController {
       userId,
       userRoles,
       dto,
+      normalizePortalContextHeader(portalContext),
     );
   }
 

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -12,13 +12,14 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { PaymentReceiptService } from '../receipts/payment-receipt.service';
 import { CreateChargeDto, UpdateChargeDto } from './finanzas.dto';
 import { ExpensesService } from './expenses.service';
-import { ChargeStatus, PaymentStatus, PaymentMethod, AuditAction } from '@prisma/client';
+import { ChargeStatus, PaymentStatus, PaymentMethod, AuditAction, ScopeType } from '@prisma/client';
 
 describe('FinanzasService', () => {
   let service: FinanzasService;
   let prismaService: PrismaService;
   let auditService: AuditService;
   let validators: FinanzasValidators;
+  let notificationsService: { createNotification: jest.Mock };
   let expensesService: ExpensesService;
   let receiptService: PaymentReceiptService;
 
@@ -45,6 +46,9 @@ describe('FinanzasService', () => {
               findFirst: jest.fn(),
               findUnique: jest.fn(),
             },
+            building: {
+              findUnique: jest.fn(),
+            },
             payment: {
               create: jest.fn(),
               findFirst: jest.fn(),
@@ -63,8 +67,15 @@ describe('FinanzasService', () => {
             paymentAuditLog: {
               create: jest.fn(),
             },
+            membership: {
+              findMany: jest.fn(),
+              findFirst: jest.fn(),
+            },
             file: {
               findFirst: jest.fn(),
+            },
+            user: {
+              findUnique: jest.fn(),
             },
             expense: {
               findMany: jest.fn(),
@@ -82,6 +93,7 @@ describe('FinanzasService', () => {
         {
           provide: NotificationsService,
           useValue: {
+            createNotification: jest.fn(),
             notifyPaymentApproved: jest.fn(),
             notifyPaymentRejected: jest.fn(),
             notifyTicketCreated: jest.fn(),
@@ -123,6 +135,7 @@ describe('FinanzasService', () => {
     prismaService = module.get<PrismaService>(PrismaService);
     auditService = module.get<AuditService>(AuditService);
     validators = module.get<FinanzasValidators>(FinanzasValidators);
+    notificationsService = module.get(NotificationsService) as never;
     expensesService = module.get<ExpensesService>(ExpensesService);
     receiptService = module.get<PaymentReceiptService>(PaymentReceiptService);
 
@@ -835,6 +848,90 @@ describe('FinanzasService', () => {
       expect(prismaService.payment.create).not.toHaveBeenCalled();
       expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
     });
+
+    it('notifies admins for a pure resident payment even when the portal context is omitted', async () => {
+      await service.submitPayment(
+        tenantId,
+        buildingId,
+        userId,
+        userRoles,
+        {
+          unitId,
+          chargeId: 'charge-123',
+          amount: 10000,
+          currency: 'ARS',
+          method: PaymentMethod.TRANSFER,
+          reference: 'TRX-RESIDENT',
+          proofFileId: 'file-123',
+        },
+      );
+
+      expect((service as any).notifyAdminsOfPaymentSubmitted).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not notify admins for an admin-context payment', async () => {
+      jest.spyOn(validators, 'isResidentOrOwner').mockReturnValue(false);
+
+      await service.submitPayment(
+        tenantId,
+        buildingId,
+        userId,
+        ['TENANT_ADMIN'],
+        {
+          amount: 10000,
+          method: PaymentMethod.TRANSFER,
+          reference: 'TRX-ADMIN',
+          proofFileId: 'file-123',
+        },
+        'admin',
+      );
+
+      expect((service as any).notifyAdminsOfPaymentSubmitted).not.toHaveBeenCalled();
+    });
+
+    it('respects mixed membership portal context and only notifies admins when the resident portal is explicit', async () => {
+      const mixedRoles = ['RESIDENT', 'TENANT_ADMIN'];
+
+      await service.submitPayment(
+        tenantId,
+        buildingId,
+        userId,
+        mixedRoles,
+        {
+          unitId,
+          chargeId: 'charge-123',
+          amount: 10000,
+          currency: 'ARS',
+          method: PaymentMethod.TRANSFER,
+          reference: 'TRX-MIXED',
+          proofFileId: 'file-123',
+        },
+        'resident',
+      );
+
+      expect((service as any).notifyAdminsOfPaymentSubmitted).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not let an admin portal header suppress resident-origin payment notifications', async () => {
+      await service.submitPayment(
+        tenantId,
+        buildingId,
+        userId,
+        userRoles,
+        {
+          unitId,
+          chargeId: 'charge-123',
+          amount: 10000,
+          currency: 'ARS',
+          method: PaymentMethod.TRANSFER,
+          reference: 'TRX-RESIDENT-ADMIN-HEADER',
+          proofFileId: 'file-123',
+        },
+        'admin',
+      );
+
+      expect((service as any).notifyAdminsOfPaymentSubmitted).toHaveBeenCalledTimes(1);
+    });
   });
 
   // ========== TESTS: APPROVE PAYMENT ==========
@@ -1543,6 +1640,7 @@ describe('FinanzasService', () => {
       jest.spyOn(validators, 'canReviewPayments').mockReturnValue(true);
       jest.spyOn(service as any, 'sendPaymentReceivedNotification').mockResolvedValue(undefined);
       jest.spyOn(receiptService, 'ensureReceiptForPayment').mockResolvedValue(undefined);
+      jest.spyOn(prismaService.membership, 'findFirst').mockResolvedValue({ userId: 'member-user-1' } as never);
     });
 
     it('serializes approvePayment so the same payment cannot be applied twice', async () => {
@@ -2044,7 +2142,7 @@ describe('FinanzasService', () => {
         where: { tenantId, paymentId },
       });
       expect(makeAllocation()).toHaveLength(0);
-      expect(notificationSpy).toHaveBeenCalledWith(tenantId, expect.any(Object), 'OTHER');
+      expect(notificationSpy).toHaveBeenCalledWith(tenantId, expect.any(Object), 'OTHER', undefined);
 
       await expect(
         service.updateCharge(tenantId, buildingId, chargeId, ['TENANT_ADMIN'], {
@@ -2099,7 +2197,7 @@ describe('FinanzasService', () => {
         where: { tenantId, paymentId },
       });
       expect(makeAllocation()).toHaveLength(0);
-      expect(notificationSpy).toHaveBeenCalledWith(tenantId, expect.any(Object), 'OTHER');
+      expect(notificationSpy).toHaveBeenCalledWith(tenantId, expect.any(Object), 'OTHER', undefined);
     });
 
     it('cancelPayment removes provisional allocations for submitted payments', async () => {
@@ -2877,6 +2975,114 @@ describe('FinanzasService', () => {
           metadata: expect.objectContaining({ validatedCount: 2, errorCount: 0 }),
         }),
       );
+    });
+  });
+
+  describe('notification recipient filtering', () => {
+    const tenantId = 'tenant-123';
+    const buildingId = 'building-123';
+    const unitId = 'unit-123';
+    const residentId = 'resident-1';
+    const adminId = 'admin-1';
+
+    beforeEach(() => {
+      jest.spyOn(prismaService.membership, 'findMany').mockResolvedValue([
+        { user: { id: residentId } },
+        { user: { id: adminId } },
+        { user: { id: adminId } },
+      ] as never);
+      jest.spyOn(prismaService.user, 'findUnique').mockResolvedValue({
+        name: 'Resident',
+        email: 'resident@example.com',
+      } as never);
+      jest.spyOn(prismaService.unit, 'findUnique').mockResolvedValue({
+        label: 'TN-01-01',
+        unitOccupants: [
+          { member: { user: { id: residentId } } },
+          { member: { user: { id: 'resident-2' } } },
+        ],
+      } as never);
+      jest.spyOn(prismaService.building, 'findUnique').mockResolvedValue({
+        name: 'Building A',
+      } as never);
+      jest.spyOn(notificationsService, 'createNotification').mockResolvedValue(undefined);
+    });
+
+    it('excludes the submitting resident from admin payment notifications', async () => {
+      await (service as any).notifyAdminsOfPaymentSubmitted(
+        tenantId,
+        {
+          id: 'payment-1',
+          tenantId,
+          buildingId,
+          unitId,
+          amount: 10000,
+          currency: 'ARS',
+          method: PaymentMethod.TRANSFER,
+          reference: 'TRX-1',
+          createdByUserId: residentId,
+          proofFileId: 'file-1',
+        },
+        residentId,
+      );
+
+      expect(notificationsService.createNotification).toHaveBeenCalledTimes(1);
+      expect(notificationsService.createNotification).toHaveBeenCalledWith(expect.objectContaining({
+        tenantId,
+        userId: adminId,
+        type: 'BUILDING_ALERT',
+      }));
+      expect(notificationsService.createNotification).not.toHaveBeenCalledWith(expect.objectContaining({
+        userId: residentId,
+      }));
+      expect(prismaService.membership.findMany).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          tenantId,
+          roles: expect.objectContaining({
+            some: expect.objectContaining({
+              role: { in: ['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR'] },
+              OR: expect.arrayContaining([
+                { scopeType: ScopeType.TENANT },
+                { scopeType: ScopeType.BUILDING, scopeBuildingId: buildingId },
+                { scopeType: ScopeType.UNIT, scopeUnitId: unitId },
+              ]),
+            }),
+          }),
+        }),
+      }));
+    });
+
+    it.each([
+      ['sendPaymentReceivedNotification', 'PAYMENT_RECEIVED'],
+      ['sendPaymentRejectedNotification', 'PAYMENT_REJECTED'],
+    ])('excludes the actor from resident payment notifications (%s)', async (helperName, notificationType) => {
+      const payment = {
+        id: 'payment-1',
+        tenantId,
+        buildingId,
+        unitId,
+        amount: 10000,
+        currency: 'ARS',
+        method: PaymentMethod.TRANSFER,
+        createdByUserId: residentId,
+        reference: 'TRX-1',
+        paidAt: new Date('2026-07-24T12:00:00.000Z'),
+      };
+
+      if (helperName === 'sendPaymentRejectedNotification') {
+        await (service as any)[helperName](tenantId, payment, 'Not specified', residentId);
+      } else {
+        await (service as any)[helperName](tenantId, payment, residentId);
+      }
+
+      expect(notificationsService.createNotification).toHaveBeenCalledWith(expect.objectContaining({
+        tenantId,
+        userId: 'resident-2',
+        type: notificationType,
+      }));
+      expect(notificationsService.createNotification).not.toHaveBeenCalledWith(expect.objectContaining({
+        userId: residentId,
+      }));
     });
   });
 });

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -1,10 +1,12 @@
 import { Injectable, ConflictException, NotFoundException, BadRequestException, Logger, PayloadTooLargeException } from '@nestjs/common';
-import { Charge, Payment, PaymentAllocation, Prisma, ChargeStatus, PaymentStatus, PaymentMethod, AuditAction, PaymentAuditAction, RejectionReason, ReceiptStatus } from '@prisma/client';
+import { Charge, Payment, PaymentAllocation, Prisma, ChargeStatus, PaymentStatus, PaymentMethod, AuditAction, PaymentAuditAction, RejectionReason, ReceiptStatus, ScopeType } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { FinanzasValidators } from './finanzas.validators';
 import { PaymentReceiptService } from '../receipts/payment-receipt.service';
+import type { PortalContext } from '../common/types/request.types';
+import { resolveNotificationPortalContext } from '../common/portal-context';
 import { ExpensesService } from './expenses.service';
 import {
   CreateChargeDto,
@@ -447,6 +449,7 @@ export class FinanzasService {
     userId: string,
     userRoles: string[],
     dto: SubmitPaymentDto,
+    portalContext?: PortalContext,
   ): Promise<Payment> {
     // 1. Permission check
     if (!this.validators.canSubmitPayments(userRoles)) {
@@ -611,7 +614,9 @@ export class FinanzasService {
         return payment;
       });
 
-      void this.notifyAdminsOfPaymentSubmitted(tenantId, payment);
+      if (resolveNotificationPortalContext(userRoles, portalContext) === 'resident') {
+        void this.notifyAdminsOfPaymentSubmitted(tenantId, payment, userId);
+      }
       return this.sanitizePaymentForResponse(payment);
     }
 
@@ -632,7 +637,9 @@ export class FinanzasService {
     });
 
     // 9. Notify admins about new payment submitted
-    void this.notifyAdminsOfPaymentSubmitted(tenantId, payment);
+    if (resolveNotificationPortalContext(userRoles, portalContext) === 'resident') {
+      void this.notifyAdminsOfPaymentSubmitted(tenantId, payment, userId);
+    }
 
     return this.sanitizePaymentForResponse(payment);
   }
@@ -965,10 +972,11 @@ export class FinanzasService {
     });
 
     // [PHASE 2 QUICK #3] Send PAYMENT_RECEIVED notification
-    void this.sendPaymentReceivedNotification(tenantId, result);
+    const actorUserId = await this.resolveMembershipUserId(tenantId, membershipId);
+    void this.sendPaymentReceivedNotification(tenantId, result, actorUserId ?? undefined);
 
     // Generate receipt for approved payment (async, non-blocking)
-    void this.receiptService.ensureReceiptForPayment(paymentId).catch((err) => {
+    void this.receiptService.ensureReceiptForPayment(paymentId, actorUserId ?? undefined).catch((err) => {
       this.logger.error(`Failed to generate receipt for payment ${paymentId}: ${err.message}`);
     });
 
@@ -1055,7 +1063,8 @@ export class FinanzasService {
       return rejectedPayment;
     });
 
-    void this.sendPaymentRejectedNotification(tenantId, result, dto.reason);
+    const actorUserId = await this.resolveMembershipUserId(tenantId, membershipId);
+    void this.sendPaymentRejectedNotification(tenantId, result, dto.reason, actorUserId ?? undefined);
 
     return this.sanitizePaymentForResponse(result);
   }
@@ -2891,10 +2900,11 @@ export class FinanzasService {
 
     // Send notification to resident about approval (outside transaction, using returned payment)
     if (approvedPaymentResult) {
-      void this.sendPaymentReceivedNotification(tenantId, approvedPaymentResult);
+      const actorUserId = await this.resolveMembershipUserId(tenantId, membershipId);
+      void this.sendPaymentReceivedNotification(tenantId, approvedPaymentResult, actorUserId ?? undefined);
       
       // Generate receipt for approved payment (async, non-blocking)
-      void this.receiptService.ensureReceiptForPayment(paymentId).catch((err) => {
+      void this.receiptService.ensureReceiptForPayment(paymentId, actorUserId ?? undefined).catch((err) => {
         this.logger.error(`Failed to generate receipt for payment ${paymentId}: ${err.message}`);
       });
     }
@@ -2981,7 +2991,8 @@ export class FinanzasService {
       return rejectedPayment;
     });
 
-    void this.sendPaymentRejectedNotification(tenantId, result, dto.reason);
+    const actorUserId = await this.resolveMembershipUserId(tenantId, membershipId);
+    void this.sendPaymentRejectedNotification(tenantId, result, dto.reason, actorUserId ?? undefined);
 
     return this.sanitizePaymentForResponse(result);
   }
@@ -3200,63 +3211,10 @@ export class FinanzasService {
    * [PHASE 2 QUICK #3] Send PAYMENT_RECEIVED notification
    * Fire-and-forget: logs errors but never throws
    */
-  private async sendPaymentReceivedNotification(tenantId: string, payment: Payment): Promise<void> {
-    try {
-      // Load unit occupants if this payment is unit-scoped
-      if (!payment.unitId) return;
-
-      const unit = await this.prisma.unit.findUnique({
-        where: { id: payment.unitId },
-        include: {
-          unitOccupants: {
-            where: { endDate: null }, // Active only
-            include: {
-              member: { select: { id: true, user: { select: { id: true } } } },
-            },
-          },
-        },
-      });
-
-      if (!unit) return;
-
-      // Send to all active residents
-      for (const occupant of unit.unitOccupants) {
-        if (occupant.member?.user?.id) {
-          const amount = (payment.amount / 100).toFixed(2);
-          await this.notificationsService.createNotification({
-            tenantId,
-            userId: occupant.member.user.id,
-            type: 'PAYMENT_RECEIVED',
-            title: 'Pago aprobado',
-            body: `Tu pago de ${amount} ${payment.currency} ha sido aprobado y procesado correctamente.`,
-            data: {
-              paymentId: payment.id,
-              paymentAmount: payment.amount / 100,
-              paymentCurrency: payment.currency,
-              reference: payment.reference || 'N/A',
-              paidAt: payment.paidAt?.toISOString(),
-            },
-            deliveryMethods: ['IN_APP', 'EMAIL'],
-          });
-        }
-      }
-    } catch (error) {
-      // Fire-and-forget: log but never fail
-      this.logger.error(
-        `[FinanzasService] Failed to send payment received notification for payment ${payment.id}: ${error instanceof Error ? error.message : String(error)}`,
-        error instanceof Error ? error.stack : undefined,
-      );
-    }
-  }
-
-  /**
-   * [PHASE 2 QUICK #4] Send PAYMENT_REJECTED notification
-   * Fire-and-forget: logs errors but never throws
-   */
-  private async sendPaymentRejectedNotification(
+  private async sendPaymentReceivedNotification(
     tenantId: string,
     payment: Payment,
-    reason?: string,
+    excludeUserId?: string,
   ): Promise<void> {
     try {
       // Load unit occupants if this payment is unit-scoped
@@ -3276,25 +3234,91 @@ export class FinanzasService {
 
       if (!unit) return;
 
+      const recipientIds = new Set(
+        unit.unitOccupants
+          .map((occupant) => occupant.member?.user?.id)
+          .filter((userId): userId is string => !!userId && userId !== excludeUserId),
+      );
+
       // Send to all active residents
-      for (const occupant of unit.unitOccupants) {
-        if (occupant.member?.user?.id) {
-          const amount = (payment.amount / 100).toFixed(2);
-          await this.notificationsService.createNotification({
-            tenantId,
-            userId: occupant.member.user.id,
-            type: 'PAYMENT_REJECTED',
-            title: 'Pago rechazado',
-            body: `Tu pago de ${amount} ${payment.currency} ha sido rechazado. Motivo: ${reason || 'No especificado'}. Por favor intenta nuevamente.`,
-            data: {
-              paymentId: payment.id,
-              paymentAmount: payment.amount / 100,
-              paymentCurrency: payment.currency,
-              rejectionReason: reason || 'No especificado',
+      for (const userId of recipientIds) {
+        const amount = (payment.amount / 100).toFixed(2);
+        await this.notificationsService.createNotification({
+          tenantId,
+          userId,
+          type: 'PAYMENT_RECEIVED',
+          title: 'Pago aprobado',
+          body: `Tu pago de ${amount} ${payment.currency} ha sido aprobado y procesado correctamente.`,
+          data: {
+            paymentId: payment.id,
+            paymentAmount: payment.amount / 100,
+            paymentCurrency: payment.currency,
+            reference: payment.reference || 'N/A',
+            paidAt: payment.paidAt?.toISOString(),
+          },
+          deliveryMethods: ['IN_APP', 'EMAIL'],
+        });
+      }
+    } catch (error) {
+      // Fire-and-forget: log but never fail
+      this.logger.error(
+        `[FinanzasService] Failed to send payment received notification for payment ${payment.id}: ${error instanceof Error ? error.message : String(error)}`,
+        error instanceof Error ? error.stack : undefined,
+      );
+    }
+  }
+
+  /**
+   * [PHASE 2 QUICK #4] Send PAYMENT_REJECTED notification
+   * Fire-and-forget: logs errors but never throws
+   */
+  private async sendPaymentRejectedNotification(
+    tenantId: string,
+    payment: Payment,
+    reason?: string,
+    excludeUserId?: string,
+  ): Promise<void> {
+    try {
+      // Load unit occupants if this payment is unit-scoped
+      if (!payment.unitId) return;
+
+      const unit = await this.prisma.unit.findUnique({
+        where: { id: payment.unitId },
+        include: {
+          unitOccupants: {
+            where: { endDate: null }, // Active only
+            include: {
+              member: { select: { id: true, user: { select: { id: true } } } },
             },
-            deliveryMethods: ['IN_APP', 'EMAIL'],
-          });
-        }
+          },
+        },
+      });
+
+      if (!unit) return;
+
+      const recipientIds = new Set(
+        unit.unitOccupants
+          .map((occupant) => occupant.member?.user?.id)
+          .filter((userId): userId is string => !!userId && userId !== excludeUserId),
+      );
+
+      // Send to all active residents
+      for (const userId of recipientIds) {
+        const amount = (payment.amount / 100).toFixed(2);
+        await this.notificationsService.createNotification({
+          tenantId,
+          userId,
+          type: 'PAYMENT_REJECTED',
+          title: 'Pago rechazado',
+          body: `Tu pago de ${amount} ${payment.currency} ha sido rechazado. Motivo: ${reason || 'No especificado'}. Por favor intenta nuevamente.`,
+          data: {
+            paymentId: payment.id,
+            paymentAmount: payment.amount / 100,
+            paymentCurrency: payment.currency,
+            rejectionReason: reason || 'No especificado',
+          },
+          deliveryMethods: ['IN_APP', 'EMAIL'],
+        });
       }
     } catch (error) {
       // Fire-and-forget: log but never fail
@@ -3309,54 +3333,20 @@ export class FinanzasService {
    * Notify admins when a new payment is submitted by a resident
    * Fire-and-forget: logs errors but never throws
    */
-  private async notifyAdminsOfPaymentSubmitted(tenantId: string, payment: Payment): Promise<void> {
+  private async notifyAdminsOfPaymentSubmitted(
+    tenantId: string,
+    payment: Payment,
+    actorUserId?: string,
+  ): Promise<void> {
     try {
-      // Get all admin/operator memberships for this tenant via MembershipRole
-      const adminMemberships = await this.prisma.membership.findMany({
-        where: {
-          tenantId,
-          roles: {
-            some: {
-              role: { in: ['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR'] },
-            },
-          },
-        },
-        include: {
-          user: { select: { id: true, name: true, email: true } },
-        },
-      });
+      const adminIds = await this.resolveAdministrativeRecipientIds(
+        tenantId,
+        payment.buildingId,
+        payment.unitId,
+        actorUserId ? [actorUserId] : [],
+      );
 
-      // Also check TenantMember for admins (fallback if MembershipRole is empty)
-      const adminTenantMembers = await this.prisma.tenantMember.findMany({
-        where: {
-          tenantId,
-          status: 'ACTIVE',
-          role: { in: ['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR'] },
-        },
-        include: {
-          user: { select: { id: true, name: true, email: true } },
-        },
-      });
-
-      // Merge unique users from both sources
-      const adminUserIds = new Set<string>();
-      const adminsToNotify: Array<{ id: string; name: string | null; email: string | null }> = [];
-
-      for (const m of adminMemberships) {
-        if (m.user && !adminUserIds.has(m.user.id)) {
-          adminUserIds.add(m.user.id);
-          adminsToNotify.push({ id: m.user.id, name: m.user.name, email: m.user.email });
-        }
-      }
-
-      for (const tm of adminTenantMembers) {
-        if (tm.user && !adminUserIds.has(tm.user.id)) {
-          adminUserIds.add(tm.user.id);
-          adminsToNotify.push({ id: tm.user.id, name: tm.user.name, email: tm.user.email });
-        }
-      }
-
-      if (adminsToNotify.length === 0) {
+      if (adminIds.length === 0) {
         this.logger.debug(`[FinanzasService] No admins found for tenant ${tenantId}, skipping notification`);
         return;
       }
@@ -3375,12 +3365,12 @@ export class FinanzasService {
         : null;
       const amount = (payment.amount / 100).toFixed(2);
 
-      this.logger.debug(`[FinanzasService] Notifying ${adminsToNotify.length} admins about payment ${payment.id}`);
+      this.logger.debug(`[FinanzasService] Notifying ${adminIds.length} admins about payment ${payment.id}`);
 
-      for (const admin of adminsToNotify) {
+      for (const adminId of adminIds) {
         await this.notificationsService.createNotification({
           tenantId,
-          userId: admin.id,
+          userId: adminId,
           type: 'BUILDING_ALERT',
           title: '💰 Nuevo pago pendiente de revisión',
           body: `El residente ${submittedByUser?.name || submittedByUser?.email || 'unknown'} envió un pago de ${amount} ${payment.currency} para la unidad ${unitLabel || payment.unitId || 'N/A'}${buildingName ? ` en ${buildingName}` : ''}. Método: ${payment.method}. ${payment.proofFileId ? '✅ Tiene comprobante.' : '⚠️ Sin comprobante.'}`,
@@ -3405,6 +3395,56 @@ export class FinanzasService {
         error instanceof Error ? error.stack : undefined,
       );
     }
+  }
+
+  private async resolveAdministrativeRecipientIds(
+    tenantId: string,
+    buildingId?: string | null,
+    unitId?: string | null,
+    excludedUserIds: readonly string[] = [],
+  ): Promise<string[]> {
+    const adminMemberships = await this.prisma.membership.findMany({
+      where: {
+        tenantId,
+        roles: {
+          some: {
+            role: { in: ['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR'] },
+            OR: [
+              { scopeType: ScopeType.TENANT },
+              ...(buildingId ? [{ scopeType: ScopeType.BUILDING, scopeBuildingId: buildingId }] : []),
+              ...(unitId ? [{ scopeType: ScopeType.UNIT, scopeUnitId: unitId }] : []),
+            ],
+          },
+        },
+      },
+      include: {
+        user: { select: { id: true } },
+      },
+    });
+
+    const excluded = new Set(excludedUserIds.filter((id): id is string => !!id));
+    const recipientIds = new Set<string>();
+    for (const userId of [
+      ...adminMemberships.map((admin) => admin.user?.id),
+    ]) {
+      if (userId && !excluded.has(userId)) {
+        recipientIds.add(userId);
+      }
+    }
+
+    return [...recipientIds];
+  }
+
+  private async resolveMembershipUserId(
+    tenantId: string,
+    membershipId: string,
+  ): Promise<string | null> {
+    const membership = await this.prisma.membership.findFirst({
+      where: { id: membershipId, tenantId },
+      select: { userId: true },
+    });
+
+    return membership?.userId ?? null;
   }
 
   /**
@@ -3637,6 +3677,7 @@ export class FinanzasService {
     tenantId: string,
     paymentId: string,
     userRoles: string[],
+    excludeUserId?: string,
   ): Promise<{ success: boolean; receiptNumber?: string; error?: string }> {
     if (!this.validators.canReviewPayments(userRoles)) {
       this.validators.throwForbidden('payments', 'retry receipt');
@@ -3672,7 +3713,7 @@ export class FinanzasService {
     });
 
     // Try to generate receipt
-    const result = await this.receiptService.ensureReceiptForPayment(paymentId);
+    const result = await this.receiptService.ensureReceiptForPayment(paymentId, excludeUserId);
 
     if (result) {
       return {

--- a/apps/api/src/finanzas/liquidation-publication.use-case.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.spec.ts
@@ -5,6 +5,7 @@ import {
 import { Prisma } from '@prisma/client';
 import {
   LiquidationPublicationUseCase,
+  sendChargePublishedNotifications,
   type LiquidationWorkflowDependencies,
 } from './liquidation-publication.use-case';
 
@@ -59,11 +60,12 @@ describe('LiquidationPublicationUseCase', () => {
   beforeEach(() => {
     tx = {
       membership: {
-        findFirst: jest.fn().mockResolvedValue({
-          id: 'member-1',
-          tenantId: 'tenant-1',
-          roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
-        }),
+      findFirst: jest.fn().mockResolvedValue({
+        id: 'member-1',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+      }),
       },
       liquidation: {
         findFirst: jest
@@ -294,5 +296,57 @@ describe('LiquidationPublicationUseCase', () => {
         }),
       }),
     );
+  });
+
+  it('excludes the publishing actor from charge-published notifications', async () => {
+    const notificationsService = {
+      createNotification: jest.fn().mockResolvedValue(undefined),
+    };
+    const prisma = {
+      charge: {
+        findMany: jest.fn().mockResolvedValue([
+          {
+            id: 'charge-1',
+            unitId: 'unit-1',
+            dueDate: new Date('2026-05-10T00:00:00.000Z'),
+            amount: 101,
+            currency: 'ARS',
+          },
+        ]),
+      },
+      unit: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'unit-1',
+          label: '1A',
+          unitOccupants: [
+            { member: { user: { id: 'user-1' } } },
+            { member: { user: { id: 'resident-2' } } },
+          ],
+        }),
+      },
+    } as never;
+
+    await sendChargePublishedNotifications(
+      prisma,
+      notificationsService,
+      'tenant-1',
+      'liq-1',
+      {
+        period: '2026-05',
+        buildingId: 'building-1',
+        baseCurrency: 'ARS',
+      },
+      'user-1',
+    );
+
+    expect(notificationsService.createNotification).toHaveBeenCalledTimes(1);
+    expect(notificationsService.createNotification).toHaveBeenCalledWith(expect.objectContaining({
+      tenantId: 'tenant-1',
+      userId: 'resident-2',
+      type: 'CHARGE_PUBLISHED',
+    }));
+    expect(notificationsService.createNotification).not.toHaveBeenCalledWith(expect.objectContaining({
+      userId: 'user-1',
+    }));
   });
 });

--- a/apps/api/src/finanzas/liquidation-publication.use-case.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.ts
@@ -25,6 +25,7 @@ export type NotificationPolicy = 'post-commit' | 'disabled';
 interface FinanceMembershipRecord {
   id: string;
   tenantId: string;
+  userId: string;
   roles: Array<{
     role: string;
     scopeType: 'TENANT' | 'BUILDING' | 'UNIT';
@@ -34,6 +35,7 @@ interface FinanceMembershipRecord {
 export interface FinanceMembershipContext {
   readonly id: string;
   readonly tenantId: string;
+  readonly userId: string;
   readonly roles: string[];
 }
 
@@ -44,6 +46,7 @@ interface FinanceMembershipClient {
       select: {
         id: boolean;
         tenantId: boolean;
+        userId: boolean;
         roles: { select: { role: boolean; scopeType: boolean } };
       };
     }) => Promise<FinanceMembershipRecord | null>;
@@ -123,6 +126,7 @@ export interface LiquidationWorkflowDependencies {
       buildingId: string;
       baseCurrency: string;
     },
+    excludeUserId?: string,
   ) => Promise<NotificationDispatchResult>;
 }
 
@@ -172,6 +176,7 @@ export async function requireFinanceMembership(
     select: {
       id: true,
       tenantId: true,
+      userId: true,
       roles: { select: { role: true, scopeType: true } },
     },
   });
@@ -191,6 +196,7 @@ export async function requireFinanceMembership(
   return {
     id: membership.id,
     tenantId: membership.tenantId,
+    userId: membership.userId,
     roles: tenantRoles,
   };
 }
@@ -227,6 +233,7 @@ export async function sendChargePublishedNotifications(
     buildingId: string;
     baseCurrency: string;
   },
+  excludeUserId?: string,
 ): Promise<NotificationDispatchResult> {
   const logger = new Logger(LiquidationPublicationUseCase.name);
   let sentCount = 0;
@@ -261,7 +268,7 @@ export async function sendChargePublishedNotifications(
     }
 
     for (const occupant of unit.unitOccupants) {
-      if (!occupant.member?.user?.id) {
+      if (!occupant.member?.user?.id || occupant.member.user.id === excludeUserId) {
         continue;
       }
 
@@ -320,13 +327,14 @@ export function createLiquidationWorkflowDependencies(params: {
     createAuditLogRequired: (input, tx) => params.auditService.createLogRequired(input, tx),
     createAuditLog: (input) => params.auditService.createLog(input),
     toPublishedLiquidationDto: (liquidation) => toLiquidationResponseDto(liquidation),
-    sendChargePublishedNotifications: (tenantId, liquidationId, liquidation) =>
+    sendChargePublishedNotifications: (tenantId, liquidationId, liquidation, excludeUserId) =>
       sendChargePublishedNotifications(
         params.prisma,
         params.notificationsService,
         tenantId,
         liquidationId,
         liquidation,
+        excludeUserId,
       ),
   };
 }
@@ -465,6 +473,7 @@ export class LiquidationPublicationUseCase {
     notificationPolicy: NotificationPolicy = 'post-commit',
   ): Promise<LiquidationResponseDto> {
     let publishResult: { liquidation: LiquidationResponseDto; publishedNow: boolean } | null = null;
+    let actorUserId: string | null = null;
 
     try {
       publishResult = await this.deps.prisma.$transaction(
@@ -475,6 +484,7 @@ export class LiquidationPublicationUseCase {
             membershipId,
             this.deps.isAdminOrOperator,
           );
+          actorUserId = membership.userId;
 
           const current = await tx.liquidation.findFirst({
             where: { id: liquidationId, tenantId },
@@ -746,6 +756,7 @@ export class LiquidationPublicationUseCase {
           buildingId: publishResult.liquidation.buildingId,
           baseCurrency: publishResult.liquidation.baseCurrency,
         },
+        actorUserId ?? undefined,
       );
 
       if (notificationResult.failedCount > 0) {

--- a/apps/api/src/finanzas/liquidations.service.spec.ts
+++ b/apps/api/src/finanzas/liquidations.service.spec.ts
@@ -89,11 +89,12 @@ describe('LiquidationsService', () => {
   beforeEach(async () => {
     tx = {
       membership: {
-        findFirst: jest.fn().mockResolvedValue({
-          id: 'member-1',
-          tenantId: 'tenant-1',
-          roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
-        }),
+      findFirst: jest.fn().mockResolvedValue({
+        id: 'member-1',
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+        roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+      }),
       },
       building: {
         findFirst: jest.fn().mockResolvedValue({ id: 'building-1' }),
@@ -159,11 +160,12 @@ describe('LiquidationsService', () => {
           provide: PrismaService,
           useValue: {
             membership: {
-              findFirst: jest.fn().mockResolvedValue({
-                id: 'member-1',
-                tenantId: 'tenant-1',
-                roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
-              }),
+            findFirst: jest.fn().mockResolvedValue({
+              id: 'member-1',
+              tenantId: 'tenant-1',
+              userId: 'user-1',
+              roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+            }),
             },
             unit: {
               findMany: jest.fn().mockResolvedValue([
@@ -793,7 +795,19 @@ describe('LiquidationsService', () => {
         dueDate: '2026-06-10',
       }),
     ).resolves.toMatchObject({ status: 'PUBLISHED' });
-    expect(notifications).toHaveBeenCalledTimes(2);
+    expect(notifications).toHaveBeenCalledTimes(1);
+    expect(notifications).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant-1',
+        userId: 'user-2',
+      }),
+    );
+    expect(notifications).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant-1',
+        userId: 'user-1',
+      }),
+    );
     expect(auditService.createLogRequired).toHaveBeenCalledWith(
       expect.objectContaining({
         tenantId: 'tenant-1',

--- a/apps/api/src/finanzas/tenant-finance.controller.ts
+++ b/apps/api/src/finanzas/tenant-finance.controller.ts
@@ -202,6 +202,6 @@ export class TenantFinanceController {
   ) {
     const tenantId = req.tenantId!;
     const userRoles = req.user.roles || [];
-    return this.finanzasService.retryReceiptGeneration(tenantId, paymentId, userRoles);
+    return this.finanzasService.retryReceiptGeneration(tenantId, paymentId, userRoles, req.user.id);
   }
 }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -44,7 +44,7 @@ async function bootstrap() {
     },
     credentials: true,
     methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'Authorization', 'X-Tenant-Id'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Tenant-Id', 'X-Portal-Context'],
   });
 
   // =========================================================

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -305,6 +305,24 @@ describe('PaymentReceiptService', () => {
     expect(result?.fileKey).toContain('/receipt_R-');
   });
 
+  it('does not notify the receipt owner when excluded from the approval flow', async () => {
+    await (service as any).notifyResidentReceiptReady(
+      {
+        tenantId: 'tenant-1',
+        createdByUserId: 'resident-1',
+        amount: 4050000,
+        currency: 'ARS',
+        id: 'payment-1',
+      },
+      'R-2026-001',
+      'https://download.example/receipt.pdf',
+      'Admin',
+      'resident-1',
+    );
+
+    expect(notificationsService.createNotification).not.toHaveBeenCalled();
+  });
+
   it('encodes WinAnsi punctuation and falls back safely for unsupported characters', async () => {
     prisma.tenant.findUnique.mockResolvedValue({
       name: 'Consorcio “Central”',

--- a/apps/api/src/receipts/payment-receipt.service.ts
+++ b/apps/api/src/receipts/payment-receipt.service.ts
@@ -106,7 +106,7 @@ export class PaymentReceiptService {
    * Idempotent: if receipt already exists, return it.
    * If generation fails, sets receiptStatus = FAILED with error message.
    */
-  async ensureReceiptForPayment(paymentId: string): Promise<ReceiptData | null> {
+  async ensureReceiptForPayment(paymentId: string, excludeUserId?: string): Promise<ReceiptData | null> {
     const payment = await this.prisma.payment.findUnique({
       where: { id: paymentId },
       include: {
@@ -235,7 +235,13 @@ export class PaymentReceiptService {
       const url = await this.minio.presignDownload(this.bucket, objectKey, 3600);
 
       // Notify resident
-      await this.notifyResidentReceiptReady(payment, receiptNumber, url, approvedByUserName);
+      await this.notifyResidentReceiptReady(
+        payment,
+        receiptNumber,
+        url,
+        approvedByUserName,
+        excludeUserId,
+      );
 
       this.logger.log(`Receipt ${receiptNumber} generated for payment ${paymentId}`);
 
@@ -799,8 +805,13 @@ export class PaymentReceiptService {
     receiptNumber: string,
     receiptUrl: string,
     approvedByUserName: string,
+    excludeUserId?: string,
   ) {
     try {
+      if (excludeUserId && payment.createdByUserId === excludeUserId) {
+        return;
+      }
+
       await this.notificationsService.createNotification({
         tenantId: payment.tenantId,
         userId: payment.createdByUserId,

--- a/apps/api/src/tickets/tickets.controller.spec.ts
+++ b/apps/api/src/tickets/tickets.controller.spec.ts
@@ -42,6 +42,7 @@ describe('TicketsController', () => {
       'building-1',
       { title: 'Leak', description: 'Water leak', unitId: 'unit-1', assignedToMembershipId: 'member-1', priority: 'URGENT', category: 'REPAIR' } as never,
       { tenantId: 'tenant-1', user: { id: 'resident-1', roles: ['RESIDENT'] } } as never,
+      'resident',
     );
 
     expect(ticketsService.create).toHaveBeenCalledWith(
@@ -49,6 +50,7 @@ describe('TicketsController', () => {
       'building-1',
       'resident-1',
       expect.objectContaining({ category: 'REPAIR', priority: 'MEDIUM', assignedToMembershipId: undefined }),
+      'resident',
     );
   });
 
@@ -67,9 +69,11 @@ describe('TicketsController', () => {
     const operatorRequest = { tenantId: 'tenant-1', user: { id: 'operator-1', roles: ['OPERATOR'] } } as never;
     ticketsService.update.mockResolvedValue({ id: 'ticket-1', title: 'Updated' } as never);
     await expect(controller.update('building-1', 'ticket-1', { title: 'Updated' }, operatorRequest)).resolves.toEqual({ id: 'ticket-1', title: 'Updated' });
+    expect(ticketsService.update).toHaveBeenCalledWith('tenant-1', 'building-1', 'ticket-1', { title: 'Updated' }, 'operator-1');
 
     const adminRequest = { tenantId: 'tenant-1', user: { id: 'admin-1', roles: ['TENANT_ADMIN'] } } as never;
     await expect(controller.update('building-1', 'ticket-1', { title: 'Updated' }, adminRequest)).resolves.toEqual({ id: 'ticket-1', title: 'Updated' });
+    expect(ticketsService.update).toHaveBeenCalledWith('tenant-1', 'building-1', 'ticket-1', { title: 'Updated' }, 'admin-1');
   });
 
   it('allows an operator to add an administrative comment within the building scope', async () => {
@@ -81,6 +85,7 @@ describe('TicketsController', () => {
       'ticket-1',
       { body: 'Estamos revisando' },
       { tenantId: 'tenant-1', user: { id: 'operator-1', roles: ['OPERATOR'] } } as never,
+      'admin',
     )).resolves.toEqual({ id: 'comment-1', body: 'Estamos revisando' });
 
     expect(ticketsService.addComment).toHaveBeenCalledWith(
@@ -89,6 +94,7 @@ describe('TicketsController', () => {
       'ticket-1',
       'operator-1',
       { body: 'Estamos revisando' },
+      'admin',
     );
   });
 });

--- a/apps/api/src/tickets/tickets.controller.ts
+++ b/apps/api/src/tickets/tickets.controller.ts
@@ -9,6 +9,7 @@ import {
   UseGuards,
   Request,
   Query,
+  Headers,
   ForbiddenException,
 } from '@nestjs/common';
 import { TicketCategory, TicketPriority, TicketStatus } from '@prisma/client';
@@ -22,6 +23,7 @@ import { CreateTicketDto } from './dto/create-ticket.dto';
 import { UpdateTicketDto } from './dto/update-ticket.dto';
 import { AddTicketCommentDto } from './dto/add-ticket-comment.dto';
 import type { TenantContextRequest } from '../common/types/request.types';
+import { normalizePortalContextHeader, resolveNotificationPortalContext } from '../common/portal-context';
 import { can } from '../rbac/can';
 import type { Permission } from '../rbac/permissions';
 
@@ -106,6 +108,7 @@ export class TicketsController {
     @Param('buildingId') buildingId: string,
     @Body() dto: CreateTicketDto,
     @Request() req: TenantContextRequest,
+    @Headers('x-portal-context') portalContext?: string,
   ) {
     this.requirePermission(req, 'tickets.write');
     const tenantId = req.tenantId; // Populated by BuildingAccessGuard
@@ -122,12 +125,17 @@ export class TicketsController {
     const residentDto = this.shouldEnforceResidentScope(userRoles)
       ? { ...dto, category: dto.category ?? TicketCategory.OTHER, priority: TicketPriority.MEDIUM, assignedToMembershipId: undefined }
       : dto;
+    const actorPortalContext = resolveNotificationPortalContext(
+      userRoles,
+      normalizePortalContextHeader(portalContext),
+    );
 
     return await this.ticketsService.create(
       tenantId,
       buildingId,
       userId,
       residentDto,
+      actorPortalContext,
     );
   }
 
@@ -276,6 +284,7 @@ export class TicketsController {
       buildingId,
       ticketId,
       dto,
+      req.user.id,
     );
   }
 
@@ -317,6 +326,7 @@ export class TicketsController {
     @Param('ticketId') ticketId: string,
     @Body() dto: AddTicketCommentDto,
     @Request() req: TenantContextRequest,
+    @Headers('x-portal-context') portalContext?: string,
   ) {
     this.requirePermission(req, 'tickets.read');
     const tenantId = req.tenantId; // Populated by BuildingAccessGuard
@@ -335,12 +345,18 @@ export class TicketsController {
       );
     }
 
+    const actorPortalContext = resolveNotificationPortalContext(
+      userRoles,
+      normalizePortalContextHeader(portalContext),
+    );
+
     return await this.ticketsService.addComment(
       tenantId,
       buildingId,
       ticketId,
       userId,
       dto,
+      actorPortalContext,
     );
   }
 

--- a/apps/api/src/tickets/tickets.service.spec.ts
+++ b/apps/api/src/tickets/tickets.service.spec.ts
@@ -49,8 +49,7 @@ describe('TicketsService', () => {
               findMany: jest.fn(),
             },
             tenantMember: {
-              findFirst: jest.fn(),
-              findMany: jest.fn().mockResolvedValue([]),
+              findMany: jest.fn(),
             },
             membership: {
               findFirst: jest.fn(),
@@ -214,7 +213,7 @@ describe('TicketsService', () => {
       jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
 
       // ACT
-      const result = await service.create(tenantId, buildingId, userId, dto);
+      const result = await service.create(tenantId, buildingId, userId, dto, 'resident');
 
       // ASSERT
       expect(result).toEqual(expectedTicket);
@@ -270,7 +269,7 @@ describe('TicketsService', () => {
       jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
 
       // ACT
-      const result = await service.create(tenantId, buildingId, userId, dto);
+      const result = await service.create(tenantId, buildingId, userId, dto, 'resident');
 
       // ASSERT
       expect(result.unitId).toBeNull();
@@ -295,7 +294,7 @@ describe('TicketsService', () => {
 
       // ACT & ASSERT
       await expect(
-        service.create(tenantId, buildingId, userId, dto),
+        service.create(tenantId, buildingId, userId, dto, 'resident'),
       ).rejects.toThrow(NotFoundException);
     });
 
@@ -321,7 +320,7 @@ describe('TicketsService', () => {
 
       // ACT & ASSERT
       await expect(
-        service.create(tenantId, buildingId, userId, dto),
+        service.create(tenantId, buildingId, userId, dto, 'resident'),
       ).rejects.toThrow(BadRequestException);
     });
 
@@ -373,7 +372,7 @@ describe('TicketsService', () => {
       jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
 
       await expect(
-        service.create(tenantId, buildingId, userId, dto),
+        service.create(tenantId, buildingId, userId, dto, 'resident'),
       ).resolves.toEqual(expectedTicket);
     });
   });
@@ -658,7 +657,7 @@ describe('TicketsService', () => {
           { id: 'membership-4', userId: 'owner-1', user: { id: 'owner-1' }, roles: [{ role: 'TENANT_OWNER' }] },
         ] as any);
 
-        await service.create(tenantId, buildingId, userId, dto);
+        await service.create(tenantId, buildingId, userId, dto, 'resident');
 
         // Wait for fire-and-forget
         await new Promise((r) => setTimeout(r, 10));
@@ -737,7 +736,7 @@ describe('TicketsService', () => {
           title: 'Test',
           description: 'Test',
           category: 'OTHER',
-        });
+        }, 'resident');
 
         await new Promise((r) => setTimeout(r, 10));
 
@@ -749,6 +748,99 @@ describe('TicketsService', () => {
             }),
           }),
         );
+      });
+
+      it('should not notify the resident when they also hold an admin role', async () => {
+        const tenantId = 'tenant-123';
+        const buildingId = 'building-123';
+        const userId = 'user-admin-resident';
+
+        jest.spyOn(validators, 'validateBuildingBelongsToTenant').mockResolvedValue(undefined);
+        jest.spyOn(validators, 'validateUnitBelongsToBuildingAndTenant').mockResolvedValue(undefined);
+        jest.spyOn(prismaService.ticket, 'create').mockResolvedValue({
+          id: 'ticket-self',
+          tenantId,
+          buildingId,
+          unitId: 'unit-1',
+          createdByUserId: userId,
+          title: 'Self notify',
+          description: 'Should not self notify',
+          category: 'OTHER',
+          priority: 'MEDIUM',
+          status: 'OPEN',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          createdBy: { id: userId, name: 'Resident Admin' },
+          assignedTo: null,
+          building: { id: buildingId, name: 'Edificio A' },
+          unit: { id: 'unit-1', label: '101', code: 'A01' },
+          comments: [],
+        } as any);
+        jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
+        jest.spyOn(prismaService.membership, 'findMany').mockResolvedValue([
+          { id: 'membership-self', userId, user: { id: userId }, roles: [{ role: 'TENANT_ADMIN' }] },
+          { id: 'membership-admin', userId: 'admin-2', user: { id: 'admin-2' }, roles: [{ role: 'TENANT_ADMIN' }] },
+        ] as any);
+
+        await service.create(tenantId, buildingId, userId, {
+          title: 'Self notify',
+          description: 'Should not self notify',
+          category: 'OTHER',
+          unitId: 'unit-1',
+        }, 'resident');
+
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(notificationsService.createNotification).toHaveBeenCalledTimes(1);
+        expect(notificationsService.createNotification).toHaveBeenCalledWith(
+          expect.objectContaining({
+            tenantId,
+            userId: 'admin-2',
+            type: 'SUPPORT_TICKET_CREATED',
+          }),
+        );
+        expect(notificationsService.createNotification).not.toHaveBeenCalledWith(
+          expect.objectContaining({ userId }),
+        );
+      });
+
+      it('should skip resident-origin notifications when the ticket is created from the admin portal', async () => {
+        const tenantId = 'tenant-123';
+        const buildingId = 'building-123';
+        const userId = 'user-admin';
+
+        jest.spyOn(validators, 'validateBuildingBelongsToTenant').mockResolvedValue(undefined);
+        jest.spyOn(prismaService.ticket, 'create').mockResolvedValue({
+          id: 'ticket-admin',
+          tenantId,
+          buildingId,
+          unitId: 'unit-1',
+          createdByUserId: userId,
+          title: 'Admin ticket',
+          description: 'Created from admin portal',
+          category: 'OTHER',
+          priority: 'MEDIUM',
+          status: 'OPEN',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          createdBy: { id: userId, name: 'Admin' },
+          assignedTo: null,
+          building: { id: buildingId, name: 'Edificio A' },
+          unit: { id: 'unit-1', label: '101', code: 'A01' },
+          comments: [],
+        } as any);
+        jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
+
+        await service.create(tenantId, buildingId, userId, {
+          title: 'Admin ticket',
+          description: 'Created from admin portal',
+          category: 'OTHER',
+          unitId: 'unit-1',
+        }, 'admin');
+
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(notificationsService.createNotification).not.toHaveBeenCalled();
       });
     });
 
@@ -792,6 +884,36 @@ describe('TicketsService', () => {
             }),
           }),
         );
+      });
+
+      it('should not notify the actor when they are also the ticket creator', async () => {
+        const tenantId = 'tenant-123';
+        const buildingId = 'building-123';
+        const ticketId = 'ticket-self-status';
+        const creatorId = 'creator-admin';
+
+        jest.spyOn(prismaService.ticket, 'findFirst').mockResolvedValue({
+          id: ticketId,
+          tenantId,
+          buildingId,
+          status: 'OPEN',
+          createdByUserId: creatorId,
+        } as any);
+        jest.spyOn(prismaService.ticket, 'update').mockResolvedValue({
+          id: ticketId,
+          tenantId,
+          buildingId,
+          status: 'IN_PROGRESS',
+          createdByUserId: creatorId,
+          building: { name: 'Edificio A' },
+        } as any);
+        jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
+
+        await service.update(tenantId, buildingId, ticketId, { status: 'IN_PROGRESS' }, creatorId);
+
+        await new Promise((r) => setTimeout(r, 10));
+
+        expect(notificationsService.createNotification).not.toHaveBeenCalled();
       });
 
       it('should not notify anyone when status does not change', async () => {
@@ -848,7 +970,7 @@ describe('TicketsService', () => {
 
         await service.addComment(tenantId, buildingId, ticketId, adminId, {
           body: 'Estamos revisando el problema',
-        });
+        }, 'admin');
 
         await new Promise((r) => setTimeout(r, 10));
 
@@ -888,7 +1010,7 @@ describe('TicketsService', () => {
 
         await service.addComment(tenantId, buildingId, ticketId, creatorId, {
           body: 'Gracias',
-        });
+        }, 'admin');
 
         await new Promise((r) => setTimeout(r, 10));
 
@@ -928,7 +1050,7 @@ describe('TicketsService', () => {
 
         await service.addComment(tenantId, buildingId, ticketId, creatorId, {
           body: 'Siguen las goteras',
-        });
+        }, 'resident');
 
         await new Promise((r) => setTimeout(r, 10));
 

--- a/apps/api/src/tickets/tickets.service.ts
+++ b/apps/api/src/tickets/tickets.service.ts
@@ -27,7 +27,7 @@ import { AddTicketCommentDto } from './dto/add-ticket-comment.dto';
 import { AiTicketCategoryService } from '../assistant/ai-ticket-category.service';
 import { ASSIGNABLE_TICKET_ROLES } from '../memberships/memberships.constants';
 import { ResidentAccessService } from '../resident-access/resident-access.service';
-import type { AuthenticatedServiceActor } from '../common/types/request.types';
+import type { AuthenticatedServiceActor, PortalContext } from '../common/types/request.types';
 import { PERMISSIONS } from '../rbac/permissions';
 
 /**
@@ -170,6 +170,7 @@ export class TicketsService {
     buildingId: string,
     userId: string,
     dto: CreateTicketDto,
+    actorPortalContext: PortalContext,
   ) {
     // 1. Validate building belongs to tenant
     await this.validators.validateBuildingBelongsToTenant(
@@ -239,8 +240,10 @@ export class TicketsService {
       },
     });
 
-    // Fire-and-forget: notify tenant admins of new ticket
-    void this.notifyTicketCreated(tenantId, buildingId, ticket);
+    // Fire-and-forget: notify tenant admins only when the ticket originates from the resident portal
+    if (actorPortalContext === 'resident') {
+      void this.notifyTicketCreated(tenantId, buildingId, ticket, userId);
+    }
 
     // FASE 2: Fire-and-forget AI categorization (never blocks user response)
     // Only run if user didn't explicitly provide category/priority
@@ -528,6 +531,7 @@ export class TicketsService {
     buildingId: string,
     ticketId: string,
     dto: UpdateTicketDto,
+    actorUserId?: string,
   ): Promise<Ticket> {
     // 1. Validate scope and fetch current ticket
     const currentTicket = await this.prisma.ticket.findFirst({
@@ -652,6 +656,7 @@ export class TicketsService {
         ticket,
         currentTicket.status,
         dto.status,
+        actorUserId,
       );
     }
 
@@ -759,6 +764,7 @@ export class TicketsService {
     ticketId: string,
     userId: string,
     dto: AddTicketCommentDto,
+    actorPortalContext: PortalContext,
   ): Promise<TicketComment> {
     // 1. Validate ticket scope
     await this.validators.validateTicketBelongsToBuildingAndTenant(
@@ -792,8 +798,8 @@ export class TicketsService {
       },
     });
 
-    // Fire-and-forget: notify ticket participants of new comment
-    void this.notifyTicketCommentAdded(tenantId, ticketId, userId, comment);
+    // Fire-and-forget: notify ticket participants using the explicit portal context
+    void this.notifyTicketCommentAdded(tenantId, ticketId, userId, comment, actorPortalContext);
 
     return comment;
   }
@@ -862,7 +868,6 @@ export class TicketsService {
         (Date.now() - ticket.createdAt.getTime()) / (1000 * 60 * 60),
       );
 
-      // Get all tenant admins for this building
       const tenantAdmins = await this.prisma.tenantMember.findMany({
         where: {
           tenantId: ticket.building.tenantId,
@@ -924,6 +929,7 @@ export class TicketsService {
     tenantId: string,
     buildingId: string,
     unitId?: string | null,
+    excludedUserIds: readonly string[] = [],
   ): Promise<string[]> {
     const adminMemberships = await this.prisma.membership.findMany({
       where: {
@@ -942,22 +948,12 @@ export class TicketsService {
       include: { user: { select: { id: true } } },
     });
 
-    const adminTenantMembers = await this.prisma.tenantMember.findMany({
-      where: {
-        tenantId,
-        role: { in: ['TENANT_OWNER', 'TENANT_ADMIN', 'OPERATOR'] },
-        status: 'ACTIVE',
-        userId: { not: null },
-      },
-      include: { user: { select: { id: true } } },
-    });
-
+    const excluded = new Set(excludedUserIds.filter((id): id is string => !!id));
     const recipientIds = new Set<string>();
     for (const userId of [
       ...adminMemberships.map((admin) => admin.user?.id),
-      ...adminTenantMembers.map((admin) => admin.user?.id),
     ]) {
-      if (userId) recipientIds.add(userId);
+      if (userId && !excluded.has(userId)) recipientIds.add(userId);
     }
 
     this.logger.debug(
@@ -970,12 +966,18 @@ export class TicketsService {
     tenantId: string,
     buildingId: string,
     ticket: Ticket & { building?: { name: string } | null; unit?: { label: string | null; code: string | null } | null },
+    actorUserId?: string,
   ): Promise<void> {
     try {
       const buildingName = ticket.building?.name || 'Edificio';
       const unitLabel = ticket.unit?.label || ticket.unit?.code || '';
 
-      const recipients = await this.resolveAdministrativeRecipientIds(tenantId, buildingId, ticket.unitId);
+      const recipients = await this.resolveAdministrativeRecipientIds(
+        tenantId,
+        buildingId,
+        ticket.unitId,
+        actorUserId ? [actorUserId] : [],
+      );
       for (const userId of recipients) {
         await this.notificationsService.createNotification({
           tenantId,
@@ -1009,8 +1011,13 @@ export class TicketsService {
     ticket: Ticket & { building?: { name: string } | null },
     oldStatus: string,
     newStatus: string,
+    actorUserId?: string,
   ): Promise<void> {
     try {
+      if (actorUserId && creatorUserId === actorUserId) {
+        return;
+      }
+
       const statusLabels: Record<string, string> = {
         OPEN: 'Abierto',
         IN_PROGRESS: 'En progreso',
@@ -1048,6 +1055,7 @@ export class TicketsService {
     ticketId: string,
     authorUserId: string,
     comment: TicketComment & { author?: { name: string | null } | null },
+    actorPortalContext: PortalContext,
   ): Promise<void> {
     try {
       const ticket = await this.prisma.ticket.findFirst({
@@ -1063,27 +1071,14 @@ export class TicketsService {
 
       if (!ticket) return;
 
-      const authorIsAdministrator = Boolean(await this.prisma.membership.findFirst({
-        where: {
-          tenantId,
-          userId: authorUserId,
-          roles: {
-            some: {
-              role: { in: ['TENANT_OWNER', 'TENANT_ADMIN', 'OPERATOR'] },
-              OR: [
-                { scopeType: 'TENANT' },
-                { scopeType: 'BUILDING', scopeBuildingId: ticket.buildingId },
-                ...(ticket.unitId ? [{ scopeType: 'UNIT' as const, scopeUnitId: ticket.unitId }] : []),
-              ],
-            },
-          },
-        },
-        select: { id: true },
-      }));
-
-      const recipientIds = authorIsAdministrator
+      const recipientIds = actorPortalContext === 'admin'
         ? [ticket.createdByUserId]
-        : await this.resolveAdministrativeRecipientIds(tenantId, ticket.buildingId, ticket.unitId);
+        : await this.resolveAdministrativeRecipientIds(
+          tenantId,
+          ticket.buildingId,
+          ticket.unitId,
+          [authorUserId],
+        );
 
       const authorName = comment.author?.name || 'Alguien';
 
@@ -1092,7 +1087,7 @@ export class TicketsService {
           tenantId,
           userId: recipientId,
           type: 'TICKET_COMMENT_ADDED',
-          title: authorIsAdministrator
+          title: actorPortalContext === 'admin'
             ? `La administración respondió: ${ticket.title}`
             : 'El residente agregó una respuesta',
           body: `${authorName} comentó: "${comment.body.slice(0, 100)}${comment.body.length > 100 ? '...' : ''}"`,
@@ -1102,7 +1097,7 @@ export class TicketsService {
             commentId: comment.id,
             authorName,
             authorId: authorUserId,
-            actorType: authorIsAdministrator ? 'ADMIN' : 'RESIDENT',
+            actorType: actorPortalContext === 'admin' ? 'ADMIN' : 'RESIDENT',
             buildingId: ticket.buildingId,
             unitId: ticket.unitId,
           },

--- a/apps/web/app/(tenant)/[tenantId]/notifications/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/notifications/page.test.tsx
@@ -313,6 +313,47 @@ describe('NotificationsPage', () => {
     });
   });
 
+  it('routes resident ticket notifications to the resident detail view with portal context', async () => {
+    mockedUsePathname.mockReturnValue('/tenant-1/resident/notifications' as never);
+    mockedUseAuthSession.mockReturnValue({
+      activeTenantId: 'tenant-1',
+      memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT'] }],
+      user: { id: 'user-1', email: 'user@test.com', name: 'User' },
+    } as never);
+    mockedUseNotifications.mockReturnValue({
+      notifications: [
+        {
+          id: 'n-ticket',
+          tenantId: 'tenant-1',
+          userId: 'user-1',
+          type: 'TICKET_COMMENT_ADDED',
+          title: 'Reclamo actualizado',
+          body: 'Tu reclamo recibió una respuesta',
+          data: { ticketId: 'ticket-1' },
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-01T00:00:00.000Z',
+        },
+      ],
+      total: 1,
+      unreadCount: 1,
+      loading: false,
+      error: null,
+      fetch,
+      markAsRead,
+      markAllAsRead,
+      deleteNotification,
+    } as never);
+
+    render(<NotificationsPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: /abrir/i }));
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith('/tenant-1/tickets/ticket-1?portal=resident');
+    });
+  });
+
   it('SUPPORT_TICKET_STATUS_CHANGED routes to support page', async () => {
     mockedUseNotifications.mockReturnValue({
       notifications: [

--- a/apps/web/app/(tenant)/[tenantId]/resident/dashboard/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/dashboard/page.test.tsx
@@ -14,6 +14,7 @@ import { useResidentLedger } from '@/features/resident/hooks/useResidentLedger';
 import { useResidentCommunications } from '@/features/resident/hooks/useResidentCommunications';
 import { useContextOptions } from '@/features/context/useContextOptions';
 import { useTenants } from '@/features/tenants/tenants.hooks';
+import { residentTicketDetailPath } from '@/shared/lib/routes';
 
 jest.mock('next/navigation', () => ({
   useParams: jest.fn(),
@@ -234,5 +235,36 @@ describe('ResidentDashboardPage', () => {
     });
 
     expect(screen.queryByText(/Hola,/)).toBeNull();
+  });
+
+  it('uses the resident portal ticket detail route for dashboard tickets', async () => {
+    mockedUseQuery.mockReturnValue({
+      data: [
+        {
+          id: 'ticket-1',
+          title: 'Fuga de agua',
+          description: 'Detalle',
+          status: 'OPEN',
+          priority: 'MEDIUM',
+          category: 'MAINTENANCE',
+          createdAt: '2025-01-01T00:00:00.000Z',
+          updatedAt: '2025-01-01T00:00:00.000Z',
+          closedAt: null,
+          createdBy: { id: 'resident-1', name: 'Resident' },
+          assignedTo: null,
+          building: { id: 'building-1', name: 'Torre Horizonte' },
+          unit: { id: 'unit-1', label: 'A-101', code: 'A101' },
+          comments: [],
+        },
+      ],
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    render(<ResidentDashboardPage />);
+
+    const link = screen.getByRole('link', { name: /fuga de agua/i });
+    expect(link.getAttribute('href')).toBe(residentTicketDetailPath('tenant-1', 'ticket-1'));
   });
 });

--- a/apps/web/app/(tenant)/[tenantId]/resident/dashboard/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/dashboard/page.tsx
@@ -24,7 +24,7 @@ import type { Ticket } from '../../../../../features/resident/api/resident-conte
 import Card from '../../../../../shared/components/ui/Card';
 import Skeleton from '../../../../../shared/components/ui/Skeleton';
 import { formatCurrency } from '../../../../../shared/lib/format/money';
-import { ticketDetailPath } from '../../../../../shared/lib/routes';
+import { residentTicketDetailPath } from '../../../../../shared/lib/routes';
 
 function formatDate(dateStr: string | undefined): string {
   if (!dateStr) return '—';
@@ -403,7 +403,7 @@ const ResidentDashboardPage = () => {
               {tickets.slice(0, 3).map((ticket) => (
                 <Link
                   key={ticket.id}
-                  href={ticketDetailPath(tenantId, ticket.id)}
+                  href={residentTicketDetailPath(tenantId, ticket.id)}
                   className="flex justify-between text-sm rounded-md px-1 py-0.5 hover:bg-muted focus:outline-none focus:ring-2 focus:ring-blue-500"
                 >
                   <span className="truncate flex-1">{ticket.title}</span>

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
@@ -634,6 +634,7 @@ describe('ResidentPaymentsPage', () => {
           method: PaymentMethod.TRANSFER,
           proofFileId: 'file-1',
         }),
+        'resident',
       );
     });
     expect(mockedSubmitPayment).toHaveBeenCalledTimes(1);

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
@@ -579,7 +579,7 @@ export const ResidentPaymentsPage = () => {
         reference: formData.reference.trim() || undefined,
         paidAt: formData.paidAt || undefined,
         proofFileId: proofFileId || undefined,
-      });
+      }, 'resident');
 
       setSubmitSuccess(true);
       resetForm();

--- a/apps/web/app/(tenant)/[tenantId]/resident/tickets/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/tickets/page.test.tsx
@@ -12,7 +12,7 @@ import * as residentContextHook from '@/features/resident/hooks/useResidentConte
 import * as tenanciesHook from '@/features/tenants/tenants.hooks';
 import * as authHook from '@/features/auth/useAuthSession';
 import * as reactQuery from '@tanstack/react-query';
-import { ticketDetailPath } from '@/shared/lib/routes';
+import { residentTicketDetailPath } from '@/shared/lib/routes';
 
 jest.mock('next/navigation', () => ({
   useParams: jest.fn(),
@@ -96,6 +96,6 @@ describe('ResidentTicketsPage', () => {
     render(<ResidentTicketsPage />);
 
     const link = screen.getByRole('link', { name: /ver reclamo fuga de agua/i });
-    expect(link.getAttribute('href')).toBe(ticketDetailPath('tenant-1', 'ticket-1'));
+    expect(link.getAttribute('href')).toBe(residentTicketDetailPath('tenant-1', 'ticket-1'));
   });
 });

--- a/apps/web/app/(tenant)/[tenantId]/resident/tickets/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/tickets/page.tsx
@@ -23,7 +23,7 @@ import { useAuthSession } from '../../../../../features/auth/useAuthSession';
 import Card from '../../../../../shared/components/ui/Card';
 import Badge, { type BadgeVariant } from '../../../../../shared/components/ui/Badge';
 import Skeleton from '../../../../../shared/components/ui/Skeleton';
-import { ticketDetailPath } from '../../../../../shared/lib/routes';
+import { residentTicketDetailPath } from '../../../../../shared/lib/routes';
 
 function ticketStatusLabel(status: Ticket['status']): string {
   const labels: Record<Ticket['status'], string> = {
@@ -145,7 +145,7 @@ export default function ResidentTicketsPage() {
         description,
         category: newTicket.category as Ticket['category'],
         unitId,
-      });
+      }, 'resident');
       setSuccess('Reclamo creado correctamente');
       setNewTicket({
         title: '',
@@ -349,7 +349,7 @@ export default function ResidentTicketsPage() {
           {filteredTickets.map((ticket) => (
             <Card key={ticket.id} className="p-4 hover:shadow-md transition">
               <Link
-                href={ticketDetailPath(tenantId, ticket.id)}
+                href={residentTicketDetailPath(tenantId, ticket.id)}
                 className="block rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
                 aria-label={`Ver reclamo ${ticket.title}`}
               >

--- a/apps/web/app/(tenant)/[tenantId]/tickets/[ticketId]/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/tickets/[ticketId]/page.test.tsx
@@ -2,18 +2,21 @@
  * @jest-environment jsdom
  */
 
-import { render, screen } from '@testing-library/react';
-import { useParams, useRouter } from 'next/navigation';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import TicketDetailPage from './page';
 import * as ticketsHook from '@/features/tickets/hooks/useTicketDetail';
+import * as ticketsApi from '@/features/tickets/services/tickets.api';
 import * as authModule from '@/features/auth';
 import * as reactQuery from '@tanstack/react-query';
+import { residentTicketsPath } from '@/shared/lib/routes';
 
 process.env.NEXT_PUBLIC_API_URL = 'http://localhost:3001';
 
 jest.mock('next/navigation', () => ({
   useParams: jest.fn(),
   useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
 }));
 
 jest.mock('@/features/tickets/hooks/useTicketDetail', () => ({
@@ -33,8 +36,22 @@ jest.mock('@/features/auth', () => ({
 }));
 
 jest.mock('@/features/tickets', () => ({
-  TicketDetail: ({ ticket, variant }: { ticket: { title: string }; variant?: string }) => (
-    <div data-testid="ticket-detail" data-variant={variant}>{ticket.title}</div>
+  TicketDetail: ({
+    ticket,
+    variant,
+    onAddComment,
+    onBack,
+  }: {
+    ticket: { title: string };
+    variant?: string;
+    onAddComment?: (_ticketId: string, body: string) => Promise<void> | void;
+    onBack?: () => void;
+  }) => (
+    <div data-testid="ticket-detail" data-variant={variant}>
+      {ticket.title}
+      <button type="button" onClick={() => onAddComment?.('ticket-1', 'Hola desde residente')}>Comentar</button>
+      <button type="button" onClick={() => onBack?.()}>Volver</button>
+    </div>
   ),
 }));
 
@@ -44,49 +61,57 @@ jest.mock('@tanstack/react-query', () => ({
 
 const mockedUseParams = jest.mocked(useParams);
 const mockedUseRouter = jest.mocked(useRouter);
+const mockedUseSearchParams = jest.mocked(useSearchParams);
 const mockedUseTicketDetail = jest.mocked(ticketsHook.useTicketDetail);
+const mockedAddComment = jest.mocked(ticketsApi.addComment);
 const mockedUseAuth = jest.mocked(authModule.useAuth);
 const mockedUseQueryClient = jest.mocked(reactQuery.useQueryClient);
 
 describe('TicketDetailPage', () => {
   const invalidateQueries = jest.fn();
   const push = jest.fn();
+  const loadedTicket = {
+    id: 'ticket-1',
+    title: 'Fuga de agua',
+    description: 'Detalle',
+    status: 'OPEN',
+    priority: 'MEDIUM',
+    category: 'MAINTENANCE',
+    createdAt: '2025-01-01T00:00:00.000Z',
+    updatedAt: '2025-01-01T00:00:00.000Z',
+    closedAt: null,
+    createdBy: { id: 'user-1', name: 'Usuario' },
+    assignedTo: null,
+    building: { id: 'building-1', name: 'Building One' },
+    unit: { id: 'unit-1', label: '101', code: 'A01' },
+    comments: [],
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockedUseParams.mockReturnValue({ tenantId: 'tenant-1', ticketId: 'ticket-1' } as never);
     mockedUseRouter.mockReturnValue({ push, replace: jest.fn(), back: jest.fn(), prefetch: jest.fn(), refresh: jest.fn() } as never);
+    mockedUseSearchParams.mockReturnValue(new URLSearchParams() as never);
     mockedUseAuth.mockReturnValue({ currentUser: { roles: ['TENANT_ADMIN'] } } as never);
     mockedUseQueryClient.mockReturnValue({ invalidateQueries } as never);
   });
 
-  it('loads the canonical ticket detail with tenantId and ticketId', () => {
+  function mockLoadedTicket() {
     mockedUseTicketDetail.mockReturnValue({
-      data: {
-        id: 'ticket-1',
-        title: 'Fuga de agua',
-        description: 'Detalle',
-        status: 'OPEN',
-        priority: 'MEDIUM',
-        category: 'MAINTENANCE',
-        createdAt: '2025-01-01T00:00:00.000Z',
-        updatedAt: '2025-01-01T00:00:00.000Z',
-        closedAt: null,
-        createdBy: { id: 'user-1', name: 'Usuario' },
-        assignedTo: null,
-        building: { id: 'building-1', name: 'Building One' },
-        unit: { id: 'unit-1', label: '101', code: 'A01' },
-        comments: [],
-      },
+      data: loadedTicket,
       isLoading: false,
       error: null,
       refetch: jest.fn(),
     } as never);
+  }
+
+  it('loads the canonical ticket detail with tenantId and ticketId', () => {
+    mockLoadedTicket();
 
     render(<TicketDetailPage />);
 
     expect(mockedUseTicketDetail).toHaveBeenCalledWith('tenant-1', 'ticket-1');
-    expect(screen.getByTestId('ticket-detail').textContent).toBe('Fuga de agua');
+    expect(screen.getByTestId('ticket-detail').textContent).toContain('Fuga de agua');
     expect(screen.getByTestId('ticket-detail').getAttribute('data-variant')).toBe('page');
     expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Detalle del ticket');
   });
@@ -119,5 +144,78 @@ describe('TicketDetailPage', () => {
 
     rerender(<TicketDetailPage />);
     expect(screen.getByText('Acceso denegado')).toBeTruthy();
+  });
+
+  it.each([
+    {
+      title: 'uses resident context for a pure resident without query',
+      roles: ['RESIDENT'],
+      search: '',
+      expectedPortal: 'resident',
+      expectedFallback: residentTicketsPath('tenant-1'),
+    },
+    {
+      title: 'uses resident context for a pure resident with resident query',
+      roles: ['RESIDENT'],
+      search: 'portal=resident',
+      expectedPortal: 'resident',
+      expectedFallback: residentTicketsPath('tenant-1'),
+    },
+    {
+      title: 'uses admin context for a pure tenant admin even with resident query',
+      roles: ['TENANT_ADMIN'],
+      search: 'portal=resident',
+      expectedPortal: 'admin',
+      expectedFallback: '/tenant-1/tickets',
+    },
+    {
+      title: 'uses admin context for a pure super admin even with resident query',
+      roles: ['SUPER_ADMIN'],
+      search: 'portal=resident',
+      expectedPortal: 'admin',
+      expectedFallback: '/tenant-1/tickets',
+    },
+    {
+      title: 'uses resident context for a mixed resident plus tenant admin when resident query is present',
+      roles: ['RESIDENT', 'TENANT_ADMIN'],
+      search: 'portal=resident',
+      expectedPortal: 'resident',
+      expectedFallback: residentTicketsPath('tenant-1'),
+    },
+    {
+      title: 'uses admin context for a mixed resident plus tenant admin without query',
+      roles: ['RESIDENT', 'TENANT_ADMIN'],
+      search: '',
+      expectedPortal: 'admin',
+      expectedFallback: '/tenant-1/tickets',
+    },
+    {
+      title: 'uses resident context for a mixed resident plus super admin when resident query is present',
+      roles: ['RESIDENT', 'SUPER_ADMIN'],
+      search: 'portal=resident',
+      expectedPortal: 'resident',
+      expectedFallback: residentTicketsPath('tenant-1'),
+    },
+    {
+      title: 'uses admin context for a mixed resident plus super admin without query',
+      roles: ['RESIDENT', 'SUPER_ADMIN'],
+      search: '',
+      expectedPortal: 'admin',
+      expectedFallback: '/tenant-1/tickets',
+    },
+  ])('$title', async ({ roles, search, expectedPortal, expectedFallback }) => {
+    mockedUseSearchParams.mockReturnValue(new URLSearchParams(search) as never);
+    mockedUseAuth.mockReturnValue({ currentUser: { roles } } as never);
+    mockLoadedTicket();
+
+    render(<TicketDetailPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Comentar' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Volver' }));
+
+    await waitFor(() => {
+      expect(mockedAddComment).toHaveBeenCalledWith('building-1', 'ticket-1', { body: 'Hola desde residente' }, expectedPortal);
+      expect(push).toHaveBeenCalledWith(expectedFallback);
+    });
   });
 });

--- a/apps/web/app/(tenant)/[tenantId]/tickets/[ticketId]/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/tickets/[ticketId]/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useMemo } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useQueryClient } from '@tanstack/react-query';
 import { AlertCircle, Loader2 } from 'lucide-react';
 import Card from '@/shared/components/ui/Card';
@@ -11,6 +10,9 @@ import { useAuth } from '@/features/auth';
 import { TicketDetail } from '@/features/tickets';
 import { addComment, updateTicket } from '@/features/tickets/services/tickets.api';
 import { ticketDetailKeys, useTicketDetail } from '@/features/tickets/hooks/useTicketDetail';
+import { residentTicketsPath } from '@/shared/lib/routes';
+
+const PRIVILEGED_ROLES = ['SUPER_ADMIN', 'TENANT_OWNER', 'TENANT_ADMIN', 'OPERATOR'] as const;
 
 interface TicketParams {
   tenantId: string;
@@ -21,6 +23,7 @@ interface TicketParams {
 export default function TicketDetailPage() {
   const params = useParams<TicketParams>();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const { currentUser } = useAuth();
 
@@ -29,14 +32,19 @@ export default function TicketDetailPage() {
 
   const { data: ticket, isLoading, error, refetch } = useTicketDetail(tenantId, ticketId);
 
-  const canManageTicket = useMemo(() => {
-    return currentUser?.roles?.some((role) => ['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR'].includes(role)) ?? false;
-  }, [currentUser?.roles]);
-  const isResident = useMemo(
-    () => currentUser?.roles?.includes('RESIDENT') && !canManageTicket,
-    [canManageTicket, currentUser?.roles],
-  );
-  const fallbackPath = isResident ? `/${tenantId}/resident/tickets` : `/${tenantId}/tickets`;
+  const userRoles = currentUser?.roles ?? [];
+  const hasResidentRole = userRoles.includes('RESIDENT');
+  const hasPrivilegedRole = userRoles.some((role) => PRIVILEGED_ROLES.includes(role as typeof PRIVILEGED_ROLES[number]));
+  const residentPortalRequested = searchParams?.get('portal') === 'resident' && hasResidentRole;
+  const portalContext: 'resident' | 'admin' = !hasResidentRole
+    ? 'admin'
+    : !hasPrivilegedRole
+      ? 'resident'
+      : residentPortalRequested
+        ? 'resident'
+        : 'admin';
+  const canManageTicket = userRoles.some((role) => ['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR'].includes(role));
+  const fallbackPath = portalContext === 'resident' ? residentTicketsPath(tenantId) : `/${tenantId}/tickets`;
 
   const handleBack = () => {
     if (typeof window !== 'undefined' && document.referrer.startsWith(window.location.origin)) {
@@ -70,7 +78,7 @@ export default function TicketDetailPage() {
   const handleAddComment = async (_ticketId: string, body: string) => {
     if (!ticket) return;
 
-    await addComment(ticket.building.id, ticket.id, { body });
+    await addComment(ticket.building.id, ticket.id, { body }, portalContext);
     await refreshTicket();
   };
 

--- a/apps/web/features/finance/services/finance.api.test.ts
+++ b/apps/web/features/finance/services/finance.api.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import * as httpClient from '@/shared/lib/http/client';
+import { PaymentMethod, submitPayment } from './finance.api';
+
+jest.mock('@/shared/lib/http/client', () => ({
+  apiClient: jest.fn(),
+  HttpError: class HttpError extends Error {
+    constructor(
+      public status: number,
+      public statusText: string,
+      message: string,
+    ) {
+      super(message);
+    }
+  },
+}));
+
+const mockedApiClient = jest.mocked(httpClient.apiClient);
+
+describe('finance.api', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('sends the resident portal context when submitting a resident payment', async () => {
+    mockedApiClient.mockResolvedValue({ id: 'payment-1' } as never);
+
+    await submitPayment(
+      'building-1',
+      {
+        unitId: 'unit-1',
+        chargeId: 'charge-1',
+        amount: 10000,
+        method: PaymentMethod.TRANSFER,
+        proofFileId: 'file-1',
+      },
+      'resident',
+    );
+
+    expect(mockedApiClient).toHaveBeenCalledWith(expect.objectContaining({
+      path: '/buildings/building-1/payments',
+      method: 'POST',
+      headers: { 'X-Portal-Context': 'resident' },
+    }));
+  });
+
+  it('does not add the portal header when no portal context is provided', async () => {
+    mockedApiClient.mockResolvedValue({ id: 'payment-2' } as never);
+
+    await submitPayment('building-1', {
+      amount: 10000,
+      method: PaymentMethod.TRANSFER,
+      proofFileId: 'file-1',
+    });
+
+    expect(mockedApiClient).toHaveBeenCalledWith(expect.objectContaining({
+      path: '/buildings/building-1/payments',
+      method: 'POST',
+    }));
+    expect(mockedApiClient.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      headers: undefined,
+    }));
+  });
+});

--- a/apps/web/features/finance/services/finance.api.ts
+++ b/apps/web/features/finance/services/finance.api.ts
@@ -30,6 +30,8 @@ export enum PaymentMethod {
   ONLINE = 'ONLINE',
 }
 
+export type PortalContext = 'resident' | 'admin';
+
 export enum ChargeType {
   COMMON_EXPENSE = 'COMMON_EXPENSE',
   EXTRAORDINARY = 'EXTRAORDINARY',
@@ -340,12 +342,15 @@ export async function submitPayment(
     reference?: string;
     paidAt?: string;
     proofFileId?: string;
-  }
+  },
+  portalContext?: PortalContext,
 ): Promise<Payment> {
+  const headers = portalContext ? { 'X-Portal-Context': portalContext } : undefined;
   return apiClient<Payment, typeof data>({
     path: `/buildings/${buildingId}/payments`,
     method: 'POST',
     body: data,
+    headers,
   });
 }
 

--- a/apps/web/features/tickets/components/UnitTicketsList.test.tsx
+++ b/apps/web/features/tickets/components/UnitTicketsList.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ToastProvider } from '@/shared/components/ui/Toast';
 import { UnitTicketsList } from './UnitTicketsList';
@@ -150,6 +150,31 @@ describe('UnitTicketsList', () => {
     const links = screen.getAllByRole('link', { name: /Ver reclamo/ });
     links.forEach((link) => {
       expect(link.className).toContain('focus:ring-2');
+    });
+  });
+
+  it('creates tickets without sending a portal context override', async () => {
+    const createTicketSpy = jest.mocked(ticketsApi.createTicket);
+    createTicketSpy.mockResolvedValue(mockTicket1);
+
+    renderWithProviders(<UnitTicketsList tenantId="tenant-1" buildingId="b1" unitId="u1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Crear solicitud/i }));
+
+    fireEvent.change(screen.getByPlaceholderText('Por ejemplo: Cerradura de puerta rota'), { target: { value: 'Nueva solicitud' } });
+    fireEvent.change(screen.getByPlaceholderText('Describe el problema en detalle...'), { target: { value: 'Descripción válida' } });
+    fireEvent.click(screen.getAllByRole('button', { name: /Crear solicitud/i })[1]);
+
+    await waitFor(() => {
+      expect(createTicketSpy).toHaveBeenCalledWith(
+        'b1',
+        expect.objectContaining({
+          title: 'Nueva solicitud',
+          description: 'Descripción válida',
+          unitId: 'u1',
+        }),
+      );
+      expect(createTicketSpy.mock.calls[0]?.[2]).toBeUndefined();
     });
   });
 });

--- a/apps/web/features/tickets/components/UnitTicketsList.tsx
+++ b/apps/web/features/tickets/components/UnitTicketsList.tsx
@@ -217,13 +217,13 @@ function UnitTicketForm({
     }
 
     setSubmitting(true);
-    try {
-      const ticket = await createTicket(buildingId, {
-        title: title.trim(),
-        description: description.trim(),
-        category,
-        unitId, // Pre-filled from unit context
-      });
+      try {
+        const ticket = await createTicket(buildingId, {
+          title: title.trim(),
+          description: description.trim(),
+          category,
+          unitId, // Pre-filled from unit context
+        });
 
       if (ticket) {
         onSuccess(ticket);

--- a/apps/web/features/tickets/services/tickets.api.test.ts
+++ b/apps/web/features/tickets/services/tickets.api.test.ts
@@ -3,7 +3,7 @@
  */
 
 import * as httpClient from '@/shared/lib/http/client';
-import { getTicketByTenant } from './tickets.api';
+import { addComment, createTicket, getTicketByTenant } from './tickets.api';
 
 jest.mock('@/shared/lib/http/client', () => ({
   apiClient: jest.fn(),
@@ -33,5 +33,42 @@ describe('tickets.api', () => {
       path: '/tenants/tenant-1/tickets/ticket-1',
       method: 'GET',
     });
+  });
+
+  it('sends the resident portal context when creating a resident-origin ticket', async () => {
+    mockedApiClient.mockResolvedValue({ id: 'ticket-2' } as never);
+
+    await createTicket(
+      'building-1',
+      {
+        title: 'Leak',
+        description: 'Water leak',
+        category: 'REPAIR',
+      },
+      'resident',
+    );
+
+    expect(mockedApiClient).toHaveBeenCalledWith(expect.objectContaining({
+      path: '/buildings/building-1/tickets',
+      method: 'POST',
+      headers: { 'X-Portal-Context': 'resident' },
+    }));
+  });
+
+  it('sends the admin portal context when adding an administrative comment', async () => {
+    mockedApiClient.mockResolvedValue({ id: 'comment-1' } as never);
+
+    await addComment(
+      'building-1',
+      'ticket-1',
+      { body: 'Estamos revisando' },
+      'admin',
+    );
+
+    expect(mockedApiClient).toHaveBeenCalledWith(expect.objectContaining({
+      path: '/buildings/building-1/tickets/ticket-1/comments',
+      method: 'POST',
+      headers: { 'X-Portal-Context': 'admin' },
+    }));
   });
 });

--- a/apps/web/features/tickets/services/tickets.api.ts
+++ b/apps/web/features/tickets/services/tickets.api.ts
@@ -23,6 +23,8 @@ export type TicketCategory =
   | 'MAINTENANCE' | 'REPAIR' | 'CLEANING' | 'COMPLAINT'
   | 'SAFETY' | 'BILLING' | 'OTHER';
 
+export type PortalContext = 'resident' | 'admin';
+
 export interface Ticket {
   id: string;
   status: 'OPEN' | 'IN_PROGRESS' | 'RESOLVED' | 'CLOSED';
@@ -197,15 +199,18 @@ export async function getTicketByTenant(tenantId: string, ticketId: string): Pro
  */
 export async function createTicket(
   buildingId: string,
-  input: CreateTicketInput
+  input: CreateTicketInput,
+  portalContext?: PortalContext,
 ): Promise<Ticket> {
   const endpoint = `/buildings/${buildingId}/tickets`;
+  const headers = portalContext ? { 'X-Portal-Context': portalContext } : undefined;
 
   try {
     const data = await apiClient<Ticket, CreateTicketInput>({
       path: endpoint,
       method: 'POST',
       body: input,
+      headers,
     });
     return data;
   } catch (error) {
@@ -245,15 +250,18 @@ export async function updateTicket(
 export async function addComment(
   buildingId: string,
   ticketId: string,
-  input: CreateCommentInput
+  input: CreateCommentInput,
+  portalContext?: PortalContext,
 ): Promise<TicketComment> {
   const endpoint = `/buildings/${buildingId}/tickets/${ticketId}/comments`;
+  const headers = portalContext ? { 'X-Portal-Context': portalContext } : undefined;
 
   try {
     const data = await apiClient<TicketComment, CreateCommentInput>({
       path: endpoint,
       method: 'POST',
       body: input,
+      headers,
     });
     return data;
   } catch (error) {

--- a/apps/web/shared/lib/notification-routes.test.ts
+++ b/apps/web/shared/lib/notification-routes.test.ts
@@ -1,4 +1,5 @@
 import { resolveNotificationPath, type NotificationRoleContext } from './notification-routes';
+import { residentTicketDetailPath } from './routes';
 import type { Notification } from '@/features/notifications/notifications.api';
 
 const TENANT_ID = 'tenant-1';
@@ -31,7 +32,7 @@ describe('resolveNotificationPath', () => {
         data: { ticketId: 'ticket-42', buildingId: 'b-1' },
       });
       expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBe(
-        `/${TENANT_ID}/tickets/ticket-42`
+        residentTicketDetailPath(TENANT_ID, 'ticket-42')
       );
     });
 
@@ -358,9 +359,9 @@ describe('resolveNotificationPath', () => {
     });
 
     it('resolves ticket to resident path when portalContext is resident', () => {
-      const n = makeNotification({ type: 'TICKET_COMMENT_ADDED', data: {} });
+      const n = makeNotification({ type: 'TICKET_COMMENT_ADDED', data: { ticketId: 'ticket-42' } });
       expect(resolveNotificationPath(n, TENANT_ID, mixedResidentPortal)).toBe(
-        `/${TENANT_ID}/resident/tickets`
+        `/${TENANT_ID}/tickets/ticket-42?portal=resident`
       );
     });
 

--- a/apps/web/shared/lib/notification-routes.ts
+++ b/apps/web/shared/lib/notification-routes.ts
@@ -1,5 +1,6 @@
 import {
   ticketDetailPath,
+  residentTicketDetailPath,
   residentTicketsPath,
   buildingTickets,
 } from './routes';
@@ -118,7 +119,9 @@ export function resolveNotificationPath(
   // 2. Building ticket types: first confirm type, then use ticketId if available
   if (isTicketType(type)) {
     if (ticketId && typeof ticketId === 'string') {
-      return ticketDetailPath(tenantId, ticketId);
+      return isResidentContext(roleContext)
+        ? residentTicketDetailPath(tenantId, ticketId)
+        : ticketDetailPath(tenantId, ticketId);
     }
     if (isAdminContext(roleContext)) {
       const buildingId = data?.buildingId;

--- a/apps/web/shared/lib/routes.ts
+++ b/apps/web/shared/lib/routes.ts
@@ -70,6 +70,13 @@ export function ticketDetailPath(tenantId: string, ticketId: string): string {
 }
 
 /**
+ * Resident ticket detail route preserving portal context.
+ */
+export function residentTicketDetailPath(tenantId: string, ticketId: string): string {
+  return `${ticketDetailPath(tenantId, ticketId)}?portal=resident`;
+}
+
+/**
  * Resident tickets list.
  */
 export function residentTicketsPath(tenantId: string): string {
@@ -151,6 +158,8 @@ export const routes = {
   superAdminDashboard,
   tenantCategories,
   buildingCategories,
+  ticketDetailPath,
+  residentTicketDetailPath,
 };
 
 export default routes;


### PR DESCRIPTION
## Resumen

Corrige el enrutamiento bidireccional de notificaciones transaccionales entre residentes y administración.

## Cambios principales

- Evita que el actor reciba su propia notificación.
- Evita notificaciones administrativas duplicadas por comprobantes de pago.
- Los pagos enviados desde el portal residente notifican únicamente a administradores autorizados.
- Los pagos registrados desde administración no alertan a otros administradores.
- Los tickets y comentarios distinguen correctamente entre portal residente y administrativo.
- Soporta usuarios con roles mixtos mediante `X-Portal-Context`.
- Mantiene aislamiento por tenant, edificio y unidad.
- Deduplica destinatarios.
- Conserva el contexto residente al abrir detalles de tickets.
- Mantiene intactas las notificaciones automáticas de escalación.

## Validación

### Backend

- 9 suites PASS
- 212 tests PASS
- TypeScript PASS
- ESLint PASS

### Frontend

- 9 suites PASS
- 113 tests PASS
- TypeScript PASS
- ESLint PASS

### Git

- `git diff --check` PASS
- Working tree limpio antes del push

## Fuera de alcance

- Sin cambios Prisma
- Sin migraciones
- Sin deploy