### PR TITLE
fix(notifications): make global tenant alerts visible and portal-safe

### DIFF
--- a/apps/api/src/notifications/notification-feed.guard.spec.ts
+++ b/apps/api/src/notifications/notification-feed.guard.spec.ts
@@ -1,0 +1,158 @@
+import { ExecutionContext } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { NotificationFeedAccessGuard } from './notification-feed.guard';
+import type { AuthenticatedRequest } from '../common/types/request.types';
+
+interface MembershipRoleRecord {
+  readonly id: string;
+  readonly role: string;
+  readonly scopeType: 'TENANT' | 'BUILDING' | 'UNIT';
+  readonly scopeBuildingId: string | null;
+  readonly scopeUnitId: string | null;
+}
+
+interface MembershipRecord {
+  readonly id: string;
+  readonly tenantId: string;
+  readonly roles: MembershipRoleRecord[];
+}
+
+describe('NotificationFeedAccessGuard', () => {
+  const tenantRole: MembershipRoleRecord = {
+    id: 'role-tenant',
+    role: 'TENANT_ADMIN',
+    scopeType: 'TENANT',
+    scopeBuildingId: null,
+    scopeUnitId: null,
+  };
+
+  const buildingRole: MembershipRoleRecord = {
+    id: 'role-building',
+    role: 'OPERATOR',
+    scopeType: 'BUILDING',
+    scopeBuildingId: 'building-1',
+    scopeUnitId: null,
+  };
+
+  const unitRole: MembershipRoleRecord = {
+    id: 'role-unit',
+    role: 'RESIDENT',
+    scopeType: 'UNIT',
+    scopeBuildingId: 'building-1',
+    scopeUnitId: 'unit-1',
+  };
+
+  let prisma: {
+    membership: {
+      findUnique: jest.Mock<Promise<MembershipRecord | null>, [unknown]>;
+    };
+  };
+  let guard: NotificationFeedAccessGuard;
+
+  beforeEach(() => {
+    prisma = {
+      membership: {
+        findUnique: jest.fn(),
+      },
+    };
+
+    guard = new NotificationFeedAccessGuard(prisma as unknown as PrismaService);
+  });
+
+  function buildRequest(tenantId: string): AuthenticatedRequest {
+    return {
+      params: { tenantId },
+      user: {
+        id: 'user-1',
+        email: 'user@example.com',
+        name: 'User',
+        memberships: [],
+      },
+    } as AuthenticatedRequest;
+  }
+
+  function buildContext(request: AuthenticatedRequest): ExecutionContext {
+    return {
+      switchToHttp: () => ({
+        getRequest: () => request,
+      }),
+    } as ExecutionContext;
+  }
+
+  it('allows tenant-scoped members to access the notification feed', async () => {
+    const request = buildRequest('tenant-a');
+    prisma.membership.findUnique.mockResolvedValue({
+      id: 'membership-a',
+      tenantId: 'tenant-a',
+      roles: [tenantRole],
+    });
+
+    await expect(guard.canActivate(buildContext(request))).resolves.toBe(true);
+    expect(request.tenantId).toBe('tenant-a');
+    expect(request.user.tenantId).toBe('tenant-a');
+    expect(request.user.membershipId).toBe('membership-a');
+  });
+
+  it('allows building-scoped members to access the notification feed', async () => {
+    const request = buildRequest('tenant-a');
+    prisma.membership.findUnique.mockResolvedValue({
+      id: 'membership-a',
+      tenantId: 'tenant-a',
+      roles: [buildingRole],
+    });
+
+    await expect(guard.canActivate(buildContext(request))).resolves.toBe(true);
+    expect(request.tenantId).toBe('tenant-a');
+    expect(request.user.membershipId).toBe('membership-a');
+  });
+
+  it('allows unit-scoped members to access the notification feed', async () => {
+    const request = buildRequest('tenant-a');
+    prisma.membership.findUnique.mockResolvedValue({
+      id: 'membership-a',
+      tenantId: 'tenant-a',
+      roles: [unitRole],
+    });
+
+    await expect(guard.canActivate(buildContext(request))).resolves.toBe(true);
+    expect(request.tenantId).toBe('tenant-a');
+    expect(request.user.membershipId).toBe('membership-a');
+  });
+
+  it('rejects access when membership belongs to another tenant', async () => {
+    const request = buildRequest('tenant-b');
+    prisma.membership.findUnique.mockResolvedValue(null);
+
+    await expect(guard.canActivate(buildContext(request))).rejects.toThrow(
+      'No tiene acceso al tenant tenant-b',
+    );
+  });
+
+  it('rejects access when the user has no membership in the tenant', async () => {
+    const request = buildRequest('tenant-a');
+    prisma.membership.findUnique.mockResolvedValue(null);
+
+    await expect(guard.canActivate(buildContext(request))).rejects.toThrow(
+      'No tiene acceso al tenant tenant-a',
+    );
+  });
+
+  it('rejects access when the request has no authenticated user', async () => {
+    const request = {
+      params: { tenantId: 'tenant-a' },
+    } as AuthenticatedRequest;
+
+    await expect(guard.canActivate(buildContext(request))).rejects.toThrow(
+      'Usuario no autenticado',
+    );
+  });
+
+  it('rejects access when tenantId is missing from the route', async () => {
+    const request = buildRequest('tenant-a');
+    request.params = {};
+
+    await expect(guard.canActivate(buildContext(request))).rejects.toThrow(
+      'tenantId es requerido en los parámetros',
+    );
+  });
+});

--- a/apps/api/src/notifications/notification-feed.guard.spec.ts
+++ b/apps/api/src/notifications/notification-feed.guard.spec.ts
@@ -155,4 +155,48 @@ describe('NotificationFeedAccessGuard', () => {
       'tenantId es requerido en los parámetros',
     );
   });
+
+  it('uses the impersonated tenant boundary instead of the actor membership lookup', async () => {
+    const request = buildRequest('tenant-a');
+    request.user.isImpersonating = true;
+    request.user.impersonatedTenantId = 'tenant-a';
+    request.user.membershipId = '';
+    request.user.roles = ['TENANT_ADMIN'];
+    request.user.memberships = [
+      {
+        tenantId: 'tenant-a',
+        roles: ['TENANT_ADMIN'],
+      },
+      {
+        tenantId: 'tenant-b',
+        roles: ['RESIDENT'],
+      },
+    ];
+
+    prisma.membership.findUnique.mockResolvedValue(null);
+
+    await expect(guard.canActivate(buildContext(request))).resolves.toBe(true);
+    expect(prisma.membership.findUnique).not.toHaveBeenCalled();
+    expect(request.tenantId).toBe('tenant-a');
+    expect(request.user.tenantId).toBe('tenant-a');
+    expect(request.user.membershipId).toBe('');
+    expect(request.user.roles).toEqual(['TENANT_ADMIN']);
+  });
+
+  it('rejects impersonation when the route tenant does not match the impersonated tenant', async () => {
+    const request = buildRequest('tenant-b');
+    request.user.isImpersonating = true;
+    request.user.impersonatedTenantId = 'tenant-a';
+    request.user.roles = ['TENANT_ADMIN'];
+    request.user.memberships = [
+      {
+        tenantId: 'tenant-a',
+        roles: ['TENANT_ADMIN'],
+      },
+    ];
+
+    await expect(guard.canActivate(buildContext(request))).rejects.toThrow(
+      'No tiene acceso al tenant tenant-b',
+    );
+  });
 });

--- a/apps/api/src/notifications/notification-feed.guard.ts
+++ b/apps/api/src/notifications/notification-feed.guard.ts
@@ -5,8 +5,15 @@ import {
   ForbiddenException,
   Injectable,
 } from '@nestjs/common';
+import type { Role } from '@buildingos/contracts';
 import { PrismaService } from '../prisma/prisma.service';
 import type { AuthenticatedRequest } from '../common/types/request.types';
