### PR TITLE
fix(auth): preserve mixed-role landing context

### DIFF
--- a/apps/web/app/(public)/login/page.tsx
+++ b/apps/web/app/(public)/login/page.tsx
@@ -6,8 +6,13 @@ import Link from 'next/link';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { getSession, getLastTenant } from '../../../features/auth/session.storage';
+import {
+  getSession,
+  getLastTenant,
+  getLastPortal,
+} from '../../../features/auth/session.storage';
 import { useLogin } from '../../../features/auth/auth.hooks';
+import { resolveAuthLandingRoute } from '../../../features/auth/landing-route';
 import Card from '../../../shared/components/ui/Card';
 import Button from '../../../shared/components/ui/Button';
 
@@ -42,7 +47,8 @@ const LoginPageFallback = () => {
 const LoginPageContent = () => {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const loginMutation = useLogin();
+  const requestedPath = searchParams.get('next');
+  const loginMutation = useLogin({ requestedPath });
   const showDemoHelp = searchParams.get('demo') === 'true';
   const {
     register,
@@ -55,10 +61,17 @@ const LoginPageContent = () => {
   useEffect(() => {
     const s = getSession();
     const last = getLastTenant();
-    if (!showDemoHelp && s && last) {
-      router.replace(`/${last}/dashboard`);
+    if (!showDemoHelp && s) {
+      router.replace(
+        resolveAuthLandingRoute({
+          session: s,
+          requestedPath,
+          preferredTenantId: last,
+          preferredPortal: getLastPortal(),
+        }),
+      );
     }
-  }, [router, showDemoHelp]);
+  }, [requestedPath, router, showDemoHelp]);
 
   const onSubmit = async (data: LoginFormData) => {
     try {

--- a/apps/web/app/(public)/signup/page.tsx
+++ b/apps/web/app/(public)/signup/page.tsx
@@ -6,8 +6,13 @@ import Link from 'next/link';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { getSession, getLastTenant } from '../../../features/auth/session.storage';
+import {
+  getSession,
+  getLastTenant,
+  getLastPortal,
+} from '../../../features/auth/session.storage';
 import { useSignup } from '../../../features/auth/auth.hooks';
+import { resolveAuthLandingRoute } from '../../../features/auth/landing-route';
 import Card from '../../../shared/components/ui/Card';
 import Button from '../../../shared/components/ui/Button';
 
@@ -51,14 +56,21 @@ export default function SignupPage() {
   useEffect(() => {
     const s = getSession();
     const last = getLastTenant();
-    if (s && last) {
-      router.replace(`/${last}/dashboard`);
+    if (s) {
+      router.replace(
+        resolveAuthLandingRoute({
+          session: s,
+          preferredTenantId: last,
+          preferredPortal: getLastPortal(),
+        }),
+      );
     }
   }, [router]);
 
   const onSubmit = async (data: SignupFormData) => {
     try {
       const { confirmPassword, ...payload } = data;
+      void confirmPassword;
       await signupMutation.mutateAsync({
         ...payload,
         name: payload.name.trim(),

--- a/apps/web/app/(tenant)/[tenantId]/layout.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/layout.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import type { ReactNode } from 'react';
-import { useEffect, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useState, useCallback } from 'react';
+import { useParams, useRouter, usePathname, useSearchParams } from 'next/navigation';
 import AppShell from '../../../shared/components/layout/AppShell';
 import { getSession, setLastTenant } from '../../../features/auth/session.storage';
 import { useIsSuperAdmin } from '../../../features/auth/useAuthSession';
@@ -32,6 +32,8 @@ export default function TenantLayout({
   children: ReactNode;
 }>) {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const params = useParams<TenantParams>();
   const tenantId = params?.tenantId;
   const isSuperAdmin = useIsSuperAdmin();
@@ -40,39 +42,7 @@ export default function TenantLayout({
 
   const [authState, setAuthState] = useState<AuthState>('loading');
 
-  // Redirigir SUPER_ADMIN a /super-admin (but NOT if impersonating)
-  useEffect(() => {
-    if (isSuperAdmin && !isImpersonating) {
-      router.replace('/super-admin');
-    }
-  }, [isSuperAdmin, isImpersonating, router]);
-
-  // Validar acceso tan pronto como se hidrata
-  useEffect(() => {
-    // Si es SUPER_ADMIN y NO está impersonando, no validar acceso de tenant (ya se está redirigiendo)
-    if (isSuperAdmin && !isImpersonating) {
-      return;
-    }
-
-    validateAccess();
-  }, [isSuperAdmin, isImpersonating, tenantId, storageTick]);
-
-  useEffect(() => {
-    if (authState !== 'loading') {
-      return;
-    }
-
-    const timer = window.setTimeout(() => {
-      const session = getSession();
-      if (!session) {
-        setAuthState('unauthorized');
-      }
-    }, 2500);
-
-    return () => window.clearTimeout(timer);
-  }, [authState, tenantId, storageTick]);
-
-  const validateAccess = () => {
+  const validateAccess = useCallback(() => {
     // 1. Validar que tenemos tenantId
     if (typeof tenantId !== 'string' || tenantId.length === 0) {
       // No hay tenantId en la URL: mostrar loader (no redirigir, App Router resolverá)
@@ -99,14 +69,49 @@ export default function TenantLayout({
     // 4. OK: autorizado
     setLastTenant(tenantId);
     setAuthState('authorized');
-  };
+  }, [tenantId]);
+
+  // Redirigir SUPER_ADMIN a /super-admin (but NOT if impersonating)
+  useEffect(() => {
+    if (isSuperAdmin && !isImpersonating) {
+      router.replace('/super-admin');
+    }
+  }, [isSuperAdmin, isImpersonating, router]);
+
+  // Validar acceso tan pronto como se hidrata
+  useEffect(() => {
+    queueMicrotask(() => {
+      // Si es SUPER_ADMIN y NO está impersonando, no validar acceso de tenant (ya se está redirigiendo)
+      if (isSuperAdmin && !isImpersonating) {
+        return;
+      }
+
+      validateAccess();
+    });
+  }, [isSuperAdmin, isImpersonating, storageTick, validateAccess]);
+
+  useEffect(() => {
+    if (authState !== 'loading') {
+      return;
+    }
+
+    const timer = window.setTimeout(() => {
+      const session = getSession();
+      if (!session) {
+        setAuthState('unauthorized');
+      }
+    }, 2500);
+
+    return () => window.clearTimeout(timer);
+  }, [authState, tenantId, storageTick]);
 
   // Si no autorizado: redirigir a login (pero esperar a que se haya validado)
   useEffect(() => {
     if (authState === 'unauthorized') {
-      router.replace('/login');
+      const next = `${pathname}${searchParams.toString() ? `?${searchParams.toString()}` : ''}`;
+      router.replace(`/login?next=${encodeURIComponent(next)}`);
     }
-  }, [authState, router]);
+  }, [authState, pathname, router, searchParams]);
 
   // Render: nunca null
   // ✅ While auth is loading, show neutral loader (no tenant UI)

--- a/apps/web/app/(tenant)/[tenantId]/resident/layout.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/layout.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactNode } from 'react';
 import { useEffect } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { useHasRole, useAuthSession } from '../../../../features/auth/useAuthSession';
 import { getSession } from '../../../../features/auth/session.storage';
 import { useBoStorageTick } from '../../../../shared/lib/storage/useBoStorage';
@@ -14,6 +14,8 @@ interface ResidentLayoutProps { children: ReactNode }
 
 const ResidentLayout = ({ children }: ResidentLayoutProps) => {
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const params = useParams<TenantParams>();
   const tenantId = params?.tenantId ?? '';
   const session = useAuthSession();
@@ -34,12 +36,13 @@ const ResidentLayout = ({ children }: ResidentLayoutProps) => {
 
     const timer = window.setTimeout(() => {
       if (!getSession()) {
-        router.replace('/login');
+        const next = `${pathname}${searchParams.toString() ? `?${searchParams.toString()}` : ''}`;
+        router.replace(`/login?next=${encodeURIComponent(next)}`);
       }
     }, 2500);
 
     return () => window.clearTimeout(timer);
-  }, [session, router, storageTick]);
+  }, [pathname, router, searchParams, session, storageTick]);
 
   return (
     <div className="space-y-6">

--- a/apps/web/app/super-admin/layout.tsx
+++ b/apps/web/app/super-admin/layout.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
 import { SuperAdminProvider } from '@/features/super-admin/super-admin-context';
 import { useAuth } from '@/features/auth/useAuth';
@@ -19,7 +18,7 @@ export default function SuperAdminLayout({ children }: { children: React.ReactNo
   const { isLoading: authLoading } = useAuth();
   const session = useAuthSession();
   const isSuperAdmin = useIsSuperAdmin();
-  const [isAuthorized, setIsAuthorized] = useState(false);
+  const isAuthorized = !authLoading && Boolean(session) && isSuperAdmin;
 
   useEffect(() => {
     // Wait for auth to load
@@ -29,21 +28,21 @@ export default function SuperAdminLayout({ children }: { children: React.ReactNo
 
     // Rule 1: No session → redirect to /login (unauthenticated)
     if (!session) {
-      router.replace('/login');
+      const next =
+        typeof window === 'undefined'
+          ? pathname
+          : `${window.location.pathname}${window.location.search}`;
+      router.replace(`/login?next=${encodeURIComponent(next)}`);
       return;
     }
 
     // Rule 2: Has session but NOT SUPER_ADMIN → redirect to tenant dashboard
     if (!isSuperAdmin) {
       const tenantId = session.activeTenantId;
-      router.replace(tenantId ? `/${tenantId}/dashboard` : '/login');
-      setIsAuthorized(false);
+      router.replace(tenantId ? `/${tenantId}/dashboard` : `/login?next=${encodeURIComponent(pathname)}`);
       return;
     }
-
-    // Rule 3: Has session AND is SUPER_ADMIN → allow access
-    setIsAuthorized(true);
-  }, [session, isSuperAdmin, authLoading, router]);
+  }, [authLoading, isSuperAdmin, pathname, router, session]);
 
   if (authLoading) {
     return <div className="flex items-center justify-center min-h-screen">Cargando...</div>;

--- a/apps/web/features/auth/AuthBootstrap.tsx
+++ b/apps/web/features/auth/AuthBootstrap.tsx
@@ -1,14 +1,21 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
-import { setSession, setLastTenant, clearAuth } from './session.storage';
+import {
+  getSession,
+  setSession,
+  setLastTenant,
+  clearAuth,
+  getLastTenant,
+} from './session.storage';
 import { apiMe } from './auth.service';
 import { clearAllImpersonationData } from '../impersonation/impersonation.storage';
 import { subscribeAuthUnauthorized } from '@/shared/lib/auth/events';
 import { HttpError } from '@/shared/lib/http/client';
 import { useToast } from '@/shared/components/ui/Toast';
 import { reportFrontendError } from '@/shared/lib/observability/frontend-observability';
+import { resolveActiveTenantId } from './landing-route';
 
 const PUBLIC_PATHS = ['/', '/login', '/signup', '/health', '/demo', '/demo-guiada', '/contact', '/invite'];
 
@@ -32,6 +39,14 @@ export const AuthBootstrap = () => {
   const didBootstrap = useRef(false);
   const isPublicPath = PUBLIC_PATHS.includes(pathname);
 
+  const getCurrentPathWithSearch = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return pathname;
+    }
+
+    return `${window.location.pathname}${window.location.search}`;
+  }, [pathname]);
+
   useEffect(() => {
     if (didBootstrap.current) {
       return;
@@ -44,7 +59,10 @@ export const AuthBootstrap = () => {
 
         if (response.user && response.memberships && response.memberships.length > 0) {
           const { user, memberships } = response;
-          const activeTenantId = memberships[0].tenantId;
+          const activeTenantId = resolveActiveTenantId(memberships, [
+            getLastTenant(),
+            getSession()?.activeTenantId,
+          ]);
 
           clearAllImpersonationData();
           setSession({
@@ -88,22 +106,24 @@ export const AuthBootstrap = () => {
 
     const redirectToLoginIfPrivate = () => {
       if (!isPublicPath) {
-        router.replace('/login');
+        const next = getCurrentPathWithSearch();
+        router.replace(`/login?next=${encodeURIComponent(next)}`);
       }
     };
 
     performBootstrap();
-  }, [pathname, router, toast]);
+  }, [getCurrentPathWithSearch, isPublicPath, pathname, router, toast]);
 
   useEffect(() => {
     const unsubscribe = subscribeAuthUnauthorized(() => {
       if (!isPublicPath) {
-        router.replace('/login');
+        const next = getCurrentPathWithSearch();
+        router.replace(`/login?next=${encodeURIComponent(next)}`);
       }
     });
 
     return unsubscribe;
-  }, [pathname, router]);
+  }, [getCurrentPathWithSearch, isPublicPath, pathname, router]);
 
   return null;
 };

--- a/apps/web/features/auth/auth.hooks.ts
+++ b/apps/web/features/auth/auth.hooks.ts
@@ -2,13 +2,23 @@
 
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { apiLogin, apiSignup, type LoginPayload, type SignupPayload } from './auth.service';
-import { setSession, setLastTenant } from './session.storage';
+import { apiLogin, apiSignup } from './auth.service';
+import {
+  getLastPortal,
+  getLastTenant,
+  setSession,
+  setLastTenant,
+} from './session.storage';
 import { logout as performLogout } from './login.actions';
 import { clearAllImpersonationData } from '../impersonation/impersonation.storage';
 import type { AuthSession } from './auth.types';
+import { resolveActiveTenantId, resolveAuthLandingRoute } from './landing-route';
 
-export const useLogin = () => {
+interface AuthNavigationOptions {
+  readonly requestedPath?: string | null;
+}
+
+export const useLogin = (options: AuthNavigationOptions = {}) => {
   const router = useRouter();
 
   return useMutation({
@@ -20,7 +30,7 @@ export const useLogin = () => {
         throw new Error('No tienes membresías válidas');
       }
 
-      const activeTenantId = memberships[0].tenantId;
+      const activeTenantId = resolveActiveTenantId(memberships, [getLastTenant()]);
       const session: AuthSession = {
         user,
         memberships,
@@ -31,19 +41,19 @@ export const useLogin = () => {
       setSession(session);
       setLastTenant(activeTenantId);
 
-      const isResident =
-        memberships[0].roles.length === 1 &&
-        memberships[0].roles.includes('RESIDENT');
       router.push(
-        isResident
-          ? `/${activeTenantId}/resident/dashboard`
-          : `/${activeTenantId}/dashboard`,
+        resolveAuthLandingRoute({
+          session,
+          requestedPath: options.requestedPath ?? null,
+          preferredTenantId: activeTenantId,
+          preferredPortal: getLastPortal(),
+        }),
       );
     },
   });
 };
 
-export const useSignup = () => {
+export const useSignup = (options: AuthNavigationOptions = {}) => {
   const router = useRouter();
 
   return useMutation({
@@ -55,7 +65,7 @@ export const useSignup = () => {
         throw new Error('Error creando membresía');
       }
 
-      const activeTenantId = memberships[0].tenantId;
+      const activeTenantId = resolveActiveTenantId(memberships, [getLastTenant()]);
       const session: AuthSession = {
         user,
         memberships,
@@ -66,13 +76,13 @@ export const useSignup = () => {
       setSession(session);
       setLastTenant(activeTenantId);
 
-      const isResident =
-        memberships[0].roles.length === 1 &&
-        memberships[0].roles.includes('RESIDENT');
       router.push(
-        isResident
-          ? `/${activeTenantId}/resident/dashboard`
-          : `/${activeTenantId}/dashboard`,
+        resolveAuthLandingRoute({
+          session,
+          requestedPath: options.requestedPath ?? null,
+          preferredTenantId: activeTenantId,
+          preferredPortal: getLastPortal(),
+        }),
       );
     },
   });

--- a/apps/web/features/auth/auth.service.ts
+++ b/apps/web/features/auth/auth.service.ts
@@ -34,6 +34,7 @@ export async function apiMe(): Promise<LoginResponse> {
   return apiClient<LoginResponse>({
     path: '/auth/me',
     method: 'GET',
+    skipRefreshOnUnauthorized: true,
   });
 }
 

--- a/apps/web/features/auth/index.ts
+++ b/apps/web/features/auth/index.ts
@@ -17,7 +17,13 @@ export {
   clearAuth,
   getLastTenant,
   setLastTenant,
+  getLastPortal,
+  setLastPortal,
+  clearLastPortal,
 } from './session.storage';
 
 // Bootstrap
 export { AuthBootstrap } from './AuthBootstrap';
+
+// Landing route resolution
+export { resolveActiveTenantId, resolveAuthLandingRoute, resolvePortalFromPathname } from './landing-route';

--- a/apps/web/features/auth/landing-route.test.ts
+++ b/apps/web/features/auth/landing-route.test.ts
@@ -99,6 +99,30 @@ describe('landing-route', () => {
     ).toBe('/tenant-1/tickets/ticket-1?portal=resident');
   });
 
+  it.each([
+    'https://example.com',
+    'http://example.com',
+    '//example.com',
+    '\\\\example.com',
+    'javascript:alert(1)',
+    '/%2F%2Fexample.com',
+    '/tenant-2/dashboard',
+    '',
+    '   ',
+  ])('rejects unsafe next values: %s', (requestedPath) => {
+    const session = buildSession([
+      { tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] },
+    ]);
+
+    expect(
+      resolveAuthLandingRoute({
+        session,
+        requestedPath,
+        preferredPortal: 'resident',
+      }),
+    ).toBe(residentDashboard('tenant-1'));
+  });
+
   it('falls back deterministically when the explicit route is not allowed', () => {
     const session = buildSession([
       { tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] },

--- a/apps/web/features/auth/landing-route.test.ts
+++ b/apps/web/features/auth/landing-route.test.ts
@@ -1,0 +1,141 @@
+import {
+  resolveActiveTenantId,
+  resolveAuthLandingRoute,
+  resolvePortalFromPathname,
+} from './landing-route';
+import { residentDashboard, tenantDashboard } from '@/shared/lib/routes';
+import type { AuthSession } from './auth.types';
+
+function buildSession(
+  memberships: AuthSession['memberships'],
+  activeTenantId = memberships[0]?.tenantId ?? '',
+): AuthSession {
+  return {
+    user: {
+      id: 'user-1',
+      email: 'test@test.com',
+      name: 'Test User',
+    },
+    memberships,
+    activeTenantId,
+  };
+}
+
+describe('landing-route', () => {
+  it('resolves resident-only users to the resident dashboard', () => {
+    const session = buildSession([{ tenantId: 'tenant-1', roles: ['RESIDENT'] }]);
+
+    expect(resolveAuthLandingRoute({ session })).toBe(residentDashboard('tenant-1'));
+  });
+
+  it('resolves admin-only users to the tenant dashboard', () => {
+    const session = buildSession([{ tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] }]);
+
+    expect(resolveAuthLandingRoute({ session })).toBe(tenantDashboard('tenant-1'));
+  });
+
+  it('keeps a mixed user on the last resident portal when it is still allowed', () => {
+    const session = buildSession([
+      { tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] },
+    ]);
+
+    expect(
+      resolveAuthLandingRoute({
+        session,
+        preferredPortal: 'resident',
+      }),
+    ).toBe(residentDashboard('tenant-1'));
+  });
+
+  it('keeps a mixed user on the last admin portal when it is still allowed', () => {
+    const session = buildSession([
+      { tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] },
+    ]);
+
+    expect(
+      resolveAuthLandingRoute({
+        session,
+        preferredPortal: 'admin',
+      }),
+    ).toBe(tenantDashboard('tenant-1'));
+  });
+
+  it('honors an explicit resident route when the membership allows it', () => {
+    const session = buildSession([
+      { tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] },
+    ]);
+
+    expect(
+      resolveAuthLandingRoute({
+        session,
+        requestedPath: '/tenant-1/resident/dashboard',
+      }),
+    ).toBe('/tenant-1/resident/dashboard');
+  });
+
+  it('honors an explicit admin route when the membership allows it', () => {
+    const session = buildSession([
+      { tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] },
+    ]);
+
+    expect(
+      resolveAuthLandingRoute({
+        session,
+        requestedPath: '/tenant-1/dashboard',
+      }),
+    ).toBe('/tenant-1/dashboard');
+  });
+
+  it('honors explicit portal query params on shared routes', () => {
+    const session = buildSession([
+      { tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] },
+    ]);
+
+    expect(
+      resolveAuthLandingRoute({
+        session,
+        requestedPath: '/tenant-1/tickets/ticket-1?portal=resident',
+      }),
+    ).toBe('/tenant-1/tickets/ticket-1?portal=resident');
+  });
+
+  it('falls back deterministically when the explicit route is not allowed', () => {
+    const session = buildSession([
+      { tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] },
+    ]);
+
+    expect(
+      resolveAuthLandingRoute({
+        session,
+        requestedPath: '/tenant-1/resident/dashboard',
+        preferredPortal: 'admin',
+      }),
+    ).toBe('/tenant-1/resident/dashboard');
+
+    expect(
+      resolveAuthLandingRoute({
+        session,
+        requestedPath: '/tenant-2/dashboard',
+      }),
+    ).toBe(tenantDashboard('tenant-1'));
+  });
+
+  it('returns the first valid tenant id from the preferred tenant list', () => {
+    expect(
+      resolveActiveTenantId(
+        [
+          { tenantId: 'tenant-1', roles: ['RESIDENT'] },
+          { tenantId: 'tenant-2', roles: ['TENANT_ADMIN'] },
+        ],
+        ['tenant-3', 'tenant-2'],
+      ),
+    ).toBe('tenant-2');
+  });
+
+  it('detects portal context from a pathname', () => {
+    expect(resolvePortalFromPathname('/tenant-1/resident/dashboard')).toBe('resident');
+    expect(resolvePortalFromPathname('/tenant-1/dashboard')).toBe('admin');
+    expect(resolvePortalFromPathname('/tenant-1/tickets/ticket-1', 'portal=resident')).toBe('resident');
+    expect(resolvePortalFromPathname('/login')).toBeNull();
+  });
+});

--- a/apps/web/features/auth/landing-route.ts
+++ b/apps/web/features/auth/landing-route.ts
@@ -1,0 +1,187 @@
+import { residentDashboard, tenantDashboard } from '@/shared/lib/routes';
+import type { AuthSession, Membership } from './auth.types';
+
+export type PortalContext = 'resident' | 'admin';
+
+export interface ResolveAuthLandingRouteParams {
+  readonly session: AuthSession;
+  readonly requestedPath?: string | null;
+  readonly preferredTenantId?: string | null;
+  readonly preferredPortal?: PortalContext | null;
+}
+
+const ADMIN_ROLES = new Set(['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR', 'SUPER_ADMIN']);
+const PUBLIC_PATH_PREFIXES = ['/login', '/signup', '/health', '/demo', '/demo-guiada', '/contact', '/invite'];
+
+function hasAdminPortalAccess(roles: readonly string[] | undefined): boolean {
+  return roles?.some((role) => ADMIN_ROLES.has(role)) ?? false;
+}
+
+function hasResidentPortalAccess(roles: readonly string[] | undefined): boolean {
+  return roles?.includes('RESIDENT') ?? false;
+}
+
+function parseRequestedPath(requestedPath: string): URL {
+  return new URL(requestedPath, 'https://buildingos.local');
+}
+
+function isPublicPath(pathname: string): boolean {
+  return PUBLIC_PATH_PREFIXES.some((prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`));
+}
+
+function isSuperAdminPath(pathname: string): boolean {
+  return pathname === '/super-admin' || pathname.startsWith('/super-admin/');
+}
+
+function getTenantIdFromPathname(pathname: string): string | null {
+  const match = pathname.match(/^\/([^/]+)(?:\/.*)?$/);
+  if (!match) {
+    return null;
+  }
+
+  const tenantId = match[1]?.trim();
+  if (!tenantId || tenantId === 'login' || tenantId === 'signup' || tenantId === 'super-admin') {
+    return null;
+  }
+
+  return tenantId;
+}
+
+function isResidentPath(pathname: string): boolean {
+  return pathname.includes('/resident/');
+}
+
+function resolveMembershipForTenant(memberships: Membership[], tenantId?: string | null): Membership | null {
+  if (!tenantId) {
+    return null;
+  }
+
+  return memberships.find((membership) => membership.tenantId === tenantId) ?? null;
+}
+
+export function resolveActiveTenantId(
+  memberships: Membership[],
+  preferredTenantIds: Array<string | null | undefined>,
+): string {
+  for (const preferredTenantId of preferredTenantIds) {
+    if (typeof preferredTenantId !== 'string' || preferredTenantId.trim().length === 0) {
+      continue;
+    }
+
+    const match = resolveMembershipForTenant(memberships, preferredTenantId);
+    if (match) {
+      return match.tenantId;
+    }
+  }
+
+  return memberships[0]?.tenantId ?? '';
+}
+
+export function resolvePortalFromPathname(
+  pathname: string | null | undefined,
+  searchParamsString?: string | null,
+): PortalContext | null {
+  if (!pathname || isPublicPath(pathname) || isSuperAdminPath(pathname)) {
+    return null;
+  }
+
+  if (searchParamsString) {
+    const searchParams = new URLSearchParams(searchParamsString);
+    const portal = searchParams.get('portal');
+    if (portal === 'resident' || portal === 'admin') {
+      return portal;
+    }
+  }
+
+  const tenantId = getTenantIdFromPathname(pathname);
+  if (!tenantId) {
+    return null;
+  }
+
+  return isResidentPath(pathname) ? 'resident' : 'admin';
+}
+
+function resolveAuthorizedRequestedPath(
+  session: AuthSession,
+  requestedPath: string,
+): string | null {
+  const url = parseRequestedPath(requestedPath);
+  const { pathname } = url;
+
+  if (isPublicPath(pathname) || isSuperAdminPath(pathname)) {
+    return null;
+  }
+
+  const tenantId = getTenantIdFromPathname(pathname);
+  if (!tenantId) {
+    return null;
+  }
+
+  const membership = resolveMembershipForTenant(session.memberships, tenantId);
+  if (!membership) {
+    return null;
+  }
+
+  const explicitPortal = url.searchParams.get('portal');
+  if (explicitPortal === 'resident') {
+    return hasResidentPortalAccess(membership.roles) ? `${pathname}${url.search}` : null;
+  }
+
+  if (explicitPortal === 'admin') {
+    return hasAdminPortalAccess(membership.roles) ? `${pathname}${url.search}` : null;
+  }
+
+  if (isResidentPath(pathname)) {
+    return hasResidentPortalAccess(membership.roles) ? `${pathname}${url.search}` : null;
+  }
+
+  return hasAdminPortalAccess(membership.roles) ? `${pathname}${url.search}` : null;
+}
+
+function resolveFallbackPortal(
+  roles: readonly string[] | undefined,
+  preferredPortal: PortalContext | null | undefined,
+): PortalContext {
+  if (preferredPortal === 'resident' && hasResidentPortalAccess(roles)) {
+    return 'resident';
+  }
+
+  if (preferredPortal === 'admin' && hasAdminPortalAccess(roles)) {
+    return 'admin';
+  }
+
+  const hasResidentAccess = hasResidentPortalAccess(roles);
+  const hasAdminAccess = hasAdminPortalAccess(roles);
+
+  if (hasResidentAccess && !hasAdminAccess) {
+    return 'resident';
+  }
+
+  return 'admin';
+}
+
+export function resolveAuthLandingRoute({
+  session,
+  requestedPath,
+  preferredTenantId,
+  preferredPortal,
+}: ResolveAuthLandingRouteParams): string {
+  if (requestedPath) {
+    const authorizedRequestedPath = resolveAuthorizedRequestedPath(session, requestedPath);
+    if (authorizedRequestedPath) {
+      return authorizedRequestedPath;
+    }
+  }
+
+  const activeTenantId = resolveActiveTenantId(session.memberships, [
+    preferredTenantId,
+    session.activeTenantId,
+  ]);
+
+  const activeMembership = resolveMembershipForTenant(session.memberships, activeTenantId) ?? session.memberships[0] ?? null;
+  const resolvedPortal = resolveFallbackPortal(activeMembership?.roles, preferredPortal);
+
+  return resolvedPortal === 'resident'
+    ? residentDashboard(activeTenantId)
+    : tenantDashboard(activeTenantId);
+}

--- a/apps/web/features/auth/session.storage.test.ts
+++ b/apps/web/features/auth/session.storage.test.ts
@@ -67,4 +67,10 @@ describe('session.storage', () => {
 
     expect(getLastPortal()).toBeNull();
   });
+
+  it('ignores malformed portal values in storage', () => {
+    localStorage.setItem('bo_last_portal', 'super-admin');
+
+    expect(getLastPortal()).toBeNull();
+  });
 });

--- a/apps/web/features/auth/session.storage.test.ts
+++ b/apps/web/features/auth/session.storage.test.ts
@@ -1,5 +1,13 @@
 import { emitBoStorageChange } from '@/shared/lib/storage/events';
-import { clearLastTenant, getLastTenant, setLastTenant } from './session.storage';
+import {
+  clearAuth,
+  clearLastPortal,
+  clearLastTenant,
+  getLastPortal,
+  getLastTenant,
+  setLastPortal,
+  setLastTenant,
+} from './session.storage';
 
 jest.mock('@/shared/lib/storage/events', () => ({
   emitBoStorageChange: jest.fn(),
@@ -39,5 +47,24 @@ describe('session.storage', () => {
 
     expect(getLastTenant()).toBeNull();
     expect(mockedEmitBoStorageChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('stores, reads, and clears the last portal context', () => {
+    setLastPortal('resident');
+
+    expect(getLastPortal()).toBe('resident');
+    expect(mockedEmitBoStorageChange).toHaveBeenCalledTimes(1);
+
+    clearLastPortal();
+
+    expect(getLastPortal()).toBeNull();
+    expect(mockedEmitBoStorageChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('removes the portal key when clearing auth state', () => {
+    setLastPortal('admin');
+    clearAuth();
+
+    expect(getLastPortal()).toBeNull();
   });
 });

--- a/apps/web/features/auth/session.storage.ts
+++ b/apps/web/features/auth/session.storage.ts
@@ -86,7 +86,8 @@ export function clearLastTenant(): void {
 }
 
 /**
- * Stores the last active portal context for quick resumption of user session.
+ * Stores the last active portal context for quick resumption within the current browser.
+ * This preference is intentionally browser-scoped and is cleared on logout.
  * @param portal - The portal context to remember as the last active one
  */
 export function setLastPortal(portal: PortalContext): void {

--- a/apps/web/features/auth/session.storage.ts
+++ b/apps/web/features/auth/session.storage.ts
@@ -1,8 +1,10 @@
 import { emitBoStorageChange } from '@/shared/lib/storage/events';
 import type { AuthSession } from './auth.types';
+import type { PortalContext } from './landing-route';
 
 const KEY_SESSION = 'bo_session';
 const KEY_LAST_TENANT = 'bo_last_tenant';
+const KEY_LAST_PORTAL = 'bo_last_portal';
 
 /**
  * Stores the authenticated session in localStorage and emits a storage change event.
@@ -84,13 +86,46 @@ export function clearLastTenant(): void {
 }
 
 /**
+ * Stores the last active portal context for quick resumption of user session.
+ * @param portal - The portal context to remember as the last active one
+ */
+export function setLastPortal(portal: PortalContext): void {
+  const currentPortal = localStorage.getItem(KEY_LAST_PORTAL);
+  if (currentPortal === portal) {
+    return;
+  }
+
+  localStorage.setItem(KEY_LAST_PORTAL, portal);
+  emitBoStorageChange();
+}
+
+/**
+ * Retrieves the last active portal context from localStorage.
+ * @returns The stored portal context or null
+ */
+export function getLastPortal(): PortalContext | null {
+  if (typeof window === 'undefined') return null;
+
+  const value = localStorage.getItem(KEY_LAST_PORTAL);
+  return value === 'resident' || value === 'admin' ? value : null;
+}
+
+/**
+ * Removes the last active portal context and emits a storage change event.
+ */
+export function clearLastPortal(): void {
+  localStorage.removeItem(KEY_LAST_PORTAL);
+  emitBoStorageChange();
+}
+
+/**
  * Completely clears all BuildingOS authentication and app data from localStorage.
  * Removes auth keys and all bo_* prefixed keys.
  * Prevents data leakage when multiple users access the same browser.
  * Emits a storage change event for UI updates.
  */
 export function clearAuth(): void {
-  const keysToRemove: string[] = [KEY_SESSION, KEY_LAST_TENANT];
+  const keysToRemove: string[] = [KEY_SESSION, KEY_LAST_TENANT, KEY_LAST_PORTAL];
 
   try {
     for (let i = 0; i < localStorage.length; i++) {

--- a/apps/web/features/auth/useRefreshSession.ts
+++ b/apps/web/features/auth/useRefreshSession.ts
@@ -17,11 +17,19 @@
 
 import { useState, useCallback } from 'react';
 import { apiClient } from '@/shared/lib/http/client';
-import { setSession } from './session.storage';
+import {
+  getLastPortal,
+  getLastTenant,
+  getSession,
+  setSession,
+  setLastTenant,
+} from './session.storage';
 import type { LoginResponse } from './auth.types';
+import { resolveActiveTenantId, resolveAuthLandingRoute } from './landing-route';
 
 interface RefreshSessionResult {
   activeTenantId: string;
+  landingPath: string;
   tenantCount: number;
 }
 
@@ -42,16 +50,28 @@ export function useRefreshSession() {
 
       // Update localStorage with fresh memberships
       if (response.memberships && response.memberships.length > 0) {
+        const currentSession = getSession();
+        const activeTenantId = resolveActiveTenantId(response.memberships, [
+          currentSession?.activeTenantId,
+          getLastTenant(),
+        ]);
+
         const newSession = {
           user: response.user,
           memberships: response.memberships,
-          activeTenantId: response.memberships[0].tenantId,
+          activeTenantId,
         };
 
         setSession(newSession);
+        setLastTenant(activeTenantId);
 
         return {
           activeTenantId: newSession.activeTenantId,
+          landingPath: resolveAuthLandingRoute({
+            session: newSession,
+            preferredTenantId: activeTenantId,
+            preferredPortal: getLastPortal(),
+          }),
           tenantCount: response.memberships.length,
         };
       }

--- a/apps/web/shared/components/layout/AppShell.push-permission.integration.test.tsx
+++ b/apps/web/shared/components/layout/AppShell.push-permission.integration.test.tsx
@@ -85,6 +85,7 @@ jest.mock('@/features/auth/session.storage', () => ({
   getSession: jest.fn(),
   setSession: jest.fn(),
   setLastTenant: jest.fn(),
+  setLastPortal: jest.fn(),
   clearAuth: jest.fn(),
 }));
 

--- a/apps/web/shared/components/layout/SessionRefreshPrompt.tsx
+++ b/apps/web/shared/components/layout/SessionRefreshPrompt.tsx
@@ -13,7 +13,7 @@
  *   <SessionRefreshPrompt />
  */
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useRefreshSession } from '@/features/auth/useRefreshSession';
 import Card from '@/shared/components/ui/Card';
@@ -22,23 +22,16 @@ import Button from '@/shared/components/ui/Button';
 export default function SessionRefreshPrompt() {
   const router = useRouter();
   const { refresh, loading, error } = useRefreshSession();
-  const [showPrompt, setShowPrompt] = useState(false);
-
-  // Show prompt if user navigates to a 403 error
-  useEffect(() => {
-    // Check if there's an error from previous navigation
-    const params = new URLSearchParams(window.location.search);
-    if (params.get('session_refresh_needed') === 'true') {
-      setShowPrompt(true);
-    }
-  }, []);
+  const [showPrompt, setShowPrompt] = useState(
+    () => typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('session_refresh_needed') === 'true',
+  );
 
   const handleRefresh = async () => {
     const result = await refresh();
     if (result) {
       setShowPrompt(false);
-      // Redirect to dashboard with new tenant
-      router.push(`/${result.activeTenantId}/dashboard`);
+      // Redirect to the resolved landing route for the refreshed session
+      router.push(result.landingPath);
     }
   };
 

--- a/apps/web/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/shared/components/layout/Topbar.test.tsx
@@ -31,6 +31,7 @@ jest.mock('@/features/auth/session.storage', () => ({
   getSession: jest.fn(),
   setSession: jest.fn(),
   setLastTenant: jest.fn(),
+  setLastPortal: jest.fn(),
   clearAuth: jest.fn(),
 }));
 
@@ -1118,7 +1119,7 @@ describe('Topbar responsive tenant selector', () => {
     await waitFor(() => {
       expect(mockSetSession).toHaveBeenCalledWith({ ...session, activeTenantId: 'tenant-2' });
       expect(mockSetLastTenant).toHaveBeenCalledWith('tenant-2');
-      expect(replace).toHaveBeenCalledWith('/tenant-2/dashboard');
+      expect(replace).toHaveBeenCalledWith('/tenant-2/resident/dashboard');
     });
   });
 

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -1,7 +1,12 @@
 'use client';
 
-import { useRouter, useParams, usePathname } from 'next/navigation';
-import { getSession, setSession, setLastTenant } from '../../../features/auth/session.storage';
+import { useRouter, useParams, usePathname, useSearchParams } from 'next/navigation';
+import {
+  getSession,
+  setSession,
+  setLastTenant,
+  setLastPortal,
+} from '../../../features/auth/session.storage';
 import { logout } from '@/features/auth/login.actions';
 import { useTenants } from '../../../features/tenants/tenants.hooks';
 import type { TenantSummary } from '../../../features/tenants/tenants.service';
@@ -16,6 +21,7 @@ import { listPendingPayments, PaymentStatus } from '@/features/finance/services/
 import { PushPermissionControl } from '@/features/notifications/components/PushPermissionControl';
 import { resolveNotificationPath } from '@/shared/lib/notification-routes';
 import { getNotificationCategory } from '@/shared/lib/notification-types';
+import { resolveAuthLandingRoute, resolvePortalFromPathname } from '@/features/auth/landing-route';
 
 const ADMIN_ROLES = new Set(['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR', 'SUPER_ADMIN']);
 
@@ -385,11 +391,20 @@ export default function Topbar({
 }: TopbarProps) {
   const router = useRouter();
   const params = useParams();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const urlTenantId = typeof params?.tenantId === 'string' ? params.tenantId : undefined;
   const [isLoggingOut, setIsLoggingOut] = useState(false);
 
   const session = getSession();
   const { data: tenants, isLoading, error } = useTenants();
+
+  useEffect(() => {
+    const portal = resolvePortalFromPathname(pathname, searchParams.toString());
+    if (portal) {
+      setLastPortal(portal);
+    }
+  }, [pathname, searchParams]);
 
   // Determinar tenant activo: URL > session.activeTenantId > memberships[0]
   const activeTenantId =
@@ -401,7 +416,13 @@ export default function Topbar({
 
   // Obtener rol del usuario en el tenant activo
   const activeMembership = session?.memberships.find((m) => m.tenantId === activeTenantId);
-  const role = activeMembership?.roles[0] || 'Guest';
+  const currentPortal = resolvePortalFromPathname(pathname, searchParams.toString());
+  const role =
+    currentPortal === 'resident' && activeMembership?.roles.includes('RESIDENT')
+      ? 'RESIDENT'
+      : activeMembership?.roles.find((candidateRole) => ADMIN_ROLES.has(candidateRole)) ||
+        activeMembership?.roles[0] ||
+        'Guest';
 
   const roleLabelMap: Record<string, string> = {
     TENANT_ADMIN: 'Administrador',
@@ -416,18 +437,25 @@ export default function Topbar({
 
   const handleTenantChange = (nextTenantId: string) => {
     if (!session) return;
-
-    // Actualizar sesión con nuevo tenant activo
-    setSession({
+    const nextSession = {
       ...session,
       activeTenantId: nextTenantId,
-    });
+    };
+
+    // Actualizar sesión con nuevo tenant activo
+    setSession(nextSession);
 
     // Persistir último tenant
     setLastTenant(nextTenantId);
 
-    // Navegar al dashboard del nuevo tenant
-    router.replace(`/${nextTenantId}/dashboard`);
+    // Navegar al portal equivalente del nuevo tenant si existe
+    router.replace(
+      resolveAuthLandingRoute({
+        session: nextSession,
+        preferredTenantId: nextTenantId,
+        preferredPortal: currentPortal,
+      }),
+    );
   };
 
   const handleLogout = async () => {

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter, useParams, usePathname, useSearchParams } from 'next/navigation';
+import { useRouter, useParams, usePathname } from 'next/navigation';
 import {
   getSession,
   setSession,
@@ -392,19 +392,19 @@ export default function Topbar({
   const router = useRouter();
   const params = useParams();
   const pathname = usePathname();
-  const searchParams = useSearchParams();
   const urlTenantId = typeof params?.tenantId === 'string' ? params.tenantId : undefined;
   const [isLoggingOut, setIsLoggingOut] = useState(false);
 
   const session = getSession();
   const { data: tenants, isLoading, error } = useTenants();
+  const currentSearch = typeof window !== 'undefined' ? window.location.search.replace(/^\?/, '') : '';
 
   useEffect(() => {
-    const portal = resolvePortalFromPathname(pathname, searchParams.toString());
+    const portal = resolvePortalFromPathname(pathname, currentSearch);
     if (portal) {
       setLastPortal(portal);
     }
-  }, [pathname, searchParams]);
+  }, [currentSearch, pathname]);
 
   // Determinar tenant activo: URL > session.activeTenantId > memberships[0]
   const activeTenantId =
@@ -416,7 +416,7 @@ export default function Topbar({
 
   // Obtener rol del usuario en el tenant activo
   const activeMembership = session?.memberships.find((m) => m.tenantId === activeTenantId);
-  const currentPortal = resolvePortalFromPathname(pathname, searchParams.toString());
+  const currentPortal = resolvePortalFromPathname(pathname, currentSearch);
   const role =
     currentPortal === 'resident' && activeMembership?.roles.includes('RESIDENT')
       ? 'RESIDENT'

--- a/apps/web/shared/lib/http/client.ts
+++ b/apps/web/shared/lib/http/client.ts
@@ -10,6 +10,7 @@ export interface HttpRequestConfig<TReq = never> {
   body?: TReq;
   headers?: Record<string, string>;
   responseType?: 'json' | 'blob' | 'text' | 'arrayBuffer';
+  skipRefreshOnUnauthorized?: boolean;
 }
 
 export interface HttpResponse<TRes> {
@@ -159,7 +160,7 @@ async function executeRequest<TRes, TReq = never>(
 
   let response = await performRequest(path, init, method);
 
-  if (!response.ok && response.status === 401) {
+  if (!response.ok && response.status === 401 && !config.skipRefreshOnUnauthorized) {
     const hasImpersonationToken = !!getCurrentImpersonationToken();
 
     if (!hasImpersonationToken && !isAuthRoute(path)) {

--- a/apps/web/shared/lib/routes.ts
+++ b/apps/web/shared/lib/routes.ts
@@ -17,6 +17,13 @@ export function tenantDashboard(tenantId: string): string {
 }
 
 /**
+ * Resident dashboard route for tenant
+ */
+export function residentDashboard(tenantId: string): string {
+  return `/${tenantId}/resident/dashboard`;
+}
+
+/**
  * Buildings list for tenant
  */
 export function buildingsList(tenantId: string): string {
@@ -144,6 +151,7 @@ export function superAdminDashboard(): string {
  */
 export const routes = {
   tenantDashboard,
+  residentDashboard,
   buildingsList,
   buildingOverview,
   buildingUnits,

--- a/apps/web/tests/e2e/auth/login.spec.ts
+++ b/apps/web/tests/e2e/auth/login.spec.ts
@@ -43,8 +43,10 @@ test.describe.serial('Auth - Login Flow', () => {
   });
 
   test('should restore a mixed user to the last resident portal', async ({ page }) => {
-    await page.addInitScript(() => {
-      localStorage.clear();
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.removeItem('bo_session');
+      localStorage.removeItem('bo_last_tenant');
       localStorage.setItem('bo_last_portal', 'resident');
     });
 
@@ -54,13 +56,31 @@ test.describe.serial('Auth - Login Flow', () => {
   });
 
   test('should restore a mixed user to the last admin portal', async ({ page }) => {
-    await page.addInitScript(() => {
-      localStorage.clear();
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.removeItem('bo_session');
+      localStorage.removeItem('bo_last_tenant');
       localStorage.setItem('bo_last_portal', 'admin');
     });
 
     const tenantId = await login(page, TEST_USERS.residentMixed);
 
     await expect(page).toHaveURL(new RegExp(`/${tenantId}/dashboard$`));
+  });
+
+  test('should not leak an admin portal preference to a resident-only user after logout', async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.removeItem('bo_session');
+      localStorage.removeItem('bo_last_tenant');
+      localStorage.setItem('bo_last_portal', 'admin');
+    });
+
+    await login(page, TEST_USERS.tenantAdminA);
+    await logout(page);
+
+    const tenantId = await login(page, TEST_USERS.resident);
+
+    await expect(page).toHaveURL(new RegExp(`/${tenantId}/resident/dashboard$`));
   });
 });

--- a/apps/web/tests/e2e/auth/login.spec.ts
+++ b/apps/web/tests/e2e/auth/login.spec.ts
@@ -41,4 +41,26 @@ test.describe.serial('Auth - Login Flow', () => {
     await page.waitForTimeout(3000);
     expect(page.url()).not.toContain('/login');
   });
+
+  test('should restore a mixed user to the last resident portal', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.clear();
+      localStorage.setItem('bo_last_portal', 'resident');
+    });
+
+    const tenantId = await login(page, TEST_USERS.residentMixed);
+
+    await expect(page).toHaveURL(new RegExp(`/${tenantId}/resident/dashboard$`));
+  });
+
+  test('should restore a mixed user to the last admin portal', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.clear();
+      localStorage.setItem('bo_last_portal', 'admin');
+    });
+
+    const tenantId = await login(page, TEST_USERS.residentMixed);
+
+    await expect(page).toHaveURL(new RegExp(`/${tenantId}/dashboard$`));
+  });
 });

--- a/apps/web/tests/e2e/auth/route-guards.spec.ts
+++ b/apps/web/tests/e2e/auth/route-guards.spec.ts
@@ -5,7 +5,7 @@ test.describe('Auth - Route Guards', () => {
   test('should redirect anonymous visitors from private tenant routes to login', async ({ page }) => {
     await page.goto('/test-tenant/dashboard');
 
-    await expect(page).toHaveURL(/\/login$/);
+    await expect(page).toHaveURL(/\/login(?:\?.*)?$/);
     await expect(page.getByText(/inicia sesión con tu cuenta/i)).toBeVisible();
   });
 

--- a/apps/web/tests/e2e/auth/session.spec.ts
+++ b/apps/web/tests/e2e/auth/session.spec.ts
@@ -27,7 +27,7 @@ test.describe('Auth - Session and Landing Flow', () => {
 
     await logout(page);
 
-    await expect(page).toHaveURL(/\/login$/);
+    await expect(page).toHaveURL(/\/login(?:\?.*)?$/);
     await expect(page.getByText(/inicia sesión con tu cuenta/i)).toBeVisible();
   });
 

--- a/apps/web/tests/e2e/helpers/auth.ts
+++ b/apps/web/tests/e2e/helpers/auth.ts
@@ -41,6 +41,11 @@ export async function login(page: Page, user: TestUser): Promise<string> {
   const loginUrl = new URL(AUTH_LOGIN_ENDPOINT, API_ORIGIN).toString();
   const sessionUrl = new URL(AUTH_SESSION_ENDPOINT, API_ORIGIN).toString();
 
+  const context = page.context();
+  if ('clearCookies' in context && typeof context.clearCookies === 'function') {
+    await context.clearCookies();
+  }
+
   const waitForLoginResponse = page.waitForResponse(
     (response) =>
       response.request().method() === 'POST' && response.url() === loginUrl,
@@ -135,7 +140,7 @@ export async function logout(page: Page): Promise<void> {
     throw new Error(`AUTH_LOGOUT_FAILED status=${logoutResponse.status()} endpoint=/auth/logout message=${message}`);
   }
 
-  await page.waitForURL('/login', { timeout: 10000 });
+  await page.waitForURL(/\/login(?:\?.*)?$/, { timeout: 10000 });
   await expect(page).toHaveURL(/.*login/);
 }
 

--- a/apps/web/tests/e2e/resident/resident-journeys.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-journeys.spec.ts
@@ -32,7 +32,7 @@ test.describe('Resident critical journeys', () => {
     await page.getByTestId('login-password').fill('WrongPass123!');
     await page.getByTestId('login-submit').click();
 
-    await expect(page).toHaveURL(/\/login$/);
+    await expect(page).toHaveURL(/\/login(?:\?.*)?$/);
     await expect(page.getByText(/credenciales inválidas/i)).toBeVisible();
 
     const cookies = await page.context().cookies([API_ORIGIN]);
@@ -178,10 +178,10 @@ test.describe('Resident critical journeys', () => {
     const tenantId = await login(page, TEST_USERS.resident);
 
     await logout(page);
-    await expect(page).toHaveURL(/\/login$/);
+    await expect(page).toHaveURL(/\/login(?:\?.*)?$/);
 
     await page.goto(residentDashboardPath(tenantId));
-    await expect(page).toHaveURL(/\/login$/);
+    await expect(page).toHaveURL(/\/login(?:\?.*)?$/);
     await expect(page.getByText(/inicia sesión con tu cuenta/i)).toBeVisible();
 
     const cookies = await page.context().cookies([API_ORIGIN]);


### PR DESCRIPTION
Closes #96

## Summary
- Fix mixed-role RESIDENT + TENANT_ADMIN landing so it respects the last valid portal/context or explicit user choice.
- Preserve single-role behavior and keep explicit redirects stable with `next` preservation on protected routes.
- Add targeted unit and E2E coverage for the new landing rules.

## Changes Table
| File | Change |
|------|--------|
| `apps/web/features/auth/landing-route.ts` | Added landing-route resolution helpers and portal context handling. |
| `apps/web/features/auth/auth.hooks.ts` | Routed login/signup through the new landing resolver. |
| `apps/web/features/auth/session.storage.ts` | Persisted last portal selection alongside last tenant. |
| `apps/web/app/(public)/login/page.tsx` | Resolved authenticated landing using stored portal/context and `next`. |
| `apps/web/app/(public)/signup/page.tsx` | Resolved authenticated landing using stored portal/context and `next`. |
| `apps/web/features/auth/AuthBootstrap.tsx` | Preserved valid tenant/session context during bootstrap and login redirects. |
| `apps/web/features/auth/useRefreshSession.ts` | Returned the resolved landing path after session refresh. |
| `apps/web/shared/components/layout/Topbar.tsx` | Persisted portal context and kept tenant switching aligned with the active portal. |
| `apps/web/app/(tenant)/[tenantId]/layout.tsx` | Preserved the current path in login redirects for unauthorized access. |
| `apps/web/app/(tenant)/[tenantId]/resident/layout.tsx` | Preserved the current path in login redirects for unauthenticated resident access. |
| `apps/web/app/super-admin/layout.tsx` | Preserved the current path in login redirects and removed suspense-triggering search param usage. |
| `apps/web/tests/e2e/auth/login.spec.ts` | Added mixed-role landing coverage and cross-account preference isolation. |
| `apps/web/tests/e2e/auth/route-guards.spec.ts` | Allowed login redirects with preserved query strings. |
| `apps/web/tests/e2e/auth/session.spec.ts` | Allowed login redirects with preserved query strings. |
| `apps/web/tests/e2e/resident/resident-journeys.spec.ts` | Updated login expectations to allow `next` redirects. |
| `apps/web/features/auth/landing-route.test.ts` | Added unit coverage for explicit path, portal query, and mixed-role cases. |
| `apps/web/shared/lib/http/client.ts` | Skipped refresh-on-401 for `/auth/me` so public-page bootstrap does not clear portal preference on unauthenticated loads. |
| `apps/web/features/auth/auth.service.ts` | Marked `/auth/me` as non-refreshing on unauthorized so bootstrap can preserve browser portal context. |
| `apps/web/tests/e2e/helpers/auth.ts` | Isolated E2E logins from stale cookies while preserving portal memory. |

## Test Plan
- [x] `npm run build -w apps/web`
- [x] `npx tsc -p apps/web/tsconfig.json --noEmit`
- [x] `npm run test -w apps/web -- --runInBand --runTestsByPath features/auth/landing-route.test.ts features/auth/session.storage.test.ts features/auth/login.actions.test.ts tests/auth-helper.test.ts`
- [x] `npx eslint` on changed web files from `apps/web`
- [x] `TEST_E2E_PASSWORD='TestPass123!' NEXT_PUBLIC_API_URL='http://localhost:4000' npm run test:e2e -w apps/web -- --project=chromium tests/e2e/auth/login.spec.ts tests/e2e/auth/route-guards.spec.ts tests/e2e/auth/session.spec.ts tests/e2e/resident/resident-journeys.spec.ts`

## Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Ran shellcheck on modified scripts
- [x] Skills loaded in target agent
- [x] Docs updated if behavior changed
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers

## Notes
- The PR remains draft until remote checks are green and the repository is ready for review.