### PR TITLE
fix(api): enforce tenant-scoped access for unit ledger

### DIFF
--- a/apps/api/src/finanzas/finanzas-units.controller.spec.ts
+++ b/apps/api/src/finanzas/finanzas-units.controller.spec.ts
@@ -84,6 +84,11 @@ describe('FinanzasUnitsController', () => {
       '2026-02',
       ['TENANT_ADMIN'],
       'user-1',
+      expect.objectContaining({
+        id: 'membership-b',
+        tenantId: 'tenant-b',
+        roles: ['TENANT_ADMIN'],
+      }),
     );
     expect(request.tenantId).toBe('tenant-b');
     expect(request.user.tenantId).toBe('tenant-b');

--- a/apps/api/src/finanzas/finanzas-units.controller.spec.ts
+++ b/apps/api/src/finanzas/finanzas-units.controller.spec.ts
@@ -1,0 +1,112 @@
+import type { Role } from '@buildingos/contracts';
+import { FinanzasUnitsController } from './finanzas-units.controller';
+import { FinanzasService } from './finanzas.service';
+
+describe('FinanzasUnitsController', () => {
+  const finanzasService = {
+    getUnitLedger: jest.fn(),
+  } as unknown as jest.Mocked<FinanzasService>;
+
+  const controller = new FinanzasUnitsController(finanzasService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  function buildRequest(params: {
+    tenantIdHeader?: string;
+    tenantId?: string;
+    memberships: Array<{
+      id: string;
+      tenantId: string;
+      roles: Role[];
+    }>;
+    userId?: string;
+  }) {
+    return {
+      headers: params.tenantIdHeader
+        ? { 'x-tenant-id': params.tenantIdHeader }
+        : {},
+      tenantId: params.tenantId,
+      user: {
+        id: params.userId ?? 'user-1',
+        email: 'user@example.com',
+        name: 'User',
+        tenantId: params.tenantId,
+        roles: params.memberships[0]?.roles,
+        membershipId: params.memberships[0]?.id,
+        memberships: params.memberships,
+      },
+    } as never;
+  }
+
+  it('uses the exact membership for the requested tenant instead of the first one', async () => {
+    finanzasService.getUnitLedger.mockResolvedValue({
+      unitId: 'unit-1',
+      unitLabel: '101',
+      buildingId: 'building-1',
+      buildingName: 'Building A',
+      charges: [],
+      payments: [],
+      totals: {
+        totalCharges: 0,
+        totalPaid: 0,
+        totalOutstanding: 0,
+        currency: 'ARS',
+        balance: 0,
+      },
+    } as never);
+
+    const request = buildRequest({
+      tenantIdHeader: 'tenant-b',
+      memberships: [
+        {
+          id: 'membership-a',
+          tenantId: 'tenant-a',
+          roles: ['RESIDENT'],
+        },
+        {
+          id: 'membership-b',
+          tenantId: 'tenant-b',
+          roles: ['TENANT_ADMIN'],
+        },
+      ],
+    });
+
+    await expect(
+      controller.getUnitLedger('unit-1', '2026-01', '2026-02', request),
+    ).resolves.toEqual(expect.objectContaining({ unitId: 'unit-1' }));
+
+    expect(finanzasService.getUnitLedger).toHaveBeenCalledWith(
+      'tenant-b',
+      'unit-1',
+      '2026-01',
+      '2026-02',
+      ['TENANT_ADMIN'],
+      'user-1',
+    );
+    expect(request.tenantId).toBe('tenant-b');
+    expect(request.user.tenantId).toBe('tenant-b');
+    expect(request.user.membershipId).toBe('membership-b');
+    expect(request.user.roles).toEqual(['TENANT_ADMIN']);
+  });
+
+  it('denies access when the requested tenant is not present in the user memberships', async () => {
+    const request = buildRequest({
+      tenantIdHeader: 'tenant-b',
+      memberships: [
+        {
+          id: 'membership-a',
+          tenantId: 'tenant-a',
+          roles: ['TENANT_ADMIN'],
+        },
+      ],
+    });
+
+    await expect(
+      controller.getUnitLedger('unit-1', '' as never, '' as never, request),
+    ).rejects.toThrow('No tiene acceso al tenant tenant-b');
+
+    expect(finanzasService.getUnitLedger).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/finanzas/finanzas-units.controller.ts
+++ b/apps/api/src/finanzas/finanzas-units.controller.ts
@@ -99,6 +99,7 @@ export class FinanzasUnitsController {
       periodTo || undefined,
       userRoles,
       userId,
+      membership,
     );
   }
 }

--- a/apps/api/src/finanzas/finanzas-units.controller.ts
+++ b/apps/api/src/finanzas/finanzas-units.controller.ts
@@ -5,9 +5,14 @@ import {
   Query,
   UseGuards,
   Request,
+  BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
-import { AuthenticatedRequest } from '../common/types/request.types';
+import {
+  AuthenticatedMembership,
+  AuthenticatedRequest,
+} from '../common/types/request.types';
 import { FinanzasService } from './finanzas.service';
 
 /**
@@ -35,6 +40,34 @@ export class FinanzasUnitsController {
     return Array.isArray(tenantHeader) ? tenantHeader[0] : undefined;
   }
 
+  private resolveTenantMembership(
+    req: AuthenticatedRequest,
+  ): AuthenticatedMembership {
+    const tenantId =
+      req.tenantId ?? this.getTenantIdFromHeader(req) ?? req.user.tenantId;
+
+    if (!tenantId) {
+      throw new BadRequestException('Tenant ID not found in user context');
+    }
+
+    const membership = req.user.memberships?.find(
+      (item) => item.tenantId === tenantId,
+    );
+
+    if (!membership) {
+      throw new ForbiddenException(`No tiene acceso al tenant ${tenantId}`);
+    }
+
+    req.tenantId = tenantId;
+    req.user.tenantId = tenantId;
+    req.user.membershipId = membership.id;
+    req.user.roles = membership.roles;
+    req.user.role = membership.roles[0];
+    req.user.effectiveMembership = membership;
+
+    return membership;
+  }
+
   /**
    * GET /units/:unitId/ledger?periodFrom=&periodTo=
    * Get unit financial ledger
@@ -54,17 +87,10 @@ export class FinanzasUnitsController {
     @Query('periodTo') periodTo: string = '',
     @Request() req: AuthenticatedRequest,
   ) {
-    const tenantIdFromHeader = req.tenantId ?? this.getTenantIdFromHeader(req);
-    const tenantId =
-      (typeof tenantIdFromHeader === 'string' && tenantIdFromHeader) ||
-      req.user.tenantId ||
-      req.user.memberships?.[0]?.tenantId;
+    const membership = this.resolveTenantMembership(req);
+    const tenantId = membership.tenantId;
     const userId = req.user.id;
-    const userRoles = req.user.roles || [];
-
-    if (!tenantId) {
-      throw new Error('Tenant ID not found in user context');
-    }
+    const userRoles = membership.roles || [];
 
     return this.finanzasService.getUnitLedger(
       tenantId,

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -2921,6 +2921,222 @@ describe('FinanzasService', () => {
     });
   });
 
+  describe('getUnitLedger access control', () => {
+    const tenantId = 'tenant-1';
+    const buildingId = 'building-1';
+    const otherBuildingId = 'building-2';
+    const unitId = 'unit-1';
+    const otherUnitId = 'unit-2';
+
+    const mockLedgerBase = (ledgerUnitBuildingId = buildingId) => {
+      jest.spyOn(prismaService.tenant, 'findUniqueOrThrow').mockResolvedValue({
+        currency: 'ARS',
+      } as never);
+      jest.spyOn(prismaService.unit, 'findFirst').mockResolvedValue({
+        id: unitId,
+        building: { id: ledgerUnitBuildingId },
+      } as never);
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([] as never);
+      jest.spyOn(prismaService.payment, 'findMany').mockResolvedValue([] as never);
+    };
+
+    it('allows a tenant-scoped admin membership for the requested tenant', async () => {
+      mockLedgerBase();
+
+      await expect(
+        service.getUnitLedger(
+          tenantId,
+          unitId,
+          undefined,
+          undefined,
+          ['TENANT_ADMIN'],
+          'user-1',
+          {
+            id: 'membership-1',
+            tenantId,
+            roles: ['TENANT_ADMIN'],
+            scopedRoles: [],
+          } as never,
+        ),
+      ).resolves.toEqual(expect.objectContaining({
+        totals: expect.objectContaining({
+          currency: 'ARS',
+          balance: 0,
+        }),
+      }));
+
+      expect(validators.validateResidentUnitAccess).not.toHaveBeenCalled();
+    });
+
+    it('allows a building-scoped role only for the exact building', async () => {
+      mockLedgerBase();
+
+      await expect(
+        service.getUnitLedger(
+          tenantId,
+          unitId,
+          undefined,
+          undefined,
+          [],
+          'user-1',
+          {
+            id: 'membership-1',
+            tenantId,
+            roles: [],
+            scopedRoles: [
+              {
+                id: 'scope-1',
+                role: 'TENANT_ADMIN',
+                scopeType: ScopeType.BUILDING,
+                scopeBuildingId: buildingId,
+                scopeUnitId: null,
+              },
+            ],
+          } as never,
+        ),
+      ).resolves.toEqual(expect.objectContaining({
+        totals: expect.objectContaining({
+          balance: 0,
+        }),
+      }));
+
+      expect(prismaService.charge.findMany).toHaveBeenCalledTimes(1);
+      expect(prismaService.payment.findMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects a building-scoped role when the building does not match', async () => {
+      mockLedgerBase(otherBuildingId);
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([] as never);
+      jest.spyOn(prismaService.payment, 'findMany').mockResolvedValue([] as never);
+
+      await expect(
+        service.getUnitLedger(
+          tenantId,
+          unitId,
+          undefined,
+          undefined,
+          [],
+          'user-1',
+          {
+            id: 'membership-1',
+            tenantId,
+            roles: [],
+            scopedRoles: [
+              {
+                id: 'scope-1',
+                role: 'TENANT_ADMIN',
+                scopeType: ScopeType.BUILDING,
+                scopeBuildingId: buildingId,
+                scopeUnitId: null,
+              },
+            ],
+          } as never,
+        ),
+      ).rejects.toThrow('No tiene acceso al ledger de esta unidad');
+
+      expect(prismaService.charge.findMany).not.toHaveBeenCalled();
+      expect(prismaService.payment.findMany).not.toHaveBeenCalled();
+    });
+
+    it('allows a unit-scoped role only for the exact unit', async () => {
+      mockLedgerBase();
+
+      await expect(
+        service.getUnitLedger(
+          tenantId,
+          unitId,
+          undefined,
+          undefined,
+          [],
+          'user-1',
+          {
+            id: 'membership-1',
+            tenantId,
+            roles: [],
+            scopedRoles: [
+              {
+                id: 'scope-1',
+                role: 'OPERATOR',
+                scopeType: ScopeType.UNIT,
+                scopeBuildingId: null,
+                scopeUnitId: unitId,
+              },
+            ],
+          } as never,
+        ),
+      ).resolves.toEqual(expect.objectContaining({
+        totals: expect.objectContaining({
+          balance: 0,
+        }),
+      }));
+    });
+
+    it('rejects a unit-scoped role when the unit does not match', async () => {
+      mockLedgerBase();
+
+      await expect(
+        service.getUnitLedger(
+          tenantId,
+          otherUnitId,
+          undefined,
+          undefined,
+          [],
+          'user-1',
+          {
+            id: 'membership-1',
+            tenantId,
+            roles: [],
+            scopedRoles: [
+              {
+                id: 'scope-1',
+                role: 'OPERATOR',
+                scopeType: ScopeType.UNIT,
+                scopeBuildingId: null,
+                scopeUnitId: unitId,
+              },
+            ],
+          } as never,
+        ),
+      ).rejects.toThrow('No tiene acceso al ledger de esta unidad');
+
+      expect(prismaService.charge.findMany).not.toHaveBeenCalled();
+      expect(prismaService.payment.findMany).not.toHaveBeenCalled();
+    });
+
+    it('enforces resident access against the exact unit and building', async () => {
+      mockLedgerBase();
+      jest.spyOn(validators, 'validateResidentUnitAccess').mockResolvedValue();
+
+      await expect(
+        service.getUnitLedger(
+          tenantId,
+          unitId,
+          undefined,
+          undefined,
+          ['RESIDENT'],
+          'resident-1',
+          {
+            id: 'membership-1',
+            tenantId,
+            roles: ['RESIDENT'],
+            scopedRoles: [],
+          } as never,
+        ),
+      ).resolves.toEqual(expect.objectContaining({
+        totals: expect.objectContaining({
+          balance: 0,
+        }),
+      }));
+
+      expect(validators.validateResidentUnitAccess).toHaveBeenCalledWith(
+        tenantId,
+        'resident-1',
+        unitId,
+        buildingId,
+      );
+    });
+  });
+
   describe('listPendingPayments', () => {
     it('never grants a resident access through payment creator identity', async () => {
       jest.spyOn(validators, 'isResidentOrOwner').mockReturnValue(true);

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -1,13 +1,14 @@
-import { Injectable, ConflictException, NotFoundException, BadRequestException, Logger, PayloadTooLargeException } from '@nestjs/common';
+import { Injectable, ConflictException, NotFoundException, BadRequestException, Logger, PayloadTooLargeException, ForbiddenException } from '@nestjs/common';
 import { Charge, Payment, PaymentAllocation, Prisma, ChargeStatus, PaymentStatus, PaymentMethod, AuditAction, PaymentAuditAction, RejectionReason, ReceiptStatus, ScopeType } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { FinanzasValidators } from './finanzas.validators';
 import { PaymentReceiptService } from '../receipts/payment-receipt.service';
-import type { PortalContext } from '../common/types/request.types';
+import type { AuthenticatedMembership, PortalContext } from '../common/types/request.types';
 import { resolveNotificationPortalContext } from '../common/portal-context';
 import { ExpensesService } from './expenses.service';
+import type { Role, ScopedRole } from '@buildingos/contracts';
 import {
   CreateChargeDto,
   UpdateChargeDto,
@@ -93,6 +94,12 @@ type PaymentWithAllocations = Prisma.PaymentGetPayload<{
 
 const RESIDENT_DIRECTED_PAYMENT_PREFIX = 'resident-charge-selection-requires-resubmission';
 const PAYMENT_PROOF_MAX_BYTES = 10 * 1024 * 1024;
+const TENANT_LEDGER_ROLES = new Set<string>([
+  'SUPER_ADMIN',
+  'TENANT_OWNER',
+  'TENANT_ADMIN',
+  'OPERATOR',
+]);
 
 @Injectable()
 export class FinanzasService {
@@ -1868,6 +1875,7 @@ export class FinanzasService {
     periodTo?: string,
     userRoles?: string[],
     userId?: string,
+    membership?: AuthenticatedMembership,
   ): Promise<UnitLedgerDto> {
     // Load tenant to get currency
     const tenant = await this.prisma.tenant.findUniqueOrThrow({
@@ -1892,10 +1900,15 @@ export class FinanzasService {
       );
     }
 
-    // 2. For RESIDENT: validate unit access
-    if (userRoles && userId && this.validators.isResidentOrOwner(userRoles)) {
-      await this.validators.validateResidentUnitAccess(tenantId, userId, unitId);
-    }
+    // 2. Enforce exact tenant membership and scoped roles before loading ledger data
+    await this.assertUnitLedgerAccess({
+      tenantId,
+      unitId,
+      buildingId: unit.building.id,
+      userId,
+      userRoles,
+      membership,
+    });
 
     // 3. Build charge filters
     // IMPORTANT: debt must be calculated from approved/reconciled allocations,
@@ -2006,6 +2019,91 @@ export class FinanzasService {
         currency: tenant.currency,
       },
     };
+  }
+
+  private async assertUnitLedgerAccess(params: {
+    tenantId: string;
+    unitId: string;
+    buildingId: string;
+    userRoles?: readonly string[];
+    userId?: string;
+    membership?: AuthenticatedMembership;
+  }): Promise<void> {
+    const membership = this.resolveLedgerMembership(params);
+
+    if (membership.tenantId !== params.tenantId) {
+      throw new ForbiddenException(`No tiene acceso al tenant ${params.tenantId}`);
+    }
+
+    const tenantRoles = membership.roles ?? [];
+
+    if (tenantRoles.some((role) => this.isTenantLedgerRole(role))) {
+      return;
+    }
+
+    if (this.hasScopedLedgerAccess(membership.scopedRoles ?? [], params)) {
+      return;
+    }
+
+    if (tenantRoles.includes('RESIDENT')) {
+      if (!params.userId) {
+        throw new ForbiddenException('No tiene acceso al ledger de esta unidad');
+      }
+
+      await this.validators.validateResidentUnitAccess(
+        params.tenantId,
+        params.userId,
+        params.unitId,
+        params.buildingId,
+      );
+      return;
+    }
+
+    throw new ForbiddenException('No tiene acceso al ledger de esta unidad');
+  }
+
+  private resolveLedgerMembership(params: {
+    tenantId: string;
+    userRoles?: readonly string[];
+    membership?: AuthenticatedMembership;
+  }): AuthenticatedMembership {
+    if (params.membership) {
+      return params.membership;
+    }
+
+    return {
+      tenantId: params.tenantId,
+      roles: [...(params.userRoles ?? [])] as Role[],
+      scopedRoles: [],
+    };
+  }
+
+  private hasScopedLedgerAccess(
+    scopedRoles: readonly ScopedRole[],
+    params: {
+      buildingId: string;
+      unitId: string;
+    },
+  ): boolean {
+    return scopedRoles.some((role) => {
+      if (!this.isTenantLedgerRole(role.role)) {
+        return false;
+      }
+
+      if (role.scopeType === ScopeType.BUILDING) {
+        return role.scopeBuildingId === params.buildingId;
+      }
+
+      if (role.scopeType === ScopeType.UNIT) {
+        return role.scopeUnitId === params.unitId;
+      }
+
+      return false;
+    });
+  }
+
+  private isTenantLedgerRole(role: string): boolean {
+    return TENANT_LEDGER_ROLES.has(role);
   }
 
   /**


### PR DESCRIPTION
Closes #76\n\n## Summary\n\nEnforce exact tenant membership resolution for the unit ledger endpoint so X-Tenant-Id cannot be used to read another tenant's ledger, the first JWT membership is no longer used as a tenant shortcut, and building/unit-scoped roles are evaluated against the exact membership for the requested tenant.\n\n## Validation\n\n- Finanza unit ledger controller spec: PASS\n- Finanzas service access control spec: PASS\n- TypeScript API: PASS\n- ESLint API: PASS\n- API build: PASS\n- git diff --check: PASS