### PR TITLE
fix(auth): revoke session on logout

### DIFF
--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -1,0 +1,123 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { GUARDS_METADATA } from '@nestjs/common/constants';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { PlanFeaturesService } from '../billing/plan-features.service';
+import { SentryService } from '../observability/sentry.service';
+import { JwtAuthGuard } from './jwt-auth.guard';
+
+describe('AuthController', () => {
+  let controller: AuthController;
+  let authService: {
+    logoutCurrentSession: jest.Mock;
+    logoutAllSessions: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    authService = {
+      logoutCurrentSession: jest.fn(),
+      logoutAllSessions: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AuthController],
+      providers: [
+        {
+          provide: AuthService,
+          useValue: authService,
+        },
+        {
+          provide: PlanFeaturesService,
+          useValue: {
+            getTenantFeatures: jest.fn(),
+          },
+        },
+        {
+          provide: SentryService,
+          useValue: {
+            setUser: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get(AuthController);
+  });
+
+  it('does not require JwtAuthGuard metadata on POST /auth/logout', () => {
+    const logoutGuards = Reflect.getMetadata(GUARDS_METADATA, AuthController.prototype.logout) as unknown[] | undefined;
+    const logoutAllGuards = Reflect.getMetadata(GUARDS_METADATA, AuthController.prototype.logoutAll) as unknown[] | undefined;
+
+    expect(logoutGuards ?? []).not.toContain(JwtAuthGuard);
+    expect(logoutAllGuards ?? []).toContain(JwtAuthGuard);
+  });
+
+  it('revokes the current session using refresh and access credentials when present', async () => {
+    const res = createResponseMock();
+    authService.logoutCurrentSession.mockResolvedValue(undefined);
+
+    await expect(
+      controller.logout(
+        {
+          headers: {
+            cookie: 'bo_refresh_token=refresh-123; bo_access_token=access-cookie-123',
+          },
+        } as never,
+        'Bearer access-header-123',
+        res as never,
+      ),
+    ).resolves.toEqual({ ok: true });
+
+    expect(authService.logoutCurrentSession).toHaveBeenCalledWith({
+      refreshToken: 'refresh-123',
+      accessToken: 'access-header-123',
+    });
+    expect(res.clearCookie).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns ok and clears cookies even when no credentials are present', async () => {
+    const res = createResponseMock();
+    authService.logoutCurrentSession.mockResolvedValue(undefined);
+
+    await expect(
+      controller.logout(
+        {
+          headers: {},
+        } as never,
+        undefined,
+        res as never,
+      ),
+    ).resolves.toEqual({ ok: true });
+
+    expect(authService.logoutCurrentSession).toHaveBeenCalledWith({
+      refreshToken: null,
+      accessToken: null,
+    });
+    expect(res.clearCookie).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears cookies and propagates infrastructure errors', async () => {
+    const res = createResponseMock();
+    authService.logoutCurrentSession.mockRejectedValue(new Error('database unavailable'));
+
+    await expect(
+      controller.logout(
+        {
+          headers: {
+            cookie: 'bo_refresh_token=refresh-123',
+          },
+        } as never,
+        undefined,
+        res as never,
+      ),
+    ).rejects.toThrow('database unavailable');
+
+    expect(res.clearCookie).toHaveBeenCalledTimes(2);
+  });
+
+  function createResponseMock() {
+    return {
+      clearCookie: jest.fn(),
+    };
+  }
+});

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -17,6 +17,7 @@ import { LoginDto } from './dto/login.dto';
 import { SignupDto } from './dto/signup.dto';
 import { JwtAuthGuard } from './jwt-auth.guard';
 import {
+  ACCESS_TOKEN_COOKIE,
   clearAuthCookies,
   getCookie,
   REFRESH_TOKEN_COOKIE,
@@ -45,6 +46,10 @@ interface RequestWithUser extends ExpressRequest {
   };
 }
 
+type LogoutRequest = ExpressRequest & {
+  user?: RequestWithUser['user'];
+};
+
 interface PublicAuthResponse {
   user: AuthResponse['user'];
   memberships: AuthResponse['memberships'];
@@ -65,6 +70,10 @@ export class AuthController {
     };
   }
 
+  /**
+   * POST /auth/signup
+   * Create a new user, tenant, membership, and authenticated session.
+   */
   @Post('signup')
   async signup(
     @Body() signupDto: SignupDto,
@@ -79,6 +88,10 @@ export class AuthController {
     return this.buildResponse(response);
   }
 
+  /**
+   * POST /auth/login
+   * Validate credentials and issue fresh auth cookies for the selected tenant.
+   */
   @Post('login')
   async login(
     @Body() loginDto: LoginDto,
@@ -103,6 +116,10 @@ export class AuthController {
     return this.buildResponse(response);
   }
 
+  /**
+   * POST /auth/refresh
+   * Rotate the current refresh token and return new auth cookies.
+   */
   @Post('refresh')
   async refresh(
     @Request() req: ExpressRequest,
@@ -118,20 +135,35 @@ export class AuthController {
     return this.buildResponse(response);
   }
 
-  @UseGuards(JwtAuthGuard)
+  /**
+   * POST /auth/logout
+   * Revoke the current session if possible, then always clear auth cookies.
+   */
   @Post('logout')
   async logout(
-    @Request() req: RequestWithUser,
+    @Request() req: LogoutRequest,
+    @Headers('authorization') authorization: string | undefined,
     @Res({ passthrough: true }) res: Response,
   ): Promise<{ ok: true }> {
-    if (req.user.sessionId) {
-      await this.authService.logoutSession(req.user.sessionId);
-    }
+    const refreshToken = getCookie(req, REFRESH_TOKEN_COOKIE);
+    const cookieAccessToken = getCookie(req, ACCESS_TOKEN_COOKIE);
+    const accessToken = this.extractAccessToken(authorization, cookieAccessToken);
 
-    clearAuthCookies(res);
-    return { ok: true };
+    try {
+      await this.authService.logoutCurrentSession({
+        refreshToken,
+        accessToken,
+      });
+      return { ok: true };
+    } finally {
+      clearAuthCookies(res);
+    }
   }
 
+  /**
+   * POST /auth/logout-all
+   * Revoke every active session for the current authenticated user.
+   */
   @UseGuards(JwtAuthGuard)
   @Post('logout-all')
   async logoutAll(
@@ -143,6 +175,10 @@ export class AuthController {
     return { ok: true };
   }
 
+  /**
+   * GET /auth/me
+   * Return the authenticated user's public profile and memberships.
+   */
   @UseGuards(JwtAuthGuard)
   @Get('me')
   async getProfile(
@@ -185,5 +221,17 @@ export class AuthController {
       },
       features,
     };
+  }
+
+  private extractAccessToken(
+    authorization: string | undefined,
+    cookieAccessToken: string | null,
+  ): string | null {
+    if (!authorization) {
+      return cookieAccessToken;
+    }
+
+    const bearerMatch = authorization.trim().match(/^Bearer\s+(\S+)$/i);
+    return bearerMatch?.[1] ?? cookieAccessToken;
   }
 }

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import {
   ConflictException,
   BadRequestException,
+  UnauthorizedException,
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { AuthService, AuthResponse } from './auth.service';
@@ -57,6 +58,7 @@ describe('AuthService', () => {
           provide: JwtService,
           useValue: {
             sign: jest.fn(),
+            verifyAsync: jest.fn(),
           },
         },
         {
@@ -766,11 +768,7 @@ describe('AuthService', () => {
       };
 
       jest.spyOn(prismaService.authSession, 'findUnique').mockResolvedValue(session as any);
-      jest.spyOn(prismaService.authSession, 'update').mockResolvedValue({
-        ...session,
-        refreshTokenHash: 'next-refresh-hash',
-        lastUsedAt: new Date(),
-      } as any);
+      jest.spyOn(prismaService.authSession, 'updateMany').mockResolvedValue({ count: 1 } as any);
       jest.spyOn(prismaService.user, 'findUnique').mockResolvedValue({
         id: 'user-123',
         email: 'user@example.com',
@@ -786,14 +784,22 @@ describe('AuthService', () => {
       expect(prismaService.authSession.findUnique).toHaveBeenCalledWith({
         where: { refreshTokenHash },
       });
-      expect(prismaService.authSession.update).toHaveBeenCalledWith({
-        where: { id: 'session-refresh-123' },
+      expect(prismaService.authSession.updateMany).toHaveBeenCalledWith({
+        where: {
+          id: 'session-refresh-123',
+          refreshTokenHash,
+          revokedAt: null,
+          expiresAt: { gt: expect.any(Date) },
+        },
         data: expect.objectContaining({
           refreshTokenHash: expect.any(String),
           expiresAt: expect.any(Date),
           lastUsedAt: expect.any(Date),
         }),
       });
+      expect(
+        jest.mocked(prismaService.authSession.updateMany).mock.calls[0][0].data,
+      ).not.toHaveProperty('revokedAt');
       expect(result.sessionId).toBe('session-refresh-123');
       expect(result.refreshToken).toEqual(expect.any(String));
       expect(jwtService.sign).toHaveBeenCalledWith(
@@ -801,6 +807,39 @@ describe('AuthService', () => {
           sid: 'session-refresh-123',
         }),
       );
+    });
+
+    it('should reject refresh if the session is revoked before rotation', async () => {
+      const refreshToken = 'refresh-token-raw';
+      const refreshTokenHash = crypto
+        .createHash('sha256')
+        .update(refreshToken)
+        .digest('hex');
+
+      jest.spyOn(prismaService.authSession, 'findUnique').mockResolvedValue({
+        id: 'session-refresh-123',
+        userId: 'user-123',
+        refreshTokenHash,
+        expiresAt: new Date(Date.now() + 1000 * 60 * 60),
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        lastUsedAt: null,
+        revokedAt: null,
+        userAgent: null,
+        ipAddress: null,
+      } as any);
+      jest.spyOn(prismaService.authSession, 'updateMany').mockResolvedValue({ count: 0 } as any);
+      jest.spyOn(prismaService.user, 'findUnique').mockResolvedValue({
+        id: 'user-123',
+        email: 'user@example.com',
+        name: 'User Name',
+      } as any);
+      jest.spyOn(tenancyService, 'getMembershipsForUser').mockResolvedValue([
+        { tenantId: 'tenant-123', roles: ['TENANT_OWNER'] },
+      ] as any);
+
+      await expect(service.refreshSession(refreshToken)).rejects.toThrow(UnauthorizedException);
+      expect(jwtService.sign).not.toHaveBeenCalled();
     });
   });
 
@@ -826,6 +865,94 @@ describe('AuthService', () => {
         where: { userId: 'user-123', revokedAt: null },
         data: { revokedAt: expect.any(Date) },
       });
+    });
+  });
+
+  describe('logoutCurrentSession', () => {
+    it('revokes exactly one session using the refresh token hash', async () => {
+      const refreshToken = 'refresh-token-raw';
+      const refreshTokenHash = crypto
+        .createHash('sha256')
+        .update(refreshToken)
+        .digest('hex');
+
+      jest.spyOn(prismaService.authSession, 'updateMany').mockResolvedValue({ count: 1 } as any);
+
+      await service.logoutCurrentSession({ refreshToken });
+
+      expect(prismaService.authSession.updateMany).toHaveBeenCalledWith({
+        where: {
+          refreshTokenHash,
+          revokedAt: null,
+        },
+        data: {
+          revokedAt: expect.any(Date),
+        },
+      });
+      expect(jwtService.verifyAsync).not.toHaveBeenCalled();
+    });
+
+    it('returns quietly when the refresh token does not match an active session', async () => {
+      const refreshToken = 'missing-refresh-token';
+      const refreshTokenHash = crypto
+        .createHash('sha256')
+        .update(refreshToken)
+        .digest('hex');
+
+      jest.spyOn(prismaService.authSession, 'updateMany').mockResolvedValue({ count: 0 } as any);
+
+      await expect(service.logoutCurrentSession({ refreshToken })).resolves.toBeUndefined();
+
+      expect(prismaService.authSession.updateMany).toHaveBeenCalledWith({
+        where: {
+          refreshTokenHash,
+          revokedAt: null,
+        },
+        data: {
+          revokedAt: expect.any(Date),
+        },
+      });
+    });
+
+    it('falls back to a verified access token when the refresh token does not revoke anything', async () => {
+      const accessToken = 'access-token-raw';
+
+      jest.spyOn(prismaService.authSession, 'updateMany')
+        .mockResolvedValueOnce({ count: 0 } as any)
+        .mockResolvedValueOnce({ count: 1 } as any);
+      jest.spyOn(jwtService, 'verifyAsync').mockResolvedValue({
+        sub: 'user-123',
+        sid: 'session-123',
+      } as never);
+
+      await service.logoutCurrentSession({
+        refreshToken: 'stale-refresh-token',
+        accessToken,
+      });
+
+      expect(jwtService.verifyAsync).toHaveBeenCalledWith(accessToken);
+      expect(prismaService.authSession.updateMany).toHaveBeenNthCalledWith(2, {
+        where: {
+          id: 'session-123',
+          userId: 'user-123',
+          revokedAt: null,
+        },
+        data: {
+          revokedAt: expect.any(Date),
+        },
+      });
+    });
+
+    it('returns quietly when the access token cannot be verified', async () => {
+      jest.spyOn(jwtService, 'verifyAsync').mockRejectedValue(new Error('invalid token'));
+
+      await expect(
+        service.logoutCurrentSession({
+          accessToken: 'invalid-access',
+        }),
+      ).resolves.toBeUndefined();
+
+      expect(prismaService.authSession.updateMany).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -9,24 +9,26 @@ import { PrismaService } from '../prisma/prisma.service';
 import { TenancyService } from '../tenancy/tenancy.service';
 import { AuditService } from '../audit/audit.service';
 import { SignupDto, TenantTypeEnum } from './dto/signup.dto';
-import { AuditAction, AuthSession } from '@prisma/client';
+import { AuditAction, AuthSession, Prisma } from '@prisma/client';
 import * as bcrypt from 'bcrypt';
 import * as crypto from 'crypto';
-
-interface UserWithMemberships {
-  id: string;
-  email: string;
-  name: string;
-  memberships: Array<{
-    tenantId: string;
-    roles: Array<{ role: string }>;
-  }>;
-}
 
 interface TenantMembershipForLogin {
   tenantId: string;
   roles: string[];
 }
+
+type UserWithMemberships = Prisma.UserGetPayload<{
+  include: {
+    memberships: {
+      include: {
+        roles: true;
+      };
+    };
+  };
+}>;
+
+type ValidatedUser = Omit<UserWithMemberships, 'passwordHash'>;
 
 export interface AuthResponse {
   accessToken: string;
@@ -45,6 +47,16 @@ export interface AuthResponse {
 
 interface IssueAuthResult extends AuthResponse {
   session: AuthSession;
+}
+
+interface LogoutCredentials {
+  refreshToken?: string | null;
+  accessToken?: string | null;
+}
+
+interface VerifiedAccessToken {
+  sub: string;
+  sid: string;
 }
 
 @Injectable()
@@ -143,7 +155,7 @@ export class AuthService {
     });
   }
 
-  async validateUser(email: string, pass: string): Promise<UserWithMemberships | null> {
+  async validateUser(email: string, pass: string): Promise<ValidatedUser | null> {
     const user = await this.prisma.user.findUnique({
       where: { email },
       include: {
@@ -156,17 +168,17 @@ export class AuthService {
     });
 
     if (user && (await bcrypt.compare(pass, user.passwordHash))) {
-      const { passwordHash, ...result } = user;
-      return result as UserWithMemberships;
+      const { passwordHash: _passwordHash, ...result } = user;
+      return result;
     }
     return null;
   }
 
   async login(
-    user: UserWithMemberships,
+    user: ValidatedUser,
     selectedTenantId?: string | null,
   ): Promise<AuthResponse> {
-    const memberships = (await this.tenancyService.getMembershipsForUser(user.id)) as TenantMembershipForLogin[];
+    const memberships = await this.tenancyService.getMembershipsForUser(user.id);
     const isSuperAdmin = memberships.some((m) =>
       m.roles.includes('SUPER_ADMIN'),
     );
@@ -241,8 +253,36 @@ export class AuthService {
     );
 
     const nextRefreshToken = crypto.randomBytes(32).toString('hex');
+    const nextRefreshTokenHash = this.hashToken(nextRefreshToken);
+    const now = new Date();
+    const expiresAt = this.getSessionExpiresAt();
 
-    return this.createAuthResponse({
+    const rotation = await this.prisma.authSession.updateMany({
+      where: {
+        id: session.id,
+        refreshTokenHash: tokenHash,
+        revokedAt: null,
+        expiresAt: { gt: now },
+      },
+      data: {
+        refreshTokenHash: nextRefreshTokenHash,
+        expiresAt,
+        lastUsedAt: now,
+      },
+    });
+
+    if (rotation.count === 0) {
+      throw new UnauthorizedException('Sesión expirada. Vuelve a iniciar sesión.');
+    }
+
+    const rotatedSession: AuthSession = {
+      ...session,
+      refreshTokenHash: nextRefreshTokenHash,
+      expiresAt,
+      lastUsedAt: now,
+    };
+
+    return this.issueAuthResponse({
       user: {
         id: user.id,
         email: user.email,
@@ -250,13 +290,30 @@ export class AuthService {
       },
       memberships,
       isSuperAdmin,
-      sessionContext: {
-        userAgent: null,
-        ipAddress: null,
-      },
-      existingSessionId: session.id,
-      existingRefreshToken: nextRefreshToken,
+      refreshToken: nextRefreshToken,
+      session: rotatedSession,
     });
+  }
+
+  async logoutCurrentSession(credentials: LogoutCredentials): Promise<void> {
+    const refreshToken = credentials.refreshToken?.trim();
+
+    if (refreshToken) {
+      const revokedByRefresh = await this.revokeSessionByRefreshToken(refreshToken);
+      if (revokedByRefresh) {
+        return;
+      }
+    }
+
+    const accessToken = credentials.accessToken?.trim();
+    if (!accessToken) {
+      return;
+    }
+
+    const revokedByAccess = await this.revokeSessionByAccessToken(accessToken);
+    if (revokedByAccess) {
+      return;
+    }
   }
 
   async logoutSession(sessionId: string): Promise<void> {
@@ -319,54 +376,115 @@ export class AuthService {
       userAgent: string | null;
       ipAddress: string | null;
     };
-    existingSessionId?: string;
-    existingRefreshToken?: string;
+  }): Promise<IssueAuthResult> {
+    const refreshToken = crypto.randomBytes(32).toString('hex');
+    const session = await this.prisma.authSession.create({
+      data: {
+        id: this.createSessionId(),
+        userId: params.user.id,
+        refreshTokenHash: this.hashToken(refreshToken),
+        expiresAt: this.getSessionExpiresAt(),
+        userAgent: params.sessionContext.userAgent,
+        ipAddress: params.sessionContext.ipAddress,
+      },
+    });
+
+    return this.issueAuthResponse({
+      user: params.user,
+      memberships: params.memberships,
+      isSuperAdmin: params.isSuperAdmin,
+      refreshToken,
+      session,
+    });
+  }
+
+  private async issueAuthResponse(params: {
+    user: {
+      id: string;
+      email: string;
+      name: string;
+    };
+    memberships: Array<{
+      tenantId: string;
+      roles: string[];
+    }>;
+    isSuperAdmin: boolean;
+    refreshToken: string;
+    session: AuthSession;
   }): Promise<IssueAuthResult> {
     const roles = params.memberships[0]?.roles ?? [];
-    const sessionId = params.existingSessionId ?? this.createSessionId();
-    const refreshToken =
-      params.existingRefreshToken ?? crypto.randomBytes(32).toString('hex');
-    const refreshTokenHash = this.hashToken(refreshToken);
-
-    const session = params.existingSessionId
-      ? await this.prisma.authSession.update({
-          where: { id: sessionId },
-          data: {
-            refreshTokenHash,
-            expiresAt: this.getSessionExpiresAt(),
-            lastUsedAt: new Date(),
-            userAgent: params.sessionContext.userAgent,
-            ipAddress: params.sessionContext.ipAddress,
-            revokedAt: null,
-          },
-        })
-      : await this.prisma.authSession.create({
-          data: {
-            id: sessionId,
-            userId: params.user.id,
-            refreshTokenHash,
-            expiresAt: this.getSessionExpiresAt(),
-            userAgent: params.sessionContext.userAgent,
-            ipAddress: params.sessionContext.ipAddress,
-          },
-        });
-
     const accessToken = this.jwtService.sign({
       email: params.user.email,
       sub: params.user.id,
       isSuperAdmin: params.isSuperAdmin,
       roles,
-      sid: session.id,
+      sid: params.session.id,
     });
 
     return {
       accessToken,
-      refreshToken,
-      sessionId: session.id,
+      refreshToken: params.refreshToken,
+      sessionId: params.session.id,
       user: params.user,
       memberships: params.memberships,
-      session,
+      session: params.session,
     };
+  }
+
+  private async revokeSessionByRefreshToken(refreshToken: string): Promise<boolean> {
+    const refreshTokenHash = this.hashToken(refreshToken);
+    const result = await this.prisma.authSession.updateMany({
+      where: {
+        refreshTokenHash,
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: new Date(),
+      },
+    });
+
+    return result.count > 0;
+  }
+
+  private async revokeSessionByAccessToken(accessToken: string): Promise<boolean> {
+    const payload = await this.verifyAccessToken(accessToken);
+    if (!payload) {
+      return false;
+    }
+
+    const result = await this.prisma.authSession.updateMany({
+      where: {
+        id: payload.sid,
+        userId: payload.sub,
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: new Date(),
+      },
+    });
+
+    return result.count > 0;
+  }
+
+  private async verifyAccessToken(accessToken: string): Promise<VerifiedAccessToken | null> {
+    try {
+      const payload = await this.jwtService.verifyAsync<Partial<VerifiedAccessToken>>(accessToken);
+      if (
+        typeof payload?.sub === 'string' &&
+        payload.sub.length > 0 &&
+        typeof payload?.sid === 'string' &&
+        payload.sid.length > 0
+      ) {
+        return {
+          sub: payload.sub,
+          sid: payload.sid,
+        };
+      }
+    } catch {
+      return null;
+    }
+
+    return null;
   }
 
   private hashToken(token: string): string {

--- a/apps/web/features/auth/login.actions.test.ts
+++ b/apps/web/features/auth/login.actions.test.ts
@@ -1,0 +1,61 @@
+import { logout } from './login.actions';
+import { apiLogout } from './auth.service';
+import { clearAuth } from './session.storage';
+import { clearAllImpersonationData } from '../impersonation/impersonation.storage';
+
+jest.mock('./auth.service', () => ({
+  apiLogout: jest.fn(),
+}));
+
+jest.mock('./session.storage', () => ({
+  clearAuth: jest.fn(),
+}));
+
+jest.mock('../impersonation/impersonation.storage', () => ({
+  clearAllImpersonationData: jest.fn(),
+}));
+
+const mockedApiLogout = jest.mocked(apiLogout);
+const mockedClearAuth = jest.mocked(clearAuth);
+const mockedClearAllImpersonationData = jest.mocked(clearAllImpersonationData);
+
+describe('login.actions.logout', () => {
+  const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    mockedApiLogout.mockReset();
+    mockedClearAuth.mockReset();
+    mockedClearAllImpersonationData.mockReset();
+    consoleWarnSpy.mockClear();
+  });
+
+  afterAll(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('calls apiLogout before clearing local state', async () => {
+    mockedApiLogout.mockResolvedValue({ ok: true });
+
+    await logout();
+
+    expect(mockedApiLogout).toHaveBeenCalledTimes(1);
+    expect(mockedClearAllImpersonationData).toHaveBeenCalledTimes(1);
+    expect(mockedClearAuth).toHaveBeenCalledTimes(1);
+    expect(mockedApiLogout.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedClearAllImpersonationData.mock.invocationCallOrder[0],
+    );
+    expect(mockedClearAllImpersonationData.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedClearAuth.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('clears local state and warns when apiLogout fails', async () => {
+    mockedApiLogout.mockRejectedValue(new Error('network down'));
+
+    await expect(logout()).resolves.toBeUndefined();
+
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(mockedClearAllImpersonationData).toHaveBeenCalledTimes(1);
+    expect(mockedClearAuth).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/shared/components/layout/Topbar.test.tsx
@@ -8,8 +8,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as notificationsApi from '@/features/notifications/notifications.api';
 import * as financeApi from '@/features/finance/services/finance.api';
 import * as sessionModule from '@/features/auth/session.storage';
+import { logout as sharedLogout } from '@/features/auth/login.actions';
 
 let mockTenantData: Array<{ id: string; name: string; type: 'EDIFICIO_AUTOGESTION' }> = [];
+const mockPush = jest.fn();
+const mockReplace = jest.fn();
 
 jest.mock('@/features/notifications/notifications.api', () => ({
   listNotifications: jest.fn(),
@@ -35,6 +38,10 @@ jest.mock('@/features/impersonation/impersonation.storage', () => ({
   clearAllImpersonationData: jest.fn(),
 }));
 
+jest.mock('@/features/auth/login.actions', () => ({
+  logout: jest.fn(),
+}));
+
 jest.mock('@/features/tenants/tenants.hooks', () => ({
   useTenants: () => ({ data: mockTenantData, isLoading: false, error: null }),
 }));
@@ -44,7 +51,7 @@ jest.mock('@/features/notifications/components/PushPermissionControl', () => ({
 }));
 
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
   useParams: () => ({ tenantId: 'tenant-1' }),
   usePathname: () => '/tenant-1/dashboard',
 }));
@@ -57,6 +64,7 @@ const mockListPendingPayments = jest.mocked(financeApi.listPendingPayments);
 const mockGetSession = jest.mocked(sessionModule.getSession);
 const mockSetSession = jest.mocked(sessionModule.setSession);
 const mockSetLastTenant = jest.mocked(sessionModule.setLastTenant);
+const mockedSharedLogout = jest.mocked(sharedLogout);
 
 const TENANT_ID = 'tenant-1';
 
@@ -87,9 +95,31 @@ function renderBell(tenantId = TENANT_ID) {
   };
 }
 
+function renderTopbar() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Topbar />
+    </QueryClientProvider>,
+  );
+}
+
 describe('PaymentNotificationBell', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockPush.mockReset();
+    mockReplace.mockReset();
+    mockedSharedLogout.mockReset();
     mockGetSession.mockReturnValue({
       user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
       memberships: [{ tenantId: TENANT_ID, roles: ['RESIDENT'] }],
@@ -137,6 +167,35 @@ describe('PaymentNotificationBell', () => {
       expect(mockGetUnreadCount).toHaveBeenCalled();
     });
     expect(screen.queryByText('0')).toBeNull();
+  });
+
+  it('calls the shared logout helper and redirects after it completes', async () => {
+    mockGetSession.mockReturnValue({
+      user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
+      memberships: [{ tenantId: TENANT_ID, roles: ['RESIDENT'] }],
+      activeTenantId: TENANT_ID,
+    });
+    let resolveLogout!: () => void;
+    const logoutPromise = new Promise<void>((resolve) => {
+      resolveLogout = resolve;
+    });
+    mockedSharedLogout.mockReturnValue(logoutPromise);
+
+    renderTopbar();
+
+    fireEvent.click(screen.getByRole('button', { name: /cerrar sesión/i }));
+
+    expect(mockedSharedLogout).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: /saliendo/i })).toHaveProperty('disabled', true);
+
+    fireEvent.click(screen.getByRole('button', { name: /saliendo/i }));
+    expect(mockedSharedLogout).toHaveBeenCalledTimes(1);
+
+    resolveLogout();
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith('/login');
+    });
   });
 
   it('opens dropdown on click and shows notifications', async () => {

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useRouter, useParams, usePathname } from 'next/navigation';
-import { getSession, setSession, setLastTenant, clearAuth } from '../../../features/auth/session.storage';
-import { clearAllImpersonationData } from '@/features/impersonation/impersonation.storage';
+import { getSession, setSession, setLastTenant } from '../../../features/auth/session.storage';
+import { logout } from '@/features/auth/login.actions';
 import { useTenants } from '../../../features/tenants/tenants.hooks';
 import type { TenantSummary } from '../../../features/tenants/tenants.service';
 import type { Membership } from '../../../features/auth/auth.types';
@@ -385,7 +385,8 @@ export default function Topbar({
 }: TopbarProps) {
   const router = useRouter();
   const params = useParams();
-  const urlTenantId = params?.tenantId as string | undefined;
+  const urlTenantId = typeof params?.tenantId === 'string' ? params.tenantId : undefined;
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
 
   const session = getSession();
   const { data: tenants, isLoading, error } = useTenants();
@@ -429,10 +430,18 @@ export default function Topbar({
     router.replace(`/${nextTenantId}/dashboard`);
   };
 
-  const handleLogout = () => {
-    clearAllImpersonationData();
-    clearAuth();
-    router.replace('/login');
+  const handleLogout = async () => {
+    if (isLoggingOut) {
+      return;
+    }
+
+    setIsLoggingOut(true);
+    try {
+      await logout();
+    } finally {
+      setIsLoggingOut(false);
+      router.replace('/login');
+    }
   };
 
   // Si no hay sesión, mostrar estado vacío
@@ -514,8 +523,10 @@ export default function Topbar({
         <button
           className="inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-3 py-1.5 text-sm font-medium text-primary-foreground transition hover:opacity-90"
           onClick={handleLogout}
+          disabled={isLoggingOut}
+          aria-busy={isLoggingOut}
         >
-          Cerrar sesión
+          {isLoggingOut ? 'Saliendo...' : 'Cerrar sesión'}
         </button>
         </div>
       </div>

--- a/apps/web/tests/e2e/helpers/auth.ts
+++ b/apps/web/tests/e2e/helpers/auth.ts
@@ -118,7 +118,21 @@ export async function login(page: Page, user: TestUser): Promise<string> {
  */
 export async function logout(page: Page): Promise<void> {
   const logoutButton = page.locator('button:has-text("Cerrar sesión"), button:has-text("Logout")').first();
+  const logoutUrl = new URL('/auth/logout', API_ORIGIN).toString();
+  const waitForLogoutResponse = page.waitForResponse(
+    (response) =>
+      response.request().method() === 'POST' && response.url() === logoutUrl,
+    { timeout: 20000 },
+  );
+
   await logoutButton.click();
+  const logoutResponse = await waitForLogoutResponse;
+
+  if (!logoutResponse.ok()) {
+    const message = await getResponseMessage(logoutResponse);
+    throw new Error(`AUTH_LOGOUT_FAILED status=${logoutResponse.status()} endpoint=/auth/logout message=${message}`);
+  }
+
   await page.waitForURL('/login', { timeout: 10000 });
   await expect(page).toHaveURL(/.*login/);
 }


### PR DESCRIPTION
## Summary

- makes `POST /auth/logout` idempotent and usable when the access token is absent or expired
- revokes the current `AuthSession` using the refresh-token hash, with a verified access-token fallback
- prevents refresh rotation from reactivating a concurrently revoked session
- connects the Topbar logout action to the shared backend logout flow
- strengthens unit and E2E coverage for real backend logout

## Security finding

Closes #83.

## Tests

- API auth tests: 27 passed
- Web logout tests: 43 passed
- API TypeScript: passed
- API build: passed
- API lint: passed
- Focused web lint: passed
- Focused-test guards: passed
- `git diff --check`: passed

## Known pre-existing repository blockers

The global web lint currently reports unrelated pre-existing failures outside this PR.

`next build --webpack` compiled successfully but global Next.js type validation is blocked by an unchanged pre-existing page export error in:

`apps/web/app/(tenant)/[tenantId]/buildings/[buildingId]/communications/page.tsx`

The file is identical to `origin/main`.

## Scope

No Prisma schema changes.
No migrations.
No seeds.
No infrastructure changes.
No deployment.

Closes #83
