### PR TITLE
fix(communications): exclude inactive recipients

### DIFF
--- a/apps/api/src/communications/communications.service.spec.ts
+++ b/apps/api/src/communications/communications.service.spec.ts
@@ -12,8 +12,31 @@ import { CommunicationsService, type CommunicationWithDetails } from './communic
 import { CommunicationsValidators } from './communications.validators';
 
 interface CommunicationDelegateMock {
+  readonly create?: jest.Mock;
+  readonly findFirst?: jest.Mock;
   readonly findUnique: jest.Mock;
   readonly update: jest.Mock;
+}
+
+interface CommunicationReceiptDelegateMock {
+  readonly createMany: jest.Mock;
+  readonly deleteMany: jest.Mock;
+}
+
+interface CommunicationTargetDelegateMock {
+  readonly findMany: jest.Mock;
+}
+
+interface MembershipDelegateMock {
+  readonly findFirst: jest.Mock;
+}
+
+interface UserDelegateMock {
+  readonly findMany: jest.Mock;
+}
+
+interface UnitOccupantDelegateMock {
+  readonly findMany: jest.Mock;
 }
 
 interface PushSubscriptionDelegateMock {
@@ -22,7 +45,16 @@ interface PushSubscriptionDelegateMock {
 }
 
 interface PrismaMock {
+  readonly $transaction?: jest.Mock;
   readonly communication: CommunicationDelegateMock;
+  readonly communicationReceipt?: CommunicationReceiptDelegateMock;
+  readonly communicationTarget?: CommunicationTargetDelegateMock;
+  readonly building?: {
+    readonly findFirst: jest.Mock;
+  };
+  readonly membership?: MembershipDelegateMock;
+  readonly user?: UserDelegateMock;
+  readonly unitOccupant?: UnitOccupantDelegateMock;
   readonly pushSubscription: PushSubscriptionDelegateMock;
 }
 
@@ -60,7 +92,7 @@ describe('CommunicationsService web push fanout', () => {
       communication: {
         findUnique: jest.fn().mockResolvedValue({
           priority: 'URGENT' satisfies CommunicationPriority,
-          status: 'DRAFT',
+          status: 'SENT',
         }),
         update: jest.fn().mockResolvedValue(buildPublishedCommunication()),
       },
@@ -522,3 +554,205 @@ describe('CommunicationsService findForResidentV2 scope filtering', () => {
     expect(unitConditions[0]).toEqual({ targetType: 'UNIT', targetId: unitId });
   });
 });
+
+describe('CommunicationsService receipt synchronization on publication', () => {
+  let prisma: PrismaMock & {
+    readonly $transaction: jest.Mock;
+    readonly communicationReceipt: CommunicationReceiptDelegateMock;
+    readonly communicationTarget: CommunicationTargetDelegateMock;
+    readonly membership: MembershipDelegateMock;
+    readonly user: UserDelegateMock;
+    readonly unitOccupant: UnitOccupantDelegateMock;
+  };
+  let validators: CommunicationsValidators;
+  let configService: ConfigServiceMock;
+  let pushDeliveryService: PushDeliveryServiceMock;
+  let service: CommunicationsService;
+
+  beforeEach(() => {
+    const communication = {
+      create: jest.fn().mockResolvedValue({ id: communicationId }),
+      findFirst: jest.fn().mockResolvedValue({ id: communicationId }),
+      findUnique: jest.fn(),
+      update: jest.fn().mockResolvedValue(buildPublishedCommunication()),
+    };
+    const communicationReceipt = {
+      createMany: jest.fn().mockResolvedValue({ count: 1 }),
+      deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
+    };
+    const communicationTarget = {
+      findMany: jest.fn(),
+    };
+    const membership = {
+      findFirst: jest.fn().mockResolvedValue({ id: 'membership-1' }),
+    };
+    const user = {
+      findMany: jest.fn(),
+    };
+    const unitOccupant = {
+      findMany: jest.fn(),
+    };
+    const building = {
+      findFirst: jest.fn().mockResolvedValue({ id: buildingId }),
+    };
+    const transactionClient = {
+      communication,
+      communicationReceipt,
+      communicationTarget,
+      building,
+      membership,
+      user,
+      unitOccupant,
+    };
+
+    prisma = {
+      $transaction: jest.fn(async (callback: (tx: unknown) => Promise<unknown>) =>
+        callback(transactionClient),
+      ),
+      communication,
+      communicationReceipt,
+      communicationTarget,
+      building,
+      membership,
+      user,
+      unitOccupant,
+      pushSubscription: {
+        findMany: jest.fn(),
+        updateMany: jest.fn(),
+      },
+    };
+
+    validators = new CommunicationsValidators(prisma as unknown as PrismaService);
+    configService = {
+      isFeatureEnabled: jest.fn().mockReturnValue(false),
+    };
+    pushDeliveryService = {
+      sendToSubscription: jest.fn().mockResolvedValue(buildDeliveryResult('sent')),
+    };
+
+    service = new CommunicationsService(
+      prisma as unknown as PrismaService,
+      validators as unknown as CommunicationsValidators,
+      configService as unknown as ConfigService,
+      pushDeliveryService as unknown as PushDeliveryService,
+    );
+  });
+
+  it('does not create receipts when creating a draft communication', async () => {
+    prisma.communication.create.mockResolvedValueOnce({ id: 'draft-communication' });
+    prisma.communication.findUnique.mockResolvedValueOnce(buildCommunicationWithReceipts([]));
+
+    await service.create(tenantId, userOneId, {
+      title: 'Draft notice',
+      body: 'Body',
+      channel: 'IN_APP',
+      targets: [{ targetType: 'ALL_TENANT' }],
+    });
+
+    expect(prisma.communicationReceipt.createMany).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('materializes only currently active recipients when creating a published communication', async () => {
+    prisma.communicationTarget.findMany.mockResolvedValue([
+      { targetType: 'BUILDING', targetId: buildingId },
+    ]);
+    prisma.unitOccupant.findMany.mockResolvedValue([
+      { member: { userId: userOneId } },
+    ]);
+    prisma.communication.findUnique
+      .mockResolvedValueOnce(buildCommunicationWithReceipts([userOneId]))
+      .mockResolvedValueOnce(buildCommunicationWithReceipts([userOneId]));
+
+    await service.createV2(
+      tenantId,
+      userOneId,
+      {
+        title: 'Published notice',
+        body: 'Body',
+        status: 'PUBLISHED',
+        priority: 'NORMAL',
+        scopeType: 'BUILDING',
+        buildingId,
+      },
+      false,
+    );
+
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+    expect(prisma.communicationReceipt.deleteMany).toHaveBeenCalledWith({
+      where: {
+        tenantId,
+        communicationId,
+      },
+    });
+    expect(prisma.communicationReceipt.createMany).toHaveBeenCalledWith({
+      data: [{ tenantId, communicationId, userId: userOneId }],
+      skipDuplicates: true,
+    });
+    expect(prisma.unitOccupant.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          tenantId,
+          endDate: null,
+          member: expect.objectContaining({
+            tenantId,
+            disabledAt: null,
+            status: 'ACTIVE',
+          }),
+        }),
+      }),
+    );
+  });
+
+  it('replaces stale draft receipts and sends web push only to the final recipients', async () => {
+    prisma.communication.findUnique
+      .mockResolvedValueOnce({
+        priority: 'URGENT',
+        status: 'DRAFT',
+      })
+      .mockResolvedValueOnce(buildCommunicationWithReceipts([userOneId]));
+    prisma.communicationTarget.findMany.mockResolvedValue([
+      { targetType: 'ALL_TENANT', targetId: null },
+    ]);
+    prisma.user.findMany.mockResolvedValue([
+      { id: userOneId },
+    ]);
+    prisma.pushSubscription.findMany.mockResolvedValue([
+      buildSubscription(userOneId),
+    ]);
+
+    await service.publishV2(tenantId, communicationId, true);
+
+    expect(prisma.communicationReceipt.deleteMany).toHaveBeenCalledWith({
+      where: {
+        tenantId,
+        communicationId,
+      },
+    });
+    expect(prisma.communicationReceipt.createMany).toHaveBeenCalledWith({
+      data: [{ tenantId, communicationId, userId: userOneId }],
+      skipDuplicates: true,
+    });
+    expect(prisma.pushSubscription.findMany).toHaveBeenCalledWith({
+      where: {
+        tenantId,
+        userId: { in: [userOneId] },
+        revokedAt: null,
+      },
+      select: {
+        userId: true,
+        endpoint: true,
+        p256dh: true,
+        auth: true,
+      },
+    });
+    expect(pushDeliveryService.sendToSubscription).toHaveBeenCalledTimes(1);
+  });
+});
+
+function buildCommunicationWithReceipts(receiptUserIds: string[]): CommunicationWithDetails {
+  return {
+    ...buildPublishedCommunication(),
+    receipts: receiptUserIds.map((userId) => buildReceipt(userId)),
+  } as CommunicationWithDetails;
+}

--- a/apps/api/src/communications/communications.service.spec.ts
+++ b/apps/api/src/communications/communications.service.spec.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { CommunicationPriority } from '@prisma/client';
 import { ConfigService } from '../config/config.service';
