### PR TITLE
fix(web): guard building admin subtree by portal

### DIFF
--- a/apps/web/app/(tenant)/[tenantId]/buildings/[buildingId]/layout.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/buildings/[buildingId]/layout.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { useParams, useRouter } from 'next/navigation';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
+import BuildingAdminLayout from './layout';
+
+const replace = jest.fn();
+
+let mockTenantId = 'tenant-1';
+let mockBuildingId = 'building-1';
+
+jest.mock('next/navigation', () => ({
+  useParams: jest.fn(),
+  useRouter: jest.fn(),
+}));
+
+jest.mock('@/features/auth/useAuthorizedPortalContext', () => ({
+  useAuthorizedPortalContext: jest.fn(),
+}));
+
+const mockedUseParams = jest.mocked(useParams);
+const mockedUseRouter = jest.mocked(useRouter);
+const mockedUseAuthorizedPortalContext = jest.mocked(useAuthorizedPortalContext);
+
+function renderLayout(children: React.ReactNode = <div data-testid="admin-content">Admin content</div>) {
+  return render(<BuildingAdminLayout>{children}</BuildingAdminLayout>);
+}
+
+describe('BuildingAdminLayout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTenantId = 'tenant-1';
+    mockBuildingId = 'building-1';
+    mockedUseParams.mockReturnValue({ tenantId: mockTenantId, buildingId: mockBuildingId } as never);
+    mockedUseRouter.mockReturnValue({ replace } as never);
+    mockedUseAuthorizedPortalContext.mockReturnValue('admin');
+  });
+
+  it('does not render children while the portal context resolves', () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue(null);
+
+    renderLayout();
+
+    expect(screen.queryByTestId('admin-content')).toBeNull();
+    expect(document.querySelector('[aria-busy="true"]')).not.toBeNull();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('redirects resident users to the resident dashboard', async () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue('resident');
+
+    renderLayout();
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/tenant-1/resident/dashboard');
+    });
+    expect(screen.queryByTestId('admin-content')).toBeNull();
+  });
+
+  it('never shows administrative content to resident users', async () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue('resident');
+
+    renderLayout(<div data-testid="deep-route">Deep admin route</div>);
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/tenant-1/resident/dashboard');
+    });
+
+    expect(screen.queryByTestId('deep-route')).toBeNull();
+    expect(document.querySelector('[aria-busy="true"]')).not.toBeNull();
+  });
+
+  it('renders children for administrative portal access', () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue('admin');
+
+    renderLayout();
+
+    expect(screen.getByTestId('admin-content').textContent).toBe('Admin content');
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('redirects mixed-role users when the authorized portal resolves to resident', async () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue('resident');
+
+    renderLayout();
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/tenant-1/resident/dashboard');
+    });
+  });
+
+  it('renders mixed-role users when the authorized portal resolves to admin', () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue('admin');
+
+    renderLayout();
+
+    expect(screen.getByTestId('admin-content')).not.toBeNull();
+  });
+
+  it('re-evaluates access when the tenant changes', () => {
+    const { rerender } = renderLayout();
+
+    expect(mockedUseAuthorizedPortalContext).toHaveBeenLastCalledWith('tenant-1');
+
+    mockTenantId = 'tenant-2';
+    mockBuildingId = 'building-2';
+    mockedUseParams.mockReturnValue({ tenantId: mockTenantId, buildingId: mockBuildingId } as never);
+
+    rerender(
+      <BuildingAdminLayout>
+        <div data-testid="admin-content">Admin content</div>
+      </BuildingAdminLayout>,
+    );
+
+    expect(mockedUseAuthorizedPortalContext).toHaveBeenLastCalledWith('tenant-2');
+  });
+
+  it('keeps deep administrative routes protected by the same layout gate', () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue(null);
+
+    renderLayout(<div data-testid="deep-route">Deep administrative route</div>);
+
+    expect(screen.queryByTestId('deep-route')).toBeNull();
+    expect(document.querySelector('[aria-busy="true"]')).not.toBeNull();
+  });
+});

--- a/apps/web/app/(tenant)/[tenantId]/buildings/[buildingId]/layout.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/buildings/[buildingId]/layout.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
+import { routes } from '@/shared/lib/routes';
+
+interface BuildingRouteParams {
+  tenantId?: string;
+  buildingId?: string;
+  [key: string]: string | string[] | undefined;
+}
+
+interface BuildingAdminLayoutProps {
+  children: ReactNode;
+}
+
+export default function BuildingAdminLayout({ children }: BuildingAdminLayoutProps) {
+  const router = useRouter();
+  const params = useParams<BuildingRouteParams>();
+  const tenantId = typeof params?.tenantId === 'string' ? params.tenantId.trim() : '';
+  const portalContext = useAuthorizedPortalContext(tenantId || null);
+
+  useEffect(() => {
+    if (portalContext === 'resident' && tenantId) {
+      router.replace(routes.residentDashboard(tenantId));
+    }
+  }, [portalContext, router, tenantId]);
+
+  if (portalContext !== 'admin') {
+    return <div className="min-h-screen bg-background" aria-busy="true" />;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
Closes #112

### Summary
- Adds a central layout guard for the building admin subtree.
- Redirects resident portal access to the resident dashboard and keeps admin UI hidden until the portal resolves.
- Covers loading, resident/admin, mixed-role, tenant switching, and deep-route protection.

### Changes Table
| File | Change |
|------|--------|
| `apps/web/app/(tenant)/[tenantId]/buildings/[buildingId]/layout.tsx` | Added the central portal guard and resident redirect for all building admin routes. |
| `apps/web/app/(tenant)/[tenantId]/buildings/[buildingId]/layout.test.tsx` | Added layout tests for loading, resident/admin, mixed-role, tenant change, and deep-route protection. |

### Validation
- [x] `git diff --check`
- [x] Jest: 2 suites / 23 tests
- [x] TypeScript: `npx tsc --noEmit`
- [x] ESLint on modified files
- [x] GitHub Actions E2E checks passed for HEAD `b6004f0b984e7ecdd0b5207086a0ea1fa53a6b65`

### Contributor Checklist
- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