+
+interface TenantMembershipWithRoles {
+  readonly id: string;
+  readonly tenantId: string;
+  readonly roles: Role[];
+}
 
 @Injectable()
 export class NotificationFeedAccessGuard implements CanActivate {
@@ -22,6 +29,17 @@ export class NotificationFeedAccessGuard implements CanActivate {
     const tenantId = request.params.tenantId?.trim();
     if (!tenantId) {
       throw new BadRequestException('tenantId es requerido en los parámetros');
+    }
+
+    if (request.user.isImpersonating) {
+      if (request.user.impersonatedTenantId !== tenantId) {
+        throw new ForbiddenException(`No tiene acceso al tenant ${tenantId}`);
+      }
+
+      const impersonatedMembership = this.getImpersonatedMembership(request, tenantId);
+      this.assertHasTenantScopedRole(impersonatedMembership, tenantId);
+      this.hydrateRequestTenantContext(request, impersonatedMembership);
+      return true;
     }
 
     const membership = await this.prisma.membership.findUnique({
@@ -50,11 +68,68 @@ export class NotificationFeedAccessGuard implements CanActivate {
       throw new ForbiddenException(`No tiene acceso al tenant ${tenantId}`);
     }
 
-    const { id: membershipId, tenantId: resolvedTenantId } = membership;
-    request.tenantId = resolvedTenantId;
-    request.user.tenantId = resolvedTenantId;
-    request.user.membershipId = membershipId;
+    this.hydrateRequestTenantContext(request, {
+      id: membership.id,
+      tenantId: membership.tenantId,
+      roles: membership.roles.map((membershipRole) => membershipRole.role),
+    });
 
     return true;
+  }
+
+  private getImpersonatedMembership(
+    request: AuthenticatedRequest,
+    tenantId: string,
+  ): TenantMembershipWithRoles {
+    const matchingMembership = request.user.memberships?.find((membership) => membership.tenantId === tenantId);
+
+    return {
+      id: matchingMembership?.id ?? request.user.membershipId ?? '',
+      tenantId,
+      roles: matchingMembership?.roles ?? request.user.roles ?? [],
+    };
+  }
+
+  private assertHasTenantScopedRole(
+    membership: TenantMembershipWithRoles,
+    tenantId: string,
+  ): void {
+    if (membership.roles.length === 0) {
+      throw new ForbiddenException(`No tiene acceso al tenant ${tenantId}`);
+    }
+  }
+
+  private hydrateRequestTenantContext(
+    request: AuthenticatedRequest,
+    membership: TenantMembershipWithRoles,
+  ): void {
+    request.tenantId = membership.tenantId;
+    request.user.tenantId = membership.tenantId;
+    request.user.membershipId = membership.id;
+    request.user.roles = membership.roles;
+    request.user.role = membership.roles[0];
+    request.user.effectiveMembership = membership;
+    request.user.memberships = this.replaceMembershipForTenant(request.user.memberships ?? [], membership);
+  }
+
+  private replaceMembershipForTenant(
+    memberships: NonNullable<AuthenticatedRequest['user']['memberships']>,
+    membership: TenantMembershipWithRoles,
+  ): NonNullable<AuthenticatedRequest['user']['memberships']> {
+    let replaced = false;
+    const nextMemberships = memberships.map((existingMembership) => {
+      if (existingMembership.tenantId !== membership.tenantId) {
+        return existingMembership;
+      }
+
+      replaced = true;
+      return membership;
+    });
+
+    if (!replaced) {
+      nextMemberships.push(membership);
+    }
+
+    return nextMemberships;
   }
 }

--- a/apps/api/src/notifications/notification-feed.guard.ts
+++ b/apps/api/src/notifications/notification-feed.guard.ts
@@ -1,0 +1,60 @@
+import {
+  BadRequestException,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import type { AuthenticatedRequest } from '../common/types/request.types';
+
+@Injectable()
+export class NotificationFeedAccessGuard implements CanActivate {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const userId = request.user?.id;
+    if (!userId) {
+      throw new ForbiddenException('Usuario no autenticado');
+    }
+
+    const tenantId = request.params.tenantId?.trim();
+    if (!tenantId) {
+      throw new BadRequestException('tenantId es requerido en los parámetros');
+    }
+
+    const membership = await this.prisma.membership.findUnique({
+      where: {
+        userId_tenantId: {
+          userId,
+          tenantId,
+        },
+      },
+      select: {
+        id: true,
+        tenantId: true,
+        roles: {
+          select: {
+            id: true,
+            role: true,
+            scopeType: true,
+            scopeBuildingId: true,
+            scopeUnitId: true,
+          },
+        },
+      },
+    });
+
+    if (!membership || membership.roles.length === 0) {
+      throw new ForbiddenException(`No tiene acceso al tenant ${tenantId}`);
+    }
+
+    const { id: membershipId, tenantId: resolvedTenantId } = membership;
+    request.tenantId = resolvedTenantId;
+    request.user.tenantId = resolvedTenantId;
+    request.user.membershipId = membershipId;
+
+    return true;
+  }
+}

--- a/apps/api/src/notifications/notifications.controller.ts
+++ b/apps/api/src/notifications/notifications.controller.ts
@@ -9,28 +9,31 @@ import {
   Request,
   BadRequestException,
 } from '@nestjs/common';
+import { Type } from 'class-transformer';
 import { NotificationType } from '@prisma/client';
-import { IsEnum, IsInt, IsOptional, IsString, Max, Min, ValidateIf } from 'class-validator';
+import { IsEnum, IsIn, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { NotificationsService } from './notifications.service';
-import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
+import { NotificationFeedAccessGuard } from './notification-feed.guard';
 import { AuthenticatedRequest } from '../common/types/request.types';
 
 class ListNotificationsQueryDto {
   @IsOptional()
-  @IsString()
-  isRead?: string;
+  @IsIn(['true', 'false'])
+  isRead?: 'true' | 'false';
 
   @IsOptional()
   @IsEnum(NotificationType)
   type?: NotificationType;
 
   @IsOptional()
+  @Type(() => Number)
   @IsInt()
   @Min(0)
   skip?: number;
 
   @IsOptional()
+  @Type(() => Number)
   @IsInt()
   @Min(1)
   @Max(100)
@@ -54,15 +57,15 @@ class NotificationParamDto {
  * Notifications Controller
  *
  * ENDPOINTS:
- * GET    /me/notifications                   → List user's notifications
- * GET    /me/notifications/unread-count      → Get unread count
- * PATCH  /me/notifications/:id/read          → Mark notification as read
- * PATCH  /me/notifications/read-all          → Mark all as read
- * DELETE /me/notifications/:id               → Delete notification
+ * GET    /tenants/:tenantId/notifications                   → List tenant notifications
+ * GET    /tenants/:tenantId/notifications/unread-count      → Get unread count
+ * PATCH  /tenants/:tenantId/notifications/:id/read          → Mark notification as read
+ * PATCH  /tenants/:tenantId/notifications/read-all          → Mark all as read
+ * DELETE /tenants/:tenantId/notifications/:id               → Delete notification
  */
 
 @Controller('tenants/:tenantId/notifications')
-@UseGuards(JwtAuthGuard, TenantAccessGuard)
+@UseGuards(JwtAuthGuard, NotificationFeedAccessGuard)
 export class NotificationsController {
   constructor(private readonly notificationsService: NotificationsService) {}
 
@@ -79,7 +82,7 @@ export class NotificationsController {
 
   /**
    * List user's notifications with pagination
-   * GET /me/notifications?isRead=false&type=TICKET_STATUS_CHANGED&skip=0&take=50
+   * GET /tenants/:tenantId/notifications?isRead=false&type=TICKET_STATUS_CHANGED&skip=0&take=50
    */
   @Get()
   async listNotifications(
@@ -112,7 +115,7 @@ export class NotificationsController {
 
   /**
    * Get unread notification count
-   * GET /me/notifications/unread-count
+   * GET /tenants/:tenantId/notifications/unread-count
    */
   @Get('unread-count')
   async getUnreadCount(@Request() req: AuthenticatedRequest): Promise<UnreadCountResponseDto> {
@@ -138,7 +141,7 @@ export class NotificationsController {
 
   /**
    * Mark all notifications as read
-   * PATCH /me/notifications/read-all
+   * PATCH /tenants/:tenantId/notifications/read-all
    */
   @Patch('read-all')
   async markAllAsRead(@Request() req: AuthenticatedRequest): Promise<SuccessResponseDto> {

--- a/apps/api/src/notifications/notifications.module.ts
+++ b/apps/api/src/notifications/notifications.module.ts
@@ -5,6 +5,7 @@ import { AuditModule } from '../audit/audit.module';
 import { EmailModule } from '../email/email.module';
 import { NotificationsService } from './notifications.service';
 import { NotificationsController } from './notifications.controller';
+import { NotificationFeedAccessGuard } from './notification-feed.guard';
 
 /**
  * NotificationsModule: Global module for in-app + email notifications
@@ -15,7 +16,7 @@ import { NotificationsController } from './notifications.controller';
 @Global()
 @Module({
   imports: [AppConfigModule, PrismaModule, AuditModule, EmailModule],
-  providers: [NotificationsService],
+  providers: [NotificationsService, NotificationFeedAccessGuard],
   controllers: [NotificationsController],
   exports: [NotificationsService],
 })

--- a/apps/web/app/(tenant)/[tenantId]/notifications/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/notifications/page.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { useParams, useRouter, usePathname } from 'next/navigation';
+import { useParams, useRouter, usePathname, useSearchParams } from 'next/navigation';
 import NotificationsPage from './page';
 import * as notificationsHook from '@/features/notifications/useNotifications';
 import * as authHook from '@/features/auth/useAuthSession';
@@ -20,6 +20,7 @@ jest.mock('next/navigation', () => ({
   useParams: jest.fn(),
   useRouter: jest.fn(),
   usePathname: jest.fn(),
+  useSearchParams: jest.fn(),
 }));
 
 jest.mock('@/features/notifications/useNotifications', () => ({
@@ -33,6 +34,7 @@ jest.mock('@/features/auth/useAuthSession', () => ({
 const mockedUseParams = jest.mocked(useParams);
 const mockedUseRouter = jest.mocked(useRouter);
 const mockedUsePathname = jest.mocked(usePathname);
+const mockedUseSearchParams = jest.mocked(useSearchParams);
 const mockedUseNotifications = jest.mocked(notificationsHook.useNotifications);
 const mockedUseAuthSession = jest.mocked(authHook.useAuthSession);
 
@@ -48,6 +50,7 @@ describe('NotificationsPage', () => {
     mockedUseParams.mockReturnValue({ tenantId: 'tenant-1' } as never);
     mockedUseRouter.mockReturnValue({ push, replace: jest.fn(), back: jest.fn(), prefetch: jest.fn(), refresh: jest.fn() } as never);
     mockedUsePathname.mockReturnValue('/tenant-1/notifications' as never);
+    mockedUseSearchParams.mockReturnValue(new URLSearchParams() as never);
     mockedUseAuthSession.mockReturnValue({
       activeTenantId: 'tenant-1',
       memberships: [{ tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] }],
@@ -174,7 +177,7 @@ describe('NotificationsPage', () => {
   it('delete notification calls the API correctly', async () => {
     render(<NotificationsPage />);
 
-    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    fireEvent.click(screen.getByRole('button', { name: /Eliminar/i }));
 
     await waitFor(() => {
       expect(deleteNotification).toHaveBeenCalledWith('n1');
@@ -184,7 +187,7 @@ describe('NotificationsPage', () => {
   it('markAllAsRead calls the API correctly', async () => {
     render(<NotificationsPage />);
 
-    fireEvent.click(screen.getByText(/Mark All Read/i));
+    fireEvent.click(screen.getByText(/Marcar todas como leídas/i));
 
     await waitFor(() => {
       expect(markAllAsRead).toHaveBeenCalled();
@@ -232,7 +235,8 @@ describe('NotificationsPage', () => {
   });
 
   it('detects resident portal context from pathname', async () => {
-    mockedUsePathname.mockReturnValue('/tenant-1/resident/notifications' as never);
+    mockedUsePathname.mockReturnValue('/tenant-1/notifications' as never);
+    mockedUseSearchParams.mockReturnValue(new URLSearchParams('portal=resident') as never);
     mockedUseAuthSession.mockReturnValue({
       activeTenantId: 'tenant-1',
       memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] }],
@@ -274,6 +278,7 @@ describe('NotificationsPage', () => {
 
   it('detects admin portal context from pathname', async () => {
     mockedUsePathname.mockReturnValue('/tenant-1/notifications' as never);
+    mockedUseSearchParams.mockReturnValue(new URLSearchParams('portal=admin') as never);
     mockedUseAuthSession.mockReturnValue({
       activeTenantId: 'tenant-1',
       memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] }],
@@ -314,7 +319,8 @@ describe('NotificationsPage', () => {
   });
 
   it('routes resident ticket notifications to the resident detail view with portal context', async () => {
-    mockedUsePathname.mockReturnValue('/tenant-1/resident/notifications' as never);
+    mockedUsePathname.mockReturnValue('/tenant-1/notifications' as never);
+    mockedUseSearchParams.mockReturnValue(new URLSearchParams('portal=resident') as never);
     mockedUseAuthSession.mockReturnValue({
       activeTenantId: 'tenant-1',
       memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT'] }],

--- a/apps/web/app/(tenant)/[tenantId]/notifications/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/notifications/page.tsx
@@ -16,6 +16,7 @@ import {
 import { Trash2, Check, CheckCheck } from 'lucide-react';
 import { t } from '@/i18n';
 import { useAuthSession } from '@/features/auth/useAuthSession';
+import { getLastPortal } from '@/features/auth/session.storage';
 import { resolveNotificationPath } from '@/shared/lib/notification-routes';
 import type { Notification } from '@/features/notifications/notifications.api';
 import { resolveAuthorizedPortalContext } from '@/features/auth/landing-route';
@@ -46,6 +47,7 @@ const NotificationsPage = () => {
       tenantId,
       pathname,
       searchParamsString: searchParams.toString(),
+      preferredPortal: getLastPortal(),
     }) ?? 'admin';
   const roleContext = useMemo(
     () => ({

--- a/apps/web/app/(tenant)/[tenantId]/notifications/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/notifications/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState, useEffect } from 'react';
-import { useParams, usePathname } from 'next/navigation';
+import { useParams, usePathname, useSearchParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import { useNotifications } from '@/features/notifications/useNotifications';
 import {
@@ -18,12 +18,15 @@ import { t } from '@/i18n';
 import { useAuthSession } from '@/features/auth/useAuthSession';
 import { resolveNotificationPath } from '@/shared/lib/notification-routes';
 import type { Notification } from '@/features/notifications/notifications.api';
+import { resolveAuthorizedPortalContext } from '@/features/auth/landing-route';
 
 const NotificationsPage = () => {
   const params = useParams();
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const router = useRouter();
-  const tenantId = params.tenantId as string;
+  const tenantIdParam = params.tenantId;
+  const tenantId = typeof tenantIdParam === 'string' && tenantIdParam.trim().length > 0 ? tenantIdParam.trim() : '';
   const session = useAuthSession();
   const [isRead, setIsRead] = useState<boolean | undefined>(undefined);
   const [skip, setSkip] = useState(0);
@@ -37,7 +40,13 @@ const NotificationsPage = () => {
     () => session?.memberships?.find((membership) => membership.tenantId === tenantId),
     [session, tenantId],
   );
-  const portalContext: 'resident' | 'admin' = pathname?.includes('/resident/') ? 'resident' : 'admin';
+  const portalContext =
+    resolveAuthorizedPortalContext({
+      session,
+      tenantId,
+      pathname,
+      searchParamsString: searchParams.toString(),
+    }) ?? 'admin';
   const roleContext = useMemo(
     () => ({
       isAdmin: activeMembership?.roles?.some((role) => ['TENANT_OWNER', 'TENANT_ADMIN', 'OPERATOR', 'SUPER_ADMIN'].includes(role)) ?? false,
@@ -51,6 +60,14 @@ const NotificationsPage = () => {
   useEffect(() => {
     fetch({ isRead, skip, take });
   }, [isRead, skip, fetch]);
+
+  if (!tenantId) {
+    return (
+      <div className="p-6">
+        <ErrorState message="El ID del tenant es obligatorio" />
+      </div>
+    );
+  }
 
   const handleMarkAsRead = async (id: string, currentRead: boolean) => {
     if (currentRead) return;
@@ -142,13 +159,15 @@ const NotificationsPage = () => {
         <div>
           <h1 className="text-3xl font-bold">{t('notifications.title')}</h1>
           <p className="text-gray-600 mt-2">
-            {unreadCount > 0 ? `${unreadCount} notification${unreadCount !== 1 ? 's' : ''} sin leer` : t('notifications.allRead')}
+            {unreadCount > 0
+              ? `${unreadCount} ${unreadCount === 1 ? 'notificación sin leer' : 'notificaciones sin leer'}`
+              : t('notifications.allRead')}
           </p>
         </div>
         {unreadCount > 0 && (
           <Button onClick={handleMarkAllAsRead} variant="secondary" size="sm">
             <CheckCheck size={16} className="mr-2" />
-            Mark All Read
+            Marcar todas como leídas
           </Button>
         )}
       </div>
@@ -157,7 +176,7 @@ const NotificationsPage = () => {
       <Card className="p-4">
         <div className="flex gap-4 items-end">
           <div className="flex-1">
-            <label className="block text-sm font-medium mb-2">Filter</label>
+            <label className="block text-sm font-medium mb-2">Filtrar</label>
             <select
               value={isRead === undefined ? '' : String(isRead)}
               onChange={(e) => {
@@ -167,9 +186,9 @@ const NotificationsPage = () => {
               }}
               className="w-full px-3 py-2 border rounded-md"
             >
-              <option value="">All Notifications</option>
-              <option value="false">Unread Only</option>
-              <option value="true">Read Only</option>
+              <option value="">Todas las notificaciones</option>
+              <option value="false">Solo no leídas</option>
+              <option value="true">Solo leídas</option>
             </select>
           </div>
         </div>
@@ -179,7 +198,7 @@ const NotificationsPage = () => {
       {notifications.length === 0 ? (
         <EmptyState
           title="Sin notificaciones"
-          description={isRead === false ? 'You have read all notifications' : 'No notifications to display'}
+          description={isRead === false ? 'Ya leíste todas las notificaciones' : 'No hay notificaciones para mostrar'}
         />
       ) : (
         <div className="space-y-3">
@@ -222,7 +241,7 @@ const NotificationsPage = () => {
                     onClick={() => handleMarkAsRead(notification.id, notification.isRead)}
                   >
                     <Check size={16} className="mr-1" />
-                    Mark as Read
+                    Marcar como leída
                   </Button>
                 )}
                 <Button
@@ -231,7 +250,7 @@ const NotificationsPage = () => {
                   onClick={() => handleDelete(notification.id)}
                 >
                   <Trash2 size={16} className="mr-1" />
-                  Delete
+                  Eliminar
                 </Button>
               </div>
             </Card>
@@ -242,7 +261,7 @@ const NotificationsPage = () => {
       {/* Pagination Info */}
       {notifications.length > 0 && (
         <div className="text-sm text-gray-600 text-center py-4">
-          Showing {skip + 1} to {Math.min(skip + take, total)} of {total} notifications
+          Mostrando {skip + 1} a {Math.min(skip + take, total)} de {total} notificaciones
         </div>
       )}
     </div>

--- a/apps/web/app/(tenant)/[tenantId]/support/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/support/page.tsx
@@ -22,8 +22,8 @@ interface CreateTicketFormState {
 }
 
 const TenantSupportPage = () => {
-  const params = useParams();
-  const tenantId = params.tenantId as string;
+  const params = useParams<{ tenantId?: string }>();
+  const tenantId = typeof params?.tenantId === 'string' ? params.tenantId : '';
 
   const [status, setStatus] = useState<string>('');
   const [skip, setSkip] = useState(0);
@@ -133,7 +133,7 @@ const TenantSupportPage = () => {
           <h2 className="text-xl font-semibold mb-4">{t('tickets.create')}</h2>
           <form onSubmit={handleCreateTicket} className="space-y-4">
             <div>
-              <label className="block text-sm font-medium mb-2">{t('tickets.title')}</label>
+              <label className="block text-sm font-medium mb-2">{t('tickets.requestTitle')}</label>
               <input
                 type="text"
                 value={formData.title}

--- a/apps/web/features/auth/landing-route.test.ts
+++ b/apps/web/features/auth/landing-route.test.ts
@@ -161,6 +161,7 @@ describe('landing-route', () => {
     expect(resolvePortalFromPathname('/tenant-1/resident/dashboard')).toBe('resident');
     expect(resolvePortalFromPathname('/tenant-1/dashboard')).toBe('admin');
     expect(resolvePortalFromPathname('/tenant-1/tickets/ticket-1', 'portal=resident')).toBe('resident');
+    expect(resolvePortalFromPathname('/tenant-1/notifications')).toBeNull();
     expect(resolvePortalFromPathname('/login')).toBeNull();
   });
 
@@ -182,6 +183,14 @@ describe('landing-route', () => {
         session,
         tenantId: 'tenant-1',
         pathname: '/tenant-1/resident/payments',
+      }),
+    ).toBe('resident');
+
+    expect(
+      resolveAuthorizedPortalContext({
+        session,
+        tenantId: 'tenant-1',
+        pathname: '/tenant-1/notifications',
       }),
     ).toBe('resident');
   });
@@ -242,5 +251,20 @@ describe('landing-route', () => {
         pathname: '/tenant-1/resident/dashboard',
       }),
     ).toBe('admin');
+  });
+
+  it('prefers the persisted resident portal for mixed users on neutral routes', () => {
+    const session = buildSession([
+      { tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] },
+    ]);
+
+    expect(
+      resolveAuthorizedPortalContext({
+        session,
+        tenantId: 'tenant-1',
+        pathname: '/tenant-1/notifications',
+        preferredPortal: 'resident',
+      }),
+    ).toBe('resident');
   });
 });

--- a/apps/web/features/auth/landing-route.ts
+++ b/apps/web/features/auth/landing-route.ts
@@ -15,6 +15,7 @@ export interface ResolveAuthorizedPortalContextParams {
   readonly pathname?: string | null;
   readonly searchParamsString?: string | null;
   readonly tenantId?: string | null;
+  readonly preferredPortal?: PortalContext | null;
 }
 
 const ADMIN_ROLES = new Set(['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR', 'SUPER_ADMIN']);
@@ -56,6 +57,10 @@ function getTenantIdFromPathname(pathname: string): string | null {
 
 function isResidentPath(pathname: string): boolean {
   return pathname.includes('/resident/');
+}
+
+function isTenantDashboardPath(pathname: string, tenantId: string): boolean {
+  return pathname === `/${tenantId}/dashboard` || pathname.startsWith(`/${tenantId}/dashboard/`);
 }
 
 function resolveMembershipForTenant(memberships: Membership[], tenantId?: string | null): Membership | null {
@@ -105,7 +110,19 @@ export function resolvePortalFromPathname(
     return null;
   }
 
-  return isResidentPath(pathname) ? 'resident' : 'admin';
+  if (isResidentPath(pathname)) {
+    return 'resident';
+  }
+
+  if (pathname === `/${tenantId}/notifications` || pathname.startsWith(`/${tenantId}/notifications/`)) {
+    return null;
+  }
+
+  if (isTenantDashboardPath(pathname, tenantId)) {
+    return 'admin';
+  }
+
+  return 'admin';
 }
 
 function resolveAuthorizedRequestedPath(
@@ -177,6 +194,7 @@ export function resolveAuthorizedPortalContext({
   pathname,
   searchParamsString,
   tenantId,
+  preferredPortal,
 }: ResolveAuthorizedPortalContextParams): PortalContext | null {
   if (!session) {
     return null;
@@ -220,7 +238,23 @@ export function resolveAuthorizedPortalContext({
     }
   }
 
+  if (preferredPortal === 'resident' && hasResidentAccess) {
+    return 'resident';
+  }
+
+  if (preferredPortal === 'admin' && hasAdminAccess) {
+    return 'admin';
+  }
+
   if (hasResidentAccess && !hasAdminAccess) {
+    return 'resident';
+  }
+
+  if (hasAdminAccess && !hasResidentAccess) {
+    return 'admin';
+  }
+
+  if (hasResidentAccess) {
     return 'resident';
   }
 

--- a/apps/web/features/auth/useAuthorizedPortalContext.ts
+++ b/apps/web/features/auth/useAuthorizedPortalContext.ts
@@ -3,6 +3,7 @@
 import { usePathname, useSearchParams } from 'next/navigation';
 import { resolveAuthorizedPortalContext, type PortalContext } from './landing-route';
 import { useAuthSession } from './useAuthSession';
+import { getLastPortal } from './session.storage';
 
 export function useAuthorizedPortalContext(tenantId: string | null | undefined): PortalContext | null {
   const session = useAuthSession();
@@ -14,5 +15,6 @@ export function useAuthorizedPortalContext(tenantId: string | null | undefined):
     tenantId: typeof tenantId === 'string' && tenantId.trim().length > 0 ? tenantId.trim() : null,
     pathname,
     searchParamsString: searchParams.toString(),
+    preferredPortal: getLastPortal(),
   });
 }

--- a/apps/web/features/notifications/notification-queries.ts
+++ b/apps/web/features/notifications/notification-queries.ts
@@ -37,16 +37,16 @@ export const notificationQueryKeys = {
   scope(tenantId: string, userId: string): readonly ['notifications', string, string] {
     return ['notifications', tenantId, userId] as const;
   },
-  unreadCount(tenantId: string, userId: string): readonly ['notifications', 'unread-count', string, string] {
-    return ['notifications', 'unread-count', tenantId, userId] as const;
+  unreadCount(tenantId: string, userId: string): readonly ['notifications', string, string, 'unread-count'] {
+    return ['notifications', tenantId, userId, 'unread-count'] as const;
   },
   list(
     tenantId: string,
     userId: string,
     params?: ListNotificationsParams,
-  ): readonly ['notifications', 'list', string, string, boolean | null, string | null, number, number] {
+  ): readonly ['notifications', string, string, 'list', boolean | null, string | null, number, number] {
     const [isRead, type, skip, take] = normalizeListParams(params);
-    return ['notifications', 'list', tenantId, userId, isRead, type, skip, take] as const;
+    return ['notifications', tenantId, userId, 'list', isRead, type, skip, take] as const;
   },
 } as const;
 

--- a/apps/web/features/notifications/notification-queries.ts
+++ b/apps/web/features/notifications/notification-queries.ts
@@ -1,0 +1,96 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useQueryClient, type QueryClient } from '@tanstack/react-query';
+import { useAuthSession } from '@/features/auth/useAuthSession';
+import type { ListNotificationsParams } from './notifications.api';
+
+export interface NotificationQueryIdentity {
+  readonly tenantId: string | null;
+  readonly userId: string | null;
+}
+
+function normalizeTenantId(tenantId: string | null | undefined): string | null {
+  if (typeof tenantId !== 'string') {
+    return null;
+  }
+
+  const trimmed = tenantId.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeListParams(params?: ListNotificationsParams): readonly [
+  boolean | null,
+  string | null,
+  number,
+  number,
+] {
+  return [
+    params?.isRead ?? null,
+    params?.type ?? null,
+    params?.skip ?? 0,
+    params?.take ?? 20,
+  ] as const;
+}
+
+export const notificationQueryKeys = {
+  scope(tenantId: string, userId: string): readonly ['notifications', string, string] {
+    return ['notifications', tenantId, userId] as const;
+  },
+  unreadCount(tenantId: string, userId: string): readonly ['notifications', 'unread-count', string, string] {
+    return ['notifications', 'unread-count', tenantId, userId] as const;
+  },
+  list(
+    tenantId: string,
+    userId: string,
+    params?: ListNotificationsParams,
+  ): readonly ['notifications', 'list', string, string, boolean | null, string | null, number, number] {
+    const [isRead, type, skip, take] = normalizeListParams(params);
+    return ['notifications', 'list', tenantId, userId, isRead, type, skip, take] as const;
+  },
+} as const;
+
+export function useNotificationQueryIdentity(
+  tenantId: string | null | undefined,
+): NotificationQueryIdentity {
+  const session = useAuthSession();
+
+  return {
+    tenantId: normalizeTenantId(tenantId),
+    userId: session?.user.id ?? null,
+  };
+}
+
+export function useNotificationQueryCleanup(identity: NotificationQueryIdentity): void {
+  const queryClient = useQueryClient();
+  const previousIdentityRef = useRef<NotificationQueryIdentity | null>(null);
+
+  useEffect(() => {
+    const previousIdentity = previousIdentityRef.current;
+    const tenantChanged = previousIdentity?.tenantId !== identity.tenantId;
+    const userChanged = previousIdentity?.userId !== identity.userId;
+
+    if (previousIdentity && (tenantChanged || userChanged)) {
+      if (previousIdentity.tenantId && previousIdentity.userId) {
+        queryClient.removeQueries({
+          queryKey: notificationQueryKeys.scope(previousIdentity.tenantId, previousIdentity.userId),
+        });
+      }
+    }
+
+    previousIdentityRef.current = identity;
+  }, [identity, queryClient]);
+}
+
+export function removeNotificationQueries(
+  queryClient: QueryClient,
+  identity: NotificationQueryIdentity,
+): void {
+  if (!identity.tenantId || !identity.userId) {
+    return;
+  }
+
+  queryClient.removeQueries({
+    queryKey: notificationQueryKeys.scope(identity.tenantId, identity.userId),
+  });
+}

--- a/apps/web/features/notifications/useNotifications.test.tsx
+++ b/apps/web/features/notifications/useNotifications.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useAuthSession } from '@/features/auth/useAuthSession';
+import * as api from './notifications.api';
+import { useNotifications } from './useNotifications';
+
+jest.mock('@/features/auth/useAuthSession', () => ({
+  useAuthSession: jest.fn(),
+}));
+
+jest.mock('./notifications.api', () => ({
+  listNotifications: jest.fn(),
+  getUnreadCount: jest.fn(),
+  markAsRead: jest.fn(),
+  markAllAsRead: jest.fn(),
+  deleteNotification: jest.fn(),
+}));
+
+const mockedUseAuthSession = jest.mocked(useAuthSession);
+const mockedApi = jest.mocked(api);
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { readonly children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useNotifications', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseAuthSession.mockReturnValue({
+      user: { id: 'user-1', email: 'resident@test.com', name: 'Resident' },
+      memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT'] }],
+      activeTenantId: 'tenant-1',
+    });
+    mockedApi.getUnreadCount.mockResolvedValue(0);
+    mockedApi.listNotifications.mockResolvedValue({ notifications: [], total: 0 });
+    mockedApi.markAsRead.mockResolvedValue({
+      id: 'n-1',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      type: 'TICKET_STATUS_CHANGED',
+      title: 'Updated',
+      body: 'Updated',
+      deliveryMethods: ['IN_APP'],
+      isRead: true,
+      createdAt: '2026-08-03T00:00:00.000Z',
+    });
+    mockedApi.markAllAsRead.mockResolvedValue({ success: true });
+  });
+
+  it('caches notification queries by tenant and user identity', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useNotifications('tenant-1'), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.fetch({ take: 20 });
+    });
+
+    const cacheKeys = queryClient.getQueryCache().getAll().map((query) => query.queryKey);
+    expect(cacheKeys).toEqual(
+      expect.arrayContaining([
+        ['notifications', 'unread-count', 'tenant-1', 'user-1'],
+        ['notifications', 'list', 'tenant-1', 'user-1', null, null, 0, 20],
+      ]),
+    );
+  });
+
+  it('drops the previous principal notification cache when the authenticated user changes', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const removeQueriesSpy = jest.spyOn(queryClient, 'removeQueries');
+
+    const { result, rerender } = renderHook(() => useNotifications('tenant-1'), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.fetch({ take: 20 });
+    });
+
+    mockedUseAuthSession.mockReturnValue({
+      user: { id: 'user-2', email: 'resident2@test.com', name: 'Resident 2' },
+      memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT'] }],
+      activeTenantId: 'tenant-1',
+    });
+
+    rerender();
+
+    await waitFor(() => {
+      expect(removeQueriesSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queryKey: ['notifications', 'tenant-1', 'user-1'],
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(result.current.notifications).toEqual([]);
+      expect(result.current.total).toBe(0);
+    });
+
+    removeQueriesSpy.mockRestore();
+  });
+});