+import type { AppConfig } from '../config/config.types';
 import { PrismaService } from '../prisma/prisma.service';
 import {
   PushDeliveryService,
@@ -16,6 +17,7 @@ interface CommunicationDelegateMock {
   readonly findFirst?: jest.Mock;
   readonly findUnique: jest.Mock;
   readonly update: jest.Mock;
+  readonly updateMany?: jest.Mock;
 }
 
 interface CommunicationReceiptDelegateMock {
@@ -60,6 +62,7 @@ interface PrismaMock {
 
 interface ValidatorsMock {
   readonly validateCommunicationBelongsToTenant: jest.Mock;
+  readonly resolveRecipients: jest.Mock;
 }
 
 interface ConfigServiceMock {
@@ -80,42 +83,119 @@ const communicationId = 'communication-1';
 const userOneId = 'user-1';
 const userTwoId = 'user-2';
 
+function buildTestConfig(overrides: Partial<AppConfig> = {}): AppConfig {
+  return {
+    nodeEnv: 'test',
+    port: 4000,
+    logLevel: 'debug',
+    databaseUrl: 'postgresql://test:test@localhost:5432/test',
+    jwtSecret: 'a'.repeat(64),
+    jwtExpiresIn: '7d',
+    webOrigin: 'http://localhost:3000',
+    tenantResolutionMode: 'path',
+    tenantHeaderName: 'x-tenant-id',
+    s3Endpoint: 'http://localhost:9000',
+    s3Region: 'us-east-1',
+    s3AccessKey: 'test-access-key',
+    s3SecretKey: 'test-secret-key',
+    s3Bucket: 'test-bucket',
+    s3ForcePathStyle: true,
+    s3PublicBaseUrl: 'http://localhost:9000/test-bucket',
+    appBaseUrl: 'http://localhost:3000',
+    uploadMaxBytes: 10485760,
+    uploadAllowedMime: ['image/jpeg', 'image/png', 'application/pdf'],
+    mailProvider: 'none',
+    mailFrom: 'BuildingOS <no-reply@buildingos.local>',
+    featurePortalResident: true,
+    featurePaymentsMvp: true,
+    featureEnforceUrgentForWebPush: true,
+    enableWebPush: true,
+    vapidPublicKey: 'public-vapid-key',
+    vapidPrivateKey: 'private-vapid-key',
+    vapidSubject: 'mailto:admin@example.com',
+    paymentProvider: 'none',
+    enablePaymentWebhooks: false,
+    aiProvider: 'none',
+    aiOllamaUrl: null,
+    ...overrides,
+  };
+}
+
 describe('CommunicationsService web push fanout', () => {
-  let prisma: PrismaMock;
-  let validators: ValidatorsMock;
-  let configService: ConfigServiceMock;
-  let pushDeliveryService: PushDeliveryServiceMock;
+  let prisma: PrismaService & PrismaMock;
+  let validators: CommunicationsValidators;
+  let configService: ConfigService;
+  let pushDeliveryService: PushDeliveryService;
   let service: CommunicationsService;
 
   beforeEach(() => {
-    prisma = {
-      communication: {
-        findUnique: jest.fn().mockResolvedValue({
+    const communication = {
+      findUnique: jest
+        .fn()
+        .mockResolvedValueOnce({
           priority: 'URGENT' satisfies CommunicationPriority,
-          status: 'SENT',
-        }),
-        update: jest.fn().mockResolvedValue(buildPublishedCommunication()),
-      },
+          status: 'DRAFT',
+        })
+        .mockResolvedValue(buildPublishedCommunication()),
+      update: jest.fn().mockResolvedValue(buildPublishedCommunication()),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+    };
+    const communicationReceipt = {
+      createMany: jest.fn(),
+      deleteMany: jest.fn(),
+    };
+    const communicationTarget = {
+      findMany: jest.fn().mockResolvedValue([
+        { targetType: 'ALL_TENANT', targetId: null },
+      ]),
+    };
+    const user = {
+      findMany: jest.fn().mockResolvedValue([
+        { id: userOneId },
+        { id: userTwoId },
+      ]),
+    };
+    const unitOccupant = {
+      findMany: jest.fn().mockResolvedValue([]),
+    };
+    const transactionClient = {
+      communication,
+      communicationReceipt,
+      communicationTarget,
+      user,
+      unitOccupant,
+    };
+
+    prisma = Object.assign(new PrismaService(), {
+      $transaction: jest.fn(async (callback: (tx: unknown) => Promise<unknown>) =>
+        callback(transactionClient),
+      ),
+      communication,
+      communicationReceipt,
+      communicationTarget,
+      user,
+      unitOccupant,
       pushSubscription: {
         findMany: jest.fn().mockResolvedValue([buildSubscription(userOneId), buildSubscription(userTwoId)]),
         updateMany: jest.fn().mockResolvedValue({ count: 1 }),
       },
-    };
-    validators = {
-      validateCommunicationBelongsToTenant: jest.fn().mockResolvedValue(undefined),
-    };
-    configService = {
-      isFeatureEnabled: jest.fn().mockReturnValue(true),
-    };
-    pushDeliveryService = {
-      sendToSubscription: jest.fn().mockResolvedValue(buildDeliveryResult('sent')),
-    };
+    });
+
+    validators = new CommunicationsValidators(prisma);
+    jest.spyOn(validators, 'validateCommunicationBelongsToTenant').mockResolvedValue(undefined);
+    jest.spyOn(validators, 'resolveRecipients').mockResolvedValue([userOneId, userTwoId]);
+
+    configService = new ConfigService(buildTestConfig());
+    jest.spyOn(configService, 'isFeatureEnabled').mockReturnValue(true);
+
+    pushDeliveryService = new PushDeliveryService(configService);
+    jest.spyOn(pushDeliveryService, 'sendToSubscription').mockResolvedValue(buildDeliveryResult('sent'));
 
     service = new CommunicationsService(
-      prisma as unknown as PrismaService,
-      validators as unknown as CommunicationsValidators,
-      configService as unknown as ConfigService,
-      pushDeliveryService as unknown as PushDeliveryService,
+      prisma,
+      validators,
+      configService,
+      pushDeliveryService,
     );
   });
 
@@ -150,14 +230,10 @@ describe('CommunicationsService web push fanout', () => {
           url: `/communications/${communicationId}`,
           tag: `communication:${communicationId}`,
         }),
-      }) as PushNotificationPayload,
+      }),
       expect.objectContaining({ urgency: 'high' }),
     );
-    const [, payload] = pushDeliveryService.sendToSubscription.mock.calls[0] as [
-      CommunicationPushSubscription,
-      PushNotificationPayload,
-      unknown,
-    ];
+    const payload = pushDeliveryService.sendToSubscription.mock.calls[0]?.[1];
     expect(JSON.stringify(payload)).not.toContain('Please review the update.');
     expect(prisma.pushSubscription.updateMany).not.toHaveBeenCalled();
   });
@@ -205,15 +281,15 @@ describe('CommunicationsService web push fanout', () => {
         where: expect.objectContaining({ tenantId: otherTenantId }),
       }),
     );
-    expect(prisma.pushSubscription.updateMany).toHaveBeenCalledWith({
-      where: {
-        tenantId,
-        userId: userOneId,
-        endpoint: buildSubscription(userOneId).endpoint,
-        revokedAt: null,
-      },
-      data: { revokedAt: expect.any(Date) as Date },
-    });
+      expect(prisma.pushSubscription.updateMany).toHaveBeenCalledWith({
+        where: {
+          tenantId,
+          userId: userOneId,
+          endpoint: buildSubscription(userOneId).endpoint,
+          revokedAt: null,
+        },
+        data: { revokedAt: expect.any(Date) },
+      });
   });
 
   it('revokes only the matching subscription when one delivery expires', async () => {
@@ -250,18 +326,17 @@ describe('CommunicationsService web push fanout', () => {
       expect(pushDeliveryService.sendToSubscription).toHaveBeenNthCalledWith(
         1,
         buildSubscription(userOneId),
-        expect.any(Object) as PushNotificationPayload,
+        expect.any(Object),
         expect.objectContaining({ urgency: 'high' }),
       );
       expect(pushDeliveryService.sendToSubscription).toHaveBeenNthCalledWith(
         2,
         buildSubscription(userTwoId),
-        expect.any(Object) as PushNotificationPayload,
+        expect.any(Object),
         expect.objectContaining({ urgency: 'high' }),
       );
       expect(warnSpy).toHaveBeenCalledWith(
-        '[CommunicationsService] Failed to send web push',
-        expect.not.objectContaining({ endpoint: expect.any(String) as string }),
+        expect.stringContaining('[CommunicationsService] Failed to send web push'),
       );
       expect(JSON.stringify(warnSpy.mock.calls)).not.toContain(buildSubscription(userOneId).endpoint);
       expect(prisma.pushSubscription.updateMany).toHaveBeenCalledTimes(1);
@@ -272,7 +347,7 @@ describe('CommunicationsService web push fanout', () => {
           endpoint: buildSubscription(userTwoId).endpoint,
           revokedAt: null,
         },
-        data: { revokedAt: expect.any(Date) as Date },
+        data: { revokedAt: expect.any(Date) },
       });
     } finally {
       warnSpy.mockRestore();
@@ -336,11 +411,13 @@ function buildPublishedCommunication(): CommunicationWithDetails {
         email: 'admin@example.com',
       },
     },
-  } as unknown as CommunicationWithDetails;
+  };
 }
 
