### PR TITLE
fix(api): make payment-linked documents immutable

### DIFF
--- a/apps/api/src/common/payment-linked-document-lock.ts
+++ b/apps/api/src/common/payment-linked-document-lock.ts
@@ -1,0 +1,53 @@
+import { ConflictException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+
+export const PAYMENT_LINKED_DOCUMENT_CONFLICT_MESSAGE = 'El comprobante está asociado a un pago y no puede modificarse.';
+
+function buildPaymentLinkedDocumentLockKey(tenantId: string, fileId: string): string {
+  return `payment-linked-document:${tenantId}:${fileId}`;
+}
+
+function buildPaymentReceiptLockKey(paymentId: string): string {
+  return `payment-receipt:${paymentId}`;
+}
+
+export async function acquirePaymentLinkedDocumentLock(
+  tx: Prisma.TransactionClient,
+  tenantId: string,
+  fileId: string,
+): Promise<void> {
+  const lockKey = buildPaymentLinkedDocumentLockKey(tenantId, fileId);
+  await tx.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`);
+}
+
+export async function throwIfPaymentLinkedDocumentIsMutable(
+  tx: Prisma.TransactionClient,
+  tenantId: string,
+  documentId: string,
+  fileId: string,
+): Promise<void> {
+  await acquirePaymentLinkedDocumentLock(tx, tenantId, fileId);
+
+  const linkedPayment = await tx.payment.findFirst({
+    where: {
+      tenantId,
+      OR: [
+        { receiptDocumentId: documentId },
+        { proofFileId: fileId },
+      ],
+    },
+    select: { id: true },
+  });
+
+  if (linkedPayment) {
+    throw new ConflictException(PAYMENT_LINKED_DOCUMENT_CONFLICT_MESSAGE);
+  }
+}
+
+export async function acquirePaymentReceiptLock(
+  tx: Prisma.TransactionClient,
+  paymentId: string,
+): Promise<void> {
+  const lockKey = buildPaymentReceiptLockKey(paymentId);
+  await tx.$queryRaw(Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`);
+}

--- a/apps/api/src/documents/documents.service.spec.ts
+++ b/apps/api/src/documents/documents.service.spec.ts
@@ -11,6 +11,7 @@ import { DocumentUploadPurpose } from './dto/presign-upload.dto';
 import { DocumentsValidators } from './documents.validators';
 import { ResidentAccessService } from '../resident-access/resident-access.service';
 import { Prisma } from '@prisma/client';
+import { PAYMENT_LINKED_DOCUMENT_CONFLICT_MESSAGE } from '../common/payment-linked-document-lock';
 
 const PAYMENT_PROOF_MAX_BYTES = 10 * 1024 * 1024;
 const GENERAL_DOCUMENT_MAX_BYTES = 100 * 1024 * 1024;
