### PR TITLE
test(e2e): cover resident journeys

### DIFF
--- a/apps/api/prisma/seed.test.ts
+++ b/apps/api/prisma/seed.test.ts
@@ -1,4 +1,17 @@
-import { PrismaClient, Role, TenantType, BillingPlanId, ChargeStatus, PaymentStatus, PaymentMethod } from "@prisma/client";
+import {
+  PrismaClient,
+  Role,
+  TenantType,
+  BillingPlanId,
+  ChargeStatus,
+  PaymentStatus,
+  PaymentMethod,
+  CommunicationChannel,
+  CommunicationPriority,
+  CommunicationTargetType,
+  TicketCategory,
+  TicketStatus,
+} from "@prisma/client";
 import * as bcrypt from "bcrypt";
 import { buildSeedExpenseSnapshotItem, ensureSeedPublishedLiquidation } from "./lib/seed-liquidation-workflow";
 
@@ -119,6 +132,24 @@ async function main() {
       create: {
         email: "test-resident-b@buildingos.local",
         name: "Test Resident B",
+        passwordHash: testPassword,
+      },
+    }),
+    residentMulti: await prisma.user.upsert({
+      where: { email: "test-resident-multi@buildingos.local" },
+      update: { name: "Test Resident Multi" },
+      create: {
+        email: "test-resident-multi@buildingos.local",
+        name: "Test Resident Multi",
+        passwordHash: testPassword,
+      },
+    }),
+    residentMixed: await prisma.user.upsert({
+      where: { email: "test-resident-admin@buildingos.local" },
+      update: { name: "Test Resident Admin" },
+      create: {
+        email: "test-resident-admin@buildingos.local",
+        name: "Test Resident Admin",
         passwordHash: testPassword,
       },
     }),
@@ -244,6 +275,32 @@ async function main() {
       status: "ACTIVE",
     },
   });
+
+  const residentMultiMemberA = await prisma.tenantMember.upsert({
+    where: { tenantId_email: { tenantId: tenantA.id, email: testUsers.residentMulti.email! } },
+    update: {},
+    create: {
+      tenantId: tenantA.id,
+      userId: testUsers.residentMulti.id,
+      name: testUsers.residentMulti.name,
+      email: testUsers.residentMulti.email,
+      role: "RESIDENT",
+      status: "ACTIVE",
+    },
+  });
+
+  const residentMixedMemberA = await prisma.tenantMember.upsert({
+    where: { tenantId_email: { tenantId: tenantA.id, email: testUsers.residentMixed.email! } },
+    update: {},
+    create: {
+      tenantId: tenantA.id,
+      userId: testUsers.residentMixed.id,
+      name: testUsers.residentMixed.name,
+      email: testUsers.residentMixed.email,
+      role: "RESIDENT",
+      status: "ACTIVE",
+    },
+  });
   console.log(`✅ Tenant members created`);
 
   // ============================================================================
