### PR TITLE
fix(tenancy): reject tenant context mismatch

### DIFF
--- a/apps/api/src/common/types/request.types.ts
+++ b/apps/api/src/common/types/request.types.ts
@@ -16,6 +16,9 @@ export interface AuthenticatedUser {
   email: string;
   name?: string;
   isSuperAdmin?: boolean;
+  isImpersonating?: boolean;
+  impersonatedTenantId?: string;
+  actorSuperAdminUserId?: string;
   role?: Role;
   roles?: Role[];
   membershipId?: string;

--- a/apps/api/src/finanzas/unit-group.controller.spec.ts
+++ b/apps/api/src/finanzas/unit-group.controller.spec.ts
@@ -2,8 +2,15 @@ import type { CanActivate, ExecutionContext, INestApplication } from '@nestjs/co
 import { Test } from '@nestjs/testing';
 import request from 'supertest';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import type { AuthenticatedRequest } from '../common/types/request.types';
 import { UnitGroupController } from './unit-group.controller';
 import { UnitGroupService } from './unit-group.service';
+
+type TestUser = NonNullable<AuthenticatedRequest['user']> & {
+  isImpersonating?: boolean;
+  impersonatedTenantId?: string;
+  actorSuperAdminUserId?: string;
+};
 
 describe('UnitGroupController tenant context validation', () => {
   let app: INestApplication;
@@ -27,21 +34,28 @@ describe('UnitGroupController tenant context validation', () => {
     >,
   };
 
+  const createUser = (overrides: Partial<TestUser> = {}): TestUser => ({
+    id: 'user-1',
+    email: 'admin@example.com',
+    name: 'Admin',
+    roles: ['TENANT_ADMIN'],
+    membershipId: 'membership-a',
+    memberships: [
+      {
+        id: 'membership-a',
+        tenantId: 'tenant-a',
+        roles: ['TENANT_ADMIN'],
+      },
+    ],
+    ...overrides,
+  });
+
+  let currentUser: TestUser;
+
   const jwtGuard: CanActivate = {
     canActivate: (context: ExecutionContext): boolean => {
-      const req = context.switchToHttp().getRequest();
-      req.user = {
-        id: 'user-1',
-        email: 'admin@example.com',
-        name: 'Admin',
-        memberships: [
-          {
-            id: 'membership-a',
-            tenantId: 'tenant-a',
-            roles: ['TENANT_ADMIN'],
-          },
-        ],
-      };
+      const req = context.switchToHttp().getRequest<AuthenticatedRequest>();
+      req.user = currentUser;
       return true;
     },
   };
@@ -49,9 +63,7 @@ describe('UnitGroupController tenant context validation', () => {
   beforeAll(async () => {
     const moduleRef = await Test.createTestingModule({
       controllers: [UnitGroupController],
-      providers: [
-        { provide: UnitGroupService, useValue: unitGroupService },
-      ],
+      providers: [{ provide: UnitGroupService, useValue: unitGroupService }],
     })
       .overrideGuard(JwtAuthGuard)
       .useValue(jwtGuard)
@@ -63,6 +75,8 @@ describe('UnitGroupController tenant context validation', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    currentUser = createUser();
+
     unitGroupService.createUnitGroup.mockResolvedValue({
       id: 'group-1',
       tenantId: 'tenant-a',
@@ -91,10 +105,9 @@ describe('UnitGroupController tenant context validation', () => {
     await app?.close();
   });
 
-  it('accepts the matching tenant context for read operations', async () => {
+  it('accepts matching tenant context for read operations without a tenant header', async () => {
     await request(app.getHttpServer())
       .get('/tenants/tenant-a/unit-groups')
-      .set('X-Tenant-Id', 'tenant-a')
       .expect(200);
 
     expect(unitGroupService.listUnitGroups).toHaveBeenCalledWith(
@@ -104,7 +117,22 @@ describe('UnitGroupController tenant context validation', () => {
     );
   });
 
-  it('accepts the matching tenant context for write operations', async () => {
+  it('accepts the matching tenant context for write operations and selects the matching membership', async () => {
+    currentUser = createUser({
+      memberships: [
+        {
+          id: 'membership-b',
+          tenantId: 'tenant-b',
+          roles: ['TENANT_ADMIN'],
+        },
+        {
+          id: 'membership-a',
+          tenantId: 'tenant-a',
+          roles: ['TENANT_ADMIN'],
+        },
+      ],
+    });
+
     await request(app.getHttpServer())
       .post('/tenants/tenant-a/unit-groups')
       .set('X-Tenant-Id', 'tenant-a')
@@ -126,10 +154,29 @@ describe('UnitGroupController tenant context validation', () => {
     );
   });
 
+  it('rejects contradictory tenant headers before reaching the service', async () => {
+    await request(app.getHttpServer())
+      .get('/tenants/tenant-a/unit-groups')
+      .set('X-Tenant-Id', 'tenant-a')
+      .set('Tenant-Id', 'tenant-b')
+      .expect(403);
+
+    expect(unitGroupService.listUnitGroups).not.toHaveBeenCalled();
+  });
+
+  it('rejects a mismatched tenant header even when the route tenant is authorized', async () => {
+    await request(app.getHttpServer())
+      .get('/tenants/tenant-a/unit-groups')
+      .set('X-Tenant-Id', 'tenant-b')
+      .expect(403);
+
+    expect(unitGroupService.listUnitGroups).not.toHaveBeenCalled();
+  });
+
   it('rejects a mismatched route tenant before reaching the service', async () => {
     await request(app.getHttpServer())
       .get('/tenants/tenant-b/unit-groups')
-      .set('X-Tenant-Id', 'tenant-a')
+      .set('X-Tenant-Id', 'tenant-b')
       .expect(403);
 
     expect(unitGroupService.listUnitGroups).not.toHaveBeenCalled();
@@ -142,6 +189,61 @@ describe('UnitGroupController tenant context validation', () => {
       .send({
         buildingId: 'building-1',
         name: 'Grupo B',
+        unitIds: ['unit-1'],
+      })
+      .expect(403);
+
+    expect(unitGroupService.createUnitGroup).not.toHaveBeenCalled();
+  });
+
+  it('accepts impersonated read access without a membership id', async () => {
+    currentUser = createUser({
+      membershipId: '',
+      isImpersonating: true,
+      impersonatedTenantId: 'tenant-a',
+      actorSuperAdminUserId: 'super-admin-1',
+      roles: ['TENANT_ADMIN'],
+      memberships: [
+        {
+          tenantId: 'tenant-a',
+          roles: ['TENANT_ADMIN'],
+        },
+      ],
+    });
+
+    await request(app.getHttpServer())
+      .get('/tenants/tenant-a/unit-groups')
+      .set('X-Tenant-Id', 'tenant-a')
+      .expect(200);
+
+    expect(unitGroupService.listUnitGroups).toHaveBeenCalledWith(
+      'tenant-a',
+      undefined,
+      ['TENANT_ADMIN'],
+    );
+  });
+
+  it('rejects impersonated writes explicitly', async () => {
+    currentUser = createUser({
+      membershipId: '',
+      isImpersonating: true,
+      impersonatedTenantId: 'tenant-a',
+      actorSuperAdminUserId: 'super-admin-1',
+      roles: ['TENANT_ADMIN'],
+      memberships: [
+        {
+          tenantId: 'tenant-a',
+          roles: ['TENANT_ADMIN'],
+        },
+      ],
+    });
+
+    await request(app.getHttpServer())
+      .post('/tenants/tenant-a/unit-groups')
+      .set('X-Tenant-Id', 'tenant-a')
+      .send({
+        buildingId: 'building-1',
+        name: 'Grupo A',
         unitIds: ['unit-1'],
       })
       .expect(403);

--- a/apps/api/src/finanzas/unit-group.controller.spec.ts
+++ b/apps/api/src/finanzas/unit-group.controller.spec.ts
@@ -1,0 +1,151 @@
+import type { CanActivate, ExecutionContext, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { UnitGroupController } from './unit-group.controller';
+import { UnitGroupService } from './unit-group.service';
+
+describe('UnitGroupController tenant context validation', () => {
+  let app: INestApplication;
+
+  const unitGroupService = {
+    createUnitGroup: jest.fn() as jest.MockedFunction<
+      UnitGroupService['createUnitGroup']
+    >,
+    getUnitGroup: jest.fn() as jest.MockedFunction<
+      UnitGroupService['getUnitGroup']
+    >,
+    listUnitGroups: jest.fn() as jest.MockedFunction<
+      UnitGroupService['listUnitGroups']
+    >,
+    addMember: jest.fn() as jest.MockedFunction<UnitGroupService['addMember']>,
+    removeMember: jest.fn() as jest.MockedFunction<
+      UnitGroupService['removeMember']
+    >,
+    deleteUnitGroup: jest.fn() as jest.MockedFunction<
+      UnitGroupService['deleteUnitGroup']
+    >,
+  };
+
+  const jwtGuard: CanActivate = {
+    canActivate: (context: ExecutionContext): boolean => {
+      const req = context.switchToHttp().getRequest();
+      req.user = {
+        id: 'user-1',
+        email: 'admin@example.com',
+        name: 'Admin',
+        memberships: [
+          {
+            id: 'membership-a',
+            tenantId: 'tenant-a',
+            roles: ['TENANT_ADMIN'],
+          },
+        ],
+      };
+      return true;
+    },
+  };
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [UnitGroupController],
+      providers: [
+        { provide: UnitGroupService, useValue: unitGroupService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(jwtGuard)
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    unitGroupService.createUnitGroup.mockResolvedValue({
+      id: 'group-1',
+      tenantId: 'tenant-a',
+      buildingId: 'building-1',
+      name: 'Grupo A',
+      description: null,
+      memberCount: 0,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    unitGroupService.listUnitGroups.mockResolvedValue([
+      {
+        id: 'group-1',
+        tenantId: 'tenant-a',
+        buildingId: 'building-1',
+        name: 'Grupo A',
+        description: null,
+        memberCount: 0,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      },
+    ]);
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  it('accepts the matching tenant context for read operations', async () => {
+    await request(app.getHttpServer())
+      .get('/tenants/tenant-a/unit-groups')
+      .set('X-Tenant-Id', 'tenant-a')
+      .expect(200);
+
+    expect(unitGroupService.listUnitGroups).toHaveBeenCalledWith(
+      'tenant-a',
+      undefined,
+      ['TENANT_ADMIN'],
+    );
+  });
+
+  it('accepts the matching tenant context for write operations', async () => {
+    await request(app.getHttpServer())
+      .post('/tenants/tenant-a/unit-groups')
+      .set('X-Tenant-Id', 'tenant-a')
+      .send({
+        buildingId: 'building-1',
+        name: 'Grupo A',
+        unitIds: ['unit-1'],
+      })
+      .expect(201);
+
+    expect(unitGroupService.createUnitGroup).toHaveBeenCalledWith(
+      'tenant-a',
+      'building-1',
+      'Grupo A',
+      undefined,
+      ['unit-1'],
+      'membership-a',
+      ['TENANT_ADMIN'],
+    );
+  });
+
+  it('rejects a mismatched route tenant before reaching the service', async () => {
+    await request(app.getHttpServer())
+      .get('/tenants/tenant-b/unit-groups')
+      .set('X-Tenant-Id', 'tenant-a')
+      .expect(403);
+
+    expect(unitGroupService.listUnitGroups).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unauthorized route tenant even when the header matches the URL', async () => {
+    await request(app.getHttpServer())
+      .post('/tenants/tenant-b/unit-groups')
+      .set('X-Tenant-Id', 'tenant-b')
+      .send({
+        buildingId: 'building-1',
+        name: 'Grupo B',
+        unitIds: ['unit-1'],
+      })
+      .expect(403);
+
+    expect(unitGroupService.createUnitGroup).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/finanzas/unit-group.controller.ts
+++ b/apps/api/src/finanzas/unit-group.controller.ts
@@ -9,7 +9,7 @@ import {
   UseGuards,
   Request,
   BadRequestException,
-  UnauthorizedException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { IsString, IsArray, IsOptional, MinLength } from 'class-validator';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
@@ -43,6 +43,58 @@ export class AddMemberDto {
 export class UnitGroupController {
   constructor(private readonly unitGroupService: UnitGroupService) {}
 
+  private getTenantHeader(req: AuthenticatedRequest): string | undefined {
+    const rawHeaders = [req.headers['x-tenant-id'], req.headers['tenant-id']];
+    const normalizedHeaders = rawHeaders
+      .flatMap((value) => (Array.isArray(value) ? value : [value]))
+      .filter((value): value is string => typeof value === 'string')
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+
+    if (normalizedHeaders.length === 0) {
+      return undefined;
+    }
+
+    const distinctHeaders = [...new Set(normalizedHeaders)];
+    if (distinctHeaders.length > 1) {
+      throw new ForbiddenException('Tenant context does not match the request');
+    }
+
+    return distinctHeaders[0];
+  }
+
+  private resolveTenantContext(req: AuthenticatedRequest): {
+    tenantId: string;
+    membershipId: string;
+    roles: string[];
+  } {
+    const routeTenantId = req.params.tenantId?.trim();
+    if (!routeTenantId) {
+      throw new BadRequestException('tenantId is required');
+    }
+
+    const headerTenantId = this.getTenantHeader(req);
+    if (headerTenantId && headerTenantId !== routeTenantId) {
+      throw new ForbiddenException('Tenant context does not match the request');
+    }
+
+    const membership = req.user?.memberships?.find(
+      (entry) => entry.tenantId === routeTenantId,
+    );
+
+    if (!membership?.id) {
+      throw new ForbiddenException(
+        `User does not have access to tenant ${routeTenantId}`,
+      );
+    }
+
+    return {
+      tenantId: routeTenantId,
+      membershipId: membership.id,
+      roles: membership.roles ?? [],
+    };
+  }
+
   /**
    * Create a new unit group within a building
    * @param req Authenticated request with tenantId and membershipId
@@ -54,13 +106,7 @@ export class UnitGroupController {
     @Request() req: AuthenticatedRequest,
     @Body() dto: CreateUnitGroupDto,
   ) {
-    const tenantId = req.tenantId || req.user?.tenantId;
-    const membershipId = req.user?.membershipId;
-    const roles = req.user?.roles ?? [];
-
-    if (!tenantId || !membershipId) {
-      throw new UnauthorizedException('Missing tenantId or membershipId in request');
-    }
+    const { tenantId, membershipId, roles } = this.resolveTenantContext(req);
 
     return this.unitGroupService.createUnitGroup(
       tenantId,
@@ -84,12 +130,7 @@ export class UnitGroupController {
     @Request() req: AuthenticatedRequest,
     @Param('groupId') groupId: string,
   ) {
-    const tenantId = req.tenantId || req.user?.tenantId;
-    const roles = req.user?.roles ?? [];
-
-    if (!tenantId) {
-      throw new UnauthorizedException('Missing tenantId in request');
-    }
+    const { tenantId, roles } = this.resolveTenantContext(req);
 
     return this.unitGroupService.getUnitGroup(tenantId, groupId, roles);
   }
@@ -105,12 +146,7 @@ export class UnitGroupController {
     @Request() req: AuthenticatedRequest,
     @Query('buildingId') buildingId?: string,
   ) {
-    const tenantId = req.tenantId || req.user?.tenantId;
-    const roles = req.user?.roles ?? [];
-
-    if (!tenantId) {
-      throw new UnauthorizedException('Missing tenantId in request');
-    }
+    const { tenantId, roles } = this.resolveTenantContext(req);
 
     return this.unitGroupService.listUnitGroups(tenantId, buildingId, roles);
   }
@@ -128,13 +164,7 @@ export class UnitGroupController {
     @Param('groupId') groupId: string,
     @Body() dto: AddMemberDto,
   ) {
-    const tenantId = req.tenantId || req.user?.tenantId;
-    const membershipId = req.user?.membershipId;
-    const roles = req.user?.roles ?? [];
-
-    if (!tenantId || !membershipId) {
-      throw new UnauthorizedException('Missing tenantId or membershipId in request');
-    }
+    const { tenantId, membershipId, roles } = this.resolveTenantContext(req);
 
     await this.unitGroupService.addMember(
       tenantId,
@@ -159,13 +189,7 @@ export class UnitGroupController {
     @Param('groupId') groupId: string,
     @Param('unitId') unitId: string,
   ) {
-    const tenantId = req.tenantId || req.user?.tenantId;
-    const membershipId = req.user?.membershipId;
-    const roles = req.user?.roles ?? [];
-
-    if (!tenantId || !membershipId) {
-      throw new UnauthorizedException('Missing tenantId or membershipId in request');
-    }
+    const { tenantId, membershipId, roles } = this.resolveTenantContext(req);
 
     await this.unitGroupService.removeMember(
       tenantId,
@@ -189,13 +213,7 @@ export class UnitGroupController {
     @Request() req: AuthenticatedRequest,
     @Param('groupId') groupId: string,
   ) {
-    const tenantId = req.tenantId || req.user?.tenantId;
-    const membershipId = req.user?.membershipId;
-    const roles = req.user?.roles ?? [];
-
-    if (!tenantId || !membershipId) {
-      throw new UnauthorizedException('Missing tenantId or membershipId in request');
-    }
+    const { tenantId, membershipId, roles } = this.resolveTenantContext(req);
 
     await this.unitGroupService.deleteUnitGroup(
       tenantId,

--- a/apps/api/src/finanzas/unit-group.controller.ts
+++ b/apps/api/src/finanzas/unit-group.controller.ts
@@ -65,7 +65,7 @@ export class UnitGroupController {
 
   private resolveTenantContext(req: AuthenticatedRequest): {
     tenantId: string;
-    membershipId: string;
+    membershipId?: string;
     roles: string[];
   } {
     const routeTenantId = req.params.tenantId?.trim();
@@ -82,7 +82,7 @@ export class UnitGroupController {
       (entry) => entry.tenantId === routeTenantId,
     );
 
-    if (!membership?.id) {
+    if (!membership) {
       throw new ForbiddenException(
         `User does not have access to tenant ${routeTenantId}`,
       );
@@ -90,8 +90,34 @@ export class UnitGroupController {
 
     return {
       tenantId: routeTenantId,
-      membershipId: membership.id,
+      membershipId: membership.id?.trim() || undefined,
       roles: membership.roles ?? [],
+    };
+  }
+
+  private resolveWriteTenantContext(req: AuthenticatedRequest): {
+    tenantId: string;
+    membershipId: string;
+    roles: string[];
+  } {
+    if (req.user?.isImpersonating) {
+      throw new ForbiddenException(
+        'Impersonated tenant writes are not allowed',
+      );
+    }
+
+    const context = this.resolveTenantContext(req);
+
+    if (!context.membershipId) {
+      throw new ForbiddenException(
+        `User does not have a writable membership for tenant ${context.tenantId}`,
+      );
+    }
+
+    return {
+      tenantId: context.tenantId,
+      membershipId: context.membershipId,
+      roles: context.roles,
     };
   }
 
@@ -106,7 +132,7 @@ export class UnitGroupController {
     @Request() req: AuthenticatedRequest,
     @Body() dto: CreateUnitGroupDto,
   ) {
-    const { tenantId, membershipId, roles } = this.resolveTenantContext(req);
+    const { tenantId, membershipId, roles } = this.resolveWriteTenantContext(req);
 
     return this.unitGroupService.createUnitGroup(
       tenantId,
@@ -164,7 +190,7 @@ export class UnitGroupController {
     @Param('groupId') groupId: string,
     @Body() dto: AddMemberDto,
   ) {
-    const { tenantId, membershipId, roles } = this.resolveTenantContext(req);
+    const { tenantId, membershipId, roles } = this.resolveWriteTenantContext(req);
 
     await this.unitGroupService.addMember(
       tenantId,
@@ -189,7 +215,7 @@ export class UnitGroupController {
     @Param('groupId') groupId: string,
     @Param('unitId') unitId: string,
   ) {
-    const { tenantId, membershipId, roles } = this.resolveTenantContext(req);
+    const { tenantId, membershipId, roles } = this.resolveWriteTenantContext(req);
 
     await this.unitGroupService.removeMember(
       tenantId,
@@ -213,7 +239,7 @@ export class UnitGroupController {
     @Request() req: AuthenticatedRequest,
     @Param('groupId') groupId: string,
   ) {
-    const { tenantId, membershipId, roles } = this.resolveTenantContext(req);
+    const { tenantId, membershipId, roles } = this.resolveWriteTenantContext(req);
 
     await this.unitGroupService.deleteUnitGroup(
       tenantId,


### PR DESCRIPTION
## Summary

- validates requested tenant context against authenticated memberships before unit-group actions
- rejects mismatches between route and request tenant context
- adds focused authorization regression tests for read and write paths

## Security finding

Closes #90

## Tests

- `npm test -w apps/api -- --runInBand src/finanzas/unit-group.controller.spec.ts`
- `./node_modules/.bin/tsc -p apps/api/tsconfig.json --noEmit`
- `ESLINT_USE_FLAT_CONFIG=false ./node_modules/.bin/eslint -c apps/api/.eslintrc.cjs apps/api/src/finanzas/unit-group.controller.ts apps/api/src/finanzas/unit-group.controller.spec.ts`
- `npm run test:forbid-only -w apps/api`
- `git diff --check`

## Scope

- schema: unchanged
- migrations: unchanged
- backend: updated
- frontend: unchanged
- infrastructure: unchanged
- deploy: unchanged
