### PR TITLE
fix(web): allow mixed-role users to access admin routes

### DIFF
--- a/apps/web/app/(tenant)/[tenantId]/buildings/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/buildings/page.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import Button from '@/shared/components/ui/Button';
-import { useHasRole } from '@/features/auth/useAuthSession';
 import Card from '@/shared/components/ui/Card';
 import EmptyState from '@/shared/components/ui/EmptyState';
 import ErrorState from '@/shared/components/ui/ErrorState';
@@ -15,6 +14,7 @@ import { routes } from '@/shared/lib/routes';
 import { Loader2, Plus, Edit, Trash2, Building2 } from 'lucide-react';
 import Link from 'next/link';
 import { t } from '@/i18n';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
 
 interface TenantParams {
   tenantId: string;
@@ -29,14 +29,14 @@ const BuildingsPage = () => {
   const params = useParams<TenantParams>();
   const tenantId = params?.tenantId;
   const router = useRouter();
-  const isResident = useHasRole('RESIDENT');
+  const portalContext = useAuthorizedPortalContext(tenantId);
   const { toast } = useToast();
 
   useEffect(() => {
-    if (isResident && tenantId) {
-      router.replace(`/${tenantId}/dashboard`);
+    if (portalContext === 'resident' && tenantId) {
+      router.replace(`/${tenantId}/resident/dashboard`);
     }
-  }, [isResident, tenantId, router]);
+  }, [portalContext, tenantId, router]);
 
   const { buildings, loading, error, create, delete: deleteBuilding, refetch } =
     useBuildings(tenantId);
@@ -96,6 +96,7 @@ const BuildingsPage = () => {
   };
 
   if (!tenantId) return <div>{t('common.loading')}</div>;
+  if (portalContext !== 'admin') return <div aria-busy="true" />;
 
   return (
     <div className="space-y-6">

--- a/apps/web/app/(tenant)/[tenantId]/finanzas/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/finanzas/page.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import Link from 'next/link';
 import { useParams, useRouter } from 'next/navigation';
 import { TenantFinanceDashboard } from '@/features/finance/components';
-import { useHasRole } from '@/features/auth/useAuthSession';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
 
 interface Params {
   tenantId: string;
@@ -19,16 +19,20 @@ const TenantFinanzasPage = () => {
   const params = useParams<Params>();
   const tenantId = params?.tenantId;
   const router = useRouter();
-  const isResident = useHasRole('RESIDENT');
+  const portalContext = useAuthorizedPortalContext(tenantId);
 
   useEffect(() => {
-    if (isResident && tenantId) {
-      router.replace(`/${tenantId}/dashboard`);
+    if (portalContext === 'resident' && tenantId) {
+      router.replace(`/${tenantId}/resident/dashboard`);
     }
-  }, [isResident, tenantId, router]);
+  }, [portalContext, tenantId, router]);
 
   if (!tenantId) {
     return <div>Invalid parameters</div>;
+  }
+
+  if (portalContext !== 'admin') {
+    return <div aria-busy="true" />;
   }
 
   return (

--- a/apps/web/app/(tenant)/[tenantId]/reports/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/reports/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { useHasRole } from '@/features/auth/useAuthSession';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
 import { useBuildings } from '@/features/buildings/hooks/useBuildings';
 import { useTicketsReport } from '@/features/reports/hooks/useTicketsReport';
 import { useFinanceReport } from '@/features/reports/hooks/useFinanceReport';
@@ -24,13 +24,13 @@ const ReportsPage = () => {
   const params = useParams();
   const tenantId = params.tenantId as string;
   const router = useRouter();
-  const isResident = useHasRole('RESIDENT');
+  const portalContext = useAuthorizedPortalContext(tenantId);
 
   useEffect(() => {
-    if (isResident && tenantId) {
-      router.replace(`/${tenantId}/dashboard`);
+    if (portalContext === 'resident' && tenantId) {
+      router.replace(`/${tenantId}/resident/dashboard`);
     }
-  }, [isResident, tenantId, router]);
+  }, [portalContext, tenantId, router]);
 
   const [activeTab, setActiveTab] = useState<TabType>('tickets');
   const [selectedBuildingId, setSelectedBuildingId] = useState<string | undefined>();
@@ -67,6 +67,10 @@ const ReportsPage = () => {
     activeTab === 'activity' ? tenantId : undefined,
     { buildingId: filters.buildingId, from: filters.from, to: filters.to }
   );
+
+  if (portalContext !== 'admin') {
+    return <div aria-busy="true" />;
+  }
 
   if (buildingsError) {
     return <ErrorState message={buildingsError} />;

--- a/apps/web/app/(tenant)/[tenantId]/settings/members/MembersPage.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/settings/members/MembersPage.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { useActiveTenantId, useHasRole } from '@/features/auth/useAuthSession';
+import { useActiveTenantId } from '@/features/auth/useAuthSession';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
 import { useCan } from '@/features/rbac/rbac.hooks';
 import { MembersList } from '@/features/tenant-members/components/MembersList';
 import { CreateMemberModal } from '@/features/tenant-members/components/CreateMemberModal';
@@ -56,7 +57,7 @@ export const MembersPage = () => {
     : null;
   const router = useRouter();
   const activeTenantId = useActiveTenantId();
-  const isResident = useHasRole('RESIDENT');
+  const portalContext = useAuthorizedPortalContext(routeTenantId);
   const hasMatchingTenant =
     activeTenantId !== null &&
     routeTenantId !== null &&
@@ -69,12 +70,12 @@ export const MembersPage = () => {
       return;
     }
 
-    if (isResident && tenantId) {
-      router.replace(`/${tenantId}/dashboard`);
+    if (portalContext === 'resident' && tenantId) {
+      router.replace(`/${tenantId}/resident/dashboard`);
     }
-  }, [activeTenantId, isResident, routeTenantId, router, tenantId]);
+  }, [activeTenantId, portalContext, routeTenantId, router, tenantId]);
 
-  if (!tenantId || isResident) {
+  if (!tenantId || portalContext !== 'admin') {
     return <div className="container mx-auto max-w-4xl py-8" aria-busy="true" />;
   }
 

--- a/apps/web/app/(tenant)/[tenantId]/settings/members/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/settings/members/page.test.tsx
@@ -5,6 +5,7 @@
 import { render, screen } from '@testing-library/react';
 import { useParams, useRouter } from 'next/navigation';
 import { useActiveTenantId, useHasRole } from '@/features/auth/useAuthSession';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
 import { useCan } from '@/features/rbac/rbac.hooks';
 import MembersPage from './page';
 
@@ -16,6 +17,10 @@ jest.mock('next/navigation', () => ({
 jest.mock('@/features/auth/useAuthSession', () => ({
   useActiveTenantId: jest.fn(),
   useHasRole: jest.fn(),
+}));
+
+jest.mock('@/features/auth/useAuthorizedPortalContext', () => ({
+  useAuthorizedPortalContext: jest.fn(),
 }));
 
 jest.mock('@/features/rbac/rbac.hooks', () => ({
@@ -38,6 +43,7 @@ const mockedUseParams = jest.mocked(useParams);
 const mockedUseRouter = jest.mocked(useRouter);
 const mockedUseActiveTenantId = jest.mocked(useActiveTenantId);
 const mockedUseHasRole = jest.mocked(useHasRole);
+const mockedUseAuthorizedPortalContext = jest.mocked(useAuthorizedPortalContext);
 const mockedUseCan = jest.mocked(useCan);
 
 describe('MembersPage', () => {
@@ -49,6 +55,7 @@ describe('MembersPage', () => {
     mockedUseRouter.mockReturnValue({ replace } as never);
     mockedUseHasRole.mockReturnValue(false);
     mockedUseCan.mockReturnValue(true);
+    mockedUseAuthorizedPortalContext.mockReturnValue(null);
   });
 
   it('keeps the page gated when the session has no active tenant', () => {

--- a/apps/web/app/(tenant)/[tenantId]/settings/team/TeamPage.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/settings/team/TeamPage.tsx
@@ -3,7 +3,8 @@
 import { useEffect, useState } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import type { Role } from '@buildingos/contracts';
-import { useActiveTenantId, useHasRole } from '@/features/auth/useAuthSession';
+import { useActiveTenantId } from '@/features/auth/useAuthSession';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
 import { useCan } from '@/features/rbac/rbac.hooks';
 import { OperationalMembersList } from '@/features/memberships/components/OperationalMembersList';
 import { PeopleModuleSwitcher } from '@/features/memberships/components/PeopleModuleSwitcher';
@@ -23,7 +24,6 @@ interface TeamPageContentProps {
 const TeamPageContent = ({ tenantId }: TeamPageContentProps) => {
   const { toast } = useToast();
   const canManageMembers = useCan('members.manage');
-  const isResident = useHasRole('RESIDENT');
   const [showInviteModal, setShowInviteModal] = useState(false);
   const {
     pendingInvitations,
@@ -35,20 +35,16 @@ const TeamPageContent = ({ tenantId }: TeamPageContentProps) => {
   } = useInvitations(tenantId);
 
   useEffect(() => {
-    if (!isResident && canManageMembers) {
+    if (canManageMembers) {
       void fetchInvitations();
     }
-  }, [canManageMembers, fetchInvitations, isResident]);
+  }, [canManageMembers, fetchInvitations]);
 
   const handleInvite = async (dto: CreateInvitationRequest) => {
     await createInvitation(dto);
     toast('Invitación enviada', 'success');
     setShowInviteModal(false);
   };
-
-  if (isResident) {
-    return <div className="container mx-auto max-w-4xl py-8" aria-busy="true" />;
-  }
 
   if (!canManageMembers) {
     return (
@@ -117,7 +113,7 @@ export const TeamPage = () => {
     : null;
   const router = useRouter();
   const activeTenantId = useActiveTenantId();
-  const isResident = useHasRole('RESIDENT');
+  const portalContext = useAuthorizedPortalContext(routeTenantId);
   const canManageMembers = useCan('members.manage');
   const hasMatchingTenant =
     activeTenantId !== null &&
@@ -131,12 +127,12 @@ export const TeamPage = () => {
       return;
     }
 
-    if (isResident && tenantId) {
-      router.replace(`/${tenantId}/dashboard`);
+    if (portalContext === 'resident' && tenantId) {
+      router.replace(`/${tenantId}/resident/dashboard`);
     }
-  }, [activeTenantId, isResident, routeTenantId, router, tenantId]);
+  }, [activeTenantId, portalContext, routeTenantId, router, tenantId]);
 
-  if (!tenantId || isResident) {
+  if (!tenantId || portalContext !== 'admin') {
     return <div className="container mx-auto max-w-4xl py-8" aria-busy="true" />;
   }
 

--- a/apps/web/app/(tenant)/[tenantId]/settings/team/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/settings/team/page.test.tsx
@@ -6,6 +6,7 @@ import type { ReactNode } from 'react';
 import { render, screen } from '@testing-library/react';
 import { useParams, useRouter } from 'next/navigation';
 import { useActiveTenantId, useHasRole } from '@/features/auth/useAuthSession';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
 import { useCan } from '@/features/rbac/rbac.hooks';
 import { useInvitations } from '@/features/invitations/hooks/useInvitations';
 import TeamPage from './page';
@@ -18,6 +19,10 @@ jest.mock('next/navigation', () => ({
 jest.mock('@/features/auth/useAuthSession', () => ({
   useActiveTenantId: jest.fn(),
   useHasRole: jest.fn(),
+}));
+
+jest.mock('@/features/auth/useAuthorizedPortalContext', () => ({
+  useAuthorizedPortalContext: jest.fn(),
 }));
 
 jest.mock('@/features/rbac/rbac.hooks', () => ({
@@ -60,6 +65,7 @@ const mockedUseParams = jest.mocked(useParams);
 const mockedUseRouter = jest.mocked(useRouter);
 const mockedUseActiveTenantId = jest.mocked(useActiveTenantId);
 const mockedUseHasRole = jest.mocked(useHasRole);
+const mockedUseAuthorizedPortalContext = jest.mocked(useAuthorizedPortalContext);
 const mockedUseCan = jest.mocked(useCan);
 const mockedUseInvitations = jest.mocked(useInvitations);
 
@@ -72,6 +78,7 @@ describe('TeamPage', () => {
     mockedUseRouter.mockReturnValue({ replace } as never);
     mockedUseHasRole.mockReturnValue(false);
     mockedUseCan.mockReturnValue(true);
+    mockedUseAuthorizedPortalContext.mockReturnValue(null);
     mockedUseInvitations.mockReturnValue({
       members: [],
       pendingInvitations: [],

--- a/apps/web/app/(tenant)/[tenantId]/units/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/units/page.tsx
@@ -2,20 +2,24 @@
 
 import { useEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { useHasRole } from '@/features/auth/useAuthSession';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
 import { UnitsUI } from "../../../../features/units/units.ui";
 
 const UnitsPage = () => {
   const params = useParams();
   const tenantId = params?.tenantId as string;
   const router = useRouter();
-  const isResident = useHasRole('RESIDENT');
+  const portalContext = useAuthorizedPortalContext(tenantId);
 
   useEffect(() => {
-    if (isResident && tenantId) {
-      router.replace(`/${tenantId}/dashboard`);
+    if (portalContext === 'resident' && tenantId) {
+      router.replace(`/${tenantId}/resident/dashboard`);
     }
-  }, [isResident, tenantId, router]);
+  }, [portalContext, tenantId, router]);
+
+  if (portalContext !== 'admin') {
+    return <div aria-busy="true" />;
+  }
 
   return <UnitsUI />;
 };

--- a/apps/web/features/auth/index.ts
+++ b/apps/web/features/auth/index.ts
@@ -32,3 +32,4 @@ export {
   resolveAuthorizedPortalContext,
   resolvePortalFromPathname,
 } from './landing-route';
+export { useAuthorizedPortalContext } from './useAuthorizedPortalContext';

--- a/apps/web/features/auth/landing-route.test.ts
+++ b/apps/web/features/auth/landing-route.test.ts
@@ -186,6 +186,21 @@ describe('landing-route', () => {
     ).toBe('resident');
   });
 
+  it('uses the matching tenant membership instead of memberships[0] for portal resolution', () => {
+    const session = buildSession([
+      { tenantId: 'tenant-1', roles: ['RESIDENT'] },
+      { tenantId: 'tenant-2', roles: ['TENANT_ADMIN'] },
+    ]);
+
+    expect(
+      resolveAuthorizedPortalContext({
+        session,
+        tenantId: 'tenant-2',
+        pathname: '/tenant-2/buildings',
+      }),
+    ).toBe('admin');
+  });
+
   it('returns null when tenantId is missing or does not belong to the session', () => {
     const session = buildSession([
       { tenantId: 'tenant-1', roles: ['RESIDENT'] },

--- a/apps/web/features/auth/useAuthorizedPortalContext.test.tsx
+++ b/apps/web/features/auth/useAuthorizedPortalContext.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { useAuthSession } from '@/features/auth/useAuthSession';
+import type { AuthSession, Role } from './auth.types';
+import { useAuthorizedPortalContext } from './useAuthorizedPortalContext';
+
+let mockPathname = '/tenant-1/dashboard';
+let mockSearchParams = '';
+let mockSession: AuthSession | null = null;
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
+
+jest.mock('@/features/auth/useAuthSession', () => ({
+  useAuthSession: jest.fn(),
+}));
+
+const mockedUsePathname = jest.mocked(usePathname);
+const mockedUseSearchParams = jest.mocked(useSearchParams);
+const mockedUseAuthSession = jest.mocked(useAuthSession);
+
+function buildSession(
+  memberships: Array<{ tenantId: string; roles: Role[] }>,
+  activeTenantId = 'tenant-1',
+): AuthSession {
+  return {
+    user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
+    memberships,
+    activeTenantId,
+  };
+}
+
+function PortalContextProbe({ tenantId }: { tenantId?: string | null }) {
+  const portalContext = useAuthorizedPortalContext(tenantId);
+  return <div data-testid="portal-context">{portalContext ?? 'null'}</div>;
+}
+
+function renderProbe(tenantId?: string | null) {
+  return render(<PortalContextProbe tenantId={tenantId} />);
+}
+
+describe('useAuthorizedPortalContext', () => {
+  beforeEach(() => {
+    mockPathname = '/tenant-1/dashboard';
+    mockSearchParams = '';
+    mockSession = buildSession([{ tenantId: 'tenant-1', roles: ['RESIDENT' as Role] }]);
+
+    mockedUsePathname.mockReturnValue(mockPathname);
+    mockedUseSearchParams.mockReturnValue(new URLSearchParams(mockSearchParams) as never);
+    mockedUseAuthSession.mockReturnValue(mockSession);
+  });
+
+  it.each([
+    '/tenant-1/buildings',
+    '/tenant-1/units',
+    '/tenant-1/finanzas',
+    '/tenant-1/reports',
+    '/tenant-1/settings/members',
+    '/tenant-1/settings/team',
+  ])('returns admin for %s', (pathname) => {
+    mockSession = buildSession([{ tenantId: 'tenant-1', roles: ['TENANT_ADMIN' as Role] }]);
+    mockedUseAuthSession.mockReturnValue(mockSession);
+    mockPathname = pathname;
+    mockedUsePathname.mockReturnValue(pathname);
+    renderProbe('tenant-1');
+    expect(screen.getByTestId('portal-context').textContent).toBe('admin');
+  });
+
+  it('returns resident for the resident route', () => {
+    mockPathname = '/tenant-1/resident/dashboard';
+    mockedUsePathname.mockReturnValue(mockPathname);
+
+    renderProbe('tenant-1');
+
+    expect(screen.getByTestId('portal-context').textContent).toBe('resident');
+  });
+
+  it('returns admin for a mixed user on an admin route', () => {
+    mockSession = buildSession([
+      { tenantId: 'tenant-1', roles: ['RESIDENT' as Role, 'TENANT_ADMIN' as Role] },
+    ]);
+    mockedUseAuthSession.mockReturnValue(mockSession);
+    mockPathname = '/tenant-1/buildings';
+    mockedUsePathname.mockReturnValue(mockPathname);
+
+    renderProbe('tenant-1');
+
+    expect(screen.getByTestId('portal-context').textContent).toBe('admin');
+  });
+
+  it('returns resident for a mixed user on a resident route', () => {
+    mockSession = buildSession([
+      { tenantId: 'tenant-1', roles: ['RESIDENT' as Role, 'TENANT_ADMIN' as Role] },
+    ]);
+    mockedUseAuthSession.mockReturnValue(mockSession);
+    mockPathname = '/tenant-1/resident/payments';
+    mockedUsePathname.mockReturnValue(mockPathname);
+
+    renderProbe('tenant-1');
+
+    expect(screen.getByTestId('portal-context').textContent).toBe('resident');
+  });
+
+  it('returns resident for a resident-only user on an admin route so the page can redirect safely', () => {
+    mockSession = buildSession([{ tenantId: 'tenant-1', roles: ['RESIDENT' as Role] }]);
+    mockedUseAuthSession.mockReturnValue(mockSession);
+    mockPathname = '/tenant-1/buildings';
+    mockedUsePathname.mockReturnValue(mockPathname);
+
+    renderProbe('tenant-1');
+
+    expect(screen.getByTestId('portal-context').textContent).toBe('resident');
+  });
+
+  it('returns null when the tenantId is missing or the user has no membership', () => {
+    renderProbe(null);
+    expect(screen.getByTestId('portal-context').textContent).toBe('null');
+  });
+
+  it('returns null when the user has no membership for the tenant', () => {
+    mockSession = buildSession([{ tenantId: 'tenant-2', roles: ['TENANT_ADMIN' as Role] }]);
+    mockedUseAuthSession.mockReturnValue(mockSession);
+    renderProbe('tenant-1');
+
+    expect(screen.getByTestId('portal-context').textContent).toBe('null');
+  });
+
+  it('does not fall back to memberships[0] when resolving the active tenant portal', () => {
+    mockSession = buildSession([
+      { tenantId: 'tenant-1', roles: ['RESIDENT' as Role] },
+      { tenantId: 'tenant-2', roles: ['TENANT_ADMIN' as Role] },
+    ]);
+    mockedUseAuthSession.mockReturnValue(mockSession);
+    mockPathname = '/tenant-2/buildings';
+    mockedUsePathname.mockReturnValue(mockPathname);
+
+    renderProbe('tenant-2');
+
+    expect(screen.getByTestId('portal-context').textContent).toBe('admin');
+  });
+});

--- a/apps/web/features/auth/useAuthorizedPortalContext.ts
+++ b/apps/web/features/auth/useAuthorizedPortalContext.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import { usePathname, useSearchParams } from 'next/navigation';
+import { resolveAuthorizedPortalContext, type PortalContext } from './landing-route';
+import { useAuthSession } from './useAuthSession';
+
+export function useAuthorizedPortalContext(tenantId: string | null | undefined): PortalContext | null {
+  const session = useAuthSession();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  return resolveAuthorizedPortalContext({
+    session,
+    tenantId: typeof tenantId === 'string' && tenantId.trim().length > 0 ? tenantId.trim() : null,
+    pathname,
+    searchParamsString: searchParams.toString(),
+  });
+}

--- a/apps/web/tests/e2e/resident/resident-journeys.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-journeys.spec.ts
@@ -160,6 +160,29 @@ test.describe('Resident critical journeys', () => {
     await expect(page.locator(`aside nav a[href="/${tenantId}/resident/profile"]`)).toHaveCount(0);
   });
 
+  test('allows mixed-role users to stay on admin routes and keeps resident-only users out', async ({ page }) => {
+    const tenantId = await login(page, TEST_USERS.residentMixed);
+
+    await page.goto(`/${tenantId}/dashboard`);
+    await expect(page).toHaveURL(new RegExp(`/${tenantId}/dashboard$`));
+
+    for (const route of ['buildings', 'units', 'finanzas'] as const) {
+      await page.locator(`aside nav a[href="/${tenantId}/${route}"]`).click();
+      await expect(page).toHaveURL(new RegExp(`/${tenantId}/${route}$`));
+      await expect(page.locator(`aside nav a[href="/${tenantId}/buildings"]`)).toBeVisible();
+      await expect(page.locator(`aside nav a[href="/${tenantId}/resident/profile"]`)).toHaveCount(0);
+    }
+
+    await logout(page);
+
+    const residentTenantId = await login(page, TEST_USERS.resident);
+    await page.goto(`/${residentTenantId}/buildings`);
+
+    await expect(page).toHaveURL(new RegExp(`/${residentTenantId}/resident/dashboard$`));
+    await expect(page.getByRole('heading', { name: /hola, test resident/i })).toBeVisible();
+    await expect(page.locator(`aside nav a[href="/${residentTenantId}/buildings"]`)).toHaveCount(0);
+  });
+
   test('switches the active resident unit and refreshes scoped content', async ({ page }) => {
     const tenantId = await login(page, TEST_USERS.residentMulti);
 


### PR DESCRIPTION
## Resumen

Corrige los guards administrativos que trataban a cualquier usuario con rol `RESIDENT` como si fuera exclusivamente residente.

Los usuarios mixtos `RESIDENT + TENANT_ADMIN` ahora pueden permanecer en rutas administrativas autorizadas, mientras los residentes puros continúan siendo redirigidos a su portal.

## Cambios

- agrega `useAuthorizedPortalContext` como fuente compartida;
- corrige guards en Edificios, Unidades, Finanzas y Reportes;
- corrige acceso en Configuración → Residentes y Equipo;
- evita depender de `useHasRole("RESIDENT")` como criterio exclusivo;
- agrega pruebas unitarias, de componentes y E2E.

## Validaciones

- suite web completa: 78 suites, 672 tests;
- pruebas focalizadas: PASS;
- ESLint focalizado: PASS;
- TypeScript web: PASS;
- build web: PASS;
- Playwright focalizado: PASS;
- git diff --check: PASS.

Closes #99