@@ -43,6 +44,7 @@ function expectNoPasswordHashDeep(value: unknown): void {
 }
 
 describe('DocumentsService', () => {
+  let transactionQueryRawMock: jest.Mock;
   const prisma = {
     $transaction: jest.fn(),
     document: {
@@ -58,6 +60,7 @@ describe('DocumentsService', () => {
       create: jest.fn(),
     },
     payment: {
+      findFirst: jest.fn(),
       findMany: jest.fn(),
     },
     tenant: {
@@ -113,10 +116,13 @@ describe('DocumentsService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     minio.getDefaultBucket.mockReturnValue(DEFAULT_BUCKET);
+    transactionQueryRawMock = jest.fn().mockResolvedValue([]);
     prisma.$transaction.mockImplementation(async (callback: (tx: never) => Promise<unknown>) => {
       const tx = {
         file: prisma.file,
         document: prisma.document,
+        payment: prisma.payment,
+        $queryRaw: transactionQueryRawMock,
       } as never;
 
       return callback(tx);
@@ -411,6 +417,7 @@ describe('DocumentsService', () => {
   it('sanitizes createdByMembership.user in updateDocument responses', async () => {
     prisma.document.findFirst.mockResolvedValueOnce({
       id: 'document-update',
+      fileId: 'file-update',
       tenantId: 'tenant-1',
       buildingId: 'building-1',
       unitId: 'unit-1',
@@ -476,6 +483,43 @@ describe('DocumentsService', () => {
       name: 'Resident One',
     });
     expectNoPasswordHashDeep(result);
+    expect(transactionQueryRawMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks document updates when the file is linked to a payment proof or receipt', async () => {
+    prisma.document.findFirst.mockResolvedValueOnce({
+      id: 'document-linked',
+      fileId: 'file-linked',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      visibility: 'RESIDENTS',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      createdByMembership: {
+        id: 'membership-1',
+        userId: 'user-1',
+      },
+      file: { bucket: 'tenant-legacy-bucket', objectKey: 'receipt.pdf', originalName: 'receipt.pdf', mimeType: 'application/pdf' },
+    } as never);
+    prisma.payment.findFirst.mockResolvedValueOnce({ id: 'payment-linked' } as never);
+
+    await expect(service.updateDocument('tenant-1', 'document-linked', 'user-1', ['TENANT_ADMIN'], {
+      title: 'Updated title',
+    })).rejects.toThrow('El comprobante está asociado a un pago y no puede modificarse.');
+
+    expect(transactionQueryRawMock).toHaveBeenCalledTimes(1);
+    expect(prisma.payment.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        tenantId: 'tenant-1',
+        OR: [
+          { receiptDocumentId: 'document-linked' },
+          { proofFileId: 'file-linked' },
+        ],
+      },
+      select: { id: true },
+    }));
+    expect(prisma.document.update).not.toHaveBeenCalled();
   });
 
   it('does not notify anyone for payment proofs', async () => {
@@ -507,6 +551,66 @@ describe('DocumentsService', () => {
 
     expect(prisma.unitOccupant.findMany).not.toHaveBeenCalled();
     expect(notifications.createNotification).not.toHaveBeenCalled();
+  });
+
+  it('deletes unlinked documents normally', async () => {
+    prisma.document.findFirst.mockResolvedValueOnce({
+      id: 'document-delete',
+      fileId: 'file-delete',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      visibility: 'RESIDENTS',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      createdByMembership: {
+        id: 'membership-1',
+        userId: 'user-1',
+      },
+      file: { bucket: 'tenant-delete-bucket', objectKey: 'receipt.pdf', originalName: 'receipt.pdf', mimeType: 'application/pdf' },
+    } as never);
+    prisma.document.delete.mockResolvedValueOnce({} as never);
+
+    await expect(service.deleteDocument('tenant-1', 'document-delete', 'user-1', ['TENANT_ADMIN'])).resolves.toBeUndefined();
+
+    expect(transactionQueryRawMock).toHaveBeenCalledTimes(1);
+    expect(prisma.document.delete).toHaveBeenCalledWith({ where: { id: 'document-delete' } });
+    expect(minio.deleteObject).toHaveBeenCalledWith('tenant-delete-bucket', 'receipt.pdf');
+  });
+
+  it('blocks document deletes when the file is linked to a payment proof or receipt', async () => {
+    prisma.document.findFirst.mockResolvedValueOnce({
+      id: 'document-linked-delete',
+      fileId: 'file-linked-delete',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      visibility: 'RESIDENTS',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      createdByMembership: {
+        id: 'membership-1',
+        userId: 'user-1',
+      },
+      file: { bucket: 'tenant-legacy-bucket', objectKey: 'receipt.pdf', originalName: 'receipt.pdf', mimeType: 'application/pdf' },
+    } as never);
+    prisma.payment.findFirst.mockResolvedValueOnce({ id: 'payment-linked-delete' } as never);
+
+    await expect(service.deleteDocument('tenant-1', 'document-linked-delete', 'user-1', ['TENANT_ADMIN'])).rejects.toThrow('El comprobante está asociado a un pago y no puede modificarse.');
+
+    expect(transactionQueryRawMock).toHaveBeenCalledTimes(1);
+    expect(prisma.payment.findFirst).toHaveBeenCalledWith(expect.objectContaining({
+      where: {
+        tenantId: 'tenant-1',
+        OR: [
+          { receiptDocumentId: 'document-linked-delete' },
+          { proofFileId: 'file-linked-delete' },
+        ],
+      },
+      select: { id: true },
+    }));
+    expect(prisma.document.delete).not.toHaveBeenCalled();
+    expect(minio.deleteObject).not.toHaveBeenCalled();
   });
 
   it('excludes the uploading resident from general resident document notifications', async () => {
@@ -1110,6 +1214,102 @@ describe('DocumentsService', () => {
       ['RESIDENT'],
     )).rejects.toThrow('Document not found or does not belong to you');
 
+    expect(prisma.document.delete).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      scenario: 'payment proof',
+      payment: {
+        id: 'payment-proof-1',
+        tenantId: 'tenant-1',
+        proofFileId: 'file-1',
+        receiptDocumentId: null,
+      },
+    },
+    {
+      scenario: 'payment receipt',
+      payment: {
+        id: 'payment-receipt-1',
+        tenantId: 'tenant-1',
+        proofFileId: null,
+        receiptDocumentId: 'document-1',
+      },
+    },
+  ])('blocks update when the document is linked through %s', async ({ payment }) => {
+    prisma.document.findFirst.mockResolvedValue({
+      id: 'document-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      visibility: 'RESIDENTS',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      createdByMembership: { userId: 'admin-1' },
+      file: {
+        id: 'file-1',
+        bucket: 'tenant-legacy-bucket',
+        objectKey: 'receipt.pdf',
+        originalName: 'receipt.pdf',
+        mimeType: 'application/pdf',
+      },
+    } as never);
+    prisma.payment.findFirst.mockResolvedValue(payment as never);
+
+    await expect(
+      service.updateDocument('tenant-1', 'document-1', 'admin-1', ['TENANT_ADMIN'], {
+        title: 'Updated title',
+      }),
+    ).rejects.toThrow(PAYMENT_LINKED_DOCUMENT_CONFLICT_MESSAGE);
+
+    expect(transactionQueryRawMock).toHaveBeenCalledTimes(1);
+    expect(prisma.document.update).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      scenario: 'payment proof',
+      payment: {
+        id: 'payment-proof-1',
+        tenantId: 'tenant-1',
+        proofFileId: 'file-1',
+        receiptDocumentId: null,
+      },
+    },
+    {
+      scenario: 'payment receipt',
+      payment: {
+        id: 'payment-receipt-1',
+        tenantId: 'tenant-1',
+        proofFileId: null,
+        receiptDocumentId: 'document-1',
+      },
+    },
+  ])('blocks delete when the document is linked through %s', async ({ payment }) => {
+    prisma.document.findFirst.mockResolvedValue({
+      id: 'document-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      visibility: 'RESIDENTS',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      createdByMembership: { userId: 'admin-1' },
+      file: {
+        id: 'file-1',
+        bucket: 'tenant-legacy-bucket',
+        objectKey: 'receipt.pdf',
+        originalName: 'receipt.pdf',
+        mimeType: 'application/pdf',
+      },
+    } as never);
+    prisma.payment.findFirst.mockResolvedValue(payment as never);
+
+    await expect(
+      service.deleteDocument('tenant-1', 'document-1', 'admin-1', ['TENANT_ADMIN']),
+    ).rejects.toThrow(PAYMENT_LINKED_DOCUMENT_CONFLICT_MESSAGE);
+
+    expect(transactionQueryRawMock).toHaveBeenCalledTimes(1);
     expect(prisma.document.delete).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -16,6 +16,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { AuditService } from '../audit/audit.service';
 import { DocumentsValidators } from './documents.validators';
 import { ResidentAccessService } from '../resident-access/resident-access.service';
+import { throwIfPaymentLinkedDocumentIsMutable } from '../common/payment-linked-document-lock';
 import { CreateDocumentDto } from './dto/create-document.dto';
 import { UpdateDocumentDto } from './dto/update-document.dto';
 import { DocumentUploadPurpose } from './dto/presign-upload.dto';
@@ -561,23 +562,47 @@ export class DocumentsService {
     }
 
     // Update
-    const updated = await this.prisma.document.update({
-      where: { id: documentId },
-      data: {
-        ...(dto.title && { title: dto.title }),
-        ...(dto.category && { category: dto.category }),
-        ...(dto.visibility && { visibility: dto.visibility }),
-      },
-      include: {
-        file: true,
-        createdByMembership: {
-          include: {
-            user: {
-              select: publicUserSelect,
+    const updated = await this.prisma.$transaction(async (tx) => {
+      await throwIfPaymentLinkedDocumentIsMutable(tx, tenantId, documentId, document.fileId);
+
+      const lockedDocument = await tx.document.findFirst({
+        where: { id: documentId, tenantId },
+        include: {
+          file: true,
+          createdByMembership: {
+            include: {
+              user: {
+                select: publicUserSelect,
+              },
             },
           },
         },
-      },
+      });
+
+      if (!lockedDocument) {
+        throw new NotFoundException('Document not found');
+      }
+
+      const updatedDocument = await tx.document.update({
+        where: { id: documentId },
+        data: {
+          ...(dto.title && { title: dto.title }),
+          ...(dto.category && { category: dto.category }),
+          ...(dto.visibility && { visibility: dto.visibility }),
+        },
+        include: {
+          file: true,
+          createdByMembership: {
+            include: {
+              user: {
+                select: publicUserSelect,
+              },
+            },
+          },
+        },
+      });
+
+      return updatedDocument;
     });
 
     return this.sanitizeDocumentResponse(updated);
@@ -633,9 +658,25 @@ export class DocumentsService {
     // Get file info before delete (for MinIO cleanup)
     const fileInfo = document.file;
 
-    // Delete Document (cascades to File)
-    await this.prisma.document.delete({
-      where: { id: documentId },
+    await this.prisma.$transaction(async (tx) => {
+      await throwIfPaymentLinkedDocumentIsMutable(tx, tenantId, documentId, document.fileId);
+
+      const lockedDocument = await tx.document.findFirst({
+        where: { id: documentId, tenantId },
+        include: {
+          file: true,
+          createdByMembership: true,
+        },
+      });
+
+      if (!lockedDocument) {
+        throw new NotFoundException('Document not found');
+      }
+
+      // Delete Document (cascades to File)
+      await tx.document.delete({
+        where: { id: documentId },
+      });
     });
 
     // [PHASE 2 QUICK #7] Audit: DOCUMENT_DELETE
@@ -653,14 +694,14 @@ export class DocumentsService {
 
     // Delete file from MinIO asynchronously (fire-and-forget)
     // Don't await or throw if it fails - document is already deleted
-    this.minio
-      .deleteObject(fileInfo.bucket, fileInfo.objectKey)
-      .catch((error) => {
-        this.logger.error(
-          `Failed to delete file from MinIO: ${fileInfo.bucket}/${fileInfo.objectKey}`,
-          error,
-        );
-      });
+    void Promise.resolve(
+      this.minio.deleteObject(fileInfo.bucket, fileInfo.objectKey),
+    ).catch((error) => {
+      this.logger.error(
+        `Failed to delete file from MinIO: ${fileInfo.bucket}/${fileInfo.objectKey}`,
+        error,
+      );
+    });
   }
 
   /**

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -591,6 +591,7 @@ describe('FinanzasService', () => {
           amount: 10000,
         },
       });
+      expect(prismaService.$queryRaw).toHaveBeenCalledTimes(1);
     });
 
     it('should accept an overdue resident charge as long as it still has outstanding balance', async () => {

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -8,6 +8,7 @@ import { PaymentReceiptService } from '../receipts/payment-receipt.service';
 import type { AuthenticatedMembership, PortalContext } from '../common/types/request.types';
 import { resolveNotificationPortalContext } from '../common/portal-context';
 import { ExpensesService } from './expenses.service';
+import { acquirePaymentLinkedDocumentLock } from '../common/payment-linked-document-lock';
 import type { Role, ScopedRole } from '@buildingos/contracts';
 import {
   CreateChargeDto,
@@ -542,10 +543,11 @@ export class FinanzasService {
         'Los pagos por transferencia requieren subir el comprobante de pago',
       );
     }
-    await this.validatePaymentProofFile(tenantId, dto.proofFileId);
-
     if (isResidentPayment) {
       const payment = await this.prisma.$transaction(async (tx) => {
+        await acquirePaymentLinkedDocumentLock(tx, tenantId, dto.proofFileId!);
+        await this.validatePaymentProofFileInTransaction(tx, tenantId, dto.proofFileId!);
+
         const charge = await tx.charge.findFirst({
           where: {
             id: dto.chargeId,
@@ -627,20 +629,24 @@ export class FinanzasService {
       return this.sanitizePaymentForResponse(payment);
     }
 
-    // 8. Create payment with SUBMITTED status
-    const payment = await this.prisma.payment.create({
-      data: {
-        tenantId,
-        buildingId,
-        unitId: dto.unitId || null,
-        amount: dto.amount,
-        currency: dto.currency || 'ARS',
-        method: dto.method,
-        status: PaymentStatus.SUBMITTED,
-        reference: dto.reference,
-        proofFileId: dto.proofFileId || null,
-        createdByUserId: userId,
-      },
+    const payment = await this.prisma.$transaction(async (tx) => {
+      await acquirePaymentLinkedDocumentLock(tx, tenantId, dto.proofFileId!);
+      await this.validatePaymentProofFileInTransaction(tx, tenantId, dto.proofFileId!);
+
+      return tx.payment.create({
+        data: {
+          tenantId,
+          buildingId,
+          unitId: dto.unitId || null,
+          amount: dto.amount,
+          currency: dto.currency || 'ARS',
+          method: dto.method,
+          status: PaymentStatus.SUBMITTED,
+          reference: dto.reference,
+          proofFileId: dto.proofFileId || null,
+          createdByUserId: userId,
+        },
+      });
     });
 
     // 9. Notify admins about new payment submitted
@@ -1387,11 +1393,12 @@ export class FinanzasService {
     return allocations;
   }
 
-  private async validatePaymentProofFile(
+  private async validatePaymentProofFileInTransaction(
+    tx: Prisma.TransactionClient,
     tenantId: string,
     proofFileId: string,
   ): Promise<void> {
-    const proofFile = await this.prisma.file.findFirst({
+    const proofFile = await tx.file.findFirst({
       where: { id: proofFileId, tenantId },
       select: { id: true, size: true },
     });

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -989,7 +989,7 @@ export class FinanzasService {
     void this.sendPaymentReceivedNotification(tenantId, result, actorUserId ?? undefined);
 
     // Generate receipt for approved payment (async, non-blocking)
-    void this.receiptService.ensureReceiptForPayment(paymentId, actorUserId ?? undefined).catch((err) => {
+    void this.receiptService.ensureReceiptForPayment(tenantId, paymentId, actorUserId ?? undefined).catch((err) => {
       this.logger.error(`Failed to generate receipt for payment ${paymentId}: ${err.message}`);
     });
 
@@ -3009,7 +3009,7 @@ export class FinanzasService {
       void this.sendPaymentReceivedNotification(tenantId, approvedPaymentResult, actorUserId ?? undefined);
       
       // Generate receipt for approved payment (async, non-blocking)
-      void this.receiptService.ensureReceiptForPayment(paymentId, actorUserId ?? undefined).catch((err) => {
+      void this.receiptService.ensureReceiptForPayment(tenantId, paymentId, actorUserId ?? undefined).catch((err) => {
         this.logger.error(`Failed to generate receipt for payment ${paymentId}: ${err.message}`);
       });
     }
@@ -3818,7 +3818,7 @@ export class FinanzasService {
     });
 
     // Try to generate receipt
-    const result = await this.receiptService.ensureReceiptForPayment(paymentId, excludeUserId);
+    const result = await this.receiptService.ensureReceiptForPayment(tenantId, paymentId, excludeUserId);
 
     if (result) {
       return {

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -6,6 +6,7 @@ import { writeFileSync } from 'node:fs';
 describe('PaymentReceiptService', () => {
   const DEFAULT_BUCKET = 'buildingos-test';
   const RECEIPT_MAX_TEXT_WIDTH = 595 - 72 - 72;
+  let transactionQueryRawMock: jest.Mock;
   const WIN_ANSI_DECODE_MAP: Record<number, string> = {
     0x80: '€',
     0x82: '‚',
@@ -199,9 +200,17 @@ describe('PaymentReceiptService', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     minio.getDefaultBucket.mockReturnValue(DEFAULT_BUCKET);
+    transactionQueryRawMock = jest.fn().mockResolvedValue([]);
     prisma.$transaction.mockImplementation(async (callback: (tx: never) => Promise<unknown>) => {
       const tx = {
+        file: prisma.file,
+        document: prisma.document,
+        payment: prisma.payment,
+        paymentAuditLog: prisma.paymentAuditLog,
+        tenant: prisma.tenant,
+        user: prisma.user,
         receiptSequence: prisma.receiptSequence,
+        $queryRaw: transactionQueryRawMock,
       } as never;
       return callback(tx);
     });
@@ -291,12 +300,15 @@ describe('PaymentReceiptService', () => {
         size: uploadedBuffer.length,
       }),
     }));
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(transactionQueryRawMock).toHaveBeenCalledTimes(1);
     expect(prisma.payment.update).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         receiptStatus: ReceiptStatus.READY,
         receiptError: null,
       }),
     }));
+    expect(transactionQueryRawMock).toHaveBeenCalledTimes(1);
     expect(minio.presignDownload).toHaveBeenCalledWith(
       DEFAULT_BUCKET,
       expect.stringContaining('/receipt_R-'),
@@ -442,6 +454,7 @@ describe('PaymentReceiptService', () => {
       receiptNumber: 'R-HZ-2026-000001',
       documentId: 'document-1',
       fileKey: 'receipt.pdf',
+      bucket: DEFAULT_BUCKET,
       url: 'https://download.example/receipt.pdf',
     });
   });

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -46,6 +46,7 @@ describe('PaymentReceiptService', () => {
     },
     document: {
       findUnique: jest.fn(),
+      findFirst: jest.fn(),
       create: jest.fn(),
     },
     file: {
@@ -264,6 +265,9 @@ describe('PaymentReceiptService', () => {
     prisma.payment.findFirst.mockImplementation((...args: unknown[]) =>
       prisma.payment.findUnique(...(args as Parameters<typeof prisma.payment.findUnique>)),
     );
+    prisma.document.findFirst.mockImplementation((...args: unknown[]) =>
+      prisma.document.findUnique(...(args as Parameters<typeof prisma.document.findUnique>)),
+    );
     prisma.tenant.findUnique.mockResolvedValue({ name: 'Complejo Horizonte', brandName: null } as never);
     prisma.user.findUnique.mockResolvedValue({ name: 'Admin' } as never);
     prisma.receiptSequence.findUnique.mockResolvedValue(null);
@@ -386,12 +390,15 @@ describe('PaymentReceiptService', () => {
     expect(paymentState.receiptStatus).toBe(ReceiptStatus.FAILED);
     expect(prisma.receiptSequence.create).toHaveBeenCalledTimes(1);
     expect(prisma.receiptSequence.update).toHaveBeenCalledTimes(1);
+    expect(transactionQueryRawMock).toHaveBeenCalledTimes(2);
+    expect(minio.deleteObject).not.toHaveBeenCalled();
 
     minio.uploadBuffer.mockResolvedValueOnce(undefined);
 
     const retryResult = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
 
     expect(retryResult?.receiptNumber).toBe('R-COMPLE-2026-000001');
+    expect(retryResult?.fileKey).toBe('tenant/tenant-1/payments/payment-1/receipts/R-COMPLE-2026-000001.pdf');
     expect(prisma.receiptSequence.create).toHaveBeenCalledTimes(1);
     expect(prisma.receiptSequence.update).toHaveBeenCalledTimes(1);
     expect(prisma.payment.update).toHaveBeenCalledWith(expect.objectContaining({
@@ -403,14 +410,15 @@ describe('PaymentReceiptService', () => {
 
   it('keeps an uploaded receipt object when finalization already confirmed the same key', async () => {
     prisma.document.create.mockRejectedValueOnce(new Error('database unavailable'));
-    prisma.file.findFirst.mockResolvedValueOnce({
-      document: { id: 'document-1' },
-    } as never);
+    const warnSpy = jest.spyOn(Reflect.get(service, 'logger') as { warn: (...args: unknown[]) => void }, 'warn');
 
     await expect(service.ensureReceiptForPayment('tenant-1', 'payment-1')).resolves.toBeNull();
 
     expect(minio.uploadBuffer).toHaveBeenCalled();
     expect(minio.deleteObject).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('reusable unconfirmed receipt object'),
+    );
     expect(prisma.payment.update).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         receiptStatus: ReceiptStatus.FAILED,
@@ -418,8 +426,149 @@ describe('PaymentReceiptService', () => {
     }));
   });
 
+  it('marks receipt generation failed under the receipt lock only when still pending', async () => {
+    const markFailed = Reflect.get(service, 'markReceiptGenerationFailedIfNeeded') as (
+      tenantId: string,
+      paymentId: string,
+      errorMessage: string,
+    ) => Promise<void>;
+
+    prisma.payment.findUnique.mockResolvedValueOnce({
+      receiptStatus: ReceiptStatus.PENDING,
+      receiptDocumentId: null,
+    } as never);
+
+    await markFailed.call(service, 'tenant-1', 'payment-1', 'boom');
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(transactionQueryRawMock).toHaveBeenCalledTimes(1);
+    expect(prisma.payment.update).toHaveBeenCalledWith(expect.objectContaining({
+      where: { id: 'payment-1', tenantId: 'tenant-1' },
+      data: expect.objectContaining({
+        receiptStatus: ReceiptStatus.FAILED,
+        receiptError: 'boom',
+      }),
+    }));
+  });
+
+  it('does not downgrade READY or confirmed receipts when marking failed', async () => {
+    const markFailed = Reflect.get(service, 'markReceiptGenerationFailedIfNeeded') as (
+      tenantId: string,
+      paymentId: string,
+      errorMessage: string,
+    ) => Promise<void>;
+
+    prisma.payment.findUnique.mockResolvedValueOnce({
+      receiptStatus: ReceiptStatus.READY,
+      receiptDocumentId: null,
+    } as never);
+
+    await markFailed.call(service, 'tenant-1', 'payment-1', 'presign failed');
+
+    expect(prisma.payment.update).not.toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        receiptStatus: ReceiptStatus.FAILED,
+      }),
+    }));
+
+    prisma.payment.findUnique.mockResolvedValueOnce({
+      receiptStatus: ReceiptStatus.PENDING,
+      receiptDocumentId: 'document-1',
+    } as never);
+
+    await markFailed.call(service, 'tenant-1', 'payment-1', 'notify failed');
+
+    expect(prisma.payment.update).not.toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        receiptStatus: ReceiptStatus.FAILED,
+      }),
+    }));
+  });
+
+  it('keeps READY receipts stable when presign fails after confirmation', async () => {
+    let paymentState = {
+      id: 'payment-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      amount: 4050000,
+      currency: 'ARS',
+      method: 'TRANSFER',
+      createdByUserId: 'resident-1',
+      approvedByUserId: 'admin-1',
+      approvedAt: '2026-07-24T12:00:00.000Z',
+      reference: 'TRX-001',
+      paymentAllocations: [{
+        chargeId: 'charge-1',
+        amount: 4050000,
+        charge: {
+          period: '2025-10',
+          concept: 'Condominio ordinario 2025-10',
+          expensePeriod: { year: 2025, month: 10 },
+        },
+      }],
+      unit: { label: 'TN-01-01' },
+      building: { name: 'Complejo Horizonte' },
+      receiptDocumentId: null,
+      receiptNumber: null,
+      receiptStatus: ReceiptStatus.PENDING,
+      receiptError: null,
+    } as never;
+
+    prisma.payment.findUnique.mockImplementation(async () => paymentState as never);
+    prisma.payment.update.mockImplementation(async ({ data }) => {
+      paymentState = {
+        ...paymentState,
+        ...data,
+      } as never;
+      return paymentState as never;
+    });
+    minio.presignDownload.mockRejectedValueOnce(new Error('presign failed'));
+
+    await expect(service.ensureReceiptForPayment('tenant-1', 'payment-1')).resolves.toBeNull();
+
+    expect(prisma.payment.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        receiptStatus: ReceiptStatus.READY,
+      }),
+    }));
+    expect(prisma.payment.update).not.toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        receiptStatus: ReceiptStatus.FAILED,
+      }),
+    }));
+    expect(paymentState.receiptStatus).toBe(ReceiptStatus.READY);
+    expect(transactionQueryRawMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps READY receipts stable when notification fails after confirmation', async () => {
+    notificationsService.createNotification.mockRejectedValueOnce(new Error('notify failed'));
+
+    const result = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
+
+    expect(result?.receiptNumber).toBe('R-COMPLE-2026-000001');
+    expect(prisma.payment.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        receiptStatus: ReceiptStatus.READY,
+      }),
+    }));
+    expect(prisma.payment.update).not.toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        receiptStatus: ReceiptStatus.FAILED,
+      }),
+    }));
+  });
+
   it('does not notify the receipt owner when excluded from the approval flow', async () => {
-    await (service as any).notifyResidentReceiptReady(
+    const notifyResidentReceiptReady = Reflect.get(service, 'notifyResidentReceiptReady') as (
+      payment: { tenantId: string; createdByUserId: string; amount: number; currency: string; id: string },
+      receiptNumber: string,
+      receiptUrl: string,
+      approvedByUserName: string,
+      excludeUserId?: string,
+    ) => Promise<void>;
+
+    await notifyResidentReceiptReady(
       {
         tenantId: 'tenant-1',
         createdByUserId: 'resident-1',
@@ -548,6 +697,15 @@ describe('PaymentReceiptService', () => {
 
     const result = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
 
+    expect(prisma.document.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'document-1',
+        tenantId: 'tenant-1',
+      },
+      include: {
+        file: true,
+      },
+    });
     expect(minio.presignDownload).toHaveBeenCalledWith('tenant-legacy-bucket', 'receipt.pdf', 3600);
     expect(minio.uploadBuffer).not.toHaveBeenCalled();
     expect(prisma.file.create).not.toHaveBeenCalled();

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -7,6 +7,7 @@ describe('PaymentReceiptService', () => {
   const DEFAULT_BUCKET = 'buildingos-test';
   const RECEIPT_MAX_TEXT_WIDTH = 595 - 72 - 72;
   let transactionQueryRawMock: jest.Mock;
+  let insideTransaction = false;
   const WIN_ANSI_DECODE_MAP: Record<number, string> = {
     0x80: '€',
     0x82: '‚',
@@ -40,6 +41,7 @@ describe('PaymentReceiptService', () => {
   const prisma = {
     payment: {
       findUnique: jest.fn(),
+      findFirst: jest.fn(),
       update: jest.fn(),
     },
     document: {
@@ -48,6 +50,7 @@ describe('PaymentReceiptService', () => {
     },
     file: {
       create: jest.fn(),
+      findFirst: jest.fn(),
     },
     tenant: {
       findUnique: jest.fn(),
@@ -69,6 +72,7 @@ describe('PaymentReceiptService', () => {
     getDefaultBucket: jest.fn(() => DEFAULT_BUCKET),
     uploadBuffer: jest.fn(),
     presignDownload: jest.fn(),
+    deleteObject: jest.fn(),
   };
   const notificationsService = {
     createNotification: jest.fn(),
@@ -199,7 +203,19 @@ describe('PaymentReceiptService', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    insideTransaction = false;
     minio.getDefaultBucket.mockReturnValue(DEFAULT_BUCKET);
+    minio.uploadBuffer.mockImplementation(async () => {
+      expect(insideTransaction).toBe(false);
+    });
+    minio.presignDownload.mockImplementation(async () => {
+      expect(insideTransaction).toBe(false);
+      return 'https://download.example/receipt.pdf';
+    });
+    notificationsService.createNotification.mockImplementation(async () => {
+      expect(insideTransaction).toBe(false);
+      return {};
+    });
     transactionQueryRawMock = jest.fn().mockResolvedValue([]);
     prisma.$transaction.mockImplementation(async (callback: (tx: never) => Promise<unknown>) => {
       const tx = {
@@ -212,7 +228,12 @@ describe('PaymentReceiptService', () => {
         receiptSequence: prisma.receiptSequence,
         $queryRaw: transactionQueryRawMock,
       } as never;
-      return callback(tx);
+      insideTransaction = true;
+      try {
+        return await callback(tx);
+      } finally {
+        insideTransaction = false;
+      }
     });
     prisma.payment.findUnique.mockResolvedValue({
       id: 'payment-1',
@@ -240,12 +261,16 @@ describe('PaymentReceiptService', () => {
       receiptDocumentId: null,
       receiptNumber: null,
     } as never);
+    prisma.payment.findFirst.mockImplementation((...args: unknown[]) =>
+      prisma.payment.findUnique(...(args as Parameters<typeof prisma.payment.findUnique>)),
+    );
     prisma.tenant.findUnique.mockResolvedValue({ name: 'Complejo Horizonte', brandName: null } as never);
     prisma.user.findUnique.mockResolvedValue({ name: 'Admin' } as never);
     prisma.receiptSequence.findUnique.mockResolvedValue(null);
     prisma.receiptSequence.create.mockResolvedValue({ id: 'sequence-1', lastNumber: 0 } as never);
     prisma.receiptSequence.update.mockResolvedValue({ id: 'sequence-1' } as never);
     prisma.file.create.mockResolvedValue({ id: 'file-1' } as never);
+    prisma.file.findFirst.mockResolvedValue(null);
     prisma.document.create.mockResolvedValue({ id: 'document-1', file: { bucket: DEFAULT_BUCKET, objectKey: 'object-1' } } as never);
     prisma.payment.update.mockResolvedValue({} as never);
     prisma.paymentAuditLog.create.mockResolvedValue({} as never);
@@ -254,13 +279,13 @@ describe('PaymentReceiptService', () => {
   });
 
   it('uses the configured bucket when generating a new receipt', async () => {
-    const result = await service.ensureReceiptForPayment('payment-1');
+    const result = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
     const uploadedBuffer = minio.uploadBuffer.mock.calls[0][2] as Buffer;
     const tmpReceiptPath = '/tmp/buildingos-payment-receipt-test.pdf';
 
     expect(minio.uploadBuffer).toHaveBeenCalledWith(
       DEFAULT_BUCKET,
-      expect.stringContaining('/receipt_R-'),
+      expect.stringContaining('/receipts/R-'),
       expect.any(Buffer),
       'application/pdf',
     );
@@ -300,21 +325,97 @@ describe('PaymentReceiptService', () => {
         size: uploadedBuffer.length,
       }),
     }));
-    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
-    expect(transactionQueryRawMock).toHaveBeenCalledTimes(1);
+    expect(prisma.$transaction).toHaveBeenCalledTimes(2);
+    expect(transactionQueryRawMock).toHaveBeenCalledTimes(2);
     expect(prisma.payment.update).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         receiptStatus: ReceiptStatus.READY,
         receiptError: null,
       }),
     }));
-    expect(transactionQueryRawMock).toHaveBeenCalledTimes(1);
     expect(minio.presignDownload).toHaveBeenCalledWith(
       DEFAULT_BUCKET,
-      expect.stringContaining('/receipt_R-'),
+      expect.stringContaining('/receipts/R-'),
       3600,
     );
-    expect(result?.fileKey).toContain('/receipt_R-');
+    expect(result?.fileKey).toContain('/receipts/R-');
+  });
+
+  it('reuses the reserved receipt number after an upload failure', async () => {
+    let paymentState = {
+      id: 'payment-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      amount: 4050000,
+      currency: 'ARS',
+      method: 'TRANSFER',
+      createdByUserId: 'resident-1',
+      approvedByUserId: 'admin-1',
+      approvedAt: '2026-07-24T12:00:00.000Z',
+      reference: 'TRX-001',
+      paymentAllocations: [{
+        chargeId: 'charge-1',
+        amount: 4050000,
+        charge: {
+          period: '2025-10',
+          concept: 'Condominio ordinario 2025-10',
+          expensePeriod: { year: 2025, month: 10 },
+        },
+      }],
+      unit: { label: 'TN-01-01' },
+      building: { name: 'Complejo Horizonte' },
+      receiptDocumentId: null,
+      receiptNumber: null,
+      receiptStatus: ReceiptStatus.PENDING,
+      receiptError: null,
+    } as never;
+
+    prisma.payment.findUnique.mockImplementation(async () => paymentState as never);
+    prisma.payment.update.mockImplementation(async ({ data }) => {
+      paymentState = {
+        ...paymentState,
+        ...data,
+      } as never;
+      return paymentState as never;
+    });
+    minio.uploadBuffer.mockRejectedValueOnce(new Error('upload failed'));
+
+    await expect(service.ensureReceiptForPayment('tenant-1', 'payment-1')).resolves.toBeNull();
+    expect(paymentState.receiptNumber).toBe('R-COMPLE-2026-000001');
+    expect(paymentState.receiptStatus).toBe(ReceiptStatus.FAILED);
+    expect(prisma.receiptSequence.create).toHaveBeenCalledTimes(1);
+    expect(prisma.receiptSequence.update).toHaveBeenCalledTimes(1);
+
+    minio.uploadBuffer.mockResolvedValueOnce(undefined);
+
+    const retryResult = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
+
+    expect(retryResult?.receiptNumber).toBe('R-COMPLE-2026-000001');
+    expect(prisma.receiptSequence.create).toHaveBeenCalledTimes(1);
+    expect(prisma.receiptSequence.update).toHaveBeenCalledTimes(1);
+    expect(prisma.payment.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        receiptStatus: ReceiptStatus.READY,
+      }),
+    }));
+  });
+
+  it('keeps an uploaded receipt object when finalization already confirmed the same key', async () => {
+    prisma.document.create.mockRejectedValueOnce(new Error('database unavailable'));
+    prisma.file.findFirst.mockResolvedValueOnce({
+      document: { id: 'document-1' },
+    } as never);
+
+    await expect(service.ensureReceiptForPayment('tenant-1', 'payment-1')).resolves.toBeNull();
+
+    expect(minio.uploadBuffer).toHaveBeenCalled();
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+    expect(prisma.payment.update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        receiptStatus: ReceiptStatus.FAILED,
+      }),
+    }));
   });
 
   it('does not notify the receipt owner when excluded from the approval flow', async () => {
@@ -368,7 +469,7 @@ describe('PaymentReceiptService', () => {
       receiptNumber: null,
     } as never);
 
-    await service.ensureReceiptForPayment('payment-1');
+    await service.ensureReceiptForPayment('tenant-1', 'payment-1');
 
     const uploadedBuffer = minio.uploadBuffer.mock.calls[0][2] as Buffer;
     const decodedPdfText = extractDecodedPdfTextLines(uploadedBuffer).join('\n');
@@ -411,7 +512,7 @@ describe('PaymentReceiptService', () => {
       receiptNumber: null,
     } as never);
 
-    await service.ensureReceiptForPayment('payment-1');
+    await service.ensureReceiptForPayment('tenant-1', 'payment-1');
 
     const uploadedBuffer = minio.uploadBuffer.mock.calls[0][2] as Buffer;
     const pdfText = uploadedBuffer.toString('latin1');
@@ -445,7 +546,7 @@ describe('PaymentReceiptService', () => {
       file: { bucket: 'tenant-legacy-bucket', objectKey: 'receipt.pdf' },
     } as never);
 
-    const result = await service.ensureReceiptForPayment('payment-1');
+    const result = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
 
     expect(minio.presignDownload).toHaveBeenCalledWith('tenant-legacy-bucket', 'receipt.pdf', 3600);
     expect(minio.uploadBuffer).not.toHaveBeenCalled();
@@ -454,7 +555,7 @@ describe('PaymentReceiptService', () => {
       receiptNumber: 'R-HZ-2026-000001',
       documentId: 'document-1',
       fileKey: 'receipt.pdf',
-      bucket: DEFAULT_BUCKET,
+      bucket: 'tenant-legacy-bucket',
       url: 'https://download.example/receipt.pdf',
     });
   });
@@ -487,7 +588,7 @@ describe('PaymentReceiptService', () => {
       receiptNumber: null,
     } as never);
 
-    await service.ensureReceiptForPayment('payment-1');
+    await service.ensureReceiptForPayment('tenant-1', 'payment-1');
 
     const uploadedBuffer = minio.uploadBuffer.mock.calls[0][2] as Buffer;
     const pdfText = uploadedBuffer.toString('latin1');
@@ -545,7 +646,7 @@ describe('PaymentReceiptService', () => {
     prisma.tenant.findUnique.mockResolvedValueOnce({ name: longTenantName, brandName: null } as never);
     prisma.user.findUnique.mockResolvedValueOnce({ name: 'Admin' } as never);
 
-    const result = await service.ensureReceiptForPayment('payment-1');
+    const result = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
     expect(result?.documentId).toBe('document-1');
 
     const uploadedBuffer = minio.uploadBuffer.mock.calls[0][2] as Buffer;

--- a/apps/api/src/receipts/payment-receipt.service.ts
+++ b/apps/api/src/receipts/payment-receipt.service.ts
@@ -214,8 +214,11 @@ export class PaymentReceiptService {
       if (payment.receiptDocumentId && payment.receiptNumber) {
         this.logger.log(`Receipt already exists for payment ${paymentId}, reusing ${payment.receiptNumber}`);
 
-        const existingDocument = await tx.document.findUnique({
-          where: { id: payment.receiptDocumentId },
+        const existingDocument = await tx.document.findFirst({
+          where: {
+            id: payment.receiptDocumentId,
+            tenantId,
+          },
           include: { file: true },
         });
 
@@ -294,8 +297,11 @@ export class PaymentReceiptService {
       }
 
       if (currentPayment.receiptDocumentId && currentPayment.receiptNumber) {
-        const existingDocument = await tx.document.findUnique({
-          where: { id: currentPayment.receiptDocumentId },
+        const existingDocument = await tx.document.findFirst({
+          where: {
+            id: currentPayment.receiptDocumentId,
+            tenantId,
+          },
           include: { file: true },
         });
 
@@ -374,69 +380,56 @@ export class PaymentReceiptService {
 
   private async cleanupUploadedReceiptObjectIfSafe(tenantId: string, preparedReceipt: PreparedReceiptGeneration): Promise<void> {
     try {
-      const payment = await this.prisma.payment.findUnique({
+      const payment = await this.prisma.payment.findFirst({
         where: { id: preparedReceipt.payment.id, tenantId },
         select: {
           receiptDocumentId: true,
           receiptNumber: true,
+          receiptStatus: true,
         },
       });
 
-      if (payment?.receiptDocumentId && payment.receiptNumber === preparedReceipt.receiptNumber) {
+      if (payment?.receiptDocumentId || payment?.receiptStatus === ReceiptStatus.READY) {
         this.logger.warn(
-          `Skipping cleanup for ${preparedReceipt.bucket}/${preparedReceipt.fileKey} because payment ${preparedReceipt.payment.id} is already confirmed`,
+          `Leaving reusable unconfirmed receipt object ${preparedReceipt.bucket}/${preparedReceipt.fileKey} untouched because payment ${preparedReceipt.payment.id} is already confirmed`,
         );
         return;
       }
 
-      const file = await this.prisma.file.findFirst({
-        where: {
-          tenantId: preparedReceipt.payment.tenantId,
-          bucket: preparedReceipt.bucket,
-          objectKey: preparedReceipt.fileKey,
-        },
-        include: {
-          document: {
-            select: { id: true },
-          },
-        },
-      });
-
-      if (file?.document) {
-        this.logger.warn(
-          `Skipping cleanup for ${preparedReceipt.bucket}/${preparedReceipt.fileKey} because the receipt file is already confirmed`,
-        );
-        return;
-      }
-
-      await this.minio.deleteObject(preparedReceipt.bucket, preparedReceipt.fileKey);
+      this.logger.warn(
+        `Leaving reusable unconfirmed receipt object ${preparedReceipt.bucket}/${preparedReceipt.fileKey} after failed finalization for payment ${preparedReceipt.payment.id}`,
+      );
     } catch (cleanupError) {
       const errorMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
       this.logger.warn(
-        `Failed to clean up orphaned receipt object ${preparedReceipt.bucket}/${preparedReceipt.fileKey}: ${errorMessage}`,
+        `Failed to inspect reusable receipt object ${preparedReceipt.bucket}/${preparedReceipt.fileKey}: ${errorMessage}`,
       );
     }
   }
 
   private async markReceiptGenerationFailedIfNeeded(tenantId: string, paymentId: string, errorMessage: string): Promise<void> {
-    const payment = await this.prisma.payment.findFirst({
-      where: { id: paymentId, tenantId },
-      select: {
-        receiptStatus: true,
-        receiptDocumentId: true,
-      },
-    });
+    await this.prisma.$transaction(async (tx) => {
+      await acquirePaymentReceiptLock(tx, paymentId);
 
-    if (!payment || payment.receiptStatus === ReceiptStatus.READY || payment.receiptDocumentId) {
-      return;
-    }
+      const payment = await tx.payment.findFirst({
+        where: { id: paymentId, tenantId },
+        select: {
+          receiptStatus: true,
+          receiptDocumentId: true,
+        },
+      });
 
-    await this.prisma.payment.update({
-      where: { id: paymentId, tenantId },
-      data: {
-        receiptStatus: ReceiptStatus.FAILED,
-        receiptError: errorMessage,
-      },
+      if (!payment || payment.receiptStatus === ReceiptStatus.READY || payment.receiptDocumentId) {
+        return;
+      }
+
+      await tx.payment.update({
+        where: { id: paymentId, tenantId },
+        data: {
+          receiptStatus: ReceiptStatus.FAILED,
+          receiptError: errorMessage,
+        },
+      });
     });
   }
 

--- a/apps/api/src/receipts/payment-receipt.service.ts
+++ b/apps/api/src/receipts/payment-receipt.service.ts
@@ -3,10 +3,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { MinioService } from '../storage/minio.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { DocumentCategory, DocumentVisibility, Prisma, ReceiptStatus } from '@prisma/client';
-import {
-  acquirePaymentLinkedDocumentLock,
-  acquirePaymentReceiptLock,
-} from '../common/payment-linked-document-lock';
+import { acquirePaymentReceiptLock } from '../common/payment-linked-document-lock';
 
 export interface GenerateReceiptInput {
   paymentId: string;
@@ -51,6 +48,17 @@ type ChargeWithAllocations = Prisma.ChargeGetPayload<{
     };
   };
 }>;
+
+interface PreparedReceiptGeneration {
+  payment: PaymentReceiptPayment;
+  receiptNumber: string;
+  fileKey: string;
+  bucket: string;
+  approvedByUserName: string;
+  tenantDisplayName: string;
+  reuseExisting: boolean;
+  documentId?: string;
+}
 
 interface ReceiptPdfLine {
   text: string;
@@ -109,191 +117,355 @@ export class PaymentReceiptService {
   /**
    * Ensure a receipt exists for the given payment.
    * Idempotent: if receipt already exists, return it.
-   * If generation fails, sets receiptStatus = FAILED with error message.
+   * If generation fails before confirmation, sets receiptStatus = FAILED with error message.
    */
-  async ensureReceiptForPayment(paymentId: string, excludeUserId?: string): Promise<ReceiptData | null> {
+  async ensureReceiptForPayment(tenantId: string, paymentId: string, excludeUserId?: string): Promise<ReceiptData | null> {
+    let preparedReceipt: PreparedReceiptGeneration | null = null;
+    let uploadedReceiptObject = false;
+    let receiptFinalized = false;
+
     try {
-      const receipt = await this.prisma.$transaction(async (tx) => {
-        await acquirePaymentReceiptLock(tx, paymentId);
+      preparedReceipt = await this.prepareReceiptGeneration(tenantId, paymentId);
 
-        const payment = await tx.payment.findUnique({
-          where: { id: paymentId },
-          include: {
-            unit: true,
-            building: true,
-            createdByUser: true,
-            paymentAllocations: {
-              include: {
-                charge: {
-                  include: {
-                    expensePeriod: true,
-                  },
-                },
-              },
-            },
-          },
-        });
-
-        if (!payment) {
-          this.logger.error(`Payment ${paymentId} not found`);
-          return null;
-        }
-
-        // Idempotency: if receipt already exists, return it
-        if (payment.receiptDocumentId && payment.receiptNumber) {
-          this.logger.log(`Receipt already exists for payment ${paymentId}, reusing ${payment.receiptNumber}`);
-          const document = await tx.document.findUnique({
-            where: { id: payment.receiptDocumentId },
-            include: { file: true },
-          });
-
-          if (document?.file) {
-            return {
-              payment,
-              receiptNumber: payment.receiptNumber,
-              documentId: payment.receiptDocumentId,
-              fileKey: document.file.objectKey,
-              bucket: document.file.bucket,
-              wasGenerated: false,
-              approvedByUserName: 'Administración',
-            };
-          }
-        }
-
-        let approvedByUserName = 'Administración';
-        if (payment.approvedByUserId) {
-          const approvedByUser = await tx.user.findUnique({
-            where: { id: payment.approvedByUserId },
-            select: { name: true },
-          });
-          approvedByUserName = approvedByUser?.name || 'Administración';
-        }
-
-        const receiptNumber = await this.reserveReceiptNumberInTransaction(tx, payment.tenantId);
-        const tenant = await tx.tenant.findUnique({
-          where: { id: payment.tenantId },
-          select: { name: true, brandName: true },
-        });
-        const tenantDisplayName = tenant?.brandName || tenant?.name || 'Consorcio';
-
-        const pdfContent = await this.generateReceiptPDF(
-          payment,
-          receiptNumber,
-          approvedByUserName,
-          tenantDisplayName,
-        );
-
-        const objectKey = `tenant/${payment.tenantId}/payments/${paymentId}/receipt_${receiptNumber}.pdf`;
-        await this.minio.uploadBuffer(this.bucket, objectKey, pdfContent, 'application/pdf');
-
-        const file = await tx.file.create({
-          data: {
-            tenantId: payment.tenantId,
-            bucket: this.bucket,
-            objectKey,
-            originalName: `receipt_${receiptNumber}.pdf`,
-            mimeType: 'application/pdf',
-            size: pdfContent.length,
-          },
-        });
-
-        const document = await tx.document.create({
-          data: {
-            tenantId: payment.tenantId,
-            fileId: file.id,
-            title: `Recibo de pago ${receiptNumber}`,
-            category: DocumentCategory.RECEIPT,
-            visibility: DocumentVisibility.RESIDENTS,
-            buildingId: payment.buildingId,
-            unitId: payment.unitId,
-          },
-        });
-
-        await tx.payment.update({
-          where: { id: paymentId },
-          data: {
-            receiptDocumentId: document.id,
-            receiptNumber,
-            receiptStatus: ReceiptStatus.READY,
-            receiptGeneratedAt: new Date(),
-            receiptError: null,
-          },
-        });
-
-        await tx.paymentAuditLog.create({
-          data: {
-            tenantId: payment.tenantId,
-            paymentId,
-            action: 'RECEIPT_GENERATED',
-            metadata: {
-              receiptNumber,
-              documentId: document.id,
-              objectKey,
-            },
-          },
-        });
-
-        return {
-          payment,
-          receiptNumber,
-          documentId: document.id,
-          fileKey: objectKey,
-          bucket: this.bucket,
-          wasGenerated: true,
-          approvedByUserName,
-          tenantDisplayName,
-        };
-      });
-
-      if (!receipt) {
+      if (!preparedReceipt) {
         return null;
       }
 
-      const url = await this.minio.presignDownload(receipt.bucket, receipt.fileKey, 3600);
+      if (preparedReceipt.reuseExisting) {
+        const url = await this.minio.presignDownload(preparedReceipt.bucket, preparedReceipt.fileKey, 3600);
 
-      if (!receipt.wasGenerated) {
         return {
-          receiptNumber: receipt.receiptNumber,
-          documentId: receipt.documentId,
-          fileKey: receipt.fileKey,
-          bucket: this.bucket,
+          receiptNumber: preparedReceipt.receiptNumber,
+          documentId: preparedReceipt.documentId!,
+          fileKey: preparedReceipt.fileKey,
+          bucket: preparedReceipt.bucket,
           url,
         };
       }
 
-      // Notify resident
+      const pdfContent = await this.generateReceiptPDF(
+        preparedReceipt.payment,
+        preparedReceipt.receiptNumber,
+        preparedReceipt.approvedByUserName,
+        preparedReceipt.tenantDisplayName,
+      );
+
+      await this.minio.uploadBuffer(preparedReceipt.bucket, preparedReceipt.fileKey, pdfContent, 'application/pdf');
+      uploadedReceiptObject = true;
+
+      const finalizedReceipt = await this.finalizeReceiptGeneration(tenantId, preparedReceipt, pdfContent.length);
+      receiptFinalized = true;
+
+      const url = await this.minio.presignDownload(finalizedReceipt.bucket, finalizedReceipt.fileKey, 3600);
+
+      if (!finalizedReceipt.wasGenerated) {
+        return {
+          receiptNumber: finalizedReceipt.receiptNumber,
+          documentId: finalizedReceipt.documentId,
+          fileKey: finalizedReceipt.fileKey,
+          bucket: finalizedReceipt.bucket,
+          url,
+        };
+      }
+
+      // Notify resident outside the transaction.
       await this.notifyResidentReceiptReady(
-        receipt.payment,
-        receipt.receiptNumber,
+        finalizedReceipt.payment,
+        finalizedReceipt.receiptNumber,
         url,
-        receipt.approvedByUserName,
+        finalizedReceipt.approvedByUserName,
         excludeUserId,
       );
 
-      this.logger.log(`Receipt ${receipt.receiptNumber} generated for payment ${paymentId}`);
+      this.logger.log(`Receipt ${finalizedReceipt.receiptNumber} generated for payment ${paymentId}`);
 
       return {
-        receiptNumber: receipt.receiptNumber,
-        documentId: receipt.documentId,
-        fileKey: receipt.fileKey,
-        bucket: this.bucket,
+        receiptNumber: finalizedReceipt.receiptNumber,
+        documentId: finalizedReceipt.documentId,
+        fileKey: finalizedReceipt.fileKey,
+        bucket: finalizedReceipt.bucket,
         url,
       };
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : String(error);
       this.logger.error(`Failed to generate receipt for payment ${paymentId}: ${errorMessage}`);
 
-      // Mark as failed
-      await this.prisma.payment.update({
-        where: { id: paymentId },
-        data: {
-          receiptStatus: ReceiptStatus.FAILED,
-          receiptError: errorMessage,
-        },
-      });
+      if (uploadedReceiptObject && preparedReceipt && !preparedReceipt.reuseExisting && !receiptFinalized) {
+        await this.cleanupUploadedReceiptObjectIfSafe(tenantId, preparedReceipt);
+      }
+
+      await this.markReceiptGenerationFailedIfNeeded(tenantId, paymentId, errorMessage);
 
       return null;
     }
+  }
+
+  private async prepareReceiptGeneration(tenantId: string, paymentId: string): Promise<PreparedReceiptGeneration | null> {
+    return this.prisma.$transaction(async (tx) => {
+      await acquirePaymentReceiptLock(tx, paymentId);
+
+      const payment = await this.loadPaymentForReceipt(tx, tenantId, paymentId);
+
+      if (!payment) {
+        this.logger.error(`Payment ${paymentId} not found`);
+        return null;
+      }
+
+      if (payment.receiptDocumentId && payment.receiptNumber) {
+        this.logger.log(`Receipt already exists for payment ${paymentId}, reusing ${payment.receiptNumber}`);
+
+        const existingDocument = await tx.document.findUnique({
+          where: { id: payment.receiptDocumentId },
+          include: { file: true },
+        });
+
+        if (!existingDocument?.file) {
+          throw new Error(`Receipt document ${payment.receiptDocumentId} not found for payment ${paymentId}`);
+        }
+
+        const tenant = await tx.tenant.findUnique({
+          where: { id: payment.tenantId },
+          select: { name: true, brandName: true },
+        });
+
+        return {
+          payment,
+          receiptNumber: payment.receiptNumber,
+          fileKey: existingDocument.file.objectKey,
+          bucket: existingDocument.file.bucket,
+          approvedByUserName: 'Administración',
+          tenantDisplayName: tenant?.brandName || tenant?.name || 'Consorcio',
+          reuseExisting: true,
+          documentId: existingDocument.id,
+        };
+      }
+
+      let approvedByUserName = 'Administración';
+      if (payment.approvedByUserId) {
+        const approvedByUser = await tx.user.findUnique({
+          where: { id: payment.approvedByUserId },
+          select: { name: true },
+        });
+        approvedByUserName = approvedByUser?.name || 'Administración';
+      }
+
+      const receiptNumber = payment.receiptNumber || await this.reserveReceiptNumberInTransaction(tx, payment.tenantId);
+      const tenant = await tx.tenant.findUnique({
+        where: { id: payment.tenantId },
+        select: { name: true, brandName: true },
+      });
+      const tenantDisplayName = tenant?.brandName || tenant?.name || 'Consorcio';
+      const fileKey = this.buildReceiptObjectKey(payment.tenantId, paymentId, receiptNumber);
+
+      await tx.payment.update({
+        where: { id: paymentId, tenantId },
+        data: {
+          receiptNumber,
+          receiptStatus: ReceiptStatus.PENDING,
+          receiptGeneratedAt: null,
+          receiptError: null,
+        },
+      });
+
+      return {
+        payment,
+        receiptNumber,
+        fileKey,
+        bucket: this.bucket,
+        approvedByUserName,
+        tenantDisplayName,
+        reuseExisting: false,
+      };
+    });
+  }
+
+  private async finalizeReceiptGeneration(
+    tenantId: string,
+    preparedReceipt: PreparedReceiptGeneration,
+    pdfSize: number,
+  ): Promise<PreparedReceiptGeneration & { documentId: string; wasGenerated: boolean }> {
+    return this.prisma.$transaction(async (tx) => {
+      await acquirePaymentReceiptLock(tx, preparedReceipt.payment.id);
+
+      const currentPayment = await this.loadPaymentForReceipt(tx, tenantId, preparedReceipt.payment.id);
+
+      if (!currentPayment) {
+        throw new Error(`Payment ${preparedReceipt.payment.id} not found while finalizing receipt`);
+      }
+
+      if (currentPayment.receiptDocumentId && currentPayment.receiptNumber) {
+        const existingDocument = await tx.document.findUnique({
+          where: { id: currentPayment.receiptDocumentId },
+          include: { file: true },
+        });
+
+        if (!existingDocument?.file) {
+          throw new Error(`Receipt document ${currentPayment.receiptDocumentId} not found for payment ${preparedReceipt.payment.id}`);
+        }
+
+        this.logger.log(`Receipt already finalized for payment ${preparedReceipt.payment.id}, reusing ${currentPayment.receiptNumber}`);
+
+        return {
+          ...preparedReceipt,
+          payment: currentPayment,
+          receiptNumber: currentPayment.receiptNumber,
+          fileKey: existingDocument.file.objectKey,
+          bucket: existingDocument.file.bucket,
+          documentId: existingDocument.id,
+          wasGenerated: false,
+        };
+      }
+
+      const file = await tx.file.create({
+        data: {
+          tenantId: preparedReceipt.payment.tenantId,
+          bucket: preparedReceipt.bucket,
+          objectKey: preparedReceipt.fileKey,
+          originalName: `receipt_${preparedReceipt.receiptNumber}.pdf`,
+          mimeType: 'application/pdf',
+          size: pdfSize,
+        },
+      });
+
+      const document = await tx.document.create({
+        data: {
+          tenantId: preparedReceipt.payment.tenantId,
+          fileId: file.id,
+          title: `Recibo de pago ${preparedReceipt.receiptNumber}`,
+          category: DocumentCategory.RECEIPT,
+          visibility: DocumentVisibility.RESIDENTS,
+          buildingId: preparedReceipt.payment.buildingId,
+          unitId: preparedReceipt.payment.unitId,
+        },
+      });
+
+      await tx.payment.update({
+        where: { id: preparedReceipt.payment.id, tenantId },
+        data: {
+          receiptDocumentId: document.id,
+          receiptNumber: preparedReceipt.receiptNumber,
+          receiptStatus: ReceiptStatus.READY,
+          receiptGeneratedAt: new Date(),
+          receiptError: null,
+        },
+      });
+
+      await tx.paymentAuditLog.create({
+        data: {
+          tenantId: preparedReceipt.payment.tenantId,
+          paymentId: preparedReceipt.payment.id,
+          action: 'RECEIPT_GENERATED',
+          metadata: {
+            receiptNumber: preparedReceipt.receiptNumber,
+            documentId: document.id,
+            objectKey: preparedReceipt.fileKey,
+          },
+        },
+      });
+
+      return {
+        ...preparedReceipt,
+        payment: currentPayment,
+        documentId: document.id,
+        wasGenerated: true,
+      };
+    });
+  }
+
+  private async cleanupUploadedReceiptObjectIfSafe(tenantId: string, preparedReceipt: PreparedReceiptGeneration): Promise<void> {
+    try {
+      const payment = await this.prisma.payment.findUnique({
+        where: { id: preparedReceipt.payment.id, tenantId },
+        select: {
+          receiptDocumentId: true,
+          receiptNumber: true,
+        },
+      });
+
+      if (payment?.receiptDocumentId && payment.receiptNumber === preparedReceipt.receiptNumber) {
+        this.logger.warn(
+          `Skipping cleanup for ${preparedReceipt.bucket}/${preparedReceipt.fileKey} because payment ${preparedReceipt.payment.id} is already confirmed`,
+        );
+        return;
+      }
+
+      const file = await this.prisma.file.findFirst({
+        where: {
+          tenantId: preparedReceipt.payment.tenantId,
+          bucket: preparedReceipt.bucket,
+          objectKey: preparedReceipt.fileKey,
+        },
+        include: {
+          document: {
+            select: { id: true },
+          },
+        },
+      });
+
+      if (file?.document) {
+        this.logger.warn(
+          `Skipping cleanup for ${preparedReceipt.bucket}/${preparedReceipt.fileKey} because the receipt file is already confirmed`,
+        );
+        return;
+      }
+
+      await this.minio.deleteObject(preparedReceipt.bucket, preparedReceipt.fileKey);
+    } catch (cleanupError) {
+      const errorMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+      this.logger.warn(
+        `Failed to clean up orphaned receipt object ${preparedReceipt.bucket}/${preparedReceipt.fileKey}: ${errorMessage}`,
+      );
+    }
+  }
+
+  private async markReceiptGenerationFailedIfNeeded(tenantId: string, paymentId: string, errorMessage: string): Promise<void> {
+    const payment = await this.prisma.payment.findFirst({
+      where: { id: paymentId, tenantId },
+      select: {
+        receiptStatus: true,
+        receiptDocumentId: true,
+      },
+    });
+
+    if (!payment || payment.receiptStatus === ReceiptStatus.READY || payment.receiptDocumentId) {
+      return;
+    }
+
+    await this.prisma.payment.update({
+      where: { id: paymentId, tenantId },
+      data: {
+        receiptStatus: ReceiptStatus.FAILED,
+        receiptError: errorMessage,
+      },
+    });
+  }
+
+  private async loadPaymentForReceipt(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    paymentId: string,
+  ): Promise<PaymentReceiptPayment | null> {
+    return tx.payment.findFirst({
+      where: { id: paymentId, tenantId },
+      include: {
+        unit: true,
+        building: true,
+        createdByUser: true,
+        paymentAllocations: {
+          include: {
+            charge: {
+              include: {
+                expensePeriod: true,
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  private buildReceiptObjectKey(tenantId: string, paymentId: string, receiptNumber: string): string {
+    return `tenant/${tenantId}/payments/${paymentId}/receipts/${receiptNumber}.pdf`;
   }
 
   /**

--- a/apps/api/src/receipts/payment-receipt.service.ts
+++ b/apps/api/src/receipts/payment-receipt.service.ts
@@ -3,6 +3,10 @@ import { PrismaService } from '../prisma/prisma.service';
 import { MinioService } from '../storage/minio.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { DocumentCategory, DocumentVisibility, Prisma, ReceiptStatus } from '@prisma/client';
+import {
+  acquirePaymentLinkedDocumentLock,
+  acquirePaymentReceiptLock,
+} from '../common/payment-linked-document-lock';
 
 export interface GenerateReceiptInput {
   paymentId: string;
@@ -13,6 +17,7 @@ export interface ReceiptData {
   receiptNumber: string;
   documentId: string;
   fileKey: string;
+  bucket: string;
   url: string;
 }
 
@@ -107,148 +112,171 @@ export class PaymentReceiptService {
    * If generation fails, sets receiptStatus = FAILED with error message.
    */
   async ensureReceiptForPayment(paymentId: string, excludeUserId?: string): Promise<ReceiptData | null> {
-    const payment = await this.prisma.payment.findUnique({
-      where: { id: paymentId },
-      include: {
-        unit: true,
-        building: true,
-        createdByUser: true,
-        paymentAllocations: {
+    try {
+      const receipt = await this.prisma.$transaction(async (tx) => {
+        await acquirePaymentReceiptLock(tx, paymentId);
+
+        const payment = await tx.payment.findUnique({
+          where: { id: paymentId },
           include: {
-            charge: {
+            unit: true,
+            building: true,
+            createdByUser: true,
+            paymentAllocations: {
               include: {
-                expensePeriod: true,
+                charge: {
+                  include: {
+                    expensePeriod: true,
+                  },
+                },
               },
             },
           },
-        },
-      },
-    });
+        });
 
-    // Get approvedByUser separately
-    let approvedByUserName = 'Administración';
-    if (payment?.approvedByUserId) {
-      const approvedByUser = await this.prisma.user.findUnique({
-        where: { id: payment.approvedByUserId },
-        select: { name: true },
-      });
-      approvedByUserName = approvedByUser?.name || 'Administración';
-    }
+        if (!payment) {
+          this.logger.error(`Payment ${paymentId} not found`);
+          return null;
+        }
 
-    if (!payment) {
-      this.logger.error(`Payment ${paymentId} not found`);
-      return null;
-    }
+        // Idempotency: if receipt already exists, return it
+        if (payment.receiptDocumentId && payment.receiptNumber) {
+          this.logger.log(`Receipt already exists for payment ${paymentId}, reusing ${payment.receiptNumber}`);
+          const document = await tx.document.findUnique({
+            where: { id: payment.receiptDocumentId },
+            include: { file: true },
+          });
 
-    // Idempotency: if receipt already exists, return it
-    if (payment.receiptDocumentId && payment.receiptNumber) {
-      this.logger.log(`Receipt already exists for payment ${paymentId}, reusing ${payment.receiptNumber}`);
-      const document = await this.prisma.document.findUnique({
-        where: { id: payment.receiptDocumentId },
-        include: { file: true },
-      });
+          if (document?.file) {
+            return {
+              payment,
+              receiptNumber: payment.receiptNumber,
+              documentId: payment.receiptDocumentId,
+              fileKey: document.file.objectKey,
+              bucket: document.file.bucket,
+              wasGenerated: false,
+              approvedByUserName: 'Administración',
+            };
+          }
+        }
 
-      if (document?.file) {
-        const url = await this.minio.presignDownload(document.file.bucket, document.file.objectKey, 3600);
+        let approvedByUserName = 'Administración';
+        if (payment.approvedByUserId) {
+          const approvedByUser = await tx.user.findUnique({
+            where: { id: payment.approvedByUserId },
+            select: { name: true },
+          });
+          approvedByUserName = approvedByUser?.name || 'Administración';
+        }
+
+        const receiptNumber = await this.reserveReceiptNumberInTransaction(tx, payment.tenantId);
+        const tenant = await tx.tenant.findUnique({
+          where: { id: payment.tenantId },
+          select: { name: true, brandName: true },
+        });
+        const tenantDisplayName = tenant?.brandName || tenant?.name || 'Consorcio';
+
+        const pdfContent = await this.generateReceiptPDF(
+          payment,
+          receiptNumber,
+          approvedByUserName,
+          tenantDisplayName,
+        );
+
+        const objectKey = `tenant/${payment.tenantId}/payments/${paymentId}/receipt_${receiptNumber}.pdf`;
+        await this.minio.uploadBuffer(this.bucket, objectKey, pdfContent, 'application/pdf');
+
+        const file = await tx.file.create({
+          data: {
+            tenantId: payment.tenantId,
+            bucket: this.bucket,
+            objectKey,
+            originalName: `receipt_${receiptNumber}.pdf`,
+            mimeType: 'application/pdf',
+            size: pdfContent.length,
+          },
+        });
+
+        const document = await tx.document.create({
+          data: {
+            tenantId: payment.tenantId,
+            fileId: file.id,
+            title: `Recibo de pago ${receiptNumber}`,
+            category: DocumentCategory.RECEIPT,
+            visibility: DocumentVisibility.RESIDENTS,
+            buildingId: payment.buildingId,
+            unitId: payment.unitId,
+          },
+        });
+
+        await tx.payment.update({
+          where: { id: paymentId },
+          data: {
+            receiptDocumentId: document.id,
+            receiptNumber,
+            receiptStatus: ReceiptStatus.READY,
+            receiptGeneratedAt: new Date(),
+            receiptError: null,
+          },
+        });
+
+        await tx.paymentAuditLog.create({
+          data: {
+            tenantId: payment.tenantId,
+            paymentId,
+            action: 'RECEIPT_GENERATED',
+            metadata: {
+              receiptNumber,
+              documentId: document.id,
+              objectKey,
+            },
+          },
+        });
+
         return {
-          receiptNumber: payment.receiptNumber,
-          documentId: payment.receiptDocumentId,
-          fileKey: document.file.objectKey,
+          payment,
+          receiptNumber,
+          documentId: document.id,
+          fileKey: objectKey,
+          bucket: this.bucket,
+          wasGenerated: true,
+          approvedByUserName,
+          tenantDisplayName,
+        };
+      });
+
+      if (!receipt) {
+        return null;
+      }
+
+      const url = await this.minio.presignDownload(receipt.bucket, receipt.fileKey, 3600);
+
+      if (!receipt.wasGenerated) {
+        return {
+          receiptNumber: receipt.receiptNumber,
+          documentId: receipt.documentId,
+          fileKey: receipt.fileKey,
+          bucket: this.bucket,
           url,
         };
       }
-    }
-
-    try {
-      // Generate receipt number
-      const receiptNumber = await this.reserveReceiptNumber(payment.tenantId);
-
-      // Generate PDF content (for now, simple text - can be upgraded to proper PDF later)
-      const pdfContent = await this.generateReceiptPDF(
-        payment,
-        receiptNumber,
-        approvedByUserName,
-      );
-
-      // Save to storage
-      const objectKey = `tenant/${payment.tenantId}/payments/${paymentId}/receipt_${receiptNumber}.pdf`;
-      await this.minio.uploadBuffer(this.bucket, objectKey, pdfContent, 'application/pdf');
-
-      // Create File record
-      const file = await this.prisma.file.create({
-        data: {
-          tenantId: payment.tenantId,
-          bucket: this.bucket,
-          objectKey,
-          originalName: `receipt_${receiptNumber}.pdf`,
-          mimeType: 'application/pdf',
-          size: pdfContent.length,
-        },
-      });
-
-      // Get tenant info
-      const tenant = await this.prisma.tenant.findUnique({
-        where: { id: payment.tenantId },
-        select: { name: true, brandName: true },
-      });
-      const tenantDisplayName = tenant?.brandName || tenant?.name || 'Consorcio';
-
-      // Create Document record (RECEIPT category, RESIDENTS visibility for admin+resident access)
-      const document = await this.prisma.document.create({
-        data: {
-          tenantId: payment.tenantId,
-          fileId: file.id,
-          title: `Recibo de pago ${receiptNumber}`,
-          category: DocumentCategory.RECEIPT,
-          visibility: DocumentVisibility.RESIDENTS,
-          buildingId: payment.buildingId,
-          unitId: payment.unitId,
-        },
-      });
-
-      // Update payment with receipt info
-      await this.prisma.payment.update({
-        where: { id: paymentId },
-        data: {
-          receiptDocumentId: document.id,
-          receiptNumber,
-          receiptStatus: ReceiptStatus.READY,
-          receiptGeneratedAt: new Date(),
-          receiptError: null,
-        },
-      });
-
-      // Audit log
-      await this.prisma.paymentAuditLog.create({
-        data: {
-          tenantId: payment.tenantId,
-          paymentId,
-          action: 'RECEIPT_GENERATED',
-          metadata: {
-            receiptNumber,
-            documentId: document.id,
-            objectKey,
-          },
-        },
-      });
-
-      const url = await this.minio.presignDownload(this.bucket, objectKey, 3600);
 
       // Notify resident
       await this.notifyResidentReceiptReady(
-        payment,
-        receiptNumber,
+        receipt.payment,
+        receipt.receiptNumber,
         url,
-        approvedByUserName,
+        receipt.approvedByUserName,
         excludeUserId,
       );
 
-      this.logger.log(`Receipt ${receiptNumber} generated for payment ${paymentId}`);
+      this.logger.log(`Receipt ${receipt.receiptNumber} generated for payment ${paymentId}`);
 
       return {
-        receiptNumber,
-        documentId: document.id,
-        fileKey: objectKey,
+        receiptNumber: receipt.receiptNumber,
+        documentId: receipt.documentId,
+        fileKey: receipt.fileKey,
+        bucket: this.bucket,
         url,
       };
     } catch (error) {
@@ -272,11 +300,14 @@ export class PaymentReceiptService {
    * Reserve a sequential receipt number for the tenant/year.
    * Uses transaction to ensure atomic increment.
    */
-  private async reserveReceiptNumber(tenantId: string): Promise<string> {
+  private async reserveReceiptNumberInTransaction(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+  ): Promise<string> {
     const year = new Date().getFullYear();
 
     // Get tenant for slug
-    const tenant = await this.prisma.tenant.findUnique({
+    const tenant = await tx.tenant.findUnique({
       where: { id: tenantId },
       select: { name: true },
     });
@@ -285,38 +316,33 @@ export class PaymentReceiptService {
       .replace(/[^a-z0-9]/g, '')
       .substring(0, 6) || tenantId.substring(0, 6);
 
-    // Atomic increment using transaction
-    const result = await this.prisma.$transaction(async (tx) => {
-      // Try to find existing sequence
-      let sequence = await tx.receiptSequence.findUnique({
-        where: {
-          tenantId_year: { tenantId, year },
+    // Try to find existing sequence
+    let sequence = await tx.receiptSequence.findUnique({
+      where: {
+        tenantId_year: { tenantId, year },
+      },
+    });
+
+    if (!sequence) {
+      // Create new sequence
+      sequence = await tx.receiptSequence.create({
+        data: {
+          tenantId,
+          year,
+          lastNumber: 0,
         },
       });
+    }
 
-      if (!sequence) {
-        // Create new sequence
-        sequence = await tx.receiptSequence.create({
-          data: {
-            tenantId,
-            year,
-            lastNumber: 0,
-          },
-        });
-      }
-
-      // Increment
-      const newNumber = sequence.lastNumber + 1;
-      await tx.receiptSequence.update({
-        where: { id: sequence.id },
-        data: { lastNumber: newNumber, updatedAt: new Date() },
-      });
-
-      return newNumber;
+    // Increment
+    const newNumber = sequence.lastNumber + 1;
+    await tx.receiptSequence.update({
+      where: { id: sequence.id },
+      data: { lastNumber: newNumber, updatedAt: new Date() },
     });
 
     // Format: R-{TENANT}-{YYYY}-{000001}
-    const paddedNumber = result.toString().padStart(6, '0');
+    const paddedNumber = newNumber.toString().padStart(6, '0');
     return `R-${tenantSlug.toUpperCase()}-${year}-${paddedNumber}`;
   }
 
@@ -327,13 +353,8 @@ export class PaymentReceiptService {
     payment: PaymentReceiptPayment,
     receiptNumber: string,
     approvedByUserName: string,
+    tenantDisplayName: string,
   ): Promise<Buffer> {
-    const tenant = await this.prisma.tenant.findUnique({
-      where: { id: payment.tenantId },
-      select: { name: true, brandName: true },
-    });
-    const tenantDisplayName = tenant?.brandName || tenant?.name || 'Consorcio';
-
     const approvedAt = this.formatReceiptDate(payment.approvedAt ?? new Date());
     const unitLabel = payment.unit?.label || payment.unitId || 'N/A';
     const buildingName = payment.building?.name || 'Edificio';


### PR DESCRIPTION
Closes #85

## Summary
- Enforced payment-linked document immutability with transaction-level advisory locks.
- Shortened receipt generation so the PDF build, MinIO upload, presign, and notifications happen outside the database transactions.
- Closed the remaining post-failure races so the canonical receipt object is preserved and the FAILED transition is serialized under the same receipt lock.

## Changes
| File | Change |
|------|--------|
| `apps/api/src/common/payment-linked-document-lock.ts` | Added shared advisory-lock and immutability helpers. |
| `apps/api/src/documents/documents.service.ts` | Wrapped update/delete in transactions and blocked linked documents. |
| `apps/api/src/finanzas/finanzas.service.ts` | Passed tenant context through receipt generation calls so the service can revalidate tenant scope. |
| `apps/api/src/receipts/payment-receipt.service.ts` | Split receipt generation into preparation, external work, finalization, and post-actions with tenant-scoped document lookups and serialized failure marking. |
| `apps/api/src/documents/documents.service.spec.ts` | Added immutability regression coverage for proof and receipt links. |
| `apps/api/src/finanzas/finanzas.service.spec.ts` | Added lock-path assertion for payment submission. |
| `apps/api/src/receipts/payment-receipt.service.spec.ts` | Added transaction-boundary, retry-reuse, cleanup-safety, and post-failure race coverage for receipt generation. |

## Test Plan
- [x] Focused API specs: `./node_modules/.bin/jest --config apps/api/jest.config.js apps/api/src/receipts/payment-receipt.service.spec.ts apps/api/src/finanzas/finanzas.service.spec.ts apps/api/src/documents/documents.service.spec.ts --runInBand`
- [x] Lint: `npm run lint:ci -w apps/api`
- [x] TypeScript check attempted: `./node_modules/.bin/tsc -p apps/api/tsconfig.json --noEmit` (repo still has pre-existing `@buildingos/contracts`, `@buildingos/permissions`, and `tenant-access.guard.ts` errors unrelated to this slice)
- [x] Build attempted: `npm run build -w apps/api` (repo still has the same pre-existing type errors unrelated to this slice)
- [x] Manual validation: verified `pwd`, branch, HEAD, remote main, `git diff --check`, `git diff --stat`, `git diff --name-status`, and full diff review

## Notes
- The canonical receipt object key is not deleted after a failed finalization; it remains reusable by retry with the same receipt number and object key.
- The FAILED transition now happens under the same payment receipt advisory lock, so READY and confirmed receipts are never downgraded back to FAILED.
- Existing document lookups are filtered by `tenantId`.
- The concurrency coverage in the receipt spec verifies the protocol with mocks; it is not a PostgreSQL race test.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts or marked N/A (no scripts changed)
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed or marked N/A (behavior change is captured in PR body and tests)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
