### PR TITLE
fix(web): improve resident payments mobile experience

### DIFF
--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
@@ -525,7 +525,9 @@ describe('ResidentPaymentsPage', () => {
     const fileInput = screen.getByLabelText(/comprobante de pago/i);
     const file = new File([new Uint8Array(11 * 1024 * 1024)], 'proof.pdf', { type: 'application/pdf' });
 
-    fireEvent.change(fileInput, { target: { files: [file] } });
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
 
     expect(await screen.findByText(/El archivo no puede superar 10MB/)).toBeTruthy();
     expect(mockedPresignUpload).not.toHaveBeenCalled();
@@ -541,7 +543,9 @@ describe('ResidentPaymentsPage', () => {
     const fileInput = screen.getByLabelText(/comprobante de pago/i);
     const file = new File([new Uint8Array([1, 2, 3])], 'notes.txt', { type: 'text/plain' });
 
-    fireEvent.change(fileInput, { target: { files: [file] } });
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [file] } });
+    });
 
     expect(await screen.findByText('El comprobante debe ser PDF, JPG o PNG')).toBeTruthy();
     expect(mockedPresignUpload).not.toHaveBeenCalled();
@@ -555,10 +559,12 @@ describe('ResidentPaymentsPage', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /reportar pago/i }));
     expect((screen.getByLabelText(/cargo pendiente/i) as HTMLSelectElement).value).toBe('charge-1');
-    fireEvent.change(screen.getByLabelText(/comprobante de pago/i), {
-      target: {
-        files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
-      },
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/comprobante de pago/i), {
+        target: {
+          files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
+        },
+      });
     });
 
     await waitFor(() => expect(mockedPresignUpload).toHaveBeenCalled());
@@ -620,15 +626,18 @@ describe('ResidentPaymentsPage', () => {
     render(<ResidentPaymentsPage />, { wrapper: Wrapper });
 
     fireEvent.click(await screen.findByRole('button', { name: /reportar pago/i }));
-    fireEvent.change(screen.getByLabelText(/comprobante de pago/i), {
-      target: {
-        files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
-      },
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/comprobante de pago/i), {
+        target: {
+          files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
+        },
+      });
     });
 
     await waitFor(() => expect(mockedPresignUpload).toHaveBeenCalled());
     expect(await screen.findByText(/proof\.pdf subido correctamente/i)).toBeTruthy();
-    fireEvent.click(screen.getByRole('button', { name: 'Enviar pago' }));
+    const submitButton = await screen.findByRole('button', { name: 'Enviar pago' });
+    fireEvent.click(submitButton);
 
     const dialog = await screen.findByRole('dialog', { name: /confirmar reporte de pago/i });
     expect(dialog.textContent).toContain('99,98');
@@ -689,10 +698,12 @@ describe('ResidentPaymentsPage', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /reportar pago/i }));
     fireEvent.change(screen.getByLabelText(/fecha de pago/i), { target: { value: '2026-07-24' } });
-    fireEvent.change(screen.getByLabelText(/comprobante de pago/i), {
-      target: {
-        files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
-      },
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/comprobante de pago/i), {
+        target: {
+          files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
+        },
+      });
     });
 
     await waitFor(() => expect(mockedPresignUpload).toHaveBeenCalled());
@@ -710,26 +721,27 @@ describe('ResidentPaymentsPage', () => {
     expect((screen.getByLabelText(/fecha de pago/i) as HTMLInputElement).value).toBe('2026-07-24');
   });
 
-  it('keeps civil dates exact and formats timestamps in local time in the history list', async () => {
+  it('formats civil and ISO timestamps without shifting the day in the mobile history list', async () => {
+    mockMatchMedia(true);
     mockedGetResidentLedger.mockResolvedValueOnce(makeLedger({ charges: [] }));
     mockedListPayments.mockResolvedValueOnce([
       makePayment({
         id: 'payment-civil',
-        paidAt: '2026-07-24',
-        createdAt: '2026-07-24',
+        paidAt: '2026-07-29',
+        createdAt: '2026-07-29',
         reference: 'CIVIL',
       }),
       makePayment({
-        id: 'payment-timestamp',
-        paidAt: '2026-07-26T01:00:00.000Z',
-        createdAt: '2026-07-26T01:00:00.000Z',
-        reference: 'TIMESTAMP',
+        id: 'payment-iso-utc',
+        paidAt: '2026-07-29T00:00:00.000Z',
+        createdAt: '2026-07-29T00:00:00.000Z',
+        reference: 'ISO UTC',
       }),
       makePayment({
-        id: 'payment-fallback',
-        paidAt: undefined,
-        createdAt: '2026-07-26T01:00:00.000Z',
-        reference: 'FALLBACK',
+        id: 'payment-iso-hour',
+        paidAt: '2026-07-29T03:00:00.000Z',
+        createdAt: '2026-07-29T03:00:00.000Z',
+        reference: 'ISO HOUR',
       }),
       makePayment({
         id: 'payment-invalid',
@@ -737,29 +749,187 @@ describe('ResidentPaymentsPage', () => {
         createdAt: 'invalid-date',
         reference: 'INVALID',
       }),
+      makePayment({
+        id: 'payment-absent',
+        paidAt: undefined as never,
+        createdAt: undefined as never,
+        reference: 'ABSENT',
+      }),
     ]);
-
-    const expectedTimestampDate = new Intl.DateTimeFormat('es-AR', {
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-    }).format(new Date('2026-07-26T01:00:00.000Z'));
 
     const Wrapper = createWrapper();
     render(<ResidentPaymentsPage />, { wrapper: Wrapper });
 
-    await screen.findByText('Historial de pagos');
+    fireEvent.click(await screen.findByRole('tab', { name: 'Historial' }));
 
-    expect(
-      screen.getByText((_, element) => element?.tagName === 'P' && element.textContent?.includes('24/07/2026') === true),
-    ).toBeTruthy();
-    expect(
-      screen.getAllByText(
-        (_, element) => element?.tagName === 'P' && element.textContent?.includes(expectedTimestampDate) === true,
+    expect(screen.getByText('5 pagos registrados')).toBeTruthy();
+    const mobileHistory = document.getElementById('resident-payments-mobile-history');
+    expect(mobileHistory).toBeTruthy();
+    if (!mobileHistory) {
+      throw new Error('Expected the mobile history section to be rendered');
+    }
+    const mobileHistoryTexts = Array.from(mobileHistory.querySelectorAll('p.text-sm.text-muted-foreground'))
+      .map((element) => element.textContent?.replace(/\s+/g, ' ').trim());
+    expect(mobileHistoryTexts).toContain('29 jul. 2026 · TRANSFER · CIVIL');
+    expect(mobileHistoryTexts).toContain('29 jul. 2026 · TRANSFER · ISO UTC');
+    expect(mobileHistoryTexts).toContain('29 jul. 2026 · TRANSFER · ISO HOUR');
+    expect(mobileHistoryTexts).toContain('— · TRANSFER · INVALID');
+    expect(mobileHistoryTexts).toContain('— · TRANSFER · ABSENT');
+    expect(screen.queryByText('28 jul. 2026')).toBeNull();
+    expect(screen.queryByText('29/07/2026')).toBeNull();
+  });
+
+  it('keeps the mobile success visible before closing and restores focus to the trigger', async () => {
+    mockMatchMedia(true);
+    mockedGetResidentLedger.mockResolvedValueOnce(makeLedger({ charges: [makeCharge()] }));
+    mockedListPayments.mockResolvedValueOnce([]);
+    const deferred = createDeferred<Payment>();
+    mockedSubmitPayment.mockImplementation(async () => deferred.promise);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    const openButton = await screen.findByRole('button', { name: 'Reportar pago' });
+    openButton.focus();
+    fireEvent.click(openButton);
+    const panelIntro = await screen.findByText(
+      /Cargá el comprobante y completá los datos del pago para enviarlo a revisión\./i,
+    );
+    const mobileDialog = panelIntro.closest('[role="dialog"]') as HTMLElement | null;
+    expect(mobileDialog).toBeTruthy();
+    if (!mobileDialog) {
+      throw new Error('Expected the mobile payment panel to be rendered');
+    }
+    const mobileDialogQueries = within(mobileDialog);
+
+    await act(async () => {
+      fireEvent.change(mobileDialogQueries.getByLabelText(/comprobante de pago/i), {
+        target: {
+          files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
+        },
+      });
+    });
+
+    await waitFor(() => expect(mockedPresignUpload).toHaveBeenCalled());
+    expect(await mobileDialogQueries.findByText(/proof\.pdf subido correctamente/i)).toBeTruthy();
+    const submitButtonLabel = mobileDialogQueries.getByText('Enviar pago');
+    const submitButton = submitButtonLabel.closest('button');
+    expect(submitButton).toBeTruthy();
+    if (!submitButton) {
+      throw new Error('Expected the mobile payment submit button to be rendered');
+    }
+    fireEvent.click(submitButton);
+
+    const confirmDialog = await screen.findByRole('dialog', { name: /confirmar reporte de pago/i });
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: 'Confirmar pago' }));
+
+    await waitFor(() => expect(mockedSubmitPayment).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      deferred.resolve(makePayment({ id: 'payment-success', status: PaymentStatus.SUBMITTED }));
+    });
+
+    await waitFor(() => expect(mobileDialog.textContent).toContain('Pago enviado exitosamente'));
+    expect(mobileDialog.isConnected).toBe(true);
+    expect(mockedSubmitPayment).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      jest.advanceTimersByTime(2000);
+    });
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: /reportar pago/i })).toBeNull());
+    expect(document.activeElement).toBe(openButton);
+    await waitFor(() => expect(screen.queryByRole('status')).toBeNull());
+  });
+
+  it('keeps the mobile payment panel open when the submission fails', async () => {
+    mockMatchMedia(true);
+    mockedGetResidentLedger.mockResolvedValueOnce(makeLedger({ charges: [makeCharge()] }));
+    mockedListPayments.mockResolvedValueOnce([]);
+    mockedSubmitPayment.mockRejectedValueOnce(new Error('No se pudo registrar el pago'));
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    const openButton = await screen.findByRole('button', { name: 'Reportar pago' });
+    fireEvent.click(openButton);
+    const panelIntro = await screen.findByText(
+      /Cargá el comprobante y completá los datos del pago para enviarlo a revisión\./i,
+    );
+    const mobileDialog = panelIntro.closest('[role="dialog"]') as HTMLElement | null;
+    expect(mobileDialog).toBeTruthy();
+    if (!mobileDialog) {
+      throw new Error('Expected the mobile payment panel to be rendered');
+    }
+    const mobileDialogQueries = within(mobileDialog);
+
+    await act(async () => {
+      fireEvent.change(mobileDialogQueries.getByLabelText(/comprobante de pago/i), {
+        target: {
+          files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
+        },
+      });
+    });
+
+    await waitFor(() => expect(mockedPresignUpload).toHaveBeenCalled());
+    expect(await mobileDialogQueries.findByText(/proof\.pdf subido correctamente/i)).toBeTruthy();
+    const submitButtonLabel = mobileDialogQueries.getByText('Enviar pago');
+    const submitButton = submitButtonLabel.closest('button');
+    expect(submitButton).toBeTruthy();
+    if (!submitButton) {
+      throw new Error('Expected the mobile payment submit button to be rendered');
+    }
+    fireEvent.click(submitButton);
+
+    const confirmDialog = await screen.findByRole('dialog', { name: /confirmar reporte de pago/i });
+    fireEvent.click(within(confirmDialog).getByRole('button', { name: 'Confirmar pago' }));
+
+    await waitFor(() => expect(mockedSubmitPayment).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mobileDialog.textContent).toContain('No se pudo registrar el pago'));
+    expect(mobileDialog.isConnected).toBe(true);
+    expect(mockedSubmitPayment).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).not.toBe(openButton);
+  });
+
+  it.each([
+    { count: 1, expectedLabel: '1 pago registrado' },
+    { count: 8, expectedLabel: '8 pagos registrados' },
+    { count: 20, expectedLabel: 'Mostrando los últimos 20 pagos' },
+  ])('labels mobile history as recent records when showing $count results', async ({ count, expectedLabel }) => {
+    mockMatchMedia(true);
+    mockedGetResidentLedger.mockResolvedValueOnce(makeLedger({ charges: [] }));
+    mockedListPayments.mockResolvedValueOnce(
+      Array.from({ length: count }, (_, index) =>
+        makePayment({
+          id: `payment-${index + 1}`,
+          reference: `PAY-${index + 1}`,
+          paidAt: `2026-07-${String(Math.min(count - index, 28)).padStart(2, '0')}`,
+          createdAt: `2026-07-${String(Math.min(count - index, 28)).padStart(2, '0')}`,
+        }),
       ),
-    ).toHaveLength(3);
-    expect(screen.queryByText('23/07/2026')).toBeNull();
-    expect(screen.queryByText('invalid-date')).toBeNull();
+    );
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    fireEvent.click(await screen.findByRole('tab', { name: 'Historial' }));
+
+    expect(screen.getByText(expectedLabel)).toBeTruthy();
+    expect(screen.queryByText('20 pagos registrados')).toBeNull();
+  });
+
+  it('shows an empty-state message when no mobile payment history exists', async () => {
+    mockMatchMedia(true);
+    mockedGetResidentLedger.mockResolvedValueOnce(makeLedger({ charges: [] }));
+    mockedListPayments.mockResolvedValueOnce([]);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    fireEvent.click(await screen.findByRole('tab', { name: 'Historial' }));
+
+    expect(screen.getByText('Todavía no tenés pagos registrados.')).toBeTruthy();
+    expect(screen.queryByText('Mostrando los últimos 20 pagos')).toBeNull();
   });
 
   it('lets the resident switch pending charges and always shows the selected full balance', async () => {
@@ -796,10 +966,12 @@ describe('ResidentPaymentsPage', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /reportar pago/i }));
     fireEvent.change(screen.getByLabelText(/cargo pendiente/i), { target: { value: 'charge-2' } });
