### PR TITLE
fix(web): correct notification bell routing and count

### DIFF
--- a/apps/web/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/shared/components/layout/Topbar.test.tsx
@@ -348,6 +348,31 @@ describe('PaymentNotificationBell', () => {
     });
   });
 
+  it('uses unreadCount only for the badge when pending payments also exist', async () => {
+    mockGetSession.mockReturnValue({
+      user: { id: 'admin-1', email: 'admin@test.com', name: 'Admin User' },
+      memberships: [{ tenantId: TENANT_ID, roles: ['TENANT_ADMIN'] }],
+      activeTenantId: TENANT_ID,
+    });
+    mockGetUnreadCount.mockResolvedValue(1);
+    mockListPendingPayments.mockResolvedValue([
+      { id: 'p1', status: 'SUBMITTED' },
+    ] as Awaited<ReturnType<typeof financeApi.listPendingPayments>>);
+
+    renderBell();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /notificaciones, 1 sin leer/i })).toBeTruthy();
+      expect(screen.queryByRole('button', { name: /notificaciones, 2 sin leer/i })).toBeNull();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones, 1 sin leer/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 pago pendiente por revisar/)).toBeTruthy();
+    });
+  });
+
   it('recognizes an admin when the membership also includes RESIDENT', async () => {
     mockGetSession.mockReturnValue({
       user: { id: 'admin-1', email: 'admin@test.com', name: 'Admin User' },
@@ -752,6 +777,47 @@ describe('PaymentNotificationBell', () => {
     });
   });
 
+  it('SUPPORT_TICKET_CREATED with ticketId appears in the admin dropdown and opens the ticket detail', async () => {
+    const mockPush = jest.fn();
+    jest.requireMock('next/navigation').useRouter = () => ({ push: mockPush, replace: jest.fn() });
+
+    mockGetSession.mockReturnValue({
+      user: { id: 'admin-1', email: 'admin@test.com', name: 'Admin User' },
+      memberships: [{ tenantId: TENANT_ID, roles: ['TENANT_ADMIN'] }],
+      activeTenantId: TENANT_ID,
+    });
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n-support-created',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'SUPPORT_TICKET_CREATED',
+          title: 'Nuevo reclamo',
+          body: 'Se creó un reclamo de edificio',
+          data: { ticketId: 'ticket-42', buildingId: 'building-1' },
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Nuevo reclamo')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByText('Nuevo reclamo'));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/tenant-1/tickets/ticket-42');
+    });
+  });
+
   it('mixed role user in resident portal navigates to resident payment route', async () => {
     const mockPush = jest.fn();
     jest.requireMock('next/navigation').useRouter = () => ({ push: mockPush, replace: jest.fn() });
@@ -836,6 +902,40 @@ describe('PaymentNotificationBell', () => {
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith('/tenant-1/finanzas?tab=payments');
     });
+  });
+
+  it('mixed role admin portal does not show PAYMENT_REMINDER without paymentId in the dropdown', async () => {
+    mockGetSession.mockReturnValue({
+      user: { id: 'admin-1', email: 'admin@test.com', name: 'Admin User' },
+      memberships: [{ tenantId: TENANT_ID, roles: ['RESIDENT', 'TENANT_ADMIN'] }],
+      activeTenantId: TENANT_ID,
+    });
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n-reminder',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'PAYMENT_REMINDER',
+          title: 'Recordatorio de pago',
+          body: 'Tu pago vence pronto',
+          data: {},
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/No hay notificaciones nuevas/i)).toBeTruthy();
+    });
+
+    expect(screen.queryByText('Recordatorio de pago')).toBeNull();
   });
 });
 

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -102,17 +102,24 @@ export function PaymentNotificationBell({
   // Residents see ALL notifications returned by the backend.
   // Admins filter to payment submissions and ticket types only.
   const allNotifs = notificationResult?.notifications ?? [];
+  const isSupportTicketCreatedWithTicketId = (notification: Notification): boolean =>
+    notification.type === 'SUPPORT_TICKET_CREATED' &&
+    typeof notification.data?.ticketId === 'string' &&
+    notification.data.ticketId.length > 0;
+  const isResidentPaymentSubmittedAlert = (notification: Notification): boolean =>
+    notification.type === 'BUILDING_ALERT' && notification.data?.event === 'PAYMENT_SUBMITTED';
 
   const filteredNotifications: Notification[] = isAdmin
     ? allNotifs.filter((n: Notification) =>
-        (n.type === 'BUILDING_ALERT' && n.data?.event === 'PAYMENT_SUBMITTED') ||
-        n.data?.paymentId ||
+        isResidentPaymentSubmittedAlert(n) ||
+        isSupportTicketCreatedWithTicketId(n) ||
+        Boolean(n.data?.paymentId) ||
         getNotificationCategory(n.type) === 'ticket'
       )
     : allNotifs;
 
-  // Badge: pending payments (admin) + unread notifications
-  const badgeCount = isAdmin ? pendingCount + unreadCount : unreadCount;
+  // Badge: unread notifications only. Pending payments remain in the auxiliary card.
+  const badgeCount = unreadCount;
 
   const closeDropdown = useCallback((restoreFocus = false) => {
     setIsOpen(false);

--- a/apps/web/shared/lib/notification-routes.test.ts
+++ b/apps/web/shared/lib/notification-routes.test.ts
@@ -1,5 +1,5 @@
 import { resolveNotificationPath, type NotificationRoleContext } from './notification-routes';
-import { residentTicketDetailPath } from './routes';
+import { ticketDetailPath, residentTicketDetailPath } from './routes';
 import type { Notification } from '@/features/notifications/notifications.api';
 
 const TENANT_ID = 'tenant-1';
@@ -94,6 +94,26 @@ describe('resolveNotificationPath', () => {
       );
     });
 
+    it('resolves SUPPORT_TICKET_CREATED with ticketId to ticket detail for admin', () => {
+      const n = makeNotification({
+        type: 'SUPPORT_TICKET_CREATED',
+        data: { ticketId: 'ticket-42', buildingId: 'b-1' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, adminContext)).toBe(
+        ticketDetailPath(TENANT_ID, 'ticket-42')
+      );
+    });
+
+    it('resolves SUPPORT_TICKET_CREATED with ticketId to resident ticket detail for resident', () => {
+      const n = makeNotification({
+        type: 'SUPPORT_TICKET_CREATED',
+        data: { ticketId: 'ticket-42', buildingId: 'b-1' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBe(
+        residentTicketDetailPath(TENANT_ID, 'ticket-42')
+      );
+    });
+
     it('resolves SUPPORT_TICKET_STATUS_CHANGED for admin to support page', () => {
       const n = makeNotification({ type: 'SUPPORT_TICKET_STATUS_CHANGED', data: {} });
       expect(resolveNotificationPath(n, TENANT_ID, adminContext)).toBe(
@@ -137,6 +157,35 @@ describe('resolveNotificationPath', () => {
       expect(resolveNotificationPath(n, TENANT_ID, adminContext)).toBe(
         `/${TENANT_ID}/finanzas?tab=payments`
       );
+    });
+
+    it('resolves BUILDING_ALERT with PAYMENT_SUBMITTED event for admin to finanzas payments tab', () => {
+      const n = makeNotification({
+        type: 'BUILDING_ALERT',
+        data: { event: 'PAYMENT_SUBMITTED', paymentId: 'payment-1' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, adminContext)).toBe(
+        `/${TENANT_ID}/finanzas?tab=payments`
+      );
+    });
+
+    it('resolves BUILDING_ALERT with PAYMENT_SUBMITTED event for resident to resident payments', () => {
+      const n = makeNotification({
+        type: 'BUILDING_ALERT',
+        data: { event: 'PAYMENT_SUBMITTED', paymentId: 'payment-1' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBe(
+        `/${TENANT_ID}/resident/payments`
+      );
+    });
+
+    it('does not treat other BUILDING_ALERT events as payments', () => {
+      const n = makeNotification({
+        type: 'BUILDING_ALERT',
+        data: { event: 'SOMETHING_ELSE', paymentId: 'payment-1' },
+      });
+      expect(resolveNotificationPath(n, TENANT_ID, adminContext)).toBeNull();
+      expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
     });
   });
 

--- a/apps/web/shared/lib/notification-routes.ts
+++ b/apps/web/shared/lib/notification-routes.ts
@@ -103,6 +103,10 @@ function isAdminContext(ctx: NotificationRoleContext): boolean {
   return ctx.portalContext === 'admin' || (!ctx.portalContext && ctx.isAdmin);
 }
 
+function hasTicketId(data: Notification['data']): data is Notification['data'] & { ticketId: string } {
+  return typeof data?.ticketId === 'string' && data.ticketId.length > 0;
+}
+
 export function resolveNotificationPath(
   notification: Notification,
   tenantId: string,
@@ -111,12 +115,19 @@ export function resolveNotificationPath(
   const { type, data } = notification;
   const ticketId = data?.ticketId;
 
-  // 1. Support ticket types — route to support module, not building tickets
+  // 1. Building ticket creation notifications with a ticketId route to the canonical ticket detail
+  if (type === 'SUPPORT_TICKET_CREATED' && hasTicketId(data)) {
+    return isResidentContext(roleContext)
+      ? residentTicketDetailPath(tenantId, data.ticketId)
+      : ticketDetailPath(tenantId, data.ticketId);
+  }
+
+  // 2. Support ticket status updates keep their historical support route
   if (isSupportTicketType(type)) {
     return `/${tenantId}/support`;
   }
 
-  // 2. Building ticket types: first confirm type, then use ticketId if available
+  // 3. Building ticket types: first confirm type, then use ticketId if available
   if (isTicketType(type)) {
     if (ticketId && typeof ticketId === 'string') {
       return isResidentContext(roleContext)
@@ -135,14 +146,21 @@ export function resolveNotificationPath(
     return `/${tenantId}/tickets`;
   }
 
-  // 3. Payment types
+  // 4. Resident payment submissions from building alerts behave like payments
+  if (type === 'BUILDING_ALERT' && data?.event === 'PAYMENT_SUBMITTED') {
+    return isAdminContext(roleContext)
+      ? `/${tenantId}/finanzas?tab=payments`
+      : `/${tenantId}/resident/payments`;
+  }
+
+  // 5. Payment types
   if (isPaymentType(type)) {
     return isAdminContext(roleContext)
       ? `/${tenantId}/finanzas?tab=payments`
       : `/${tenantId}/resident/payments`;
   }
 
-  // 4. Document types
+  // 6. Document types
   if ((DOCUMENT_NOTIFICATION_TYPES as readonly string[]).includes(type)) {
     if (isAdminContext(roleContext)) {
       const buildingId = data?.buildingId;
@@ -153,7 +171,7 @@ export function resolveNotificationPath(
     return `/${tenantId}/resident/documents`;
   }
 
-  // 5. Unit types
+  // 7. Unit types
   if ((UNIT_NOTIFICATION_TYPES as readonly string[]).includes(type)) {
     if (isAdminContext(roleContext)) {
       const buildingId = data?.buildingId;
@@ -164,7 +182,7 @@ export function resolveNotificationPath(
     return `/${tenantId}/resident/unit`;
   }
 
-  // 6. Fallback URL — strict validation only for known types
+  // 8. Fallback URL — strict validation only for known types
   const fallbackUrl = data?.url;
   if (typeof fallbackUrl !== 'string' || !fallbackUrl.startsWith('/')) {
     return null;


### PR DESCRIPTION
## Resumen

Corrige el comportamiento de la campana de notificaciones:

- evita duplicar el contador con pagos pendientes;
- muestra correctamente reclamos nuevos en administración;
- permite navegar desde notificaciones de pagos enviados;
- conserva las rutas de soporte existentes;
- mantiene separado el contexto administrador/residente.

## Validación

- 97 pruebas específicas aprobadas;
- TypeScript aprobado;
- lint de los 4 archivos modificados aprobado;
- git diff --check aprobado;
- validación manual de pagos y notificaciones aprobada.

## Alcance

No modifica backend, Prisma, migraciones, seeds, RBAC ni infraestructura.