### PR TITLE
fix(api): scope resident communications to active tenant

### DIFF
--- a/apps/api/src/communications/communications-user.controller.spec.ts
+++ b/apps/api/src/communications/communications-user.controller.spec.ts
@@ -6,6 +6,7 @@ import {
 import { CommunicationsService } from './communications.service';
 import { CommunicationsValidators } from './communications.validators';
 import { ResidentAccessService } from '../resident-access/resident-access.service';
+import { PrismaService } from '../prisma/prisma.service';
 import type { AuthenticatedRequest } from '../common/types/request.types';
 
 const tenantId = 'tenant-1';
@@ -24,13 +25,14 @@ function buildReq(
       memberships: [{ tenantId, roles: ['RESIDENT'] }],
       ...overrides.user,
     },
-  } as unknown as AuthenticatedRequest;
+  } as AuthenticatedRequest;
 }
 
 describe('ResidentCommunicationsController', () => {
   let service: { findForResidentV2: jest.Mock; markAsReadForResident: jest.Mock };
   let validators: { validateCommunicationBelongsToTenant: jest.Mock };
   let residentAccess: { assertUnitAccess: jest.Mock };
+  let prisma: { tenantMember: { findFirst: jest.Mock } };
   let controller: ResidentCommunicationsController;
 
   beforeEach(() => {
@@ -40,10 +42,16 @@ describe('ResidentCommunicationsController', () => {
     };
     validators = { validateCommunicationBelongsToTenant: jest.fn().mockResolvedValue(undefined) };
     residentAccess = { assertUnitAccess: jest.fn().mockResolvedValue(undefined) };
+    prisma = {
+      tenantMember: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'tenant-member-1' }),
+      },
+    };
     controller = new ResidentCommunicationsController(
-      service as unknown as CommunicationsService,
-      validators as unknown as CommunicationsValidators,
-      residentAccess as unknown as ResidentAccessService,
+      service as CommunicationsService,
+      validators as CommunicationsValidators,
+      residentAccess as ResidentAccessService,
+      prisma as PrismaService,
     );
   });
 