-    fireEvent.change(screen.getByLabelText(/comprobante de pago/i), {
-      target: {
-        files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
-      },
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/comprobante de pago/i), {
+        target: {
+          files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
+        },
+      });
     });
 
     await waitFor(() => expect(mockedPresignUpload).toHaveBeenCalled());
@@ -822,10 +994,12 @@ describe('ResidentPaymentsPage', () => {
     render(<ResidentPaymentsPage />, { wrapper: Wrapper });
 
     fireEvent.click(await screen.findByRole('button', { name: /reportar pago/i }));
-    fireEvent.change(screen.getByLabelText(/comprobante de pago/i), {
-      target: {
-        files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
-      },
+    await act(async () => {
+      fireEvent.change(screen.getByLabelText(/comprobante de pago/i), {
+        target: {
+          files: [new File([new Uint8Array([1, 2, 3])], 'proof.pdf', { type: 'application/pdf' })],
+        },
+      });
     });
 
     expect(await screen.findByText(/Error al subir el comprobante/)).toBeTruthy();

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
@@ -107,6 +107,23 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
+function mockMatchMedia(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+}
+
 function makeLedger(overrides: Partial<Record<string, unknown>> = {}) {
   return {
     unitId: 'unit-1',
@@ -228,6 +245,7 @@ describe('ResidentPaymentsPage', () => {
       id: 'document-1',
       file: { id: 'file-1' },
     } as never);
+    mockMatchMedia(false);
     (window.URL as typeof window.URL & {
       createObjectURL: jest.Mock;
       revokeObjectURL: jest.Mock;
@@ -739,7 +757,7 @@ describe('ResidentPaymentsPage', () => {
       screen.getAllByText(
         (_, element) => element?.tagName === 'P' && element.textContent?.includes(expectedTimestampDate) === true,
       ),
-    ).toHaveLength(2);
+    ).toHaveLength(3);
     expect(screen.queryByText('23/07/2026')).toBeNull();
     expect(screen.queryByText('invalid-date')).toBeNull();
   });
@@ -882,5 +900,158 @@ describe('ResidentPaymentsPage', () => {
     const reconciledBadge = screen.getByText('Conciliado');
     expect(reconciledBadge.className).toContain('bg-blue-100');
     expect(reconciledBadge.className).toContain('dark:bg-blue-950/40');
+  });
+
+  it('renders the mobile summary, locks focus inside the payment panel, and restores focus on close', async () => {
+    mockMatchMedia(true);
+    mockedGetResidentLedger.mockResolvedValueOnce(
+      makeLedger({
+        charges: [
+          makeCharge({
+            id: 'charge-1',
+            concept: 'Condominio ordinario',
+            period: '2026-03',
+            amount: 46350,
+            allocated: 0,
+            dueDate: '2026-03-09',
+          }),
+          makeCharge({
+            id: 'charge-2',
+            concept: 'Fondo de reserva',
+            period: '2026-04',
+            amount: 18500,
+            allocated: 0,
+            dueDate: '2026-04-12',
+          }),
+          makeCharge({
+            id: 'charge-3',
+            concept: 'Multa administrativa',
+            period: '2026-05',
+            amount: 3200,
+            allocated: 0,
+            dueDate: '2026-05-05',
+          }),
+        ],
+        totals: {
+          balance: 68750,
+          currency: 'ARS',
+          totalCharges: 68750,
+          totalPaid: 0,
+          totalAllocated: 0,
+        },
+      }),
+    );
+    mockedListPayments.mockResolvedValueOnce([
+      makePayment({
+        id: 'payment-recent',
+        amount: 49500,
+        paidAt: '2026-07-23',
+        createdAt: '2026-07-23',
+        method: PaymentMethod.TRANSFER,
+        status: PaymentStatus.APPROVED,
+        proofDocumentId: 'proof-doc-1',
+        receiptDocumentId: 'receipt-doc-1',
+      }),
+    ]);
+
+    const Wrapper = createWrapper();
+    const { container } = render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    await waitFor(() => expect(container.querySelector('.overflow-x-hidden')).toBeTruthy());
+    await waitFor(() => expect(screen.getByRole('tab', { name: 'Resumen' }).getAttribute('aria-selected')).toBe('true'));
+    expect(screen.getByRole('button', { name: 'Reportar pago' }).className).toContain('min-h-12');
+
+    const openMobilePanelButton = screen.getByRole('button', { name: 'Reportar pago' });
+    openMobilePanelButton.focus();
+    fireEvent.click(openMobilePanelButton);
+
+    const panelIntro = await screen.findByText(/Cargá el comprobante y completá los datos del pago para enviarlo a revisión\./i);
+    const panel = panelIntro.closest('[role="dialog"]') as HTMLElement | null;
+    expect(panel).toBeTruthy();
+    if (!panel) {
+      throw new Error('Expected the mobile payment panel to be rendered');
+    }
+    const closeButton = screen.getByLabelText('Cerrar reporte de pago');
+    const cancelButton = screen.getByText('Cancelar');
+
+    expect(document.activeElement).toBe(closeButton);
+
+    fireEvent.keyDown(panel, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(cancelButton);
+
+    fireEvent.keyDown(panel, { key: 'Tab' });
+    expect(document.activeElement).toBe(closeButton);
+
+    expect(document.body.style.overflow).toBe('hidden');
+
+    fireEvent.keyDown(panel, { key: 'Escape' });
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Reportar pago' })).toBeNull());
+    await waitFor(() => expect(document.body.style.overflow).toBe(''));
+    expect(document.activeElement).toBe(openMobilePanelButton);
+  });
+
+  it('switches mobile tabs and shows compact pending and history cards', async () => {
+    mockMatchMedia(true);
+    mockedGetResidentLedger.mockResolvedValueOnce(
+      makeLedger({
+        charges: [
+          makeCharge({
+            id: 'charge-1',
+            concept: 'Condominio ordinario',
+            period: '2026-03',
+            amount: 46350,
+            allocated: 0,
+            dueDate: '2026-03-09',
+          }),
+          makeCharge({
+            id: 'charge-2',
+            concept: 'Fondo de reserva',
+            period: '2026-04',
+            amount: 18500,
+            allocated: 0,
+            dueDate: '2026-04-12',
+          }),
+        ],
+        totals: {
+          balance: 64850,
+          currency: 'ARS',
+          totalCharges: 64850,
+          totalPaid: 0,
+          totalAllocated: 0,
+        },
+      }),
+    );
+    mockedListPayments.mockResolvedValueOnce([
+      makePayment({
+        id: 'payment-recent',
+        amount: 49500,
+        paidAt: '2026-07-23',
+        createdAt: '2026-07-23',
+        method: PaymentMethod.TRANSFER,
+        status: PaymentStatus.APPROVED,
+        proofDocumentId: 'proof-doc-1',
+        receiptDocumentId: 'receipt-doc-1',
+      }),
+    ]);
+
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Ver todos' }));
+
+    expect(screen.getByRole('tab', { name: 'Pendientes' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByText('MAR 2026')).toBeTruthy();
+    expect(screen.getAllByText('Vencido')).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Resumen' }));
+    expect(screen.getByRole('tab', { name: 'Resumen' }).getAttribute('aria-selected')).toBe('true');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Ver historial' }));
+
+    expect(screen.getByRole('tab', { name: 'Historial' }).getAttribute('aria-selected')).toBe('true');
+    expect(screen.getByText('Historial de pagos')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /ver comprobante del pago de/i })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /ver recibo del pago de/i })).toBeTruthy();
   });
 });

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
@@ -34,6 +34,7 @@ import Skeleton from '@/shared/components/ui/Skeleton';
 import { formatCurrency, getLocaleForCurrency } from '@/shared/lib/format/money';
 
 const CIVIL_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const CIVIL_DATE_OR_TIMESTAMP_PATTERN = /^(\d{4}-\d{2}-\d{2})(?:T.*)?$/;
 const MONTH_SHORT_LABELS = ['ene.', 'feb.', 'mar.', 'abr.', 'may.', 'jun.', 'jul.', 'ago.', 'sep.', 'oct.', 'nov.', 'dic.'] as const;
 const MONTH_SHORT_UPPER_LABELS = ['ENE', 'FEB', 'MAR', 'ABR', 'MAY', 'JUN', 'JUL', 'AGO', 'SEP', 'OCT', 'NOV', 'DIC'] as const;
 
@@ -69,10 +70,20 @@ function useMediaQuery(query: string): boolean {
   return matches;
 }
 
-function parseCivilDateParts(dateValue: string | undefined | null): { readonly year: number; readonly monthIndex: number; readonly day: number } | null {
-  if (!dateValue || !CIVIL_DATE_PATTERN.test(dateValue)) return null;
+function normalizeCivilDateValue(dateValue: string | undefined | null): string | null {
+  if (!dateValue) return null;
 
-  const [yearPart, monthPart, dayPart] = dateValue.split('-');
+  const normalizedMatch = CIVIL_DATE_OR_TIMESTAMP_PATTERN.exec(dateValue);
+  if (!normalizedMatch) return null;
+
+  return normalizedMatch[1];
+}
+
+function parseCivilDateParts(dateValue: string | undefined | null): { readonly year: number; readonly monthIndex: number; readonly day: number } | null {
+  const normalizedDateValue = normalizeCivilDateValue(dateValue);
+  if (!normalizedDateValue || !CIVIL_DATE_PATTERN.test(normalizedDateValue)) return null;
+
+  const [yearPart, monthPart, dayPart] = normalizedDateValue.split('-');
   const year = Number(yearPart);
   const monthIndex = Number(monthPart);
   const day = Number(dayPart);
@@ -129,9 +140,10 @@ function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
 }
 
 function formatCivilDate(dateValue: string | undefined | null): string {
-  if (!dateValue || !CIVIL_DATE_PATTERN.test(dateValue)) return '—';
+  const normalizedDateValue = normalizeCivilDateValue(dateValue);
+  if (!normalizedDateValue) return '—';
 
-  const [year, month, day] = dateValue.split('-');
+  const [year, month, day] = normalizedDateValue.split('-');
   if (!year || !month || !day) return '—';
 
   return `${day}/${month}/${year}`;
@@ -153,8 +165,9 @@ function formatLocalTimestampDate(dateValue: string | undefined | null): string 
 function formatPaymentDisplayDate(dateValue: string | undefined | null): string {
   if (!dateValue) return '—';
 
-  return CIVIL_DATE_PATTERN.test(dateValue)
-    ? formatCivilDate(dateValue)
+  const normalizedDateValue = normalizeCivilDateValue(dateValue);
+  return normalizedDateValue
+    ? formatCivilDate(normalizedDateValue)
     : formatLocalTimestampDate(dateValue);
 }
 
@@ -201,6 +214,13 @@ function getMobileChargeStatusLabel(charge: {
   }
 
   return { label: 'Pendiente', variant: 'muted' };
+}
+
+function getRecentPaymentsLabel(count: number): string | null {
+  if (count === 0) return null;
+  if (count === 1) return '1 pago registrado';
+  if (count >= 20) return 'Mostrando los últimos 20 pagos';
+  return `${count} pagos registrados`;
 }
 
 function paymentStatusLabel(status: string): string {
@@ -523,11 +543,16 @@ export const ResidentPaymentsPage = () => {
   const [isPaymentPanelOpen, setIsPaymentPanelOpen] = useState(false);
   const activeDownloadObjectUrlsRef = useRef<string[]>([]);
   const activeDownloadTimersRef = useRef<number[]>([]);
+  const submitSuccessTimerRef = useRef<number | null>(null);
   const paymentPanelRef = useRef<HTMLDivElement | null>(null);
   const paymentPanelLastFocusedRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     return () => {
+      if (submitSuccessTimerRef.current !== null) {
+        window.clearTimeout(submitSuccessTimerRef.current);
+        submitSuccessTimerRef.current = null;
+      }
       activeDownloadTimersRef.current.forEach((timerId) => window.clearTimeout(timerId));
       activeDownloadTimersRef.current = [];
       activeDownloadObjectUrlsRef.current.forEach((objectUrl) => window.URL.revokeObjectURL(objectUrl));
@@ -658,6 +683,10 @@ export const ResidentPaymentsPage = () => {
   }, []);
 
   const closePaymentPanel = useCallback((restoreFocus = true) => {
+    if (submitSuccessTimerRef.current !== null) {
+      window.clearTimeout(submitSuccessTimerRef.current);
+      submitSuccessTimerRef.current = null;
+    }
     if (!restoreFocus) {
       paymentPanelLastFocusedRef.current = null;
       setIsPaymentPanelOpen(false);
@@ -801,12 +830,19 @@ export const ResidentPaymentsPage = () => {
       resetForm();
       setIsConfirmOpen(false);
       setPaymentToConfirm(null);
-      closePaymentPanel();
       refetchLedger();
       refetchPayments();
-      setTimeout(() => {
-        setShowForm(false);
+      if (submitSuccessTimerRef.current !== null) {
+        window.clearTimeout(submitSuccessTimerRef.current);
+      }
+      submitSuccessTimerRef.current = window.setTimeout(() => {
+        if (isMobileViewport) {
+          closePaymentPanel();
+        } else {
+          setShowForm(false);
+        }
         setSubmitSuccess(false);
+        submitSuccessTimerRef.current = null;
       }, 2000);
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : 'Error al enviar pago');
@@ -941,13 +977,13 @@ export const ResidentPaymentsPage = () => {
 
           {submitError && (
             <div className="rounded-lg border border-red-200 bg-red-50 p-3">
-              <p className="text-sm text-red-600" aria-live="polite">{submitError}</p>
+              <p className="text-sm text-red-600" aria-live="polite" role="alert">{submitError}</p>
             </div>
           )}
 
           {submitSuccess && (
-            <div className="rounded-lg border border-green-200 bg-green-50 p-3">
-              <p className="text-sm text-green-600" aria-live="polite">✓ Pago enviado exitosamente</p>
+            <div className="rounded-lg border border-green-200 bg-green-50 p-3" role="status" aria-live="polite">
+              <p className="text-sm text-green-600">✓ Pago enviado exitosamente</p>
             </div>
           )}
         </div>
@@ -956,7 +992,7 @@ export const ResidentPaymentsPage = () => {
           <div className={isMobilePanel ? 'flex flex-col-reverse gap-3 sm:flex-row sm:justify-end' : 'flex gap-2'}>
             <Button
               type="submit"
-              disabled={submitting || !canSubmit}
+              disabled={submitting || submitSuccess || !canSubmit}
               className={isMobilePanel ? 'min-h-12 flex-1 gap-2 sm:flex-none' : 'gap-2'}
               id="resident-payment-submit-trigger"
             >
@@ -1121,6 +1157,7 @@ export const ResidentPaymentsPage = () => {
 
   const mobilePendingPreview = sortedPendingCharges.slice(0, 3);
   const mobileRecentPaymentsPreview = sortedRecentPayments.slice(0, 2);
+  const recentPaymentsLabel = getRecentPaymentsLabel(sortedRecentPayments.length);
 
   if (isMobileViewport) {
     const todayCivilDate = getCurrentCivilDateInputValue();
@@ -1301,12 +1338,12 @@ export const ResidentPaymentsPage = () => {
             </Card>
 
             {lastPayment ? (
-              <Card className="p-4">
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <p className="text-sm font-medium text-muted-foreground">Historial reciente</p>
-                    <h2 className="text-lg font-semibold text-foreground">Tu último movimiento</h2>
-                  </div>
+            <Card className="p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-medium text-muted-foreground">Historial reciente</p>
+                  <h2 className="text-lg font-semibold text-foreground">Tu último movimiento</h2>
+                </div>
                   {payments.length > 0 ? (
                     <Button
                       type="button"
@@ -1318,10 +1355,13 @@ export const ResidentPaymentsPage = () => {
                       Ver historial
                     </Button>
                   ) : null}
-                </div>
-                <div className="mt-4 space-y-3">
-                  {mobileRecentPaymentsPreview.length === 0 ? (
-                    <p className="text-sm text-muted-foreground">Todavía no tenés pagos registrados.</p>
+              </div>
+              {recentPaymentsLabel ? (
+                <p className="mt-1 text-sm text-muted-foreground">{recentPaymentsLabel}</p>
+              ) : null}
+              <div className="mt-4 space-y-3">
+                {mobileRecentPaymentsPreview.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">Todavía no tenés pagos registrados.</p>
                   ) : (
                     mobileRecentPaymentsPreview.map((payment) => {
                       const proofDocumentId = payment.proofDocumentId;
@@ -1495,7 +1535,9 @@ export const ResidentPaymentsPage = () => {
           <div id="resident-payments-mobile-history" role="tabpanel" aria-labelledby="resident-payments-mobile-history-tab" className="space-y-3">
             <div>
               <h2 className="text-lg font-semibold text-foreground">Historial de pagos</h2>
-              <p className="text-sm text-muted-foreground">{sortedRecentPayments.length} pagos registrados</p>
+              {recentPaymentsLabel ? (
+                <p className="text-sm text-muted-foreground">{recentPaymentsLabel}</p>
+              ) : null}
             </div>
 
             {paymentsError ? (
@@ -1514,7 +1556,7 @@ export const ResidentPaymentsPage = () => {
               </Card>
             ) : paymentsLoading ? (
               <Skeleton className="h-32" />
-            ) : sortedRecentPayments.length === 0 ? (
+                    ) : sortedRecentPayments.length === 0 ? (
               <Card className="p-4">
                 <p className="text-sm text-muted-foreground">Todavía no tenés pagos registrados.</p>
               </Card>

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
@@ -2,7 +2,7 @@
 
 import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   CreditCard,
   AlertCircle,
@@ -34,6 +34,99 @@ import Skeleton from '@/shared/components/ui/Skeleton';
 import { formatCurrency, getLocaleForCurrency } from '@/shared/lib/format/money';
 
 const CIVIL_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const MONTH_SHORT_LABELS = ['ene.', 'feb.', 'mar.', 'abr.', 'may.', 'jun.', 'jul.', 'ago.', 'sep.', 'oct.', 'nov.', 'dic.'] as const;
+const MONTH_SHORT_UPPER_LABELS = ['ENE', 'FEB', 'MAR', 'ABR', 'MAY', 'JUN', 'JUL', 'AGO', 'SEP', 'OCT', 'NOV', 'DIC'] as const;
+
+function useMediaQuery(query: string): boolean {
+  const getInitialMatch = () => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+    return window.matchMedia(query).matches;
+  };
+
+  const [matches, setMatches] = useState(getInitialMatch);
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== 'function') return;
+
+    const mediaQuery = window.matchMedia(query);
+    const updateMatches = () => setMatches(mediaQuery.matches);
+
+    updateMatches();
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', updateMatches);
+      return () => mediaQuery.removeEventListener('change', updateMatches);
+    }
+
+    if (typeof mediaQuery.addListener === 'function') {
+      mediaQuery.addListener(updateMatches);
+      return () => mediaQuery.removeListener(updateMatches);
+    }
+
+    return undefined;
+  }, [query]);
+
+  return matches;
+}
+
+function parseCivilDateParts(dateValue: string | undefined | null): { readonly year: number; readonly monthIndex: number; readonly day: number } | null {
+  if (!dateValue || !CIVIL_DATE_PATTERN.test(dateValue)) return null;
+
+  const [yearPart, monthPart, dayPart] = dateValue.split('-');
+  const year = Number(yearPart);
+  const monthIndex = Number(monthPart);
+  const day = Number(dayPart);
+
+  if (!Number.isInteger(year) || !Number.isInteger(monthIndex) || !Number.isInteger(day)) return null;
+  if (monthIndex < 1 || monthIndex > 12) return null;
+  if (day < 1 || day > 31) return null;
+
+  return { year, monthIndex, day };
+}
+
+function formatCompactCivilDayMonth(dateValue: string | undefined | null): string {
+  const parts = parseCivilDateParts(dateValue);
+  if (!parts) return '—';
+
+  return `${String(parts.day).padStart(2, '0')} ${MONTH_SHORT_LABELS[parts.monthIndex - 1]}`;
+}
+
+function formatCompactCivilDayMonthYear(dateValue: string | undefined | null): string {
+  const parts = parseCivilDateParts(dateValue);
+  if (!parts) return '—';
+
+  return `${String(parts.day).padStart(2, '0')} ${MONTH_SHORT_LABELS[parts.monthIndex - 1]} ${parts.year}`;
+}
+
+function formatCompactPeriodLabel(period: string | undefined | null): string {
+  if (!period || !CIVIL_DATE_PATTERN.test(`${period}-01`)) return '—';
+
+  const [yearPart, monthPart] = period.split('-');
+  const year = Number(yearPart);
+  const monthIndex = Number(monthPart);
+
+  if (!Number.isInteger(year) || !Number.isInteger(monthIndex) || monthIndex < 1 || monthIndex > 12) return '—';
+
+  return `${MONTH_SHORT_UPPER_LABELS[monthIndex - 1]} ${year}`;
+}
+
+function getFocusableElements(container: HTMLElement | null): HTMLElement[] {
+  if (!container) return [];
+
+  const focusableSelectors = [
+    'button:not([disabled])',
+    'a[href]',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(',');
+
+  return Array.from(container.querySelectorAll<HTMLElement>(focusableSelectors)).filter((element) => {
+    const hidden = element.getAttribute('aria-hidden') === 'true';
+    return !hidden && !element.hasAttribute('disabled');
+  });
+}
 
 function formatCivilDate(dateValue: string | undefined | null): string {
   if (!dateValue || !CIVIL_DATE_PATTERN.test(dateValue)) return '—';
@@ -80,6 +173,34 @@ function getChargeStatusFromDebt(amount: number, allocated: number | undefined, 
   if (debt <= 0) return 'Pagado';
   if (allocated && allocated > 0 && allocated < amount) return 'Parcial';
   return 'Pendiente';
+}
+
+function getMobileChargeStatusLabel(charge: {
+  readonly amount: number;
+  readonly allocated?: number;
+  readonly status: ChargeStatus;
+  readonly dueDate: string;
+}, todayCivilDate: string): { readonly label: string; readonly variant: BadgeVariant } {
+  const outstandingMinor = charge.amount - (charge.allocated ?? 0);
+  const isOverdue = charge.dueDate < todayCivilDate;
+
+  if (charge.status === ChargeStatus.CANCELED) {
+    return { label: 'Cancelado', variant: 'muted' };
+  }
+
+  if (outstandingMinor <= 0) {
+    return { label: 'Pagado', variant: 'success' };
+  }
+
+  if (charge.allocated && charge.allocated > 0 && charge.allocated < charge.amount) {
+    return { label: 'Parcial', variant: 'info' };
+  }
+
+  if (isOverdue) {
+    return { label: 'Vencido', variant: 'warning' };
+  }
+
+  return { label: 'Pendiente', variant: 'muted' };
 }
 
 function paymentStatusLabel(status: string): string {
@@ -320,9 +441,10 @@ export const ResidentPaymentsPage = () => {
   const tenantId = params.tenantId;
   const session = useAuthSession();
   const userId = session?.user.id ?? null;
+  const isMobileViewport = useMediaQuery('(max-width: 767px)');
 
   const { data: tenants } = useTenants();
-  const tenantName = tenants?.find((t) => t.id === tenantId)?.name ?? tenantId;
+  const tenantName = tenants?.find((t) => t.id === tenantId)?.name ?? 'Administración actual';
 
   const {
     data: context,
@@ -397,8 +519,12 @@ export const ResidentPaymentsPage = () => {
   const [downloadingDocumentId, setDownloadingDocumentId] = useState<string | null>(null);
   const [isConfirmOpen, setIsConfirmOpen] = useState(false);
   const [paymentToConfirm, setPaymentToConfirm] = useState<PaymentConfirmationData | null>(null);
+  const [mobileTab, setMobileTab] = useState<'summary' | 'pending' | 'history'>('summary');
+  const [isPaymentPanelOpen, setIsPaymentPanelOpen] = useState(false);
   const activeDownloadObjectUrlsRef = useRef<string[]>([]);
   const activeDownloadTimersRef = useRef<number[]>([]);
+  const paymentPanelRef = useRef<HTMLDivElement | null>(null);
+  const paymentPanelLastFocusedRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     return () => {
@@ -408,6 +534,30 @@ export const ResidentPaymentsPage = () => {
       activeDownloadObjectUrlsRef.current = [];
     };
   }, []);
+
+  useEffect(() => {
+    if (!isPaymentPanelOpen || !isMobileViewport) {
+      if (paymentPanelLastFocusedRef.current) {
+        paymentPanelLastFocusedRef.current.focus();
+        paymentPanelLastFocusedRef.current = null;
+      }
+      return undefined;
+    }
+
+    paymentPanelLastFocusedRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+
+    const originalBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const focusables = getFocusableElements(paymentPanelRef.current);
+    focusables[0]?.focus();
+
+    return () => {
+      document.body.style.overflow = originalBodyOverflow;
+    };
+  }, [isMobileViewport, isPaymentPanelOpen]);
 
   const handleOpenDocument = async (documentId: string) => {
     if (downloadingDocumentId) {
@@ -496,9 +646,67 @@ export const ResidentPaymentsPage = () => {
     setProofFileId(null);
   };
 
-  const pendingCharges = ledger?.charges?.filter(
-    (c) => (c.amount - (c.allocated ?? 0)) > 0
-  ) ?? [];
+  const openPaymentPanel = useCallback(() => {
+    paymentPanelLastFocusedRef.current = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    setShowForm(false);
+    setMobileTab('summary');
+    setIsPaymentPanelOpen(true);
+    setSubmitError(null);
+    setSubmitSuccess(false);
+  }, []);
+
+  const closePaymentPanel = useCallback((restoreFocus = true) => {
+    if (!restoreFocus) {
+      paymentPanelLastFocusedRef.current = null;
+      setIsPaymentPanelOpen(false);
+      return;
+    }
+
+    paymentPanelLastFocusedRef.current?.focus();
+    paymentPanelLastFocusedRef.current = null;
+    setIsPaymentPanelOpen(false);
+  }, []);
+
+  const handlePaymentPanelKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      if (!submitting) {
+        closePaymentPanel();
+      }
+      return;
+    }
+
+    if (event.key !== 'Tab') return;
+
+    const focusables = getFocusableElements(paymentPanelRef.current);
+    if (focusables.length === 0) return;
+
+    const activeElement = document.activeElement as HTMLElement | null;
+    const currentIndex = activeElement ? focusables.indexOf(activeElement) : -1;
+    const nextIndex = event.shiftKey
+      ? (currentIndex <= 0 ? focusables.length - 1 : currentIndex - 1)
+      : (currentIndex === focusables.length - 1 ? 0 : currentIndex + 1);
+
+    event.preventDefault();
+    focusables[nextIndex]?.focus();
+  }, [closePaymentPanel, submitting]);
+
+  const handleMobileTabChange = useCallback((tab: 'summary' | 'pending' | 'history') => {
+    setMobileTab(tab);
+  }, []);
+
+  const handleMobilePaymentFormCancel = useCallback(() => {
+    if (!submitting) {
+      setIsPaymentPanelOpen(false);
+    }
+  }, [submitting]);
+
+  const pendingCharges = useMemo(
+    () => ledger?.charges?.filter((c) => (c.amount - (c.allocated ?? 0)) > 0) ?? [],
+    [ledger?.charges],
+  );
   const selectedChargeId = pendingCharges.some((charge) => charge.id === formData.selectedChargeId)
     ? formData.selectedChargeId
     : pendingCharges[0]?.id ?? '';
@@ -507,6 +715,18 @@ export const ResidentPaymentsPage = () => {
 
   const balance = ledger?.totals?.balance ?? 0;
   const currency = ledger?.totals?.currency ?? 'ARS';
+  const sortedPendingCharges = useMemo(
+    () => pendingCharges
+      .slice()
+      .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime()),
+    [pendingCharges],
+  );
+  const sortedRecentPayments = useMemo(
+    () => payments
+      .slice()
+      .sort((a, b) => new Date(b.paidAt ?? b.createdAt).getTime() - new Date(a.paidAt ?? a.createdAt).getTime()),
+    [payments],
+  );
 
   const canSubmit = !!proofFileId && !!selectedCharge && selectedChargeOutstandingMinor > 0;
   const paymentDateId = 'resident-payment-date';
@@ -515,13 +735,9 @@ export const ResidentPaymentsPage = () => {
   const paymentProofId = 'resident-payment-proof';
 
   // Next due charge: use real outstanding, not legacy status
-  const nextDueCharge = ledger?.charges
-    ?.filter((c) => (c.amount - (c.allocated ?? 0)) > 0)
-    .sort((a, b) => new Date(a.dueDate).getTime() - new Date(b.dueDate).getTime())[0];
+  const nextDueCharge = sortedPendingCharges[0];
 
-  const lastPayment = ledger?.payments
-    ?.slice()
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())[0];
+  const lastPayment = sortedRecentPayments[0];
 
   const handleSubmitPayment = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -585,6 +801,7 @@ export const ResidentPaymentsPage = () => {
       resetForm();
       setIsConfirmOpen(false);
       setPaymentToConfirm(null);
+      closePaymentPanel();
       refetchLedger();
       refetchPayments();
       setTimeout(() => {
@@ -598,6 +815,183 @@ export const ResidentPaymentsPage = () => {
     } finally {
       setSubmitting(false);
     }
+  };
+
+  const renderPaymentFormSection = (mode: 'desktop' | 'mobile', onCancel: () => void) => {
+    const isMobilePanel = mode === 'mobile';
+    const formBody = (
+      <form
+        onSubmit={handleSubmitPayment}
+        className={isMobilePanel ? 'flex min-h-0 flex-1 flex-col' : 'space-y-4'}
+      >
+        <div className={isMobilePanel ? 'min-h-0 flex-1 space-y-4 overflow-y-auto px-4 py-4' : 'space-y-4'}>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div>
+              <label htmlFor="resident-payment-charge" className="mb-1 block text-sm font-medium">
+                Cargo pendiente
+              </label>
+              <Select
+                id="resident-payment-charge"
+                value={selectedChargeId}
+                onChange={(e) => setFormData((current) => ({ ...current, selectedChargeId: e.target.value }))}
+                disabled={pendingCharges.length === 0}
+              >
+                {pendingCharges.length === 0 ? (
+                  <option value="">No tenés cargos pendientes</option>
+                ) : (
+                  pendingCharges.map((charge) => {
+                    const outstandingMinor = charge.amount - (charge.allocated ?? 0);
+                    return (
+                      <option key={charge.id} value={charge.id}>
+                        {charge.concept} • Período {charge.period} • {formatCurrency(outstandingMinor, charge.currency, getLocaleForCurrency(charge.currency))}
+                      </option>
+                    );
+                  })
+                )}
+              </Select>
+              {selectedCharge ? (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  Los pagos informados por residentes deben cubrir el saldo completo del período.
+                </p>
+              ) : (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  No hay cargos pendientes disponibles para reportar.
+                </p>
+              )}
+              {selectedCharge ? (
+                <div className="mt-3 rounded-lg border border-border bg-muted/40 p-3">
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground">Monto a reportar</p>
+                  <p className="text-lg font-semibold">
+                    {formatCurrency(selectedChargeOutstandingMinor, selectedCharge.currency, getLocaleForCurrency(selectedCharge.currency))}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+            <div>
+              <label className="mb-1 block text-sm font-medium" htmlFor={paymentMethodId}>Método de pago</label>
+              <Select id={paymentMethodId} value={PaymentMethod.TRANSFER} disabled>
+                <option value={PaymentMethod.TRANSFER}>Transferencia bancaria</option>
+              </Select>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Por ahora BuildingOS solo acepta reportes de pago por transferencia.
+              </p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div>
+              <label htmlFor={paymentDateId} className="mb-1 block text-sm font-medium">Fecha de pago</label>
+              <Input
+                id={paymentDateId}
+                type="date"
+                value={formData.paidAt}
+                onChange={(e) => setFormData({ ...formData, paidAt: e.target.value })}
+              />
+            </div>
+            <div>
+              <label htmlFor={paymentReferenceId} className="mb-1 block text-sm font-medium">Referencia (opcional)</label>
+              <Input
+                id={paymentReferenceId}
+                type="text"
+                value={formData.reference}
+                onChange={(e) => setFormData({ ...formData, reference: e.target.value })}
+                placeholder="Ej: Transferencia #12345"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label htmlFor={paymentProofId} className="mb-1 block text-sm font-medium">
+              Comprobante de pago {formData.method === PaymentMethod.TRANSFER && <span className="text-red-500">*</span>}
+            </label>
+            {formData.method === PaymentMethod.TRANSFER && !proofFile && (
+              <p className="mb-2 text-xs text-amber-600">Los pagos por transferencia requieren comprobante</p>
+            )}
+            <input
+              id={paymentProofId}
+              type="file"
+              accept=".pdf,image/jpeg,image/png"
+              onChange={handleFileChange}
+              className="block w-full text-sm text-muted-foreground
+                file:mr-4 file:rounded-md file:border-0 file:bg-blue-50 file:px-4 file:py-2 file:text-sm file:font-medium file:text-blue-700
+                hover:file:bg-blue-100"
+            />
+            {proofFile && (
+              <p className="mt-1 flex items-center gap-2 text-sm text-green-600">
+                ✓ {proofFile.name} subido correctamente
+                <button
+                  type="button"
+                  onClick={() => {
+                    setProofFile(null);
+                    setProofFileId(null);
+                  }}
+                  className="font-medium text-red-500 hover:text-red-700"
+                >
+                  (Quitar)
+                </button>
+              </p>
+            )}
+            {uploadingProof && (
+              <p className="mt-1 flex items-center gap-2 text-sm text-blue-600">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Subiendo comprobante...
+              </p>
+            )}
+          </div>
+
+          {submitError && (
+            <div className="rounded-lg border border-red-200 bg-red-50 p-3">
+              <p className="text-sm text-red-600" aria-live="polite">{submitError}</p>
+            </div>
+          )}
+
+          {submitSuccess && (
+            <div className="rounded-lg border border-green-200 bg-green-50 p-3">
+              <p className="text-sm text-green-600" aria-live="polite">✓ Pago enviado exitosamente</p>
+            </div>
+          )}
+        </div>
+
+        <div className={isMobilePanel ? 'shrink-0 border-t border-border bg-card p-4 pb-[max(1rem,env(safe-area-inset-bottom))]' : 'flex gap-2'}>
+          <div className={isMobilePanel ? 'flex flex-col-reverse gap-3 sm:flex-row sm:justify-end' : 'flex gap-2'}>
+            <Button
+              type="submit"
+              disabled={submitting || !canSubmit}
+              className={isMobilePanel ? 'min-h-12 flex-1 gap-2 sm:flex-none' : 'gap-2'}
+              id="resident-payment-submit-trigger"
+            >
+              {submitting && <Loader2 className="h-4 w-4 animate-spin" />}
+              {submitting
+                ? 'Enviando...'
+                : !selectedCharge
+                  ? 'Seleccioná un cargo'
+                  : !proofFile
+                    ? 'Subí el comprobante'
+                    : 'Enviar pago'}
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={onCancel}
+              className={isMobilePanel ? 'min-h-11 flex-1 sm:flex-none' : undefined}
+            >
+              Cancelar
+            </Button>
+          </div>
+        </div>
+      </form>
+    );
+
+    if (isMobilePanel) {
+      return formBody;
+    }
+
+    return (
+      <Card className="p-4">
+        <h3 className="mb-4 text-lg font-semibold">Reportar nuevo pago</h3>
+        {formBody}
+      </Card>
+    );
   };
 
   if (contextLoading || ledgerLoading) {
@@ -724,6 +1118,575 @@ export const ResidentPaymentsPage = () => {
       </div>
     </Card>
   ) : null;
+
+  const mobilePendingPreview = sortedPendingCharges.slice(0, 3);
+  const mobileRecentPaymentsPreview = sortedRecentPayments.slice(0, 2);
+
+  if (isMobileViewport) {
+    const todayCivilDate = getCurrentCivilDateInputValue();
+    const mobileSections = [
+      { id: 'summary', label: 'Resumen' },
+      { id: 'pending', label: 'Pendientes' },
+      { id: 'history', label: 'Historial' },
+    ] as const;
+
+    return (
+      <div className="space-y-5 overflow-x-hidden px-4 pb-6">
+        <div className="space-y-1">
+          <h1 className="text-2xl font-bold leading-tight text-foreground">Pagos</h1>
+          <p className="line-clamp-2 text-sm text-muted-foreground">
+            {tenantName}
+            {buildingName && ` • ${buildingName}`}
+            {unitLabel && ` • Unidad ${unitLabel}`}
+          </p>
+        </div>
+
+        {downloadError && (
+          <Card className="p-3 border-red-200 bg-red-50">
+            <div className="flex items-start gap-3">
+              <AlertCircle className="text-red-600 mt-0.5" size={18} />
+              <div className="space-y-1">
+                <p className="font-medium text-red-800">No pudimos abrir el documento.</p>
+                <p className="text-sm text-red-700">{downloadError}</p>
+              </div>
+            </div>
+          </Card>
+        )}
+
+        {contextOptionsWarning ? <div className="text-sm">{contextOptionsWarning}</div> : null}
+
+        <div role="tablist" aria-label="Secciones de pagos" className="grid grid-cols-3 gap-2 rounded-2xl border border-border bg-muted/40 p-1">
+          {mobileSections.map((section) => {
+            const isSelected = mobileTab === section.id;
+            return (
+              <button
+                key={section.id}
+                type="button"
+                role="tab"
+                id={`resident-payments-mobile-${section.id}-tab`}
+                aria-selected={isSelected}
+                aria-controls={`resident-payments-mobile-${section.id}`}
+                onClick={() => handleMobileTabChange(section.id)}
+                className={[
+                  'flex min-h-11 items-center justify-center rounded-xl px-3 text-sm font-medium transition',
+                  isSelected
+                    ? 'bg-card text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:bg-background/80 hover:text-foreground',
+                ].join(' ')}
+              >
+                {section.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {mobileTab === 'summary' && (
+          <div id="resident-payments-mobile-summary" role="tabpanel" aria-labelledby="resident-payments-mobile-summary-tab" className="space-y-4">
+            <Card className="p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0 space-y-1">
+                  <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">Saldo pendiente</p>
+                  <p className="text-[clamp(1.75rem,8vw,2rem)] font-bold leading-none tabular-nums text-foreground">
+                    {formatCurrency(balance, currency, getLocaleForCurrency(currency))}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    {pendingCharges.length} cargos pendientes
+                  </p>
+                </div>
+                {balance > 0 ? (
+                  <AlertCircle className="mt-1 text-orange-500" size={24} />
+                ) : (
+                  <CheckCircle className="mt-1 text-green-500" size={24} />
+                )}
+              </div>
+              <div className="mt-4">
+                <Button
+                  type="button"
+                  onClick={openPaymentPanel}
+                  className="w-full min-h-12 gap-2"
+                  aria-controls="resident-payments-mobile-panel"
+                  aria-expanded={isPaymentPanelOpen}
+                >
+                  <Upload size={16} />
+                  Reportar pago
+                </Button>
+              </div>
+            </Card>
+
+            <div className="grid grid-cols-1 gap-3 min-[360px]:grid-cols-2">
+              <Card className="p-3">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Próximo vencimiento</p>
+                <p className="mt-2 text-lg font-semibold tabular-nums text-foreground">
+                  {nextDueCharge ? formatCompactCivilDayMonth(nextDueCharge.dueDate) : '—'}
+                </p>
+                {nextDueCharge ? (
+                  <p className="text-sm text-muted-foreground">
+                    {formatCurrency(nextDueCharge.amount, currency, getLocaleForCurrency(currency))}
+                  </p>
+                ) : null}
+              </Card>
+              <Card className="p-3">
+                <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Último pago</p>
+                <p className="mt-2 text-lg font-semibold tabular-nums text-foreground">
+                  {lastPayment ? formatCurrency(lastPayment.amount, lastPayment.currency, getLocaleForCurrency(lastPayment.currency)) : '—'}
+                </p>
+                {lastPayment ? (
+                  <p className="text-sm text-muted-foreground">
+                    {formatCompactCivilDayMonthYear(lastPayment.paidAt ?? lastPayment.createdAt)}
+                  </p>
+                ) : null}
+              </Card>
+            </div>
+
+            <Card className="p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-medium text-muted-foreground">Cargos próximos</p>
+                  <h2 className="text-lg font-semibold text-foreground">Lo que tenés por resolver</h2>
+                </div>
+                {pendingCharges.length > 0 ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="min-h-11 px-3"
+                    onClick={() => handleMobileTabChange('pending')}
+                  >
+                    Ver todos
+                  </Button>
+                ) : null}
+              </div>
+
+              {mobilePendingPreview.length === 0 ? (
+                <p className="mt-4 text-sm text-muted-foreground">No tenés cargos pendientes por ahora.</p>
+              ) : (
+                <div className="mt-4 space-y-3">
+                  {mobilePendingPreview.map((charge) => {
+                    const outstandingMinor = charge.amount - (charge.allocated ?? 0);
+                    const statusInfo = getMobileChargeStatusLabel(charge, todayCivilDate);
+                    const isOverdue = statusInfo.label === 'Vencido';
+
+                    return (
+                      <div
+                        key={charge.id}
+                        className={[
+                          'rounded-2xl border bg-card p-4',
+                          isOverdue ? 'border-amber-300 dark:border-amber-900/60' : 'border-border',
+                        ].join(' ')}
+                      >
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0 flex-1 space-y-1">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                              {formatCompactPeriodLabel(charge.period)}
+                            </p>
+                            <p className="line-clamp-2 text-sm font-medium text-foreground">{charge.concept}</p>
+                            <p className="text-xs text-muted-foreground">
+                              Vence {formatCompactCivilDayMonth(charge.dueDate)}
+                            </p>
+                          </div>
+                          <div className="shrink-0 text-right">
+                            <p className="text-base font-semibold tabular-nums text-foreground">
+                              {formatCurrency(outstandingMinor, charge.currency, getLocaleForCurrency(charge.currency))}
+                            </p>
+                            <div className="mt-2 flex justify-end">
+                              <Badge variant={statusInfo.variant}>{statusInfo.label}</Badge>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </Card>
+
+            {lastPayment ? (
+              <Card className="p-4">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-medium text-muted-foreground">Historial reciente</p>
+                    <h2 className="text-lg font-semibold text-foreground">Tu último movimiento</h2>
+                  </div>
+                  {payments.length > 0 ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      className="min-h-11 px-3"
+                      onClick={() => handleMobileTabChange('history')}
+                    >
+                      Ver historial
+                    </Button>
+                  ) : null}
+                </div>
+                <div className="mt-4 space-y-3">
+                  {mobileRecentPaymentsPreview.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">Todavía no tenés pagos registrados.</p>
+                  ) : (
+                    mobileRecentPaymentsPreview.map((payment) => {
+                      const proofDocumentId = payment.proofDocumentId;
+                      const receiptDocumentId = payment.receiptDocumentId;
+                      const rejectionReasonLabel = getPaymentRejectionReasonLabel(payment.rejectionReason);
+                      const hasReceipt = !!receiptDocumentId;
+                      const hasProof = !!proofDocumentId;
+                      const isReceiptTrackingPayment =
+                        payment.status === PaymentStatus.APPROVED ||
+                        payment.status === PaymentStatus.RECONCILED;
+                      const showReceiptGenerationState =
+                        isReceiptTrackingPayment &&
+                        !hasReceipt &&
+                        payment.receiptStatus === 'PENDING';
+                      const showReceiptErrorState =
+                        isReceiptTrackingPayment &&
+                        !hasReceipt &&
+                        payment.receiptStatus === 'FAILED';
+                      const downloadDisabled = downloadingDocumentId !== null;
+                      const paymentDate = formatCompactCivilDayMonthYear(payment.paidAt ?? payment.createdAt);
+                      const statusLabel = paymentStatusLabel(payment.status);
+
+                      return (
+                        <div key={payment.id} className="rounded-2xl border border-border bg-card p-4">
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="min-w-0 flex-1 space-y-1">
+                              <p className="text-base font-semibold tabular-nums text-foreground">
+                                {formatCurrency(payment.amount, payment.currency, getLocaleForCurrency(payment.currency))}
+                              </p>
+                              <p className="text-sm text-muted-foreground">
+                                {paymentDate} · {payment.method}
+                                {payment.reference ? ` · ${payment.reference}` : ''}
+                              </p>
+                              {payment.status === 'REJECTED' && (rejectionReasonLabel || payment.rejectionComment) && (
+                                <p className="line-clamp-2 text-sm text-red-700 dark:text-red-300">
+                                  {rejectionReasonLabel && <span className="font-medium">Motivo: {rejectionReasonLabel}</span>}
+                                  {rejectionReasonLabel && payment.rejectionComment ? ' — ' : null}
+                                  {payment.rejectionComment}
+                                </p>
+                              )}
+                              {showReceiptGenerationState && (
+                                <p className="text-sm text-muted-foreground">Recibo en generación</p>
+                              )}
+                              {showReceiptErrorState && (
+                                <p className="text-sm text-red-700 dark:text-red-300">
+                                  {payment.receiptError || 'No pudimos generar el recibo. La administración ya fue notificada.'}
+                                </p>
+                              )}
+                            </div>
+                            <Badge variant={paymentStatusVariant(payment.status)} className="shrink-0 whitespace-nowrap">
+                              {statusLabel}
+                            </Badge>
+                          </div>
+                          <div className="mt-3 flex flex-wrap gap-2">
+                            {hasProof ? (
+                              <button
+                                onClick={() => handleOpenDocument(proofDocumentId)}
+                                disabled={downloadDisabled}
+                                type="button"
+                                aria-label={`Ver comprobante del pago de ${formatCurrency(payment.amount, payment.currency, getLocaleForCurrency(payment.currency))}`}
+                                className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-border px-3 text-sm text-blue-600 hover:bg-blue-50 hover:text-blue-800 disabled:opacity-50"
+                              >
+                                {downloadingDocumentId === proofDocumentId ? (
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : (
+                                  <FileText className="h-4 w-4" />
+                                )}
+                                Ver comprobante
+                              </button>
+                            ) : payment.proofFileId ? (
+                              <span className="inline-flex min-h-11 items-center rounded-lg border border-amber-200 bg-amber-50 px-3 text-xs text-amber-700">
+                                Comprobante en procesamiento
+                              </span>
+                            ) : null}
+                            {hasReceipt ? (
+                              <button
+                                onClick={() => handleOpenDocument(receiptDocumentId)}
+                                disabled={downloadDisabled}
+                                type="button"
+                                aria-label={`Ver recibo del pago de ${formatCurrency(payment.amount, payment.currency, getLocaleForCurrency(payment.currency))}`}
+                                className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-border px-3 text-sm text-emerald-600 hover:bg-emerald-50 hover:text-emerald-800 disabled:opacity-50"
+                              >
+                                {downloadingDocumentId === receiptDocumentId ? (
+                                  <Loader2 className="h-4 w-4 animate-spin" />
+                                ) : (
+                                  <FileText className="h-4 w-4" />
+                                )}
+                                Ver recibo
+                              </button>
+                            ) : null}
+                          </div>
+                        </div>
+                      );
+                    })
+                  )}
+                </div>
+              </Card>
+            ) : null}
+          </div>
+        )}
+
+        {mobileTab === 'pending' && (
+          <div id="resident-payments-mobile-pending" role="tabpanel" aria-labelledby="resident-payments-mobile-pending-tab" className="space-y-3">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h2 className="text-lg font-semibold text-foreground">Cargos pendientes</h2>
+                <p className="text-sm text-muted-foreground">{sortedPendingCharges.length} cargos con saldo pendiente</p>
+              </div>
+              <Button
+                type="button"
+                onClick={openPaymentPanel}
+                className="min-h-11 gap-2"
+                aria-controls="resident-payments-mobile-panel"
+                aria-expanded={isPaymentPanelOpen}
+              >
+                <Upload size={16} />
+                Reportar pago
+              </Button>
+            </div>
+
+            {sortedPendingCharges.length === 0 ? (
+              <Card className="p-4">
+                <p className="text-sm text-muted-foreground">No tenés cargos pendientes por ahora.</p>
+              </Card>
+            ) : (
+              <div className="space-y-3">
+                {sortedPendingCharges.map((charge) => {
+                  const outstandingMinor = charge.amount - (charge.allocated ?? 0);
+                  const statusInfo = getMobileChargeStatusLabel(charge, todayCivilDate);
+                  const isOverdue = statusInfo.label === 'Vencido';
+
+                  return (
+                    <Card
+                      key={charge.id}
+                      className={[
+                        'p-4',
+                        isOverdue ? 'border-amber-300 dark:border-amber-900/60' : '',
+                      ].join(' ')}
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 flex-1 space-y-2">
+                          <div className="flex items-start justify-between gap-3">
+                            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                              {formatCompactPeriodLabel(charge.period)}
+                            </p>
+                            <Badge variant={statusInfo.variant}>{statusInfo.label}</Badge>
+                          </div>
+                          <p className="line-clamp-2 text-sm font-medium text-foreground">{charge.concept}</p>
+                          <p className="text-sm text-muted-foreground">
+                            Vence {formatCompactCivilDayMonth(charge.dueDate)}
+                          </p>
+                        </div>
+                        <div className="shrink-0 text-right">
+                          <p className="text-lg font-semibold tabular-nums text-foreground">
+                            {formatCurrency(outstandingMinor, charge.currency, getLocaleForCurrency(charge.currency))}
+                          </p>
+                          <p className="text-xs text-muted-foreground">
+                            Saldo pendiente
+                          </p>
+                        </div>
+                      </div>
+                    </Card>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        {mobileTab === 'history' && (
+          <div id="resident-payments-mobile-history" role="tabpanel" aria-labelledby="resident-payments-mobile-history-tab" className="space-y-3">
+            <div>
+              <h2 className="text-lg font-semibold text-foreground">Historial de pagos</h2>
+              <p className="text-sm text-muted-foreground">{sortedRecentPayments.length} pagos registrados</p>
+            </div>
+
+            {paymentsError ? (
+              <Card className="border-red-200 bg-red-50 p-4">
+                <p className="font-medium text-red-800">No pudimos cargar tu historial de pagos.</p>
+                <p className="mt-1 text-sm text-red-700">
+                  {paymentsErrorValue instanceof Error ? paymentsErrorValue.message : 'Intentá nuevamente en unos segundos.'}
+                </p>
+                <button
+                  type="button"
+                  onClick={() => refetchPayments()}
+                  className="mt-3 text-sm font-medium text-red-700 hover:underline"
+                >
+                  Reintentar
+                </button>
+              </Card>
+            ) : paymentsLoading ? (
+              <Skeleton className="h-32" />
+            ) : sortedRecentPayments.length === 0 ? (
+              <Card className="p-4">
+                <p className="text-sm text-muted-foreground">Todavía no tenés pagos registrados.</p>
+              </Card>
+            ) : (
+              <div className="space-y-3">
+                {sortedRecentPayments.map((payment) => {
+                  const proofDocumentId = payment.proofDocumentId;
+                  const receiptDocumentId = payment.receiptDocumentId;
+                  const rejectionReasonLabel = getPaymentRejectionReasonLabel(payment.rejectionReason);
+                  const hasReceipt = !!receiptDocumentId;
+                  const hasProof = !!proofDocumentId;
+                  const isReceiptTrackingPayment =
+                    payment.status === PaymentStatus.APPROVED ||
+                    payment.status === PaymentStatus.RECONCILED;
+                  const showReceiptGenerationState =
+                    isReceiptTrackingPayment &&
+                    !hasReceipt &&
+                    payment.receiptStatus === 'PENDING';
+                  const showReceiptErrorState =
+                    isReceiptTrackingPayment &&
+                    !hasReceipt &&
+                    payment.receiptStatus === 'FAILED';
+                  const downloadDisabled = downloadingDocumentId !== null;
+                  const paymentDate = formatCompactCivilDayMonthYear(payment.paidAt ?? payment.createdAt);
+                  const statusLabel = paymentStatusLabel(payment.status);
+
+                  return (
+                    <Card key={payment.id} className="p-4">
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 flex-1 space-y-1">
+                          <p className="text-base font-semibold tabular-nums text-foreground">
+                            {formatCurrency(payment.amount, payment.currency, getLocaleForCurrency(payment.currency))}
+                          </p>
+                          <p className="text-sm text-muted-foreground">
+                            {paymentDate} · {payment.method}
+                            {payment.reference ? ` · ${payment.reference}` : ''}
+                          </p>
+                          {payment.status === 'REJECTED' && (rejectionReasonLabel || payment.rejectionComment) && (
+                            <p className="line-clamp-2 text-sm text-red-700 dark:text-red-300">
+                              {rejectionReasonLabel && <span className="font-medium">Motivo: {rejectionReasonLabel}</span>}
+                              {rejectionReasonLabel && payment.rejectionComment ? ' — ' : null}
+                              {payment.rejectionComment}
+                            </p>
+                          )}
+                          {showReceiptGenerationState && (
+                            <p className="text-sm text-muted-foreground">Recibo en generación</p>
+                          )}
+                          {showReceiptErrorState && (
+                            <p className="text-sm text-red-700 dark:text-red-300">
+                              {payment.receiptError || 'No pudimos generar el recibo. La administración ya fue notificada.'}
+                            </p>
+                          )}
+                        </div>
+                        <Badge variant={paymentStatusVariant(payment.status)} className="shrink-0 whitespace-nowrap">
+                          {statusLabel}
+                        </Badge>
+                      </div>
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {hasProof ? (
+                          <button
+                            onClick={() => handleOpenDocument(proofDocumentId)}
+                            disabled={downloadDisabled}
+                            type="button"
+                            aria-label={`Ver comprobante del pago de ${formatCurrency(payment.amount, payment.currency, getLocaleForCurrency(payment.currency))}`}
+                            className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-border px-3 text-sm text-blue-600 hover:bg-blue-50 hover:text-blue-800 disabled:opacity-50"
+                          >
+                            {downloadingDocumentId === proofDocumentId ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <FileText className="h-4 w-4" />
+                            )}
+                            Ver comprobante
+                          </button>
+                        ) : payment.proofFileId ? (
+                          <span className="inline-flex min-h-11 items-center rounded-lg border border-amber-200 bg-amber-50 px-3 text-xs text-amber-700">
+                            Comprobante en procesamiento
+                          </span>
+                        ) : null}
+                        {hasReceipt ? (
+                          <button
+                            onClick={() => handleOpenDocument(receiptDocumentId)}
+                            disabled={downloadDisabled}
+                            type="button"
+                            aria-label={`Ver recibo del pago de ${formatCurrency(payment.amount, payment.currency, getLocaleForCurrency(payment.currency))}`}
+                            className="inline-flex min-h-11 items-center gap-1 rounded-lg border border-border px-3 text-sm text-emerald-600 hover:bg-emerald-50 hover:text-emerald-800 disabled:opacity-50"
+                          >
+                            {downloadingDocumentId === receiptDocumentId ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              <FileText className="h-4 w-4" />
+                            )}
+                            Ver recibo
+                          </button>
+                        ) : null}
+                      </div>
+                    </Card>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        )}
+
+        {isPaymentPanelOpen && (
+          <div
+            className="fixed inset-0 z-40 bg-black/50"
+            onClick={() => {
+              if (!submitting) {
+                closePaymentPanel();
+              }
+            }}
+            aria-hidden="true"
+          >
+            <div className="flex h-full items-end justify-center">
+              <div
+                id="resident-payments-mobile-panel"
+                ref={paymentPanelRef}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="resident-payments-mobile-panel-title"
+                className="flex h-[100dvh] w-full flex-col overflow-hidden rounded-t-2xl border border-border bg-card text-card-foreground shadow-2xl"
+                onClick={(event) => event.stopPropagation()}
+                onKeyDown={handlePaymentPanelKeyDown}
+              >
+                <div className="shrink-0 border-b border-border px-4 py-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 space-y-1">
+                      <p id="resident-payments-mobile-panel-title" className="text-lg font-semibold text-foreground">
+                        Reportar pago
+                      </p>
+                      <p className="line-clamp-2 text-sm text-muted-foreground">
+                        Cargá el comprobante y completá los datos del pago para enviarlo a revisión.
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (!submitting) {
+                          closePaymentPanel();
+                        }
+                      }}
+                      className="inline-flex size-11 items-center justify-center rounded-lg text-muted-foreground transition hover:bg-muted hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+                      aria-label="Cerrar reporte de pago"
+                    >
+                      ×
+                    </button>
+                  </div>
+                </div>
+
+                {renderPaymentFormSection('mobile', handleMobilePaymentFormCancel)}
+              </div>
+            </div>
+          </div>
+        )}
+
+        <PaymentConfirmDialog
+          isOpen={isConfirmOpen}
+          data={paymentToConfirm}
+          errorMessage={submitError}
+          isLoading={submitting}
+          onCancel={() => {
+            setIsConfirmOpen(false);
+            setPaymentToConfirm(null);
+            window.setTimeout(() => {
+              document.getElementById('resident-payment-submit-trigger')?.focus();
+            }, 0);
+          }}
+          onConfirm={handleConfirmPayment}
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6">
@@ -955,161 +1918,7 @@ export const ResidentPaymentsPage = () => {
       </Card>
 
       {/* Submit Payment Form */}
-      {showForm && (
-        <Card className="p-4">
-          <h3 className="font-semibold text-lg mb-4">Reportar nuevo pago</h3>
-          <form onSubmit={handleSubmitPayment} className="space-y-4">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label htmlFor="resident-payment-charge" className="block text-sm font-medium mb-1">
-                  Cargo pendiente
-                </label>
-                <Select
-                  id="resident-payment-charge"
-                  value={selectedChargeId}
-                  onChange={(e) => setFormData((current) => ({ ...current, selectedChargeId: e.target.value }))}
-                  disabled={pendingCharges.length === 0}
-                >
-                  {pendingCharges.length === 0 ? (
-                    <option value="">No tenés cargos pendientes</option>
-                  ) : (
-                    pendingCharges.map((charge) => {
-                      const outstandingMinor = charge.amount - (charge.allocated ?? 0);
-                      return (
-                        <option key={charge.id} value={charge.id}>
-                          {charge.concept} • Período {charge.period} • {formatCurrency(outstandingMinor, charge.currency, getLocaleForCurrency(charge.currency))}
-                        </option>
-                      );
-                    })
-                  )}
-                </Select>
-                {selectedCharge ? (
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Los pagos informados por residentes deben cubrir el saldo completo del período.
-                  </p>
-                ) : (
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    No hay cargos pendientes disponibles para reportar.
-                  </p>
-                )}
-                {selectedCharge ? (
-                  <div className="mt-3 rounded-lg border border-border bg-muted/40 p-3">
-                    <p className="text-xs uppercase tracking-wide text-muted-foreground">Monto a reportar</p>
-                    <p className="text-lg font-semibold">
-                      {formatCurrency(selectedChargeOutstandingMinor, selectedCharge.currency, getLocaleForCurrency(selectedCharge.currency))}
-                    </p>
-                  </div>
-                ) : null}
-              </div>
-              <div>
-                <label className="block text-sm font-medium mb-1" htmlFor={paymentMethodId}>Método de pago</label>
-                <Select id={paymentMethodId} value={PaymentMethod.TRANSFER} disabled>
-                  <option value={PaymentMethod.TRANSFER}>Transferencia bancaria</option>
-                </Select>
-                <p className="text-xs text-muted-foreground mt-1">
-                  Por ahora BuildingOS solo acepta reportes de pago por transferencia.
-                </p>
-              </div>
-            </div>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label htmlFor={paymentDateId} className="block text-sm font-medium mb-1">Fecha de pago</label>
-                <Input
-                  id={paymentDateId}
-                  type="date"
-                  value={formData.paidAt}
-                  onChange={(e) => setFormData({ ...formData, paidAt: e.target.value })}
-                />
-              </div>
-              <div>
-                <label htmlFor={paymentReferenceId} className="block text-sm font-medium mb-1">Referencia (opcional)</label>
-                <Input
-                  id={paymentReferenceId}
-                  type="text"
-                  value={formData.reference}
-                  onChange={(e) => setFormData({ ...formData, reference: e.target.value })}
-                  placeholder="Ej: Transferencia #12345"
-                />
-              </div>
-            </div>
-
-            <div>
-              <label htmlFor={paymentProofId} className="block text-sm font-medium mb-1">
-                Comprobante de pago {formData.method === PaymentMethod.TRANSFER && <span className="text-red-500">*</span>}
-              </label>
-              {formData.method === PaymentMethod.TRANSFER && !proofFile && (
-                <p className="text-xs text-amber-600 mb-2">Los pagos por transferencia requieren comprobante</p>
-              )}
-              <input
-                id={paymentProofId}
-                type="file"
-                accept=".pdf,image/jpeg,image/png"
-                onChange={handleFileChange}
-                className="block w-full text-sm text-muted-foreground
-                  file:mr-4 file:py-2 file:px-4
-                  file:rounded-md file:border-0
-                  file:text-sm file:font-medium
-                  file:bg-blue-50 file:text-blue-700
-                  hover:file:bg-blue-100"
-              />
-              {proofFile && (
-                <p className="text-sm text-green-600 mt-1 flex items-center gap-2">
-                  ✓ {proofFile.name} subido correctamente
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setProofFile(null);
-                      setProofFileId(null);
-                    }}
-                    className="text-red-500 hover:text-red-700 font-medium"
-                  >
-                    (Quitar)
-                  </button>
-                </p>
-              )}
-              {uploadingProof && (
-                <p className="text-sm text-blue-600 mt-1 flex items-center gap-2">
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                  Subiendo comprobante...
-                </p>
-              )}
-            </div>
-
-            {submitError && (
-              <div className="p-3 bg-red-50 border border-red-200 rounded-lg">
-                <p className="text-sm text-red-600" aria-live="polite">{submitError}</p>
-              </div>
-            )}
-
-            {submitSuccess && (
-              <div className="p-3 bg-green-50 border border-green-200 rounded-lg">
-                <p className="text-sm text-green-600" aria-live="polite">✓ Pago enviado exitosamente</p>
-              </div>
-            )}
-
-            <div className="flex gap-2">
-              <Button 
-                type="submit" 
-                disabled={submitting || !canSubmit} 
-                className="gap-2"
-                id="resident-payment-submit-trigger"
-              >
-                {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
-                {submitting
-                  ? 'Enviando...'
-                  : !selectedCharge
-                    ? 'Seleccioná un cargo'
-                    : !proofFile
-                      ? 'Subí el comprobante'
-                      : 'Enviar pago'}
-              </Button>
-              <Button type="button" variant="secondary" onClick={() => setShowForm(false)}>
-                Cancelar
-              </Button>
-            </div>
-          </form>
-        </Card>
-      )}
+      {showForm && renderPaymentFormSection('desktop', () => setShowForm(false))}
 
       <PaymentConfirmDialog
         isOpen={isConfirmOpen}


### PR DESCRIPTION
Closes #66

## Summary

- Improves the resident payments experience on mobile with compact summary, pending, and history views.
- Moves the payment report flow into an accessible mobile panel while preserving the desktop form.
- Keeps the financial workflow, permissions, and civil-date handling intact.
- Normalizes ISO timestamps in the mobile payment history without shifting the civil date.

## Changes

| File | Change |
|------|--------|
| `apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx` | Adds mobile responsive layout, shared payment form rendering, and panel behavior for small screens. |
| `apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx` | Extends coverage for responsive behavior, focus, panel interactions, timestamp normalization, and recent-history labeling. |

## Validation

- [x] Tests: `npm test -w apps/web -- --runInBand --no-coverage --runTestsByPath 'app/(tenant)/[tenantId]/resident/payments/page.test.tsx'` (1 suite, 28 tests PASS)
- [x] TypeScript: `npx tsc --noEmit -p apps/web/tsconfig.json` PASS
- [x] ESLint slice: `cd apps/web && npx eslint 'app/(tenant)/[tenantId]/resident/payments/page.tsx' 'app/(tenant)/[tenantId]/resident/payments/page.test.tsx' --max-warnings=0` PASS
- [x] Build: `npm run build -w apps/web` PASS
- [x] `git diff --check` PASS
- [x] Latest focused test run completed without act warnings
- [x] Responsive validation checked at 320x568, 375x812, 390x844, 430x932, and 1440x900

## Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran validation on the affected slice
- [x] Conventional commit format
- [x] No Co-Authored-By trailers
