### PR TITLE
fix(web): improve resident documents mobile experience

### DIFF
--- a/apps/web/app/(tenant)/[tenantId]/resident/documents/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/documents/page.test.tsx
@@ -370,9 +370,123 @@ describe('ResidentDocumentsPage', () => {
     expect(source).not.toContain('minio');
   });
 
+  it('keeps the context loading guard ahead of the desktop empty state', () => {
+    setMatchMedia(false);
+    mockedUseResidentContext.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    mockedUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+
+    render(<ResidentDocumentsPage />);
+
+    expect(screen.queryByText('No hay documentos disponibles para tu unidad.')).toBeNull();
+    expect(screen.queryByText('Sin unidad asignada')).toBeNull();
+    expect(document.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+    const lastQueryOptions = mockedUseQuery.mock.calls[mockedUseQuery.mock.calls.length - 1]?.[0] as {
+      enabled?: boolean;
+    };
+    expect(lastQueryOptions?.enabled).toBe(false);
+  });
+
+  it('keeps the missing unit guard ahead of the desktop empty state', () => {
+    setMatchMedia(false);
+    mockedUseResidentContext.mockReturnValue({
+      data: {
+        activeBuildingId: 'building-1',
+        activeUnitId: null,
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    mockedUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+
+    render(<ResidentDocumentsPage />);
+
+    expect(screen.getByText('Sin unidad asignada')).toBeTruthy();
+    expect(screen.queryByText('No hay documentos disponibles para tu unidad.')).toBeNull();
+    const lastQueryOptions = mockedUseQuery.mock.calls[mockedUseQuery.mock.calls.length - 1]?.[0] as {
+      enabled?: boolean;
+    };
+    expect(lastQueryOptions?.enabled).toBe(false);
+  });
+
   describe('Mobile layout', () => {
     beforeEach(() => {
       setMatchMedia(true);
+    });
+
+    it('keeps the context loading guard ahead of the mobile empty state', () => {
+      mockedUseResidentContext.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as never);
+      mockedUseQuery.mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as never);
+
+      render(<ResidentDocumentsPage />);
+
+      expect(screen.queryByText('No hay documentos disponibles para tu unidad.')).toBeNull();
+      expect(screen.queryByText('Sin unidad asignada')).toBeNull();
+      expect(document.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+      const lastQueryOptions = mockedUseQuery.mock.calls[mockedUseQuery.mock.calls.length - 1]?.[0] as {
+        enabled?: boolean;
+      };
+      expect(lastQueryOptions?.enabled).toBe(false);
+    });
+
+    it('keeps the missing unit guard before the mobile empty state', () => {
+      mockedUseResidentContext.mockReturnValue({
+        data: {
+          activeBuildingId: 'building-1',
+          activeUnitId: null,
+        },
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as never);
+      mockedUseQuery.mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as never);
+
+      render(<ResidentDocumentsPage />);
+
+      expect(screen.getByText('Sin unidad asignada')).toBeTruthy();
+      expect(screen.queryByText('No hay documentos disponibles para tu unidad.')).toBeNull();
+      const lastQueryOptions = mockedUseQuery.mock.calls[mockedUseQuery.mock.calls.length - 1]?.[0] as {
+        enabled?: boolean;
+      };
+      expect(lastQueryOptions?.enabled).toBe(false);
     });
 
     it('renders compact context without leaking the tenantId fallback', () => {
@@ -412,15 +526,21 @@ describe('ResidentDocumentsPage', () => {
       expect(screen.getByRole('button', { name: /Recibos de pago.*\(1\)/ }).getAttribute('aria-pressed')).toBe('false');
     });
 
-    it('groups receipt and proof documents only when they share the same payment id', () => {
+    it('groups receipt and proof documents only when they share the same payment id across months', () => {
       mockedUseQuery.mockReturnValue({
         data: [
           makeReceiptDocument(
-            { payment: { ...makeReceiptDocument().payment!, id: 'shared-payment', period: '2025-07' } },
+            {
+              createdAt: '2026-07-31T23:30:00.000Z',
+              payment: { ...makeReceiptDocument().payment!, id: 'shared-payment', period: null },
+            },
             'shared-payment',
           ),
           makeProofDocument(
-            { payment: { ...makeProofDocument().payment!, id: 'shared-payment', period: '2025-07' } },
+            {
+              createdAt: '2026-08-01T00:05:00.000Z',
+              payment: { ...makeProofDocument().payment!, id: 'shared-payment', period: null },
+            },
             'shared-payment',
           ),
           makeDocument({ id: 'document-2', title: 'Reglamento' }),
@@ -433,7 +553,7 @@ describe('ResidentDocumentsPage', () => {
 
       render(<ResidentDocumentsPage />);
 
-      expect(screen.getAllByText(/2 documentos/i).length).toBeGreaterThanOrEqual(1);
+      expect(screen.getAllByText(/2 documentos/i)).toHaveLength(1);
       expect(screen.getByRole('button', { name: /ver comprobante/i })).toBeTruthy();
       expect(screen.getByRole('button', { name: /ver recibo/i })).toBeTruthy();
       expect(screen.getByText('Reglamento')).toBeTruthy();
@@ -453,6 +573,25 @@ describe('ResidentDocumentsPage', () => {
       expect(screen.queryByText(/2 documentos/i)).toBeNull();
       expect(screen.getAllByRole('button', { name: /ver comprobante/i })).toHaveLength(1);
       expect(screen.getAllByRole('button', { name: /ver recibo/i })).toHaveLength(1);
+    });
+
+    it('keeps documents without payment ids independent even when they share the same month', () => {
+      mockedUseQuery.mockReturnValue({
+        data: [
+          makeDocument({ id: 'free-doc-1', title: 'Reglamento', createdAt: '2026-07-01T00:00:00.000Z' }),
+          makeDocument({ id: 'free-doc-2', title: 'Acta', createdAt: '2026-07-02T00:00:00.000Z' }),
+        ],
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as never);
+
+      render(<ResidentDocumentsPage />);
+
+      expect(screen.queryByText(/2 documentos/i)).toBeNull();
+      expect(screen.getByText('Reglamento')).toBeTruthy();
+      expect(screen.getByText('Acta')).toBeTruthy();
     });
 
     it('supports search and clear in the compact mobile view', () => {

--- a/apps/web/app/(tenant)/[tenantId]/resident/documents/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/documents/page.test.tsx
@@ -489,12 +489,12 @@ describe('ResidentDocumentsPage', () => {
       expect(lastQueryOptions?.enabled).toBe(false);
     });
 
-    it('renders compact context without leaking the tenantId fallback', () => {
+    it('does not render a second mobile context block', () => {
       mockedUseTenants.mockReturnValue({
         data: undefined,
       } as never);
       mockedUseQuery.mockReturnValue({
-        data: [],
+        data: [makeReceiptDocument()],
         isLoading: false,
         isError: false,
         error: null,
@@ -503,10 +503,11 @@ describe('ResidentDocumentsPage', () => {
 
       render(<ResidentDocumentsPage />);
 
-      expect(screen.getByText('Administración actual')).toBeTruthy();
-      expect(screen.queryByText('tenant-1')).toBeNull();
       expect(screen.getByText('Documentos')).toBeTruthy();
       expect(screen.getByText(/Consulta comprobantes, recibos y archivos de tu unidad\./i)).toBeTruthy();
+      expect(screen.queryByText('Contexto activo')).toBeNull();
+      expect(screen.queryByText('tenant-1')).toBeNull();
+      expect(screen.getByPlaceholderText(/Buscar por título/)).toBeTruthy();
     });
 
     it('keeps the filter bar horizontal and uses pressed toggles', () => {
@@ -592,6 +593,73 @@ describe('ResidentDocumentsPage', () => {
       expect(screen.queryByText(/2 documentos/i)).toBeNull();
       expect(screen.getByText('Reglamento')).toBeTruthy();
       expect(screen.getByText('Acta')).toBeTruthy();
+    });
+
+    it('orders payment periods descending and keeps general documents under Otros documentos', () => {
+      mockedUseQuery.mockReturnValue({
+        data: [
+          makeReceiptDocument(
+            {
+              id: 'doc-july',
+              title: 'Pago julio',
+              createdAt: '2026-07-31T23:30:00.000Z',
+              payment: { ...makeReceiptDocument().payment!, id: 'pay-july', period: '2026-07', reference: 'Julio' },
+            },
+            'pay-july',
+          ),
+          makeProofDocument(
+            {
+              id: 'doc-june',
+              title: 'Pago junio',
+              createdAt: '2026-06-15T12:00:00.000Z',
+              payment: { ...makeProofDocument().payment!, id: 'pay-june', period: '2026-06', reference: 'Junio' },
+            },
+            'pay-june',
+          ),
+          makeReceiptDocument(
+            {
+              id: 'doc-may',
+              title: 'Pago mayo',
+              createdAt: '2026-05-20T12:00:00.000Z',
+              payment: { ...makeReceiptDocument().payment!, id: 'pay-may', period: null, reference: null },
+            },
+            'pay-may',
+          ),
+          makeDocument({
+            id: 'free-doc-1',
+            title: 'Reglamento de convivencia',
+            createdAt: '2026-08-01T09:00:00.000Z',
+          }),
+          makeDocument({
+            id: 'free-doc-2',
+            title: 'Acta',
+            createdAt: '2026-04-01T09:00:00.000Z',
+          }),
+        ],
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as never);
+
+      render(<ResidentDocumentsPage />);
+
+      const sectionHeadings = screen.getAllByRole('heading', { level: 2 }).map((heading) => heading.textContent);
+      expect(sectionHeadings).toEqual([
+        'Julio de 2026',
+        'Junio de 2026',
+        'Mayo de 2026',
+        'Otros documentos',
+      ]);
+
+      const otherSection = screen.getByRole('heading', { name: 'Otros documentos' }).closest('section');
+      expect(otherSection).toBeTruthy();
+      const otherSectionTexts = otherSection
+        ? Array.from(otherSection.querySelectorAll('h3, p')).map((node) => node.textContent?.trim()).filter(Boolean)
+        : [];
+      expect(otherSectionTexts).toContain('Reglamento de convivencia');
+      expect(otherSectionTexts).toContain('Acta');
+      expect(otherSectionTexts.indexOf('Reglamento de convivencia')).toBeLessThan(otherSectionTexts.indexOf('Acta'));
     });
 
     it('supports search and clear in the compact mobile view', () => {

--- a/apps/web/app/(tenant)/[tenantId]/resident/documents/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/documents/page.test.tsx
@@ -54,6 +54,22 @@ const mockedUseQuery = jest.mocked(reactQuery.useQuery);
 const mockedListDocuments = jest.mocked(listDocuments);
 const mockedDownloadProtectedDocumentContent = jest.mocked(downloadProtectedDocumentContent);
 
+function setMatchMedia(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query: string) => ({
+      matches: query === '(max-width: 767px)' ? matches : !matches,
+      media: query,
+      onchange: null,
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+}
+
 function makeDocument(overrides: Partial<Document> = {}): Document {
   return {
     id: 'document-1',
@@ -79,7 +95,7 @@ function makeDocument(overrides: Partial<Document> = {}): Document {
   };
 }
 
-function makeReceiptDocument(overrides: Partial<Document> = {}): Document {
+function makeReceiptDocument(overrides: Partial<Document> = {}, paymentId = 'pay-1'): Document {
   return makeDocument({
     id: 'doc-receipt',
     title: 'Comprobante pago - transfer.pdf',
@@ -87,7 +103,7 @@ function makeReceiptDocument(overrides: Partial<Document> = {}): Document {
     functionalType: 'PAYMENT_RECEIPT',
     origin: 'GENERATED',
     payment: {
-      id: 'pay-1',
+      id: paymentId,
       amount: 500000,
       currency: 'UYU',
       status: 'APPROVED',
@@ -99,7 +115,7 @@ function makeReceiptDocument(overrides: Partial<Document> = {}): Document {
   });
 }
 
-function makeProofDocument(overrides: Partial<Document> = {}): Document {
+function makeProofDocument(overrides: Partial<Document> = {}, paymentId = 'pay-2'): Document {
   return makeDocument({
     id: 'doc-proof',
     title: 'Comprobante pago - BBVA.pdf',
@@ -107,7 +123,7 @@ function makeProofDocument(overrides: Partial<Document> = {}): Document {
     functionalType: 'PAYMENT_PROOF',
     origin: 'UPLOADED',
     payment: {
-      id: 'pay-2',
+      id: paymentId,
       amount: 350000,
       currency: 'UYU',
       status: 'SUBMITTED',
@@ -127,6 +143,7 @@ describe('ResidentDocumentsPage', () => {
     jest.useFakeTimers();
     jest.clearAllMocks();
     appendSpy = null;
+    setMatchMedia(false);
 
     mockedUseParams.mockReturnValue({ tenantId: 'tenant-1' } as never);
     mockedUseResidentContext.mockReturnValue({
@@ -351,6 +368,145 @@ describe('ResidentDocumentsPage', () => {
     expect(source).not.toContain('bucket');
     expect(source).not.toContain('objectKey');
     expect(source).not.toContain('minio');
+  });
+
+  describe('Mobile layout', () => {
+    beforeEach(() => {
+      setMatchMedia(true);
+    });
+
+    it('renders compact context without leaking the tenantId fallback', () => {
+      mockedUseTenants.mockReturnValue({
+        data: undefined,
+      } as never);
+      mockedUseQuery.mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as never);
+
+      render(<ResidentDocumentsPage />);
+
+      expect(screen.getByText('Administración actual')).toBeTruthy();
+      expect(screen.queryByText('tenant-1')).toBeNull();
+      expect(screen.getByText('Documentos')).toBeTruthy();
+      expect(screen.getByText(/Consulta comprobantes, recibos y archivos de tu unidad\./i)).toBeTruthy();
+    });
+
+    it('keeps the filter bar horizontal and uses pressed toggles', () => {
+      mockedUseQuery.mockReturnValue({
+        data: [makeReceiptDocument(), makeProofDocument(), makeDocument()],
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as never);
+
+      render(<ResidentDocumentsPage />);
+
+      const filterBar = screen.getByLabelText('Filtrar documentos');
+      expect(filterBar.className).toContain('overflow-x-auto');
+      expect(screen.getByRole('button', { name: /Todos.*\(3\)/ }).getAttribute('aria-pressed')).toBe('true');
+      expect(screen.getByRole('button', { name: /Recibos de pago.*\(1\)/ }).getAttribute('aria-pressed')).toBe('false');
+    });
+
+    it('groups receipt and proof documents only when they share the same payment id', () => {
+      mockedUseQuery.mockReturnValue({
+        data: [
+          makeReceiptDocument(
+            { payment: { ...makeReceiptDocument().payment!, id: 'shared-payment', period: '2025-07' } },
+            'shared-payment',
+          ),
+          makeProofDocument(
+            { payment: { ...makeProofDocument().payment!, id: 'shared-payment', period: '2025-07' } },
+            'shared-payment',
+          ),
+          makeDocument({ id: 'document-2', title: 'Reglamento' }),
+        ],
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as never);
+
+      render(<ResidentDocumentsPage />);
+
+      expect(screen.getAllByText(/2 documentos/i).length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByRole('button', { name: /ver comprobante/i })).toBeTruthy();
+      expect(screen.getByRole('button', { name: /ver recibo/i })).toBeTruthy();
+      expect(screen.getByText('Reglamento')).toBeTruthy();
+    });
+
+    it('keeps unrelated payment documents separate when their payment ids differ', () => {
+      mockedUseQuery.mockReturnValue({
+        data: [makeReceiptDocument(), makeProofDocument()],
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as never);
+
+      render(<ResidentDocumentsPage />);
+
+      expect(screen.queryByText(/2 documentos/i)).toBeNull();
+      expect(screen.getAllByRole('button', { name: /ver comprobante/i })).toHaveLength(1);
+      expect(screen.getAllByRole('button', { name: /ver recibo/i })).toHaveLength(1);
+    });
+
+    it('supports search and clear in the compact mobile view', () => {
+      mockedUseQuery.mockReturnValue({
+        data: [makeReceiptDocument(), makeDocument({ title: 'Reglamento de convivencia' })],
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as never);
+
+      render(<ResidentDocumentsPage />);
+
+      const input = screen.getByLabelText('Buscar documentos');
+      fireEvent.change(input, { target: { value: 'Reglamento' } });
+
+      expect(screen.queryByText('Comprobante pago - transfer.pdf')).toBeNull();
+      expect(screen.getByText('Reglamento de convivencia')).toBeTruthy();
+
+      fireEvent.click(screen.getByLabelText('Limpiar búsqueda'));
+      expect((screen.getByLabelText('Buscar documentos') as HTMLInputElement).value).toBe('');
+    });
+
+    it('keeps civil dates stable for ISO and date-only inputs', () => {
+      mockedUseQuery.mockReturnValue({
+        data: [
+          makeDocument({ id: 'date-only', title: 'Fecha civil', createdAt: '2026-07-24' }),
+          makeDocument({ id: 'iso-ts', title: 'Timestamp ISO', createdAt: '2026-07-24T00:00:00.000Z' }),
+        ],
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as never);
+
+      render(<ResidentDocumentsPage />);
+
+      expect(screen.getAllByText(/24 de jul de 2026/i).length).toBeGreaterThanOrEqual(2);
+      expect(screen.queryByText(/Fecha desconocida/i)).toBeNull();
+    });
+
+    it('shows a safe fallback for invalid dates', () => {
+      mockedUseQuery.mockReturnValue({
+        data: [makeDocument({ id: 'invalid-date', title: 'Sin fecha', createdAt: 'not-a-date' })],
+        isLoading: false,
+        isError: false,
+        error: null,
+        refetch: jest.fn(),
+      } as never);
+
+      render(<ResidentDocumentsPage />);
+
+      expect(screen.getByText(/Fecha desconocida/i)).toBeTruthy();
+    });
   });
 
   describe('Filter bar', () => {

--- a/apps/web/app/(tenant)/[tenantId]/resident/documents/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/documents/page.tsx
@@ -65,11 +65,220 @@ const PAYMENT_STATUS_VARIANTS: Record<string, BadgeVariant> = {
 };
 
 function formatDate(dateValue: string): string {
+  const civilDate = parseCivilDate(dateValue);
+  if (!civilDate) {
+    return 'Fecha desconocida';
+  }
+
   return new Intl.DateTimeFormat('es-AR', {
     day: '2-digit',
     month: 'short',
     year: 'numeric',
-  }).format(new Date(dateValue));
+    timeZone: 'UTC',
+  }).format(civilDate);
+}
+
+function parseCivilDate(dateValue: string | null | undefined): Date | null {
+  if (!dateValue || dateValue.trim() === '') return null;
+
+  const trimmed = dateValue.trim();
+  const civilDateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(trimmed);
+  if (civilDateMatch) {
+    const [, year, month, day] = civilDateMatch;
+    const date = new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)));
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  const date = new Date(trimmed);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatMonthLabel(monthValue: string): string {
+  const normalized = monthValue.trim();
+  const monthMatch = /^(\d{4})-(\d{2})$/.exec(normalized);
+  if (monthMatch) {
+    const [, year, month] = monthMatch;
+    const date = new Date(Date.UTC(Number(year), Number(month) - 1, 1));
+    const label = new Intl.DateTimeFormat('es-AR', {
+      month: 'long',
+      year: 'numeric',
+      timeZone: 'UTC',
+    }).format(date);
+    return label.charAt(0).toUpperCase() + label.slice(1);
+  }
+
+  const date = parseCivilDate(normalized);
+  if (!date) return normalized;
+  const label = new Intl.DateTimeFormat('es-AR', {
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(date);
+  return label.charAt(0).toUpperCase() + label.slice(1);
+}
+
+function useIsMobileViewport(): boolean {
+  return useSyncExternalStore(
+    (onStoreChange) => {
+      if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+        return () => {};
+      }
+
+      const mediaQueryList = window.matchMedia('(max-width: 767px)');
+      const handleChange = () => onStoreChange();
+
+      if (typeof mediaQueryList.addEventListener === 'function') {
+        mediaQueryList.addEventListener('change', handleChange);
+        return () => mediaQueryList.removeEventListener('change', handleChange);
+      }
+
+      mediaQueryList.addListener(handleChange);
+      return () => mediaQueryList.removeListener(handleChange);
+    },
+    () => {
+      if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+        return false;
+      }
+      return window.matchMedia('(max-width: 767px)').matches;
+    },
+    () => false,
+  );
+}
+
+type MobileDocumentItem =
+  | {
+      kind: 'bundle';
+      key: string;
+      paymentId: string;
+      title: string;
+      payment: NonNullable<Document['payment']>;
+      documents: Document[];
+      primaryDocument: Document;
+      sectionLabel: string;
+    }
+  | {
+      kind: 'document';
+      key: string;
+      document: Document;
+      sectionLabel: string;
+    };
+
+interface MobileDocumentSection {
+  key: string;
+  label: string;
+  items: MobileDocumentItem[];
+}
+
+function getDocumentSectionKey(document: Document): string {
+  if (document.payment?.period && /^\d{4}-\d{2}$/.test(document.payment.period.trim())) {
+    return `payment:${document.payment.period.trim()}`;
+  }
+
+  const parsedDate = parseCivilDate(document.createdAt);
+  if (!parsedDate) {
+    return 'unknown';
+  }
+
+  return `date:${parsedDate.getUTCFullYear()}-${String(parsedDate.getUTCMonth() + 1).padStart(2, '0')}`;
+}
+
+function getDocumentSectionLabel(document: Document): string {
+  if (document.payment?.period && /^\d{4}-\d{2}$/.test(document.payment.period.trim())) {
+    return formatMonthLabel(document.payment.period.trim());
+  }
+
+  return parseCivilDate(document.createdAt) ? formatMonthLabel(document.createdAt) : 'Documentos';
+}
+
+function getPaymentBundleTitle(payment: NonNullable<Document['payment']>, fallbackTitle: string): string {
+  if (payment.period && /^\d{4}-\d{2}$/.test(payment.period.trim())) {
+    return `Pago ${formatMonthLabel(payment.period.trim())}`;
+  }
+
+  if (payment.reference && payment.reference.trim() !== '') {
+    return payment.reference.trim();
+  }
+
+  return fallbackTitle;
+}
+
+function buildMobileDocumentSections(documents: Document[]): MobileDocumentSection[] {
+  const sectionMap = new Map<string, { label: string; items: MobileDocumentItem[]; bundleIndex: Map<string, number> }>();
+  const order: string[] = [];
+
+  for (const document of documents) {
+    const sectionKey = getDocumentSectionKey(document);
+    const sectionLabel = getDocumentSectionLabel(document);
+    let section = sectionMap.get(sectionKey);
+
+    if (!section) {
+      section = {
+        label: sectionLabel,
+        items: [],
+        bundleIndex: new Map<string, number>(),
+      };
+      sectionMap.set(sectionKey, section);
+      order.push(sectionKey);
+    }
+
+    if (document.functionalType && document.payment?.id) {
+      const bundleKey = document.payment.id;
+      const existingIndex = section.bundleIndex.get(bundleKey);
+
+      if (typeof existingIndex === 'number') {
+        const item = section.items[existingIndex];
+        if (item.kind === 'bundle') {
+          item.documents.push(document);
+          if (document.functionalType === 'PAYMENT_RECEIPT' && item.primaryDocument.functionalType !== 'PAYMENT_RECEIPT') {
+            item.primaryDocument = document;
+            item.title = getPaymentBundleTitle(document.payment, getSafeFileName(document));
+          }
+        }
+        continue;
+      }
+
+      const bundleItem: MobileDocumentItem = {
+        kind: 'bundle',
+        key: `bundle:${sectionKey}:${bundleKey}`,
+        paymentId: bundleKey,
+        title: getPaymentBundleTitle(document.payment, getSafeFileName(document)),
+        payment: document.payment,
+        documents: [document],
+        primaryDocument: document,
+        sectionLabel,
+      };
+      section.bundleIndex.set(bundleKey, section.items.length);
+      section.items.push(bundleItem);
+      continue;
+    }
+
+    section.items.push({
+      kind: 'document',
+      key: `document:${document.id}`,
+      document,
+      sectionLabel,
+    });
+  }
+
+  return order.map((key) => {
+    const section = sectionMap.get(key);
+    if (!section) return { key, label: 'Documentos', items: [] };
+    return {
+      key,
+      label: section.label,
+      items: section.items,
+    };
+  });
+}
+
+function getBundleActionLabel(document: Document): string {
+  if (document.functionalType === 'PAYMENT_RECEIPT') {
+    return 'Ver recibo';
+  }
+  if (document.functionalType === 'PAYMENT_PROOF') {
+    return 'Ver comprobante';
+  }
+  return 'Ver documento';
 }
 
 function formatFileSize(bytes?: number): string {
@@ -195,14 +404,23 @@ export default function ResidentDocumentsPage() {
   const [previewError, setPreviewError] = useState<string | null>(null);
 
   const { data: tenants } = useTenants();
-  const tenantName = tenants?.find((tenant) => tenant.id === tenantId)?.name ?? tenantId;
+  const tenantName = tenants?.find((tenant) => tenant.id === tenantId)?.name ?? 'Administración actual';
 
   const { data: context, isLoading: contextLoading } = useResidentContext(tenantId ?? null);
   const buildingId = context?.activeBuildingId;
   const unitId = context?.activeUnitId;
 
   const { data: contextOptions } = useContextOptions(tenantId ?? null);
+  const unitsForBuilding = buildingId ? contextOptions?.unitsByBuilding?.[buildingId] ?? [] : [];
   const buildingName = contextOptions?.buildings.find((building) => building.id === buildingId)?.name ?? null;
+  const unitName = buildingId && unitId
+    ? unitsForBuilding.find((unit) => unit.id === unitId)?.label ??
+      unitsForBuilding.find((unit) => unit.id === unitId)?.code ??
+      null
+    : null;
+  const isMobileViewport = useIsMobileViewport();
+  const mobileContextPrimaryLabel = [buildingName, unitName].filter(Boolean).join(' · ') || tenantName;
+  const mobileContextSecondaryLabel = mobileContextPrimaryLabel !== tenantName ? tenantName : null;
 
   useEffect(() => {
     return () => {
@@ -246,6 +464,8 @@ export default function ResidentDocumentsPage() {
     }
     return counts;
   }, [documents]);
+
+  const mobileSections = useMemo(() => buildMobileDocumentSections(filteredDocuments), [filteredDocuments]);
 
   const listErrorMessage = useMemo(() => {
     if (!docsError) return null;
@@ -408,6 +628,377 @@ export default function ResidentDocumentsPage() {
     );
     registerObjectUrl(objectUrl, DOWNLOAD_URL_REVOKE_DELAY_MS);
   };
+
+  const renderMobileDocumentCard = (document: Document) => {
+    const fileName = getSafeFileName(document);
+    const typeLabel = getDocumentTypeLabel(document);
+    const mimeType = getSafeMimeType(document);
+    const scopeLabel = getDocumentScopeLabel(document.buildingId ?? null, document.unitId ?? null);
+    const dateLabel = formatDate(document.createdAt);
+    const sizeLabel = getSafeSize(document);
+
+    return (
+      <Card key={document.id} className="overflow-hidden border-border/70 bg-background">
+        <button
+          type="button"
+          onClick={(e) => {
+            triggerButtonRef.current = e.currentTarget as HTMLButtonElement;
+            void handleViewDocument(document);
+          }}
+          aria-label={`Ver documento ${document.title}`}
+          className="flex w-full items-start gap-3 p-3 text-left transition hover:bg-muted/40 focus:outline-none focus:ring-2 focus:ring-blue-500/50"
+        >
+          <span className="text-xl" aria-hidden="true">
+            {getFileIcon(mimeType)}
+          </span>
+          <div className="min-w-0 flex-1 space-y-1">
+            <p className="truncate text-[15px] font-medium text-foreground" title={document.title}>
+              {document.title}
+            </p>
+            <p className="truncate text-xs text-muted-foreground" title={fileName}>
+              {typeLabel || document.category}
+              {' · '}
+              {scopeLabel}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {dateLabel}
+              {' · '}
+              {sizeLabel}
+            </p>
+          </div>
+          <span className="shrink-0 pt-0.5 text-sm font-medium text-blue-700 dark:text-blue-300">
+            Ver documento
+          </span>
+        </button>
+      </Card>
+    );
+  };
+
+  const renderMobileBundleCard = (_sectionLabel: string, bundle: MobileDocumentItem & { kind: 'bundle' }) => {
+    const payment = bundle.payment;
+    const actionDocs = Array.from(
+      new Map(
+        bundle.documents.map((document) => [getBundleActionLabel(document), document] as const),
+      ).entries(),
+    );
+    const paymentStatusLabel = payment.status ? PAYMENT_STATUS_LABELS[payment.status] ?? payment.status : null;
+    const amountLabel = formatCurrency(payment.amount, payment.currency);
+    const referenceLabel = payment.reference?.trim() || null;
+
+    return (
+      <Card key={bundle.key} className="overflow-hidden border-border/70 bg-background">
+        <div className="space-y-3 p-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 space-y-1">
+              <p className="text-lg font-semibold tabular-nums text-foreground">{amountLabel}</p>
+              <p className="truncate text-sm font-medium text-foreground" title={bundle.title}>
+                {bundle.title}
+              </p>
+            </div>
+            {paymentStatusLabel && (
+              <Badge variant={PAYMENT_STATUS_VARIANTS[payment.status] ?? 'muted'}>
+                {paymentStatusLabel}
+              </Badge>
+            )}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+            {referenceLabel && <span>Ref {referenceLabel}</span>}
+            <span>{bundle.documents.length} {bundle.documents.length === 1 ? 'documento' : 'documentos'}</span>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {actionDocs.map(([actionLabel, document]) => (
+              <button
+                key={document.id}
+                type="button"
+                onClick={(e) => {
+                  triggerButtonRef.current = e.currentTarget as HTMLButtonElement;
+                  void handleViewDocument(document);
+                }}
+                aria-label={`${actionLabel} ${document.title}`}
+                className="inline-flex min-h-11 items-center justify-center rounded-full border border-blue-200 bg-blue-50 px-3 text-sm font-medium text-blue-700 transition hover:bg-blue-100 dark:border-blue-900/60 dark:bg-blue-950/30 dark:text-blue-200"
+              >
+                {actionLabel}
+              </button>
+            ))}
+          </div>
+        </div>
+      </Card>
+    );
+  };
+
+  const previewDialog = previewDocument && (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-black/50 p-2 pb-[calc(env(safe-area-inset-bottom)+0.5rem)] sm:items-center sm:p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Vista de ${previewDocument.title}`}
+    >
+      <div
+        ref={dialogRef}
+        className="relative flex max-h-[min(92dvh,92svh)] w-full max-w-4xl flex-col overflow-hidden rounded-2xl bg-white shadow-xl dark:bg-slate-900 sm:max-h-[90vh]"
+      >
+        <div className="flex items-center justify-between gap-3 border-b px-4 py-3">
+          <div className="min-w-0 flex-1">
+            <h2 className="truncate text-lg font-medium" data-testid="modal-title">
+              {previewDocument.title}
+            </h2>
+            <p className="truncate text-sm text-muted-foreground">
+              {getSafeFileName(previewDocument)}
+              {previewDocument.payment?.period && ` — Período ${previewDocument.payment.period}`}
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void handleDownloadFromPreview()}
+              disabled={!previewContent}
+              className="inline-flex items-center gap-1 rounded bg-blue-600 px-3 py-1.5 text-sm text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <Download className="h-4 w-4" />
+              Descargar
+            </button>
+            <button
+              type="button"
+              onClick={handleClosePreview}
+              className="rounded p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600"
+              aria-label="Cerrar"
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-auto p-4">
+          {previewLoading && (
+            <div className="flex flex-col items-center justify-center py-16">
+              <Loader2 className="mb-4 h-8 w-8 animate-spin text-blue-600" />
+              <p className="text-sm text-muted-foreground">Cargando documento...</p>
+            </div>
+          )}
+
+          {previewError && (
+            <div className="flex flex-col items-center justify-center py-16">
+              <AlertCircle className="mb-4 h-8 w-8 text-red-500" />
+              <p className="text-sm text-red-600">{previewError}</p>
+              <button
+                type="button"
+                onClick={handleClosePreview}
+                className="mt-4 text-sm font-medium text-blue-600 hover:underline"
+              >
+                Cerrar
+              </button>
+            </div>
+          )}
+
+          {previewObjectUrl && previewDocument && (
+            <>
+              {previewDocument.file?.mimeType?.toLowerCase().startsWith('image/') ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={previewObjectUrl}
+                  alt={previewDocument.title}
+                  className="mx-auto max-h-[70vh] object-contain"
+                />
+              ) : previewDocument.file?.mimeType?.toLowerCase() === 'application/pdf' ? (
+                <iframe
+                  src={previewObjectUrl}
+                  title={previewDocument.title}
+                  className="h-[70vh] w-full border-0"
+                />
+              ) : (
+                <div className="flex flex-col items-center justify-center py-16">
+                  <FileText className="mb-4 h-12 w-12 text-muted-foreground" />
+                  <p className="text-sm text-muted-foreground">
+                    No se puede previsualizar este tipo de archivo.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => void handleDownloadFromPreview()}
+                    className="mt-4 text-sm font-medium text-blue-600 hover:underline"
+                  >
+                    Descargar archivo
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  if (isMobileViewport) {
+    return (
+      <div className="space-y-5">
+        <div className="space-y-2">
+          <h1 className="flex items-center gap-2 text-2xl font-semibold">
+            <FileText className="h-6 w-6" />
+            Documentos
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Consulta comprobantes, recibos y archivos de tu unidad.
+          </p>
+        </div>
+
+        <Card className="border-border/70 bg-muted/30 p-3 dark:bg-muted/20">
+          <div className="min-w-0 space-y-1">
+            <p className="text-sm font-semibold text-foreground">Contexto activo</p>
+            <p className="truncate text-sm font-medium text-foreground" title={mobileContextPrimaryLabel}>
+              {mobileContextPrimaryLabel}
+            </p>
+            {mobileContextSecondaryLabel && (
+              <p className="truncate text-xs text-muted-foreground" title={mobileContextSecondaryLabel}>
+                {mobileContextSecondaryLabel}
+              </p>
+            )}
+          </div>
+        </Card>
+
+        {listErrorMessage && (
+          <Card className="border-red-200 bg-red-50 p-3 dark:border-red-900/60 dark:bg-red-950/40">
+            <div className="flex items-start gap-2">
+              <AlertCircle className="mt-0.5 shrink-0 text-red-600 dark:text-red-400" size={18} />
+              <div className="space-y-1">
+                <p className="font-medium text-red-800 dark:text-red-200">No pudimos cargar los documentos</p>
+                <p className="text-sm text-red-700 dark:text-red-300">{listErrorMessage}</p>
+                <button
+                  type="button"
+                  onClick={() => void refetch()}
+                  className="text-sm font-medium text-red-700 hover:underline dark:text-red-300"
+                >
+                  Reintentar
+                </button>
+              </div>
+            </div>
+          </Card>
+        )}
+
+        {openError && (
+          <Card className="border-red-200 bg-red-50 p-3 dark:border-red-900/60 dark:bg-red-950/40">
+            <div className="flex items-start gap-2">
+              <AlertCircle className="mt-0.5 shrink-0 text-red-600 dark:text-red-400" size={18} />
+              <div className="space-y-1">
+                <p className="font-medium text-red-800 dark:text-red-200">
+                  {openErrorDocumentTitle
+                    ? `No pudimos abrir "${openErrorDocumentTitle}"`
+                    : 'No pudimos abrir el documento'}
+                </p>
+                <p className="text-sm text-red-700 dark:text-red-300">{openError}</p>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setOpenError(null);
+                    setOpenErrorDocumentTitle(null);
+                  }}
+                  className="text-sm font-medium text-red-700 hover:underline dark:text-red-300"
+                >
+                  Cerrar
+                </button>
+              </div>
+            </div>
+          </Card>
+        )}
+
+        {!docsLoading && documents.length > 0 && (
+          <div className="space-y-3">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <input
+                type="text"
+                aria-label="Buscar documentos"
+                placeholder="Buscar por título, referencia, recibo..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                className="h-11 w-full rounded-xl border bg-white py-2 pl-9 pr-10 text-sm outline-none focus:border-blue-400 focus:ring-2 focus:ring-blue-100"
+              />
+              {searchQuery && (
+                <button
+                  type="button"
+                  onClick={() => setSearchQuery('')}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1.5 text-muted-foreground hover:text-foreground"
+                  aria-label="Limpiar búsqueda"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+
+            <div
+              className="flex gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+              aria-label="Filtrar documentos"
+            >
+              {FUNCTIONAL_TYPE_FILTER_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  onClick={() => setTypeFilter(option.value)}
+                  aria-pressed={typeFilter === option.value}
+                  className={`inline-flex min-h-11 flex-none items-center gap-2 rounded-full px-4 py-2 text-sm transition ${
+                    typeFilter === option.value
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700'
+                  }`}
+                >
+                  <span>{option.label}</span>
+                  <span className="text-xs opacity-75">({documentCounts[option.value]})</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {docsLoading ? (
+          <div className="space-y-3">
+            {[1, 2, 3].map((index) => (
+              <Skeleton key={index} className="h-20 rounded-2xl" />
+            ))}
+          </div>
+        ) : documents.length === 0 ? (
+          <Card className="p-6 text-center">
+            <Folder className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">No hay documentos disponibles para tu unidad.</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Cuando la administración comparta documentos con tu unidad o edificio, los vas a ver acá.
+            </p>
+          </Card>
+        ) : filteredDocuments.length === 0 ? (
+          <Card className="p-6 text-center">
+            <Search className="mx-auto mb-3 h-10 w-10 text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">No se encontraron documentos con los filtros aplicados.</p>
+            <button
+              type="button"
+              onClick={() => {
+                setTypeFilter('ALL');
+                setSearchQuery('');
+              }}
+              className="mt-2 text-sm font-medium text-blue-600 hover:underline"
+            >
+              Limpiar filtros
+            </button>
+          </Card>
+        ) : (
+          <div className="space-y-4">
+            {mobileSections.map((section) => (
+              <section key={section.key} className="space-y-2">
+                <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">{section.label}</h2>
+                <div className="space-y-2">
+                  {section.items.map((item) => (
+                    item.kind === 'bundle'
+                      ? renderMobileBundleCard(section.label, item)
+                      : renderMobileDocumentCard(item.document)
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
+
+        {previewDialog}
+      </div>
+    );
+  }
 
   if (contextLoading) {
     return (
@@ -699,103 +1290,7 @@ export default function ResidentDocumentsPage() {
         </div>
       )}
 
-      {previewDocument && (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
-          role="dialog"
-          aria-modal="true"
-          aria-label={`Vista de ${previewDocument.title}`}
-        >
-          <div ref={dialogRef} className="relative mx-4 flex max-h-[90vh] w-full max-w-4xl flex-col rounded-lg bg-white shadow-xl">
-            <div className="flex items-center justify-between border-b px-4 py-3">
-              <div className="min-w-0 flex-1">
-                <h2 className="truncate text-lg font-medium" data-testid="modal-title">
-                  {previewDocument.title}
-                </h2>
-                <p className="truncate text-sm text-muted-foreground">
-                  {getSafeFileName(previewDocument)}
-                  {previewDocument.payment?.period && ` — Período ${previewDocument.payment.period}`}
-                </p>
-              </div>
-              <div className="flex shrink-0 items-center gap-2">
-                <button
-                  type="button"
-                  onClick={() => void handleDownloadFromPreview()}
-                  disabled={!previewContent}
-                  className="inline-flex items-center gap-1 rounded bg-blue-600 px-3 py-1.5 text-sm text-white transition hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  <Download className="h-4 w-4" />
-                  Descargar
-                </button>
-                <button
-                  type="button"
-                  onClick={handleClosePreview}
-                  className="rounded p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600"
-                  aria-label="Cerrar"
-                >
-                  <X className="h-5 w-5" />
-                </button>
-              </div>
-            </div>
-
-            <div className="flex-1 overflow-auto p-4">
-              {previewLoading && (
-                <div className="flex flex-col items-center justify-center py-16">
-                  <Loader2 className="mb-4 h-8 w-8 animate-spin text-blue-600" />
-                  <p className="text-sm text-muted-foreground">Cargando documento...</p>
-                </div>
-              )}
-
-              {previewError && (
-                <div className="flex flex-col items-center justify-center py-16">
-                  <AlertCircle className="mb-4 h-8 w-8 text-red-500" />
-                  <p className="text-sm text-red-600">{previewError}</p>
-                  <button
-                    type="button"
-                    onClick={handleClosePreview}
-                    className="mt-4 text-sm font-medium text-blue-600 hover:underline"
-                  >
-                    Cerrar
-                  </button>
-                </div>
-              )}
-
-              {previewObjectUrl && previewDocument && (
-                <>
-                  {previewDocument.file?.mimeType?.toLowerCase().startsWith('image/') ? (
-                    // eslint-disable-next-line @next/next/no-img-element
-                    <img
-                      src={previewObjectUrl}
-                      alt={previewDocument.title}
-                      className="mx-auto max-h-[70vh] object-contain"
-                    />
-                  ) : previewDocument.file?.mimeType?.toLowerCase() === 'application/pdf' ? (
-                    <iframe
-                      src={previewObjectUrl}
-                      title={previewDocument.title}
-                      className="h-[70vh] w-full border-0"
-                    />
-                  ) : (
-                    <div className="flex flex-col items-center justify-center py-16">
-                      <FileText className="mb-4 h-12 w-12 text-muted-foreground" />
-                      <p className="text-sm text-muted-foreground">
-                        No se puede previsualizar este tipo de archivo.
-                      </p>
-                      <button
-                        type="button"
-                        onClick={() => void handleDownloadFromPreview()}
-                        className="mt-4 text-sm font-medium text-blue-600 hover:underline"
-                      >
-                        Descargar archivo
-                      </button>
-                    </div>
-                  )}
-                </>
-              )}
-            </div>
-          </div>
-        </div>
-      )}
+      {previewDialog}
     </div>
   );
 }

--- a/apps/web/app/(tenant)/[tenantId]/resident/documents/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/documents/page.tsx
@@ -174,6 +174,9 @@ interface MobilePaymentBundle {
   payment: NonNullable<Document['payment']>;
   documents: Document[];
   primaryDocument: Document;
+  sectionKey: string;
+  sectionLabel: string;
+  sortKey: number;
 }
 
 function isPaymentDocument(document: Document): document is Document & {
@@ -183,26 +186,36 @@ function isPaymentDocument(document: Document): document is Document & {
   return Boolean(document.functionalType && document.payment?.id);
 }
 
-function getDocumentSectionKey(document: Document): string {
-  const sectionDate = parseCivilDate(document.createdAt);
-  if (!sectionDate) {
-    return 'unknown';
-  }
-
-  return `date:${sectionDate.getUTCFullYear()}-${String(sectionDate.getUTCMonth() + 1).padStart(2, '0')}`;
+function getYearMonthFromPeriod(periodValue: string | null | undefined): { year: number; month: number } | null {
+  if (!periodValue) return null;
+  const normalized = periodValue.trim();
+  const match = /^(\d{4})-(\d{2})$/.exec(normalized);
+  if (!match) return null;
+  const [, year, month] = match;
+  return {
+    year: Number(year),
+    month: Number(month),
+  };
 }
 
-function getDocumentSectionLabel(document: Document): string {
-  return parseCivilDate(document.createdAt) ? formatMonthLabel(document.createdAt) : 'Documentos';
+function getMonthOrderKey(year: number, month: number): number {
+  return year * 12 + month;
 }
 
-function getBundleSectionKey(bundle: MobilePaymentBundle): string {
+function getBundleSectionInfo(bundle: MobilePaymentBundle): { key: string; label: string; sortKey: number } {
   const explicitPeriod = bundle.documents
     .map((document) => document.payment?.period?.trim())
     .find((period): period is string => Boolean(period && /^\d{4}-\d{2}$/.test(period)));
 
   if (explicitPeriod) {
-    return `payment:${explicitPeriod}`;
+    const yearMonth = getYearMonthFromPeriod(explicitPeriod);
+    if (yearMonth) {
+      return {
+        key: `payment:${explicitPeriod}`,
+        label: formatMonthLabel(explicitPeriod),
+        sortKey: getMonthOrderKey(yearMonth.year, yearMonth.month),
+      };
+    }
   }
 
   const latestDocument = bundle.documents.reduce((latest, current) => {
@@ -211,25 +224,20 @@ function getBundleSectionKey(bundle: MobilePaymentBundle): string {
     return currentDate >= latestDate ? current : latest;
   });
 
-  return getDocumentSectionKey(latestDocument);
-}
-
-function getBundleSectionLabel(bundle: MobilePaymentBundle): string {
-  const explicitPeriod = bundle.documents
-    .map((document) => document.payment?.period?.trim())
-    .find((period): period is string => Boolean(period && /^\d{4}-\d{2}$/.test(period)));
-
-  if (explicitPeriod) {
-    return formatMonthLabel(explicitPeriod);
+  const latestDate = parseCivilDate(latestDocument.createdAt);
+  if (!latestDate) {
+    return {
+      key: 'payment:unknown',
+      label: 'Documentos',
+      sortKey: Number.NEGATIVE_INFINITY,
+    };
   }
 
-  const latestDocument = bundle.documents.reduce((latest, current) => {
-    const latestDate = parseCivilDate(latest.createdAt)?.getTime() ?? Number.NEGATIVE_INFINITY;
-    const currentDate = parseCivilDate(current.createdAt)?.getTime() ?? Number.NEGATIVE_INFINITY;
-    return currentDate >= latestDate ? current : latest;
-  });
-
-  return getDocumentSectionLabel(latestDocument);
+  return {
+    key: `payment:${latestDate.getUTCFullYear()}-${String(latestDate.getUTCMonth() + 1).padStart(2, '0')}`,
+    label: formatMonthLabel(latestDocument.createdAt),
+    sortKey: getMonthOrderKey(latestDate.getUTCFullYear(), latestDate.getUTCMonth() + 1),
+  };
 }
 
 function getPaymentBundleTitle(bundle: MobilePaymentBundle): string {
@@ -262,6 +270,9 @@ function buildMobileDocumentSections(documents: Document[]): MobileDocumentSecti
         payment: document.payment,
         documents: [document],
         primaryDocument: document,
+        sectionKey: '',
+        sectionLabel: '',
+        sortKey: Number.NEGATIVE_INFINITY,
       });
       continue;
     }
@@ -280,30 +291,29 @@ function buildMobileDocumentSections(documents: Document[]): MobileDocumentSecti
     }
   }
 
-  const sectionMap = new Map<string, { label: string; items: MobileDocumentItem[] }>();
-  const order: string[] = [];
+  const paymentSectionMap = new Map<string, { key: string; label: string; sortKey: number; items: MobileDocumentItem[] }>();
+  const otherDocuments: Document[] = [];
 
   for (const document of documents) {
-    const sectionKey = isPaymentDocument(document)
-      ? getBundleSectionKey(paymentBundles.get(document.payment.id)!)
-      : getDocumentSectionKey(document);
-    const sectionLabel = isPaymentDocument(document)
-      ? getBundleSectionLabel(paymentBundles.get(document.payment.id)!)
-      : getDocumentSectionLabel(document);
-    let section = sectionMap.get(sectionKey);
-
-    if (!section) {
-      section = {
-        label: sectionLabel,
-        items: [],
-      };
-      sectionMap.set(sectionKey, section);
-      order.push(sectionKey);
-    }
-
     if (isPaymentDocument(document)) {
       const bundle = paymentBundles.get(document.payment.id);
       if (!bundle) continue;
+
+      const sectionInfo = getBundleSectionInfo(bundle);
+      bundle.sectionKey = sectionInfo.key;
+      bundle.sectionLabel = sectionInfo.label;
+      bundle.sortKey = sectionInfo.sortKey;
+      let section = paymentSectionMap.get(sectionInfo.key);
+
+      if (!section) {
+        section = {
+          key: sectionInfo.key,
+          label: sectionInfo.label,
+          sortKey: sectionInfo.sortKey,
+          items: [],
+        };
+        paymentSectionMap.set(sectionInfo.key, section);
+      }
 
       if (section.items.some((item) => item.kind === 'bundle' && item.paymentId === bundle.paymentId)) {
         continue;
@@ -317,28 +327,69 @@ function buildMobileDocumentSections(documents: Document[]): MobileDocumentSecti
         payment: bundle.payment,
         documents: bundle.documents,
         primaryDocument: bundle.primaryDocument,
-        sectionLabel,
+        sectionLabel: section.label,
       });
       continue;
     }
 
-    section.items.push({
+    otherDocuments.push(document);
+  }
+
+  const paymentSections = Array.from(paymentSectionMap.values())
+    .sort((left, right) => {
+      if (right.sortKey !== left.sortKey) {
+        return right.sortKey - left.sortKey;
+      }
+      return left.label.localeCompare(right.label, 'es-AR');
+    })
+    .map((section) => ({
+      key: section.key,
+      label: section.label,
+      items: section.items.sort((left, right) => {
+        const leftTime =
+          (left.kind === 'bundle' ? parseCivilDate(left.primaryDocument.createdAt) : parseCivilDate(left.document.createdAt))?.getTime() ??
+          Number.NEGATIVE_INFINITY;
+        const rightTime =
+          (right.kind === 'bundle' ? parseCivilDate(right.primaryDocument.createdAt) : parseCivilDate(right.document.createdAt))?.getTime() ??
+          Number.NEGATIVE_INFINITY;
+
+        if (rightTime !== leftTime) {
+          return rightTime - leftTime;
+        }
+
+        const leftTitle = left.kind === 'bundle' ? left.title : left.document.title;
+        const rightTitle = right.kind === 'bundle' ? right.title : right.document.title;
+        return leftTitle.localeCompare(rightTitle, 'es-AR');
+      }),
+    }));
+
+  const otherSectionItems = otherDocuments
+    .sort((left, right) => {
+      const leftTime = parseCivilDate(left.createdAt)?.getTime() ?? Number.NEGATIVE_INFINITY;
+      const rightTime = parseCivilDate(right.createdAt)?.getTime() ?? Number.NEGATIVE_INFINITY;
+      if (rightTime !== leftTime) {
+        return rightTime - leftTime;
+      }
+      return left.title.localeCompare(right.title, 'es-AR');
+    })
+    .map<MobileDocumentItem>((document) => ({
       kind: 'document',
       key: `document:${document.id}`,
       document,
-      sectionLabel,
+      sectionLabel: 'Otros documentos',
+    }));
+
+  const sections: MobileDocumentSection[] = [...paymentSections];
+
+  if (otherSectionItems.length > 0) {
+    sections.push({
+      key: 'other-documents',
+      label: 'Otros documentos',
+      items: otherSectionItems,
     });
   }
 
-  return order.map((key) => {
-    const section = sectionMap.get(key);
-    if (!section) return { key, label: 'Documentos', items: [] };
-    return {
-      key,
-      label: section.label,
-      items: section.items,
-    };
-  });
+  return sections;
 }
 
 function getBundleActionLabel(document: Document): string {
@@ -481,16 +532,8 @@ export default function ResidentDocumentsPage() {
   const unitId = context?.activeUnitId;
 
   const { data: contextOptions } = useContextOptions(tenantId ?? null);
-  const unitsForBuilding = buildingId ? contextOptions?.unitsByBuilding?.[buildingId] ?? [] : [];
   const buildingName = contextOptions?.buildings.find((building) => building.id === buildingId)?.name ?? null;
-  const unitName = buildingId && unitId
-    ? unitsForBuilding.find((unit) => unit.id === unitId)?.label ??
-      unitsForBuilding.find((unit) => unit.id === unitId)?.code ??
-      null
-    : null;
   const isMobileViewport = useIsMobileViewport();
-  const mobileContextPrimaryLabel = [buildingName, unitName].filter(Boolean).join(' · ') || tenantName;
-  const mobileContextSecondaryLabel = mobileContextPrimaryLabel !== tenantName ? tenantName : null;
 
   useEffect(() => {
     return () => {
@@ -946,20 +989,6 @@ export default function ResidentDocumentsPage() {
             Consulta comprobantes, recibos y archivos de tu unidad.
           </p>
         </div>
-
-        <Card className="border-border/70 bg-muted/30 p-3 dark:bg-muted/20">
-          <div className="min-w-0 space-y-1">
-            <p className="text-sm font-semibold text-foreground">Contexto activo</p>
-            <p className="truncate text-sm font-medium text-foreground" title={mobileContextPrimaryLabel}>
-              {mobileContextPrimaryLabel}
-            </p>
-            {mobileContextSecondaryLabel && (
-              <p className="truncate text-xs text-muted-foreground" title={mobileContextSecondaryLabel}>
-                {mobileContextSecondaryLabel}
-              </p>
-            )}
-          </div>
-        </Card>
 
         {listErrorMessage && (
           <Card className="border-red-200 bg-red-50 p-3 dark:border-red-900/60 dark:bg-red-950/40">

--- a/apps/web/app/(tenant)/[tenantId]/resident/documents/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/documents/page.tsx
@@ -169,86 +169,156 @@ interface MobileDocumentSection {
   items: MobileDocumentItem[];
 }
 
-function getDocumentSectionKey(document: Document): string {
-  if (document.payment?.period && /^\d{4}-\d{2}$/.test(document.payment.period.trim())) {
-    return `payment:${document.payment.period.trim()}`;
-  }
+interface MobilePaymentBundle {
+  paymentId: string;
+  payment: NonNullable<Document['payment']>;
+  documents: Document[];
+  primaryDocument: Document;
+}
 
-  const parsedDate = parseCivilDate(document.createdAt);
-  if (!parsedDate) {
+function isPaymentDocument(document: Document): document is Document & {
+  functionalType: NonNullable<Document['functionalType']>;
+  payment: NonNullable<Document['payment']>;
+} {
+  return Boolean(document.functionalType && document.payment?.id);
+}
+
+function getDocumentSectionKey(document: Document): string {
+  const sectionDate = parseCivilDate(document.createdAt);
+  if (!sectionDate) {
     return 'unknown';
   }
 
-  return `date:${parsedDate.getUTCFullYear()}-${String(parsedDate.getUTCMonth() + 1).padStart(2, '0')}`;
+  return `date:${sectionDate.getUTCFullYear()}-${String(sectionDate.getUTCMonth() + 1).padStart(2, '0')}`;
 }
 
 function getDocumentSectionLabel(document: Document): string {
-  if (document.payment?.period && /^\d{4}-\d{2}$/.test(document.payment.period.trim())) {
-    return formatMonthLabel(document.payment.period.trim());
-  }
-
   return parseCivilDate(document.createdAt) ? formatMonthLabel(document.createdAt) : 'Documentos';
 }
 
-function getPaymentBundleTitle(payment: NonNullable<Document['payment']>, fallbackTitle: string): string {
-  if (payment.period && /^\d{4}-\d{2}$/.test(payment.period.trim())) {
-    return `Pago ${formatMonthLabel(payment.period.trim())}`;
+function getBundleSectionKey(bundle: MobilePaymentBundle): string {
+  const explicitPeriod = bundle.documents
+    .map((document) => document.payment?.period?.trim())
+    .find((period): period is string => Boolean(period && /^\d{4}-\d{2}$/.test(period)));
+
+  if (explicitPeriod) {
+    return `payment:${explicitPeriod}`;
   }
 
-  if (payment.reference && payment.reference.trim() !== '') {
-    return payment.reference.trim();
+  const latestDocument = bundle.documents.reduce((latest, current) => {
+    const latestDate = parseCivilDate(latest.createdAt)?.getTime() ?? Number.NEGATIVE_INFINITY;
+    const currentDate = parseCivilDate(current.createdAt)?.getTime() ?? Number.NEGATIVE_INFINITY;
+    return currentDate >= latestDate ? current : latest;
+  });
+
+  return getDocumentSectionKey(latestDocument);
+}
+
+function getBundleSectionLabel(bundle: MobilePaymentBundle): string {
+  const explicitPeriod = bundle.documents
+    .map((document) => document.payment?.period?.trim())
+    .find((period): period is string => Boolean(period && /^\d{4}-\d{2}$/.test(period)));
+
+  if (explicitPeriod) {
+    return formatMonthLabel(explicitPeriod);
   }
 
-  return fallbackTitle;
+  const latestDocument = bundle.documents.reduce((latest, current) => {
+    const latestDate = parseCivilDate(latest.createdAt)?.getTime() ?? Number.NEGATIVE_INFINITY;
+    const currentDate = parseCivilDate(current.createdAt)?.getTime() ?? Number.NEGATIVE_INFINITY;
+    return currentDate >= latestDate ? current : latest;
+  });
+
+  return getDocumentSectionLabel(latestDocument);
+}
+
+function getPaymentBundleTitle(bundle: MobilePaymentBundle): string {
+  const explicitPeriod = bundle.documents
+    .map((document) => document.payment?.period?.trim())
+    .find((period): period is string => Boolean(period && /^\d{4}-\d{2}$/.test(period)));
+
+  if (explicitPeriod) {
+    return `Pago ${formatMonthLabel(explicitPeriod)}`;
+  }
+
+  if (bundle.payment.reference && bundle.payment.reference.trim() !== '') {
+    return bundle.payment.reference.trim();
+  }
+
+  return getSafeFileName(bundle.primaryDocument);
 }
 
 function buildMobileDocumentSections(documents: Document[]): MobileDocumentSection[] {
-  const sectionMap = new Map<string, { label: string; items: MobileDocumentItem[]; bundleIndex: Map<string, number> }>();
+  const paymentBundles = new Map<string, MobilePaymentBundle>();
+
+  for (const document of documents) {
+    if (!isPaymentDocument(document)) continue;
+
+    const paymentId = document.payment.id;
+    const existingBundle = paymentBundles.get(paymentId);
+    if (!existingBundle) {
+      paymentBundles.set(paymentId, {
+        paymentId,
+        payment: document.payment,
+        documents: [document],
+        primaryDocument: document,
+      });
+      continue;
+    }
+
+    existingBundle.documents.push(document);
+
+    if (!existingBundle.payment.period && document.payment.period) {
+      existingBundle.payment = document.payment;
+    }
+
+    if (
+      document.functionalType === 'PAYMENT_RECEIPT' &&
+      existingBundle.primaryDocument.functionalType !== 'PAYMENT_RECEIPT'
+    ) {
+      existingBundle.primaryDocument = document;
+    }
+  }
+
+  const sectionMap = new Map<string, { label: string; items: MobileDocumentItem[] }>();
   const order: string[] = [];
 
   for (const document of documents) {
-    const sectionKey = getDocumentSectionKey(document);
-    const sectionLabel = getDocumentSectionLabel(document);
+    const sectionKey = isPaymentDocument(document)
+      ? getBundleSectionKey(paymentBundles.get(document.payment.id)!)
+      : getDocumentSectionKey(document);
+    const sectionLabel = isPaymentDocument(document)
+      ? getBundleSectionLabel(paymentBundles.get(document.payment.id)!)
+      : getDocumentSectionLabel(document);
     let section = sectionMap.get(sectionKey);
 
     if (!section) {
       section = {
         label: sectionLabel,
         items: [],
-        bundleIndex: new Map<string, number>(),
       };
       sectionMap.set(sectionKey, section);
       order.push(sectionKey);
     }
 
-    if (document.functionalType && document.payment?.id) {
-      const bundleKey = document.payment.id;
-      const existingIndex = section.bundleIndex.get(bundleKey);
+    if (isPaymentDocument(document)) {
+      const bundle = paymentBundles.get(document.payment.id);
+      if (!bundle) continue;
 
-      if (typeof existingIndex === 'number') {
-        const item = section.items[existingIndex];
-        if (item.kind === 'bundle') {
-          item.documents.push(document);
-          if (document.functionalType === 'PAYMENT_RECEIPT' && item.primaryDocument.functionalType !== 'PAYMENT_RECEIPT') {
-            item.primaryDocument = document;
-            item.title = getPaymentBundleTitle(document.payment, getSafeFileName(document));
-          }
-        }
+      if (section.items.some((item) => item.kind === 'bundle' && item.paymentId === bundle.paymentId)) {
         continue;
       }
 
-      const bundleItem: MobileDocumentItem = {
+      section.items.push({
         kind: 'bundle',
-        key: `bundle:${sectionKey}:${bundleKey}`,
-        paymentId: bundleKey,
-        title: getPaymentBundleTitle(document.payment, getSafeFileName(document)),
-        payment: document.payment,
-        documents: [document],
-        primaryDocument: document,
+        key: `bundle:${bundle.paymentId}`,
+        paymentId: bundle.paymentId,
+        title: getPaymentBundleTitle(bundle),
+        payment: bundle.payment,
+        documents: bundle.documents,
+        primaryDocument: bundle.primaryDocument,
         sectionLabel,
-      };
-      section.bundleIndex.set(bundleKey, section.items.length);
-      section.items.push(bundleItem);
+      });
       continue;
     }
 
@@ -829,6 +899,41 @@ export default function ResidentDocumentsPage() {
     </div>
   );
 
+  if (contextLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-48" />
+        <div className="grid gap-4">
+          {[1, 2, 3].map((index) => (
+            <Skeleton key={index} className="h-24" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (!buildingId || !unitId) {
+    return (
+      <div>
+        <h1 className="flex items-center gap-2 text-2xl font-semibold">
+          <FileText className="h-6 w-6" />
+          Documentos
+        </h1>
+        <p className="mt-1 text-muted-foreground">{tenantName}</p>
+
+        <Card className="mt-6 border-yellow-300 bg-yellow-50 p-4 dark:border-yellow-900/60 dark:bg-yellow-950/40">
+          <div className="flex items-center gap-2">
+            <AlertCircle className="text-yellow-600 dark:text-yellow-400" size={20} />
+            <div>
+              <p className="font-medium text-yellow-800 dark:text-yellow-200">Sin unidad asignada</p>
+              <p className="text-sm text-yellow-700 dark:text-yellow-300">Comunicate con la administración para que te asignen una unidad.</p>
+            </div>
+          </div>
+        </Card>
+      </div>
+    );
+  }
+
   if (isMobileViewport) {
     return (
       <div className="space-y-5">
@@ -996,41 +1101,6 @@ export default function ResidentDocumentsPage() {
         )}
 
         {previewDialog}
-      </div>
-    );
-  }
-
-  if (contextLoading) {
-    return (
-      <div className="space-y-6">
-        <Skeleton className="h-8 w-48" />
-        <div className="grid gap-4">
-          {[1, 2, 3].map((index) => (
-            <Skeleton key={index} className="h-24" />
-          ))}
-        </div>
-      </div>
-    );
-  }
-
-  if (!buildingId || !unitId) {
-    return (
-      <div>
-        <h1 className="flex items-center gap-2 text-2xl font-semibold">
-          <FileText className="h-6 w-6" />
-          Documentos
-        </h1>
-        <p className="mt-1 text-muted-foreground">{tenantName}</p>
-
-        <Card className="mt-6 border-yellow-300 bg-yellow-50 p-4 dark:border-yellow-900/60 dark:bg-yellow-950/40">
-          <div className="flex items-center gap-2">
-            <AlertCircle className="text-yellow-600 dark:text-yellow-400" size={20} />
-            <div>
-              <p className="font-medium text-yellow-800 dark:text-yellow-200">Sin unidad asignada</p>
-              <p className="text-sm text-yellow-700 dark:text-yellow-300">Comunicate con la administración para que te asignen una unidad.</p>
-            </div>
-          </div>
-        </Card>
       </div>
     );
   }


### PR DESCRIPTION
Closes #73

## Resumen

Mejora la experiencia móvil de Documentos del residente:

- compacta el contexto, buscador y filtros;
- presenta documentos mediante tarjetas móviles más breves;
- agrupa comprobante y recibo únicamente cuando existe una relación confiable;
- mueve metadata secundaria a un panel accesible;
- preserva búsqueda, filtros, permisos y apertura de archivos;
- conserva el comportamiento de escritorio.

## Validación

- Pruebas específicas: 1 suite, 65 tests PASS
- TypeScript web: PASS
- ESLint del slice: PASS
- Build web: PASS
- git diff --check: PASS
- Validación responsive automatizada con Playwright: no ejecutada porque Chromium no está instalado en el entorno
- No se instalaron dependencias ni navegadores adicionales
- La validación visual manual queda pendiente antes del merge
- Warnings act(...): no se observaron en el último run del slice

## Alcance

No modifica backend, Prisma, migraciones, seeds, RBAC, almacenamiento, infraestructura ni contratos API.