### PR TITLE
fix(e2e): harden resident scoped journeys

### DIFF
--- a/apps/api/prisma/seed.test.ts
+++ b/apps/api/prisma/seed.test.ts
@@ -306,6 +306,46 @@ async function main() {
   // ============================================================================
   // MEMBERSHIPS & ROLES
   // ============================================================================
+  async function ensureMembershipRole(params: {
+    tenantId: string;
+    membershipId: string;
+    role: Role;
+    scopeType?: "TENANT" | "BUILDING" | "UNIT";
+    scopeBuildingId?: string | null;
+    scopeUnitId?: string | null;
+  }) {
+    const scopeType = params.scopeType ?? "TENANT";
+    const existingRole = await prisma.membershipRole.findFirst({
+      where: {
+        tenantId: params.tenantId,
+        membershipId: params.membershipId,
+        role: params.role,
+        scopeType,
+        ...(params.scopeBuildingId !== undefined ? { scopeBuildingId: params.scopeBuildingId } : {}),
+        ...(params.scopeUnitId !== undefined ? { scopeUnitId: params.scopeUnitId } : {}),
+      },
+      select: { id: true },
+    });
+
+    if (existingRole) {
+      return existingRole.id;
+    }
+
+    const createdRole = await prisma.membershipRole.create({
+      data: {
+        tenantId: params.tenantId,
+        membershipId: params.membershipId,
+        role: params.role,
+        scopeType,
+        ...(params.scopeBuildingId !== undefined ? { scopeBuildingId: params.scopeBuildingId } : {}),
+        ...(params.scopeUnitId !== undefined ? { scopeUnitId: params.scopeUnitId } : {}),
+      },
+      select: { id: true },
+    });
+
+    return createdRole.id;
+  }
+
   async function upsertMembership(params: { tenantId: string; userId: string; role: Role }) {
     const membership = await prisma.membership.upsert({
       where: { userId_tenantId: { userId: params.userId, tenantId: params.tenantId } },
@@ -313,13 +353,12 @@ async function main() {
       create: { tenantId: params.tenantId, userId: params.userId },
     });
 
-    try {
-      await prisma.membershipRole.create({
-        data: { tenantId: params.tenantId, membershipId: membership.id, role: params.role, scopeType: "TENANT" },
-      });
-    } catch (_e: unknown) {
-      if ((_e as { code?: string }).code !== "P2002") throw _e;
-    }
+    await ensureMembershipRole({
+      tenantId: params.tenantId,
+      membershipId: membership.id,
+      role: params.role,
+      scopeType: "TENANT",
+    });
     return membership;
   }
 
@@ -328,25 +367,12 @@ async function main() {
   await upsertMembership({ tenantId: tenantA.id, userId: testUsers.resident.id, role: Role.RESIDENT });
   await upsertMembership({ tenantId: tenantA.id, userId: testUsers.residentMulti.id, role: Role.RESIDENT });
   const residentMixedMembershipA = await upsertMembership({ tenantId: tenantA.id, userId: testUsers.residentMixed.id, role: Role.RESIDENT });
-  const residentMixedAdminRole = await prisma.membershipRole.findFirst({
-    where: {
-      tenantId: tenantA.id,
-      membershipId: residentMixedMembershipA.id,
-      role: Role.TENANT_ADMIN,
-      scopeType: "TENANT",
-    },
-    select: { id: true },
+  await ensureMembershipRole({
+    tenantId: tenantA.id,
+    membershipId: residentMixedMembershipA.id,
+    role: Role.TENANT_ADMIN,
+    scopeType: "TENANT",
   });
-  if (!residentMixedAdminRole) {
-    await prisma.membershipRole.create({
-      data: {
-        tenantId: tenantA.id,
-        membershipId: residentMixedMembershipA.id,
-        role: Role.TENANT_ADMIN,
-        scopeType: "TENANT",
-      },
-    });
-  }
   await upsertMembership({ tenantId: tenantB.id, userId: testUsers.tenantAdminB.id, role: Role.TENANT_ADMIN });
   await upsertMembership({ tenantId: tenantB.id, userId: testUsers.residentB.id, role: Role.RESIDENT });
 
@@ -356,11 +382,12 @@ async function main() {
     update: {},
     create: { tenantId: tenantA.id, userId: testUsers.superAdmin.id },
   });
-  try {
-    await prisma.membershipRole.create({
-      data: { tenantId: tenantA.id, membershipId: superAdminMembership.id, role: Role.SUPER_ADMIN, scopeType: "TENANT" },
-    });
-  } catch { /* ignore duplicate */ }
+  await ensureMembershipRole({
+    tenantId: tenantA.id,
+    membershipId: superAdminMembership.id,
+    role: Role.SUPER_ADMIN,
+    scopeType: "TENANT",
+  });
   console.log(`✅ Memberships & roles created`);
 
   // ============================================================================

--- a/apps/web/tests/e2e/resident/resident-journeys.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-journeys.spec.ts
@@ -310,9 +310,13 @@ test.describe('Resident critical journeys', () => {
 
     await page.goto(residentDashboardPath(tenantBId));
 
-    await expect(page).toHaveURL(/\/login(?:\?|$)/);
-    await expect(page.getByText(/inicia sesión con tu cuenta/i)).toBeVisible();
-    await expect(page.getByRole('heading', { name: /hola, test resident/i })).toHaveCount(0);
+    await expect(page).toHaveURL(
+      new RegExp(`/${tenantAId}/resident/dashboard$`),
+      { timeout: 15000 },
+    );
+    await expect(page).not.toHaveURL(new RegExp(`/${tenantBId}/resident/`));
+    await expect(page).not.toHaveURL(/\/login(?:\?|$)/);
+    await expect(page.getByRole('heading', { name: /hola, test resident/i })).toBeVisible();
   });
 
   test('keeps the resident route tenant when activeTenantId points to a different admin tenant', async ({ page }) => {

--- a/apps/web/tests/e2e/resident/resident-journeys.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-journeys.spec.ts
@@ -310,8 +310,9 @@ test.describe('Resident critical journeys', () => {
 
     await page.goto(residentDashboardPath(tenantBId));
 
-    await expect(page).toHaveURL(new RegExp(`/${tenantAId}/resident/dashboard$`));
-    await expect(page.getByRole('heading', { name: /hola, test resident/i })).toBeVisible();
+    await expect(page).toHaveURL(/\/login(?:\?|$)/);
+    await expect(page.getByText(/inicia sesión con tu cuenta/i)).toBeVisible();
+    await expect(page.getByRole('heading', { name: /hola, test resident/i })).toHaveCount(0);
   });
 
   test('keeps the resident route tenant when activeTenantId points to a different admin tenant', async ({ page }) => {
@@ -470,9 +471,13 @@ test.describe('Resident critical journeys', () => {
 
     await setResidentUnit(unit102Id);
     await expect(page.getByText(/contexto actual:.*unidad a1-102/i)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Comunicado Unidad 102')).toBeVisible();
+    await expect(page.getByText('Comunicado Unidad 103')).toHaveCount(0);
 
     await setResidentUnit(unit103Id);
     await expect(page.getByText(/contexto actual:.*unidad a1-103/i)).toBeVisible({ timeout: 15000 });
+    await expect(page.getByText('Comunicado Unidad 103')).toBeVisible();
+    await expect(page.getByText('Comunicado Unidad 102')).toHaveCount(0);
   });
 
   test('logs out and keeps protected resident routes inaccessible', async ({ page }) => {


### PR DESCRIPTION
## Summary

- makes MembershipRole test seeding idempotent
- verifies unit-scoped announcements after resident context switches
- verifies the stable authorized fallback after cross-tenant URL tampering
- preserves the full resident journey coverage already merged through PR #93

## Context

- RES-019 was already merged through PR #93
- PR #106 was based on stale history and is superseded by this clean PR
- only the valid follow-up fixes were manually ported onto current main

## Tests

- seed executed twice against an isolated local E2E database
- duplicate `MembershipRole` groups query returned 0
- TypeScript API
- TypeScript web
- lint
- forbid-only guards
- Playwright resident suite: 14 tests
- Playwright resident suite: `repeat-each=3` (42 executions)
- focused resident login passed with same-site localhost origins
- cross-tenant tampering test passed
- resident suite repeat-each=3: 42 passed

## Scope

- no schema changes
- no migrations
- no workflow changes
- no staging seed
- no deploy
- production untouched

Closes #107