@@ -269,6 +326,27 @@ async function main() {
   const adminMembershipA = await upsertMembership({ tenantId: tenantA.id, userId: testUsers.tenantAdminA.id, role: Role.TENANT_ADMIN });
   await upsertMembership({ tenantId: tenantA.id, userId: testUsers.operator.id, role: Role.OPERATOR });
   await upsertMembership({ tenantId: tenantA.id, userId: testUsers.resident.id, role: Role.RESIDENT });
+  await upsertMembership({ tenantId: tenantA.id, userId: testUsers.residentMulti.id, role: Role.RESIDENT });
+  const residentMixedMembershipA = await upsertMembership({ tenantId: tenantA.id, userId: testUsers.residentMixed.id, role: Role.RESIDENT });
+  const residentMixedAdminRole = await prisma.membershipRole.findFirst({
+    where: {
+      tenantId: tenantA.id,
+      membershipId: residentMixedMembershipA.id,
+      role: Role.TENANT_ADMIN,
+      scopeType: "TENANT",
+    },
+    select: { id: true },
+  });
+  if (!residentMixedAdminRole) {
+    await prisma.membershipRole.create({
+      data: {
+        tenantId: tenantA.id,
+        membershipId: residentMixedMembershipA.id,
+        role: Role.TENANT_ADMIN,
+        scopeType: "TENANT",
+      },
+    });
+  }
   await upsertMembership({ tenantId: tenantB.id, userId: testUsers.tenantAdminB.id, role: Role.TENANT_ADMIN });
   await upsertMembership({ tenantId: tenantB.id, userId: testUsers.residentB.id, role: Role.RESIDENT });
 
@@ -399,6 +477,21 @@ async function main() {
     create: { tenantId: tenantA.id, unitId: unitsA1[1]!, memberId: residentMemberA.id, role: "RESIDENT" },
   });
   await prisma.unitOccupant.upsert({
+    where: { unitId_memberId: { unitId: unitsA1[1]!, memberId: residentMultiMemberA.id } },
+    update: {},
+    create: { tenantId: tenantA.id, unitId: unitsA1[1]!, memberId: residentMultiMemberA.id, role: "RESIDENT" },
+  });
+  await prisma.unitOccupant.upsert({
+    where: { unitId_memberId: { unitId: unitsA1[2]!, memberId: residentMultiMemberA.id } },
+    update: {},
+    create: { tenantId: tenantA.id, unitId: unitsA1[2]!, memberId: residentMultiMemberA.id, role: "RESIDENT" },
+  });
+  await prisma.unitOccupant.upsert({
+    where: { unitId_memberId: { unitId: unitsA1[1]!, memberId: residentMixedMemberA.id } },
+    update: {},
+    create: { tenantId: tenantA.id, unitId: unitsA1[1]!, memberId: residentMixedMemberA.id, role: "RESIDENT" },
+  });
+  await prisma.unitOccupant.upsert({
     where: { unitId_memberId: { unitId: unitsA1[2]!, memberId: operatorMemberA.id } },
     update: {},
     create: { tenantId: tenantA.id, unitId: unitsA1[2]!, memberId: operatorMemberA.id, role: "OWNER" },
@@ -512,6 +605,162 @@ async function main() {
   console.log(`✅ Finances: Liquidation + ${unitsA1.length} charges + 1 payment created`);
 
   // ============================================================================
+  // RESIDENT COMMUNICATIONS & TICKETS
+  // ============================================================================
+  const communicationUnit102 = await prisma.communication.upsert({
+    where: { id: `seed-comm-unit-102` },
+    update: {},
+    create: {
+      id: `seed-comm-unit-102`,
+      tenantId: tenantA.id,
+      buildingId: buildingA1.id,
+      title: "Comunicado Unidad 102",
+      body: "Comunicación de prueba para la unidad 102 del edificio A.",
+      channel: CommunicationChannel.IN_APP,
+      status: "SENT",
+      priority: CommunicationPriority.NORMAL,
+      createdByMembershipId: adminMembershipA.id,
+      sentAt: new Date(),
+      targets: {
+        create: [
+          {
+            tenantId: tenantA.id,
+            targetType: CommunicationTargetType.UNIT,
+            targetId: unitsA1[1]!,
+          },
+        ],
+      },
+    },
+  });
+
+  const communicationUnit103 = await prisma.communication.upsert({
+    where: { id: `seed-comm-unit-103` },
+    update: {},
+    create: {
+      id: `seed-comm-unit-103`,
+      tenantId: tenantA.id,
+      buildingId: buildingA1.id,
+      title: "Comunicado Unidad 103",
+      body: "Comunicación de prueba para la unidad 103 del edificio A.",
+      channel: CommunicationChannel.IN_APP,
+      status: "SENT",
+      priority: CommunicationPriority.NORMAL,
+      createdByMembershipId: adminMembershipA.id,
+      sentAt: new Date(),
+      targets: {
+        create: [
+          {
+            tenantId: tenantA.id,
+            targetType: CommunicationTargetType.UNIT,
+            targetId: unitsA1[2]!,
+          },
+        ],
+      },
+    },
+  });
+
+  await prisma.communicationReceipt.upsert({
+    where: {
+      communicationId_userId: {
+        communicationId: communicationUnit102.id,
+        userId: testUsers.resident.id,
+      },
+    },
+    update: {},
+    create: {
+      tenantId: tenantA.id,
+      communicationId: communicationUnit102.id,
+      userId: testUsers.resident.id,
+      deliveredAt: new Date(),
+    },
+  });
+
+  await prisma.communicationReceipt.upsert({
+    where: {
+      communicationId_userId: {
+        communicationId: communicationUnit102.id,
+        userId: testUsers.residentMulti.id,
+      },
+    },
+    update: {},
+    create: {
+      tenantId: tenantA.id,
+      communicationId: communicationUnit102.id,
+      userId: testUsers.residentMulti.id,
+      deliveredAt: new Date(),
+    },
+  });
+
+  await prisma.communicationReceipt.upsert({
+    where: {
+      communicationId_userId: {
+        communicationId: communicationUnit103.id,
+        userId: testUsers.residentMulti.id,
+      },
+    },
+    update: {},
+    create: {
+      tenantId: tenantA.id,
+      communicationId: communicationUnit103.id,
+      userId: testUsers.residentMulti.id,
+      deliveredAt: new Date(),
+    },
+  });
+
+  await prisma.communicationReceipt.upsert({
+    where: {
+      communicationId_userId: {
+        communicationId: communicationUnit102.id,
+        userId: testUsers.residentMixed.id,
+      },
+    },
+    update: {},
+    create: {
+      tenantId: tenantA.id,
+      communicationId: communicationUnit102.id,
+      userId: testUsers.residentMixed.id,
+      deliveredAt: new Date(),
+    },
+  });
+
+  const ticketUnit102 = await prisma.ticket.upsert({
+    where: { id: `seed-ticket-unit-102` },
+    update: {},
+    create: {
+      id: `seed-ticket-unit-102`,
+      tenantId: tenantA.id,
+      buildingId: buildingA1.id,
+      unitId: unitsA1[1]!,
+      createdByUserId: testUsers.resident.id,
+      title: "Fuga en lavadero",
+      description: "La canilla del lavadero pierde agua de forma constante.",
+      category: TicketCategory.MAINTENANCE,
+      priority: "MEDIUM",
+      status: TicketStatus.OPEN,
+    },
+  });
+
+  const ticketUnit103 = await prisma.ticket.upsert({
+    where: { id: `seed-ticket-unit-103` },
+    update: {},
+    create: {
+      id: `seed-ticket-unit-103`,
+      tenantId: tenantA.id,
+      buildingId: buildingA1.id,
+      unitId: unitsA1[2]!,
+      createdByUserId: testUsers.residentMulti.id,
+      title: "Ruido nocturno",
+      description: "Se percibe ruido en el pasillo durante la noche.",
+      category: TicketCategory.COMPLAINT,
+      priority: "LOW",
+      status: TicketStatus.IN_PROGRESS,
+    },
+  });
+
+  console.log(`✅ Resident communications: ${communicationUnit102.id}, ${communicationUnit103.id}`);
+  console.log(`✅ Resident tickets: ${ticketUnit102.id}, ${ticketUnit103.id}`);
+
+  // ============================================================================
   // SUMMARY
   // ============================================================================
   console.log(`
@@ -526,6 +775,8 @@ async function main() {
    Operador:     test-operator@buildingos.local
    Residente A:  test-resident@buildingos.local
    Residente B:  test-resident-b@buildingos.local
+   Residente M:  test-resident-multi@buildingos.local
+   Residente X:  test-resident-admin@buildingos.local
 
 🏢 TENANTS:
    Tenant A: ${tenantA.id} (ADMINISTRADORA, PRO)
@@ -535,6 +786,14 @@ async function main() {
    Torre A Test:      ${buildingA1.id} (5 unidades)
    Torre B Test:      ${buildingA2.id} (3 unidades)
    Edificio Test B:   ${buildingB1.id} (3 unidades)
+
+💬 COMUNICADOS:
+   ${communicationUnit102.id} → Unidad 102
+   ${communicationUnit103.id} → Unidad 103
+
+🛠️ RECLAMOS:
+   ${ticketUnit102.id} → Fuga en lavadero
+   ${ticketUnit103.id} → Ruido nocturno
 
 💰 FINANZAS (Período: ${currentPeriod}):
    Liquidación: ${liquidationA1.id} (PUBLISHED)

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm run dev',
+    command: 'npm run dev -w apps/web',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm run dev -w apps/web',
+    command: 'cd ../.. && npm run dev -w apps/web',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120000,

--- a/apps/web/tests/e2e/helpers/auth.ts
+++ b/apps/web/tests/e2e/helpers/auth.ts
@@ -28,6 +28,8 @@ export const TEST_USERS = {
   operator: { email: 'test-operator@buildingos.local', password: TEST_PASSWORD, fullName: 'Test Operator' },
   resident: { email: 'test-resident@buildingos.local', password: TEST_PASSWORD, fullName: 'Test Resident' },
   residentB: { email: 'test-resident-b@buildingos.local', password: TEST_PASSWORD, fullName: 'Test Resident B' },
+  residentMulti: { email: 'test-resident-multi@buildingos.local', password: TEST_PASSWORD, fullName: 'Test Resident Multi' },
+  residentMixed: { email: 'test-resident-admin@buildingos.local', password: TEST_PASSWORD, fullName: 'Test Resident Admin' },
 } as const satisfies Record<string, TestUser>;
 
 /**

--- a/apps/web/tests/e2e/resident/resident-journeys.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-journeys.spec.ts
@@ -1,0 +1,192 @@
+import { expect, test } from '@playwright/test';
+import { residentTicketDetailPath } from '../../../shared/lib/routes';
+import { login, logout, TEST_USERS } from '../helpers/auth';
+
+const API_ORIGIN = process.env.NEXT_PUBLIC_API_URL?.trim() || 'http://localhost:4000';
+
+function residentDashboardPath(tenantId: string): string {
+  return `/${tenantId}/resident/dashboard`;
+}
+
+function residentUnitPath(tenantId: string): string {
+  return `/${tenantId}/resident/unit`;
+}
+
+function residentPaymentsPath(tenantId: string): string {
+  return `/${tenantId}/resident/payments`;
+}
+
+function residentAnnouncementsPath(tenantId: string): string {
+  return `/${tenantId}/resident/announcements`;
+}
+
+function residentTicketsPath(tenantId: string): string {
+  return `/${tenantId}/resident/tickets`;
+}
+
+test.describe('Resident critical journeys', () => {
+  test('rejects invalid credentials without leaving auth cookies behind', async ({ page }) => {
+    await page.goto('/login');
+
+    await page.getByTestId('login-email').fill(TEST_USERS.resident.email);
+    await page.getByTestId('login-password').fill('WrongPass123!');
+    await page.getByTestId('login-submit').click();
+
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByText(/credenciales inválidas/i)).toBeVisible();
+
+    const cookies = await page.context().cookies([API_ORIGIN]);
+    const cookieNames = cookies.map((cookie) => cookie.name);
+
+    expect(cookieNames).not.toContain('bo_access_token');
+    expect(cookieNames).not.toContain('bo_refresh_token');
+  });
+
+  test('logs in a resident and shows the authorized dashboard context', async ({ page }) => {
+    const tenantId = await login(page, TEST_USERS.resident);
+
+    await expect(page).toHaveURL(new RegExp(`/${tenantId}/resident/dashboard$`));
+    await expect(page.getByRole('heading', { name: /hola, test resident/i })).toBeVisible();
+    await expect(page.getByText('Test Tenant A', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('Torre A Test', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('Unidad A1-102', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('Saldo pendiente')).toBeVisible();
+    await expect(page.getByText('Comunicado Unidad 102')).toBeVisible();
+    await expect(page.getByText('Fuga en lavadero')).toBeVisible();
+    await expect(page.getByRole('link', { name: /ver comunicados/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /crear reclamo/i })).toBeVisible();
+
+    await page.goto(residentUnitPath(tenantId));
+    await expect(page.getByRole('heading', { name: /mi unidad/i })).toBeVisible();
+    await expect(
+      page.getByText('Código', { exact: true }).locator('..').getByText('A1-102', { exact: true }),
+    ).toBeVisible();
+    await expect(page.getByText('Test Resident', { exact: true }).first()).toBeVisible();
+  });
+
+  test('shows the resident finance snapshot and seeded payment history', async ({ page }) => {
+    const tenantId = await login(page, TEST_USERS.resident);
+
+    await page.goto(residentPaymentsPath(tenantId));
+
+    await expect(page).toHaveURL(new RegExp(`/${tenantId}/resident/payments$`));
+    await expect(page.getByRole('heading', { name: /^pagos$/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /reportar pago/i })).toBeVisible();
+    await expect(page.getByText('Saldo pendiente')).toBeVisible();
+    await expect(page.getByText('Próximo vencimiento')).toBeVisible();
+    await expect(page.getByText('TEST-REF-001')).toBeVisible();
+  });
+
+  test('shows the resident communications inbox for the authorized unit', async ({ page }) => {
+    const tenantId = await login(page, TEST_USERS.resident);
+
+    await page.goto(residentAnnouncementsPath(tenantId));
+
+    await expect(page).toHaveURL(new RegExp(`/${tenantId}/resident/announcements$`));
+    await expect(page.getByRole('heading', { name: /comunicados/i })).toBeVisible();
+    await expect(page.getByText('Comunicado Unidad 102')).toBeVisible();
+  });
+
+  test('opens a resident ticket detail from the resident list', async ({ page }) => {
+    const tenantId = await login(page, TEST_USERS.resident);
+
+    await page.goto(residentTicketsPath(tenantId));
+
+    await expect(page).toHaveURL(new RegExp(`/${tenantId}/resident/tickets$`));
+    await expect(page.getByRole('heading', { name: /mis reclamos/i })).toBeVisible();
+    await expect(page.getByText('Fuga en lavadero')).toBeVisible();
+
+    await page.getByRole('link', { name: /ver reclamo fuga en lavadero/i }).click();
+
+    await expect(page).toHaveURL(residentTicketDetailPath(tenantId, 'seed-ticket-unit-102'));
+    await expect(page.getByRole('heading', { name: /detalle del ticket/i })).toBeVisible();
+    await expect(page.getByText('Fuga en lavadero')).toBeVisible();
+    await expect(page.getByText('Torre A Test', { exact: true })).toBeVisible();
+    await expect(page.getByText('Unidad A1-102 (A1-102)', { exact: true })).toBeVisible();
+  });
+
+  test('blocks cross-tenant resident URL tampering', async ({ page }) => {
+    const tenantBId = await login(page, TEST_USERS.tenantAdminB);
+    await logout(page);
+
+    const tenantAId = await login(page, TEST_USERS.resident);
+    expect(tenantAId).not.toBe(tenantBId);
+
+    await page.goto(residentDashboardPath(tenantBId));
+
+    await expect(page).toHaveURL(new RegExp(`/${tenantAId}/resident/dashboard$`));
+    await expect(page.getByRole('heading', { name: /hola, test resident/i })).toBeVisible();
+  });
+
+  test('keeps the resident portal available for a mixed RESIDENT + ADMIN user', async ({ page }) => {
+    const tenantId = await login(page, TEST_USERS.residentMixed);
+
+    await page.goto(residentDashboardPath(tenantId));
+    await expect(page).toHaveURL(new RegExp(`/${tenantId}/resident/dashboard$`));
+    await expect(page.getByRole('heading', { name: /hola, test resident admin/i })).toBeVisible();
+
+    await page.goto(residentUnitPath(tenantId));
+    await expect(page).toHaveURL(new RegExp(`/${tenantId}/resident/unit$`));
+    await expect(page.getByRole('heading', { name: /mi unidad/i })).toBeVisible();
+  });
+
+  test('switches the active resident unit and refreshes scoped content', async ({ page }) => {
+    const tenantId = await login(page, TEST_USERS.residentMulti);
+
+    await page.goto(residentAnnouncementsPath(tenantId));
+
+    const unitSelectId = `#context-unit-select-${tenantId}`;
+    const [unit102Id, unit103Id] = await page.locator(unitSelectId).evaluate((select) => {
+      const options = Array.from(select.options).map((option) => option.value);
+      return [options[0] ?? '', options[1] ?? ''] as const;
+    });
+
+    expect(unit102Id).toBeTruthy();
+    expect(unit103Id).toBeTruthy();
+
+    const setResidentUnit = async (unitId: string): Promise<void> => {
+      await Promise.all([
+        page.waitForResponse(
+          (response) =>
+            response.request().method() === 'POST' &&
+            response.url().includes('/me/context'),
+        ),
+        page.evaluate(
+          ({ selectId, value }) => {
+            const select = document.querySelector<HTMLSelectElement>(selectId);
+            if (!select) {
+              throw new Error(`Missing select ${selectId}`);
+            }
+
+            select.value = value;
+            select.dispatchEvent(new Event('change', { bubbles: true }));
+          },
+          { selectId: unitSelectId, value: unitId },
+        ),
+      ]);
+    };
+
+    await setResidentUnit(unit102Id);
+    await expect(page.getByText(/contexto actual:.*unidad a1-102/i)).toBeVisible({ timeout: 15000 });
+
+    await setResidentUnit(unit103Id);
+    await expect(page.getByText(/contexto actual:.*unidad a1-103/i)).toBeVisible({ timeout: 15000 });
+  });
+
+  test('logs out and keeps protected resident routes inaccessible', async ({ page }) => {
+    const tenantId = await login(page, TEST_USERS.resident);
+
+    await logout(page);
+    await expect(page).toHaveURL(/\/login$/);
+
+    await page.goto(residentDashboardPath(tenantId));
+    await expect(page).toHaveURL(/\/login$/);
+    await expect(page.getByText(/inicia sesión con tu cuenta/i)).toBeVisible();
+
+    const cookies = await page.context().cookies([API_ORIGIN]);
+    const cookieNames = cookies.map((cookie) => cookie.name);
+
+    expect(cookieNames).not.toContain('bo_access_token');
+    expect(cookieNames).not.toContain('bo_refresh_token');
+  });
+});

