### PR TITLE
chore(release): add isolated release-staging pipeline

### DIFF
--- a/.github/workflows/deploy-release-staging.yml
+++ b/.github/workflows/deploy-release-staging.yml
@@ -1,0 +1,218 @@
+name: Deploy release-staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: Exact release branch to deploy
+        required: true
+        type: string
+      sha:
+        description: Exact 40-character commit SHA to deploy
+        required: true
+        type: string
+
+concurrency:
+  group: release-staging-deploy
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy release-staging exact SHA
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: release-staging
+    env:
+      RELEASE_BRANCH: ${{ inputs.branch }}
+      DEPLOY_SHA: ${{ inputs.sha }}
+      SSH_HOST: ${{ secrets.RELEASE_STAGING_SSH_HOST }}
+      SSH_USER: ${{ secrets.RELEASE_STAGING_SSH_USER }}
+      SSH_PRIVATE_KEY: ${{ secrets.RELEASE_STAGING_SSH_PRIVATE_KEY }}
+      SSH_KNOWN_HOSTS: ${{ secrets.RELEASE_STAGING_SSH_KNOWN_HOSTS }}
+      SSH_PORT: ${{ vars.RELEASE_STAGING_SSH_PORT || '22' }}
+      REMOTE_DIR: ${{ vars.RELEASE_STAGING_REMOTE_DIR }}
+      COMPOSE_FILE: ${{ vars.RELEASE_STAGING_COMPOSE_FILE }}
+      COMPOSE_PROJECT: ${{ vars.RELEASE_STAGING_COMPOSE_PROJECT }}
+      ENV_FILE: ${{ vars.RELEASE_STAGING_ENV_FILE }}
+      API_HEALTH_URL: ${{ vars.RELEASE_STAGING_API_HEALTH_URL }}
+      API_READY_URL: ${{ vars.RELEASE_STAGING_API_READY_URL }}
+      API_READYZ_URL: ${{ vars.RELEASE_STAGING_API_READYZ_URL }}
+      WEB_LOCAL_URL: ${{ vars.RELEASE_STAGING_WEB_LOCAL_URL }}
+      API_PUBLIC_HEALTH_URL: ${{ vars.RELEASE_STAGING_API_PUBLIC_HEALTH_URL }}
+      WEB_PUBLIC_LOGIN_URL: ${{ vars.RELEASE_STAGING_WEB_PUBLIC_LOGIN_URL }}
+    steps:
+      - name: Validate trusted workflow source and inputs
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          fail() {
+            printf 'ERROR: %s\n' "$1" >&2
+            exit 1
+          }
+
+          [[ "$GITHUB_REF" == "refs/heads/main" ]] || fail "This workflow can only run from refs/heads/main"
+          [[ -n "$RELEASE_BRANCH" ]] || fail "branch input is required"
+          [[ -n "$DEPLOY_SHA" ]] || fail "sha input is required"
+          [[ "$RELEASE_BRANCH" != main ]] || fail "main is not allowed"
+          [[ "$RELEASE_BRANCH" != staging ]] || fail "staging is not allowed"
+          [[ "$RELEASE_BRANCH" != develop ]] || fail "develop is not allowed"
+          [[ "$RELEASE_BRANCH" != master ]] || fail "master is not allowed"
+          [[ "$RELEASE_BRANCH" != feature/* ]] || fail "feature/* branches are not allowed"
+          [[ "$RELEASE_BRANCH" != fix/* ]] || fail "fix/* branches are not allowed"
+          [[ "$RELEASE_BRANCH" != chore/* ]] || fail "chore/* branches are not allowed"
+          [[ "$RELEASE_BRANCH" == release/prod-wave-* ]] || fail "Branch must start with release/prod-wave-"
+          [[ "$RELEASE_BRANCH" != */ ]] || fail "Branch must not end with /"
+          [[ "$RELEASE_BRANCH" != *"//"* ]] || fail "Branch must not contain //"
+          [[ "$RELEASE_BRANCH" != *".."* ]] || fail "Branch must not contain .."
+          [[ "$RELEASE_BRANCH" != *"~"* ]] || fail "Branch must not contain ~"
+          [[ "$RELEASE_BRANCH" != *"^"* ]] || fail "Branch must not contain ^"
+          [[ "$RELEASE_BRANCH" != *":"* ]] || fail "Branch must not contain :"
+          [[ "$RELEASE_BRANCH" != *"?"* ]] || fail "Branch must not contain ?"
+          [[ "$RELEASE_BRANCH" != *"*"* ]] || fail "Branch must not contain *"
+          [[ "$RELEASE_BRANCH" != *"["* ]] || fail "Branch must not contain ["
+          [[ "$RELEASE_BRANCH" != *"\\"* ]] || fail "Branch must not contain backslashes"
+          git check-ref-format --branch "$RELEASE_BRANCH" >/dev/null || fail "Branch contains invalid ref characters"
+          [[ "$RELEASE_BRANCH" =~ ^release/prod-wave-[0-9]+(-[a-z0-9][a-z0-9-]*)?$ ]] || fail "Branch does not match the authorized release pattern"
+          [[ "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "SHA must be exactly 40 lowercase hex characters"
+
+      - name: Checkout requested SHA
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+          fetch-depth: 0
+
+      - name: Validate ancestry and release-staging settings
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          fail() {
+            printf 'ERROR: %s\n' "$1" >&2
+            exit 1
+          }
+
+          require_exact() {
+            local label="$1"
+            local actual="$2"
+            local expected="$3"
+            [[ -n "$actual" ]] || fail "$label is required"
+            [[ "$actual" == "$expected" ]] || fail "$label must be exactly $expected"
+          }
+
+          [[ "$GITHUB_REF" == "refs/heads/main" ]] || fail "Trusted workflow source mismatch"
+          git cat-file -e "${DEPLOY_SHA}^{commit}"
+          git fetch --no-tags origin "+refs/heads/${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}"
+          git show-ref --verify --quiet "refs/remotes/origin/${RELEASE_BRANCH}" || fail "Missing remote ref for ${RELEASE_BRANCH}"
+          git merge-base --is-ancestor "${DEPLOY_SHA}" "refs/remotes/origin/${RELEASE_BRANCH}"
+          test "$(git rev-parse HEAD)" = "${DEPLOY_SHA}"
+
+          require_exact 'RELEASE_STAGING_REMOTE_DIR' "$REMOTE_DIR" '/opt/pawtech/apps/buildingos-release-staging/buildingos-app'
+          require_exact 'RELEASE_STAGING_COMPOSE_FILE' "$COMPOSE_FILE" 'infra/docker/docker-compose.release-staging.yml'
+          require_exact 'RELEASE_STAGING_COMPOSE_PROJECT' "$COMPOSE_PROJECT" 'buildingos-release-staging'
+          require_exact 'RELEASE_STAGING_ENV_FILE' "$ENV_FILE" '/opt/pawtech/env/buildingos-release-staging.env'
+
+          case "$REMOTE_DIR" in
+            ''|'/')
+              fail "Remote directory cannot be empty or /"
+              ;;
+            /opt/pawtech/apps/buildingos|/opt/pawtech/apps/buildingos/*)
+              fail "Production path is not allowed"
+              ;;
+            /opt/pawtech/apps/buildingos-staging|/opt/pawtech/apps/buildingos-staging/*)
+              fail "Staging path is not allowed"
+              ;;
+          esac
+
+          [[ -n "$SSH_HOST" && -n "$SSH_USER" && -n "$SSH_PRIVATE_KEY" && -n "$SSH_KNOWN_HOSTS" ]] || fail "SSH secrets are incomplete"
+          [[ "$SSH_PORT" =~ ^[0-9]+$ ]] || fail "SSH port must be numeric"
+          [[ -n "$API_HEALTH_URL" && -n "$API_READY_URL" && -n "$API_READYZ_URL" && -n "$WEB_LOCAL_URL" && -n "$API_PUBLIC_HEALTH_URL" && -n "$WEB_PUBLIC_LOGIN_URL" ]] || fail "Release-staging URLs are incomplete"
+
+      - name: Prepare SSH material and deploy release-staging
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          fail() {
+            printf 'ERROR: %s\n' "$1" >&2
+            exit 1
+          }
+
+          require_exact() {
+            local label="$1"
+            local actual="$2"
+            local expected="$3"
+            [[ -n "$actual" ]] || fail "$label is required"
+            [[ "$actual" == "$expected" ]] || fail "$label must be exactly $expected"
+          }
+
+          require_exact 'RELEASE_STAGING_REMOTE_DIR' "$REMOTE_DIR" '/opt/pawtech/apps/buildingos-release-staging/buildingos-app'
+          require_exact 'RELEASE_STAGING_COMPOSE_FILE' "$COMPOSE_FILE" 'infra/docker/docker-compose.release-staging.yml'
+          require_exact 'RELEASE_STAGING_COMPOSE_PROJECT' "$COMPOSE_PROJECT" 'buildingos-release-staging'
+          require_exact 'RELEASE_STAGING_ENV_FILE' "$ENV_FILE" '/opt/pawtech/env/buildingos-release-staging.env'
+
+          install -d -m 700 "$HOME/.ssh"
+          key_file="$(mktemp "$HOME/.ssh/release-staging-key.XXXXXX")"
+          known_hosts_file="$(mktemp "$HOME/.ssh/release-staging-known-hosts.XXXXXX")"
+          cleanup() {
+            rm -f "$key_file" "$known_hosts_file"
+          }
+          trap cleanup EXIT
+          chmod 600 "$key_file" "$known_hosts_file"
+          printf '%s\n' "$SSH_PRIVATE_KEY" > "$key_file"
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > "$known_hosts_file"
+
+          ssh_opts=(
+            -i "$key_file"
+            -o UserKnownHostsFile="$known_hosts_file"
+            -o StrictHostKeyChecking=yes
+            -o BatchMode=yes
+            -p "$SSH_PORT"
+            -o ServerAliveInterval=30
+            -o ServerAliveCountMax=6
+          )
+
+          remote_env=(
+            "RELEASE_STAGING_REMOTE_DIR=$REMOTE_DIR"
+            "RELEASE_STAGING_COMPOSE_FILE=$COMPOSE_FILE"
+            "RELEASE_STAGING_COMPOSE_PROJECT=$COMPOSE_PROJECT"
+            "RELEASE_STAGING_ENV_FILE=$ENV_FILE"
+          )
+
+          remote_args=()
+          for arg in "$RELEASE_BRANCH" "$DEPLOY_SHA"; do
+            printf -v quoted '%q' "$arg"
+            remote_args+=("$quoted")
+          done
+
+          deploy_output="$(
+            ssh "${ssh_opts[@]}" "$SSH_USER@$SSH_HOST" "${remote_env[*]} bash -s -- ${remote_args[*]}" < scripts/deploy-release-staging.sh
+          )"
+          printf '%s\n' "$deploy_output"
+
+          remote_head="$(
+            ssh "${ssh_opts[@]}" "$SSH_USER@$SSH_HOST" "cd \"$REMOTE_DIR\" && git rev-parse HEAD"
+          )"
+          remote_status="$(
+            ssh "${ssh_opts[@]}" "$SSH_USER@$SSH_HOST" "cd \"$REMOTE_DIR\" && git status --porcelain --untracked-files=all"
+          )"
+
+          [[ "$remote_head" == "$DEPLOY_SHA" ]] || fail "Remote HEAD does not match the requested SHA"
+          [[ -z "$remote_status" ]] || fail "Remote working tree must be clean"
+
+          {
+            echo "### release-staging deployment"
+            echo "- branch: \`$RELEASE_BRANCH\`"
+            echo "- requested SHA: \`$DEPLOY_SHA\`"
+            echo "- validated SHA: \`$(git rev-parse HEAD)\`"
+            echo "- remote SHA after deploy: \`$remote_head\`"
+            echo "- remote working tree: clean"
+            echo "- compose project: \`$COMPOSE_PROJECT\`"
+            echo "- compose file: \`$COMPOSE_FILE\`"
+            echo "- env file: \`$ENV_FILE\`"
+            echo "- smoke: completed via scripts/deploy-release-staging.sh"
+            echo "- evidence id: \`run-${GITHUB_RUN_ID}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-release-staging.yml
+++ b/.github/workflows/deploy-release-staging.yml
@@ -28,6 +28,8 @@ jobs:
     env:
       RELEASE_BRANCH: ${{ inputs.branch }}
       DEPLOY_SHA: ${{ inputs.sha }}
+      TRUSTED_CONTROL_DIR: trusted-control
+      RELEASE_SOURCE_DIR: release-source
       SSH_HOST: ${{ secrets.RELEASE_STAGING_SSH_HOST }}
       SSH_USER: ${{ secrets.RELEASE_STAGING_SSH_USER }}
       SSH_PRIVATE_KEY: ${{ secrets.RELEASE_STAGING_SSH_PRIVATE_KEY }}
@@ -44,7 +46,23 @@ jobs:
       API_PUBLIC_HEALTH_URL: ${{ vars.RELEASE_STAGING_API_PUBLIC_HEALTH_URL }}
       WEB_PUBLIC_LOGIN_URL: ${{ vars.RELEASE_STAGING_WEB_PUBLIC_LOGIN_URL }}
     steps:
-      - name: Validate trusted workflow source and inputs
+      - name: Checkout trusted control from github.sha
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          path: trusted-control
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout requested release source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+          path: release-source
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate trusted and release checkouts
         shell: bash
         run: |
           set -Eeuo pipefail
@@ -52,6 +70,14 @@ jobs:
           fail() {
             printf 'ERROR: %s\n' "$1" >&2
             exit 1
+          }
+
+          require_exact() {
+            local label="$1"
+            local actual="$2"
+            local expected="$3"
+            [[ -n "$actual" ]] || fail "$label is required"
+            [[ "$actual" == "$expected" ]] || fail "$label must be exactly $expected"
           }
 
           [[ "$GITHUB_REF" == "refs/heads/main" ]] || fail "This workflow can only run from refs/heads/main"
@@ -79,37 +105,15 @@ jobs:
           [[ "$RELEASE_BRANCH" =~ ^release/prod-wave-[0-9]+(-[a-z0-9][a-z0-9-]*)?$ ]] || fail "Branch does not match the authorized release pattern"
           [[ "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "SHA must be exactly 40 lowercase hex characters"
 
-      - name: Checkout requested SHA
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.sha }}
-          fetch-depth: 0
-
-      - name: Validate ancestry and release-staging settings
-        shell: bash
-        run: |
-          set -Eeuo pipefail
-
-          fail() {
-            printf 'ERROR: %s\n' "$1" >&2
-            exit 1
-          }
-
-          require_exact() {
-            local label="$1"
-            local actual="$2"
-            local expected="$3"
-            [[ -n "$actual" ]] || fail "$label is required"
-            [[ "$actual" == "$expected" ]] || fail "$label must be exactly $expected"
-          }
-
-          [[ "$GITHUB_REF" == "refs/heads/main" ]] || fail "Trusted workflow source mismatch"
-          git cat-file -e "${DEPLOY_SHA}^{commit}"
-          git fetch --no-tags origin "+refs/heads/${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}"
-          git show-ref --verify --quiet "refs/remotes/origin/${RELEASE_BRANCH}" || fail "Missing remote ref for ${RELEASE_BRANCH}"
-          git merge-base --is-ancestor "${DEPLOY_SHA}" "refs/remotes/origin/${RELEASE_BRANCH}"
-          test "$(git rev-parse HEAD)" = "${DEPLOY_SHA}"
-
+          require_exact 'trusted control HEAD' "$(git -C "$TRUSTED_CONTROL_DIR" rev-parse HEAD)" "$GITHUB_SHA"
+          require_exact 'release source HEAD' "$(git -C "$RELEASE_SOURCE_DIR" rev-parse HEAD)" "$DEPLOY_SHA"
+          git -C "$RELEASE_SOURCE_DIR" cat-file -e "${DEPLOY_SHA}^{commit}"
+          git -C "$RELEASE_SOURCE_DIR" fetch --no-tags origin "+refs/heads/${RELEASE_BRANCH}:refs/remotes/origin/${RELEASE_BRANCH}"
+          git -C "$RELEASE_SOURCE_DIR" show-ref --verify --quiet "refs/remotes/origin/${RELEASE_BRANCH}" || fail "Missing remote ref for ${RELEASE_BRANCH}"
+          git -C "$RELEASE_SOURCE_DIR" merge-base --is-ancestor "${DEPLOY_SHA}" "refs/remotes/origin/${RELEASE_BRANCH}"
+          test -x "$TRUSTED_CONTROL_DIR/scripts/deploy-release-staging.sh"
+          test -x "$TRUSTED_CONTROL_DIR/scripts/smoke-release-staging.sh"
+          test -x "$TRUSTED_CONTROL_DIR/scripts/rollback-release-staging.sh"
           require_exact 'RELEASE_STAGING_REMOTE_DIR' "$REMOTE_DIR" '/opt/pawtech/apps/buildingos-release-staging/buildingos-app'
           require_exact 'RELEASE_STAGING_COMPOSE_FILE' "$COMPOSE_FILE" 'infra/docker/docker-compose.release-staging.yml'
           require_exact 'RELEASE_STAGING_COMPOSE_PROJECT' "$COMPOSE_PROJECT" 'buildingos-release-staging'
@@ -131,7 +135,7 @@ jobs:
           [[ "$SSH_PORT" =~ ^[0-9]+$ ]] || fail "SSH port must be numeric"
           [[ -n "$API_HEALTH_URL" && -n "$API_READY_URL" && -n "$API_READYZ_URL" && -n "$WEB_LOCAL_URL" && -n "$API_PUBLIC_HEALTH_URL" && -n "$WEB_PUBLIC_LOGIN_URL" ]] || fail "Release-staging URLs are incomplete"
 
-      - name: Prepare SSH material and deploy release-staging
+      - name: Prepare SSH material and run trusted deploy and smoke
         shell: bash
         run: |
           set -Eeuo pipefail
@@ -182,16 +186,25 @@ jobs:
             "RELEASE_STAGING_ENV_FILE=$ENV_FILE"
           )
 
-          remote_args=()
+          remote_deploy_args=()
           for arg in "$RELEASE_BRANCH" "$DEPLOY_SHA"; do
             printf -v quoted '%q' "$arg"
-            remote_args+=("$quoted")
+            remote_deploy_args+=("$quoted")
           done
 
+          remote_smoke_args=()
+          printf -v quoted_smoke '%q' "$DEPLOY_SHA"
+          remote_smoke_args+=("$quoted_smoke")
+
           deploy_output="$(
-            ssh "${ssh_opts[@]}" "$SSH_USER@$SSH_HOST" "${remote_env[*]} bash -s -- ${remote_args[*]}" < scripts/deploy-release-staging.sh
+            ssh "${ssh_opts[@]}" "$SSH_USER@$SSH_HOST" "${remote_env[*]} bash -s -- ${remote_deploy_args[*]}" < "$TRUSTED_CONTROL_DIR/scripts/deploy-release-staging.sh"
           )"
           printf '%s\n' "$deploy_output"
+
+          smoke_output="$(
+            ssh "${ssh_opts[@]}" "$SSH_USER@$SSH_HOST" "${remote_env[*]} bash -s -- ${remote_smoke_args[*]}" < "$TRUSTED_CONTROL_DIR/scripts/smoke-release-staging.sh"
+          )"
+          printf '%s\n' "$smoke_output"
 
           remote_head="$(
             ssh "${ssh_opts[@]}" "$SSH_USER@$SSH_HOST" "cd \"$REMOTE_DIR\" && git rev-parse HEAD"
@@ -207,12 +220,14 @@ jobs:
             echo "### release-staging deployment"
             echo "- branch: \`$RELEASE_BRANCH\`"
             echo "- requested SHA: \`$DEPLOY_SHA\`"
-            echo "- validated SHA: \`$(git rev-parse HEAD)\`"
+            echo "- trusted control SHA: \`$(git -C "$TRUSTED_CONTROL_DIR" rev-parse HEAD)\`"
+            echo "- release source SHA: \`$(git -C "$RELEASE_SOURCE_DIR" rev-parse HEAD)\`"
             echo "- remote SHA after deploy: \`$remote_head\`"
             echo "- remote working tree: clean"
             echo "- compose project: \`$COMPOSE_PROJECT\`"
             echo "- compose file: \`$COMPOSE_FILE\`"
             echo "- env file: \`$ENV_FILE\`"
-            echo "- smoke: completed via scripts/deploy-release-staging.sh"
+            echo "- deploy evidence: \`phase=deploy\`"
+            echo "- smoke evidence: \`phase=smoke\`"
             echo "- evidence id: \`run-${GITHUB_RUN_ID}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/operations/release-staging.md
+++ b/docs/operations/release-staging.md
@@ -6,9 +6,9 @@ Release-staging is a temporary, isolated environment for validating production w
 
 1. Verify the branch follows the release-wave pattern and the SHA belongs to that branch.
 2. Open GitHub Actions and run the `Deploy release-staging` workflow from `main`.
-3. Confirm the Environment, deploy summary, smoke checks, and evidence.
+3. Confirm the Environment, deploy summary, trusted smoke checks, and evidence.
 4. If needed, rerun the exact same SHA to prove idempotency.
-5. Roll back with the rollback script only; do not restore data automatically.
+5. Roll back with the trusted rollback script and then run the trusted smoke script; do not restore data automatically.
 
 ## Architecture
 
@@ -28,6 +28,8 @@ Release-staging is a temporary, isolated environment for validating production w
 | PostgreSQL DB | `buildingos_release_staging_db` |
 | PostgreSQL user | `buildingos_release_staging` |
 | MinIO bucket | `buildingos-release-staging` |
+| MinIO server image | `minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e` |
+| MinIO client image | `minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727` |
 
 ### Services
 
@@ -56,10 +58,10 @@ Release-staging is a temporary, isolated environment for validating production w
 |---|---|
 | `infra/docker/docker-compose.release-staging.yml` | Isolated Compose stack with release-staging-only names, ports, network, and routers. |
 | `infra/docker/.env.release-staging.example` | Placeholder env contract for the release-staging VPS. |
-| `scripts/deploy-release-staging.sh` | Remote deploy orchestration, detached checkout, Compose validation, smoke, and evidence. |
-| `scripts/smoke-release-staging.sh` | Local and public smoke verification for the release-staging deployment. |
-| `scripts/rollback-release-staging.sh` | Roll back to an earlier approved SHA without automatic database restore. |
-| `.github/workflows/deploy-release-staging.yml` | Manual GitHub Actions workflow that validates `main`, branch, SHA, SSH, and evidence. |
+| `scripts/deploy-release-staging.sh` | Remote deploy orchestration, detached checkout, Compose validation, rebuild, and deploy evidence. |
+| `scripts/smoke-release-staging.sh` | Trusted-control smoke verification for the release-staging deployment. |
+| `scripts/rollback-release-staging.sh` | Trusted rollback to an earlier approved SHA without automatic database restore. |
+| `.github/workflows/deploy-release-staging.yml` | Manual GitHub Actions workflow that validates `main`, branch, SHA, SSH, and trusted-control execution. |
 | `docs/operations/release-staging.md` | This runbook. |
 
 ## GitHub Environment
@@ -93,6 +95,8 @@ The exact Environment name is:
 | `RELEASE_STAGING_API_PUBLIC_HEALTH_URL` | Public API health URL used by the workflow. |
 | `RELEASE_STAGING_WEB_PUBLIC_LOGIN_URL` | Public web login URL used by the workflow. |
 
+The release-staging runtime env uses `LOG_LEVEL=log`, which is one of the API-accepted log levels.
+
 No secret values are stored in this repository.
 
 ## Preparing the VPS
@@ -114,6 +118,7 @@ The following checklist is future work. Mark every item as **pending** until the
 - [ ] Backups and metadata directories exist under `/opt/pawtech/apps/buildingos-release-staging`.
 - [ ] Evidence directories exist under `/opt/pawtech/apps/buildingos-release-staging/deployments`.
 - [ ] Log directories exist under `/opt/pawtech/apps/buildingos-release-staging/logs`.
+- [ ] MinIO server and client images are pinned to immutable identifiers.
 
 ## Creating a release branch
 
@@ -173,12 +178,13 @@ The deploy script is responsible for the following:
 4. Fetch the exact branch and verify the SHA belongs to it.
 5. Switch the remote checkout to detached HEAD at the requested SHA.
 6. Verify the working tree is clean.
-7. Render the release-staging Compose configuration.
-8. Start the release-staging services.
-9. Run the smoke checks.
-10. Record sanitized evidence.
+7. Render the release-staging Compose configuration and scan the rendered output for migration commands.
+8. Rebuild the API and Web images while starting the release-staging services.
+9. Run the trusted-control smoke checks after deploy.
+10. Record sanitized deploy evidence.
 
 Wave 0 does **not** run functional migrations.
+The deploy script never executes smoke from the release SHA checkout.
 
 ## Smoke
 
@@ -205,6 +211,8 @@ FAIL criteria:
 - The repository is not in detached HEAD.
 - The working tree is dirty.
 
+The smoke script must always come from `trusted-control/scripts/smoke-release-staging.sh`; the release-source checkout is never trusted for deployment control.
+
 ## Evidence
 
 The workflow and scripts should preserve sanitized evidence only. Record:
@@ -212,12 +220,16 @@ The workflow and scripts should preserve sanitized evidence only. Record:
 - requested branch
 - requested SHA
 - validated SHA
+- trusted control SHA
+- release source SHA
 - remote SHA after deploy
 - working tree status
 - Compose project
 - Compose file
 - env file
-- health and smoke results
+- deploy phase evidence
+- smoke phase evidence
+- rollback phase evidence
 - execution identifier
 
 Evidence is stored under the release-staging evidence directory on the host. Do not store secret values in evidence.
@@ -231,6 +243,7 @@ Expected results:
 - the remote HEAD stays on the same SHA;
 - the Compose project remains `buildingos-release-staging`;
 - the services stay healthy;
+- the images are rebuilt for the selected SHA;
 - no duplicate resources are created;
 - the smoke script still passes.
 
@@ -243,9 +256,9 @@ The rollback procedure:
 1. Select the earlier approved SHA.
 2. Validate the release branch and SHA.
 3. Switch the remote checkout to detached HEAD at the rollback SHA.
-4. Bring up the fixed Compose project.
-5. Run smoke checks again.
-6. Record sanitized rollback evidence.
+4. Rebuild the fixed Compose project.
+5. Record sanitized rollback evidence.
+6. Run the trusted smoke script separately from trusted control.
 
 Important:
 
@@ -325,7 +338,9 @@ Wave 1 may not start until all of the following are true:
 |---|---|
 | Keep release-staging separate from normal staging | It must validate release waves without replacing the always-on staging environment. |
 | Execute the workflow from `main` | This prevents a modified workflow from being run from an untrusted release branch. |
+| Keep deploy and smoke scripts on the trusted ref | Release branches must never be able to replace deployment control logic. |
 | Validate branch and SHA together | The branch proves provenance; the SHA proves the exact deployment target. |
+| Pin MinIO images to immutable digests | Reproducible deploys and rollbacks must not depend on mutable tags. |
 | Avoid functional migrations in Wave 0 | Wave 0 validates the deployment substrate, not schema changes. |
 
 ## References

--- a/docs/operations/release-staging.md
+++ b/docs/operations/release-staging.md
@@ -1,0 +1,338 @@
+# BuildingOS release-staging runbook
+
+Release-staging is a temporary, isolated environment for validating production waves before they are allowed to reach production. It is **not** production, it does **not** replace the normal staging environment, it does **not** deploy `main`, and it only accepts release branches that match `release/prod-wave-*`.
+
+## Quick path
+
+1. Verify the branch follows the release-wave pattern and the SHA belongs to that branch.
+2. Open GitHub Actions and run the `Deploy release-staging` workflow from `main`.
+3. Confirm the Environment, deploy summary, smoke checks, and evidence.
+4. If needed, rerun the exact same SHA to prove idempotency.
+5. Roll back with the rollback script only; do not restore data automatically.
+
+## Architecture
+
+| Topic | Value |
+|---|---|
+| Remote root | `/opt/pawtech/apps/buildingos-release-staging` |
+| Remote checkout | `/opt/pawtech/apps/buildingos-release-staging/buildingos-app` |
+| Compose project | `buildingos-release-staging` |
+| Compose file | `infra/docker/docker-compose.release-staging.yml` |
+| Runtime env file | `/opt/pawtech/env/buildingos-release-staging.env` |
+| Backups | `/opt/pawtech/apps/buildingos-release-staging/backups` |
+| Backup metadata | `/opt/pawtech/apps/buildingos-release-staging/backups/metadata` |
+| Evidence | `/opt/pawtech/apps/buildingos-release-staging/deployments` |
+| Logs | `/opt/pawtech/apps/buildingos-release-staging/logs` |
+| Internal network | `buildingos_release_staging_net` |
+| Shared proxy network | `pawtech_public` |
+| PostgreSQL DB | `buildingos_release_staging_db` |
+| PostgreSQL user | `buildingos_release_staging` |
+| MinIO bucket | `buildingos-release-staging` |
+
+### Services
+
+| Service | Container | Purpose | Local port |
+|---|---|---|---|
+| PostgreSQL | `buildingos-release-staging-postgres` | Database for release-staging | `127.0.0.1:5435:5432` |
+| Redis | `buildingos-release-staging-redis` | Cache / queue support | `127.0.0.1:6382:6379` |
+| MinIO | `buildingos-release-staging-minio` | S3-compatible storage | `127.0.0.1:9120:9000` |
+| MinIO console | `buildingos-release-staging-minio` | Console on the same container | `127.0.0.1:9121:9001` |
+| Bucket creator | `buildingos-release-staging-mc` | Creates the release bucket | no host port |
+| Mailpit | `buildingos-release-staging-mailpit` | Local email sink | `127.0.0.1:8027:8025` |
+| API | `buildingos-release-staging-api` | Backend service | `127.0.0.1:4020:3000` |
+| Web | `buildingos-release-staging-web` | Frontend service | `127.0.0.1:4021:3000` |
+
+### Public URLs
+
+| Purpose | URL | Traefik router |
+|---|---|---|
+| Web | `https://buildingos-release-staging.31-220-98-21.sslip.io` | `buildingos-release-staging` |
+| API | `https://buildingos-api-release-staging.31-220-98-21.sslip.io` | `buildingos-api-release-staging` |
+| Files | `https://buildingos-release-staging-files.31-220-98-21.sslip.io` | `buildingos-release-staging-files` |
+
+## Wave 0 files
+
+| File | Responsibility |
+|---|---|
+| `infra/docker/docker-compose.release-staging.yml` | Isolated Compose stack with release-staging-only names, ports, network, and routers. |
+| `infra/docker/.env.release-staging.example` | Placeholder env contract for the release-staging VPS. |
+| `scripts/deploy-release-staging.sh` | Remote deploy orchestration, detached checkout, Compose validation, smoke, and evidence. |
+| `scripts/smoke-release-staging.sh` | Local and public smoke verification for the release-staging deployment. |
+| `scripts/rollback-release-staging.sh` | Roll back to an earlier approved SHA without automatic database restore. |
+| `.github/workflows/deploy-release-staging.yml` | Manual GitHub Actions workflow that validates `main`, branch, SHA, SSH, and evidence. |
+| `docs/operations/release-staging.md` | This runbook. |
+
+## GitHub Environment
+
+The exact Environment name is:
+
+- `release-staging`
+
+### Secrets
+
+| Secret | Purpose |
+|---|---|
+| `RELEASE_STAGING_SSH_HOST` | SSH host for the release-staging VPS. |
+| `RELEASE_STAGING_SSH_USER` | SSH user for the release-staging VPS. |
+| `RELEASE_STAGING_SSH_PRIVATE_KEY` | Private key used for SSH authentication. |
+| `RELEASE_STAGING_SSH_KNOWN_HOSTS` | Approved known-hosts entry for strict host checking. |
+
+### Variables
+
+| Variable | Purpose |
+|---|---|
+| `RELEASE_STAGING_SSH_PORT` | SSH port, default `22` if not overridden. |
+| `RELEASE_STAGING_REMOTE_DIR` | Must be `/opt/pawtech/apps/buildingos-release-staging/buildingos-app`. |
+| `RELEASE_STAGING_COMPOSE_FILE` | Must be `infra/docker/docker-compose.release-staging.yml`. |
+| `RELEASE_STAGING_COMPOSE_PROJECT` | Must be `buildingos-release-staging`. |
+| `RELEASE_STAGING_ENV_FILE` | Must be `/opt/pawtech/env/buildingos-release-staging.env`. |
+| `RELEASE_STAGING_API_HEALTH_URL` | Public or local health evidence URL for the API. |
+| `RELEASE_STAGING_API_READY_URL` | Public or local readiness evidence URL for the API. |
+| `RELEASE_STAGING_API_READYZ_URL` | Readiness alias URL for orchestrator compatibility. |
+| `RELEASE_STAGING_WEB_LOCAL_URL` | Local web URL used by the workflow. |
+| `RELEASE_STAGING_API_PUBLIC_HEALTH_URL` | Public API health URL used by the workflow. |
+| `RELEASE_STAGING_WEB_PUBLIC_LOGIN_URL` | Public web login URL used by the workflow. |
+
+No secret values are stored in this repository.
+
+## Preparing the VPS
+
+The following checklist is future work. Mark every item as **pending** until the VPS is provisioned and verified.
+
+- [ ] Capacity is available for a separate release-staging stack.
+- [ ] The release-staging host ports are free: `4020`, `4021`, `5435`, `6382`, `9120`, `9121`, `8027`.
+- [ ] The remote root exists: `/opt/pawtech/apps/buildingos-release-staging`.
+- [ ] The remote checkout exists: `/opt/pawtech/apps/buildingos-release-staging/buildingos-app`.
+- [ ] The runtime env file exists at `/opt/pawtech/env/buildingos-release-staging.env`.
+- [ ] The release-staging PostgreSQL database is provisioned separately from staging and production.
+- [ ] The release-staging Redis instance or namespace is isolated.
+- [ ] The release-staging MinIO instance is isolated and the bucket `buildingos-release-staging` exists.
+- [ ] Mailpit is available for release-staging and does not expose SMTP on the host.
+- [ ] The release-staging Compose project uses `buildingos-release-staging`.
+- [ ] The release-staging network uses `buildingos_release_staging_net`.
+- [ ] Traefik routes only the three intended public services.
+- [ ] Backups and metadata directories exist under `/opt/pawtech/apps/buildingos-release-staging`.
+- [ ] Evidence directories exist under `/opt/pawtech/apps/buildingos-release-staging/deployments`.
+- [ ] Log directories exist under `/opt/pawtech/apps/buildingos-release-staging/logs`.
+
+## Creating a release branch
+
+Create release branches from the approved production SHA, not from `main`.
+
+Branch name pattern:
+
+- `release/prod-wave-<n>-<nombre>`
+
+Rules:
+
+- The branch must begin with `release/prod-wave-`.
+- It must not be `main`, `staging`, `develop`, `feature/*`, `fix/*`, or `chore/*`.
+- The branch SHA and the release branch name must be validated together.
+- The SHA deployed by the workflow must belong to the selected release branch.
+
+## Running the workflow
+
+1. Open **GitHub Actions** in the repository.
+2. Select **Deploy release-staging**.
+3. Run it from the definition on `main`.
+4. Provide the required inputs:
+   - `branch`
+   - `sha`
+5. Confirm the selected Environment is `release-staging`.
+6. Review the workflow summary after it completes.
+
+Important:
+
+- `github.ref` must be `refs/heads/main`.
+- `inputs.branch` identifies the release branch to deploy.
+- The workflow must reject `main` as an input branch.
+
+## Prechecks before deploy
+
+Before deploying, confirm all of the following:
+
+- [ ] The branch matches `release/prod-wave-*`.
+- [ ] The SHA is exactly 40 lowercase hexadecimal characters.
+- [ ] The SHA belongs to the selected release branch.
+- [ ] The GitHub Environment `release-staging` is configured.
+- [ ] The VPS is provisioned and reachable.
+- [ ] The runtime env file exists and is readable on the host.
+- [ ] The remote working tree is clean.
+- [ ] A rollback SHA is recorded.
+- [ ] A backup is available when the wave requires one.
+- [ ] Production remains intact.
+- [ ] The normal staging environment remains intact.
+
+## Deploy
+
+The deploy script is responsible for the following:
+
+1. Validate the branch and SHA.
+2. Validate the release-staging remote directory and fixed file paths.
+3. Confirm the remote repository is present.
+4. Fetch the exact branch and verify the SHA belongs to it.
+5. Switch the remote checkout to detached HEAD at the requested SHA.
+6. Verify the working tree is clean.
+7. Render the release-staging Compose configuration.
+8. Start the release-staging services.
+9. Run the smoke checks.
+10. Record sanitized evidence.
+
+Wave 0 does **not** run functional migrations.
+
+## Smoke
+
+The smoke script checks the following endpoints:
+
+- API `GET /health`
+- API `GET /ready`
+- API `GET /readyz`
+- Web `GET /login`
+- Public API health URL
+- Public web login URL
+
+PASS criteria:
+
+- `GET /health` returns HTTP 200 and a JSON body with `status: "ok"`.
+- `GET /ready` and `GET /readyz` return HTTP 200 when readiness is healthy or degraded.
+- `GET /login` returns the login page and includes the BuildingOS login shell.
+- Public health and login checks return HTTP 200.
+
+FAIL criteria:
+
+- Any endpoint returns a non-200 status when the script expects 200.
+- The readiness payload is malformed.
+- The repository is not in detached HEAD.
+- The working tree is dirty.
+
+## Evidence
+
+The workflow and scripts should preserve sanitized evidence only. Record:
+
+- requested branch
+- requested SHA
+- validated SHA
+- remote SHA after deploy
+- working tree status
+- Compose project
+- Compose file
+- env file
+- health and smoke results
+- execution identifier
+
+Evidence is stored under the release-staging evidence directory on the host. Do not store secret values in evidence.
+
+## Redeploy idempotency
+
+To prove idempotency, rerun the same branch and same SHA after a successful deployment.
+
+Expected results:
+
+- the remote HEAD stays on the same SHA;
+- the Compose project remains `buildingos-release-staging`;
+- the services stay healthy;
+- no duplicate resources are created;
+- the smoke script still passes.
+
+## Rollback
+
+Use the rollback script only for release-staging and only with a previously approved SHA.
+
+The rollback procedure:
+
+1. Select the earlier approved SHA.
+2. Validate the release branch and SHA.
+3. Switch the remote checkout to detached HEAD at the rollback SHA.
+4. Bring up the fixed Compose project.
+5. Run smoke checks again.
+6. Record sanitized rollback evidence.
+
+Important:
+
+- The rollback script does **not** restore the database automatically.
+- The rollback script does **not** revert migrations automatically.
+- If a future wave includes migrations, backup and restore must be handled separately.
+
+## Backup and restore
+
+Release-staging backups are required before higher-risk waves or any wave that changes data.
+
+Model:
+
+- back up the release-staging database only;
+- validate the dump checksum;
+- keep 7 daily backups and 4 weekly backups;
+- restore to a temporary or isolated database before trusting the backup.
+
+Restore remains a separate operation. Do not overwrite production or normal staging during backup validation.
+
+## Cleanup
+
+Cleanup must target release-staging only.
+
+Checklist:
+
+- [ ] Remove the release-staging containers only.
+- [ ] Remove the release-staging volumes only.
+- [ ] Remove the release-staging network only.
+- [ ] Remove the release-staging database only.
+- [ ] Remove the release-staging bucket only.
+- [ ] Remove the release-staging routers only.
+- [ ] Remove the release-staging checkout only.
+- [ ] Remove release-staging secrets only if a future admin process explicitly allows it.
+- [ ] Retain evidence according to the retention policy.
+
+Do not affect:
+
+- `/opt/pawtech/apps/buildingos`
+- `/opt/pawtech/apps/buildingos-staging`
+- production containers
+- normal staging containers
+
+## Negative checks
+
+The following situations must fail before any deployment effect:
+
+- running the workflow from a ref other than `main`
+- using an unauthorized branch
+- using an invalid SHA
+- using a SHA that does not exist
+- using a SHA that does not belong to the selected branch
+- using the wrong remote path
+- missing or incomplete Environment settings
+- failing health checks
+- a dirty remote working tree
+
+## Wave 1 gate
+
+Wave 1 may not start until all of the following are true:
+
+- [ ] The Wave 0 PR has been reviewed and approved.
+- [ ] The `release-staging` Environment is configured.
+- [ ] The VPS is provisioned.
+- [ ] The workflow has executed successfully.
+- [ ] The same SHA has been redeployed successfully.
+- [ ] Isolation has been verified.
+- [ ] Smoke checks passed.
+- [ ] Rollback was tested.
+- [ ] Cleanup was tested or validated.
+- [ ] Production stayed intact.
+- [ ] Normal staging stayed intact.
+
+## Decision record
+
+| Decision | Why |
+|---|---|
+| Keep release-staging separate from normal staging | It must validate release waves without replacing the always-on staging environment. |
+| Execute the workflow from `main` | This prevents a modified workflow from being run from an untrusted release branch. |
+| Validate branch and SHA together | The branch proves provenance; the SHA proves the exact deployment target. |
+| Avoid functional migrations in Wave 0 | Wave 0 validates the deployment substrate, not schema changes. |
+
+## References
+
+- `infra/docker/docker-compose.release-staging.yml`
+- `infra/docker/.env.release-staging.example`
+- `scripts/deploy-release-staging.sh`
+- `scripts/smoke-release-staging.sh`
+- `scripts/rollback-release-staging.sh`
+- `.github/workflows/deploy-release-staging.yml`

--- a/infra/docker/.env.release-staging.example
+++ b/infra/docker/.env.release-staging.example
@@ -67,6 +67,6 @@ FEATURE_PORTAL_RESIDENT=true
 FEATURE_PAYMENTS_MVP=true
 
 # --- Observability ---
-LOG_LEVEL=info
+LOG_LEVEL=log
 SENTRY_DSN=
 SENTRY_ENVIRONMENT=release-staging

--- a/infra/docker/.env.release-staging.example
+++ b/infra/docker/.env.release-staging.example
@@ -1,0 +1,72 @@
+# =============================================================================
+# BuildingOS - Release Staging Environment Example
+# =============================================================================
+# Copy this file to the release-staging VPS as:
+#   /opt/pawtech/env/buildingos-release-staging.env
+# Never commit the real file with secrets.
+# =============================================================================
+
+# --- Environment ---
+APP_ENV=release-staging
+NODE_ENV=production
+
+# --- Service ports on the VPS host ---
+API_PORT=4020
+WEB_PORT=4021
+POSTGRES_PORT=5435
+REDIS_PORT=6382
+MINIO_API_PORT=9120
+MINIO_CONSOLE_PORT=9121
+MAILPIT_UI_PORT=8027
+
+# --- PostgreSQL ---
+POSTGRES_USER=buildingos_release_staging
+POSTGRES_PASSWORD=REPLACE_WITH_RELEASE_STAGING_POSTGRES_PASSWORD
+POSTGRES_DB=buildingos_release_staging_db
+
+# --- Redis ---
+REDIS_URL=redis://redis:6379
+
+# --- Web / API URLs ---
+WEB_ORIGIN=https://buildingos-release-staging.31-220-98-21.sslip.io
+APP_BASE_URL=https://buildingos-release-staging.31-220-98-21.sslip.io
+API_URL=https://buildingos-api-release-staging.31-220-98-21.sslip.io
+
+# --- JWT / Auth ---
+JWT_SECRET=REPLACE_WITH_RELEASE_STAGING_JWT_SECRET_64_CHARS_MINIMUM
+JWT_EXPIRES_IN=24h
+
+# --- Storage / MinIO ---
+MINIO_ROOT_USER=REPLACE_WITH_RELEASE_STAGING_MINIO_ROOT_USER
+MINIO_ROOT_PASSWORD=REPLACE_WITH_RELEASE_STAGING_MINIO_ROOT_PASSWORD
+S3_ENDPOINT=http://minio:9000
+S3_REGION=us-east-1
+S3_BUCKET=buildingos-release-staging
+S3_PUBLIC_BASE_URL=https://buildingos-release-staging-files.31-220-98-21.sslip.io
+S3_FORCE_PATH_STYLE=true
+
+# --- Mail / Payments ---
+MAIL_PROVIDER=smtp
+MAIL_FROM=BuildingOS Release Staging <no-reply@buildingos.local>
+SMTP_HOST=mailpit
+SMTP_PORT=1025
+SMTP_USER=
+SMTP_PASS=
+SALES_TEAM_EMAIL=
+INFO_EMAIL=
+PAYMENT_PROVIDER=none
+
+# --- Assistant / AI ---
+AI_PROVIDER=none
+AI_OLLAMA_URL=
+AI_OLLAMA_MODEL=
+AI_CLASSIFIER_MODEL=
+
+# --- Feature flags ---
+FEATURE_PORTAL_RESIDENT=true
+FEATURE_PAYMENTS_MVP=true
+
+# --- Observability ---
+LOG_LEVEL=info
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=release-staging

--- a/infra/docker/docker-compose.release-staging.yml
+++ b/infra/docker/docker-compose.release-staging.yml
@@ -49,7 +49,7 @@ services:
     restart: unless-stopped
 
   minio:
-    image: minio/minio:latest
+    image: minio/minio@sha256:14cea493d9a34af32f524e538b8346cf79f3321eff8e708c1e2960462bd8936e
     container_name: buildingos-release-staging-minio
     networks:
       - buildingos_release_staging_net
@@ -80,7 +80,7 @@ services:
     restart: unless-stopped
 
   createbuckets:
-    image: minio/mc:latest
+    image: minio/mc@sha256:a7fe349ef4bd8521fb8497f55c6042871b2ae640607cf99d9bede5e9bdf11727
     container_name: buildingos-release-staging-mc
     networks:
       - buildingos_release_staging_net

--- a/infra/docker/docker-compose.release-staging.yml
+++ b/infra/docker/docker-compose.release-staging.yml
@@ -1,0 +1,223 @@
+name: buildingos-release-staging
+
+networks:
+  buildingos_release_staging_net:
+    name: buildingos_release_staging_net
+    driver: bridge
+  pawtech_public:
+    external: true
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: buildingos-release-staging-postgres
+    networks:
+      - buildingos_release_staging_net
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:?POSTGRES_USER is required}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
+      POSTGRES_DB: ${POSTGRES_DB:?POSTGRES_DB is required}
+    ports:
+      - "127.0.0.1:${POSTGRES_PORT:-5435}:5432"
+    volumes:
+      - buildingos_release_staging_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${POSTGRES_USER:-buildingos_release_staging} -d ${POSTGRES_DB:-buildingos_release_staging_db}",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  redis:
+    image: redis:7-alpine
+    container_name: buildingos-release-staging-redis
+    networks:
+      - buildingos_release_staging_net
+    ports:
+      - "127.0.0.1:${REDIS_PORT:-6382}:6379"
+    volumes:
+      - buildingos_release_staging_redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  minio:
+    image: minio/minio:latest
+    container_name: buildingos-release-staging-minio
+    networks:
+      - buildingos_release_staging_net
+      - pawtech_public
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
+      S3_BUCKET: ${S3_BUCKET:?S3_BUCKET is required}
+    ports:
+      - "127.0.0.1:${MINIO_API_PORT:-9120}:9000"
+      - "127.0.0.1:${MINIO_CONSOLE_PORT:-9121}:9001"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=pawtech_public"
+      - "traefik.http.routers.buildingos-release-staging-files.rule=Host(`buildingos-release-staging-files.31-220-98-21.sslip.io`)"
+      - "traefik.http.routers.buildingos-release-staging-files.entrypoints=websecure"
+      - "traefik.http.routers.buildingos-release-staging-files.tls=true"
+      - "traefik.http.routers.buildingos-release-staging-files.tls.certresolver=letsencrypt"
+      - "traefik.http.services.buildingos-release-staging-files.loadbalancer.server.port=9000"
+    volumes:
+      - buildingos_release_staging_miniodata:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  createbuckets:
+    image: minio/mc:latest
+    container_name: buildingos-release-staging-mc
+    networks:
+      - buildingos_release_staging_net
+    depends_on:
+      minio:
+        condition: service_healthy
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
+      S3_BUCKET: ${S3_BUCKET:?S3_BUCKET is required}
+    entrypoint:
+      - /bin/sh
+      - -c
+      - >
+        mc alias set myminio http://minio:9000 ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required} ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required};
+        mc mb --ignore-existing myminio/${S3_BUCKET:?S3_BUCKET is required};
+        exit 0;
+    restart: on-failure
+
+  mailpit:
+    image: axllent/mailpit:v1.30.0
+    container_name: buildingos-release-staging-mailpit
+    networks:
+      - buildingos_release_staging_net
+    ports:
+      - "127.0.0.1:${MAILPIT_UI_PORT:-8027}:8025"
+    restart: unless-stopped
+
+  buildingos-api:
+    build:
+      context: ../../
+      dockerfile: apps/api/Dockerfile
+    container_name: buildingos-release-staging-api
+    networks:
+      - buildingos_release_staging_net
+      - pawtech_public
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+      mailpit:
+        condition: service_started
+    ports:
+      - "127.0.0.1:${API_PORT:-4020}:3000"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=pawtech_public"
+      - "traefik.http.routers.buildingos-api-release-staging.rule=Host(`buildingos-api-release-staging.31-220-98-21.sslip.io`)"
+      - "traefik.http.routers.buildingos-api-release-staging.entrypoints=websecure"
+      - "traefik.http.routers.buildingos-api-release-staging.tls=true"
+      - "traefik.http.routers.buildingos-api-release-staging.tls.certresolver=letsencrypt"
+      - "traefik.http.services.buildingos-api-release-staging.loadbalancer.server.port=3000"
+    environment:
+      APP_ENV: release-staging
+      NODE_ENV: ${NODE_ENV:?NODE_ENV is required}
+      DATABASE_URL: postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB is required}
+      REDIS_URL: ${REDIS_URL:?REDIS_URL is required}
+      WEB_ORIGIN: ${WEB_ORIGIN:?WEB_ORIGIN is required}
+      APP_BASE_URL: ${APP_BASE_URL:?APP_BASE_URL is required}
+      S3_ENDPOINT: http://minio:9000
+      S3_REGION: ${S3_REGION:?S3_REGION is required}
+      S3_ACCESS_KEY: ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required}
+      S3_SECRET_KEY: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
+      S3_BUCKET: ${S3_BUCKET:?S3_BUCKET is required}
+      S3_FORCE_PATH_STYLE: "true"
+      S3_PUBLIC_BASE_URL: ${S3_PUBLIC_BASE_URL:?S3_PUBLIC_BASE_URL is required}
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
+      JWT_EXPIRES_IN: ${JWT_EXPIRES_IN:?JWT_EXPIRES_IN is required}
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-release-staging}
+      MAIL_PROVIDER: ${MAIL_PROVIDER:?MAIL_PROVIDER is required}
+      MAIL_FROM: ${MAIL_FROM:?MAIL_FROM is required}
+      SMTP_HOST: ${SMTP_HOST:-}
+      SMTP_PORT: ${SMTP_PORT:-}
+      SMTP_USER: ${SMTP_USER:-}
+      SMTP_PASS: ${SMTP_PASS:-}
+      SALES_TEAM_EMAIL: ${SALES_TEAM_EMAIL:-}
+      INFO_EMAIL: ${INFO_EMAIL:-}
+      PAYMENT_PROVIDER: ${PAYMENT_PROVIDER:?PAYMENT_PROVIDER is required}
+      AI_PROVIDER: ${AI_PROVIDER:?AI_PROVIDER is required}
+      AI_OLLAMA_URL: ${AI_OLLAMA_URL:-}
+      AI_OLLAMA_MODEL: ${AI_OLLAMA_MODEL:-}
+      AI_CLASSIFIER_MODEL: ${AI_CLASSIFIER_MODEL:-}
+      FEATURE_PORTAL_RESIDENT: ${FEATURE_PORTAL_RESIDENT:?FEATURE_PORTAL_RESIDENT is required}
+      FEATURE_PAYMENTS_MVP: ${FEATURE_PAYMENTS_MVP:?FEATURE_PAYMENTS_MVP is required}
+      LOG_LEVEL: ${LOG_LEVEL:?LOG_LEVEL is required}
+      PORT: "3000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/ready"]
+      interval: 30s
+      timeout: 10s
+      start_period: 10s
+      retries: 3
+    restart: unless-stopped
+
+  buildingos-web:
+    build:
+      context: ../../
+      dockerfile: apps/web/Dockerfile
+      args:
+        NEXT_PUBLIC_API_URL: ${API_URL:?API_URL is required}
+    container_name: buildingos-release-staging-web
+    networks:
+      - buildingos_release_staging_net
+      - pawtech_public
+    depends_on:
+      buildingos-api:
+        condition: service_healthy
+    ports:
+      - "127.0.0.1:${WEB_PORT:-4021}:3000"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=pawtech_public"
+      - "traefik.http.routers.buildingos-release-staging.rule=Host(`buildingos-release-staging.31-220-98-21.sslip.io`)"
+      - "traefik.http.routers.buildingos-release-staging.entrypoints=websecure"
+      - "traefik.http.routers.buildingos-release-staging.tls=true"
+      - "traefik.http.routers.buildingos-release-staging.tls.certresolver=letsencrypt"
+      - "traefik.http.services.buildingos-release-staging.loadbalancer.server.port=3000"
+    environment:
+      APP_ENV: release-staging
+      NODE_ENV: ${NODE_ENV:?NODE_ENV is required}
+      NEXT_PUBLIC_API_URL: ${API_URL:?API_URL is required}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 30s
+      timeout: 10s
+      start_period: 15s
+      retries: 3
+    restart: unless-stopped
+
+volumes:
+  buildingos_release_staging_pgdata:
+    name: buildingos_release_staging_pgdata
+  buildingos_release_staging_miniodata:
+    name: buildingos_release_staging_miniodata
+  buildingos_release_staging_redisdata:
+    name: buildingos_release_staging_redisdata

--- a/scripts/deploy-release-staging.sh
+++ b/scripts/deploy-release-staging.sh
@@ -66,14 +66,15 @@ record_evidence() {
   local branch="$2"
   local previous_sha="$3"
   local target_sha="$4"
-  local compose_output="$5"
-  local smoke_output="$6"
+  local compose_config_status="$5"
+  local phase="$6"
 
   install -d -m 700 "$EXPECTED_ROOT/deployments"
-  local evidence_file="$EXPECTED_ROOT/deployments/$(date -u +%Y%m%dT%H%M%SZ)-${target_sha}.txt"
+  local evidence_file="$EXPECTED_ROOT/deployments/deploy-$(date -u +%Y%m%dT%H%M%SZ)-${target_sha}.txt"
   umask 077
   {
     printf 'timestamp_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'phase=%s\n' "$phase"
     printf 'status=%s\n' "$status"
     printf 'branch=%s\n' "$branch"
     printf 'previous_sha=%s\n' "$previous_sha"
@@ -81,8 +82,7 @@ record_evidence() {
     printf 'compose_project=%s\n' "$EXPECTED_COMPOSE_PROJECT"
     printf 'compose_file=%s\n' "$EXPECTED_COMPOSE_FILE"
     printf 'env_file=%s\n' "$EXPECTED_ENV_FILE"
-    printf 'compose_config=%s\n' "$compose_output"
-    printf 'smoke=%s\n' "$smoke_output"
+    printf 'compose_config=%s\n' "$compose_config_status"
   } > "$evidence_file"
   chmod 600 "$evidence_file"
   printf '%s\n' "$evidence_file"
@@ -152,20 +152,16 @@ main() {
   )
 
   local compose_config_output
-  compose_config_output="$("${compose_cmd[@]}" config --quiet 2>&1 || true)"
   "${compose_cmd[@]}" config --quiet
+  compose_config_output="$("${compose_cmd[@]}" config)"
 
-  if grep -qiE 'migrate|api-migrate|prisma[[:space:]]+migrate' <<<"$compose_config_output"; then
+  if grep -qiE 'prisma[[:space:]]+migrate|migrate[[:space:]]+deploy|migrate[[:space:]]+dev|api-migrate' <<<"$compose_config_output"; then
     fail "Wave 0 deploy must not include migrations"
   fi
 
-  "${compose_cmd[@]}" up --detach
+  "${compose_cmd[@]}" up --detach --build
 
-  local smoke_output
-  smoke_output="$(scripts/smoke-release-staging.sh "$target_sha" 2>&1)"
-  printf '%s\n' "$smoke_output"
-
-  record_evidence "SUCCESS" "$branch" "$previous_sha" "$target_sha" "compose-config-ok" "smoke-ok" >/dev/null
+  record_evidence "SUCCESS" "$branch" "$previous_sha" "$target_sha" "validated-no-migrations" "deploy" >/dev/null
   printf 'Deployment completed for %s at %s\n' "$target_sha" "$branch"
 }
 

--- a/scripts/deploy-release-staging.sh
+++ b/scripts/deploy-release-staging.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly EXPECTED_BRANCH_PATTERN='^release/prod-wave-[0-9]+(-[a-z0-9][a-z0-9-]*)?$'
+readonly EXPECTED_REMOTE_DIR='/opt/pawtech/apps/buildingos-release-staging/buildingos-app'
+readonly EXPECTED_ROOT='/opt/pawtech/apps/buildingos-release-staging'
+readonly EXPECTED_COMPOSE_PROJECT='buildingos-release-staging'
+readonly EXPECTED_COMPOSE_FILE='infra/docker/docker-compose.release-staging.yml'
+readonly EXPECTED_ENV_FILE='/opt/pawtech/env/buildingos-release-staging.env'
+readonly BLOCKED_ROOT_PROD='/opt/pawtech/apps/buildingos'
+readonly BLOCKED_ROOT_STAGING='/opt/pawtech/apps/buildingos-staging'
+
+usage() {
+  printf 'Usage: %s <branch> <sha>\n' "${0##*/}" >&2
+  exit 64
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+trap 'rc=$?; printf "ERROR: deploy failed at line %s (exit %s)\n" "$LINENO" "$rc" >&2' ERR
+
+validate_sha() {
+  local sha="$1"
+  [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || fail "SHA must be exactly 40 lowercase hex characters"
+}
+
+validate_branch() {
+  local branch="$1"
+
+  [[ -n "$branch" ]] || fail "Branch cannot be empty"
+  [[ "$branch" != '/' ]] || fail "Branch cannot be /"
+  [[ "$branch" != main ]] || fail "Branch main is not allowed"
+  [[ "$branch" != staging ]] || fail "Branch staging is not allowed"
+  [[ "$branch" != develop ]] || fail "Branch develop is not allowed"
+  [[ "$branch" != feature/* ]] || fail "Feature branches are not allowed"
+  [[ "$branch" != fix/* ]] || fail "Fix branches are not allowed"
+  [[ "$branch" != chore/* ]] || fail "Chore branches are not allowed"
+  [[ "$branch" =~ $EXPECTED_BRANCH_PATTERN ]] || fail "Branch must match release/prod-wave-* pattern"
+}
+
+validate_exact_setting() {
+  local label="$1"
+  local actual="$2"
+  local expected="$3"
+
+  [[ -n "$actual" ]] || fail "$label cannot be empty"
+  [[ "$actual" == "$expected" ]] || fail "$label must be exactly: $expected"
+}
+
+read_setting() {
+  local env_name="$1"
+  local default_value="$2"
+
+  if [[ -n "${!env_name+x}" ]]; then
+    printf '%s' "${!env_name}"
+  else
+    printf '%s' "$default_value"
+  fi
+}
+
+record_evidence() {
+  local status="$1"
+  local branch="$2"
+  local previous_sha="$3"
+  local target_sha="$4"
+  local compose_output="$5"
+  local smoke_output="$6"
+
+  install -d -m 700 "$EXPECTED_ROOT/deployments"
+  local evidence_file="$EXPECTED_ROOT/deployments/$(date -u +%Y%m%dT%H%M%SZ)-${target_sha}.txt"
+  umask 077
+  {
+    printf 'timestamp_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'status=%s\n' "$status"
+    printf 'branch=%s\n' "$branch"
+    printf 'previous_sha=%s\n' "$previous_sha"
+    printf 'target_sha=%s\n' "$target_sha"
+    printf 'compose_project=%s\n' "$EXPECTED_COMPOSE_PROJECT"
+    printf 'compose_file=%s\n' "$EXPECTED_COMPOSE_FILE"
+    printf 'env_file=%s\n' "$EXPECTED_ENV_FILE"
+    printf 'compose_config=%s\n' "$compose_output"
+    printf 'smoke=%s\n' "$smoke_output"
+  } > "$evidence_file"
+  chmod 600 "$evidence_file"
+  printf '%s\n' "$evidence_file"
+}
+
+main() {
+  [[ $# -eq 2 ]] || usage
+
+  local branch="$1"
+  local target_sha="$2"
+  local remote_dir
+  local compose_project
+  local compose_file
+  local env_file
+
+  validate_branch "$branch"
+  validate_sha "$target_sha"
+
+  remote_dir="$(read_setting RELEASE_STAGING_REMOTE_DIR "$EXPECTED_REMOTE_DIR")"
+  compose_project="$(read_setting RELEASE_STAGING_COMPOSE_PROJECT "$EXPECTED_COMPOSE_PROJECT")"
+  compose_file="$(read_setting RELEASE_STAGING_COMPOSE_FILE "$EXPECTED_COMPOSE_FILE")"
+  env_file="$(read_setting RELEASE_STAGING_ENV_FILE "$EXPECTED_ENV_FILE")"
+
+  validate_exact_setting 'release-staging remote directory' "$remote_dir" "$EXPECTED_REMOTE_DIR"
+  validate_exact_setting 'release-staging Compose project' "$compose_project" "$EXPECTED_COMPOSE_PROJECT"
+  validate_exact_setting 'release-staging Compose file' "$compose_file" "$EXPECTED_COMPOSE_FILE"
+  validate_exact_setting 'release-staging env file' "$env_file" "$EXPECTED_ENV_FILE"
+
+  case "$remote_dir" in
+    ''|'/') fail "Remote directory cannot be empty or /" ;;
+    "$BLOCKED_ROOT_PROD"|"$BLOCKED_ROOT_STAGING"|"$BLOCKED_ROOT_PROD"/*|"$BLOCKED_ROOT_STAGING"/*)
+      fail "Remote directory must never target production or staging"
+      ;;
+  esac
+
+  command -v git >/dev/null || fail "git is required"
+  command -v docker >/dev/null || fail "docker is required"
+
+  cd "$remote_dir"
+  [[ -d .git ]] || fail "Git repository not found at $remote_dir"
+
+  local origin_url
+  origin_url="$(git remote get-url origin 2>/dev/null)" || fail "Remote origin is missing"
+  [[ -n "$origin_url" ]] || fail "Remote origin is missing"
+
+  local current_tree
+  current_tree="$(git status --porcelain --untracked-files=all)"
+  [[ -z "$current_tree" ]] || fail "Working tree must be clean before deploy"
+
+  local previous_sha
+  previous_sha="$(git rev-parse HEAD)"
+
+  git fetch --no-tags origin "+refs/heads/$branch:refs/remotes/origin/$branch"
+  git cat-file -e "$target_sha^{commit}"
+  git merge-base --is-ancestor "$target_sha" "refs/remotes/origin/$branch"
+  test "$(git rev-parse "$target_sha^{commit}")" = "$target_sha"
+
+  git switch --detach --quiet "$target_sha"
+  test "$(git rev-parse HEAD)" = "$target_sha"
+  test -z "$(git status --porcelain --untracked-files=all)"
+
+  local compose_cmd=(
+    docker compose
+    --project-name "$compose_project"
+    --env-file "$env_file"
+    -f "$compose_file"
+  )
+
+  local compose_config_output
+  compose_config_output="$("${compose_cmd[@]}" config --quiet 2>&1 || true)"
+  "${compose_cmd[@]}" config --quiet
+
+  if grep -qiE 'migrate|api-migrate|prisma[[:space:]]+migrate' <<<"$compose_config_output"; then
+    fail "Wave 0 deploy must not include migrations"
+  fi
+
+  "${compose_cmd[@]}" up --detach
+
+  local smoke_output
+  smoke_output="$(scripts/smoke-release-staging.sh "$target_sha" 2>&1)"
+  printf '%s\n' "$smoke_output"
+
+  record_evidence "SUCCESS" "$branch" "$previous_sha" "$target_sha" "compose-config-ok" "smoke-ok" >/dev/null
+  printf 'Deployment completed for %s at %s\n' "$target_sha" "$branch"
+}
+
+main "$@"

--- a/scripts/rollback-release-staging.sh
+++ b/scripts/rollback-release-staging.sh
@@ -66,12 +66,15 @@ record_evidence() {
   local branch="$2"
   local previous_sha="$3"
   local target_sha="$4"
+  local compose_config_status="$5"
+  local phase="$6"
 
   install -d -m 700 "$EXPECTED_ROOT/deployments"
   local evidence_file="$EXPECTED_ROOT/deployments/rollback-$(date -u +%Y%m%dT%H%M%SZ)-${target_sha}.txt"
   umask 077
   {
     printf 'timestamp_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'phase=%s\n' "$phase"
     printf 'status=%s\n' "$status"
     printf 'branch=%s\n' "$branch"
     printf 'previous_sha=%s\n' "$previous_sha"
@@ -79,7 +82,7 @@ record_evidence() {
     printf 'compose_project=%s\n' "$EXPECTED_COMPOSE_PROJECT"
     printf 'compose_file=%s\n' "$EXPECTED_COMPOSE_FILE"
     printf 'env_file=%s\n' "$EXPECTED_ENV_FILE"
-    printf 'restore_db=manual_only\n'
+    printf 'compose_config=%s\n' "$compose_config_status"
   } > "$evidence_file"
   chmod 600 "$evidence_file"
   printf '%s\n' "$evidence_file"
@@ -94,6 +97,7 @@ main() {
   local compose_project
   local compose_file
   local env_file
+  local compose_config_output
 
   validate_branch "$branch"
   validate_sha "$target_sha"
@@ -148,13 +152,15 @@ main() {
   )
 
   "${compose_cmd[@]}" config --quiet
-  "${compose_cmd[@]}" up --detach
+  compose_config_output="$("${compose_cmd[@]}" config)"
 
-  local smoke_output
-  smoke_output="$(scripts/smoke-release-staging.sh "$target_sha" 2>&1)"
-  printf '%s\n' "$smoke_output"
+  if grep -qiE 'prisma[[:space:]]+migrate|migrate[[:space:]]+deploy|migrate[[:space:]]+dev|api-migrate' <<<"$compose_config_output"; then
+    fail "Wave 0 rollback must not include migrations"
+  fi
 
-  record_evidence "SUCCESS" "$branch" "$previous_sha" "$target_sha" >/dev/null
+  "${compose_cmd[@]}" up --detach --build
+
+  record_evidence "SUCCESS" "$branch" "$previous_sha" "$target_sha" "validated-no-migrations" "rollback" >/dev/null
   printf 'Rollback completed for %s to %s\n' "$branch" "$target_sha"
   printf 'Manual database restore is not performed automatically in Wave 0; keep restore separate if a future wave requires it.\n'
 }

--- a/scripts/rollback-release-staging.sh
+++ b/scripts/rollback-release-staging.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly EXPECTED_BRANCH_PATTERN='^release/prod-wave-[0-9]+(-[a-z0-9][a-z0-9-]*)?$'
+readonly EXPECTED_REMOTE_DIR='/opt/pawtech/apps/buildingos-release-staging/buildingos-app'
+readonly EXPECTED_ROOT='/opt/pawtech/apps/buildingos-release-staging'
+readonly EXPECTED_COMPOSE_PROJECT='buildingos-release-staging'
+readonly EXPECTED_COMPOSE_FILE='infra/docker/docker-compose.release-staging.yml'
+readonly EXPECTED_ENV_FILE='/opt/pawtech/env/buildingos-release-staging.env'
+readonly BLOCKED_ROOT_PROD='/opt/pawtech/apps/buildingos'
+readonly BLOCKED_ROOT_STAGING='/opt/pawtech/apps/buildingos-staging'
+
+usage() {
+  printf 'Usage: %s <branch> <previous_sha>\n' "${0##*/}" >&2
+  exit 64
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+trap 'rc=$?; printf "ERROR: rollback failed at line %s (exit %s)\n" "$LINENO" "$rc" >&2' ERR
+
+validate_sha() {
+  local sha="$1"
+  [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || fail "SHA must be exactly 40 lowercase hex characters"
+}
+
+validate_branch() {
+  local branch="$1"
+
+  [[ -n "$branch" ]] || fail "Branch cannot be empty"
+  [[ "$branch" != '/' ]] || fail "Branch cannot be /"
+  [[ "$branch" != main ]] || fail "Branch main is not allowed"
+  [[ "$branch" != staging ]] || fail "Branch staging is not allowed"
+  [[ "$branch" != develop ]] || fail "Branch develop is not allowed"
+  [[ "$branch" != feature/* ]] || fail "Feature branches are not allowed"
+  [[ "$branch" != fix/* ]] || fail "Fix branches are not allowed"
+  [[ "$branch" != chore/* ]] || fail "Chore branches are not allowed"
+  [[ "$branch" =~ $EXPECTED_BRANCH_PATTERN ]] || fail "Branch must match release/prod-wave-* pattern"
+}
+
+validate_exact_setting() {
+  local label="$1"
+  local actual="$2"
+  local expected="$3"
+
+  [[ -n "$actual" ]] || fail "$label cannot be empty"
+  [[ "$actual" == "$expected" ]] || fail "$label must be exactly: $expected"
+}
+
+read_setting() {
+  local env_name="$1"
+  local default_value="$2"
+
+  if [[ -n "${!env_name+x}" ]]; then
+    printf '%s' "${!env_name}"
+  else
+    printf '%s' "$default_value"
+  fi
+}
+
+record_evidence() {
+  local status="$1"
+  local branch="$2"
+  local previous_sha="$3"
+  local target_sha="$4"
+
+  install -d -m 700 "$EXPECTED_ROOT/deployments"
+  local evidence_file="$EXPECTED_ROOT/deployments/rollback-$(date -u +%Y%m%dT%H%M%SZ)-${target_sha}.txt"
+  umask 077
+  {
+    printf 'timestamp_utc=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'status=%s\n' "$status"
+    printf 'branch=%s\n' "$branch"
+    printf 'previous_sha=%s\n' "$previous_sha"
+    printf 'target_sha=%s\n' "$target_sha"
+    printf 'compose_project=%s\n' "$EXPECTED_COMPOSE_PROJECT"
+    printf 'compose_file=%s\n' "$EXPECTED_COMPOSE_FILE"
+    printf 'env_file=%s\n' "$EXPECTED_ENV_FILE"
+    printf 'restore_db=manual_only\n'
+  } > "$evidence_file"
+  chmod 600 "$evidence_file"
+  printf '%s\n' "$evidence_file"
+}
+
+main() {
+  [[ $# -eq 2 ]] || usage
+
+  local branch="$1"
+  local target_sha="$2"
+  local remote_dir
+  local compose_project
+  local compose_file
+  local env_file
+
+  validate_branch "$branch"
+  validate_sha "$target_sha"
+
+  remote_dir="$(read_setting RELEASE_STAGING_REMOTE_DIR "$EXPECTED_REMOTE_DIR")"
+  compose_project="$(read_setting RELEASE_STAGING_COMPOSE_PROJECT "$EXPECTED_COMPOSE_PROJECT")"
+  compose_file="$(read_setting RELEASE_STAGING_COMPOSE_FILE "$EXPECTED_COMPOSE_FILE")"
+  env_file="$(read_setting RELEASE_STAGING_ENV_FILE "$EXPECTED_ENV_FILE")"
+
+  validate_exact_setting 'release-staging remote directory' "$remote_dir" "$EXPECTED_REMOTE_DIR"
+  validate_exact_setting 'release-staging Compose project' "$compose_project" "$EXPECTED_COMPOSE_PROJECT"
+  validate_exact_setting 'release-staging Compose file' "$compose_file" "$EXPECTED_COMPOSE_FILE"
+  validate_exact_setting 'release-staging env file' "$env_file" "$EXPECTED_ENV_FILE"
+
+  case "$remote_dir" in
+    ''|'/') fail "Remote directory cannot be empty or /" ;;
+    "$BLOCKED_ROOT_PROD"|"$BLOCKED_ROOT_STAGING"|"$BLOCKED_ROOT_PROD"/*|"$BLOCKED_ROOT_STAGING"/*)
+      fail "Remote directory must never target production or staging"
+      ;;
+  esac
+
+  command -v git >/dev/null || fail "git is required"
+  command -v docker >/dev/null || fail "docker is required"
+
+  cd "$remote_dir"
+  [[ -d .git ]] || fail "Git repository not found at $remote_dir"
+  local origin_url
+  origin_url="$(git remote get-url origin 2>/dev/null)" || fail "Remote origin is missing"
+  [[ -n "$origin_url" ]] || fail "Remote origin is missing"
+
+  local current_tree
+  current_tree="$(git status --porcelain --untracked-files=all)"
+  [[ -z "$current_tree" ]] || fail "Working tree must be clean before rollback"
+
+  local previous_sha
+  previous_sha="$(git rev-parse HEAD)"
+
+  git fetch --no-tags origin "+refs/heads/$branch:refs/remotes/origin/$branch"
+  git cat-file -e "$target_sha^{commit}"
+  git merge-base --is-ancestor "$target_sha" "refs/remotes/origin/$branch"
+  test "$(git rev-parse "$target_sha^{commit}")" = "$target_sha"
+
+  git switch --detach --quiet "$target_sha"
+  test "$(git rev-parse HEAD)" = "$target_sha"
+  test -z "$(git status --porcelain --untracked-files=all)"
+
+  local compose_cmd=(
+    docker compose
+    --project-name "$compose_project"
+    --env-file "$env_file"
+    -f "$compose_file"
+  )
+
+  "${compose_cmd[@]}" config --quiet
+  "${compose_cmd[@]}" up --detach
+
+  local smoke_output
+  smoke_output="$(scripts/smoke-release-staging.sh "$target_sha" 2>&1)"
+  printf '%s\n' "$smoke_output"
+
+  record_evidence "SUCCESS" "$branch" "$previous_sha" "$target_sha" >/dev/null
+  printf 'Rollback completed for %s to %s\n' "$branch" "$target_sha"
+  printf 'Manual database restore is not performed automatically in Wave 0; keep restore separate if a future wave requires it.\n'
+}
+
+main "$@"

--- a/scripts/smoke-release-staging.sh
+++ b/scripts/smoke-release-staging.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly EXPECTED_SHA_PATTERN='^[0-9a-f]{40}$'
+readonly EXPECTED_ROOT='/opt/pawtech/apps/buildingos-release-staging'
+readonly APP_DIR='/opt/pawtech/apps/buildingos-release-staging/buildingos-app'
+readonly COMPOSE_PROJECT='buildingos-release-staging'
+readonly COMPOSE_FILE='infra/docker/docker-compose.release-staging.yml'
+readonly ENV_FILE='/opt/pawtech/env/buildingos-release-staging.env'
+readonly LOCAL_API_BASE='http://127.0.0.1:4020'
+readonly LOCAL_WEB_BASE='http://127.0.0.1:4021'
+readonly PUBLIC_API_BASE='https://buildingos-api-release-staging.31-220-98-21.sslip.io'
+readonly PUBLIC_WEB_BASE='https://buildingos-release-staging.31-220-98-21.sslip.io'
+readonly MAX_ATTEMPTS=8
+readonly ATTEMPT_DELAY_SECONDS=5
+
+usage() {
+  printf 'Usage: %s <sha>\n' "${0##*/}" >&2
+  exit 64
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+trap 'rc=$?; printf "ERROR: smoke failed at line %s (exit %s)\n" "$LINENO" "$rc" >&2' ERR
+
+validate_sha() {
+  local sha="$1"
+  [[ "$sha" =~ $EXPECTED_SHA_PATTERN ]] || fail "SHA must be exactly 40 lowercase hex characters"
+}
+
+assert_detached_clean_tree() {
+  cd "$APP_DIR"
+  [[ -d .git ]] || fail "Git repository not found at $APP_DIR"
+  test "$(git rev-parse HEAD)" = "$1"
+  git symbolic-ref -q HEAD >/dev/null && fail "Repository must be in detached HEAD"
+  test -z "$(git status --porcelain --untracked-files=all)"
+}
+
+compose_ps_check() {
+  local output
+  output="$(
+    docker compose \
+      --project-name "$COMPOSE_PROJECT" \
+      --env-file "$ENV_FILE" \
+      -f "$COMPOSE_FILE" \
+      ps 2>&1
+  )"
+
+  printf '%s\n' "$output"
+
+  grep -q 'buildingos-release-staging-api' <<<"$output" || fail "API service missing from compose ps"
+  grep -q 'buildingos-release-staging-web' <<<"$output" || fail "Web service missing from compose ps"
+  grep -q 'buildingos-release-staging-postgres' <<<"$output" || fail "PostgreSQL service missing from compose ps"
+  grep -q 'buildingos-release-staging-redis' <<<"$output" || fail "Redis service missing from compose ps"
+  grep -q 'buildingos-release-staging-minio' <<<"$output" || fail "MinIO service missing from compose ps"
+  grep -q 'buildingos-release-staging-mailpit' <<<"$output" || fail "Mailpit service missing from compose ps"
+}
+
+http_fetch() {
+  local label="$1"
+  local url="$2"
+  local body_file status_code attempt
+
+  body_file="${TMPDIR:-/tmp}/buildingos-smoke-${label//[^a-zA-Z0-9]/_}.$$"
+  trap 'rm -f "$body_file"' RETURN
+
+  for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+    status_code="$(curl --silent --show-error --connect-timeout 5 --max-time 15 --output "$body_file" --write-out '%{http_code}' "$url" || true)"
+    if [[ "$status_code" == "200" ]]; then
+      printf '%s\n' "$body_file"
+      trap - RETURN
+      return 0
+    fi
+    sleep "$ATTEMPT_DELAY_SECONDS"
+  done
+
+  fail "$label did not return HTTP 200 after $MAX_ATTEMPTS attempts: $url"
+}
+
+check_liveness_json() {
+  local label="$1"
+  local body_file="$2"
+
+  python3 - "$label" "$body_file" <<'PY'
+import json
+import pathlib
+import sys
+
+label = sys.argv[1]
+body = pathlib.Path(sys.argv[2]).read_text(encoding='utf-8')
+payload = json.loads(body)
+if payload.get('status') != 'ok':
+    raise SystemExit(f"{label}: expected status=ok, got {payload.get('status')!r}")
+if not isinstance(payload.get('timestamp'), str) or not payload['timestamp']:
+    raise SystemExit(f"{label}: timestamp missing or invalid")
+PY
+}
+
+check_readiness_json() {
+  local label="$1"
+  local body_file="$2"
+
+  python3 - "$label" "$body_file" <<'PY'
+import json
+import pathlib
+import sys
+
+label = sys.argv[1]
+body = pathlib.Path(sys.argv[2]).read_text(encoding='utf-8')
+payload = json.loads(body)
+status = payload.get('status')
+if status not in {'healthy', 'degraded'}:
+    raise SystemExit(f"{label}: expected healthy/degraded readiness, got {status!r}")
+if not isinstance(payload.get('timestamp'), str) or not payload['timestamp']:
+    raise SystemExit(f"{label}: timestamp missing or invalid")
+checks = payload.get('checks')
+if not isinstance(checks, dict) or 'database' not in checks or 'email' not in checks or 'storage' not in checks:
+    raise SystemExit(f"{label}: readiness checks are incomplete")
+PY
+}
+
+check_login_html() {
+  local label="$1"
+  local body_file="$2"
+  grep -q 'BuildingOS' "$body_file" || fail "$label should render the BuildingOS login page"
+}
+
+main() {
+  [[ $# -eq 1 ]] || usage
+  local target_sha="$1"
+  validate_sha "$target_sha"
+
+  command -v git >/dev/null || fail "git is required"
+  command -v curl >/dev/null || fail "curl is required"
+  command -v python3 >/dev/null || fail "python3 is required"
+
+  assert_detached_clean_tree "$target_sha"
+  compose_ps_check
+
+  local body_file
+
+  body_file="$(http_fetch 'local-api-health' "$LOCAL_API_BASE/health")"
+  check_liveness_json 'local-api-health' "$body_file"
+
+  body_file="$(http_fetch 'local-api-ready' "$LOCAL_API_BASE/ready")"
+  check_readiness_json 'local-api-ready' "$body_file"
+
+  body_file="$(http_fetch 'local-api-readyz' "$LOCAL_API_BASE/readyz")"
+  check_readiness_json 'local-api-readyz' "$body_file"
+
+  body_file="$(http_fetch 'local-web-login' "$LOCAL_WEB_BASE/login")"
+  check_login_html 'local-web-login' "$body_file"
+
+  body_file="$(http_fetch 'public-api-health' "$PUBLIC_API_BASE/health")"
+  check_liveness_json 'public-api-health' "$body_file"
+
+  body_file="$(http_fetch 'public-web-login' "$PUBLIC_WEB_BASE/login")"
+  check_login_html 'public-web-login' "$body_file"
+
+  printf 'Smoke checks passed for %s\n' "$target_sha"
+}
+
+main "$@"


### PR DESCRIPTION
Closes #105

## Summary

Adds Wave 0 infrastructure for an isolated `release-staging` environment used to validate progressive production release waves.

This PR adds:

- an isolated Docker Compose stack for `buildingos-release-staging`;
- a separate release-staging environment contract;
- guarded deploy, smoke and rollback scripts;
- a manual GitHub Actions workflow restricted to approved release branches and exact SHAs;
- an operations runbook covering provisioning, deploy, evidence, rollback, backup and cleanup.

## Isolation

The release-staging environment uses dedicated:

- containers;
- ports;
- database;
- Redis;
- MinIO storage and bucket;
- volumes;
- internal network;
- Traefik routers;
- GitHub Environment;
- deployment directory.

It does not replace or modify normal staging or production.

## Security controls

- workflow execution is manual only;
- workflow definition must run from `main`;
- release branches must match `release/prod-wave-*`;
- deploy SHA must be a 40-character commit belonging to the requested branch;
- remote path, Compose project and env file are fixed and validated;
- production and normal staging paths are explicitly rejected;
- SSH uses approved known hosts and strict host-key checking;
- Wave 0 does not execute Prisma migrations;
- evidence is sanitized.

## Validation

- YAML parsing: PASS
- Docker Compose config render: PASS
- Bash syntax checks: PASS
- Negative input tests: PASS
- Git diff check: PASS
- Secret scan by inspection: PASS
- Runbook/code consistency: PASS
- 12 security controls: PASS

The following tools were unavailable locally and were not installed:

- ShellCheck
- actionlint
- markdownlint

## Scope

This PR contains infrastructure, release tooling and documentation only.

It does not modify:

- API functionality;
- Web functionality;
- Prisma schema or migrations;
- seeds;
- production deployment;
- normal staging deployment.

## Deployment status

No deployment has been performed.

The GitHub Environment and VPS resources for `release-staging` remain pending and must not be created until this PR is reviewed and merged with explicit authorization.

## Safety

- production untouched;
- normal staging untouched;
- no migrations;
- no secrets included;
- no automatic deploy trigger.
