### PR TITLE
fix(api): sanitize resident user responses

### DIFF
--- a/apps/api/src/common/public-user.ts
+++ b/apps/api/src/common/public-user.ts
@@ -1,0 +1,27 @@
+import { Prisma } from '@prisma/client';
+
+export interface PublicUser {
+  readonly id: string;
+  readonly email: string;
+  readonly name: string;
+}
+
+export const publicUserSelect = Prisma.validator<Prisma.UserSelect>()({
+  id: true,
+  email: true,
+  name: true,
+});
+
+export function toPublicUser(
+  user: { id: string; email: string; name: string } | null | undefined,
+): PublicUser | undefined {
+  if (!user) {
+    return undefined;
+  }
+
+  return {
+    id: user.id,
+    email: user.email,
+    name: user.name,
+  };
+}

--- a/apps/api/src/documents/documents.service.spec.ts
+++ b/apps/api/src/documents/documents.service.spec.ts
@@ -23,6 +23,25 @@ function createPrismaKnownRequestError(code: string): Prisma.PrismaClientKnownRe
   return error as Prisma.PrismaClientKnownRequestError;
 }
 
+function expectNoPasswordHashDeep(value: unknown): void {
+  const seen = new Set<unknown>();
+  const visit = (current: unknown): void => {
+    if (current == null || typeof current !== 'object' || seen.has(current)) {
+      return;
+    }
+
+    seen.add(current);
+    expect(Object.prototype.hasOwnProperty.call(current, 'passwordHash')).toBe(false);
+
+    for (const nested of Object.values(current as Record<string, unknown>)) {
+      visit(nested);
+    }
+  };
+
+  visit(value);
+  expect(JSON.stringify(value)).not.toContain('passwordHash');
+}
+
 describe('DocumentsService', () => {
   const prisma = {
     $transaction: jest.fn(),
@@ -231,7 +250,235 @@ describe('DocumentsService', () => {
     expect(result.file.objectKey).toContain('expensas..julio.pdf');
   });
 
-  it('notifies admins instead of the uploading resident for payment proofs', async () => {
+  it('sanitizes createdByMembership.user in createDocument responses', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    prisma.file.create.mockResolvedValueOnce({ id: 'file-create' } as never);
+    prisma.document.create.mockResolvedValueOnce({
+      id: 'document-create',
+      tenantId: 'tenant-1',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      createdByMembership: {
+        id: 'membership-1',
+        userId: 'user-1',
+        user: {
+          id: 'user-1',
+          email: 'resident@example.com',
+          name: 'Resident One',
+          passwordHash: 'secret-create-hash',
+        },
+      },
+      file: { bucket: DEFAULT_BUCKET, objectKey: uploadFile.objectKey },
+    } as never);
+
+    const result = await service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'RESIDENTS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    });
+
+    expect(prisma.document.create).toHaveBeenCalledWith(expect.objectContaining({
+      include: {
+        file: true,
+        createdByMembership: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                email: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    }));
+    expect(result.createdByMembership?.user).toEqual({
+      id: 'user-1',
+      email: 'resident@example.com',
+      name: 'Resident One',
+    });
+    expectNoPasswordHashDeep(result);
+  });
+
+  it('sanitizes createdByMembership.user in listDocuments responses', async () => {
+    prisma.document.findMany.mockResolvedValueOnce([
+      {
+        id: 'document-list',
+        tenantId: 'tenant-1',
+        fileId: 'file-1',
+        title: 'Reglamento',
+        category: 'OTHER',
+        visibility: 'RESIDENTS',
+        buildingId: 'building-1',
+        unitId: 'unit-1',
+        createdByMembership: {
+          id: 'membership-1',
+          userId: 'user-1',
+          user: {
+            id: 'user-1',
+            email: 'resident@example.com',
+            name: 'Resident One',
+            passwordHash: 'secret-list-hash',
+          },
+        },
+        file: { bucket: DEFAULT_BUCKET, objectKey: 'tenant-tenant-1/documents/reglamento.pdf', originalName: 'reglamento.pdf', mimeType: 'application/pdf' },
+      },
+    ] as never);
+    prisma.payment.findMany.mockResolvedValueOnce([]);
+
+    const result = await service.listDocuments('tenant-1', 'resident-1', ['RESIDENT'], false);
+
+    expect(prisma.document.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      include: {
+        file: true,
+        createdByMembership: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                email: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    }));
+    expect(result[0].createdByMembership?.user).toEqual({
+      id: 'user-1',
+      email: 'resident@example.com',
+      name: 'Resident One',
+    });
+    expectNoPasswordHashDeep(result);
+  });
+
+  it('sanitizes createdByMembership.user in getDocument responses', async () => {
+    prisma.document.findFirst.mockResolvedValueOnce({
+      id: 'document-detail',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      visibility: 'RESIDENTS',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      createdByMembership: {
+        id: 'membership-1',
+        userId: 'user-1',
+        user: {
+          id: 'user-1',
+          email: 'resident@example.com',
+          name: 'Resident One',
+          passwordHash: 'secret-detail-hash',
+        },
+      },
+      file: { bucket: 'tenant-legacy-bucket', objectKey: 'receipt.pdf', originalName: 'receipt.pdf', mimeType: 'application/pdf' },
+    } as never);
+
+    const result = await service.getDocument('tenant-1', 'document-1', 'resident-1', ['RESIDENT'], false);
+
+    expect(prisma.document.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      include: {
+        file: true,
+        createdByMembership: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                email: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    }));
+    expect(result.createdByMembership?.user).toEqual({
+      id: 'user-1',
+      email: 'resident@example.com',
+      name: 'Resident One',
+    });
+    expectNoPasswordHashDeep(result);
+  });
+
+  it('sanitizes createdByMembership.user in updateDocument responses', async () => {
+    prisma.document.findFirst.mockResolvedValueOnce({
+      id: 'document-update',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      visibility: 'RESIDENTS',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      createdByMembership: {
+        id: 'membership-1',
+        userId: 'user-1',
+        user: {
+          id: 'user-1',
+          email: 'resident@example.com',
+          name: 'Resident One',
+          passwordHash: 'secret-update-hash',
+        },
+      },
+      file: { bucket: 'tenant-legacy-bucket', objectKey: 'receipt.pdf', originalName: 'receipt.pdf', mimeType: 'application/pdf' },
+    } as never);
+    prisma.document.update.mockResolvedValueOnce({
+      id: 'document-update',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      visibility: 'RESIDENTS',
+      title: 'Updated title',
+      category: 'RECEIPT',
+      createdByMembership: {
+        id: 'membership-1',
+        userId: 'user-1',
+        user: {
+          id: 'user-1',
+          email: 'resident@example.com',
+          name: 'Resident One',
+          passwordHash: 'secret-update-hash',
+        },
+      },
+      file: { bucket: 'tenant-legacy-bucket', objectKey: 'receipt.pdf', originalName: 'receipt.pdf', mimeType: 'application/pdf' },
+    } as never);
+
+    const result = await service.updateDocument('tenant-1', 'document-1', 'user-1', ['RESIDENT'], {
+      title: 'Updated title',
+    });
+
+    expect(prisma.document.update).toHaveBeenCalledWith(expect.objectContaining({
+      include: {
+        file: true,
+        createdByMembership: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                email: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    }));
+    expect(result.createdByMembership?.user).toEqual({
+      id: 'user-1',
+      email: 'resident@example.com',
+      name: 'Resident One',
+    });
+    expectNoPasswordHashDeep(result);
+  });
+
+  it('does not notify anyone for payment proofs', async () => {
     minio.objectExists.mockResolvedValue(true);
     minio.statObject.mockResolvedValue({ size: 1024 } as never);
     prisma.file.create.mockResolvedValueOnce({ id: 'file-proof' } as never);

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -7,7 +7,7 @@ import {
   PayloadTooLargeException,
   Logger,
 } from '@nestjs/common';
-import { Document, AuditAction } from '@prisma/client';
+import { AuditAction } from '@prisma/client';
 import { posix as pathPosix } from 'node:path';
 import type { Readable } from 'node:stream';
 import { PrismaService } from '../prisma/prisma.service';
@@ -21,23 +21,35 @@ import { UpdateDocumentDto } from './dto/update-document.dto';
 import { DocumentUploadPurpose } from './dto/presign-upload.dto';
 import {
   PresignedUrlResponse,
-  DocumentResponseDto,
   DocumentWithFileResponseDto,
   DownloadUrlResponseDto,
   DocumentPaymentMetadataDto,
 } from './dto';
 import { DocumentCategory, DocumentVisibility, Role, Prisma } from '@prisma/client';
+import { publicUserSelect, toPublicUser } from '../common/public-user';
 
 type DocumentNotificationTarget = Prisma.DocumentGetPayload<{
   include: {
     file: true;
     createdByMembership: {
       include: {
-        user: true;
+        user: {
+          select: typeof publicUserSelect;
+        };
       };
     };
   };
 }>;
+
+type DocumentWithPublicMembershipUser = {
+  createdByMembership?: {
+    user?: {
+      id: string;
+      email: string;
+      name: string;
+    } | null;
+  } | null;
+};
 
 type UnitOccupantNotificationRecipient = Prisma.UnitOccupantGetPayload<{
   include: {
@@ -276,7 +288,11 @@ export class DocumentsService {
           include: {
             file: true,
             createdByMembership: {
-              include: { user: true },
+              include: {
+                user: {
+                  select: publicUserSelect,
+                },
+              },
             },
           },
         });
@@ -312,7 +328,7 @@ export class DocumentsService {
       },
     });
 
-    return document as unknown as DocumentWithFileResponseDto;
+    return this.sanitizeDocumentResponse(document);
   }
 
   /**
@@ -395,7 +411,11 @@ export class DocumentsService {
       include: {
         file: true,
         createdByMembership: {
-          include: { user: true },
+          include: {
+            user: {
+              select: publicUserSelect,
+            },
+          },
         },
       },
       orderBy: { createdAt: 'desc' },
@@ -427,7 +447,9 @@ export class DocumentsService {
     // Enrich documents with payment metadata (batch, no N+1)
     const enriched = await this.enrichDocumentsWithPaymentMetadata(tenantId, documents);
 
-    return enriched as unknown as DocumentWithFileResponseDto[];
+    return enriched.map((document) =>
+      this.sanitizeDocumentResponse(document as DocumentWithPublicMembershipUser & Record<string, unknown>),
+    );
   }
 
   /**
@@ -447,7 +469,11 @@ export class DocumentsService {
       include: {
         file: true,
         createdByMembership: {
-          include: { user: true },
+          include: {
+            user: {
+              select: publicUserSelect,
+            },
+          },
         },
       },
     });
@@ -486,7 +512,7 @@ export class DocumentsService {
       );
     }
 
-    return document as unknown as DocumentWithFileResponseDto;
+    return this.sanitizeDocumentResponse(document);
   }
 
   /**
@@ -545,12 +571,16 @@ export class DocumentsService {
       include: {
         file: true,
         createdByMembership: {
-          include: { user: true },
+          include: {
+            user: {
+              select: publicUserSelect,
+            },
+          },
         },
       },
     });
 
-    return updated as unknown as DocumentWithFileResponseDto;
+    return this.sanitizeDocumentResponse(updated);
   }
 
   /**
@@ -1158,6 +1188,22 @@ export class DocumentsService {
         error instanceof Error ? error.stack : String(error),
       );
     }
+  }
+
+  private sanitizeDocumentResponse(
+    document: DocumentWithPublicMembershipUser & Record<string, unknown>,
+  ): DocumentWithFileResponseDto {
+    if (!document.createdByMembership) {
+      return document as unknown as DocumentWithFileResponseDto;
+    }
+
+    return {
+      ...document,
+      createdByMembership: {
+        ...document.createdByMembership,
+        user: toPublicUser(document.createdByMembership.user) ?? undefined,
+      },
+    } as unknown as DocumentWithFileResponseDto;
   }
 
 }

--- a/apps/api/src/occupants/occupants.service.spec.ts
+++ b/apps/api/src/occupants/occupants.service.spec.ts
@@ -1,0 +1,154 @@
+import { NotFoundException } from '@nestjs/common';
+import { OccupantsService } from './occupants.service';
+import { AuditService } from '../audit/audit.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { PlanEntitlementsService } from '../billing/plan-entitlements.service';
+import { AuthorizeService } from '../rbac/authorize.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+function expectNoPasswordHashDeep(value: unknown): void {
+  const seen = new Set<unknown>();
+  const visit = (current: unknown): void => {
+    if (current == null || typeof current !== 'object' || seen.has(current)) {
+      return;
+    }
+
+    seen.add(current);
+    expect(Object.prototype.hasOwnProperty.call(current, 'passwordHash')).toBe(false);
+
+    for (const nested of Object.values(current as Record<string, unknown>)) {
+      visit(nested);
+    }
+  };
+
+  visit(value);
+  expect(JSON.stringify(value)).not.toContain('passwordHash');
+}
+
+describe('OccupantsService', () => {
+  const prisma = {
+    unit: {
+      findFirst: jest.fn(),
+    },
+    unitOccupant: {
+      findMany: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+    },
+    tenantMember: {
+      findFirst: jest.fn(),
+      findUnique: jest.fn(),
+    },
+  } as unknown as jest.Mocked<PrismaService>;
+
+  const audit = {
+    createLog: jest.fn(),
+  } as unknown as jest.Mocked<AuditService>;
+
+  const notifications = {
+    createNotification: jest.fn(),
+  } as unknown as jest.Mocked<NotificationsService>;
+
+  const planEntitlements = {
+    assertLimit: jest.fn(),
+  } as unknown as jest.Mocked<PlanEntitlementsService>;
+
+  const authorizeService = {
+    authorize: jest.fn(),
+  } as unknown as jest.Mocked<AuthorizeService>;
+
+  const service = new OccupantsService(
+    prisma,
+    audit,
+    notifications,
+    planEntitlements,
+    authorizeService,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prisma.unit.findFirst.mockResolvedValue({ id: 'unit-1' } as never);
+    prisma.unitOccupant.findMany.mockResolvedValue([]);
+  });
+
+  it('selects only public user fields and strips passwordHash from occupant responses', async () => {
+    prisma.unitOccupant.findMany.mockResolvedValueOnce([
+      {
+        id: 'occupant-1',
+        tenantId: 'tenant-1',
+        unitId: 'unit-1',
+        memberId: 'member-1',
+        role: 'RESIDENT',
+        createdAt: new Date('2026-07-29T00:00:00.000Z'),
+        updatedAt: new Date('2026-07-29T00:00:00.000Z'),
+        member: {
+          id: 'member-1',
+          tenantId: 'tenant-1',
+          userId: 'user-1',
+          name: 'Resident One',
+          email: 'resident@example.com',
+          phone: '+584141111111',
+          role: 'RESIDENT',
+          status: 'ACTIVE',
+          disabledAt: null,
+          notes: null,
+          createdAt: new Date('2026-07-29T00:00:00.000Z'),
+          updatedAt: new Date('2026-07-29T00:00:00.000Z'),
+          user: {
+            id: 'user-1',
+            email: 'resident@example.com',
+            name: 'Resident One',
+            passwordHash: 'super-secret-hash',
+          },
+        },
+      },
+    ] as never);
+
+    const result = await service.findOccupants('tenant-1', 'building-1', 'unit-1');
+
+    expect(prisma.unitOccupant.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { unitId: 'unit-1' },
+        include: {
+          member: {
+            include: {
+              user: {
+                select: {
+                  id: true,
+                  email: true,
+                  name: true,
+                },
+              },
+            },
+          },
+        },
+      }),
+    );
+    expect(result[0].member?.user).toEqual({
+      id: 'user-1',
+      email: 'resident@example.com',
+      name: 'Resident One',
+    });
+    expectNoPasswordHashDeep(result);
+  });
+
+  it('preserves the occupant list shape while validating unit ownership', async () => {
+    const result = await service.findOccupants('tenant-1', 'building-1', 'unit-1');
+
+    expect(result).toEqual([]);
+    expect(prisma.unit.findFirst).toHaveBeenCalledWith({
+      where: { id: 'unit-1', building: { id: 'building-1', tenantId: 'tenant-1' } },
+    });
+    expectNoPasswordHashDeep(result);
+  });
+
+  it('rejects units outside the requested tenant/building scope', async () => {
+    prisma.unit.findFirst.mockResolvedValueOnce(null);
+
+    await expect(
+      service.findOccupants('tenant-1', 'building-1', 'unit-1'),
+    ).rejects.toBeInstanceOf(NotFoundException);
+
+    expect(prisma.unitOccupant.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/occupants/occupants.service.ts
+++ b/apps/api/src/occupants/occupants.service.ts
@@ -6,6 +6,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { PlanEntitlementsService } from '../billing/plan-entitlements.service';
 import { AuthorizeService } from '../rbac/authorize.service';
 import { CreateOccupantDto } from './dto/create-occupant.dto';
+import { publicUserSelect, toPublicUser } from '../common/public-user';
 
 type OccupantNotificationUnit = {
   id: string;
@@ -18,6 +19,18 @@ type OccupantNotificationUnit = {
 
 type OccupantWithRelations = UnitOccupant & {
   unit?: OccupantNotificationUnit | null;
+};
+
+type OccupantUserWithPublicFields = {
+  id: string;
+  email: string;
+  name: string;
+};
+
+type OccupantWithPublicMemberUser = UnitOccupant & {
+  member?: {
+    user?: OccupantUserWithPublicFields | null;
+  } | null;
 };
 
 @Injectable()
@@ -142,13 +155,17 @@ export class OccupantsService {
 
     return await this.prisma.unitOccupant.findMany({
       where: { unitId },
-      include: { 
+      include: {
         member: {
-          include: { user: true }
-        } 
+          include: {
+            user: {
+              select: publicUserSelect,
+            },
+          },
+        },
       },
       orderBy: { createdAt: 'desc' },
-    });
+    }).then((occupants) => occupants.map((occupant) => this.sanitizeOccupantUser(occupant)));
   }
 
   /**
@@ -262,5 +279,19 @@ export class OccupantsService {
         error instanceof Error ? error.stack : String(error),
       );
     }
+  }
+
+  private sanitizeOccupantUser(occupant: OccupantWithPublicMemberUser): UnitOccupant {
+    if (!occupant.member) {
+      return occupant;
+    }
+
+    return {
+      ...occupant,
+      member: {
+        ...occupant.member,
+        user: toPublicUser(occupant.member.user) ?? null,
+      },
+    } as unknown as UnitOccupant;
   }
 }


### PR DESCRIPTION
Closes #57

## Problema

Las respuestas de ocupantes y documentos utilizaban relaciones Prisma con `user: true`, lo que permitía que campos internos de `User`, incluido `passwordHash`, llegaran al JSON HTTP.

Los casts TypeScript a DTO no eliminaban propiedades en runtime.

## Solución

- reemplaza `user: true` por un `select` público explícito;
- expone únicamente `id`, `email` y `name`;
- agrega sanitización runtime defensiva;
- preserva los campos propios de `TenantMember`, incluido `phone`;
- mantiene permisos, scopes y contratos funcionales existentes;
- no modifica Prisma, base de datos ni frontend.

## Endpoints protegidos

- GET /tenants/:tenantId/buildings/:buildingId/units/:unitId/occupants
- POST /tenants/:tenantId/documents
- GET /tenants/:tenantId/documents
- GET /tenants/:tenantId/documents/:documentId
- PATCH /tenants/:tenantId/documents/:documentId

## Validación

- Tests focalizados API: 2 suites, 58 tests PASS
- TypeScript API: PASS
- TypeScript web: PASS
- ESLint de archivos API modificados: PASS
- Build API: PASS
- Build web: PASS
- git diff --check: PASS

Existe un `Unexpected any` preexistente en `apps/web/features/buildings/services/buildings.api.ts`. Ese archivo no fue modificado y el hallazgo queda fuera del alcance de este PR.

## Alcance

No modifica:

- Prisma schema;
- migraciones;
- base de datos;
- frontend;
- RBAC;
- scopes tenant/building/unit;
- infraestructura;
- staging;
- producción.