-function buildReceipt(userId: string): unknown {
-  return {
+type CommunicationReceiptWithUser = NonNullable<CommunicationWithDetails['receipts']>[number];
+
+function buildReceipt(userId: string): CommunicationReceiptWithUser {
+  const receipt: CommunicationReceiptWithUser = {
     id: `receipt-${userId}`,
     tenantId,
     communicationId,
@@ -354,6 +431,8 @@ function buildReceipt(userId: string): unknown {
       email: `${userId}@example.com`,
     },
   };
+
+  return receipt;
 }
 
 function buildSubscription(userId: string): CommunicationPushSubscription {
@@ -375,8 +454,6 @@ function buildDeliveryResult(status: PushDeliveryResult['status']): PushDelivery
 
 const buildingId = 'building-1';
 const unitId = 'unit-1';
-const otherBuildingId = 'building-other';
-const otherUnitId = 'unit-other';
 
 interface ReceiptDelegateMock {
   readonly findMany: jest.Mock;
@@ -424,21 +501,22 @@ function buildReceiptWithComm(
 }
 
 describe('CommunicationsService findForResidentV2 scope filtering', () => {
-  let prisma: PrismaResidentMock;
+  let prisma: PrismaService & PrismaResidentMock;
+  let validators: CommunicationsValidators;
   let service: CommunicationsService;
 
   beforeEach(() => {
-    prisma = {
+    prisma = Object.assign(new PrismaService(), {
       communicationReceipt: {
         findMany: jest.fn().mockResolvedValue([]),
       },
-    };
-    service = new CommunicationsService(
-      prisma as unknown as PrismaService,
-      { validateCommunicationBelongsToTenant: jest.fn() } as unknown as CommunicationsValidators,
-      { isFeatureEnabled: jest.fn() } as unknown as ConfigService,
-      { sendToSubscription: jest.fn() } as unknown as PushDeliveryService,
-    );
+    });
+    validators = new CommunicationsValidators(prisma);
+    jest.spyOn(validators, 'validateBuildingBelongsToTenant').mockResolvedValue(undefined);
+    jest.spyOn(validators, 'validateUnitBelongsToTenant').mockResolvedValue(undefined);
+    const configService = new ConfigService(buildTestConfig());
+    const pushDeliveryService = new PushDeliveryService(configService);
+    service = new CommunicationsService(prisma, validators, configService, pushDeliveryService);
   });
 
   it('allows ALL_TENANT communications regardless of buildingId/unitId', async () => {
@@ -556,17 +634,10 @@ describe('CommunicationsService findForResidentV2 scope filtering', () => {
 });
 
 describe('CommunicationsService receipt synchronization on publication', () => {
-  let prisma: PrismaMock & {
-    readonly $transaction: jest.Mock;
-    readonly communicationReceipt: CommunicationReceiptDelegateMock;
-    readonly communicationTarget: CommunicationTargetDelegateMock;
-    readonly membership: MembershipDelegateMock;
-    readonly user: UserDelegateMock;
-    readonly unitOccupant: UnitOccupantDelegateMock;
-  };
+  let prisma: PrismaService & PrismaMock;
   let validators: CommunicationsValidators;
-  let configService: ConfigServiceMock;
-  let pushDeliveryService: PushDeliveryServiceMock;
+  let configService: ConfigService;
+  let pushDeliveryService: PushDeliveryService;
   let service: CommunicationsService;
 
   beforeEach(() => {
@@ -575,22 +646,27 @@ describe('CommunicationsService receipt synchronization on publication', () => {
       findFirst: jest.fn().mockResolvedValue({ id: communicationId }),
       findUnique: jest.fn(),
       update: jest.fn().mockResolvedValue(buildPublishedCommunication()),
+      updateMany: jest.fn().mockResolvedValue({ count: 1 }),
     };
     const communicationReceipt = {
       createMany: jest.fn().mockResolvedValue({ count: 1 }),
       deleteMany: jest.fn().mockResolvedValue({ count: 1 }),
     };
     const communicationTarget = {
-      findMany: jest.fn(),
+      findMany: jest.fn().mockResolvedValue([
+        { targetType: 'ALL_TENANT', targetId: null },
+      ]),
     };
     const membership = {
       findFirst: jest.fn().mockResolvedValue({ id: 'membership-1' }),
     };
     const user = {
-      findMany: jest.fn(),
+      findMany: jest.fn().mockResolvedValue([
+        { id: userOneId },
+      ]),
     };
     const unitOccupant = {
-      findMany: jest.fn(),
+      findMany: jest.fn().mockResolvedValue([]),
     };
     const building = {
       findFirst: jest.fn().mockResolvedValue({ id: buildingId }),
@@ -605,7 +681,7 @@ describe('CommunicationsService receipt synchronization on publication', () => {
       unitOccupant,
     };
 
-    prisma = {
+    prisma = Object.assign(new PrismaService(), {
       $transaction: jest.fn(async (callback: (tx: unknown) => Promise<unknown>) =>
         callback(transactionClient),
       ),
@@ -620,21 +696,20 @@ describe('CommunicationsService receipt synchronization on publication', () => {
         findMany: jest.fn(),
         updateMany: jest.fn(),
       },
-    };
+    });
 
-    validators = new CommunicationsValidators(prisma as unknown as PrismaService);
-    configService = {
-      isFeatureEnabled: jest.fn().mockReturnValue(false),
-    };
-    pushDeliveryService = {
-      sendToSubscription: jest.fn().mockResolvedValue(buildDeliveryResult('sent')),
-    };
+    validators = new CommunicationsValidators(prisma);
+    configService = new ConfigService(buildTestConfig());
+    jest.spyOn(configService, 'isFeatureEnabled').mockReturnValue(false);
+
+    pushDeliveryService = new PushDeliveryService(configService);
+    jest.spyOn(pushDeliveryService, 'sendToSubscription').mockResolvedValue(buildDeliveryResult('sent'));
 
     service = new CommunicationsService(
-      prisma as unknown as PrismaService,
-      validators as unknown as CommunicationsValidators,
-      configService as unknown as ConfigService,
-      pushDeliveryService as unknown as PushDeliveryService,
+      prisma,
+      validators,
+      configService,
+      pushDeliveryService,
     );
   });
 
@@ -748,11 +823,182 @@ describe('CommunicationsService receipt synchronization on publication', () => {
     });
     expect(pushDeliveryService.sendToSubscription).toHaveBeenCalledTimes(1);
   });
+
+  it('transitions to SENT once, keeps sentAt stable, and becomes idempotent on repeated send()', async () => {
+    const sentAt = new Date('2026-07-05T00:00:00.000Z');
+    const publishedCommunication = buildCommunicationWithReceipts([userOneId]);
+    const existingSentCommunication = buildCommunicationWithReceipts([userOneId]);
+    Object.assign(existingSentCommunication, { sentAt });
+
+    prisma.communication.findUnique
+      .mockResolvedValueOnce({ status: 'DRAFT' })
+      .mockResolvedValueOnce(publishedCommunication)
+      .mockResolvedValueOnce({ status: 'SENT' })
+      .mockResolvedValueOnce(existingSentCommunication);
+    prisma.communication.updateMany.mockResolvedValueOnce({ count: 1 });
+
+    const firstResult = await service.send(tenantId, communicationId);
+    const secondResult = await service.send(tenantId, communicationId);
+
+    expect(prisma.communication.updateMany).toHaveBeenCalledTimes(1);
+    expect(prisma.communication.updateMany).toHaveBeenCalledWith({
+      where: {
+        id: communicationId,
+        tenantId,
+        status: { not: 'SENT' },
+      },
+      data: {
+        status: 'SENT',
+        sentAt: expect.any(Date) as Date,
+        updatedAt: expect.any(Date) as Date,
+      },
+    });
+    expect(prisma.communicationReceipt.deleteMany).toHaveBeenCalledTimes(1);
+    expect(prisma.communicationReceipt.createMany).toHaveBeenCalledTimes(1);
+    expect(firstResult.receipts).toEqual(publishedCommunication.receipts);
+    expect(secondResult.receipts).toEqual(existingSentCommunication.receipts);
+    expect(secondResult.sentAt).toBe(sentAt);
+  });
+
+  it('does not resend web push when publishV2() receives an already SENT communication', async () => {
+    const sentAt = new Date('2026-07-05T00:00:00.000Z');
+    const currentCommunication = buildCommunicationWithReceipts([userOneId]);
+    Object.assign(currentCommunication, { sentAt });
+
+    prisma.communication.findUnique
+      .mockResolvedValueOnce({
+        priority: 'URGENT',
+        status: 'SENT',
+      })
+      .mockResolvedValueOnce(currentCommunication);
+
+    await service.publishV2(tenantId, communicationId, true);
+
+    expect(prisma.communication.updateMany).not.toHaveBeenCalled();
+    expect(prisma.communicationReceipt.deleteMany).not.toHaveBeenCalled();
+    expect(prisma.communicationReceipt.createMany).not.toHaveBeenCalled();
+    expect(pushDeliveryService.sendToSubscription).not.toHaveBeenCalled();
+  });
+
+  it('does not resend web push when publish() receives an already SENT communication', async () => {
+    const sentAt = new Date('2026-07-05T00:00:00.000Z');
+    const currentCommunication = buildCommunicationWithReceipts([userOneId]);
+    Object.assign(currentCommunication, { sentAt });
+
+    prisma.communication.findUnique
+      .mockResolvedValueOnce({
+        priority: 'URGENT',
+        status: 'SENT',
+      })
+      .mockResolvedValueOnce(currentCommunication);
+
+    await service.publish(tenantId, communicationId, true);
+
+    expect(prisma.communication.updateMany).not.toHaveBeenCalled();
+    expect(prisma.communicationReceipt.deleteMany).not.toHaveBeenCalled();
+    expect(prisma.communicationReceipt.createMany).not.toHaveBeenCalled();
+    expect(pushDeliveryService.sendToSubscription).not.toHaveBeenCalled();
+  });
+
+  it('publishes only once when updateMany wins the race and returns the refreshed recipients', async () => {
+    prisma.communication.findUnique
+      .mockResolvedValueOnce({
+        priority: 'URGENT',
+        status: 'DRAFT',
+      })
+      .mockResolvedValueOnce(buildCommunicationWithReceipts([userOneId]));
+    prisma.communication.updateMany.mockResolvedValueOnce({ count: 1 });
+    prisma.communicationTarget.findMany.mockResolvedValue([
+      { targetType: 'ALL_TENANT', targetId: null },
+    ]);
+    prisma.user.findMany.mockResolvedValue([
+      { id: userOneId },
+    ]);
+    prisma.pushSubscription.findMany.mockResolvedValue([
+      buildSubscription(userOneId),
+    ]);
+
+    const published = await service.publishV2(tenantId, communicationId, true);
+
+    expect(prisma.communication.updateMany).toHaveBeenCalledTimes(1);
+    expect(prisma.communicationReceipt.deleteMany).toHaveBeenCalledTimes(1);
+    expect(prisma.communicationReceipt.createMany).toHaveBeenCalledTimes(1);
+    expect(prisma.pushSubscription.findMany).toHaveBeenCalledTimes(1);
+    expect(pushDeliveryService.sendToSubscription).toHaveBeenCalledTimes(1);
+    expect(published.receipts).toEqual([buildReceipt(userOneId)]);
+  });
+
+  it('does not resync or push when updateMany loses the race and returns the already published communication', async () => {
+    const publishedAt = new Date('2026-07-06T00:00:00.000Z');
+    const alreadyPublished = buildCommunicationWithReceipts([userOneId]);
+    Object.assign(alreadyPublished, { sentAt: publishedAt });
+
+    prisma.communication.findUnique
+      .mockResolvedValueOnce({
+        priority: 'URGENT',
+        status: 'DRAFT',
+      })
+      .mockResolvedValueOnce(alreadyPublished);
+    prisma.communication.updateMany.mockResolvedValueOnce({ count: 0 });
+
+    const published = await service.publishV2(tenantId, communicationId, true);
+
+    expect(prisma.communication.updateMany).toHaveBeenCalledTimes(1);
+    expect(prisma.communicationReceipt.deleteMany).not.toHaveBeenCalled();
+    expect(prisma.communicationReceipt.createMany).not.toHaveBeenCalled();
+    expect(pushDeliveryService.sendToSubscription).not.toHaveBeenCalled();
+    expect(published.sentAt).toBe(publishedAt);
+    expect(published.receipts).toEqual(alreadyPublished.receipts);
+  });
 });
 
 function buildCommunicationWithReceipts(receiptUserIds: string[]): CommunicationWithDetails {
   return {
     ...buildPublishedCommunication(),
     receipts: receiptUserIds.map((userId) => buildReceipt(userId)),
-  } as CommunicationWithDetails;
+  };
 }
+
+describe('CommunicationsService markAsReadForResident tenant scoping', () => {
+  it('uses tenantId when reading and updating a resident receipt', async () => {
+    const prisma = Object.assign(new PrismaService(), {
+      communicationReceipt: {
+        findFirst: jest.fn().mockResolvedValue({ readAt: null }),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+    });
+    const validators = new CommunicationsValidators(prisma);
+    const configService = new ConfigService(buildTestConfig());
+    const pushDeliveryService = new PushDeliveryService(configService);
+
+    const service = new CommunicationsService(
+      prisma,
+      validators,
+      configService,
+      pushDeliveryService,
+    );
+
+    await expect(
+      service.markAsReadForResident(tenantId, userOneId, communicationId),
+    ).resolves.toEqual({ readAt: expect.any(Date) as Date });
+
+    expect(prisma.communicationReceipt.findFirst).toHaveBeenCalledWith({
+      where: {
+        tenantId,
+        communicationId,
+        userId: userOneId,
+      },
+      select: { readAt: true },
+    });
+    expect(prisma.communicationReceipt.updateMany).toHaveBeenCalledWith({
+      where: {
+        tenantId,
+        communicationId,
+        userId: userOneId,
+      },
+      data: {
+        readAt: expect.any(Date) as Date,
+      },
+    });
+  });
+});

--- a/apps/api/src/communications/communications.service.ts
+++ b/apps/api/src/communications/communications.service.ts
@@ -133,7 +133,7 @@ export class CommunicationsService {
    * Creates:
    * - Communication with DRAFT status
    * - CommunicationTarget entries
-   * - CommunicationReceipt entries (one per recipient)
+   * - CommunicationReceipt entries only when the communication is truly sent/published
    *
    * @throws NotFoundException if building/target doesn't belong to tenant
    * @throws BadRequestException if input is invalid
@@ -183,7 +183,7 @@ export class CommunicationsService {
     // Strict validation: if scheduledFor is provided but is in the past, reject with clear error
     if (scheduledFor && scheduledFor <= new Date()) {
       throw new BadRequestException(
-        'La fecha de programación debe ser futura. No se puede programar en el pasado.',
+        'The scheduled date must be in the future. You cannot schedule a communication in the past.',
       );
     }
     
@@ -215,23 +215,6 @@ export class CommunicationsService {
         targets: true,
       },
     });
-
-    // 4. Resolve recipients and create receipts
-    const recipientIds = await this.validators.resolveRecipients(
-      tenantId,
-      communication.id,
-    );
-
-    if (recipientIds.length > 0) {
-      await this.prisma.communicationReceipt.createMany({
-        data: recipientIds.map((recipientUserId) => ({
-          tenantId,
-          communicationId: communication.id,
-          userId: recipientUserId,
-        })),
-        skipDuplicates: true, // If user is in multiple targets
-      });
-    }
 
     return this.findOne(tenantId, communication.id);
   }
@@ -409,14 +392,49 @@ export class CommunicationsService {
       communicationId,
     );
 
-    return await this.prisma.communication.update({
+    const communication = await this.prisma.communication.findUnique({
       where: { id: communicationId },
-      data: {
-        status: 'SENT',
-        sentAt: new Date(),
-        updatedAt: new Date(),
-      },
-      include: COMMUNICATION_INCLUDE,
+      select: { status: true },
+    });
+
+    if (!communication) {
+      throw new NotFoundException('Communication not found');
+    }
+
+    if (communication.status === 'SENT') {
+      return await this.prisma.communication.update({
+        where: { id: communicationId },
+        data: {
+          status: 'SENT',
+          sentAt: new Date(),
+          updatedAt: new Date(),
+        },
+        include: COMMUNICATION_INCLUDE,
+      });
+    }
+
+    return await this.prisma.$transaction(async (tx) => {
+      await tx.communication.update({
+        where: { id: communicationId },
+        data: {
+          status: 'SENT',
+          sentAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+
+      await this.refreshCommunicationReceipts(tx, tenantId, communicationId);
+
+      const sent = await tx.communication.findUnique({
+        where: { id: communicationId },
+        include: COMMUNICATION_INCLUDE,
+      });
+
+      if (!sent) {
+        throw new NotFoundException('Communication not found');
+      }
+
+      return sent;
     });
   }
 
@@ -460,16 +478,42 @@ export class CommunicationsService {
       });
     }
 
-    // Mark as published (SENT in current schema)
-    const published = await this.prisma.communication.update({
-      where: { id: communicationId },
-      data: {
-        status: 'SENT',
-        sentAt: new Date(),
-        updatedAt: new Date(),
-      },
-      include: COMMUNICATION_INCLUDE,
-    });
+    let published: CommunicationWithDetails;
+    if (communication.status === 'SENT') {
+      published = await this.prisma.communication.update({
+        where: { id: communicationId },
+        data: {
+          status: 'SENT',
+          sentAt: new Date(),
+          updatedAt: new Date(),
+        },
+        include: COMMUNICATION_INCLUDE,
+      });
+    } else {
+      published = await this.prisma.$transaction(async (tx) => {
+        await tx.communication.update({
+          where: { id: communicationId },
+          data: {
+            status: 'SENT',
+            sentAt: new Date(),
+            updatedAt: new Date(),
+          },
+        });
+
+        await this.refreshCommunicationReceipts(tx, tenantId, communicationId);
+
+        const sent = await tx.communication.findUnique({
+          where: { id: communicationId },
+          include: COMMUNICATION_INCLUDE,
+        });
+
+        if (!sent) {
+          throw new NotFoundException('Communication not found');
+        }
+
+        return sent;
+      });
+    }
 
     if (sendWebPush) {
       await this.dispatchWebPushNotifications(tenantId, published);
@@ -804,8 +848,8 @@ export class CommunicationsService {
    * Create a new communication V2 (with scopeType pattern)
    *
    * If status=PUBLISHED:
-   * - Sets publishedAt=now() (mapped to sentAt internally)
-   * - Creates communication_deliveries with UNREAD status
+   * - Persists the communication as SENT immediately
+   * - Materializes the final recipient receipts immediately
    * - sendWebPush defaults to false (no push from this endpoint)
    *
    * @throws NotFoundException if building/target doesn't belong to tenant
@@ -859,6 +903,49 @@ export class CommunicationsService {
 
     const shouldPublish = input.status === 'PUBLISHED';
 
+    if (shouldPublish) {
+      return await this.prisma.$transaction(async (tx) => {
+        const communication = await tx.communication.create({
+          data: {
+            tenantId,
+            buildingId: input.scopeType === 'BUILDING' ? input.buildingId || null : null,
+            title: input.title,
+            body: input.body,
+            channel: 'IN_APP',
+            status: 'SENT',
+            priority: input.priority || 'NORMAL',
+            sentAt: new Date(),
+            createdByMembershipId,
+            targets: {
+              createMany: {
+                data: targets.map((t) => ({
+                  tenantId,
+                  targetType: t.targetType,
+                  targetId: t.targetId || null,
+                })),
+              },
+            },
+          },
+          include: {
+            targets: true,
+          },
+        });
+
+        await this.refreshCommunicationReceipts(tx, tenantId, communication.id);
+
+        const published = await tx.communication.findUnique({
+          where: { id: communication.id },
+          include: COMMUNICATION_INCLUDE,
+        });
+
+        if (!published) {
+          throw new NotFoundException('Communication not found');
+        }
+
+        return published;
+      });
+    }
+
     const communication = await this.prisma.communication.create({
       data: {
         tenantId,
@@ -866,9 +953,9 @@ export class CommunicationsService {
         title: input.title,
         body: input.body,
         channel: 'IN_APP',
-        status: shouldPublish ? 'SENT' as const : 'DRAFT' as const,
+        status: 'DRAFT',
         priority: input.priority || 'NORMAL',
-        sentAt: shouldPublish ? new Date() : null,
+        sentAt: null,
         createdByMembershipId,
         targets: {
           createMany: {
@@ -884,22 +971,6 @@ export class CommunicationsService {
         targets: true,
       },
     });
-
-    const recipientIds = await this.validators.resolveRecipients(
-      tenantId,
-      communication.id,
-    );
-
-    if (recipientIds.length > 0) {
-      await this.prisma.communicationReceipt.createMany({
-        data: recipientIds.map((recipientUserId) => ({
-          tenantId,
-          communicationId: communication.id,
-          userId: recipientUserId,
-        })),
-        skipDuplicates: true,
-      });
-    }
 
     return this.findOne(tenantId, communication.id);
   }
@@ -946,15 +1017,42 @@ export class CommunicationsService {
       });
     }
 
-    const published = await this.prisma.communication.update({
-      where: { id: communicationId },
-      data: {
-        status: 'SENT',
-        sentAt: new Date(),
-        updatedAt: new Date(),
-      },
-      include: COMMUNICATION_INCLUDE,
-    });
+    let published: CommunicationWithDetails;
+    if (communication.status === 'SENT') {
+      published = await this.prisma.communication.update({
+        where: { id: communicationId },
+        data: {
+          status: 'SENT',
+          sentAt: new Date(),
+          updatedAt: new Date(),
+        },
+        include: COMMUNICATION_INCLUDE,
+      });
+    } else {
+      published = await this.prisma.$transaction(async (tx) => {
+        await tx.communication.update({
+          where: { id: communicationId },
+          data: {
+            status: 'SENT',
+            sentAt: new Date(),
+            updatedAt: new Date(),
+          },
+        });
+
+        await this.refreshCommunicationReceipts(tx, tenantId, communicationId);
+
+        const sent = await tx.communication.findUnique({
+          where: { id: communicationId },
+          include: COMMUNICATION_INCLUDE,
+        });
+
+        if (!sent) {
+          throw new NotFoundException('Communication not found');
+        }
+
+        return sent;
+      });
+    }
 
     if (sendWebPush) {
       await this.dispatchWebPushNotifications(tenantId, published);
@@ -1014,6 +1112,38 @@ export class CommunicationsService {
         this.sendCommunicationPush(tenantId, subscription, payload),
       ),
     );
+  }
+
+  private async refreshCommunicationReceipts(
+    prismaClient: Prisma.TransactionClient,
+    tenantId: string,
+    communicationId: string,
+  ): Promise<string[]> {
+    const recipientIds = await this.validators.resolveRecipients(
+      tenantId,
+      communicationId,
+      prismaClient,
+    );
+
+    await prismaClient.communicationReceipt.deleteMany({
+      where: {
+        tenantId,
+        communicationId,
+      },
+    });
+
+    if (recipientIds.length > 0) {
+      await prismaClient.communicationReceipt.createMany({
+        data: recipientIds.map((recipientUserId) => ({
+          tenantId,
+          communicationId,
+          userId: recipientUserId,
+        })),
+        skipDuplicates: true,
+      });
+    }
+
+    return recipientIds;
   }
 
   private async sendCommunicationPush(

--- a/apps/api/src/communications/communications.service.ts
+++ b/apps/api/src/communications/communications.service.ts
@@ -9,7 +9,6 @@ import {
   Injectable,
   BadRequestException,
   NotFoundException,
-  UnprocessableEntityException,
   Logger,
 } from '@nestjs/common';
 import {
@@ -51,6 +50,18 @@ const COMMUNICATION_INCLUDE = {
 
 export type CommunicationWithDetails = Prisma.CommunicationGetPayload<{
   include: typeof COMMUNICATION_INCLUDE;
+}>;
+
+type CommunicationReceiptWithCommunication = Prisma.CommunicationReceiptGetPayload<{
+  include: {
+    communication: {
+      include: {
+        targets: {
+          select: { targetId: true; targetType: true };
+        };
+      };
+    };
+  };
 }>;
 
 export interface FindAllFilters {
@@ -179,16 +190,22 @@ export class CommunicationsService {
 
     // 3. Create communication in transaction
     const scheduledFor = input.scheduledFor ? new Date(input.scheduledFor) : null;
-    
+
+    if (scheduledFor && Number.isNaN(scheduledFor.getTime())) {
+      throw new BadRequestException(
+        'scheduledFor must be a valid ISO date',
+      );
+    }
+
     // Strict validation: if scheduledFor is provided but is in the past, reject with clear error
     if (scheduledFor && scheduledFor <= new Date()) {
       throw new BadRequestException(
         'The scheduled date must be in the future. You cannot schedule a communication in the past.',
       );
     }
-    
+
     const isScheduled = scheduledFor && scheduledFor > new Date();
-    
+
     const communication = await this.prisma.communication.create({
       data: {
         tenantId,
@@ -402,40 +419,23 @@ export class CommunicationsService {
     }
 
     if (communication.status === 'SENT') {
-      return await this.prisma.communication.update({
-        where: { id: communicationId },
-        data: {
-          status: 'SENT',
-          sentAt: new Date(),
-          updatedAt: new Date(),
-        },
-        include: COMMUNICATION_INCLUDE,
-      });
-    }
-
-    return await this.prisma.$transaction(async (tx) => {
-      await tx.communication.update({
-        where: { id: communicationId },
-        data: {
-          status: 'SENT',
-          sentAt: new Date(),
-          updatedAt: new Date(),
-        },
-      });
-
-      await this.refreshCommunicationReceipts(tx, tenantId, communicationId);
-
-      const sent = await tx.communication.findUnique({
+      const current = await this.prisma.communication.findUnique({
         where: { id: communicationId },
         include: COMMUNICATION_INCLUDE,
       });
 
-      if (!sent) {
+      if (!current) {
         throw new NotFoundException('Communication not found');
       }
 
-      return sent;
-    });
+      return current;
+    }
+
+    const result = await this.prisma.$transaction(async (tx) =>
+      this.transitionCommunicationToSent(tx, tenantId, communicationId),
+    );
+
+    return result.communication;
   }
 
   /**
@@ -479,43 +479,29 @@ export class CommunicationsService {
     }
 
     let published: CommunicationWithDetails;
+    let transitionedToSent: boolean;
     if (communication.status === 'SENT') {
-      published = await this.prisma.communication.update({
+      const current = await this.prisma.communication.findUnique({
         where: { id: communicationId },
-        data: {
-          status: 'SENT',
-          sentAt: new Date(),
-          updatedAt: new Date(),
-        },
         include: COMMUNICATION_INCLUDE,
       });
+
+      if (!current) {
+        throw new NotFoundException('Communication not found');
+      }
+
+      published = current;
+      transitionedToSent = false;
     } else {
-      published = await this.prisma.$transaction(async (tx) => {
-        await tx.communication.update({
-          where: { id: communicationId },
-          data: {
-            status: 'SENT',
-            sentAt: new Date(),
-            updatedAt: new Date(),
-          },
-        });
+      const result = await this.prisma.$transaction(async (tx) =>
+        this.transitionCommunicationToSent(tx, tenantId, communicationId),
+      );
 
-        await this.refreshCommunicationReceipts(tx, tenantId, communicationId);
-
-        const sent = await tx.communication.findUnique({
-          where: { id: communicationId },
-          include: COMMUNICATION_INCLUDE,
-        });
-
-        if (!sent) {
-          throw new NotFoundException('Communication not found');
-        }
-
-        return sent;
-      });
+      published = result.communication;
+      transitionedToSent = result.transitionedToSent;
     }
 
-    if (sendWebPush) {
+    if (sendWebPush && transitionedToSent) {
       await this.dispatchWebPushNotifications(tenantId, published);
     }
 
@@ -582,7 +568,8 @@ export class CommunicationsService {
       );
     }
 
-    const isAdmin = userRoles.some((r) => ADMIN_ROLES.includes(r as typeof ADMIN_ROLES[number]));
+    const adminRoleSet = new Set<string>(ADMIN_ROLES);
+    const isAdmin = userRoles.some((r) => adminRoleSet.has(r));
 
     if (isAdmin) {
       // Admin sees all communications
@@ -712,7 +699,7 @@ export class CommunicationsService {
     };
 
     // Apply cursor if provided
-    let receipts;
+    let receipts: CommunicationReceiptWithCommunication[];
     if (cursorDate && cursorId) {
       receipts = await this.prisma.communicationReceipt.findMany({
         where: {
@@ -765,19 +752,20 @@ export class CommunicationsService {
       const buildingIds = comm.targets
         .filter((t) => t.targetType === 'BUILDING' && t.targetId)
         .map((t) => t.targetId!);
-      const scopeType: string =
+      const scopeType =
         buildingIds.length === 0
           ? 'TENANT_ALL'
           : buildingIds.length === 1
             ? 'BUILDING'
             : 'MULTI_BUILDING';
+      const priority = comm.priority === 'URGENT' ? 'URGENT' : 'NORMAL';
 
       return {
         id: comm.id,
         title: comm.title,
         body: comm.body,
-        priority: (comm.priority || 'NORMAL') as 'NORMAL' | 'URGENT',
-        scopeType: scopeType as 'BUILDING' | 'MULTI_BUILDING' | 'TENANT_ALL',
+        priority,
+        scopeType,
         buildingIds,
         createdAt: comm.createdAt.toISOString(),
         publishedAt: comm.sentAt?.toISOString() ?? null,
@@ -811,12 +799,11 @@ export class CommunicationsService {
     communicationId: string,
   ): Promise<{ readAt: Date | null }> {
     // First check if there's a receipt
-    const receipt = await this.prisma.communicationReceipt.findUnique({
+    const receipt = await this.prisma.communicationReceipt.findFirst({
       where: {
-        communicationId_userId: {
-          communicationId,
-          userId,
-        },
+        tenantId,
+        communicationId,
+        userId,
       },
       select: { readAt: true },
     });
@@ -831,17 +818,18 @@ export class CommunicationsService {
     }
 
     // Mark as read
-    await this.prisma.communicationReceipt.update({
+    const readAt = new Date();
+
+    await this.prisma.communicationReceipt.updateMany({
       where: {
-        communicationId_userId: {
-          communicationId,
-          userId,
-        },
+        tenantId,
+        communicationId,
+        userId,
       },
-      data: { readAt: new Date() },
+      data: { readAt },
     });
 
-    return { readAt: new Date() };
+    return { readAt };
   }
 
   /**
@@ -895,7 +883,7 @@ export class CommunicationsService {
           await this.validators.validateBuildingBelongsToTenant(tenantId, buildingId);
         }
         targets = input.buildingIds.map((buildingId) => ({
-          targetType: 'BUILDING' as CommunicationTargetType,
+          targetType: 'BUILDING',
           targetId: buildingId,
         }));
         break;
@@ -981,14 +969,14 @@ export class CommunicationsService {
    * Anti-spam rule:
    * - If sendWebPush=true and feature flag enforceUrgentForWebPush is enabled (default true),
    *   only allows priority=URGENT
-   * - Returns 422 with code WEB_PUSH_REQUIRES_URGENT if violated
+   * - Returns 400 with code WEB_PUSH_REQUIRES_URGENT if violated
    *
    * If sendWebPush=true:
    * - Sends WEB_PUSH only to users with active PushSubscription
    * - If no subscriptions, does NOT fail (silent no-op)
    *
    * @throws NotFoundException if communication doesn't belong to tenant
-   * @throws UnprocessableEntityException if sendWebPush=true but priority!=URGENT (when flag enabled)
+   * @throws BadRequestException if sendWebPush=true but priority!=URGENT (when flag enabled)
    */
   async publishV2(
     tenantId: string,
@@ -1011,50 +999,36 @@ export class CommunicationsService {
 
     const enforceUrgent = this.configService.isFeatureEnabled('enforceUrgentForWebPush');
     if (sendWebPush && enforceUrgent && communication.priority !== 'URGENT') {
-      throw new UnprocessableEntityException({
+      throw new BadRequestException({
         code: 'WEB_PUSH_REQUIRES_URGENT',
         message: 'Web push can only be sent for URGENT communications',
       });
     }
 
     let published: CommunicationWithDetails;
+    let transitionedToSent: boolean;
     if (communication.status === 'SENT') {
-      published = await this.prisma.communication.update({
+      const current = await this.prisma.communication.findUnique({
         where: { id: communicationId },
-        data: {
-          status: 'SENT',
-          sentAt: new Date(),
-          updatedAt: new Date(),
-        },
         include: COMMUNICATION_INCLUDE,
       });
+
+      if (!current) {
+        throw new NotFoundException('Communication not found');
+      }
+
+      published = current;
+      transitionedToSent = false;
     } else {
-      published = await this.prisma.$transaction(async (tx) => {
-        await tx.communication.update({
-          where: { id: communicationId },
-          data: {
-            status: 'SENT',
-            sentAt: new Date(),
-            updatedAt: new Date(),
-          },
-        });
+      const result = await this.prisma.$transaction(async (tx) =>
+        this.transitionCommunicationToSent(tx, tenantId, communicationId),
+      );
 
-        await this.refreshCommunicationReceipts(tx, tenantId, communicationId);
-
-        const sent = await tx.communication.findUnique({
-          where: { id: communicationId },
-          include: COMMUNICATION_INCLUDE,
-        });
-
-        if (!sent) {
-          throw new NotFoundException('Communication not found');
-        }
-
-        return sent;
-      });
+      published = result.communication;
+      transitionedToSent = result.transitionedToSent;
     }
 
-    if (sendWebPush) {
+    if (sendWebPush && transitionedToSent) {
       await this.dispatchWebPushNotifications(tenantId, published);
     }
 
@@ -1146,6 +1120,47 @@ export class CommunicationsService {
     return recipientIds;
   }
 
+  private async transitionCommunicationToSent(
+    prismaClient: Prisma.TransactionClient,
+    tenantId: string,
+    communicationId: string,
+  ): Promise<{
+    communication: CommunicationWithDetails;
+    transitionedToSent: boolean;
+  }> {
+    const now = new Date();
+    const result = await prismaClient.communication.updateMany({
+      where: {
+        id: communicationId,
+        tenantId,
+        status: { not: 'SENT' },
+      },
+      data: {
+        status: 'SENT',
+        sentAt: now,
+        updatedAt: now,
+      },
+    });
+
+    if (result.count === 1) {
+      await this.refreshCommunicationReceipts(prismaClient, tenantId, communicationId);
+    }
+
+    const communication = await prismaClient.communication.findUnique({
+      where: { id: communicationId },
+      include: COMMUNICATION_INCLUDE,
+    });
+
+    if (!communication) {
+      throw new NotFoundException('Communication not found');
+    }
+
+    return {
+      communication,
+      transitionedToSent: result.count === 1,
+    };
+  }
+
   private async sendCommunicationPush(
     tenantId: string,
     subscription: CommunicationPushSubscription,
@@ -1175,11 +1190,9 @@ export class CommunicationsService {
         });
       }
     } catch (error) {
-      this.logger.warn('[CommunicationsService] Failed to send web push', {
-        tenantId,
-        userId: subscription.userId,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      this.logger.warn(
+        `[CommunicationsService] Failed to send web push tenantId=${tenantId} userId=${subscription.userId} error=${error instanceof Error ? error.message : String(error)}`,
+      );
     }
   }
 
@@ -1206,6 +1219,9 @@ export class CommunicationsService {
     limit: number = 20,
     cursor?: string,
   ): Promise<ResidentCommunicationListResponse> {
+    await this.validators.validateBuildingBelongsToTenant(tenantId, buildingId);
+    await this.validators.validateUnitBelongsToTenant(tenantId, unitId);
+
     let cursorDate: Date | undefined;
     let cursorId: string | undefined;
     if (cursor) {
@@ -1237,7 +1253,7 @@ export class CommunicationsService {
       },
     };
 
-    let receipts;
+    let receipts: CommunicationReceiptWithCommunication[];
     if (cursorDate && cursorId) {
       receipts = await this.prisma.communicationReceipt.findMany({
         where: {
@@ -1299,12 +1315,16 @@ export class CommunicationsService {
       readAt: string | null;
     } => {
       const comm = receipt.communication;
+      const hasUnitTarget = comm.targets.some((t) => t.targetType === 'UNIT');
       const buildingIds = comm.targets
         .filter((t) => t.targetType === 'BUILDING' && t.targetId)
         .map((t) => t.targetId!);
+      if (buildingIds.length === 0 && hasUnitTarget && comm.buildingId) {
+        buildingIds.push(comm.buildingId);
+      }
       const scopeType: 'BUILDING' | 'MULTI_BUILDING' | 'TENANT_ALL' =
         buildingIds.length === 0
-          ? 'TENANT_ALL'
+          ? (hasUnitTarget ? 'BUILDING' : 'TENANT_ALL')
           : buildingIds.length === 1
             ? 'BUILDING'
             : 'MULTI_BUILDING';
@@ -1313,7 +1333,7 @@ export class CommunicationsService {
         id: comm.id,
         title: comm.title,
         body: comm.body,
-        priority: (comm.priority || 'NORMAL') as 'NORMAL' | 'URGENT',
+        priority: comm.priority === 'URGENT' ? 'URGENT' : 'NORMAL',
         scopeType,
         buildingIds,
         createdAt: comm.createdAt.toISOString(),

--- a/apps/api/src/communications/communications.validators.spec.ts
+++ b/apps/api/src/communications/communications.validators.spec.ts
@@ -14,6 +14,24 @@ const communicationId = 'communication-1';
 const buildingId = 'building-1';
 const unitId = 'unit-1';
 
+const activeTenantMemberEligibility = {
+  none: {
+    tenantId,
+    OR: [
+      {
+        disabledAt: {
+          not: null,
+        },
+      },
+      {
+        status: {
+          not: MemberStatus.ACTIVE,
+        },
+      },
+    ],
+  },
+} as const;
+
 describe('CommunicationsValidators recipient eligibility', () => {
   let prisma: PrismaMock;
   let validators: CommunicationsValidators;
@@ -28,7 +46,7 @@ describe('CommunicationsValidators recipient eligibility', () => {
     validators = new CommunicationsValidators(prisma as unknown as PrismaService);
   });
 
-  it('filters ALL_TENANT recipients to active tenant members only', async () => {
+  it('includes membership-only signup owners in ALL_TENANT recipients', async () => {
     prisma.communicationTarget.findMany.mockResolvedValue([
       { targetType: 'ALL_TENANT', targetId: null },
     ]);
@@ -45,13 +63,7 @@ describe('CommunicationsValidators recipient eligibility', () => {
             tenantId,
           },
         },
-        tenantMembers: {
-          some: {
-            tenantId,
-            disabledAt: null,
-            status: MemberStatus.ACTIVE,
-          },
-        },
+        tenantMembers: activeTenantMemberEligibility,
       },
       select: { id: true },
     });
@@ -123,7 +135,7 @@ describe('CommunicationsValidators recipient eligibility', () => {
     });
   });
 
-  it('filters ROLE recipients to active tenant members only and deduplicates overlapping targets', async () => {
+  it('includes membership-only signup owners in ROLE recipients and deduplicates overlapping targets', async () => {
     prisma.communicationTarget.findMany.mockResolvedValue([
       { targetType: 'ALL_TENANT', targetId: null },
       { targetType: 'ROLE', targetId: 'RESIDENT' },
@@ -148,13 +160,50 @@ describe('CommunicationsValidators recipient eligibility', () => {
             },
           },
         },
-        tenantMembers: {
+        tenantMembers: activeTenantMemberEligibility,
+      },
+      select: { id: true },
+    });
+  });
+
+  it('excludes users with inactive tenant members from ALL_TENANT and ROLE queries', async () => {
+    prisma.communicationTarget.findMany.mockResolvedValue([
+      { targetType: 'ALL_TENANT', targetId: null },
+      { targetType: 'ROLE', targetId: 'TENANT_OWNER' },
+    ]);
+    prisma.user.findMany
+      .mockResolvedValueOnce([{ id: 'user-1' }])
+      .mockResolvedValueOnce([{ id: 'user-2' }]);
+
+    await expect(
+      validators.resolveRecipients(tenantId, communicationId, prisma as unknown as Prisma.TransactionClient),
+    ).resolves.toEqual(['user-1', 'user-2']);
+
+    expect(prisma.user.findMany).toHaveBeenNthCalledWith(1, {
+      where: {
+        memberships: {
           some: {
             tenantId,
-            disabledAt: null,
-            status: MemberStatus.ACTIVE,
           },
         },
+        tenantMembers: activeTenantMemberEligibility,
+      },
+      select: { id: true },
+    });
+
+    expect(prisma.user.findMany).toHaveBeenNthCalledWith(2, {
+      where: {
+        memberships: {
+          some: {
+            tenantId,
+            roles: {
+              some: {
+                role: 'TENANT_OWNER',
+              },
+            },
+          },
+        },
+        tenantMembers: activeTenantMemberEligibility,
       },
       select: { id: true },
     });

--- a/apps/api/src/communications/communications.validators.spec.ts
+++ b/apps/api/src/communications/communications.validators.spec.ts
@@ -1,0 +1,179 @@
+import { MemberStatus, type Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { CommunicationsValidators } from './communications.validators';
+
+interface PrismaMock {
+  readonly communicationTarget: { findMany: jest.Mock };
+  readonly communicationReceipt: { findFirst: jest.Mock };
+  readonly user: { findMany: jest.Mock };
+  readonly unitOccupant: { findMany: jest.Mock };
+}
+
+const tenantId = 'tenant-1';
+const communicationId = 'communication-1';
+const buildingId = 'building-1';
+const unitId = 'unit-1';
+
+describe('CommunicationsValidators recipient eligibility', () => {
+  let prisma: PrismaMock;
+  let validators: CommunicationsValidators;
+
+  beforeEach(() => {
+    prisma = {
+      communicationTarget: { findMany: jest.fn() },
+      communicationReceipt: { findFirst: jest.fn() },
+      user: { findMany: jest.fn() },
+      unitOccupant: { findMany: jest.fn() },
+    };
+    validators = new CommunicationsValidators(prisma as unknown as PrismaService);
+  });
+
+  it('filters ALL_TENANT recipients to active tenant members only', async () => {
+    prisma.communicationTarget.findMany.mockResolvedValue([
+      { targetType: 'ALL_TENANT', targetId: null },
+    ]);
+    prisma.user.findMany.mockResolvedValue([{ id: 'user-1' }, { id: 'user-2' }]);
+
+    await expect(
+      validators.resolveRecipients(tenantId, communicationId, prisma as unknown as Prisma.TransactionClient),
+    ).resolves.toEqual(['user-1', 'user-2']);
+
+    expect(prisma.user.findMany).toHaveBeenCalledWith({
+      where: {
+        memberships: {
+          some: {
+            tenantId,
+          },
+        },
+        tenantMembers: {
+          some: {
+            tenantId,
+            disabledAt: null,
+            status: MemberStatus.ACTIVE,
+          },
+        },
+      },
+      select: { id: true },
+    });
+  });
+
+  it('filters BUILDING recipients to active current occupancies only', async () => {
+    prisma.communicationTarget.findMany.mockResolvedValue([
+      { targetType: 'BUILDING', targetId: buildingId },
+    ]);
+    prisma.unitOccupant.findMany.mockResolvedValue([
+      { member: { userId: 'user-1' } },
+    ]);
+
+    await expect(
+      validators.resolveRecipients(tenantId, communicationId, prisma as unknown as Prisma.TransactionClient),
+    ).resolves.toEqual(['user-1']);
+
+    expect(prisma.unitOccupant.findMany).toHaveBeenCalledWith({
+      where: {
+        tenantId,
+        endDate: null,
+        unit: {
+          building: {
+            id: buildingId,
+            tenantId,
+          },
+        },
+        member: {
+          tenantId,
+          disabledAt: null,
+          status: MemberStatus.ACTIVE,
+          userId: { not: null },
+        },
+      },
+      include: { member: { select: { userId: true } } },
+      distinct: ['memberId'],
+    });
+  });
+
+  it('filters UNIT recipients to active current occupancies only', async () => {
+    prisma.communicationTarget.findMany.mockResolvedValue([
+      { targetType: 'UNIT', targetId: unitId },
+    ]);
+    prisma.unitOccupant.findMany.mockResolvedValue([
+      { member: { userId: 'user-1' } },
+    ]);
+
+    await expect(
+      validators.resolveRecipients(tenantId, communicationId, prisma as unknown as Prisma.TransactionClient),
+    ).resolves.toEqual(['user-1']);
+
+    expect(prisma.unitOccupant.findMany).toHaveBeenCalledWith({
+      where: {
+        tenantId,
+        endDate: null,
+        unitId,
+        unit: {
+          building: { tenantId },
+        },
+        member: {
+          tenantId,
+          disabledAt: null,
+          status: MemberStatus.ACTIVE,
+          userId: { not: null },
+        },
+      },
+      include: { member: { select: { userId: true } } },
+      distinct: ['memberId'],
+    });
+  });
+
+  it('filters ROLE recipients to active tenant members only and deduplicates overlapping targets', async () => {
+    prisma.communicationTarget.findMany.mockResolvedValue([
+      { targetType: 'ALL_TENANT', targetId: null },
+      { targetType: 'ROLE', targetId: 'RESIDENT' },
+    ]);
+    prisma.user.findMany
+      .mockResolvedValueOnce([{ id: 'user-1' }, { id: 'user-2' }])
+      .mockResolvedValueOnce([{ id: 'user-2' }, { id: 'user-3' }]);
+
+    await expect(
+      validators.resolveRecipients(tenantId, communicationId, prisma as unknown as Prisma.TransactionClient),
+    ).resolves.toEqual(['user-1', 'user-2', 'user-3']);
+
+    expect(prisma.user.findMany).toHaveBeenNthCalledWith(2, {
+      where: {
+        memberships: {
+          some: {
+            tenantId,
+            roles: {
+              some: {
+                role: 'RESIDENT',
+              },
+            },
+          },
+        },
+        tenantMembers: {
+          some: {
+            tenantId,
+            disabledAt: null,
+            status: MemberStatus.ACTIVE,
+          },
+        },
+      },
+      select: { id: true },
+    });
+  });
+
+  it('uses tenant scope when checking resident access to a communication', async () => {
+    prisma.communicationReceipt.findFirst.mockResolvedValue({ id: 'receipt-1' });
+
+    await expect(
+      validators.canUserReadCommunication(tenantId, 'user-1', communicationId, ['RESIDENT']),
+    ).resolves.toBe(true);
+
+    expect(prisma.communicationReceipt.findFirst).toHaveBeenCalledWith({
+      where: {
+        tenantId,
+        communicationId,
+        userId: 'user-1',
+      },
+      select: { id: true },
+    });
+  });
+});

--- a/apps/api/src/communications/communications.validators.ts
+++ b/apps/api/src/communications/communications.validators.ts
@@ -249,10 +249,20 @@ export class CommunicationsValidators {
               },
             },
             tenantMembers: {
-              some: {
+              none: {
                 tenantId,
-                disabledAt: null,
-                status: MemberStatus.ACTIVE,
+                OR: [
+                  {
+                    disabledAt: {
+                      not: null,
+                    },
+                  },
+                  {
+                    status: {
+                      not: MemberStatus.ACTIVE,
+                    },
+                  },
+                ],
               },
             },
           },
@@ -328,10 +338,20 @@ export class CommunicationsValidators {
               },
             },
             tenantMembers: {
-              some: {
+              none: {
                 tenantId,
-                disabledAt: null,
-                status: MemberStatus.ACTIVE,
+                OR: [
+                  {
+                    disabledAt: {
+                      not: null,
+                    },
+                  },
+                  {
+                    status: {
+                      not: MemberStatus.ACTIVE,
+                    },
+                  },
+                ],
               },
             },
           },

--- a/apps/api/src/communications/communications.validators.ts
+++ b/apps/api/src/communications/communications.validators.ts
@@ -14,7 +14,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { CommunicationTargetType, Role } from '@prisma/client';
+import { CommunicationTargetType, MemberStatus, Prisma, Role } from '@prisma/client';
 
 @Injectable()
 export class CommunicationsValidators {
@@ -194,9 +194,10 @@ export class CommunicationsValidators {
   async resolveRecipients(
     tenantId: string,
     communicationId: string,
+    prismaClient: PrismaService | Prisma.TransactionClient = this.prisma,
   ): Promise<string[]> {
     // Get all targets for this communication
-    const targets = await this.prisma.communicationTarget.findMany({
+    const targets = await prismaClient.communicationTarget.findMany({
       where: {
         communicationId,
         tenantId,
@@ -214,7 +215,12 @@ export class CommunicationsValidators {
     const recipientIds = new Set<string>();
 
     for (const target of targets) {
-      const userIds = await this.resolveTarget(tenantId, target.targetType, target.targetId);
+      const userIds = await this.resolveTarget(
+        tenantId,
+        target.targetType,
+        target.targetId,
+        prismaClient,
+      );
       userIds.forEach((id) => recipientIds.add(id));
     }
 
@@ -230,15 +236,23 @@ export class CommunicationsValidators {
     tenantId: string,
     targetType: CommunicationTargetType,
     targetId: string | null,
+    prismaClient: PrismaService | Prisma.TransactionClient = this.prisma,
   ): Promise<string[]> {
     switch (targetType) {
       case 'ALL_TENANT': {
-        // All users in the tenant
-        const tenantUsers = await this.prisma.user.findMany({
+        // All active users in the tenant
+        const tenantUsers = await prismaClient.user.findMany({
           where: {
             memberships: {
               some: {
                 tenantId,
+              },
+            },
+            tenantMembers: {
+              some: {
+                tenantId,
+                disabledAt: null,
+                status: MemberStatus.ACTIVE,
               },
             },
           },
@@ -248,14 +262,22 @@ export class CommunicationsValidators {
       }
 
       case 'BUILDING': {
-        // All unit occupants in this building
-        const buildingOccupants = await this.prisma.unitOccupant.findMany({
+        // All active unit occupants in this building
+        const buildingOccupants = await prismaClient.unitOccupant.findMany({
           where: {
+            tenantId,
+            endDate: null,
             unit: {
               building: {
                 id: targetId as string,
                 tenantId,
               },
+            },
+            member: {
+              tenantId,
+              disabledAt: null,
+              status: MemberStatus.ACTIVE,
+              userId: { not: null },
             },
           },
           include: { member: { select: { userId: true } } },
@@ -267,12 +289,20 @@ export class CommunicationsValidators {
       }
 
       case 'UNIT': {
-        // All unit occupants in this unit
-        const unitOccupants = await this.prisma.unitOccupant.findMany({
+        // All active unit occupants in this unit
+        const unitOccupants = await prismaClient.unitOccupant.findMany({
           where: {
+            tenantId,
+            endDate: null,
             unitId: targetId as string,
             unit: {
               building: { tenantId },
+            },
+            member: {
+              tenantId,
+              disabledAt: null,
+              status: MemberStatus.ACTIVE,
+              userId: { not: null },
             },
           },
           include: { member: { select: { userId: true } } },
@@ -284,8 +314,8 @@ export class CommunicationsValidators {
       }
 
       case 'ROLE':
-        // All users with this role in the tenant
-        const roleUsers = await this.prisma.user.findMany({
+        // All active users with this role in the tenant
+        const roleUsers = await prismaClient.user.findMany({
           where: {
             memberships: {
               some: {
@@ -295,6 +325,13 @@ export class CommunicationsValidators {
                     role: targetId as Role,
                   },
                 },
+              },
+            },
+            tenantMembers: {
+              some: {
+                tenantId,
+                disabledAt: null,
+                status: MemberStatus.ACTIVE,
               },
             },
           },
@@ -317,7 +354,7 @@ export class CommunicationsValidators {
    * @returns true if user can read, false otherwise
    */
   async canUserReadCommunication(
-    _tenantId: string,
+    tenantId: string,
     userId: string,
     communicationId: string,
     userRoles: string[],
@@ -330,12 +367,11 @@ export class CommunicationsValidators {
 
     // RESIDENT can only read if they have a receipt
     // (i.e., they were in the targets)
-    const receipt = await this.prisma.communicationReceipt.findUnique({
+    const receipt = await this.prisma.communicationReceipt.findFirst({
       where: {
-        communicationId_userId: {
-          communicationId,
-          userId,
-        },
+        tenantId,
+        communicationId,
+        userId,
       },
       select: { id: true },
     });


### PR DESCRIPTION
Closes #88

## Summary
- Filters communication recipients to active tenant members and active occupancies only.
- Synchronizes communication receipts at publication time so stale drafts do not leak recipients.
- Keeps resident read access tenant-scoped.

## Changes Table
| File | Change |
|------|--------|
| `apps/api/src/communications/communications.validators.ts` | Filters recipients by active tenant membership/occupancy and tenant-scoped receipt reads. |
| `apps/api/src/communications/communications.service.ts` | Synchronizes receipts on publication and normalizes the scheduled-date validation message. |
| `apps/api/src/communications/communications.validators.spec.ts` | Covers recipient eligibility and tenant-scoped resident access. |
| `apps/api/src/communications/communications.service.spec.ts` | Covers draft/publication receipt synchronization and web push fanout. |

## Test Plan
- [x] Scripts run without errors: `npm run test -w apps/api -- --runInBand --no-coverage src/communications/communications.validators.spec.ts src/communications/communications.service.spec.ts src/communications/communications-user.controller.spec.ts`
- [x] Scripts run without errors: `./node_modules/.bin/tsc -p apps/api/tsconfig.json --noEmit`
- [x] Scripts run without errors: `npm run build -w apps/api`
- [x] Scripts run without errors: `ESLINT_USE_FLAT_CONFIG=false ./node_modules/.bin/eslint apps/api/src/communications/communications.validators.ts apps/api/src/communications/communications.service.ts apps/api/src/communications/communications.validators.spec.ts apps/api/src/communications/communications.service.spec.ts`
- [x] Scripts run without errors: `npm run test:forbid-only -w apps/api`
- [x] Shellcheck not applicable: no shell scripts were modified.

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts or confirmed it was not applicable
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
