### PR TITLE
fix(onboarding-imports): avoid expired preview fixture

### DIFF
--- a/apps/api/src/onboarding-imports/onboarding-imports.service.spec.ts
+++ b/apps/api/src/onboarding-imports/onboarding-imports.service.spec.ts
@@ -528,6 +528,7 @@ describe('OnboardingImportsService', () => {
       summary: createSummary(),
       issues: [],
     });
+    const futureExpiresAt = new Date(Date.now() + 86_400_000);
 
     transactionCreate.mockResolvedValue({
       id: 'import-2',
@@ -538,7 +539,7 @@ describe('OnboardingImportsService', () => {
       schemaVersion: 'v1',
       status: ImportJobStatus.READY,
       canConfirm: true,
-      expiresAt: new Date('2026-08-01T00:00:00.000Z'),
+      expiresAt: futureExpiresAt,
       createdAt: new Date('2026-07-01T00:00:00.000Z'),
       updatedAt: new Date('2026-07-01T00:00:00.000Z'),
       summary: createSummary(),


### PR DESCRIPTION
Closes #33

## Summary
- Fixes the onboarding-imports unit test that was asserting READY with an already expired fixture date.
- Uses a relative future expiration so the test stays deterministic across CI and local runs.
- Confirms the actual domain behavior remains unchanged: READY previews become EXPIRED when past `expiresAt`.

## Changes
| File | Change |
|------|--------|
| `apps/api/src/onboarding-imports/onboarding-imports.service.spec.ts` | Replaced the hard-coded expiration timestamp with a relative future date in the READY preview test |

## Test Plan
- [x] `npm run test -w apps/api -- --runInBand src/onboarding-imports/onboarding-imports.service.spec.ts -t "persists a ready preview and stores the normalized payload only when approved"`
- [x] `npm run test -w apps/api -- --runInBand --no-coverage src/onboarding-imports`
- [x] `npm exec --workspace apps/api -- eslint src/onboarding-imports/onboarding-imports.service.spec.ts --max-warnings=0`
- [x] `./node_modules/.bin/tsc --noEmit -p apps/api/tsconfig.json --pretty false`
- [x] `git diff --check`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts (not applicable; no scripts changed)
- [x] Skills tested in at least one agent
- [x] Docs updated if behavior changed (not applicable; test-only fix)
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers