### PR TITLE
fix(web): align mixed-role navigation with active portal

### DIFF
--- a/apps/web/features/auth/index.ts
+++ b/apps/web/features/auth/index.ts
@@ -26,4 +26,9 @@ export {
 export { AuthBootstrap } from './AuthBootstrap';
 
 // Landing route resolution
-export { resolveActiveTenantId, resolveAuthLandingRoute, resolvePortalFromPathname } from './landing-route';
+export {
+  resolveActiveTenantId,
+  resolveAuthLandingRoute,
+  resolveAuthorizedPortalContext,
+  resolvePortalFromPathname,
+} from './landing-route';

--- a/apps/web/features/auth/landing-route.test.ts
+++ b/apps/web/features/auth/landing-route.test.ts
@@ -1,6 +1,7 @@
 import {
   resolveActiveTenantId,
   resolveAuthLandingRoute,
+  resolveAuthorizedPortalContext,
   resolvePortalFromPathname,
 } from './landing-route';
 import { residentDashboard, tenantDashboard } from '@/shared/lib/routes';
@@ -161,5 +162,70 @@ describe('landing-route', () => {
     expect(resolvePortalFromPathname('/tenant-1/dashboard')).toBe('admin');
     expect(resolvePortalFromPathname('/tenant-1/tickets/ticket-1', 'portal=resident')).toBe('resident');
     expect(resolvePortalFromPathname('/login')).toBeNull();
+  });
+
+  it('resolves the authorized portal context for mixed-role users from the active route', () => {
+    const session = buildSession([
+      { tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] },
+    ]);
+
+    expect(
+      resolveAuthorizedPortalContext({
+        session,
+        tenantId: 'tenant-1',
+        pathname: '/tenant-1/dashboard',
+      }),
+    ).toBe('admin');
+
+    expect(
+      resolveAuthorizedPortalContext({
+        session,
+        tenantId: 'tenant-1',
+        pathname: '/tenant-1/resident/payments',
+      }),
+    ).toBe('resident');
+  });
+
+  it('returns null when tenantId is missing or does not belong to the session', () => {
+    const session = buildSession([
+      { tenantId: 'tenant-1', roles: ['RESIDENT'] },
+      { tenantId: 'tenant-2', roles: ['TENANT_ADMIN'] },
+    ]);
+
+    expect(
+      resolveAuthorizedPortalContext({
+        session,
+        pathname: '/tenant-1/dashboard',
+      }),
+    ).toBeNull();
+
+    expect(
+      resolveAuthorizedPortalContext({
+        session,
+        tenantId: 'tenant-2',
+        pathname: '/tenant-1/dashboard',
+      }),
+    ).toBeNull();
+  });
+
+  it('falls back to the only portal a single-role user can access', () => {
+    const residentSession = buildSession([{ tenantId: 'tenant-1', roles: ['RESIDENT'] }]);
+    const adminSession = buildSession([{ tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] }]);
+
+    expect(
+      resolveAuthorizedPortalContext({
+        session: residentSession,
+        tenantId: 'tenant-1',
+        pathname: '/tenant-1/dashboard',
+      }),
+    ).toBe('resident');
+
+    expect(
+      resolveAuthorizedPortalContext({
+        session: adminSession,
+        tenantId: 'tenant-1',
+        pathname: '/tenant-1/resident/dashboard',
+      }),
+    ).toBe('admin');
   });
 });

--- a/apps/web/features/auth/landing-route.ts
+++ b/apps/web/features/auth/landing-route.ts
@@ -10,6 +10,13 @@ export interface ResolveAuthLandingRouteParams {
   readonly preferredPortal?: PortalContext | null;
 }
 
+export interface ResolveAuthorizedPortalContextParams {
+  readonly session: AuthSession | null;
+  readonly pathname?: string | null;
+  readonly searchParamsString?: string | null;
+  readonly tenantId?: string | null;
+}
+
 const ADMIN_ROLES = new Set(['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR', 'SUPER_ADMIN']);
 const PUBLIC_PATH_PREFIXES = ['/login', '/signup', '/health', '/demo', '/demo-guiada', '/contact', '/invite'];
 
@@ -117,6 +124,11 @@ function resolveAuthorizedRequestedPath(
     return null;
   }
 
+  const pathnameTenantId = pathname ? getTenantIdFromPathname(pathname) : null;
+  if (pathnameTenantId !== tenantId) {
+    return null;
+  }
+
   const membership = resolveMembershipForTenant(session.memberships, tenantId);
   if (!membership) {
     return null;
@@ -158,6 +170,65 @@ function resolveFallbackPortal(
   }
 
   return 'admin';
+}
+
+export function resolveAuthorizedPortalContext({
+  session,
+  pathname,
+  searchParamsString,
+  tenantId,
+}: ResolveAuthorizedPortalContextParams): PortalContext | null {
+  if (!session) {
+    return null;
+  }
+
+  if (!tenantId) {
+    return null;
+  }
+
+  const pathnameTenantId = pathname ? getTenantIdFromPathname(pathname) : null;
+  if (pathnameTenantId !== tenantId) {
+    return null;
+  }
+
+  const membership = resolveMembershipForTenant(session.memberships, tenantId);
+  if (!membership) {
+    return null;
+  }
+
+  const hasResidentAccess = hasResidentPortalAccess(membership.roles);
+  const hasAdminAccess = hasAdminPortalAccess(membership.roles);
+  const requestedPortal = resolvePortalFromPathname(pathname, searchParamsString);
+
+  if (requestedPortal === 'resident') {
+    if (hasResidentAccess) {
+      return 'resident';
+    }
+
+    if (hasAdminAccess) {
+      return 'admin';
+    }
+  }
+
+  if (requestedPortal === 'admin') {
+    if (hasAdminAccess) {
+      return 'admin';
+    }
+
+    if (hasResidentAccess) {
+      return 'resident';
+    }
+  }
+
+  if (hasResidentAccess && !hasAdminAccess) {
+    return 'resident';
+  }
+
+  if (hasAdminAccess) {
+    return 'admin';
+  }
+
+  return null;
 }
 
 export function resolveAuthLandingRoute({

--- a/apps/web/shared/components/layout/AppShell.push-permission.integration.test.tsx
+++ b/apps/web/shared/components/layout/AppShell.push-permission.integration.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import AppShell from './AppShell';
+import type { AuthSession, Role } from '@/features/auth/auth.types';
 import * as notificationsApi from '@/features/notifications/notifications.api';
 import * as pushSubscriptionApi from '@/features/notifications/push-subscription.api';
 import * as financeApi from '@/features/finance/services/finance.api';
@@ -14,10 +15,17 @@ import * as sessionModule from '@/features/auth/session.storage';
 let mockTenantData: Array<{ id: string; name: string; type: 'EDIFICIO_AUTOGESTION' }> = [];
 let mockTenantId = 'tenant-1';
 let mockPathname = '/tenant-1/dashboard';
+let mockSearchParams = '';
+let mockAuthSession: AuthSession = {
+  user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
+  memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT' as Role] }],
+  activeTenantId: 'tenant-1',
+};
 
 jest.mock('next/navigation', () => ({
   useParams: () => ({ tenantId: mockTenantId }),
   usePathname: () => mockPathname,
+  useSearchParams: () => new URLSearchParams(mockSearchParams),
   useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
 }));
 
@@ -26,6 +34,7 @@ jest.mock('@/features/tenants/tenants.hooks', () => ({
 }));
 
 jest.mock('@/features/auth/useAuthSession', () => ({
+  useAuthSession: () => mockAuthSession,
   useIsSuperAdmin: () => false,
   useHasRole: (role: string) => role === 'RESIDENT',
 }));
@@ -122,13 +131,15 @@ describe('AppShell push permission integration', () => {
     mockTenantData = [{ id: 'tenant-1', name: 'Tenant 1', type: 'EDIFICIO_AUTOGESTION' }];
     mockTenantId = 'tenant-1';
     mockPathname = '/tenant-1/dashboard';
+    mockSearchParams = '';
+    mockAuthSession = {
+      user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
+      memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT' as Role] }],
+      activeTenantId: 'tenant-1',
+    };
     jest.clearAllMocks();
 
-    mockGetSession.mockReturnValue({
-      user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
-      memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT'] }],
-      activeTenantId: 'tenant-1',
-    });
+    mockGetSession.mockReturnValue(mockAuthSession);
     mockGetUnreadCount.mockResolvedValue(0);
     mockListNotifications.mockResolvedValue({ notifications: [], total: 0 });
     mockListPendingPayments.mockResolvedValue([]);

--- a/apps/web/shared/components/layout/Sidebar.test.tsx
+++ b/apps/web/shared/components/layout/Sidebar.test.tsx
@@ -6,6 +6,12 @@ import { render, screen } from "@testing-library/react";
 import { Sidebar } from "./Sidebar";
 
 let pathname = "/tenant-1/tickets/ticket-1";
+let currentSearch = "";
+let session: {
+  user: { id: string; email: string; name: string };
+  memberships: Array<{ tenantId: string; roles: string[] }>;
+  activeTenantId: string;
+} | null = null;
 
 jest.mock("next/link", () => ({
   __esModule: true,
@@ -14,6 +20,7 @@ jest.mock("next/link", () => ({
 
 jest.mock("next/navigation", () => ({
   usePathname: () => pathname,
+  useSearchParams: () => new URLSearchParams(currentSearch),
 }));
 
 jest.mock("../../../features/tenancy/tenant.hooks", () => ({
@@ -21,8 +28,8 @@ jest.mock("../../../features/tenancy/tenant.hooks", () => ({
 }));
 
 jest.mock("../../../features/auth/useAuthSession", () => ({
+  useAuthSession: () => session,
   useIsSuperAdmin: () => false,
-  useHasRole: (role: string) => role === "RESIDENT",
 }));
 
 jest.mock("../../../features/impersonation/useImpersonation", () => ({
@@ -49,6 +56,13 @@ jest.mock("@/i18n", () => ({
 describe("Sidebar", () => {
   beforeEach(() => {
     pathname = "/tenant-1/tickets/ticket-1";
+    currentSearch = "";
+    window.history.pushState({}, "", pathname);
+    session = {
+      user: { id: "user-1", email: "test@test.com", name: "Test User" },
+      memberships: [{ tenantId: "tenant-1", roles: ["RESIDENT", "TENANT_ADMIN"] }],
+      activeTenantId: "tenant-1",
+    };
   });
 
   it("uses desktop-only structural classes and desktop link density by default", () => {
@@ -58,7 +72,7 @@ describe("Sidebar", () => {
     expect(aside?.className).toContain("hidden");
     expect(aside?.className).toContain("w-64");
     expect(aside?.className).toContain("lg:block");
-    expect(screen.getByRole("link", { name: "Solicitudes" }).className).not.toContain("min-h-11");
+    expect(screen.getByRole("link", { name: "navigation.buildings" }).className).not.toContain("min-h-11");
   });
 
   it("uses visible touch-sized links without a fixed desktop width in the drawer variant", () => {
@@ -73,17 +87,49 @@ describe("Sidebar", () => {
     });
   });
 
-  it("keeps Mi perfil active on the resident profile route", () => {
+  it("renders resident navigation on resident routes for mixed-role users", () => {
     pathname = "/tenant-1/resident/profile";
+    currentSearch = "portal=resident";
 
     render(<Sidebar variant="drawer" />);
 
+    expect(screen.getByRole("link", { name: "Panel" }).getAttribute("href")).toBe("/tenant-1/resident/dashboard");
     expect(screen.getByRole("link", { name: "Mi perfil" }).className).toContain("bg-primary");
   });
 
-  it("keeps Solicitudes active for the canonical resident ticket detail route", () => {
+  it("renders admin navigation on admin routes for mixed-role users", () => {
+    pathname = "/tenant-1/dashboard";
+    window.history.pushState({}, "", pathname);
+
+    render(<Sidebar variant="drawer" />);
+
+    expect(screen.getByRole("link", { name: "Panel" }).getAttribute("href")).toBe("/tenant-1/dashboard");
+    expect(screen.getByRole("link", { name: "navigation.buildings" })).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "Mi perfil" })).toBeNull();
+  });
+
+  it("keeps resident navigation active on the canonical resident ticket detail route", () => {
+    pathname = "/tenant-1/tickets/ticket-1";
+    currentSearch = "portal=resident";
+
     render(<Sidebar variant="drawer" />);
 
     expect(screen.getByRole("link", { name: "Solicitudes" }).className).toContain("bg-primary");
+  });
+
+  it("falls back to resident navigation for resident-only users on admin routes", () => {
+    pathname = "/tenant-1/dashboard";
+    window.history.pushState({}, "", pathname);
+    session = {
+      user: { id: "resident-1", email: "resident@test.com", name: "Resident User" },
+      memberships: [{ tenantId: "tenant-1", roles: ["RESIDENT"] }],
+      activeTenantId: "tenant-1",
+    };
+
+    render(<Sidebar variant="drawer" />);
+
+    expect(screen.getByRole("link", { name: "Panel" }).getAttribute("href")).toBe("/tenant-1/resident/dashboard");
+    expect(screen.getByRole("link", { name: "Mi perfil" })).toBeTruthy();
+    expect(screen.queryByRole("link", { name: "navigation.buildings" })).toBeNull();
   });
 });

--- a/apps/web/shared/components/layout/Sidebar.tsx
+++ b/apps/web/shared/components/layout/Sidebar.tsx
@@ -2,12 +2,13 @@
 
 import type { ReactNode } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 import { routes } from "../../../shared/lib/routes";
 import { useTenantId } from "../../../features/tenancy/tenant.hooks";
-import { useIsSuperAdmin, useHasRole } from "../../../features/auth/useAuthSession";
+import { useAuthSession, useIsSuperAdmin } from "../../../features/auth/useAuthSession";
 import { useImpersonation } from "../../../features/impersonation/useImpersonation";
 import { useTenants } from "../../../features/tenants/tenants.hooks";
+import { resolveAuthorizedPortalContext } from "../../../features/auth/landing-route";
 import { t } from "@/i18n";
 
 interface NavItemProps {
@@ -45,19 +46,33 @@ const NavItem = ({ href, label, isActive, onNavigate, variant }: NavItemProps) =
 export const Sidebar = ({ className, footer, id, onNavigate, variant = "desktop" }: SidebarProps) => {
   const tenantId = useTenantId();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentSearch = searchParams.toString();
+  const session = useAuthSession();
   const { data: tenants } = useTenants();
   const tenantName = tenants?.find((tenant) => tenant.id === tenantId)?.name;
   const isSuperAdmin = useIsSuperAdmin();
-  const isResident = useHasRole("RESIDENT");
   const { isImpersonating } = useImpersonation();
 
   if ((isSuperAdmin && !isImpersonating) || !tenantId) return null;
 
+  const activeTenantId = tenantId;
+  const portalContext = resolveAuthorizedPortalContext({
+    session,
+    tenantId: activeTenantId,
+    pathname,
+    searchParamsString: currentSearch,
+  });
+  const isResidentPortal = portalContext === "resident";
+  const dashboardHref = isResidentPortal
+    ? routes.residentDashboard(activeTenantId)
+    : routes.tenantDashboard(activeTenantId);
+
   const isActive = (href: string) =>
     pathname === href || (
-      isResident &&
-      href === `/${tenantId}/resident/tickets` &&
-      pathname.startsWith(`/${tenantId}/tickets/`)
+      isResidentPortal &&
+      href === `/${activeTenantId}/resident/tickets` &&
+      pathname.startsWith(`/${activeTenantId}/tickets/`)
     );
 
   const navItem = (href: string, label: string) => (
@@ -90,9 +105,9 @@ export const Sidebar = ({ className, footer, id, onNavigate, variant = "desktop"
       </div>
 
       <nav className="flex flex-col gap-1 px-2 pb-4">
-        {navItem(routes.tenantDashboard(tenantId), t("navigation.dashboard"))}
+        {navItem(dashboardHref, t("navigation.dashboard"))}
 
-        {isResident ? (
+        {isResidentPortal ? (
           <>
             {navItem(`/${tenantId}/resident/profile`, t("navigation.myProfile"))}
             {navItem(`/${tenantId}/resident/payments`, t("navigation.payments"))}

--- a/apps/web/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/shared/components/layout/Topbar.test.tsx
@@ -13,6 +13,7 @@ import { logout as sharedLogout } from '@/features/auth/login.actions';
 let mockTenantData: Array<{ id: string; name: string; type: 'EDIFICIO_AUTOGESTION' }> = [];
 const mockPush = jest.fn();
 const mockReplace = jest.fn();
+let currentSearch = '';
 
 jest.mock('@/features/notifications/notifications.api', () => ({
   listNotifications: jest.fn(),
@@ -55,6 +56,7 @@ jest.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush, replace: mockReplace }),
   useParams: () => ({ tenantId: 'tenant-1' }),
   usePathname: () => '/tenant-1/dashboard',
+  useSearchParams: () => new URLSearchParams(currentSearch),
 }));
 
 const mockGetUnreadCount = jest.mocked(notificationsApi.getUnreadCount);
@@ -65,11 +67,12 @@ const mockListPendingPayments = jest.mocked(financeApi.listPendingPayments);
 const mockGetSession = jest.mocked(sessionModule.getSession);
 const mockSetSession = jest.mocked(sessionModule.setSession);
 const mockSetLastTenant = jest.mocked(sessionModule.setLastTenant);
+const mockSetLastPortal = jest.mocked(sessionModule.setLastPortal);
 const mockedSharedLogout = jest.mocked(sharedLogout);
 
 const TENANT_ID = 'tenant-1';
 
-let PaymentNotificationBell: React.ComponentType<{ tenantId: string }>;
+let PaymentNotificationBell: React.ComponentType<{ tenantId: string; currentSearch: string }>;
 let Topbar: React.ComponentType<{
   isMobileMenuOpen?: boolean;
   menuButtonRef?: React.RefObject<HTMLButtonElement | null>;
@@ -89,7 +92,7 @@ function renderBell(tenantId = TENANT_ID) {
   return {
     ...render(
       <QueryClientProvider client={queryClient}>
-        <PaymentNotificationBell tenantId={tenantId} />
+        <PaymentNotificationBell tenantId={tenantId} currentSearch={currentSearch} />
       </QueryClientProvider>,
     ),
     queryClient,
@@ -121,6 +124,7 @@ describe('PaymentNotificationBell', () => {
     mockPush.mockReset();
     mockReplace.mockReset();
     mockedSharedLogout.mockReset();
+    currentSearch = '';
     mockGetSession.mockReturnValue({
       user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
       memberships: [{ tenantId: TENANT_ID, roles: ['RESIDENT'] }],
@@ -290,7 +294,7 @@ describe('PaymentNotificationBell', () => {
 
     await waitFor(() => {
       expect(mockMarkAsRead).toHaveBeenCalledWith(TENANT_ID, 'n1');
-      expect(mockPush).toHaveBeenCalledWith('/tenant-1/tickets/ticket-1');
+      expect(mockPush).toHaveBeenCalledWith('/tenant-1/tickets/ticket-1?portal=resident');
     });
   });
 
@@ -1060,6 +1064,7 @@ describe('Topbar responsive tenant selector', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockTenantData = [];
+    currentSearch = '';
     jest.requireMock('next/navigation').useRouter = () => ({ push: jest.fn(), replace: jest.fn() });
   });
 
@@ -1138,6 +1143,51 @@ describe('Topbar responsive tenant selector', () => {
   });
 });
 
+describe('Topbar portal persistence', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTenantData = [];
+    currentSearch = '';
+    mockGetSession.mockReturnValue({
+      user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
+      memberships: [
+        { tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] },
+      ],
+      activeTenantId: 'tenant-1',
+    });
+  });
+
+  it('persists the resident portal when the active route is resident', async () => {
+    jest.requireMock('next/navigation').usePathname = () => '/tenant-1/resident/dashboard';
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Topbar />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockSetLastPortal).toHaveBeenCalledWith('resident');
+    });
+  });
+
+  it('persists the admin portal when the active route is administrative', async () => {
+    jest.requireMock('next/navigation').usePathname = () => '/tenant-1/dashboard';
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    render(
+      <QueryClientProvider client={queryClient}>
+        <Topbar />
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(mockSetLastPortal).toHaveBeenCalledWith('admin');
+    });
+  });
+});
+
 
 function MobileMenuHarness() {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
@@ -1154,6 +1204,7 @@ describe('PaymentNotificationBell drawer coordination', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockTenantData = [];
+    currentSearch = '';
     mockGetSession.mockReturnValue({
       user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
       memberships: [{ tenantId: TENANT_ID, roles: ['RESIDENT'] }],

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { useRouter, useParams, usePathname } from 'next/navigation';
+import { useRouter, useParams, usePathname, useSearchParams } from 'next/navigation';
 import {
-  getSession,
   setSession,
   setLastTenant,
   setLastPortal,
@@ -21,7 +20,11 @@ import { listPendingPayments, PaymentStatus } from '@/features/finance/services/
 import { PushPermissionControl } from '@/features/notifications/components/PushPermissionControl';
 import { resolveNotificationPath } from '@/shared/lib/notification-routes';
 import { getNotificationCategory } from '@/shared/lib/notification-types';
-import { resolveAuthLandingRoute, resolvePortalFromPathname } from '@/features/auth/landing-route';
+import {
+  resolveAuthLandingRoute,
+  resolveAuthorizedPortalContext,
+} from '@/features/auth/landing-route';
+import { useAuthSession } from '@/features/auth/useAuthSession';
 
 const ADMIN_ROLES = new Set(['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR', 'SUPER_ADMIN']);
 
@@ -29,23 +32,31 @@ const POLL_INTERVAL = 30_000;
 
 export function PaymentNotificationBell({
   tenantId,
+  currentSearch,
   isMobileMenuOpen = false,
 }: {
   readonly tenantId: string;
+  readonly currentSearch: string;
   readonly isMobileMenuOpen?: boolean;
 }) {
   const queryClient = useQueryClient();
   const router = useRouter();
   const pathname = usePathname();
+  const session = useAuthSession();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
 
-  const session = getSession();
   const activeMembership = session?.memberships?.find((membership: Membership) => membership.tenantId === tenantId);
   const isAdmin = activeMembership?.roles?.some((candidateRole) => ADMIN_ROLES.has(candidateRole)) ?? false;
   const isResident = activeMembership?.roles?.includes('RESIDENT') ?? false;
-  const portalContext: 'resident' | 'admin' = pathname?.includes('/resident/') ? 'resident' : 'admin';
+  const portalContext =
+    resolveAuthorizedPortalContext({
+      session,
+      tenantId,
+      pathname,
+      searchParamsString: currentSearch,
+    }) ?? 'admin';
   const roleContext = {
     isAdmin,
     isResident,
@@ -392,19 +403,24 @@ export default function Topbar({
   const router = useRouter();
   const params = useParams();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentSearch = searchParams.toString();
   const urlTenantId = typeof params?.tenantId === 'string' ? params.tenantId : undefined;
   const [isLoggingOut, setIsLoggingOut] = useState(false);
-
-  const session = getSession();
+  const session = useAuthSession();
   const { data: tenants, isLoading, error } = useTenants();
-  const currentSearch = typeof window !== 'undefined' ? window.location.search.replace(/^\?/, '') : '';
 
   useEffect(() => {
-    const portal = resolvePortalFromPathname(pathname, currentSearch);
+    const portal = resolveAuthorizedPortalContext({
+      session,
+      tenantId: urlTenantId,
+      pathname,
+      searchParamsString: currentSearch,
+    });
     if (portal) {
       setLastPortal(portal);
     }
-  }, [currentSearch, pathname]);
+  }, [currentSearch, pathname, session, urlTenantId]);
 
   // Determinar tenant activo: URL > session.activeTenantId > memberships[0]
   const activeTenantId =
@@ -416,9 +432,14 @@ export default function Topbar({
 
   // Obtener rol del usuario en el tenant activo
   const activeMembership = session?.memberships.find((m) => m.tenantId === activeTenantId);
-  const currentPortal = resolvePortalFromPathname(pathname, currentSearch);
+  const activePortal = resolveAuthorizedPortalContext({
+    session,
+    tenantId: activeTenantId,
+    pathname,
+    searchParamsString: currentSearch,
+  });
   const role =
-    currentPortal === 'resident' && activeMembership?.roles.includes('RESIDENT')
+    activePortal === 'resident' && activeMembership?.roles.includes('RESIDENT')
       ? 'RESIDENT'
       : activeMembership?.roles.find((candidateRole) => ADMIN_ROLES.has(candidateRole)) ||
         activeMembership?.roles[0] ||
@@ -453,7 +474,7 @@ export default function Topbar({
       resolveAuthLandingRoute({
         session: nextSession,
         preferredTenantId: nextTenantId,
-        preferredPortal: currentPortal,
+        preferredPortal: activePortal,
       }),
     );
   };
@@ -543,7 +564,13 @@ export default function Topbar({
 
         <div className="flex shrink-0 items-center gap-1 sm:gap-3">
         {urlTenantId && <div className="hidden lg:block"><PushPermissionControl /></div>}
-        {urlTenantId && <PaymentNotificationBell tenantId={urlTenantId} isMobileMenuOpen={isMobileMenuOpen} />}
+        {urlTenantId && (
+          <PaymentNotificationBell
+            tenantId={urlTenantId}
+            currentSearch={currentSearch}
+            isMobileMenuOpen={isMobileMenuOpen}
+          />
+        )}
         <span className="hidden items-center rounded-full border border-border bg-muted px-2 py-0.5 text-xs font-medium lg:inline-flex">
           {roleLabel}
         </span>

--- a/apps/web/tests/e2e/resident/resident-journeys.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-journeys.spec.ts
@@ -130,6 +130,36 @@ test.describe('Resident critical journeys', () => {
     await expect(page.getByRole('heading', { name: /mi unidad/i })).toBeVisible();
   });
 
+  test('keeps the mixed portal sidebar aligned with the active context', async ({ page }) => {
+    const tenantId = await login(page, TEST_USERS.residentMixed);
+
+    await page.goto(`/${tenantId}/dashboard`);
+    await expect(page).toHaveURL(new RegExp(`/${tenantId}/dashboard$`));
+    await expect(page.getByRole('heading', { name: /panel de administración/i })).toBeVisible();
+    await expect(page.locator(`aside nav a[href="/${tenantId}/buildings"]`)).toBeVisible();
+    await expect(page.locator(`aside nav a[href="/${tenantId}/units"]`)).toBeVisible();
+    await expect(page.locator(`aside nav a[href="/${tenantId}/finanzas"]`)).toBeVisible();
+    await expect(page.locator(`aside nav a[href="/${tenantId}/resident/profile"]`)).toHaveCount(0);
+    await expect(page.locator(`aside nav a[href="/${tenantId}/resident/payments"]`)).toHaveCount(0);
+    await expect(page.locator(`aside nav a[href="/${tenantId}/resident/unit"]`)).toHaveCount(0);
+
+    await page.goto(`/${tenantId}/resident/dashboard`);
+    await expect(page).toHaveURL(new RegExp(`/${tenantId}/resident/dashboard$`));
+    await expect(page.getByRole('heading', { name: /hola, test resident admin/i })).toBeVisible();
+    await expect(page.locator(`aside nav a[href="/${tenantId}/resident/profile"]`)).toBeVisible();
+    await expect(page.locator(`aside nav a[href="/${tenantId}/resident/payments"]`)).toBeVisible();
+    await expect(page.locator(`aside nav a[href="/${tenantId}/resident/unit"]`)).toBeVisible();
+    await expect(page.locator(`aside nav a[href="/${tenantId}/buildings"]`)).toHaveCount(0);
+    await expect(page.locator(`aside nav a[href="/${tenantId}/units"]`)).toHaveCount(0);
+    await expect(page.locator(`aside nav a[href="/${tenantId}/finanzas"]`)).toHaveCount(0);
+
+    await page.goto(`/${tenantId}/dashboard`);
+    await expect(page).toHaveURL(new RegExp(`/${tenantId}/dashboard$`));
+    await expect(page.getByRole('heading', { name: /panel de administración/i })).toBeVisible();
+    await expect(page.locator(`aside nav a[href="/${tenantId}/buildings"]`)).toBeVisible();
+    await expect(page.locator(`aside nav a[href="/${tenantId}/resident/profile"]`)).toHaveCount(0);
+  });
+
   test('switches the active resident unit and refreshes scoped content', async ({ page }) => {
     const tenantId = await login(page, TEST_USERS.residentMulti);
 


### PR DESCRIPTION
## Resumen

Corrige la navegación inconsistente de usuarios con roles mixtos `RESIDENT + TENANT_ADMIN`.

El portal activo ahora se resuelve mediante ruta + autorización, evitando mostrar navegación residente dentro del dashboard administrativo.

## Cambios

- centraliza la resolución del portal activo autorizado;
- alinea Sidebar y Topbar con la ruta activa;
- mantiene actualizado `bo_last_portal`;
- evita depender de `memberships[0]` en el nuevo helper;
- agrega pruebas unitarias y E2E para cambios entre portal administrativo y residente.

## Validaciones

- pruebas unitarias focalizadas: 71 passed;
- ESLint focalizado: PASS;
- TypeScript web: PASS;
- build web: PASS;
- Playwright focalizado: 1 passed;
- git diff --check: PASS.

Closes #97