### PR TITLE
fix(auth): harden resident route and expired-session handling

### DIFF
--- a/apps/web/app/(tenant)/[tenantId]/resident/layout.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/layout.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
+import ResidentLayout from './layout';
+import { useAuthSession } from '@/features/auth/useAuthSession';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
+
+const replace = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+  usePathname: jest.fn(),
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
+
+jest.mock('@/features/auth/useAuthSession', () => ({
+  useAuthSession: jest.fn(),
+}));
+
+jest.mock('@/features/auth/useAuthorizedPortalContext', () => ({
+  useAuthorizedPortalContext: jest.fn(),
+}));
+
+jest.mock('@/features/resident/components/ResidentContextSwitcher', () => ({
+  ResidentContextSwitcher: ({ tenantId }: { tenantId: string }) => (
+    <div data-testid="resident-context-switcher">{tenantId}</div>
+  ),
+}));
+
+const mockedUseParams = jest.mocked(useParams);
+const mockedUsePathname = jest.mocked(usePathname);
+const mockedUseRouter = jest.mocked(useRouter);
+const mockedUseSearchParams = jest.mocked(useSearchParams);
+const mockedUseAuthSession = jest.mocked(useAuthSession);
+const mockedUseAuthorizedPortalContext = jest.mocked(useAuthorizedPortalContext);
+
+function renderLayout(children: React.ReactNode = <div data-testid="page">Contenido</div>) {
+  return render(<ResidentLayout>{children}</ResidentLayout>);
+}
+
+describe('ResidentLayout', () => {
+  beforeEach(() => {
+    replace.mockReset();
+    mockedUseParams.mockReturnValue({ tenantId: 'tenant-1' } as never);
+    mockedUsePathname.mockReturnValue('/tenant-1/resident/dashboard' as never);
+    mockedUseSearchParams.mockReturnValue(new URLSearchParams('') as never);
+    mockedUseRouter.mockReturnValue({ replace } as never);
+    mockedUseAuthSession.mockReturnValue({
+      user: { id: 'user-1', email: 'resident@test.com', name: 'Resident User' },
+      memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT'] }],
+      activeTenantId: 'tenant-1',
+    } as never);
+    mockedUseAuthorizedPortalContext.mockReturnValue('resident');
+  });
+
+  it('authorizes against the tenantId from the route and renders the resident portal', () => {
+    renderLayout();
+
+    expect(mockedUseAuthorizedPortalContext).toHaveBeenCalledWith('tenant-1');
+    expect(screen.getByTestId('resident-context-switcher').textContent).toBe('tenant-1');
+    expect(screen.getByTestId('page').textContent).toBe('Contenido');
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('keeps a valid resident route open even when activeTenantId points elsewhere', () => {
+    mockedUseAuthSession.mockReturnValue({
+      user: { id: 'user-1', email: 'resident@test.com', name: 'Resident User' },
+      memberships: [
+        { tenantId: 'tenant-1', roles: ['RESIDENT'] },
+        { tenantId: 'tenant-2', roles: ['TENANT_ADMIN'] },
+      ],
+      activeTenantId: 'tenant-2',
+    } as never);
+
+    renderLayout();
+
+    expect(screen.getByTestId('resident-context-switcher').textContent).toBe('tenant-1');
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('redirects admin-only access away from the resident portal', async () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue('admin');
+
+    renderLayout();
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/tenant-1/dashboard');
+    });
+  });
+
+  it('treats a mixed-role user as resident when the authorized portal context resolves to resident', () => {
+    mockedUseAuthSession.mockReturnValue({
+      user: { id: 'user-1', email: 'resident@test.com', name: 'Resident Admin' },
+      memberships: [
+        { tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] },
+        { tenantId: 'tenant-2', roles: ['TENANT_ADMIN'] },
+      ],
+      activeTenantId: 'tenant-2',
+    } as never);
+    mockedUseAuthorizedPortalContext.mockReturnValue('resident');
+
+    renderLayout();
+
+    expect(screen.getByTestId('resident-context-switcher').textContent).toBe('tenant-1');
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('rejects a route when the authorized portal context is missing for the tenant', async () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue(null);
+
+    renderLayout();
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/tenant-1/dashboard');
+    });
+  });
+});