@@ -72,6 +80,14 @@ describe('ResidentCommunicationsController', () => {
         10,
         undefined,
       );
+      expect(prisma.tenantMember.findFirst).toHaveBeenCalledWith({
+        where: {
+          tenantId,
+          userId,
+          disabledAt: null,
+        },
+        select: { id: true },
+      });
     });
 
     it('validates active occupancy via assertUnitAccess', async () => {
@@ -147,11 +163,22 @@ describe('ResidentCommunicationsController', () => {
 
       expect(service.findForResidentV2).not.toHaveBeenCalled();
     });
+
+    it('rejects a disabled membership before calling the service', async () => {
+      prisma.tenantMember.findFirst.mockResolvedValueOnce(null);
+      const req = buildReq();
+
+      await expect(
+        controller.getResidentCommunications({ buildingId, unitId, limit: 10 }, req),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(service.findForResidentV2).not.toHaveBeenCalled();
+    });
   });
 
   describe('markResidentAsRead', () => {
     it('requires X-Tenant-Id header', async () => {
-      const req = buildReq({ headers: { 'x-tenant-id': undefined as unknown as string } });
+      const req = buildReq({ headers: { 'x-tenant-id': undefined } });
 
       await expect(
         controller.markResidentAsRead(communicationId, req),
@@ -205,14 +232,14 @@ describe('ResidentCommunicationsController', () => {
 
       await expect(
         controller.markResidentAsRead(communicationId, req),
-      ).rejects.toThrow(BadRequestException);
+      ).rejects.toThrow(ForbiddenException);
 
       expect(validators.validateCommunicationBelongsToTenant).not.toHaveBeenCalled();
       expect(service.markAsReadForResident).not.toHaveBeenCalled();
     });
 
     it('does not call service when header is missing', async () => {
-      const req = buildReq({ headers: { 'x-tenant-id': undefined as unknown as string } });
+      const req = buildReq({ headers: { 'x-tenant-id': undefined } });
 
       await expect(
         controller.markResidentAsRead(communicationId, req),
@@ -228,9 +255,11 @@ describe('CommunicationsInboxController', () => {
   let service: { findForUser: jest.Mock; findOne: jest.Mock; markAsRead: jest.Mock };
   let validators: {
     validateBuildingBelongsToTenant: jest.Mock;
+    validateUnitBelongsToTenant: jest.Mock;
     validateCommunicationBelongsToTenant: jest.Mock;
     canUserReadCommunication: jest.Mock;
   };
+  let prisma: { tenantMember: { findFirst: jest.Mock } };
   let controller: CommunicationsInboxController;
 
   beforeEach(() => {
@@ -241,12 +270,19 @@ describe('CommunicationsInboxController', () => {
     };
     validators = {
       validateBuildingBelongsToTenant: jest.fn().mockResolvedValue(undefined),
+      validateUnitBelongsToTenant: jest.fn().mockResolvedValue(undefined),
       validateCommunicationBelongsToTenant: jest.fn().mockResolvedValue(undefined),
       canUserReadCommunication: jest.fn().mockResolvedValue(true),
     };
+    prisma = {
+      tenantMember: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'tenant-member-1' }),
+      },
+    };
     controller = new CommunicationsInboxController(
-      service as unknown as CommunicationsService,
-      validators as unknown as CommunicationsValidators,
+      service as CommunicationsService,
+      validators as CommunicationsValidators,
+      prisma as PrismaService,
     );
   });
 
@@ -275,6 +311,28 @@ describe('CommunicationsInboxController', () => {
         }),
       );
       expect(validators.validateBuildingBelongsToTenant).toHaveBeenCalledWith(tenantId, buildingId);
+      expect(prisma.tenantMember.findFirst).toHaveBeenCalledWith({
+        where: {
+          tenantId,
+          userId,
+          disabledAt: null,
+        },
+        select: { id: true },
+      });
+    });
+
+    it('rejects a unit that does not belong to the tenant', async () => {
+      validators.validateUnitBelongsToTenant.mockRejectedValueOnce(
+        new BadRequestException('Unit not found or does not belong to this tenant'),
+      );
+
+      const req = buildReq();
+
+      await expect(
+        controller.getInbox(req, buildingId, unitId, 'false'),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(service.findForUser).not.toHaveBeenCalled();
     });
 
     it('rejects a missing tenant header before calling the service', async () => {
@@ -298,17 +356,8 @@ describe('CommunicationsInboxController', () => {
     });
 
     it('rejects a disabled membership', async () => {
+      prisma.tenantMember.findFirst.mockResolvedValueOnce(null);
       const req = buildReq({
-        user: {
-          id: userId,
-          memberships: [
-            {
-              tenantId,
-              roles: ['RESIDENT'],
-              disabledAt: new Date().toISOString(),
-            },
-          ],
-        },
       });
 
       await expect(controller.getInbox(req)).rejects.toThrow(ForbiddenException);

--- a/apps/api/src/communications/communications-user.controller.spec.ts
+++ b/apps/api/src/communications/communications-user.controller.spec.ts
@@ -1,5 +1,6 @@
-import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
 import {
+  CommunicationsUserController,
   CommunicationsInboxController,
   ResidentCommunicationsController,
 } from './communications-user.controller';
@@ -251,6 +252,145 @@ describe('ResidentCommunicationsController', () => {
   });
 });
 
+describe('CommunicationsUserController', () => {
+  let service: {
+    findAll: jest.Mock;
+    findOne: jest.Mock;
+    createV2: jest.Mock;
+    publishV2: jest.Mock;
+  };
+  let validators: {
+    validateBuildingBelongsToTenant: jest.Mock;
+    validateCommunicationBelongsToTenant: jest.Mock;
+  };
+  let prisma: { tenantMember: { findFirst: jest.Mock } };
+  let controller: CommunicationsUserController;
+
+  beforeEach(() => {
+    service = {
+      findAll: jest.fn().mockResolvedValue([]),
+      findOne: jest.fn().mockResolvedValue({ id: communicationId }),
+      createV2: jest.fn().mockResolvedValue({ id: communicationId }),
+      publishV2: jest.fn().mockResolvedValue({ id: communicationId }),
+    };
+    validators = {
+      validateBuildingBelongsToTenant: jest.fn().mockResolvedValue(undefined),
+      validateCommunicationBelongsToTenant: jest.fn().mockResolvedValue(undefined),
+    };
+    prisma = {
+      tenantMember: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'tenant-member-1' }),
+      },
+    };
+    controller = new CommunicationsUserController(
+      service as CommunicationsService,
+      validators as CommunicationsValidators,
+      prisma as PrismaService,
+    );
+  });
+
+  it('lists tenant communications for an admin using the requested tenant', async () => {
+    const req = buildReq({
+      user: {
+        id: userId,
+        memberships: [
+          { tenantId: 'tenant-other', roles: ['RESIDENT'] },
+          { tenantId, roles: ['TENANT_ADMIN'] },
+        ],
+      },
+    });
+
+    await controller.listCommunications(req, buildingId, 'SENT');
+
+    expect(prisma.tenantMember.findFirst).toHaveBeenCalledWith({
+      where: {
+        tenantId,
+        userId,
+        disabledAt: null,
+      },
+      select: { id: true },
+    });
+    expect(validators.validateBuildingBelongsToTenant).toHaveBeenCalledWith(tenantId, buildingId);
+    expect(service.findAll).toHaveBeenCalledWith(tenantId, {
+      buildingId,
+      status: 'SENT',
+    });
+  });
+
+  it('rejects non-admin users before calling the list service', async () => {
+    const req = buildReq();
+
+    await expect(controller.listCommunications(req)).rejects.toThrow(ForbiddenException);
+
+    expect(service.findAll).not.toHaveBeenCalled();
+  });
+
+  it('gets communication detail for an admin tenant member', async () => {
+    const req = buildReq({
+      user: {
+        id: userId,
+        memberships: [{ tenantId, roles: ['TENANT_OWNER'] }],
+      },
+    });
+
+    await controller.getCommunication(communicationId, req);
+
+    expect(validators.validateCommunicationBelongsToTenant).toHaveBeenCalledWith(
+      tenantId,
+      communicationId,
+    );
+    expect(service.findOne).toHaveBeenCalledWith(tenantId, communicationId);
+  });
+
+  it('creates a tenant communication for an admin', async () => {
+    const req = buildReq({
+      user: {
+        id: userId,
+        memberships: [{ tenantId, roles: ['OPERATOR'] }],
+      },
+    });
+
+    await controller.createCommunication(
+      {
+        title: 'Maintenance notice',
+        body: 'Water shutdown tomorrow',
+        status: 'DRAFT',
+        priority: 'NORMAL',
+        scopeType: 'TENANT_ALL',
+      },
+      req,
+    );
+
+    expect(service.createV2).toHaveBeenCalledWith(
+      tenantId,
+      userId,
+      {
+        title: 'Maintenance notice',
+        body: 'Water shutdown tomorrow',
+        status: 'DRAFT',
+        priority: 'NORMAL',
+        scopeType: 'TENANT_ALL',
+        buildingId: undefined,
+        buildingIds: undefined,
+      },
+      false,
+    );
+  });
+
+  it('publishes a tenant communication for an admin', async () => {
+    const req = buildReq({
+      user: {
+        id: userId,
+        memberships: [{ tenantId, roles: ['TENANT_ADMIN'] }],
+      },
+    });
+
+    await controller.publishCommunication(communicationId, { sendWebPush: false }, req);
+
+    expect(service.publishV2).toHaveBeenCalledWith(tenantId, communicationId, false);
+  });
+});
+
 describe('CommunicationsInboxController', () => {
   let service: { findForUser: jest.Mock; findOne: jest.Mock; markAsRead: jest.Mock };
   let validators: {
@@ -298,7 +438,11 @@ describe('CommunicationsInboxController', () => {
         },
       });
 
-      await controller.getInbox(req, buildingId, unitId, 'false');
+      await controller.getInbox(req, {
+        buildingId,
+        unitId,
+        readOnly: 'false',
+      });
 
       expect(service.findForUser).toHaveBeenCalledWith(
         tenantId,
@@ -329,7 +473,11 @@ describe('CommunicationsInboxController', () => {
       const req = buildReq();
 
       await expect(
-        controller.getInbox(req, buildingId, unitId, 'false'),
+        controller.getInbox(req, {
+          buildingId,
+          unitId,
+          readOnly: 'false',
+        }),
       ).rejects.toThrow(BadRequestException);
 
       expect(service.findForUser).not.toHaveBeenCalled();
@@ -340,7 +488,7 @@ describe('CommunicationsInboxController', () => {
         headers: { 'x-tenant-id': undefined },
       });
 
-      await expect(controller.getInbox(req)).rejects.toThrow(BadRequestException);
+      await expect(controller.getInbox(req, {})).rejects.toThrow(BadRequestException);
 
       expect(service.findForUser).not.toHaveBeenCalled();
     });
@@ -350,17 +498,28 @@ describe('CommunicationsInboxController', () => {
         headers: { 'x-tenant-id': 'tenant-unknown' },
       });
 
-      await expect(controller.getInbox(req)).rejects.toThrow(ForbiddenException);
+      await expect(controller.getInbox(req, {})).rejects.toThrow(ForbiddenException);
 
       expect(service.findForUser).not.toHaveBeenCalled();
     });
 
     it('rejects a disabled membership', async () => {
       prisma.tenantMember.findFirst.mockResolvedValueOnce(null);
-      const req = buildReq({
-      });
+      const req = buildReq({});
 
-      await expect(controller.getInbox(req)).rejects.toThrow(ForbiddenException);
+      await expect(controller.getInbox(req, {})).rejects.toThrow(ForbiddenException);
+
+      expect(service.findForUser).not.toHaveBeenCalled();
+    });
+
+    it('rejects malformed inbox query parameters', async () => {
+      const req = buildReq();
+
+      await expect(
+        controller.getInbox(req, {
+          readOnly: 'maybe',
+        }),
+      ).rejects.toThrow(BadRequestException);
 
       expect(service.findForUser).not.toHaveBeenCalled();
     });
@@ -377,6 +536,17 @@ describe('CommunicationsInboxController', () => {
       );
 
       expect(validators.validateCommunicationBelongsToTenant).not.toHaveBeenCalled();
+      expect(service.findOne).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when the user did not receive the communication', async () => {
+      validators.canUserReadCommunication.mockResolvedValueOnce(false);
+      const req = buildReq();
+
+      await expect(controller.getCommunicationDetail(communicationId, req)).rejects.toThrow(
+        NotFoundException,
+      );
+
       expect(service.findOne).not.toHaveBeenCalled();
     });
 

--- a/apps/api/src/communications/communications-user.controller.spec.ts
+++ b/apps/api/src/communications/communications-user.controller.spec.ts
@@ -1,5 +1,8 @@
-import { BadRequestException } from '@nestjs/common';
-import { ResidentCommunicationsController } from './communications-user.controller';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import {
+  CommunicationsInboxController,
+  ResidentCommunicationsController,
+} from './communications-user.controller';
 import { CommunicationsService } from './communications.service';
 import { CommunicationsValidators } from './communications.validators';
 import { ResidentAccessService } from '../resident-access/resident-access.service';
@@ -12,7 +15,7 @@ const unitId = 'unit-1';
 const communicationId = 'comm-1';
 
 function buildReq(
-  overrides: Partial<{ headers: Record<string, string>; user: Record<string, unknown> }> = {},
+  overrides: Partial<{ headers: Record<string, string | undefined>; user: Record<string, unknown> }> = {},
 ): AuthenticatedRequest {
   return {
     headers: { 'x-tenant-id': tenantId, ...overrides.headers },
@@ -113,7 +116,7 @@ describe('ResidentCommunicationsController', () => {
 
       await expect(
         controller.getResidentCommunications({ buildingId, unitId, limit: 10 }, req),
-      ).rejects.toThrow(BadRequestException);
+      ).rejects.toThrow(ForbiddenException);
     });
 
     it('rejects query without buildingId', async () => {
@@ -217,6 +220,141 @@ describe('ResidentCommunicationsController', () => {
 
       expect(validators.validateCommunicationBelongsToTenant).not.toHaveBeenCalled();
       expect(service.markAsReadForResident).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('CommunicationsInboxController', () => {
+  let service: { findForUser: jest.Mock; findOne: jest.Mock; markAsRead: jest.Mock };
+  let validators: {
+    validateBuildingBelongsToTenant: jest.Mock;
+    validateCommunicationBelongsToTenant: jest.Mock;
+    canUserReadCommunication: jest.Mock;
+  };
+  let controller: CommunicationsInboxController;
+
+  beforeEach(() => {
+    service = {
+      findForUser: jest.fn().mockResolvedValue([]),
+      findOne: jest.fn().mockResolvedValue({}),
+      markAsRead: jest.fn().mockResolvedValue({ count: 1 }),
+    };
+    validators = {
+      validateBuildingBelongsToTenant: jest.fn().mockResolvedValue(undefined),
+      validateCommunicationBelongsToTenant: jest.fn().mockResolvedValue(undefined),
+      canUserReadCommunication: jest.fn().mockResolvedValue(true),
+    };
+    controller = new CommunicationsInboxController(
+      service as unknown as CommunicationsService,
+      validators as unknown as CommunicationsValidators,
+    );
+  });
+
+  describe('getInbox', () => {
+    it('uses X-Tenant-Id and ignores the first membership when resolving the tenant', async () => {
+      const req = buildReq({
+        user: {
+          id: userId,
+          memberships: [
+            { tenantId: 'tenant-other', roles: ['RESIDENT'] },
+            { tenantId, roles: ['RESIDENT'] },
+          ],
+        },
+      });
+
+      await controller.getInbox(req, buildingId, unitId, 'false');
+
+      expect(service.findForUser).toHaveBeenCalledWith(
+        tenantId,
+        userId,
+        ['RESIDENT'],
+        expect.objectContaining({
+          buildingId,
+          unitId,
+          readOnly: false,
+        }),
+      );
+      expect(validators.validateBuildingBelongsToTenant).toHaveBeenCalledWith(tenantId, buildingId);
+    });
+
+    it('rejects a missing tenant header before calling the service', async () => {
+      const req = buildReq({
+        headers: { 'x-tenant-id': undefined },
+      });
+
+      await expect(controller.getInbox(req)).rejects.toThrow(BadRequestException);
+
+      expect(service.findForUser).not.toHaveBeenCalled();
+    });
+
+    it('rejects a tenant that the user does not belong to', async () => {
+      const req = buildReq({
+        headers: { 'x-tenant-id': 'tenant-unknown' },
+      });
+
+      await expect(controller.getInbox(req)).rejects.toThrow(ForbiddenException);
+
+      expect(service.findForUser).not.toHaveBeenCalled();
+    });
+
+    it('rejects a disabled membership', async () => {
+      const req = buildReq({
+        user: {
+          id: userId,
+          memberships: [
+            {
+              tenantId,
+              roles: ['RESIDENT'],
+              disabledAt: new Date().toISOString(),
+            },
+          ],
+        },
+      });
+
+      await expect(controller.getInbox(req)).rejects.toThrow(ForbiddenException);
+
+      expect(service.findForUser).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getCommunicationDetail', () => {
+    it('does not call the service when the tenant header is missing', async () => {
+      const req = buildReq({
+        headers: { 'x-tenant-id': undefined },
+      });
+
+      await expect(controller.getCommunicationDetail(communicationId, req)).rejects.toThrow(
+        BadRequestException,
+      );
+
+      expect(validators.validateCommunicationBelongsToTenant).not.toHaveBeenCalled();
+      expect(service.findOne).not.toHaveBeenCalled();
+    });
+
+    it('uses the requested tenant and not memberships[0]', async () => {
+      const req = buildReq({
+        user: {
+          id: userId,
+          memberships: [
+            { tenantId: 'tenant-other', roles: ['RESIDENT'] },
+            { tenantId, roles: ['RESIDENT'] },
+          ],
+        },
+      });
+
+      await controller.getCommunicationDetail(communicationId, req);
+
+      expect(validators.validateCommunicationBelongsToTenant).toHaveBeenCalledWith(
+        tenantId,
+        communicationId,
+      );
+      expect(validators.canUserReadCommunication).toHaveBeenCalledWith(
+        tenantId,
+        userId,
+        communicationId,
+        ['RESIDENT'],
+      );
+      expect(service.findOne).toHaveBeenCalledWith(tenantId, communicationId);
     });
   });
 });

--- a/apps/api/src/communications/communications-user.controller.ts
+++ b/apps/api/src/communications/communications-user.controller.ts
@@ -2,7 +2,6 @@ import {
   Controller,
   Get,
   Post,
-  Patch,
   Param,
   UseGuards,
   Request,
@@ -11,14 +10,14 @@ import {
   BadRequestException,
   ForbiddenException,
   HttpCode,
-  UnprocessableEntityException,
+  NotFoundException,
 } from '@nestjs/common';
 import { z } from 'zod';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CommunicationsService } from './communications.service';
 import type { FindAllFilters, FindForUserFilters } from './communications.service';
 import { CommunicationsValidators } from './communications.validators';
-import { CommunicationStatus } from '@prisma/client';
+import type { CommunicationStatus } from '@prisma/client';
 import {
   ResidentCommunicationListResponse,
   CreateCommunicationRequestSchema,
@@ -32,7 +31,14 @@ import type {
 import { ResidentAccessService } from '../resident-access/resident-access.service';
 import { PrismaService } from '../prisma/prisma.service';
 
-const CommunicationStatusQuerySchema = z.enum(['DRAFT', 'SCHEDULED', 'SENT']);
+const CommunicationStatusValues = ['DRAFT', 'SCHEDULED', 'SENT'] as const satisfies readonly CommunicationStatus[];
+const CommunicationStatusQuerySchema = z.enum(CommunicationStatusValues);
+
+const ResidentInboxQuerySchema = z.object({
+  buildingId: z.string().trim().min(1).optional(),
+  unitId: z.string().trim().min(1).optional(),
+  readOnly: z.enum(['true', 'false']).optional(),
+});
 
 interface TenantMembershipContext {
   readonly tenantId: string;
@@ -42,7 +48,7 @@ interface TenantMembershipContext {
 async function resolveRequestedTenantMembership(
   req: AuthenticatedRequest,
   prisma: PrismaService,
-): TenantMembershipContext {
+): Promise<TenantMembershipContext> {
   const tenantHeader = req.headers['x-tenant-id'];
   const tenantId = Array.isArray(tenantHeader)
     ? tenantHeader[0]
@@ -165,7 +171,7 @@ export class CommunicationsUserController {
         throw new BadRequestException('Invalid communication status');
       }
 
-      filters.status = parsedStatus.data as CommunicationStatus;
+      filters.status = parsedStatus.data;
     }
 
     return await this.communicationsService.findAll(tenantId, filters);
@@ -273,6 +279,7 @@ export class CommunicationsUserController {
    * Requires: admin role + X-Tenant-Id header
    */
   @Post(':communicationId/publish')
+  @HttpCode(200)
   async publishCommunication(
     @Param('communicationId') communicationId: string,
     @Body() rawBody: unknown,
@@ -307,11 +314,10 @@ export class CommunicationsUserController {
  *
  * Routes:
  * - GET /me/communications - List communications for current user
- * - POST /me/communications/:communicationId/read - Mark communication as read
  *
  * Security:
  * 1. JwtAuthGuard: Requires valid JWT
-   * 2. X-Tenant-Id header is required and validated against the active JWT memberships
+ * 2. X-Tenant-Id header is required and validated against the active JWT memberships
  * 3. User can only see/interact with communications targeted to them
  *
  * RESIDENT Workflow:
@@ -346,13 +352,18 @@ export class CommunicationsInboxController {
   @Get()
   async getInbox(
     @Request() req: AuthenticatedRequest,
-    @Query('buildingId') buildingId?: string,
-    @Query('unitId') unitId?: string,
-    @Query('readOnly') readOnly?: string,
+    @Query() query: Record<string, unknown>,
   ) {
     const { tenantId, membership } = await resolveRequestedTenantMembership(req, this.prisma);
     const userId = req.user.id;
     const userRoles = membership.roles || [];
+
+    const parsedQuery = ResidentInboxQuerySchema.safeParse(query);
+    if (!parsedQuery.success) {
+      throw new BadRequestException('Invalid inbox query parameters');
+    }
+
+    const { buildingId, unitId, readOnly } = parsedQuery.data;
 
     // Validate building if provided
     const filters: FindForUserFilters & { unitId?: string } = {};
@@ -419,9 +430,7 @@ export class CommunicationsInboxController {
     );
 
     if (!canRead) {
-      throw new ForbiddenException(
-        'Communication not found or you do not have access to it',
-      );
+      throw new NotFoundException('Communication not found');
     }
 
     return await this.communicationsService.findOne(tenantId, communicationId);
@@ -430,7 +439,7 @@ export class CommunicationsInboxController {
 }
 
 /**
- * ResidentCommunicationsController: Public resident endpoints (/resident/communications)
+ * ResidentCommunicationsController: Protected resident endpoints (/resident/communications)
  *
  * Routes:
  * - GET /resident/communications - List communications for resident (inbox)
@@ -513,8 +522,9 @@ export class ResidentCommunicationsController {
    * Security:
    * 1. JwtAuthGuard: Requires valid JWT token
    * 2. X-Tenant-Id header: Required, validated against user memberships
-   */
+  */
   @Post('communications/:communicationId/read')
+  @HttpCode(200)
   async markResidentAsRead(
     @Param('communicationId') communicationId: string,
     @Request() req: AuthenticatedRequest,

--- a/apps/api/src/communications/communications-user.controller.ts
+++ b/apps/api/src/communications/communications-user.controller.ts
@@ -13,6 +13,7 @@ import {
   HttpCode,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import { z } from 'zod';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { CommunicationsService } from './communications.service';
 import type { FindAllFilters, FindForUserFilters } from './communications.service';
@@ -24,20 +25,23 @@ import {
   PublishCommunicationRequestSchema,
   ResidentCommunicationsQuerySchema,
 } from '@buildingos/contracts';
-import type { AuthenticatedRequest } from '../common/types/request.types';
+import type {
+  AuthenticatedMembership,
+  AuthenticatedRequest,
+} from '../common/types/request.types';
 import { ResidentAccessService } from '../resident-access/resident-access.service';
+import { PrismaService } from '../prisma/prisma.service';
+
+const CommunicationStatusQuerySchema = z.enum(['DRAFT', 'SCHEDULED', 'SENT']);
 
 interface TenantMembershipContext {
   readonly tenantId: string;
-  readonly membership: {
-    readonly tenantId: string;
-    readonly roles?: string[];
-    readonly disabledAt?: Date | string | null;
-  };
+  readonly membership: AuthenticatedMembership;
 }
 
-function resolveRequestedTenantMembership(
+async function resolveRequestedTenantMembership(
   req: AuthenticatedRequest,
+  prisma: PrismaService,
 ): TenantMembershipContext {
   const tenantHeader = req.headers['x-tenant-id'];
   const tenantId = Array.isArray(tenantHeader)
@@ -51,11 +55,31 @@ function resolveRequestedTenantMembership(
   const normalizedTenantId = tenantId.trim();
   const membership = req.user?.memberships?.find(
     (candidate) => candidate.tenantId === normalizedTenantId,
-  ) as TenantMembershipContext['membership'] | undefined;
+  );
 
-  if (!membership || membership.disabledAt) {
+  if (!membership) {
     throw new ForbiddenException(
       'User does not have membership in the specified tenant',
+    );
+  }
+
+  const userId = req.user?.id;
+  if (!userId) {
+    throw new ForbiddenException('User is not authenticated');
+  }
+
+  const activeTenantMember = await prisma.tenantMember.findFirst({
+    where: {
+      tenantId: normalizedTenantId,
+      userId,
+      disabledAt: null,
+    },
+    select: { id: true },
+  });
+
+  if (!activeTenantMember) {
+    throw new ForbiddenException(
+      'User does not have an active membership in the specified tenant',
     );
   }
 
@@ -90,6 +114,7 @@ export class CommunicationsUserController {
   constructor(
     private communicationsService: CommunicationsService,
     private validators: CommunicationsValidators,
+    private readonly prisma: PrismaService,
   ) {}
 
   /**
@@ -117,12 +142,12 @@ export class CommunicationsUserController {
   async listCommunications(
     @Request() req: AuthenticatedRequest,
     @Query('buildingId') buildingId?: string,
-    @Query('status') status?: CommunicationStatus,
+    @Query('status') status?: string,
   ) {
-    const { tenantId, membership } = resolveRequestedTenantMembership(req);
+    const { tenantId, membership } = await resolveRequestedTenantMembership(req, this.prisma);
     const userRoles = membership.roles || [];
     if (!this.isAdminRole(userRoles)) {
-      throw new BadRequestException('Only administrators can list communications');
+      throw new ForbiddenException('Only administrators can list communications');
     }
 
     const filters: FindAllFilters = {};
@@ -134,7 +159,14 @@ export class CommunicationsUserController {
       );
       filters.buildingId = buildingId;
     }
-    if (status) filters.status = status;
+    if (status) {
+      const parsedStatus = CommunicationStatusQuerySchema.safeParse(status);
+      if (!parsedStatus.success) {
+        throw new BadRequestException('Invalid communication status');
+      }
+
+      filters.status = parsedStatus.data as CommunicationStatus;
+    }
 
     return await this.communicationsService.findAll(tenantId, filters);
   }
@@ -154,10 +186,10 @@ export class CommunicationsUserController {
     @Param('communicationId') communicationId: string,
     @Request() req: AuthenticatedRequest,
   ) {
-    const { tenantId, membership } = resolveRequestedTenantMembership(req);
+    const { tenantId, membership } = await resolveRequestedTenantMembership(req, this.prisma);
     const userRoles = membership.roles || [];
     if (!this.isAdminRole(userRoles)) {
-      throw new BadRequestException('Only administrators can view communications');
+      throw new ForbiddenException('Only administrators can view communications');
     }
 
     // Validate scope
@@ -191,10 +223,10 @@ export class CommunicationsUserController {
     @Body() rawBody: unknown,
     @Request() req: AuthenticatedRequest,
   ) {
-    const { tenantId, membership } = resolveRequestedTenantMembership(req);
+    const { tenantId, membership } = await resolveRequestedTenantMembership(req, this.prisma);
     const userRoles = membership.roles || [];
     if (!this.isAdminRole(userRoles)) {
-      throw new BadRequestException('Only administrators can create communications');
+      throw new ForbiddenException('Only administrators can create communications');
     }
 
     const parsed = CreateCommunicationRequestSchema.safeParse(rawBody);
@@ -209,7 +241,7 @@ export class CommunicationsUserController {
     const userId = req.user.id;
 
     return await this.communicationsService.createV2(
-      tenantId as string,
+      tenantId,
       userId,
       {
         title: input.title,
@@ -246,10 +278,10 @@ export class CommunicationsUserController {
     @Body() rawBody: unknown,
     @Request() req: AuthenticatedRequest,
   ) {
-    const { tenantId, membership } = resolveRequestedTenantMembership(req);
+    const { tenantId, membership } = await resolveRequestedTenantMembership(req, this.prisma);
     const userRoles = membership.roles || [];
     if (!this.isAdminRole(userRoles)) {
-      throw new BadRequestException('Only administrators can publish communications');
+      throw new ForbiddenException('Only administrators can publish communications');
     }
 
     const parsed = PublishCommunicationRequestSchema.safeParse(rawBody);
@@ -263,7 +295,7 @@ export class CommunicationsUserController {
     const { sendWebPush } = parsed.data;
 
     return await this.communicationsService.publishV2(
-      tenantId as string,
+      tenantId,
       communicationId,
       sendWebPush,
     );
@@ -279,7 +311,7 @@ export class CommunicationsUserController {
  *
  * Security:
  * 1. JwtAuthGuard: Requires valid JWT
- * 2. No X-Tenant-Id header needed (uses user's tenant from JWT)
+   * 2. X-Tenant-Id header is required and validated against the active JWT memberships
  * 3. User can only see/interact with communications targeted to them
  *
  * RESIDENT Workflow:
@@ -293,6 +325,7 @@ export class CommunicationsInboxController {
   constructor(
     private communicationsService: CommunicationsService,
     private validators: CommunicationsValidators,
+    private readonly prisma: PrismaService,
   ) {}
 
   /**
@@ -317,7 +350,7 @@ export class CommunicationsInboxController {
     @Query('unitId') unitId?: string,
     @Query('readOnly') readOnly?: string,
   ) {
-    const { tenantId, membership } = resolveRequestedTenantMembership(req);
+    const { tenantId, membership } = await resolveRequestedTenantMembership(req, this.prisma);
     const userId = req.user.id;
     const userRoles = membership.roles || [];
 
@@ -331,9 +364,8 @@ export class CommunicationsInboxController {
       filters.buildingId = buildingId;
     }
 
-    // For now, unitId filter is accepted but not validated (UX feature)
-    // In production, validate unit belongs to tenant if needed
     if (unitId) {
+      await this.validators.validateUnitBelongsToTenant(tenantId, unitId);
       filters.unitId = unitId;
     }
 
@@ -368,7 +400,7 @@ export class CommunicationsInboxController {
     @Param('communicationId') communicationId: string,
     @Request() req: AuthenticatedRequest,
   ) {
-    const { tenantId, membership } = resolveRequestedTenantMembership(req);
+    const { tenantId, membership } = await resolveRequestedTenantMembership(req, this.prisma);
     const userId = req.user.id;
     const userRoles = membership.roles || [];
 
@@ -387,7 +419,7 @@ export class CommunicationsInboxController {
     );
 
     if (!canRead) {
-      throw new BadRequestException(
+      throw new ForbiddenException(
         'Communication not found or you do not have access to it',
       );
     }
@@ -395,93 +427,6 @@ export class CommunicationsInboxController {
     return await this.communicationsService.findOne(tenantId, communicationId);
   }
 
-  /**
-   * POST /me/communications/:communicationId/read
-   * Mark communication as read
-   *
-   * Updates receipt.readAt = now
-   * Idempotent: if already read, no change
-   *
-   * Returns: { success: true, readAt: timestamp }
-   *
-   * Throws 404 if:
-   * - Communication doesn't exist
-   * - User didn't receive it (no receipt)
-   *
-   * No permission required (authenticated users only)
-   */
-  @Post(':communicationId/read')
-  @HttpCode(200)
-  async markAsRead(
-    @Param('communicationId') communicationId: string,
-    @Request() req: AuthenticatedRequest,
-  ) {
-    const { tenantId, membership } = resolveRequestedTenantMembership(req);
-    const userId = req.user.id;
-    const userRoles = membership.roles || [];
-
-    // Validate communication belongs to tenant
-    await this.validators.validateCommunicationBelongsToTenant(
-      tenantId,
-      communicationId,
-    );
-
-    // Check if user can read this communication (has receipt)
-    const canRead = await this.validators.canUserReadCommunication(
-      tenantId,
-      userId,
-      communicationId,
-      userRoles,
-    );
-
-    if (!canRead) {
-      throw new BadRequestException(
-        'Communication not found or you do not have access to it',
-      );
-    }
-
-    // Mark as read
-    await this.communicationsService.markAsRead(
-      tenantId,
-      userId,
-      communicationId,
-    );
-
-    return {
-      success: true,
-      communicationId,
-      readAt: new Date(),
-    };
-  }
-
-  /**
-   * POST /resident/communications/:communicationId/read
-   * Mark communication as read (idempotent)
-   *
-   * Returns: { readAt: Date | null }
-   *
-   * No permission required (authenticated users only)
-   */
-  @Post('resident/communications/:communicationId/read')
-  async markResidentAsRead(
-    @Param('communicationId') communicationId: string,
-    @Request() req: AuthenticatedRequest,
-  ): Promise<{ readAt: Date | null }> {
-    const { tenantId } = resolveRequestedTenantMembership(req);
-    const userId = req.user.id;
-
-    // Validate communication belongs to tenant
-    await this.validators.validateCommunicationBelongsToTenant(
-      tenantId,
-      communicationId,
-    );
-
-    return await this.communicationsService.markAsReadForResident(
-      tenantId,
-      userId,
-      communicationId,
-    );
-  }
 }
 
 /**
@@ -502,6 +447,7 @@ export class ResidentCommunicationsController {
     private communicationsService: CommunicationsService,
     private validators: CommunicationsValidators,
     private residentAccessService: ResidentAccessService,
+    private readonly prisma: PrismaService,
   ) {}
 
   /**
@@ -528,7 +474,7 @@ export class ResidentCommunicationsController {
     @Query() rawQuery: Record<string, unknown>,
     @Request() req: AuthenticatedRequest,
   ): Promise<ResidentCommunicationListResponse> {
-    const { tenantId } = resolveRequestedTenantMembership(req);
+    const { tenantId } = await resolveRequestedTenantMembership(req, this.prisma);
 
     const parsedQuery = ResidentCommunicationsQuerySchema.safeParse(rawQuery);
     if (!parsedQuery.success) {
@@ -573,20 +519,7 @@ export class ResidentCommunicationsController {
     @Param('communicationId') communicationId: string,
     @Request() req: AuthenticatedRequest,
   ): Promise<{ readAt: Date | null }> {
-    const xTenantId = req.headers['x-tenant-id'] as string | undefined;
-    if (!xTenantId) {
-      throw new BadRequestException('X-Tenant-Id header is required');
-    }
-
-    const userMemberships = req.user?.memberships || [];
-    const membership = userMemberships.find((m) => m.tenantId === xTenantId);
-    if (!membership) {
-      throw new BadRequestException(
-        'User does not have membership in the specified tenant',
-      );
-    }
-
-    const tenantId = xTenantId;
+    const { tenantId } = await resolveRequestedTenantMembership(req, this.prisma);
     const userId = req.user.id;
 
     await this.validators.validateCommunicationBelongsToTenant(

--- a/apps/api/src/communications/communications-user.controller.ts
+++ b/apps/api/src/communications/communications-user.controller.ts
@@ -9,6 +9,7 @@ import {
   Query,
   Body,
   BadRequestException,
+  ForbiddenException,
   HttpCode,
   UnprocessableEntityException,
 } from '@nestjs/common';
@@ -26,6 +27,44 @@ import {
 import type { AuthenticatedRequest } from '../common/types/request.types';
 import { ResidentAccessService } from '../resident-access/resident-access.service';
 
+interface TenantMembershipContext {
+  readonly tenantId: string;
+  readonly membership: {
+    readonly tenantId: string;
+    readonly roles?: string[];
+    readonly disabledAt?: Date | string | null;
+  };
+}
+
+function resolveRequestedTenantMembership(
+  req: AuthenticatedRequest,
+): TenantMembershipContext {
+  const tenantHeader = req.headers['x-tenant-id'];
+  const tenantId = Array.isArray(tenantHeader)
+    ? tenantHeader[0]
+    : tenantHeader;
+
+  if (!tenantId || tenantId.trim().length === 0) {
+    throw new BadRequestException('X-Tenant-Id header is required');
+  }
+
+  const normalizedTenantId = tenantId.trim();
+  const membership = req.user?.memberships?.find(
+    (candidate) => candidate.tenantId === normalizedTenantId,
+  ) as TenantMembershipContext['membership'] | undefined;
+
+  if (!membership || membership.disabledAt) {
+    throw new ForbiddenException(
+      'User does not have membership in the specified tenant',
+    );
+  }
+
+  return {
+    tenantId: normalizedTenantId,
+    membership,
+  };
+}
+
 /**
  * CommunicationsUserController: Tenant-level and user-level Communications endpoints
  *
@@ -37,7 +76,7 @@ import { ResidentAccessService } from '../resident-access/resident-access.servic
  *
  * Security:
  * 1. JwtAuthGuard: Requires valid JWT token
- * 2. X-Tenant-Id header: Required for admin routes, auto-extracted for /me
+ * 2. X-Tenant-Id header: Required for all routes and validated against memberships
  * 3. Service validates scope (communication belongs to tenant)
  * 4. /me routes: User can only access their own communications
  *
@@ -80,22 +119,7 @@ export class CommunicationsUserController {
     @Query('buildingId') buildingId?: string,
     @Query('status') status?: CommunicationStatus,
   ) {
-    // Extract X-Tenant-Id from request headers
-    const xTenantId = req.headers['x-tenant-id'] as string | undefined;
-    if (!xTenantId) {
-      throw new BadRequestException('X-Tenant-Id header is required');
-    }
-
-    // Get user's memberships to find matching tenant
-    const userMemberships = req.user?.memberships || [];
-    const membership = userMemberships.find((m) => m.tenantId === xTenantId);
-    if (!membership) {
-      throw new BadRequestException(
-        'User does not have membership in the specified tenant',
-      );
-    }
-
-    const tenantId = xTenantId;
+    const { tenantId, membership } = resolveRequestedTenantMembership(req);
     const userRoles = membership.roles || [];
     if (!this.isAdminRole(userRoles)) {
       throw new BadRequestException('Only administrators can list communications');
@@ -130,22 +154,7 @@ export class CommunicationsUserController {
     @Param('communicationId') communicationId: string,
     @Request() req: AuthenticatedRequest,
   ) {
-    // Extract X-Tenant-Id from request headers
-    const xTenantId = req.headers['x-tenant-id'] as string | undefined;
-    if (!xTenantId) {
-      throw new BadRequestException('X-Tenant-Id header is required');
-    }
-
-    // Get user's memberships to find matching tenant
-    const userMemberships = req.user?.memberships || [];
-    const membership = userMemberships.find((m) => m.tenantId === xTenantId);
-    if (!membership) {
-      throw new BadRequestException(
-        'User does not have membership in the specified tenant',
-      );
-    }
-
-    const tenantId = xTenantId;
+    const { tenantId, membership } = resolveRequestedTenantMembership(req);
     const userRoles = membership.roles || [];
     if (!this.isAdminRole(userRoles)) {
       throw new BadRequestException('Only administrators can view communications');
@@ -182,20 +191,7 @@ export class CommunicationsUserController {
     @Body() rawBody: unknown,
     @Request() req: AuthenticatedRequest,
   ) {
-    const xTenantId = req.headers['x-tenant-id'];
-    if (!xTenantId) {
-      throw new BadRequestException('X-Tenant-Id header is required');
-    }
-
-    const userMemberships = req.user?.memberships || [];
-    const membership = userMemberships.find((m: { tenantId: string }) => m.tenantId === xTenantId);
-    if (!membership) {
-      throw new BadRequestException(
-        'User does not have membership in the specified tenant',
-      );
-    }
-
-    const tenantId = xTenantId;
+    const { tenantId, membership } = resolveRequestedTenantMembership(req);
     const userRoles = membership.roles || [];
     if (!this.isAdminRole(userRoles)) {
       throw new BadRequestException('Only administrators can create communications');
@@ -250,20 +246,7 @@ export class CommunicationsUserController {
     @Body() rawBody: unknown,
     @Request() req: AuthenticatedRequest,
   ) {
-    const xTenantId = req.headers['x-tenant-id'];
-    if (!xTenantId) {
-      throw new BadRequestException('X-Tenant-Id header is required');
-    }
-
-    const userMemberships = req.user?.memberships || [];
-    const membership = userMemberships.find((m: { tenantId: string }) => m.tenantId === xTenantId);
-    if (!membership) {
-      throw new BadRequestException(
-        'User does not have membership in the specified tenant',
-      );
-    }
-
-    const tenantId = xTenantId;
+    const { tenantId, membership } = resolveRequestedTenantMembership(req);
     const userRoles = membership.roles || [];
     if (!this.isAdminRole(userRoles)) {
       throw new BadRequestException('Only administrators can publish communications');
@@ -334,15 +317,9 @@ export class CommunicationsInboxController {
     @Query('unitId') unitId?: string,
     @Query('readOnly') readOnly?: string,
   ) {
-    // Get user's primary tenant membership
-    const userMemberships = req.user?.memberships || [];
-    if (userMemberships.length === 0) {
-      throw new BadRequestException('User does not have a tenant membership');
-    }
-
-    const tenantId = userMemberships[0]!.tenantId;
+    const { tenantId, membership } = resolveRequestedTenantMembership(req);
     const userId = req.user.id;
-    const userRoles = userMemberships[0]!.roles || [];
+    const userRoles = membership.roles || [];
 
     // Validate building if provided
     const filters: FindForUserFilters & { unitId?: string } = {};
@@ -391,15 +368,9 @@ export class CommunicationsInboxController {
     @Param('communicationId') communicationId: string,
     @Request() req: AuthenticatedRequest,
   ) {
-    // Get user's primary tenant membership
-    const userMemberships = req.user?.memberships || [];
-    if (userMemberships.length === 0) {
-      throw new BadRequestException('User does not have a tenant membership');
-    }
-
-    const tenantId = userMemberships[0]!.tenantId;
+    const { tenantId, membership } = resolveRequestedTenantMembership(req);
     const userId = req.user.id;
-    const userRoles = userMemberships[0]!.roles || [];
+    const userRoles = membership.roles || [];
 
     // Validate communication belongs to tenant
     await this.validators.validateCommunicationBelongsToTenant(
@@ -445,15 +416,9 @@ export class CommunicationsInboxController {
     @Param('communicationId') communicationId: string,
     @Request() req: AuthenticatedRequest,
   ) {
-    // Get user's primary tenant membership
-    const userMemberships = req.user?.memberships || [];
-    if (userMemberships.length === 0) {
-      throw new BadRequestException('User does not have a tenant membership');
-    }
-
-    const tenantId = userMemberships[0]!.tenantId;
+    const { tenantId, membership } = resolveRequestedTenantMembership(req);
     const userId = req.user.id;
-    const userRoles = userMemberships[0]!.roles || [];
+    const userRoles = membership.roles || [];
 
     // Validate communication belongs to tenant
     await this.validators.validateCommunicationBelongsToTenant(
@@ -502,12 +467,7 @@ export class CommunicationsInboxController {
     @Param('communicationId') communicationId: string,
     @Request() req: AuthenticatedRequest,
   ): Promise<{ readAt: Date | null }> {
-    const userMemberships = req.user?.memberships || [];
-    if (userMemberships.length === 0) {
-      throw new BadRequestException('User does not have a tenant membership');
-    }
-
-    const tenantId = userMemberships[0]!.tenantId;
+    const { tenantId } = resolveRequestedTenantMembership(req);
     const userId = req.user.id;
 
     // Validate communication belongs to tenant
@@ -568,18 +528,7 @@ export class ResidentCommunicationsController {
     @Query() rawQuery: Record<string, unknown>,
     @Request() req: AuthenticatedRequest,
   ): Promise<ResidentCommunicationListResponse> {
-    const xTenantId = req.headers['x-tenant-id'] as string | undefined;
-    if (!xTenantId) {
-      throw new BadRequestException('X-Tenant-Id header is required');
-    }
-
-    const userMemberships = req.user?.memberships || [];
-    const membership = userMemberships.find((m) => m.tenantId === xTenantId);
-    if (!membership) {
-      throw new BadRequestException(
-        'User does not have membership in the specified tenant',
-      );
-    }
+    const { tenantId } = resolveRequestedTenantMembership(req);
 
     const parsedQuery = ResidentCommunicationsQuerySchema.safeParse(rawQuery);
     if (!parsedQuery.success) {
@@ -590,7 +539,6 @@ export class ResidentCommunicationsController {
     }
 
     const { buildingId, unitId, limit, cursor } = parsedQuery.data;
-    const tenantId = xTenantId;
     const userId = req.user.id;
 
     await this.residentAccessService.assertUnitAccess(

--- a/apps/web/app/(tenant)/[tenantId]/buildings/[buildingId]/units/[unitId]/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/buildings/[buildingId]/units/[unitId]/page.tsx
@@ -14,8 +14,7 @@ import { useBuildings } from '@/features/buildings/hooks';
 import { useUnits } from '@/features/buildings/hooks/useUnits';
 import { useOccupants } from '@/features/buildings/hooks/useOccupants';
 import { useAuth } from '@/features/auth/useAuth';
-import { routes } from '@/shared/lib/routes';
-import { BuildingBreadcrumb, BuildingSubnav } from '@/features/buildings/components';
+import { BuildingBreadcrumb } from '@/features/buildings/components';
 import { UnitTicketsList } from '@/features/tickets';
 import { InboxList } from '@/features/communications';
 import { t } from '@/i18n';
@@ -25,7 +24,6 @@ import { UnitFinanceTab } from '@/features/finance/components/UnitFinanceTab';
 import { useUnitLedger } from '@/features/finance/hooks/useUnitLedger';
 import { formatCurrency } from '@/shared/lib/format/money';
 import { Users, Mail, Phone, User, Trash2, Plus, Lock, AlertCircle, CheckCircle2 } from 'lucide-react';
-import type { Unit } from '@/features/units/units.types';
 import { ErrorBoundary } from '@/shared/components/error-boundary';
 import { AssignResidentModal } from './AssignResidentModal';
 
@@ -34,6 +32,12 @@ interface UnitParams {
   buildingId: string;
   unitId: string;
   [key: string]: string | string[];
+}
+
+interface UnitDashboardContentProps {
+  tenantId: string;
+  buildingId: string;
+  unitId: string;
 }
 
 /**
@@ -46,6 +50,25 @@ const UnitDashboardPage = () => {
   const tenantId = params?.tenantId;
   const buildingId = params?.buildingId;
   const unitId = params?.unitId;
+
+  if (!tenantId || !buildingId || !unitId) {
+    return <div>{t('common.invalidParameters')}</div>;
+  }
+
+  return (
+    <UnitDashboardContent
+      tenantId={tenantId}
+      buildingId={buildingId}
+      unitId={unitId}
+    />
+  );
+};
+
+const UnitDashboardContent = ({
+  tenantId,
+  buildingId,
+  unitId,
+}: UnitDashboardContentProps) => {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { toast } = useToast();
@@ -84,14 +107,10 @@ const UnitDashboardPage = () => {
   const isAdmin = currentUser?.roles?.some((r) => ['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR'].includes(r));
 
   // Check if current user is occupant of this unit
-  const isOccupantOfUnit = occupants.some((o) => o.user?.id === currentUser?.id);
+  const isOccupantOfUnit = !occupantsLoading && occupants.some((o) => o.user?.id === currentUser?.id);
 
   // Access control: residents can only see their own unit
   const hasAccess = isAdmin || isOccupantOfUnit;
-
-  if (!tenantId || !buildingId || !unitId) {
-    return <div>{t('common.invalidParameters')}</div>;
-  }
 
   if (buildingsError || unitsError) {
     return (
@@ -108,6 +127,21 @@ const UnitDashboardPage = () => {
         <Skeleton width="300px" height="32px" />
         <Card>
           <div className="h-40 animate-pulse bg-muted rounded" />
+        </Card>
+      </div>
+    );
+  }
+
+  if (occupantsLoading && !isAdmin) {
+    return (
+      <div className="space-y-6">
+        <BuildingBreadcrumb tenantId={tenantId} buildingName={unit?.label || t('common.loading')} buildingId={buildingId} />
+        <Card>
+          <div className="space-y-3">
+            <Skeleton width="220px" height="32px" />
+            <Skeleton width="100%" height="180px" />
+            <Skeleton width="100%" height="220px" />
+          </div>
         </Card>
       </div>
     );
@@ -457,7 +491,12 @@ const UnitDashboardPage = () => {
         {/* Messages Tab */}
         {activeTab === 'messages' && (
           <div>
-            <InboxList buildingId={buildingId} />
+            <InboxList
+              key={`${tenantId}:${buildingId}:${unitId}`}
+              tenantId={tenantId}
+              buildingId={buildingId}
+              unitId={unitId}
+            />
           </div>
         )}
 

--- a/apps/web/features/communications/components/InboxList.tsx
+++ b/apps/web/features/communications/components/InboxList.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { t } from '@/i18n';
 import Card from '@/shared/components/ui/Card';
 import ErrorState from '@/shared/components/ui/ErrorState';
 import EmptyState from '@/shared/components/ui/EmptyState';
@@ -12,13 +11,15 @@ import { Bell, Mail } from 'lucide-react';
 import type { InboxCommunication } from '../services/communications.api';
 
 interface InboxListProps {
+  tenantId: string;
   buildingId: string;
+  unitId: string;
 }
 
 /**
  * InboxList: Resident view of communications inbox
  */
-export function InboxList({ buildingId }: InboxListProps) {
+export function InboxList({ tenantId, buildingId, unitId }: InboxListProps) {
   const [selectedComm, setSelectedComm] = useState<InboxCommunication | null>(null);
   const {
     inbox,
@@ -27,7 +28,7 @@ export function InboxList({ buildingId }: InboxListProps) {
     markAsRead,
     unreadCount,
     refetch,
-  } = useCommunicationsInbox({ buildingId });
+  } = useCommunicationsInbox({ tenantId, buildingId, unitId });
 
   if (error && inbox.length === 0) {
     return <ErrorState message={error} onRetry={refetch} />;
@@ -111,7 +112,9 @@ export function InboxList({ buildingId }: InboxListProps) {
       {selectedComm && (
         <InboxDetail
           communication={selectedComm}
-          onMarkAsRead={() => markAsRead(selectedComm.id)}
+          onMarkAsRead={async () => {
+            await markAsRead(selectedComm.id);
+          }}
           onClose={() => setSelectedComm(null)}
         />
       )}

--- a/apps/web/features/communications/hooks/useCommunicationsInbox.test.tsx
+++ b/apps/web/features/communications/hooks/useCommunicationsInbox.test.tsx
@@ -1,0 +1,138 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAuthSession } from '@/features/auth/useAuthSession';
+import {
+  getInbox,
+  markAsRead as markAsReadAPI,
+} from '../services/communications.api';
+import { useCommunicationsInbox } from './useCommunicationsInbox';
+
+jest.mock('@/features/auth/useAuthSession', () => ({
+  useAuthSession: jest.fn(),
+}));
+
+jest.mock('../services/communications.api', () => ({
+  getInbox: jest.fn(),
+  markAsRead: jest.fn(),
+}));
+
+const mockedUseAuthSession = jest.mocked(useAuthSession);
+const mockedGetInbox = jest.mocked(getInbox);
+const mockedMarkAsReadAPI = jest.mocked(markAsReadAPI);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useCommunicationsInbox', () => {
+  beforeEach(() => {
+    mockedUseAuthSession.mockReset();
+    mockedGetInbox.mockReset();
+    mockedMarkAsReadAPI.mockReset();
+  });
+
+  it('loads inbox messages for the active tenant and sends the tenant header', async () => {
+    mockedUseAuthSession.mockReturnValue({
+      user: { id: 'user-1', email: 'resident@buildingos.test', name: 'Resident' },
+      memberships: [],
+      activeTenantId: 'tenant-1',
+    });
+    mockedGetInbox.mockResolvedValue([]);
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(
+      () => useCommunicationsInbox({ tenantId: 'tenant-1', buildingId: 'building-1', unitId: 'unit-1' }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockedGetInbox).toHaveBeenCalledWith('tenant-1', {
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    });
+    expect(result.current.inbox).toEqual([]);
+  });
+
+  it('clears transient inbox data when the active tenant changes', async () => {
+    const session = {
+      user: { id: 'user-1', email: 'resident@buildingos.test', name: 'Resident' },
+      memberships: [],
+      activeTenantId: 'tenant-1',
+    };
+
+    mockedUseAuthSession.mockImplementation(() => session);
+    mockedGetInbox.mockResolvedValue([
+      {
+        id: 'comm-1',
+        title: 'Tenant 1 notice',
+        body: 'Hello tenant 1',
+        channel: 'IN_APP',
+        priority: 'NORMAL',
+        status: 'SENT',
+        buildingId: 'building-1',
+        createdBy: { id: 'admin-1', name: 'Admin', email: 'admin@buildingos.test' },
+        targets: [],
+        receipts: [{ id: 'receipt-1', userId: 'user-1', readAt: undefined }],
+        createdAt: '2026-07-30T00:00:00.000Z',
+      },
+    ]);
+
+    const wrapper = createWrapper();
+    const { result, rerender } = renderHook(
+      ({ tenantId }) => useCommunicationsInbox({ tenantId, buildingId: 'building-1', unitId: 'unit-1' }),
+      {
+        wrapper,
+        initialProps: { tenantId: 'tenant-1' },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.inbox).toHaveLength(1);
+    });
+
+    session.activeTenantId = 'tenant-2';
+    rerender({ tenantId: 'tenant-1' });
+
+    expect(result.current.inbox).toEqual([]);
+    expect(result.current.loading).toBe(false);
+    expect(mockedGetInbox).toHaveBeenCalledTimes(1);
+  });
+
+  it('marks a communication as read for the active tenant', async () => {
+    mockedUseAuthSession.mockReturnValue({
+      user: { id: 'user-1', email: 'resident@buildingos.test', name: 'Resident' },
+      memberships: [],
+      activeTenantId: 'tenant-1',
+    });
+    mockedGetInbox.mockResolvedValue([]);
+    mockedMarkAsReadAPI.mockResolvedValue(undefined);
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(
+      () => useCommunicationsInbox({ tenantId: 'tenant-1', buildingId: 'building-1', unitId: 'unit-1' }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    await result.current.markAsRead('comm-1');
+
+    expect(mockedMarkAsReadAPI).toHaveBeenCalledWith('tenant-1', 'comm-1');
+  });
+});

--- a/apps/web/features/communications/hooks/useCommunicationsInbox.ts
+++ b/apps/web/features/communications/hooks/useCommunicationsInbox.ts
@@ -1,9 +1,8 @@
-/**
- * useCommunicationsInbox Hook
- * Manages user inbox communications + mark as read
- */
+'use client';
 
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useAuthSession } from '@/features/auth/useAuthSession';
 import {
   getInbox,
   markAsRead as markAsReadAPI,
@@ -12,83 +11,110 @@ import {
 
 interface UseCommunicationsInboxOptions {
   buildingId?: string;
+  unitId?: string;
+  tenantId?: string | null;
 }
 
+const COMMUNICATIONS_INBOX_QUERY_KEY = 'communicationsInbox';
+
 export function useCommunicationsInbox(options: UseCommunicationsInboxOptions) {
-  const { buildingId } = options;
+  const { buildingId, unitId, tenantId } = options;
+  const session = useAuthSession();
+  const queryClient = useQueryClient();
+  const userId = session?.user.id ?? null;
+  const activeTenantId = session?.activeTenantId ?? null;
+  const requestedTenantId = tenantId?.trim() ?? null;
+  const canFetch = !!requestedTenantId && !!userId && requestedTenantId === activeTenantId;
 
-  const [inbox, setInbox] = useState<InboxCommunication[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  // Fetch inbox communications
-  const fetchInbox = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await getInbox({ buildingId });
-      setInbox(data);
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Failed to fetch inbox';
-      setError(message);
-    } finally {
-      setLoading(false);
-    }
-  }, [buildingId]);
-
-  // Auto-fetch on mount and dependency changes
-  useEffect(() => {
-    fetchInbox();
-  }, [fetchInbox]);
-
-  // Mark a communication as read
-  const markAsRead = useCallback(
-    async (communicationId: string): Promise<void> => {
-      try {
-        await markAsReadAPI(communicationId);
-        // Update local state: set readAt timestamp on the receipt
-        setInbox((prev) =>
-          prev.map((c) => {
-            if (c.id === communicationId) {
-              return {
-                ...c,
-                receipts: c.receipts.map((r) => ({
-                  ...r,
-                  readAt: r.readAt || new Date().toISOString(),
-                })),
-              };
-            }
-            return c;
-          })
-        );
-      } catch (err) {
-        const message = err instanceof Error ? err.message : 'Failed to mark as read';
-        setError(message);
-        throw err;
+  const inboxQuery = useQuery<InboxCommunication[]>({
+    queryKey: [
+      COMMUNICATIONS_INBOX_QUERY_KEY,
+      requestedTenantId,
+      activeTenantId,
+      buildingId,
+      unitId,
+      userId,
+    ],
+    queryFn: () => {
+      if (!requestedTenantId) {
+        throw new Error('Missing tenantId for inbox query');
       }
-    },
-    []
-  );
 
-  // Calculate unread count
+      return getInbox(
+        requestedTenantId,
+        buildingId || unitId ? { buildingId, unitId } : undefined,
+      );
+    },
+    enabled: canFetch,
+    staleTime: 2 * 60 * 1000,
+    gcTime: 5 * 60 * 1000,
+    retry: 1,
+  });
+
+  const inbox = useMemo(() => {
+    return canFetch ? inboxQuery.data ?? [] : [];
+  }, [canFetch, inboxQuery.data]);
+
+  const markAsReadMutation = useMutation({
+    mutationFn: async (communicationId: string) => {
+      if (!requestedTenantId) {
+        throw new Error('Missing tenantId for inbox mutation');
+      }
+
+      await markAsReadAPI(requestedTenantId, communicationId);
+      return communicationId;
+    },
+    onSuccess: async (communicationId) => {
+      if (!requestedTenantId) {
+        return;
+      }
+
+      const queryKey = [
+        COMMUNICATIONS_INBOX_QUERY_KEY,
+        requestedTenantId,
+        activeTenantId,
+        buildingId,
+        unitId,
+        userId,
+      ];
+      const now = new Date().toISOString();
+
+      queryClient.setQueryData<InboxCommunication[]>(queryKey, (current) =>
+        current?.map((communication) => {
+          if (communication.id !== communicationId) {
+            return communication;
+          }
+
+          return {
+            ...communication,
+            receipts: communication.receipts.map((receipt) => ({
+              ...receipt,
+              readAt: receipt.readAt ?? now,
+            })),
+          };
+        }) ?? current,
+      );
+
+      await queryClient.invalidateQueries({
+        queryKey: [COMMUNICATIONS_INBOX_QUERY_KEY, requestedTenantId, activeTenantId],
+        exact: false,
+      });
+    },
+  });
+
   const unreadCount = useMemo(() => {
-    return inbox.filter((c) => {
-      const receipt = c.receipts?.[0];
+    return inbox.filter((communication) => {
+      const receipt = communication.receipts?.[0];
       return !receipt?.readAt;
     }).length;
   }, [inbox]);
 
-  // Refetch inbox
-  const refetch = useCallback(() => {
-    fetchInbox();
-  }, [fetchInbox]);
-
   return {
     inbox,
-    loading,
-    error,
-    markAsRead,
+    loading: canFetch ? inboxQuery.isLoading : false,
+    error: inboxQuery.error instanceof Error ? inboxQuery.error.message : null,
+    markAsRead: markAsReadMutation.mutateAsync,
     unreadCount,
-    refetch,
+    refetch: inboxQuery.refetch,
   };
 }

--- a/apps/web/features/communications/services/communications.api.test.ts
+++ b/apps/web/features/communications/services/communications.api.test.ts
@@ -1,6 +1,8 @@
 import { apiClient } from '@/shared/lib/http/client';
 import {
+  getInbox,
   getResidentCommunications,
+  markAsRead,
   markResidentAsRead,
 } from './communications.api';
 
@@ -37,6 +39,42 @@ describe('communications.api resident helpers', () => {
 
     expect(mockedApiClient).toHaveBeenCalledWith({
       path: '/resident/communications/comm-1/read',
+      method: 'POST',
+      headers: {
+        'X-Tenant-Id': 'tenant-1',
+        'X-Portal-Context': 'resident',
+      },
+    });
+  });
+});
+
+describe('communications.api legacy inbox helpers', () => {
+  beforeEach(() => {
+    mockedApiClient.mockReset();
+  });
+
+  it('sends the active tenant and resident portal context when loading the legacy inbox', async () => {
+    mockedApiClient.mockResolvedValue([]);
+
+    await getInbox('tenant-1', { buildingId: 'building-1', unitId: 'unit-1' });
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/me/communications?buildingId=building-1&unitId=unit-1',
+      method: 'GET',
+      headers: {
+        'X-Tenant-Id': 'tenant-1',
+        'X-Portal-Context': 'resident',
+      },
+    });
+  });
+
+  it('sends the active tenant and resident portal context when marking legacy inbox communications as read', async () => {
+    mockedApiClient.mockResolvedValue(undefined);
+
+    await markAsRead('tenant-1', 'comm-1');
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/me/communications/comm-1/read',
       method: 'POST',
       headers: {
         'X-Tenant-Id': 'tenant-1',

--- a/apps/web/features/communications/services/communications.api.test.ts
+++ b/apps/web/features/communications/services/communications.api.test.ts
@@ -1,0 +1,47 @@
+import { apiClient } from '@/shared/lib/http/client';
+import {
+  getResidentCommunications,
+  markResidentAsRead,
+} from './communications.api';
+
+jest.mock('@/shared/lib/http/client', () => ({
+  apiClient: jest.fn(),
+}));
+
+const mockedApiClient = jest.mocked(apiClient);
+
+describe('communications.api resident helpers', () => {
+  beforeEach(() => {
+    mockedApiClient.mockReset();
+  });
+
+  it('sends the active tenant and resident portal context when loading resident communications', async () => {
+    mockedApiClient.mockResolvedValue({ items: [], nextCursor: undefined });
+
+    await getResidentCommunications('tenant-1', 'building-1', 'unit-1', 20);
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/resident/communications?buildingId=building-1&unitId=unit-1&limit=20',
+      method: 'GET',
+      headers: {
+        'X-Tenant-Id': 'tenant-1',
+        'X-Portal-Context': 'resident',
+      },
+    });
+  });
+
+  it('sends the active tenant and resident portal context when marking resident communications as read', async () => {
+    mockedApiClient.mockResolvedValue({ readAt: null });
+
+    await markResidentAsRead('tenant-1', 'comm-1');
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/resident/communications/comm-1/read',
+      method: 'POST',
+      headers: {
+        'X-Tenant-Id': 'tenant-1',
+        'X-Portal-Context': 'resident',
+      },
+    });
+  });
+});

--- a/apps/web/features/communications/services/communications.api.ts
+++ b/apps/web/features/communications/services/communications.api.ts
@@ -408,7 +408,10 @@ export async function getResidentCommunications(
     return await apiClient<ResidentCommunicationsResponse>({
       path: endpoint,
       method: 'GET',
-      headers: { 'X-Tenant-Id': tenantId },
+      headers: {
+        'X-Tenant-Id': tenantId,
+        'X-Portal-Context': 'resident',
+      },
     });
   } catch (error) {
     const message = `Failed to get resident communications: ${(error as Error).message}`;
@@ -428,7 +431,10 @@ export async function markResidentAsRead(
     return await apiClient<{ readAt: string | null }>({
       path: endpoint,
       method: 'POST',
-      headers: { 'X-Tenant-Id': tenantId },
+      headers: {
+        'X-Tenant-Id': tenantId,
+        'X-Portal-Context': 'resident',
+      },
     });
   } catch (error) {
     const message = `Failed to mark as read: ${(error as Error).message}`;

--- a/apps/web/features/communications/services/communications.api.ts
+++ b/apps/web/features/communications/services/communications.api.ts
@@ -310,15 +310,20 @@ export async function publishCommunication(
 export interface GetInboxFilters {
   status?: CommunicationStatus;
   buildingId?: string;
+  unitId?: string;
 }
 
 /**
  * Get user's inbox communications
  */
-export async function getInbox(filters?: GetInboxFilters): Promise<InboxCommunication[]> {
+export async function getInbox(
+  tenantId: string,
+  filters?: GetInboxFilters,
+): Promise<InboxCommunication[]> {
   const params = new URLSearchParams();
   if (filters?.status) params.append('status', filters.status);
   if (filters?.buildingId) params.append('buildingId', filters.buildingId);
+  if (filters?.unitId) params.append('unitId', filters.unitId);
 
   const endpoint = `/me/communications${params.toString() ? '?' + params.toString() : ''}`;
   logRequest('GET', endpoint);
@@ -327,6 +332,10 @@ export async function getInbox(filters?: GetInboxFilters): Promise<InboxCommunic
     return await apiClient<InboxCommunication[]>({
       path: endpoint,
       method: 'GET',
+      headers: {
+        'X-Tenant-Id': tenantId,
+        'X-Portal-Context': 'resident',
+      },
     });
   } catch (error) {
     const message = `Failed to get inbox: ${(error as Error).message}`;
@@ -338,7 +347,10 @@ export async function getInbox(filters?: GetInboxFilters): Promise<InboxCommunic
 /**
  * Mark a communication as read
  */
-export async function markAsRead(communicationId: string): Promise<void> {
+export async function markAsRead(
+  tenantId: string,
+  communicationId: string,
+): Promise<void> {
   const endpoint = `/me/communications/${communicationId}/read`;
   logRequest('POST', endpoint);
 
@@ -346,6 +358,10 @@ export async function markAsRead(communicationId: string): Promise<void> {
     await apiClient<void>({
       path: endpoint,
       method: 'POST',
+      headers: {
+        'X-Tenant-Id': tenantId,
+        'X-Portal-Context': 'resident',
+      },
     });
   } catch (error) {
     const message = `Failed to mark as read: ${(error as Error).message}`;

--- a/apps/web/features/resident/api/resident-context.api.test.ts
+++ b/apps/web/features/resident/api/resident-context.api.test.ts
@@ -1,0 +1,29 @@
+import { apiClient } from '@/shared/lib/http/client';
+import { getResidentCommunications } from './resident-context.api';
+
+jest.mock('@/shared/lib/http/client', () => ({
+  apiClient: jest.fn(),
+}));
+
+const mockedApiClient = jest.mocked(apiClient);
+
+describe('resident-context.api', () => {
+  beforeEach(() => {
+    mockedApiClient.mockReset();
+  });
+
+  it('sends the active tenant and resident portal context for inbox requests', async () => {
+    mockedApiClient.mockResolvedValue([]);
+
+    await getResidentCommunications('tenant-1', 5);
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/me/communications?limit=5',
+      method: 'GET',
+      headers: {
+        'X-Tenant-Id': 'tenant-1',
+        'X-Portal-Context': 'resident',
+      },
+    });
+  });
+});

--- a/apps/web/features/resident/api/resident-context.api.ts
+++ b/apps/web/features/resident/api/resident-context.api.ts
@@ -11,6 +11,18 @@ import type { Ticket } from '../../tickets/services/tickets.api';
 
 export type { UnitLedger, InboxCommunication, Ticket };
 
+function buildResidentHeaders(tenantId: string): Record<string, string> {
+  const normalizedTenantId = tenantId.trim();
+  if (normalizedTenantId.length === 0) {
+    throw new Error('[resident] Missing tenantId for resident-scoped API call');
+  }
+
+  return {
+    'X-Tenant-Id': normalizedTenantId,
+    'X-Portal-Context': 'resident',
+  };
+}
+
 export interface ResidentContext {
   tenantId: string;
   activeBuildingId: string | null;
@@ -48,10 +60,14 @@ export async function getResidentLedger(
  * Get inbox communications (last N for the resident).
  * @param limit - Max items to return (default 3)
  */
-export async function getResidentCommunications(limit = 3): Promise<InboxCommunication[]> {
+export async function getResidentCommunications(
+  tenantId: string,
+  limit = 3,
+): Promise<InboxCommunication[]> {
   return apiClient<InboxCommunication[]>({
     path: `/me/communications?limit=${limit}`,
     method: 'GET',
+    headers: buildResidentHeaders(tenantId),
   });
 }
 

--- a/apps/web/features/resident/hooks/useResidentCommunications.test.tsx
+++ b/apps/web/features/resident/hooks/useResidentCommunications.test.tsx
@@ -1,0 +1,73 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useAuthSession } from '@/features/auth/useAuthSession';
+import { getResidentCommunications } from '../api/resident-context.api';
+import { useResidentCommunications } from './useResidentCommunications';
+
+jest.mock('@/features/auth/useAuthSession', () => ({
+  useAuthSession: jest.fn(),
+}));
+
+jest.mock('../api/resident-context.api', () => ({
+  getResidentCommunications: jest.fn(),
+}));
+
+const mockedUseAuthSession = jest.mocked(useAuthSession);
+const mockedGetResidentCommunications = jest.mocked(getResidentCommunications);
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useResidentCommunications', () => {
+  beforeEach(() => {
+    mockedUseAuthSession.mockReset();
+    mockedGetResidentCommunications.mockReset();
+  });
+
+  it('loads communications using the active tenant instead of the route tenant alone', async () => {
+    mockedUseAuthSession.mockReturnValue({
+      user: { id: 'user-1', email: 'resident@buildingos.test', name: 'Resident' },
+      memberships: [],
+      activeTenantId: 'tenant-1',
+    });
+    mockedGetResidentCommunications.mockResolvedValue([]);
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useResidentCommunications('tenant-1', 7), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockedGetResidentCommunications).toHaveBeenCalledWith('tenant-1', 7);
+  });
+
+  it('does not fetch when the route tenant differs from the active tenant', () => {
+    mockedUseAuthSession.mockReturnValue({
+      user: { id: 'user-1', email: 'resident@buildingos.test', name: 'Resident' },
+      memberships: [],
+      activeTenantId: 'tenant-current',
+    });
+
+    const wrapper = createWrapper();
+    const { result } = renderHook(() => useResidentCommunications('tenant-previous', 3), {
+      wrapper,
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(mockedGetResidentCommunications).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/features/resident/hooks/useResidentCommunications.ts
+++ b/apps/web/features/resident/hooks/useResidentCommunications.ts
@@ -13,11 +13,13 @@ import { getResidentCommunications, type InboxCommunication } from '../api/resid
 export function useResidentCommunications(tenantId: string | null, limit = 3) {
   const session = useAuthSession();
   const userId = session?.user.id ?? null;
+  const activeTenantId = session?.activeTenantId ?? null;
+  const shouldFetch = !!tenantId && !!userId && tenantId === activeTenantId;
 
   return useQuery<InboxCommunication[]>({
-    queryKey: ['residentCommunications', tenantId, userId, limit],
-    queryFn: () => getResidentCommunications(limit),
-    enabled: !!tenantId && !!userId,
+    queryKey: ['residentCommunications', tenantId, activeTenantId, userId, limit],
+    queryFn: () => getResidentCommunications(activeTenantId!, limit),
+    enabled: shouldFetch,
     staleTime: 2 * 60 * 1000,
     gcTime: 5 * 60 * 1000,
     retry: 1,


### PR DESCRIPTION
Closes #81

## Summary
- Resident communications now resolve the active tenant explicitly and reject disabled or missing memberships via `TenantMember` with `disabledAt: null`.
- The legacy inbox flow is fixed end-to-end: backend `/me/communications`, resident portal headers, and frontend query keys all stay tenant-scoped.
- Final implementation commit: `493dbf1f170cb942f85c0ee1a81bed481941ea7f`.

## Root Cause
The resident communications flow could derive tenant context implicitly or fall back to the first membership, which created a multi-tenant isolation risk for users with access to more than one tenant.

## Changes
| File | Change |
|------|--------|
| `apps/api/src/communications/communications-user.controller.ts` | Resolve tenant from `X-Tenant-Id`, validate active membership with `TenantMember.disabledAt: null`, and protect legacy inbox/detail/read actions with explicit tenant checks and proper HTTP codes. |
| `apps/api/src/communications/communications-user.controller.spec.ts` | Cover active vs disabled membership, tenant mismatch, admin routes, inbox validation, and 404/403 behavior. |
| `apps/web/features/communications/services/communications.api.ts` | Send resident portal headers and the active tenant for inbox/read requests. |
| `apps/web/features/communications/hooks/useCommunicationsInbox.ts` | Separate query keys by tenant and active tenant to avoid showing stale data across tenant switches. |
| `apps/web/features/communications/components/InboxList.tsx` | Pass tenant, building, and unit context explicitly into the inbox hook. |
| `apps/web/app/(tenant)/[tenantId]/buildings/[buildingId]/units/[unitId]/page.tsx` | Provide resident portal context from the tenant/unit page without leaking prior tenant state. |

## Validation
- [x] API controller tests: `src/communications/communications-user.controller.spec.ts`
- [x] Web communications tests: `features/communications/services/communications.api.test.ts`, `features/communications/hooks/useCommunicationsInbox.test.tsx`
- [x] API lint and web lint on modified files
- [x] API build: GitHub Actions `Build, Lint, Test, E2E` passed on `493dbf1f170cb942f85c0ee1a81bed481941ea7f`
- [x] Web build: GitHub Actions `Build, Lint, Test, E2E` passed on `493dbf1f170cb942f85c0ee1a81bed481941ea7f`
- [x] E2E workflow: passed on `493dbf1f170cb942f85c0ee1a81bed481941ea7f`
- [x] `git diff --check`

## Notes
- No Prisma schema changes.
- No migrations, seeds, deploys, or production changes.