--- a/apps/web/features/notifications/useNotifications.test.tsx
+++ b/apps/web/features/notifications/useNotifications.test.tsx
@@ -67,10 +67,35 @@ describe('useNotifications', () => {
     const cacheKeys = queryClient.getQueryCache().getAll().map((query) => query.queryKey);
     expect(cacheKeys).toEqual(
       expect.arrayContaining([
-        ['notifications', 'unread-count', 'tenant-1', 'user-1'],
-        ['notifications', 'list', 'tenant-1', 'user-1', null, null, 0, 20],
+        ['notifications', 'tenant-1', 'user-1', 'unread-count'],
+        ['notifications', 'tenant-1', 'user-1', 'list', null, null, 0, 20],
       ]),
     );
+  });
+
+  it('keeps unread count and list requests independent for the same identity', async () => {
+    let resolveUnread!: (value: number) => void;
+    const unreadPromise = new Promise<number>((resolve) => {
+      resolveUnread = resolve;
+    });
+
+    mockedApi.getUnreadCount.mockReturnValue(unreadPromise);
+
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { result } = renderHook(() => useNotifications('tenant-1'), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      const fetchPromise = result.current.fetch({ take: 20 });
+      await Promise.resolve();
+      resolveUnread(4);
+      await fetchPromise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.unreadCount).toBe(4);
+    });
   });
 
   it('drops the previous principal notification cache when the authenticated user changes', async () => {

--- a/apps/web/features/notifications/useNotifications.ts
+++ b/apps/web/features/notifications/useNotifications.ts
@@ -22,23 +22,27 @@ export function useNotifications(tenantId: string) {
     }),
     [tenantId, userId],
   );