--- a/apps/web/tests/e2e/resident/resident-journeys.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-journeys.spec.ts
@@ -136,7 +136,8 @@ test.describe('Resident critical journeys', () => {
     await page.goto(residentAnnouncementsPath(tenantId));
 
     const unitSelectId = `#context-unit-select-${tenantId}`;
-    const [unit102Id, unit103Id] = await page.locator(unitSelectId).evaluate((select) => {
+    const [unit102Id, unit103Id] = await page.locator(unitSelectId).evaluate((element) => {
+      const select = element as HTMLSelectElement;
       const options = Array.from(select.options).map((option) => option.value);
       return [options[0] ?? '', options[1] ?? ''] as const;
     });


### PR DESCRIPTION
Closes #92\n\nAdds resident Playwright coverage for login, dashboard, payments, communications, tickets, cross-tenant access, unit switching, and logout.\n\nValidation:\n- ./node_modules/.bin/eslint tests/e2e/resident/resident-journeys.spec.ts tests/e2e/helpers/auth.ts playwright.config.ts --max-warnings=0\n- TEST_E2E_PASSWORD=TestPass123! NEXT_PUBLIC_API_URL=http://localhost:4000 npm run test:e2e -w apps/web -- --project=chromium tests/e2e/resident/resident-journeys.spec.ts