--- a/apps/web/app/(tenant)/[tenantId]/resident/layout.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/layout.tsx
@@ -3,7 +3,8 @@
 import type { ReactNode } from 'react';
 import { useEffect } from 'react';
 import { useParams, useRouter, usePathname, useSearchParams } from 'next/navigation';
-import { useHasRole, useAuthSession } from '../../../../features/auth/useAuthSession';
+import { useAuthSession } from '../../../../features/auth/useAuthSession';
+import { useAuthorizedPortalContext } from '../../../../features/auth/useAuthorizedPortalContext';
 import { getSession } from '../../../../features/auth/session.storage';
 import { useBoStorageTick } from '../../../../shared/lib/storage/useBoStorage';
 import { ResidentContextSwitcher } from '../../../../features/resident/components/ResidentContextSwitcher';
@@ -19,15 +20,15 @@ const ResidentLayout = ({ children }: ResidentLayoutProps) => {
   const params = useParams<TenantParams>();
   const tenantId = params?.tenantId ?? '';
   const session = useAuthSession();
-  const isResident = useHasRole('RESIDENT');
+  const portalContext = useAuthorizedPortalContext(tenantId);
   const storageTick = useBoStorageTick();
 
   useEffect(() => {
     if (!session) return;
-    if (!isResident) {
+    if (portalContext !== 'resident') {
       router.replace(`/${tenantId}/dashboard`);
     }
-  }, [session, isResident, tenantId, router, storageTick]);
+  }, [session, portalContext, tenantId, router, storageTick]);
 
   useEffect(() => {
     if (session) {
@@ -46,7 +47,7 @@ const ResidentLayout = ({ children }: ResidentLayoutProps) => {
 
   return (
     <div className="space-y-6">
-      {session && isResident && (
+      {session && portalContext === 'resident' && (
         <ResidentContextSwitcher tenantId={tenantId} />
       )}
       {children}

--- a/apps/web/features/auth/AuthBootstrap.test.tsx
+++ b/apps/web/features/auth/AuthBootstrap.test.tsx
@@ -1,0 +1,216 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, waitFor } from '@testing-library/react';
+import { usePathname, useRouter } from 'next/navigation';
+import { AuthBootstrap } from './AuthBootstrap';
+import { apiMe } from './auth.service';
+import {
+  clearAuth,
+  clearSession,
+  getLastTenant,
+  getSession,
+  setLastTenant,
+  setSession,
+} from './session.storage';
+import { clearAllImpersonationData } from '../impersonation/impersonation.storage';
+import { useToast } from '@/shared/components/ui/Toast';
+import { reportFrontendError } from '@/shared/lib/observability/frontend-observability';
+import { subscribeAuthUnauthorized } from '@/shared/lib/auth/events';
+import { HttpError } from '@/shared/lib/http/client';
+
+jest.mock('next/navigation', () => ({
+  usePathname: jest.fn(),
+  useRouter: jest.fn(),
+}));
+
+jest.mock('@/shared/lib/public-api-url', () => ({
+  getPublicApiUrl: () => 'http://localhost:4000',
+}));
+
+jest.mock('./auth.service', () => ({
+  apiMe: jest.fn(),
+}));
+
+jest.mock('./session.storage', () => ({
+  clearAuth: jest.fn(),
+  clearSession: jest.fn(),
+  getLastTenant: jest.fn(),
+  getSession: jest.fn(),
+  setLastTenant: jest.fn(),
+  setSession: jest.fn(),
+}));
+
+jest.mock('../impersonation/impersonation.storage', () => ({
+  clearAllImpersonationData: jest.fn(),
+}));
+
+jest.mock('@/shared/components/ui/Toast', () => ({
+  useToast: jest.fn(),
+}));
+
+jest.mock('@/shared/lib/observability/frontend-observability', () => ({
+  reportFrontendError: jest.fn(),
+}));
+
+jest.mock('@/shared/lib/auth/events', () => ({
+  subscribeAuthUnauthorized: jest.fn(),
+}));
+
+const mockedUsePathname = jest.mocked(usePathname);
+const mockedUseRouter = jest.mocked(useRouter);
+const mockedApiMe = jest.mocked(apiMe);
+const mockedClearAuth = jest.mocked(clearAuth);
+const mockedClearSession = jest.mocked(clearSession);
+const mockedGetLastTenant = jest.mocked(getLastTenant);
+const mockedGetSession = jest.mocked(getSession);
+const mockedSetLastTenant = jest.mocked(setLastTenant);
+const mockedSetSession = jest.mocked(setSession);
+const mockedClearAllImpersonationData = jest.mocked(clearAllImpersonationData);
+const mockedUseToast = jest.mocked(useToast);
+const mockedReportFrontendError = jest.mocked(reportFrontendError);
+const mockedSubscribeAuthUnauthorized = jest.mocked(subscribeAuthUnauthorized);
+
+function renderBootstrap(pathname = '/tenant-1/dashboard') {
+  window.history.pushState({}, '', pathname);
+  mockedUsePathname.mockReturnValue(pathname);
+  const replace = jest.fn();
+  mockedUseRouter.mockReturnValue({ replace } as never);
+  mockedUseToast.mockReturnValue({ toast: jest.fn() } as never);
+  mockedSubscribeAuthUnauthorized.mockReturnValue(jest.fn());
+
+  render(<AuthBootstrap />);
+
+  return { replace };
+}
+
+describe('AuthBootstrap', () => {
+  const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+
+  beforeEach(() => {
+    mockedApiMe.mockReset();
+    mockedClearAuth.mockReset();
+    mockedClearSession.mockReset();
+    mockedGetLastTenant.mockReset();
+    mockedGetSession.mockReset();
+    mockedSetLastTenant.mockReset();
+    mockedSetSession.mockReset();
+    mockedClearAllImpersonationData.mockReset();
+    mockedUseToast.mockReset();
+    mockedReportFrontendError.mockReset();
+    mockedSubscribeAuthUnauthorized.mockReset();
+    consoleErrorSpy.mockClear();
+    mockedGetLastTenant.mockReturnValue(null);
+    mockedGetSession.mockReturnValue(null);
+  });
+
+  afterAll(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('clears the local session and impersonation data when /auth/me returns 401', async () => {
+    mockedApiMe.mockRejectedValue(new HttpError(401, 'Unauthorized', 'Unauthorized'));
+    const { replace } = renderBootstrap();
+
+    await waitFor(() => {
+      expect(mockedClearAllImpersonationData).toHaveBeenCalledTimes(1);
+      expect(mockedClearSession).toHaveBeenCalledTimes(1);
+      expect(replace).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockedClearAuth).not.toHaveBeenCalled();
+    expect(mockedSetSession).not.toHaveBeenCalled();
+    expect(mockedSetLastTenant).not.toHaveBeenCalled();
+    expect(mockedClearAllImpersonationData.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedClearSession.mock.invocationCallOrder[0],
+    );
+    expect(mockedClearSession.mock.invocationCallOrder[0]).toBeLessThan(
+      replace.mock.invocationCallOrder[0],
+    );
+    expect(replace).toHaveBeenCalledWith('/login?next=%2Ftenant-1%2Fdashboard');
+  });
+
+  it('keeps public routes public when /auth/me returns 401', async () => {
+    mockedApiMe.mockRejectedValue(new HttpError(401, 'Unauthorized', 'Unauthorized'));
+    const { replace } = renderBootstrap('/login');
+
+    await waitFor(() => {
+      expect(mockedClearSession).toHaveBeenCalledTimes(1);
+      expect(mockedClearAllImpersonationData).toHaveBeenCalledTimes(1);
+    });
+
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('preserves the existing non-401 handling for bootstrap failures', async () => {
+    mockedApiMe.mockRejectedValue(new HttpError(500, 'Internal Server Error', 'Boom'));
+    const { replace } = renderBootstrap();
+
+    await waitFor(() => {
+      expect(mockedReportFrontendError).toHaveBeenCalledTimes(1);
+      expect(mockedClearSession).not.toHaveBeenCalled();
+      expect(mockedClearAllImpersonationData).not.toHaveBeenCalled();
+      expect(replace).not.toHaveBeenCalled();
+    });
+
+    expect(mockedClearAuth).not.toHaveBeenCalled();
+  });
+
+  it('restores a valid session and persists the active tenant', async () => {
+    mockedGetLastTenant.mockReturnValue('tenant-b');
+    mockedGetSession.mockReturnValue(null);
+    mockedApiMe.mockResolvedValue({
+      user: { id: 'user-1', email: 'resident@test.com', name: 'Resident' },
+      memberships: [
+        { tenantId: 'tenant-a', roles: ['RESIDENT'] },
+        { tenantId: 'tenant-b', roles: ['TENANT_ADMIN'] },
+      ],
+    });
+
+    renderBootstrap();
+
+    await waitFor(() => {
+      expect(mockedSetSession).toHaveBeenCalledTimes(1);
+      expect(mockedSetLastTenant).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockedClearSession).not.toHaveBeenCalled();
+    expect(mockedClearAllImpersonationData).toHaveBeenCalledTimes(1);
+    expect(mockedSetSession).toHaveBeenCalledWith({
+      user: { id: 'user-1', email: 'resident@test.com', name: 'Resident' },
+      memberships: [
+        { tenantId: 'tenant-a', roles: ['RESIDENT'] },
+        { tenantId: 'tenant-b', roles: ['TENANT_ADMIN'] },
+      ],
+      activeTenantId: 'tenant-b',
+    });
+    expect(mockedSetLastTenant).toHaveBeenCalledWith('tenant-b');
+  });
+
+  it('does not restore a stale session before the 401 cleanup runs', async () => {
+    mockedApiMe.mockRejectedValue(new HttpError(401, 'Unauthorized', 'Unauthorized'));
+    const { replace } = renderBootstrap();
+
+    await waitFor(() => {
+      expect(mockedClearSession).toHaveBeenCalledTimes(1);
+      expect(replace).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockedSetSession).not.toHaveBeenCalled();
+    expect(mockedSetLastTenant).not.toHaveBeenCalled();
+    expect(mockedClearSession.mock.invocationCallOrder[0]).toBeLessThan(
+      replace.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('keeps safe tenant preferences untouched by using clearSession instead of clearAuth', async () => {
+    mockedApiMe.mockRejectedValue(new HttpError(401, 'Unauthorized', 'Unauthorized'));
+    renderBootstrap();
+
+    await waitFor(() => {
+      expect(mockedClearSession).toHaveBeenCalledTimes(1);
+      expect(mockedClearAuth).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/features/auth/AuthBootstrap.tsx
+++ b/apps/web/features/auth/AuthBootstrap.tsx
@@ -6,7 +6,7 @@ import {
   getSession,
   setSession,
   setLastTenant,
-  clearAuth,
+  clearSession,
   getLastTenant,
 } from './session.storage';
 import { apiMe } from './auth.service';
@@ -53,6 +53,11 @@ export const AuthBootstrap = () => {
     }
     didBootstrap.current = true;
 
+    const clearStaleBootstrapAuthState = () => {
+      clearAllImpersonationData();
+      clearSession();
+    };
+
     const performBootstrap = async () => {
       try {
         const response = await apiMe();
@@ -82,13 +87,14 @@ export const AuthBootstrap = () => {
 
         toast(getBootstrapErrorMessage(new Error('Invalid session bootstrap payload')), 'error', 5000);
 
-        clearAllImpersonationData();
-        clearAuth();
+        clearStaleBootstrapAuthState();
         redirectToLoginIfPrivate();
       } catch (error) {
         const is401 = error instanceof HttpError && error.status === 401;
 
         if (is401) {
+          clearStaleBootstrapAuthState();
+          redirectToLoginIfPrivate();
           return;
         }
 

--- a/apps/web/features/auth/useAuthorizedPortalContext.test.tsx
+++ b/apps/web/features/auth/useAuthorizedPortalContext.test.tsx
@@ -131,6 +131,38 @@ describe('useAuthorizedPortalContext', () => {
     expect(screen.getByTestId('portal-context').textContent).toBe('null');
   });
 
+  it('resolves the portal from the route tenant even when activeTenantId points elsewhere', () => {
+    mockSession = buildSession(
+      [
+        { tenantId: 'tenant-1', roles: ['RESIDENT' as Role] },
+        { tenantId: 'tenant-2', roles: ['TENANT_ADMIN' as Role] },
+      ],
+      'tenant-2',
+    );
+    mockedUseAuthSession.mockReturnValue(mockSession);
+    mockPathname = '/tenant-1/resident/dashboard';
+    mockedUsePathname.mockReturnValue(mockPathname);
+
+    renderProbe('tenant-1');
+
+    expect(screen.getByTestId('portal-context').textContent).toBe('resident');
+  });
+
+  it('keeps the result stable regardless of membership order', () => {
+    const memberships = [
+      { tenantId: 'tenant-2', roles: ['TENANT_ADMIN' as Role] },
+      { tenantId: 'tenant-1', roles: ['RESIDENT' as Role] },
+    ];
+    mockSession = buildSession(memberships, 'tenant-2');
+    mockedUseAuthSession.mockReturnValue(mockSession);
+    mockPathname = '/tenant-1/resident/payments';
+    mockedUsePathname.mockReturnValue(mockPathname);
+
+    renderProbe('tenant-1');
+
+    expect(screen.getByTestId('portal-context').textContent).toBe('resident');
+  });
+
   it('does not fall back to memberships[0] when resolving the active tenant portal', () => {
     mockSession = buildSession([
       { tenantId: 'tenant-1', roles: ['RESIDENT' as Role] },

--- a/apps/web/tests/e2e/auth/session.spec.ts
+++ b/apps/web/tests/e2e/auth/session.spec.ts
@@ -38,4 +38,59 @@ test.describe('Auth - Session and Landing Flow', () => {
 
     await expect(page).toHaveURL(new RegExp(`/${tenantId}/dashboard$`));
   });
+
+  test('should clear revoked bootstrap state on /auth/me 401 and keep protected access revoked after reload, back, and forward', async ({
+    page,
+  }) => {
+    const tenantId = await login(page, TEST_USERS.tenantAdminA);
+
+    await page.goto(`/${tenantId}/dashboard`);
+
+    await page.evaluate(() => {
+      localStorage.setItem('bo_impersonation', JSON.stringify({ source: 'test' }));
+      sessionStorage.setItem('bo_impersonation_token', 'impersonation-token');
+      sessionStorage.setItem('bo_impersonation_token_backup', 'impersonation-backup');
+      sessionStorage.setItem('bo_session_sa_backup', 'session-backup');
+    });
+
+    await page.route('**/auth/me', async (route) => {
+      await route.fulfill({
+        status: 401,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'Unauthorized' }),
+      });
+    });
+
+    await page.reload();
+
+    await expect(page).toHaveURL(/\/login(?:\?.*)?$/);
+    await expect(page.getByText(/inicia sesión con tu cuenta/i)).toBeVisible();
+
+    const authStorage = await page.evaluate(() => ({
+      session: localStorage.getItem('bo_session'),
+      lastTenant: localStorage.getItem('bo_last_tenant'),
+      lastPortal: localStorage.getItem('bo_last_portal'),
+      impersonation: localStorage.getItem('bo_impersonation'),
+      impersonationToken: sessionStorage.getItem('bo_impersonation_token'),
+      impersonationTokenBackup: sessionStorage.getItem('bo_impersonation_token_backup'),
+      sessionBackup: sessionStorage.getItem('bo_session_sa_backup'),
+    }));
+
+    expect(authStorage.session).toBeNull();
+    expect(authStorage.impersonation).toBeNull();
+    expect(authStorage.impersonationToken).toBeNull();
+    expect(authStorage.impersonationTokenBackup).toBeNull();
+    expect(authStorage.sessionBackup).toBeNull();
+    expect(authStorage.lastTenant).toBe(tenantId);
+    expect(authStorage.lastPortal).toBe('admin');
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/login(?:\?.*)?$/);
+
+    await page.goForward();
+    await expect(page).toHaveURL(/\/login(?:\?.*)?$/);
+
+    await page.waitForTimeout(300);
+    await expect(page).toHaveURL(/\/login(?:\?.*)?$/);
+  });
 });

--- a/apps/web/tests/e2e/resident/resident-journeys.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-journeys.spec.ts
@@ -118,16 +118,68 @@ test.describe('Resident critical journeys', () => {
     await expect(page.getByRole('heading', { name: /hola, test resident/i })).toBeVisible();
   });
 
-  test('keeps the resident portal available for a mixed RESIDENT + ADMIN user', async ({ page }) => {
-    const tenantId = await login(page, TEST_USERS.residentMixed);
+  test('keeps the resident route tenant when activeTenantId points to a different admin tenant', async ({ page }) => {
+    const tenantBId = await login(page, TEST_USERS.tenantAdminB);
+    await logout(page);
 
-    await page.goto(residentDashboardPath(tenantId));
-    await expect(page).toHaveURL(new RegExp(`/${tenantId}/resident/dashboard$`));
+    const tenantAId = await login(page, TEST_USERS.residentMixed);
+
+    await page.route('**/auth/me', async (route) => {
+      const upstreamResponse = await route.fetch();
+      const body = (await upstreamResponse.json()) as {
+        user: { id: string; email: string; name: string };
+        memberships: Array<{ tenantId: string; roles: string[]; scopedRoles?: unknown }>;
+      };
+
+      const memberships = body.memberships.some((membership) => membership.tenantId === tenantBId)
+        ? body.memberships
+        : [...body.memberships, { tenantId: tenantBId, roles: ['TENANT_ADMIN'] }];
+
+      await route.fulfill({
+        response: upstreamResponse,
+        json: {
+          ...body,
+          memberships,
+        },
+      });
+    });
+
+    await page.evaluate((tenantId) => {
+      localStorage.setItem('bo_last_tenant', tenantId);
+      localStorage.removeItem('bo_session');
+    }, tenantBId);
+
+    await page.goto(residentDashboardPath(tenantAId), { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveURL(new RegExp(`/${tenantAId}/resident/dashboard$`));
+    await expect(page).not.toHaveURL(new RegExp(`/${tenantAId}/dashboard$`));
     await expect(page.getByRole('heading', { name: /hola, test resident admin/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /panel/i })).toHaveAttribute(
+      'href',
+      `/${tenantAId}/resident/dashboard`,
+    );
+    await expect(page.getByRole('link', { name: /mi perfil/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /pagos/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /comunicados/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /solicitudes/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /mi unidad/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /documentos/i })).toBeVisible();
+    await expect(page.locator(`aside nav a[href="/${tenantAId}/buildings"]`)).toHaveCount(0);
+    await expect(page.locator(`aside nav a[href="/${tenantAId}/units"]`)).toHaveCount(0);
+    await expect(page.locator(`aside nav a[href="/${tenantAId}/finanzas"]`)).toHaveCount(0);
 
-    await page.goto(residentUnitPath(tenantId));
-    await expect(page).toHaveURL(new RegExp(`/${tenantId}/resident/unit$`));
-    await expect(page.getByRole('heading', { name: /mi unidad/i })).toBeVisible();
+    const authSession = await page.evaluate(() => {
+      const raw = localStorage.getItem('bo_session');
+      return raw ? JSON.parse(raw) : null;
+    });
+
+    expect(authSession?.activeTenantId).toBe(tenantBId);
+    expect(authSession?.memberships).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ tenantId: tenantAId }),
+        expect.objectContaining({ tenantId: tenantBId }),
+      ]),
+    );
   });
 
   test('keeps the mixed portal sidebar aligned with the active context', async ({ page }) => {


### PR DESCRIPTION
## Resumen

Corrige los dos defectos del límite de autenticación descritos en el issue #101.

### Portal residente

- Autoriza el layout residente usando la membership del `tenantId` de la ruta.
- Evita depender de `activeTenantId` y del orden de las memberships.
- Mantiene acceso correcto para usuarios residentes, administradores y de roles mixtos.

### Sesiones expiradas o revocadas

- Un `401` de `/auth/me` elimina inmediatamente la sesión local obsoleta.
- Elimina también los datos de impersonación.
- Conserva preferencias seguras de tenant y portal.
- Las rutas protegidas terminan en `/login`.
- Reload, back y forward no restauran una sesión revocada.

## Validaciones

- Unitarias: 3 suites, 26 tests aprobados.
- Playwright auth: 5 tests aprobados.
- Playwright resident: 11 tests aprobados.
- ESLint: aprobado.
- TypeScript: aprobado.
- Build web de producción: aprobado.
- `git diff --check`: aprobado.

Closes #101