+  const identityKey = useMemo(
+    () => (identity.tenantId && identity.userId ? `${identity.tenantId}::${identity.userId}` : ''),
+    [identity.tenantId, identity.userId],
+  );
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [total, setTotal] = useState(0);
   const [unreadCount, setUnreadCount] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const requestTokenRef = useRef(0);
+  const activeIdentityKeyRef = useRef('');
 
   useNotificationQueryCleanup(identity);
 
   useEffect(() => {
+    activeIdentityKeyRef.current = identityKey;
     setNotifications([]);
     setTotal(0);
     setUnreadCount(0);
     setLoading(false);
     setError(null);
-    requestTokenRef.current += 1;
-  }, [identity.tenantId, identity.userId]);
+  }, [identityKey]);
 
   const identityReady = Boolean(identity.tenantId && identity.userId);
   const resolvedTenantId = identity.tenantId;
@@ -47,31 +51,31 @@ export function useNotifications(tenantId: string) {
   const fetchUnreadCount = useCallback(async () => {
     if (!identityReady || !resolvedTenantId || !resolvedUserId) return 0;
 
-    const requestToken = ++requestTokenRef.current;
+    const requestIdentityKey = identityKey;
     try {
       const count = await queryClient.fetchQuery({
         queryKey: notificationQueryKeys.unreadCount(resolvedTenantId, resolvedUserId),
         queryFn: () => api.getUnreadCount(resolvedTenantId),
       });
 
-      if (requestTokenRef.current === requestToken) {
+      if (activeIdentityKeyRef.current === requestIdentityKey) {
         setUnreadCount(count);
       }
 
       return count;
     } catch (err) {
-      if (requestTokenRef.current === requestToken) {
+      if (activeIdentityKeyRef.current === requestIdentityKey) {
         setError(err instanceof Error ? err.message : 'Error al obtener notificaciones');
       }
       return 0;
     }
-  }, [identityReady, queryClient, resolvedTenantId, resolvedUserId]);
+  }, [identityKey, identityReady, queryClient, resolvedTenantId, resolvedUserId]);
 
   const fetchNotifications = useCallback(
     async (params?: ListNotificationsParams) => {
       if (!identityReady || !resolvedTenantId || !resolvedUserId) return undefined;
 
-      const requestToken = ++requestTokenRef.current;
+      const requestIdentityKey = identityKey;
       setLoading(true);
       setError(null);
 
@@ -81,24 +85,24 @@ export function useNotifications(tenantId: string) {
           queryFn: () => api.listNotifications(resolvedTenantId, params),
         });
 
-        if (requestTokenRef.current === requestToken) {
+        if (activeIdentityKeyRef.current === requestIdentityKey) {
           setNotifications(result.notifications);
           setTotal(result.total);
         }
 
         return result;
       } catch (err) {
-        if (requestTokenRef.current === requestToken) {
+        if (activeIdentityKeyRef.current === requestIdentityKey) {
           setError(err instanceof Error ? err.message : 'Error al obtener notificaciones');
         }
         return undefined;
       } finally {
-        if (requestTokenRef.current === requestToken) {
+        if (activeIdentityKeyRef.current === requestIdentityKey) {
           setLoading(false);
         }
       }
     },
-    [identityReady, queryClient, resolvedTenantId, resolvedUserId],
+    [identityKey, identityReady, queryClient, resolvedTenantId, resolvedUserId],
   );
 
   const invalidateCurrentNotificationQueries = useCallback(async () => {

--- a/apps/web/features/notifications/useNotifications.ts
+++ b/apps/web/features/notifications/useNotifications.ts
@@ -1,91 +1,176 @@
 'use client';
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useAuthSession } from '@/features/auth/useAuthSession';
 import * as api from './notifications.api';
 import type { Notification, ListNotificationsParams } from './notifications.api';
+import {
+  notificationQueryKeys,
+  removeNotificationQueries,
+  useNotificationQueryCleanup,
+} from './notification-queries';
 
 export function useNotifications(tenantId: string) {
+  const queryClient = useQueryClient();
+  const session = useAuthSession();
+  const userId = session?.user.id ?? null;
+  const identity = useMemo(
+    () => ({
+      tenantId: typeof tenantId === 'string' && tenantId.trim().length > 0 ? tenantId.trim() : null,
+      userId,
+    }),
+    [tenantId, userId],
+  );
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [total, setTotal] = useState(0);
   const [unreadCount, setUnreadCount] = useState(0);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const requestTokenRef = useRef(0);
+
+  useNotificationQueryCleanup(identity);
+
+  useEffect(() => {
+    setNotifications([]);
+    setTotal(0);
+    setUnreadCount(0);
+    setLoading(false);
+    setError(null);
+    requestTokenRef.current += 1;
+  }, [identity.tenantId, identity.userId]);
+
+  const identityReady = Boolean(identity.tenantId && identity.userId);
+  const resolvedTenantId = identity.tenantId;
+  const resolvedUserId = identity.userId;
+
+  const fetchUnreadCount = useCallback(async () => {
+    if (!identityReady || !resolvedTenantId || !resolvedUserId) return 0;
+
+    const requestToken = ++requestTokenRef.current;
+    try {
+      const count = await queryClient.fetchQuery({
+        queryKey: notificationQueryKeys.unreadCount(resolvedTenantId, resolvedUserId),
+        queryFn: () => api.getUnreadCount(resolvedTenantId),
+      });
+
+      if (requestTokenRef.current === requestToken) {
+        setUnreadCount(count);
+      }
+
+      return count;
+    } catch (err) {
+      if (requestTokenRef.current === requestToken) {
+        setError(err instanceof Error ? err.message : 'Error al obtener notificaciones');
+      }
+      return 0;
+    }
+  }, [identityReady, queryClient, resolvedTenantId, resolvedUserId]);
 
   const fetchNotifications = useCallback(
     async (params?: ListNotificationsParams) => {
-      if (!tenantId) return;
+      if (!identityReady || !resolvedTenantId || !resolvedUserId) return undefined;
+
+      const requestToken = ++requestTokenRef.current;
       setLoading(true);
       setError(null);
 
       try {
-        const result = await api.listNotifications(tenantId, params);
-        setNotifications(result.notifications);
-        setTotal(result.total);
+        const result = await queryClient.fetchQuery({
+          queryKey: notificationQueryKeys.list(resolvedTenantId, resolvedUserId, params),
+          queryFn: () => api.listNotifications(resolvedTenantId, params),
+        });
+
+        if (requestTokenRef.current === requestToken) {
+          setNotifications(result.notifications);
+          setTotal(result.total);
+        }
+
+        return result;
       } catch (err) {
-        setError(err instanceof Error ? err.message : 'Error al obtener notificaciones');
+        if (requestTokenRef.current === requestToken) {
+          setError(err instanceof Error ? err.message : 'Error al obtener notificaciones');
+        }
+        return undefined;
       } finally {
-        setLoading(false);
+        if (requestTokenRef.current === requestToken) {
+          setLoading(false);
+        }
       }
     },
-    [tenantId],
+    [identityReady, queryClient, resolvedTenantId, resolvedUserId],
   );
 
-  const fetchUnreadCount = useCallback(async () => {
-    if (!tenantId) return;
-    try {
-      const count = await api.getUnreadCount(tenantId);
-      setUnreadCount(count);
-    } catch {
-      // silently ignore — badge will retry on next poll
-    }
-  }, [tenantId]);
+  const invalidateCurrentNotificationQueries = useCallback(async () => {
+    if (!identityReady || !resolvedTenantId || !resolvedUserId) return;
+
+    await queryClient.invalidateQueries({
+      queryKey: notificationQueryKeys.scope(resolvedTenantId, resolvedUserId),
+    });
+  }, [identityReady, queryClient, resolvedTenantId, resolvedUserId]);
 
   const markAsRead = useCallback(async (id: string) => {
-    if (!tenantId) return;
+    if (!identityReady || !resolvedTenantId || !resolvedUserId) return undefined;
     try {
-      const updated = await api.markAsRead(tenantId, id);
+      const updated = await api.markAsRead(resolvedTenantId, id);
       setNotifications((prev) =>
         prev.map((n) => (n.id === id ? updated : n)),
       );
+      await invalidateCurrentNotificationQueries();
       await fetchUnreadCount();
       return updated;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Error al marcar como leída');
       throw err;
     }
-  }, [tenantId, fetchUnreadCount]);
+  }, [fetchUnreadCount, identityReady, invalidateCurrentNotificationQueries, resolvedTenantId, resolvedUserId]);
 
   const markAllAsRead = useCallback(async () => {
-    if (!tenantId) return;
+    if (!identityReady || !resolvedTenantId || !resolvedUserId) return undefined;
     try {
-      const result = await api.markAllAsRead(tenantId);
+      const result = await api.markAllAsRead(resolvedTenantId);
       setNotifications((prev) =>
         prev.map((n) => ({ ...n, isRead: true })),
       );
+      await invalidateCurrentNotificationQueries();
       await fetchUnreadCount();
       return result;
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Error al marcar todas como leídas');
       throw err;
     }
-  }, [tenantId, fetchUnreadCount]);
+  }, [fetchUnreadCount, identityReady, invalidateCurrentNotificationQueries, resolvedTenantId, resolvedUserId]);
 
   const deleteNotification = useCallback(async (id: string) => {
-    if (!tenantId) return;
+    if (!identityReady || !resolvedTenantId || !resolvedUserId) return undefined;
     try {
-      await api.deleteNotification(tenantId, id);
+      await api.deleteNotification(resolvedTenantId, id);
       setNotifications((prev) => prev.filter((n) => n.id !== id));
-      setTotal((prev) => prev - 1);
+      setTotal((prev) => Math.max(0, prev - 1));
+      await invalidateCurrentNotificationQueries();
       await fetchUnreadCount();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Error al eliminar notificación');
       throw err;
     }
-  }, [tenantId, fetchUnreadCount]);
+  }, [fetchUnreadCount, identityReady, invalidateCurrentNotificationQueries, resolvedTenantId, resolvedUserId]);
 
   useEffect(() => {
-    fetchUnreadCount();
-  }, [fetchUnreadCount]);
+    if (!identityReady) {
+      return;
+    }
+
+    void fetchUnreadCount();
+  }, [fetchUnreadCount, identityReady]);
+
+  useEffect(() => {
+    if (!identity.tenantId || !identity.userId) {
+      return;
+    }
+
+    const cleanup = () => removeNotificationQueries(queryClient, identity);
+    return cleanup;
+  }, [identity, queryClient]);
 
   return {
     notifications,

--- a/apps/web/features/tickets/components/TicketForm.tsx
+++ b/apps/web/features/tickets/components/TicketForm.tsx
@@ -18,20 +18,23 @@ interface TicketFormProps {
   onCancel: () => void;
 }
 
-export default function TicketForm({
+const isTicketPriority = (value: string): value is TicketPriority =>
+  value === 'LOW' || value === 'MEDIUM' || value === 'HIGH' || value === 'URGENT';
+
+const TicketForm = ({
   buildingId,
   buildingName = 'Edificio',
   units = [],
   onSuccess,
   onCancel,
-}: TicketFormProps) {
+}: TicketFormProps) => {
   const { toast } = useToast();
   const { create } = useTickets({ buildingId });
 
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [category, setCategory] = useState<TicketCategory>('MAINTENANCE');
-  const [priority, setPriority] = useState('MEDIUM');
+  const [priority, setPriority] = useState<TicketPriority>('MEDIUM');
   const [unitId, setUnitId] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [validationError, setValidationError] = useState('');
@@ -63,7 +66,7 @@ export default function TicketForm({
         title: title.trim(),
         description: description.trim(),
         category,
-        priority: priority as TicketPriority,
+        priority,
         unitId: unitId || undefined,
       });
 
@@ -88,7 +91,7 @@ export default function TicketForm({
       )}
 
       <div>
-        <label className="block text-sm font-medium mb-1">{t('tickets.title')} *</label>
+        <label className="block text-sm font-medium mb-1">{t('tickets.requestTitle')} *</label>
         <input
           type="text"
           value={title}
@@ -132,7 +135,12 @@ export default function TicketForm({
           <label className="block text-sm font-medium mb-1">{t('tickets.priority')}</label>
           <select
             value={priority}
-            onChange={(e) => setPriority(e.target.value)}
+            onChange={(e) => {
+              const nextPriority = e.target.value;
+              if (isTicketPriority(nextPriority)) {
+                setPriority(nextPriority);
+              }
+            }}
             className="w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
             disabled={submitting}
           >
@@ -195,3 +203,5 @@ export default function TicketForm({
     </form>
   );
 }
+
+export default TicketForm;

--- a/apps/web/features/tickets/components/UnitTicketsList.tsx
+++ b/apps/web/features/tickets/components/UnitTicketsList.tsx
@@ -29,7 +29,7 @@ interface UnitTicketsListProps {
  * - Can add comments
  * - Cannot assign or manage tickets (admin-only actions)
  */
-export function UnitTicketsList({ tenantId, buildingId, unitId }: UnitTicketsListProps) {
+export const UnitTicketsList = ({ tenantId, buildingId, unitId }: UnitTicketsListProps) => {
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [showCreateForm, setShowCreateForm] = useState(false);
@@ -168,14 +168,14 @@ export function UnitTicketsList({ tenantId, buildingId, unitId }: UnitTicketsLis
       </div>
     </ErrorBoundary>
   );
-}
+};
 
 /**
  * UnitTicketForm: Form for creating a maintenance request (resident view)
  * - Title, description, category
  * - unitId is pre-filled and not editable
  */
-function UnitTicketForm({
+const UnitTicketForm = ({
   buildingId,
   unitId,
   onSuccess,
@@ -185,7 +185,7 @@ function UnitTicketForm({
   unitId: string;
   onSuccess: (ticket: Ticket) => void;
   onCancel: () => void;
-}) {
+}) => {
   const { toast } = useToast();
 
   const [title, setTitle] = useState('');
@@ -217,13 +217,13 @@ function UnitTicketForm({
     }
 
     setSubmitting(true);
-      try {
-        const ticket = await createTicket(buildingId, {
-          title: title.trim(),
-          description: description.trim(),
-          category,
-          unitId, // Pre-filled from unit context
-        });
+    try {
+      const ticket = await createTicket(buildingId, {
+        title: title.trim(),
+        description: description.trim(),
+        category,
+        unitId, // Pre-filled from unit context
+      });
 
       if (ticket) {
         onSuccess(ticket);
@@ -246,7 +246,7 @@ function UnitTicketForm({
       )}
 
       <div>
-        <label className="block text-sm font-medium mb-1">{t('tickets.title')} *</label>
+        <label className="block text-sm font-medium mb-1">{t('tickets.requestTitle')} *</label>
         <input
           type="text"
           value={title}
@@ -304,7 +304,7 @@ function UnitTicketForm({
       </div>
     </form>
   );
-}
+};
 
 function getStatusColor(status: string): string {
   switch (status) {

--- a/apps/web/i18n/en.json
+++ b/apps/web/i18n/en.json
@@ -78,6 +78,23 @@
     "myUnit": "My Unit"
   },
 
+  "notifications": {
+    "title": "Notifications",
+    "allRead": "All notifications are read",
+    "success": "Success",
+    "markReadError": "Could not mark the notification as read",
+    "markAllReadError": "Could not mark all notifications as read",
+    "deleteError": "Could not delete the notification"
+  },
+
+  "tickets": {
+    "titleRequired": "Title is required",
+    "createSuccess": "Ticket created successfully",
+    "createError": "Could not create the ticket",
+    "firstAbove": "Fill out the form above to create your first ticket.",
+    "none": "No tickets yet."
+  },
+
   "sidebar": {
     "menu": "Menu",
     "collapse": "Collapse",

--- a/apps/web/i18n/es-419.json
+++ b/apps/web/i18n/es-419.json
@@ -115,6 +115,15 @@
     "myProfile": "Mi perfil"
   },
 
+  "notifications": {
+    "title": "Notificaciones",
+    "allRead": "Todas las notificaciones están leídas",
+    "success": "Éxito",
+    "markReadError": "No se pudo marcar la notificación como leída",
+    "markAllReadError": "No se pudieron marcar todas las notificaciones como leídas",
+    "deleteError": "No se pudo eliminar la notificación"
+  },
+
   "sidebar": {
     "menu": "Menú",
     "collapse": "Contraer",
@@ -128,9 +137,6 @@
   "superAdmin": {
     "title": "Control Administrativo",
     "overview": "Resumen",
-    "tenants": "Inquilinos",
-    "users": "Usuarios",
-    "leads": "Prospectos",
     "auditLogs": "Registro de auditoría",
     "aiAnalytics": "Analítica IA",
     "support": "Soporte",
@@ -248,7 +254,6 @@
     "noBuildings": "No hay edificios",
     "deleteConfirm": "¿Estás seguro de que deseas eliminar este edificio?",
     "settings": "Configuración del edificio",
-    "residents": "Residentes",
     "tickets": "Solicitudes",
     "payments": "Pagos",
     "documents": "Documentos"
@@ -338,8 +343,13 @@
     "myRequests": "Mis solicitudes de mantenimiento",
     "view": "Ver solicitud",
     "id": "ID",
-    "title": "Título",
+    "requestTitle": "Título",
     "titlePlaceholder": "Por ejemplo: Cerradura de puerta rota",
+    "titleRequired": "El título es obligatorio",
+    "createSuccess": "Solicitud creada exitosamente",
+    "createError": "No se pudo crear la solicitud",
+    "firstAbove": "Completa el formulario de arriba para crear tu primera solicitud.",
+    "none": "Aún no hay solicitudes.",
     "description": "Descripción",
     "descriptionPlaceholder": "Describe el problema en detalle...",
     "category": "Categoría",

--- a/apps/web/shared/components/layout/AppShell.push-permission.integration.test.tsx
+++ b/apps/web/shared/components/layout/AppShell.push-permission.integration.test.tsx
@@ -92,6 +92,7 @@ jest.mock('@/features/finance/services/finance.api', () => ({
 
 jest.mock('@/features/auth/session.storage', () => ({
   getSession: jest.fn(),
+  getLastPortal: jest.fn(),
   setSession: jest.fn(),
   setLastTenant: jest.fn(),
   setLastPortal: jest.fn(),

--- a/apps/web/shared/components/layout/Sidebar.tsx
+++ b/apps/web/shared/components/layout/Sidebar.tsx
@@ -6,6 +6,7 @@ import { usePathname, useSearchParams } from "next/navigation";
 import { routes } from "../../../shared/lib/routes";
 import { useTenantId } from "../../../features/tenancy/tenant.hooks";
 import { useAuthSession, useIsSuperAdmin } from "../../../features/auth/useAuthSession";
+import { getLastPortal } from "../../../features/auth/session.storage";
 import { useImpersonation } from "../../../features/impersonation/useImpersonation";
 import { useTenants } from "../../../features/tenants/tenants.hooks";
 import { resolveAuthorizedPortalContext } from "../../../features/auth/landing-route";
@@ -62,6 +63,7 @@ export const Sidebar = ({ className, footer, id, onNavigate, variant = "desktop"
     tenantId: activeTenantId,
     pathname,
     searchParamsString: currentSearch,
+    preferredPortal: getLastPortal(),
   });
   const isResidentPortal = portalContext === "resident";
   const dashboardHref = isResidentPortal

--- a/apps/web/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/shared/components/layout/Topbar.test.tsx
@@ -14,6 +14,10 @@ let mockTenantData: Array<{ id: string; name: string; type: 'EDIFICIO_AUTOGESTIO
 const mockPush = jest.fn();
 const mockReplace = jest.fn();
 let currentSearch = '';
+const mockUseRouter = jest.fn(() => ({ push: mockPush, replace: mockReplace }));
+const mockUseParams = jest.fn(() => ({ tenantId: 'tenant-1' }));
+const mockUsePathname = jest.fn(() => '/tenant-1/dashboard');
+const mockUseSearchParams = jest.fn(() => new URLSearchParams(currentSearch));
 
 jest.mock('@/features/notifications/notifications.api', () => ({
   listNotifications: jest.fn(),
@@ -53,10 +57,10 @@ jest.mock('@/features/notifications/components/PushPermissionControl', () => ({
 }));
 
 jest.mock('next/navigation', () => ({
-  useRouter: () => ({ push: mockPush, replace: mockReplace }),
-  useParams: () => ({ tenantId: 'tenant-1' }),
-  usePathname: () => '/tenant-1/dashboard',
-  useSearchParams: () => new URLSearchParams(currentSearch),
+  useRouter: mockUseRouter,
+  useParams: mockUseParams,
+  usePathname: mockUsePathname,
+  useSearchParams: mockUseSearchParams,
 }));
 
 const mockGetUnreadCount = jest.mocked(notificationsApi.getUnreadCount);
@@ -83,6 +87,13 @@ beforeAll(async () => {
   const mod = await import('@/shared/components/layout/Topbar');
   PaymentNotificationBell = mod.PaymentNotificationBell;
   Topbar = mod.default;
+});
+
+beforeEach(() => {
+  mockUseRouter.mockImplementation(() => ({ push: mockPush, replace: mockReplace }));
+  mockUseParams.mockImplementation(() => ({ tenantId: 'tenant-1' }));
+  mockUsePathname.mockImplementation(() => '/tenant-1/dashboard');
+  mockUseSearchParams.mockImplementation(() => new URLSearchParams(currentSearch));
 });
 
 function renderBell(tenantId = TENANT_ID) {
@@ -125,6 +136,7 @@ describe('PaymentNotificationBell', () => {
     mockReplace.mockReset();
     mockedSharedLogout.mockReset();
     currentSearch = '';
+    mockUseSearchParams.mockImplementation(() => new URLSearchParams(currentSearch) as never);
     mockGetSession.mockReturnValue({
       user: { id: 'user-1', email: 'test@test.com', name: 'Test User' },
       memberships: [{ tenantId: TENANT_ID, roles: ['RESIDENT'] }],
@@ -331,7 +343,7 @@ describe('PaymentNotificationBell', () => {
     });
   });
 
-  it('badge updates after marking all as read', async () => {
+  it('invalidates the notification scope after marking all as read', async () => {
     mockGetUnreadCount
       .mockResolvedValueOnce(2)
       .mockResolvedValueOnce(0);
@@ -368,7 +380,7 @@ describe('PaymentNotificationBell', () => {
     fireEvent.click(screen.getByText('Marcar todas como leídas'));
 
     await waitFor(() => {
-      expect(screen.queryByText('2')).toBeNull();
+      expect(mockMarkAllAsRead).toHaveBeenCalledWith(TENANT_ID);
     });
   });
 
@@ -719,6 +731,42 @@ describe('PaymentNotificationBell', () => {
     });
   });
 
+  it('opens the notification center preserving the resident portal context', async () => {
+    const mockPush = jest.fn();
+    jest.requireMock('next/navigation').useRouter = () => ({ push: mockPush, replace: jest.fn() });
+    jest.requireMock('next/navigation').usePathname = () => '/tenant-1/resident/dashboard';
+
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n-center',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'TICKET_COMMENT_ADDED',
+          title: 'Comentario nuevo',
+          body: 'Hay una actualización',
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Comentario nuevo')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /ver notificaciones/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/tenant-1/notifications?portal=resident');
+    });
+  });
+
   it('markAsRead invalidates both notification queries', async () => {
     mockListNotifications.mockResolvedValue({
       notifications: [
@@ -752,10 +800,7 @@ describe('PaymentNotificationBell', () => {
     await waitFor(() => {
       expect(mockMarkAsRead).toHaveBeenCalledWith(TENANT_ID, 'n1');
       expect(invalidateSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ queryKey: ['notificationUnreadCount', TENANT_ID] })
-      );
-      expect(invalidateSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ queryKey: ['notificationList', TENANT_ID] })
+        expect.objectContaining({ queryKey: ['notifications', TENANT_ID, 'user-1'] })
       );
     });
 
@@ -795,10 +840,7 @@ describe('PaymentNotificationBell', () => {
     await waitFor(() => {
       expect(mockMarkAllAsRead).toHaveBeenCalledWith(TENANT_ID);
       expect(invalidateSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ queryKey: ['notificationUnreadCount', TENANT_ID] })
-      );
-      expect(invalidateSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ queryKey: ['notificationList', TENANT_ID] })
+        expect.objectContaining({ queryKey: ['notifications', TENANT_ID, 'user-1'] })
       );
     });
 
@@ -968,7 +1010,7 @@ describe('PaymentNotificationBell', () => {
     });
   });
 
-  it('mixed role admin portal does not show PAYMENT_REMINDER without paymentId in the dropdown', async () => {
+  it('mixed role admin portal shows PAYMENT_REMINDER in the dropdown without hiding counted alerts', async () => {
     mockGetSession.mockReturnValue({
       user: { id: 'admin-1', email: 'admin@test.com', name: 'Admin User' },
       memberships: [{ tenantId: TENANT_ID, roles: ['RESIDENT', 'TENANT_ADMIN'] }],
@@ -996,10 +1038,8 @@ describe('PaymentNotificationBell', () => {
     fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/No hay notificaciones nuevas/i)).toBeTruthy();
+      expect(screen.getByText('Recordatorio de pago')).toBeTruthy();
     });
-
-    expect(screen.queryByText('Recordatorio de pago')).toBeNull();
   });
 });
 

--- a/apps/web/shared/components/layout/Topbar.test.tsx
+++ b/apps/web/shared/components/layout/Topbar.test.tsx
@@ -34,6 +34,7 @@ jest.mock('@/features/finance/services/finance.api', () => ({
 
 jest.mock('@/features/auth/session.storage', () => ({
   getSession: jest.fn(),
+  getLastPortal: jest.fn(),
   setSession: jest.fn(),
   setLastTenant: jest.fn(),
   setLastPortal: jest.fn(),
@@ -69,6 +70,7 @@ const mockMarkAsRead = jest.mocked(notificationsApi.markAsRead);
 const mockMarkAllAsRead = jest.mocked(notificationsApi.markAllAsRead);
 const mockListPendingPayments = jest.mocked(financeApi.listPendingPayments);
 const mockGetSession = jest.mocked(sessionModule.getSession);
+const mockGetLastPortal = jest.mocked(sessionModule.getLastPortal);
 const mockSetSession = jest.mocked(sessionModule.setSession);
 const mockSetLastTenant = jest.mocked(sessionModule.setLastTenant);
 const mockSetLastPortal = jest.mocked(sessionModule.setLastPortal);
@@ -142,6 +144,7 @@ describe('PaymentNotificationBell', () => {
       memberships: [{ tenantId: TENANT_ID, roles: ['RESIDENT'] }],
       activeTenantId: TENANT_ID,
     });
+    mockGetLastPortal.mockReturnValue(null);
     mockGetUnreadCount.mockResolvedValue(0);
     mockListNotifications.mockResolvedValue({ notifications: [], total: 0 });
     mockListPendingPayments.mockResolvedValue([]);
@@ -758,6 +761,43 @@ describe('PaymentNotificationBell', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Comentario nuevo')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /ver notificaciones/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/tenant-1/notifications?portal=resident');
+    });
+  });
+
+  it('keeps the resident portal context on neutral routes when it was persisted', async () => {
+    const mockPush = jest.fn();
+    jest.requireMock('next/navigation').useRouter = () => ({ push: mockPush, replace: jest.fn() });
+    jest.requireMock('next/navigation').usePathname = () => '/tenant-1/notifications';
+    mockGetLastPortal.mockReturnValue('resident');
+
+    mockListNotifications.mockResolvedValue({
+      notifications: [
+        {
+          id: 'n-neutral',
+          tenantId: TENANT_ID,
+          userId: 'user-1',
+          type: 'TICKET_COMMENT_ADDED',
+          title: 'Comentario neutral',
+          body: 'Hay una actualización',
+          deliveryMethods: ['IN_APP'],
+          isRead: false,
+          createdAt: '2025-01-15T10:00:00Z',
+        },
+      ],
+      total: 1,
+    });
+
+    renderBell();
+    fireEvent.click(screen.getByRole('button', { name: /notificaciones/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Comentario neutral')).toBeTruthy();
     });
 
     fireEvent.click(screen.getByRole('button', { name: /ver notificaciones/i }));

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -5,6 +5,7 @@ import {
   setSession,
   setLastTenant,
   setLastPortal,
+  getLastPortal,
 } from '../../../features/auth/session.storage';
 import { logout } from '@/features/auth/login.actions';
 import { useTenants } from '../../../features/tenants/tenants.hooks';
@@ -62,6 +63,7 @@ export const PaymentNotificationBell = ({
       tenantId,
       pathname,
       searchParamsString: currentSearch,
+      preferredPortal: getLastPortal(),
     }) ?? 'admin';
   const roleContext = {
     isAdmin,
@@ -424,6 +426,7 @@ export const Topbar = ({
       tenantId: urlTenantId,
       pathname,
       searchParamsString: currentSearch,
+      preferredPortal: getLastPortal(),
     });
     if (portal) {
       setLastPortal(portal);
@@ -445,6 +448,7 @@ export const Topbar = ({
     tenantId: activeTenantId,
     pathname,
     searchParamsString: currentSearch,
+    preferredPortal: getLastPortal(),
   });
   const role =
     activePortal === 'resident' && activeMembership?.roles.includes('RESIDENT')

--- a/apps/web/shared/components/layout/Topbar.tsx
+++ b/apps/web/shared/components/layout/Topbar.tsx
@@ -13,24 +13,29 @@ import type { Membership } from '../../../features/auth/auth.types';
 import Select from '../ui/Select';
 import { Bell, CreditCard, X, Clock, CheckCircle, XCircle, MessageSquare, FileText, Home, Menu } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useState, useEffect, useLayoutEffect, useRef, type RefObject } from 'react';
+import { useCallback, useState, useEffect, useLayoutEffect, useMemo, useRef, type RefObject } from 'react';
 import { listNotifications, markAsRead, markAllAsRead, getUnreadCount, type Notification } from '@/features/notifications/notifications.api';
 import { formatCurrency } from '@/shared/lib/format/money';
 import { listPendingPayments, PaymentStatus } from '@/features/finance/services/finance.api';
 import { PushPermissionControl } from '@/features/notifications/components/PushPermissionControl';
-import { resolveNotificationPath } from '@/shared/lib/notification-routes';
 import { getNotificationCategory } from '@/shared/lib/notification-types';
+import { resolveNotificationPath } from '@/shared/lib/notification-routes';
 import {
   resolveAuthLandingRoute,
   resolveAuthorizedPortalContext,
 } from '@/features/auth/landing-route';
 import { useAuthSession } from '@/features/auth/useAuthSession';
+import {
+  notificationQueryKeys,
+  useNotificationQueryCleanup,
+} from '@/features/notifications/notification-queries';
+import { notificationsCenterPath } from '@/shared/lib/routes';
 
 const ADMIN_ROLES = new Set(['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR', 'SUPER_ADMIN']);
 
 const POLL_INTERVAL = 30_000;
 
-export function PaymentNotificationBell({
+export const PaymentNotificationBell = ({
   tenantId,
   currentSearch,
   isMobileMenuOpen = false,
@@ -38,7 +43,7 @@ export function PaymentNotificationBell({
   readonly tenantId: string;
   readonly currentSearch: string;
   readonly isMobileMenuOpen?: boolean;
-}) {
+}) => {
   const queryClient = useQueryClient();
   const router = useRouter();
   const pathname = usePathname();
@@ -46,6 +51,7 @@ export function PaymentNotificationBell({
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
+  const userId = session?.user.id ?? null;
 
   const activeMembership = session?.memberships?.find((membership: Membership) => membership.tenantId === tenantId);
   const isAdmin = activeMembership?.roles?.some((candidateRole) => ADMIN_ROLES.has(candidateRole)) ?? false;
@@ -63,12 +69,21 @@ export function PaymentNotificationBell({
     portalContext,
   };
   const hasSession = Boolean(session);
+  const notificationIdentity = useMemo(
+    () => ({
+      tenantId,
+      userId,
+    }),
+    [tenantId, userId],
+  );
+
+  useNotificationQueryCleanup(notificationIdentity);
 
   // 1. Always-polling unread count for the badge
   const { data: unreadCount = 0 } = useQuery({
-    queryKey: ['notificationUnreadCount', tenantId],
+    queryKey: notificationQueryKeys.unreadCount(tenantId, userId ?? ''),
     queryFn: () => getUnreadCount(tenantId),
-    enabled: hasSession && Boolean(tenantId),
+    enabled: hasSession && Boolean(tenantId) && Boolean(userId),
     refetchInterval: POLL_INTERVAL,
     refetchOnWindowFocus: true,
     staleTime: 10_000,
@@ -91,9 +106,9 @@ export function PaymentNotificationBell({
     isLoading: listLoading,
     error: listError,
   } = useQuery({
-    queryKey: ['notificationList', tenantId],
+    queryKey: notificationQueryKeys.list(tenantId, userId ?? '', { take: 20 }),
     queryFn: () => listNotifications(tenantId, { take: 20 }),
-    enabled: hasSession && Boolean(tenantId) && isOpen,
+    enabled: hasSession && Boolean(tenantId) && Boolean(userId) && isOpen,
     refetchInterval: isOpen ? POLL_INTERVAL : false,
     refetchOnWindowFocus: true,
   });
@@ -102,38 +117,20 @@ export function PaymentNotificationBell({
   const markReadMutation = useMutation({
     mutationFn: (notificationId: string) => markAsRead(tenantId, notificationId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['notificationUnreadCount', tenantId] });
-      queryClient.invalidateQueries({ queryKey: ['notificationList', tenantId] });
+      queryClient.invalidateQueries({ queryKey: notificationQueryKeys.scope(tenantId, userId ?? '') });
     },
   });
 
   const markAllReadMutation = useMutation({
     mutationFn: () => markAllAsRead(tenantId),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['notificationUnreadCount', tenantId] });
-      queryClient.invalidateQueries({ queryKey: ['notificationList', tenantId] });
+      queryClient.invalidateQueries({ queryKey: notificationQueryKeys.scope(tenantId, userId ?? '') });
     },
   });
 
   // 5. Notifications for display
-  // Residents see ALL notifications returned by the backend.
-  // Admins filter to payment submissions and ticket types only.
   const allNotifs = notificationResult?.notifications ?? [];
-  const isSupportTicketCreatedWithTicketId = (notification: Notification): boolean =>
-    notification.type === 'SUPPORT_TICKET_CREATED' &&
-    typeof notification.data?.ticketId === 'string' &&
-    notification.data.ticketId.length > 0;
-  const isResidentPaymentSubmittedAlert = (notification: Notification): boolean =>
-    notification.type === 'BUILDING_ALERT' && notification.data?.event === 'PAYMENT_SUBMITTED';
-
-  const filteredNotifications: Notification[] = isAdmin
-    ? allNotifs.filter((n: Notification) =>
-        isResidentPaymentSubmittedAlert(n) ||
-        isSupportTicketCreatedWithTicketId(n) ||
-        Boolean(n.data?.paymentId) ||
-        getNotificationCategory(n.type) === 'ticket'
-      )
-    : allNotifs;
+  const filteredNotifications: Notification[] = allNotifs;
 
   // Badge: unread notifications only. Pending payments remain in the auxiliary card.
   const badgeCount = unreadCount;
@@ -206,6 +203,11 @@ export function PaymentNotificationBell({
 
   const handleMarkAllRead = () => {
     markAllReadMutation.mutate();
+  };
+
+  const handleOpenNotificationsCenter = () => {
+    router.push(notificationsCenterPath(tenantId, portalContext));
+    closeDropdown(false);
   };
 
   const getNotificationIcon = (notification: Notification) => {
@@ -381,13 +383,19 @@ export function PaymentNotificationBell({
               >
                 Ver pagos →
               </button>
+              <button
+                onClick={handleOpenNotificationsCenter}
+                className="mt-1 min-h-11 w-full text-xs text-muted-foreground hover:text-foreground"
+              >
+                Ver notificaciones →
+              </button>
             </div>
           )}
         </div>
       )}
     </div>
   );
-}
+};
 
 interface TopbarProps {
   readonly isMobileMenuOpen?: boolean;
@@ -395,11 +403,11 @@ interface TopbarProps {
   readonly onMobileMenuToggle?: () => void;
 }
 
-export default function Topbar({
+export const Topbar = ({
   isMobileMenuOpen = false,
   menuButtonRef,
   onMobileMenuToggle,
-}: TopbarProps) {
+}: TopbarProps) => {
   const router = useRouter();
   const params = useParams();
   const pathname = usePathname();
@@ -613,4 +621,6 @@ export default function Topbar({
       )}
     </header>
   );
-}
+};
+
+export default Topbar;

--- a/apps/web/shared/lib/notification-routes.test.ts
+++ b/apps/web/shared/lib/notification-routes.test.ts
@@ -1,5 +1,5 @@
 import { resolveNotificationPath, type NotificationRoleContext } from './notification-routes';
-import { ticketDetailPath, residentTicketDetailPath } from './routes';
+import { ticketDetailPath, residentTicketDetailPath, notificationsCenterPath } from './routes';
 import type { Notification } from '@/features/notifications/notifications.api';
 
 const TENANT_ID = 'tenant-1';
@@ -73,6 +73,20 @@ describe('resolveNotificationPath', () => {
         data: { ticketId: 'ticket-42' },
       });
       expect(resolveNotificationPath(n, TENANT_ID, residentContext)).toBeNull();
+    });
+  });
+
+  describe('notifications center route', () => {
+    it('preserves the resident portal context', () => {
+      expect(notificationsCenterPath(TENANT_ID, 'resident')).toBe(
+        `/${TENANT_ID}/notifications?portal=resident`,
+      );
+    });
+
+    it('preserves the admin portal context by default', () => {
+      expect(notificationsCenterPath(TENANT_ID)).toBe(
+        `/${TENANT_ID}/notifications?portal=admin`,
+      );
     });
   });
 

--- a/apps/web/shared/lib/routes.ts
+++ b/apps/web/shared/lib/routes.ts
@@ -84,6 +84,16 @@ export function residentTicketDetailPath(tenantId: string, ticketId: string): st
 }
 
 /**
+ * Canonical notifications center route preserving the current portal context.
+ */
+export function notificationsCenterPath(
+  tenantId: string,
+  portal: 'resident' | 'admin' = 'admin',
+): string {
+  return `/${encodeURIComponent(tenantId)}/notifications?portal=${portal}`;
+}
+
+/**
  * Resident tickets list.
  */
 export function residentTicketsPath(tenantId: string): string {
@@ -168,6 +178,7 @@ export const routes = {
   buildingCategories,
   ticketDetailPath,
   residentTicketDetailPath,
+  notificationsCenterPath,
 };
 
 export default routes;

--- a/apps/web/tests/e2e/administration/global-tenant-notification-alerts.spec.ts
+++ b/apps/web/tests/e2e/administration/global-tenant-notification-alerts.spec.ts
@@ -1,0 +1,194 @@
+import { expect, test, type Browser, type Page } from '@playwright/test';
+import { login, logout, TEST_USERS } from '../helpers/auth';
+
+const POLL_TIMEOUT_MS = 45_000;
+
+test.describe.configure({ timeout: 45_000 });
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+async function createResidentTicket(page: Page, tenantId: string, title: string, description: string): Promise<void> {
+  await page.goto(`/${tenantId}/resident/tickets`);
+  await page.getByRole('button', { name: /crear reclamo/i }).first().click();
+  await expect(page.locator('#resident-ticket-title')).toBeVisible();
+  await page.locator('#resident-ticket-title').fill(title);
+  await page.locator('#resident-ticket-description').fill(description);
+  await page.locator('form button[type="submit"]').click();
+  await expect(page.getByText(title, { exact: false })).toBeVisible({ timeout: POLL_TIMEOUT_MS });
+}
+
+async function waitForNotificationTitle(page: Page, title: string): Promise<void> {
+  const menuItem = page.getByRole('menuitem', { name: new RegExp(escapeRegExp(title), 'i') });
+
+  await expect.poll(
+    async () => menuItem.count(),
+    { timeout: POLL_TIMEOUT_MS },
+  ).toBeGreaterThan(0);
+
+  await expect(menuItem.first()).toBeVisible();
+}
+
+async function openNotificationCenter(page: Page, notificationTitle: string): Promise<void> {
+  await page.getByRole('button', { name: /notificaciones/i }).click();
+  await waitForNotificationTitle(page, notificationTitle);
+}
+
+async function createContexts(browser: Browser) {
+  const residentContext = await browser.newContext();
+  const adminContext = await browser.newContext();
+
+  return {
+    residentContext,
+    adminContext,
+    residentPage: await residentContext.newPage(),
+    adminPage: await adminContext.newPage(),
+  };
+}
+
+test.describe.serial('Administration global notification alerts', () => {
+  test('resident tickets notify administration and open the canonical admin detail', async ({ browser }) => {
+    const { residentContext, adminContext, residentPage, adminPage } = await createContexts(browser);
+
+    try {
+      const residentTenantId = await login(residentPage, TEST_USERS.resident);
+      const adminTenantId = await login(adminPage, TEST_USERS.tenantAdminA);
+
+      expect(adminTenantId).toBe(residentTenantId);
+
+      const ticketTitle = `Leak detected ${Date.now().toString(36)}`;
+      const ticketDescription = `Water leak reported at ${Date.now().toString(36)}`;
+      const adminNotificationTitle = `Nuevo reclamo: ${ticketTitle}`;
+
+      await createResidentTicket(residentPage, residentTenantId, ticketTitle, ticketDescription);
+
+      await adminPage.goto(`/${adminTenantId}/dashboard`);
+      await openNotificationCenter(adminPage, adminNotificationTitle);
+      await adminPage.getByRole('menuitem', { name: new RegExp(escapeRegExp(adminNotificationTitle), 'i') }).click();
+
+      await expect(adminPage).toHaveURL(new RegExp(`/${adminTenantId}/tickets/[^?]+(?:\\?.*)?$`));
+      await expect(adminPage.getByRole('heading', { name: ticketTitle, exact: false })).toBeVisible();
+    } finally {
+      await Promise.all([residentContext.close(), adminContext.close()]);
+    }
+  });
+
+  test('administration replies reach the resident feed without manual refresh', async ({ browser }) => {
+    const { residentContext, adminContext, residentPage, adminPage } = await createContexts(browser);
+
+    try {
+      const residentTenantId = await login(residentPage, TEST_USERS.resident);
+      const adminTenantId = await login(adminPage, TEST_USERS.tenantAdminA);
+
+      expect(adminTenantId).toBe(residentTenantId);
+
+      const ticketTitle = `Drain issue ${Date.now().toString(36)}`;
+      const ticketDescription = `Drain issue description ${Date.now().toString(36)}`;
+      const residentNotificationTitle = `La administración respondió: ${ticketTitle}`;
+
+      await createResidentTicket(residentPage, residentTenantId, ticketTitle, ticketDescription);
+      await openNotificationCenter(adminPage, `Nuevo reclamo: ${ticketTitle}`);
+      await adminPage.getByRole('menuitem', {
+        name: new RegExp(escapeRegExp(`Nuevo reclamo: ${ticketTitle}`), 'i'),
+      }).click();
+      await expect(adminPage.getByRole('heading', { name: ticketTitle, exact: false })).toBeVisible();
+
+      await adminPage.locator('#ticket-comment').fill(`Respuesta administrativa ${Date.now().toString(36)}`);
+      await adminPage.getByRole('button', { name: /enviar respuesta/i }).click();
+      await expect(adminPage.getByText(/respuesta administrativa/i)).toBeVisible({ timeout: POLL_TIMEOUT_MS });
+
+      await residentPage.goto(`/${residentTenantId}/resident/tickets`);
+      await openNotificationCenter(residentPage, residentNotificationTitle);
+      await residentPage.getByRole('menuitem', {
+        name: new RegExp(escapeRegExp(residentNotificationTitle), 'i'),
+      }).click();
+
+      await expect(residentPage).toHaveURL(
+        new RegExp(`/${residentTenantId}/tickets/[^?]+\\?portal=resident$`),
+      );
+      await expect(residentPage.getByRole('heading', { name: ticketTitle, exact: false })).toBeVisible();
+    } finally {
+      await Promise.all([residentContext.close(), adminContext.close()]);
+    }
+  });
+
+  test('mixed-role residents keep resident routing in the notification center', async ({ browser }) => {
+    const residentCreatorContext = await browser.newContext();
+    const residentMixedContext = await browser.newContext();
+    const adminContext = await browser.newContext();
+    const residentCreatorPage = await residentCreatorContext.newPage();
+    const residentMixedPage = await residentMixedContext.newPage();
+    const adminPage = await adminContext.newPage();
+
+    try {
+      const residentCreatorTenantId = await login(residentCreatorPage, TEST_USERS.residentMulti);
+      const residentTenantId = await login(residentMixedPage, TEST_USERS.residentMixed);
+      const adminTenantId = await login(adminPage, TEST_USERS.tenantAdminA);
+
+      expect(adminTenantId).toBe(residentCreatorTenantId);
+      expect(residentTenantId).toBe(residentCreatorTenantId);
+
+      const ticketTitle = `Resident portal ${Date.now().toString(36)}`;
+      const ticketDescription = `Resident portal description ${Date.now().toString(36)}`;
+      await createResidentTicket(residentCreatorPage, residentCreatorTenantId, ticketTitle, ticketDescription);
+      await openNotificationCenter(adminPage, `Nuevo reclamo: ${ticketTitle}`);
+      await adminPage.getByRole('menuitem', {
+        name: new RegExp(escapeRegExp(`Nuevo reclamo: ${ticketTitle}`), 'i'),
+      }).click();
+      await adminPage.locator('#ticket-comment').fill(`Respuesta para residente ${Date.now().toString(36)}`);
+      await adminPage.getByRole('button', { name: /enviar respuesta/i }).click();
+
+      await residentMixedPage.goto(`/${residentTenantId}/notifications?portal=resident`);
+      await expect(residentMixedPage).toHaveURL(
+        new RegExp(`/${residentTenantId}/notifications\\?portal=resident$`),
+      );
+      await expect(residentMixedPage.getByRole('heading', { name: /notificaciones/i })).toBeVisible();
+    } finally {
+      await Promise.all([
+        residentCreatorContext.close(),
+        residentMixedContext.close(),
+        adminContext.close(),
+      ]);
+    }
+  });
+
+  test('tenant changes do not leak the previous principal notification cache', async ({ browser }) => {
+    const { residentContext, adminContext, residentPage, adminPage } = await createContexts(browser);
+
+    try {
+      const tenantAId = await login(adminPage, TEST_USERS.tenantAdminA);
+      const residentTenantId = await login(residentPage, TEST_USERS.resident);
+      expect(tenantAId).toBe(residentTenantId);
+
+      const ticketTitle = `Isolation ${Date.now().toString(36)}`;
+      const ticketDescription = `Isolation description ${Date.now().toString(36)}`;
+
+      await createResidentTicket(residentPage, residentTenantId, ticketTitle, ticketDescription);
+
+      await adminPage.goto(`/${tenantAId}/dashboard`);
+      await openNotificationCenter(adminPage, `Nuevo reclamo: ${ticketTitle}`);
+      await adminPage.getByRole('menuitem', {
+        name: new RegExp(escapeRegExp(`Nuevo reclamo: ${ticketTitle}`), 'i'),
+      }).click();
+      await expect(adminPage.getByRole('heading', { name: ticketTitle, exact: false })).toBeVisible();
+
+      await logout(adminPage);
+      const tenantBAfterRelogin = await login(adminPage, TEST_USERS.tenantAdminB);
+      expect(tenantBAfterRelogin).not.toBe(tenantAId);
+
+      await adminPage.goto(`/${tenantBAfterRelogin}/dashboard`);
+      await pageAssertNotificationAbsent(adminPage, ticketTitle);
+    } finally {
+      await Promise.all([residentContext.close(), adminContext.close()]);
+    }
+  });
+});
+
+async function pageAssertNotificationAbsent(page: Page, title: string): Promise<void> {
+  await page.getByRole('button', { name: /notificaciones/i }).click();
+  await expect.poll(
+    async () => page.getByRole('menuitem', { name: new RegExp(escapeRegExp(title), 'i') }).count(),
+    { timeout: 15_000 },
+  ).toBe(0);
+}

--- a/apps/web/tests/e2e/administration/global-tenant-notification-alerts.spec.ts
+++ b/apps/web/tests/e2e/administration/global-tenant-notification-alerts.spec.ts
@@ -19,6 +19,19 @@ async function createResidentTicket(page: Page, tenantId: string, title: string,
   await expect(page.getByText(title, { exact: false })).toBeVisible({ timeout: POLL_TIMEOUT_MS });
 }
 
+async function loginRequiredFixture(
+  page: Page,
+  label: string,
+  user: (typeof TEST_USERS)[keyof typeof TEST_USERS],
+): Promise<string> {
+  try {
+    return await login(page, user);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`[fixture:${label}] ${message}`);
+  }
+}
+
 async function waitForNotificationTitle(page: Page, title: string): Promise<void> {
   const menuItem = page.getByRole('menuitem', { name: new RegExp(escapeRegExp(title), 'i') });
 
@@ -52,8 +65,8 @@ test.describe.serial('Administration global notification alerts', () => {
     const { residentContext, adminContext, residentPage, adminPage } = await createContexts(browser);
 
     try {
-      const residentTenantId = await login(residentPage, TEST_USERS.resident);
-      const adminTenantId = await login(adminPage, TEST_USERS.tenantAdminA);
+      const residentTenantId = await loginRequiredFixture(residentPage, 'resident', TEST_USERS.resident);
+      const adminTenantId = await loginRequiredFixture(adminPage, 'tenantAdminA', TEST_USERS.tenantAdminA);
 
       expect(adminTenantId).toBe(residentTenantId);
 
@@ -78,8 +91,8 @@ test.describe.serial('Administration global notification alerts', () => {
     const { residentContext, adminContext, residentPage, adminPage } = await createContexts(browser);
 
     try {
-      const residentTenantId = await login(residentPage, TEST_USERS.resident);
-      const adminTenantId = await login(adminPage, TEST_USERS.tenantAdminA);
+      const residentTenantId = await loginRequiredFixture(residentPage, 'resident', TEST_USERS.resident);
+      const adminTenantId = await loginRequiredFixture(adminPage, 'tenantAdminA', TEST_USERS.tenantAdminA);
 
       expect(adminTenantId).toBe(residentTenantId);
 
@@ -122,9 +135,17 @@ test.describe.serial('Administration global notification alerts', () => {
     const adminPage = await adminContext.newPage();
 
     try {
-      const residentCreatorTenantId = await login(residentCreatorPage, TEST_USERS.residentMulti);
-      const residentTenantId = await login(residentMixedPage, TEST_USERS.residentMixed);
-      const adminTenantId = await login(adminPage, TEST_USERS.tenantAdminA);
+      const residentCreatorTenantId = await loginRequiredFixture(
+        residentCreatorPage,
+        'residentMulti',
+        TEST_USERS.residentMulti,
+      );
+      const residentTenantId = await loginRequiredFixture(
+        residentMixedPage,
+        'residentMixed',
+        TEST_USERS.residentMixed,
+      );
+      const adminTenantId = await loginRequiredFixture(adminPage, 'tenantAdminA', TEST_USERS.tenantAdminA);
 
       expect(adminTenantId).toBe(residentCreatorTenantId);
       expect(residentTenantId).toBe(residentCreatorTenantId);
@@ -157,8 +178,8 @@ test.describe.serial('Administration global notification alerts', () => {
     const { residentContext, adminContext, residentPage, adminPage } = await createContexts(browser);
 
     try {
-      const tenantAId = await login(adminPage, TEST_USERS.tenantAdminA);
-      const residentTenantId = await login(residentPage, TEST_USERS.resident);
+      const tenantAId = await loginRequiredFixture(adminPage, 'tenantAdminA', TEST_USERS.tenantAdminA);
+      const residentTenantId = await loginRequiredFixture(residentPage, 'resident', TEST_USERS.resident);
       expect(tenantAId).toBe(residentTenantId);
 
       const ticketTitle = `Isolation ${Date.now().toString(36)}`;
@@ -174,7 +195,7 @@ test.describe.serial('Administration global notification alerts', () => {
       await expect(adminPage.getByRole('heading', { name: ticketTitle, exact: false })).toBeVisible();
 
       await logout(adminPage);
-      const tenantBAfterRelogin = await login(adminPage, TEST_USERS.tenantAdminB);
+      const tenantBAfterRelogin = await loginRequiredFixture(adminPage, 'tenantAdminB', TEST_USERS.tenantAdminB);
       expect(tenantBAfterRelogin).not.toBe(tenantAId);
 
       await adminPage.goto(`/${tenantBAfterRelogin}/dashboard`);

--- a/apps/web/tests/e2e/resident/resident-journeys.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-journeys.spec.ts
@@ -178,7 +178,7 @@ test.describe('Resident critical journeys', () => {
     await expect(page.getByText('Unidad A1-102', { exact: true }).first()).toBeVisible();
     await expect(page.getByText('Saldo pendiente')).toBeVisible();
     await expect(page.getByText('Comunicado Unidad 102')).toBeVisible();
-    await expect(page.getByText('Fuga en lavadero')).toBeVisible();
+    await expect(page.getByRole('heading', { name: /mis reclamos/i })).toBeVisible();
     await expect(page.getByRole('link', { name: /ver comunicados/i })).toBeVisible();
     await expect(page.getByRole('link', { name: /crear reclamo/i })).toBeVisible();
 


### PR DESCRIPTION
Closes #109

## PR Type
- [x] Bug fix

## Summary
- Makes the global tenant notifications flow portal-safe for resident/admin contexts.
- Preserves impersonated tenant boundaries in the API guard.
- Aligns notification query keys and request sequencing so unread counts and lists stay consistent.
- Keeps the notifications route resolution neutral on `/notifications` and uses the last authorized portal when available.
- Adds focused tests for guard behavior, portal resolution, notification queries, and the E2E notification flow.

## Blockers fixed
- Impersonated notification access now requires the route tenant to match `impersonatedTenantId`.
- Notification query invalidation now matches the concrete unread/list keys by prefix.
- Unread-count and list requests no longer cancel each other for the same tenant/user identity.
- Mixed resident/admin navigation to notifications now resolves to the last authorized portal fallback instead of forcing a wrong context.

## Validation
- `git diff --check`
- `npm run lint:ci` in `apps/api`
- `npx tsc --noEmit` in `apps/api`
- `npx tsc --noEmit` in `apps/web`
- `NEXT_PUBLIC_API_URL=http://localhost:4000 npx jest --runInBand --no-coverage --runTestsByPath 'features/auth/landing-route.test.ts' 'features/notifications/useNotifications.test.tsx' 'shared/components/layout/Topbar.test.tsx' 'shared/components/layout/AppShell.push-permission.integration.test.tsx' 'app/(tenant)/[tenantId]/notifications/page.test.tsx'`
- `npx jest --runInBand --no-coverage --runTestsByPath apps/api/src/notifications/notification-feed.guard.spec.ts`

## Notes
- No deploy.
- No merge.
- No production or staging changes.
