### PR TITLE
fix(ai): restrict tenant AI analytics to authorized roles

### DIFF
--- a/apps/api/src/assistant/ai-budget.controller.ts
+++ b/apps/api/src/assistant/ai-budget.controller.ts
@@ -23,6 +23,7 @@ import { SuperAdminGuard } from '../auth/super-admin.guard';
 import { AiBudgetService, UsageData, UsageWithLimits } from './budget.service';
 import { AiRouterService } from './router.service';
 import { AiCacheService } from './cache.service';
+import { TenantAiAccessGuard } from './tenant-ai-access.guard';
 import { UpdateAiBudgetDto } from './dto/update-ai-budget.dto';
 import { AuthenticatedRequest } from '../common/types/request.types';
 
@@ -53,6 +54,7 @@ export class AiBudgetController {
    * - blockedAt: When 100% was exceeded (if any)
    */
   @Get(':tenantId/ai/usage')
+  @UseGuards(TenantAiAccessGuard)
   async getAiUsage(
     @Param('tenantId') tenantId: string,
     @Query('month') month?: string,
@@ -70,6 +72,7 @@ export class AiBudgetController {
    * Tenant endpoint: usage + effective limits in one payload
    */
   @Get(':tenantId/assistant/usage-with-limits')
+  @UseGuards(TenantAiAccessGuard)
   async getUsageWithLimits(
     @Param('tenantId') tenantId: string,
     @Query('month') month?: string,
@@ -156,6 +159,7 @@ export class AiBudgetController {
    * Used for: Observability dashboards, cost monitoring, optimization tracking
    */
   @Get(':tenantId/ai/stats')
+  @UseGuards(TenantAiAccessGuard)
   async getAiStats(
     @Param('tenantId') tenantId: string,
   ): Promise<{

--- a/apps/api/src/assistant/ai-nudges.controller.ts
+++ b/apps/api/src/assistant/ai-nudges.controller.ts
@@ -12,9 +12,10 @@ import {
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { AiNudge, AiNudgesService } from './ai-nudges.service';
 import type { AuthenticatedRequest } from '../common/types/request.types';
+import { TenantAiAccessGuard } from './tenant-ai-access.guard';
 
 @Controller('me/ai')
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, TenantAiAccessGuard)
 export class AiNudgesController {
   constructor(private readonly aiNudgesService: AiNudgesService) {}
 

--- a/apps/api/src/assistant/ai-settings-access.integration.spec.ts
+++ b/apps/api/src/assistant/ai-settings-access.integration.spec.ts
@@ -1,0 +1,203 @@
+import { ForbiddenException, INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import request from 'supertest';
+import { AssistantController } from './assistant.controller';
+import { AiBudgetController } from './ai-budget.controller';
+import { AiNudgesController } from './ai-nudges.controller';
+import { AiAnalyticsService } from './analytics.service';
+import { AiBudgetService } from './budget.service';
+import { AiNudgesService } from './ai-nudges.service';
+import { AiRouterService } from './router.service';
+import { AiCacheService } from './cache.service';
+import { AssistantService } from './assistant.service';
+import { AiActionEventsService } from './action-events.service';
+import { AiEntitlementsService } from '../billing/ai-entitlements.service';
+import { PlanFeaturesService } from '../billing/plan-features.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import type { AuthenticatedRequest } from '../common/types/request.types';
+
+describe('AI settings authorization integration', () => {
+  let app: INestApplication;
+  let currentUser: AuthenticatedRequest['user'];
+  const analyticsService = {
+    getTenantAnalytics: jest.fn().mockResolvedValue({ ok: true }),
+  } as unknown as AiAnalyticsService;
+  const budgetService = {
+    getUsageWithLimits: jest.fn().mockResolvedValue({ ok: true }),
+    getUsageData: jest.fn().mockResolvedValue({ ok: true }),
+  } as unknown as AiBudgetService;
+  const nudgesService = {
+    resolveTenantId: jest.fn((user, requestedTenantId?: string) => {
+      if (!requestedTenantId) {
+        throw new ForbiddenException('tenantId requerido para esta prueba');
+      }
+
+      const memberships = user.memberships ?? [];
+      if (!memberships.some((membership) => membership.tenantId === requestedTenantId)) {
+        throw new ForbiddenException('No tienes acceso al tenant indicado');
+      }
+
+      return requestedTenantId;
+    }),
+    getActiveNudges: jest.fn().mockResolvedValue([{ key: 'NUDGE_80' }]),
+    dismissNudge: jest.fn().mockResolvedValue({ key: 'NUDGE_80', dismissedUntil: new Date().toISOString() }),
+    createRecommendedUpgradeRequest: jest.fn().mockResolvedValue({
+      requestId: 'request-1',
+      requestedPlanId: 'plan-pro',
+      note: 'ok',
+      alreadyPending: false,
+    }),
+  } as unknown as AiNudgesService;
+  const assistantService = {} as unknown as AssistantService;
+  const actionEventsService = {} as unknown as AiActionEventsService;
+  const aiEntitlements = {} as unknown as AiEntitlementsService;
+  const routerService = {} as unknown as AiRouterService;
+  const cacheService = {} as unknown as AiCacheService;
+  const prismaServiceMock = {
+    membership: {
+      findUnique: jest.fn(),
+    },
+  };
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      controllers: [AssistantController, AiBudgetController, AiNudgesController],
+      providers: [
+        { provide: AiAnalyticsService, useValue: analyticsService },
+        { provide: AiBudgetService, useValue: budgetService },
+        { provide: AiNudgesService, useValue: nudgesService },
+        { provide: AssistantService, useValue: assistantService },
+        { provide: AiActionEventsService, useValue: actionEventsService },
+        { provide: AiEntitlementsService, useValue: aiEntitlements },
+        {
+          provide: PlanFeaturesService,
+          useValue: {
+            hasFeature: jest.fn().mockResolvedValue(true),
+          },
+        },
+        { provide: AiRouterService, useValue: routerService },
+        { provide: AiCacheService, useValue: cacheService },
+        { provide: PrismaService, useValue: prismaServiceMock as unknown as PrismaService },
+        TenantAccessGuard,
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({
+        canActivate: (context: { switchToHttp: () => { getRequest: () => AuthenticatedRequest } }) => {
+          const request = context.switchToHttp().getRequest();
+          request.user = currentUser;
+          return true;
+        },
+      })
+      .compile();
+
+    app = moduleRef.createNestApplication();
+    await app.init();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentUser = {
+      id: 'user-1',
+      email: 'user@example.com',
+      name: 'User One',
+      memberships: [],
+    };
+    prismaServiceMock.membership.findUnique.mockReset();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  function mockTenantMembership(tenantId: string, roles: string[]) {
+    prismaServiceMock.membership.findUnique.mockResolvedValue({
+      id: 'membership-1',
+      tenantId,
+      roles: roles.map((role, index) => ({
+        id: `role-${index}`,
+        role,
+        scopeType: 'TENANT',
+        scopeBuildingId: null,
+        scopeUnitId: null,
+      })),
+    });
+  }
+
+  it('denies residents on tenant AI analytics before the service executes', async () => {
+    mockTenantMembership('tenant-1', ['RESIDENT']);
+
+    await request(app.getHttpServer())
+      .get('/tenants/tenant-1/assistant/analytics')
+      .set('X-Tenant-Id', 'tenant-1')
+      .expect(403);
+
+    expect(analyticsService.getTenantAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('allows tenant admins on usage-with-limits and passes the tenant through', async () => {
+    mockTenantMembership('tenant-1', ['TENANT_ADMIN']);
+
+    await request(app.getHttpServer())
+      .get('/tenants/tenant-1/assistant/usage-with-limits')
+      .set('X-Tenant-Id', 'tenant-1')
+      .expect(200);
+
+    expect(budgetService.getUsageWithLimits).toHaveBeenCalledWith('tenant-1', undefined);
+  });
+
+  it('denies residents on nudge dismissal before any mutation runs', async () => {
+    currentUser = {
+      id: 'resident-1',
+      email: 'resident@example.com',
+      name: 'Resident One',
+      memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT'] }],
+    };
+
+    await request(app.getHttpServer())
+      .post('/me/ai/nudges/NUDGE_80/dismiss')
+      .set('X-Tenant-Id', 'tenant-1')
+      .expect(403);
+
+    expect(nudgesService.dismissNudge).not.toHaveBeenCalled();
+  });
+
+  it('denies residents on upgrade requests before any mutation runs', async () => {
+    currentUser = {
+      id: 'resident-1',
+      email: 'resident@example.com',
+      name: 'Resident One',
+      memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT'] }],
+    };
+
+    await request(app.getHttpServer())
+      .post('/me/ai/upgrade-request/recommended')
+      .set('X-Tenant-Id', 'tenant-1')
+      .send({ tenantId: 'tenant-1' })
+      .expect(403);
+
+    expect(nudgesService.createRecommendedUpgradeRequest).not.toHaveBeenCalled();
+  });
+
+  it('allows operators to request an upgrade for their tenant', async () => {
+    currentUser = {
+      id: 'operator-1',
+      email: 'operator@example.com',
+      name: 'Operator One',
+      memberships: [{ tenantId: 'tenant-1', roles: ['OPERATOR'] }],
+    };
+
+    await request(app.getHttpServer())
+      .post('/me/ai/upgrade-request/recommended')
+      .set('X-Tenant-Id', 'tenant-1')
+      .send({ tenantId: 'tenant-1' })
+      .expect(201);
+
+    expect(nudgesService.createRecommendedUpgradeRequest).toHaveBeenCalledWith(
+      currentUser,
+      'tenant-1',
+    );
+  });
+});

--- a/apps/api/src/assistant/ai-settings-access.integration.spec.ts
+++ b/apps/api/src/assistant/ai-settings-access.integration.spec.ts
@@ -181,6 +181,64 @@ describe('AI settings authorization integration', () => {
     expect(nudgesService.createRecommendedUpgradeRequest).not.toHaveBeenCalled();
   });
 
+  it('allows impersonating tenant admins when the impersonated tenant matches the requested tenant', async () => {
+    currentUser = {
+      id: 'impersonator-1',
+      email: 'impersonator@example.com',
+      name: 'Impersonator One',
+      isImpersonating: true,
+      impersonatedTenantId: 'tenant-1',
+      memberships: [{ tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] }],
+      effectiveMembership: { tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] },
+    };
+
+    await request(app.getHttpServer())
+      .get('/me/ai/nudges')
+      .set('X-Tenant-Id', 'tenant-1')
+      .expect(200);
+
+    expect(nudgesService.getActiveNudges).toHaveBeenCalledWith(currentUser, 'tenant-1');
+  });
+
+  it('denies impersonation when the requested tenant does not match the impersonated tenant', async () => {
+    currentUser = {
+      id: 'impersonator-1',
+      email: 'impersonator@example.com',
+      name: 'Impersonator One',
+      isImpersonating: true,
+      impersonatedTenantId: 'tenant-1',
+      memberships: [
+        { tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] },
+        { tenantId: 'tenant-2', roles: ['TENANT_ADMIN'] },
+      ],
+      effectiveMembership: { tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] },
+    };
+
+    await request(app.getHttpServer())
+      .get('/me/ai/nudges')
+      .set('X-Tenant-Id', 'tenant-2')
+      .expect(403);
+
+    expect(nudgesService.getActiveNudges).not.toHaveBeenCalled();
+  });
+
+  it('rejects conflicting tenant sources on upgrade requests before any mutation runs', async () => {
+    currentUser = {
+      id: 'operator-1',
+      email: 'operator@example.com',
+      name: 'Operator One',
+      memberships: [{ tenantId: 'tenant-1', roles: ['OPERATOR'] }],
+    };
+
+    await request(app.getHttpServer())
+      .post('/me/ai/upgrade-request/recommended')
+      .set('X-Tenant-Id', 'tenant-1')
+      .send({ tenantId: 'tenant-2' })
+      .expect(400);
+
+    expect(nudgesService.createRecommendedUpgradeRequest).not.toHaveBeenCalled();
+  });
+
   it('allows operators to request an upgrade for their tenant', async () => {
     currentUser = {
       id: 'operator-1',

--- a/apps/api/src/assistant/assistant.controller.ts
+++ b/apps/api/src/assistant/assistant.controller.ts
@@ -19,6 +19,7 @@ import { AiEntitlementsService } from '../billing/ai-entitlements.service';
 import { AssistantService, ChatRequest, ChatResponse } from './assistant.service';
 import { AiAnalyticsService, TenantAnalyticsResponse, TenantSummaryItem } from './analytics.service';
 import { AiActionEventsService, CreateActionEventDto } from './action-events.service';
+import { TenantAiAccessGuard } from './tenant-ai-access.guard';
 import { StructuredResponse } from './ai.types';
 import type { AuthenticatedRequest } from '../common/types/request.types';
 
@@ -359,6 +360,7 @@ export class AssistantController {
    * Returns: TenantAnalyticsResponse with usage, efficiency, adoption, templates, actions
    */
   @Get('analytics')
+  @UseGuards(TenantAiAccessGuard)
   async getTenantAnalytics(
     @Param('tenantId') tenantId: string,
     @Query('month') month?: string,

--- a/apps/api/src/assistant/tenant-ai-access.guard.spec.ts
+++ b/apps/api/src/assistant/tenant-ai-access.guard.spec.ts
@@ -1,0 +1,124 @@
+import { BadRequestException, ForbiddenException, ExecutionContext } from '@nestjs/common';
+import { TenantAiAccessGuard } from './tenant-ai-access.guard';
+
+function buildContext(input: {
+  params?: Record<string, string | undefined>;
+  headers?: Record<string, unknown>;
+  body?: { tenantId?: unknown };
+  user?: {
+    tenantId?: string;
+    roles?: string[];
+    memberships?: Array<{ tenantId: string; roles: string[] }>;
+    effectiveMembership?: { tenantId: string; roles: string[] };
+    isImpersonating?: boolean;
+  };
+}): ExecutionContext {
+  const request = {
+    params: input.params ?? {},
+    headers: input.headers ?? {},
+    body: input.body ?? {},
+    user: input.user ?? {},
+  } as never;
+
+  return {
+    switchToHttp: () => ({
+      getRequest: () => request,
+    }),
+  } as ExecutionContext;
+}
+
+describe('TenantAiAccessGuard', () => {
+  const guard = new TenantAiAccessGuard();
+
+  it('allows tenant owners for route parameters', () => {
+    const allowed = guard.canActivate(
+      buildContext({
+        params: { tenantId: 'tenant-1' },
+        user: {
+          memberships: [{ tenantId: 'tenant-1', roles: ['TENANT_OWNER'] }],
+        },
+      }),
+    );
+
+    expect(allowed).toBe(true);
+  });
+
+  it('allows operators from x-tenant-id headers', () => {
+    const allowed = guard.canActivate(
+      buildContext({
+        headers: { 'x-tenant-id': 'tenant-1' },
+        user: {
+          memberships: [{ tenantId: 'tenant-1', roles: ['OPERATOR'] }],
+        },
+      }),
+    );
+
+    expect(allowed).toBe(true);
+  });
+
+  it('allows tenant admins from body tenantId', () => {
+    const allowed = guard.canActivate(
+      buildContext({
+        body: { tenantId: 'tenant-1' },
+        user: {
+          memberships: [{ tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] }],
+        },
+      }),
+    );
+
+    expect(allowed).toBe(true);
+  });
+
+  it('denies residents even when the tenant matches', () => {
+    expect(() =>
+      guard.canActivate(
+        buildContext({
+          params: { tenantId: 'tenant-1' },
+          user: {
+            memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT'] }],
+          },
+        }),
+      ),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('denies super-admin users without an authorized tenant membership', () => {
+    expect(() =>
+      guard.canActivate(
+        buildContext({
+          params: { tenantId: 'tenant-1' },
+          user: {
+            tenantId: 'tenant-1',
+            roles: ['SUPER_ADMIN'],
+            memberships: [],
+          },
+        }),
+      ),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('allows impersonated tenant admins through the effective membership', () => {
+    const allowed = guard.canActivate(
+      buildContext({
+        params: { tenantId: 'tenant-1' },
+        user: {
+          isImpersonating: true,
+          memberships: [{ tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] }],
+          effectiveMembership: { tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] },
+        },
+      }),
+    );
+
+    expect(allowed).toBe(true);
+  });
+
+  it('rejects missing tenant context', () => {
+    expect(() =>
+      guard.canActivate(
+        buildContext({
+          user: {},
+        }),
+      ),
+    ).toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/assistant/tenant-ai-access.guard.spec.ts
+++ b/apps/api/src/assistant/tenant-ai-access.guard.spec.ts
@@ -11,6 +11,7 @@ function buildContext(input: {
     memberships?: Array<{ tenantId: string; roles: string[] }>;
     effectiveMembership?: { tenantId: string; roles: string[] };
     isImpersonating?: boolean;
+    impersonatedTenantId?: string;
   };
 }): ExecutionContext {
   const request = {
@@ -103,6 +104,7 @@ describe('TenantAiAccessGuard', () => {
         params: { tenantId: 'tenant-1' },
         user: {
           isImpersonating: true,
+          impersonatedTenantId: 'tenant-1',
           memberships: [{ tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] }],
           effectiveMembership: { tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] },
         },
@@ -110,6 +112,36 @@ describe('TenantAiAccessGuard', () => {
     );
 
     expect(allowed).toBe(true);
+  });
+
+  it('rejects impersonation when the requested tenant does not match the impersonated tenant', () => {
+    expect(() =>
+      guard.canActivate(
+        buildContext({
+          headers: { 'x-tenant-id': 'tenant-2' },
+          user: {
+            isImpersonating: true,
+            impersonatedTenantId: 'tenant-1',
+            memberships: [{ tenantId: 'tenant-2', roles: ['TENANT_ADMIN'] }],
+            effectiveMembership: { tenantId: 'tenant-2', roles: ['TENANT_ADMIN'] },
+          },
+        }),
+      ),
+    ).toThrow(ForbiddenException);
+  });
+
+  it('rejects conflicting tenant sources before evaluating roles', () => {
+    expect(() =>
+      guard.canActivate(
+        buildContext({
+          params: { tenantId: 'tenant-1' },
+          headers: { 'x-tenant-id': 'tenant-2' },
+          user: {
+            memberships: [{ tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] }],
+          },
+        }),
+      ),
+    ).toThrow(BadRequestException);
   });
 
   it('rejects missing tenant context', () => {

--- a/apps/api/src/assistant/tenant-ai-access.guard.ts
+++ b/apps/api/src/assistant/tenant-ai-access.guard.ts
@@ -1,0 +1,101 @@
+import {
+  BadRequestException,
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
+import type { Role } from '@buildingos/contracts';
+import type { AuthenticatedRequest } from '../common/types/request.types';
+
+const AUTHORIZED_AI_ROLES: readonly Role[] = ['TENANT_OWNER', 'TENANT_ADMIN', 'OPERATOR'];
+
+@Injectable()
+export class TenantAiAccessGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest & {
+      body?: { tenantId?: unknown };
+      params?: Record<string, string | undefined>;
+      headers?: Record<string, unknown>;
+    }>();
+
+    const tenantId = this.resolveTenantId(request);
+    const roles = this.resolveRoles(request, tenantId);
+
+    if (!roles.some((role) => AUTHORIZED_AI_ROLES.includes(role))) {
+      throw new ForbiddenException(
+        'AI settings are available only to tenant owners, admins and operators',
+      );
+    }
+
+    return true;
+  }
+
+  private resolveTenantId(
+    request: AuthenticatedRequest & {
+      body?: { tenantId?: unknown };
+      params?: Record<string, string | undefined>;
+      headers?: Record<string, unknown>;
+    },
+  ): string {
+    const memberships = request.user?.memberships ?? [];
+    const candidates = [
+      request.params?.tenantId,
+      this.readStringHeader(request.headers?.['x-tenant-id']),
+      this.readString(request.body?.tenantId),
+    ];
+
+    for (const candidate of candidates) {
+      if (candidate) {
+        return candidate;
+      }
+    }
+
+    if (memberships.length === 1) {
+      return memberships[0]!.tenantId;
+    }
+
+    throw new BadRequestException('tenantId is required');
+  }
+
+  private resolveRoles(
+    request: AuthenticatedRequest,
+    tenantId: string,
+  ): Role[] {
+    const effectiveMembership = request.user?.effectiveMembership;
+    if (effectiveMembership?.tenantId === tenantId) {
+      return effectiveMembership.roles;
+    }
+
+    const membership = request.user?.memberships?.find(
+      (entry) => entry.tenantId === tenantId,
+    );
+
+    if (membership) {
+      return membership.roles;
+    }
+
+    if (request.user?.tenantId === tenantId && Array.isArray(request.user.roles)) {
+      return request.user.roles;
+    }
+
+    return [];
+  }
+
+  private readStringHeader(value: unknown): string | undefined {
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+
+    return this.readString(value);
+  }
+
+  private readString(value: unknown): string | undefined {
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : undefined;
+  }
+}

--- a/apps/api/src/assistant/tenant-ai-access.guard.ts
+++ b/apps/api/src/assistant/tenant-ai-access.guard.ts
@@ -40,15 +40,18 @@ export class TenantAiAccessGuard implements CanActivate {
   ): string {
     const memberships = request.user?.memberships ?? [];
     const candidates = [
-      request.params?.tenantId,
+      this.readString(request.params?.tenantId),
       this.readStringHeader(request.headers?.['x-tenant-id']),
       this.readString(request.body?.tenantId),
-    ];
+    ].filter((candidate): candidate is string => Boolean(candidate));
 
-    for (const candidate of candidates) {
-      if (candidate) {
-        return candidate;
+    if (candidates.length > 0) {
+      const uniqueCandidates = new Set(candidates);
+      if (uniqueCandidates.size > 1) {
+        throw new BadRequestException('Conflicting tenantId sources');
       }
+
+      return candidates[0]!;
     }
 
     if (memberships.length === 1) {
@@ -62,6 +65,19 @@ export class TenantAiAccessGuard implements CanActivate {
     request: AuthenticatedRequest,
     tenantId: string,
   ): Role[] {
+    if (request.user?.isImpersonating) {
+      if (request.user.impersonatedTenantId !== tenantId) {
+        throw new ForbiddenException('Impersonation tenant mismatch');
+      }
+
+      const effectiveMembership = request.user.effectiveMembership;
+      if (effectiveMembership?.tenantId !== tenantId) {
+        throw new ForbiddenException('Impersonation membership mismatch');
+      }
+
+      return effectiveMembership.roles;
+    }
+
     const effectiveMembership = request.user?.effectiveMembership;
     if (effectiveMembership?.tenantId === tenantId) {
       return effectiveMembership.roles;

--- a/apps/web/app/(tenant)/[tenantId]/settings/ai/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/settings/ai/page.test.tsx
@@ -4,8 +4,7 @@
 
 import { render, screen, waitFor } from '@testing-library/react';
 import { useRouter } from 'next/navigation';
-import { useActiveTenantId } from '@/features/auth/useAuthSession';
-import { useCanAccessAi } from '@/features/auth/useUserRoles';
+import { useAuthSession, useActiveTenantId } from '@/features/auth/useAuthSession';
 import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
 import { useTenantId } from '@/features/tenancy/tenant.hooks';
 import { useAiAnalytics } from '@/features/assistant/hooks/useAiAnalytics';
@@ -18,11 +17,8 @@ jest.mock('next/navigation', () => ({
 }));
 
 jest.mock('@/features/auth/useAuthSession', () => ({
+  useAuthSession: jest.fn(),
   useActiveTenantId: jest.fn(),
-}));
-
-jest.mock('@/features/auth/useUserRoles', () => ({
-  useCanAccessAi: jest.fn(),
 }));
 
 jest.mock('@/features/auth/useAuthorizedPortalContext', () => ({
@@ -70,8 +66,8 @@ jest.mock('@/shared/lib/routes', () => ({
 }));
 
 const mockedUseRouter = jest.mocked(useRouter);
+const mockedUseAuthSession = jest.mocked(useAuthSession);
 const mockedUseActiveTenantId = jest.mocked(useActiveTenantId);
-const mockedUseCanAccessAi = jest.mocked(useCanAccessAi);
 const mockedUseAuthorizedPortalContext = jest.mocked(useAuthorizedPortalContext);
 const mockedUseTenantId = jest.mocked(useTenantId);
 const mockedUseAiAnalytics = jest.mocked(useAiAnalytics);
@@ -88,12 +84,20 @@ describe('TenantAiAnalyticsPage', () => {
     refresh: jest.fn(),
     replace,
   };
+  let mockSession: {
+    activeTenantId: string | null;
+    memberships: Array<{ tenantId: string; roles: string[] }>;
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSession = {
+      activeTenantId: 'tenant-1',
+      memberships: [{ tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] }],
+    };
     mockedUseRouter.mockReturnValue(routerMock);
-    mockedUseActiveTenantId.mockReturnValue('tenant-1');
-    mockedUseCanAccessAi.mockReturnValue(true);
+    mockedUseAuthSession.mockImplementation(() => mockSession as never);
+    mockedUseActiveTenantId.mockImplementation(() => mockSession.activeTenantId);
     mockedUseAuthorizedPortalContext.mockReturnValue('admin');
     mockedUseTenantId.mockReturnValue('tenant-1');
     mockedUseAiAnalytics.mockReturnValue({
@@ -159,7 +163,10 @@ describe('TenantAiAnalyticsPage', () => {
   });
 
   it('renders the AI settings content for tenant owners', () => {
-    mockedUseCanAccessAi.mockReturnValue(true);
+    mockSession = {
+      activeTenantId: 'tenant-1',
+      memberships: [{ tenantId: 'tenant-1', roles: ['TENANT_OWNER'] }],
+    };
 
     render(<TenantAiAnalyticsPage />);
 
@@ -170,7 +177,10 @@ describe('TenantAiAnalyticsPage', () => {
   });
 
   it('renders the AI settings content for tenant admins', () => {
-    mockedUseCanAccessAi.mockReturnValue(true);
+    mockSession = {
+      activeTenantId: 'tenant-1',
+      memberships: [{ tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] }],
+    };
 
     render(<TenantAiAnalyticsPage />);
 
@@ -178,7 +188,10 @@ describe('TenantAiAnalyticsPage', () => {
   });
 
   it('renders the AI settings content for operators', () => {
-    mockedUseCanAccessAi.mockReturnValue(true);
+    mockSession = {
+      activeTenantId: 'tenant-1',
+      memberships: [{ tenantId: 'tenant-1', roles: ['OPERATOR'] }],
+    };
 
     render(<TenantAiAnalyticsPage />);
 
@@ -186,7 +199,10 @@ describe('TenantAiAnalyticsPage', () => {
   });
 
   it('shows access denied for admin portal users without AI capability', () => {
-    mockedUseCanAccessAi.mockReturnValue(false);
+    mockSession = {
+      activeTenantId: 'tenant-1',
+      memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT'] }],
+    };
 
     render(<TenantAiAnalyticsPage />);
 
@@ -198,7 +214,10 @@ describe('TenantAiAnalyticsPage', () => {
 
   it('redirects mixed-role users when the portal resolves to resident', async () => {
     mockedUseAuthorizedPortalContext.mockReturnValue('resident');
-    mockedUseCanAccessAi.mockReturnValue(true);
+    mockSession = {
+      activeTenantId: 'tenant-1',
+      memberships: [{ tenantId: 'tenant-1', roles: ['TENANT_ADMIN', 'RESIDENT'] }],
+    };
 
     render(<TenantAiAnalyticsPage />);
 
@@ -211,7 +230,10 @@ describe('TenantAiAnalyticsPage', () => {
 
   it('renders mixed-role users when the portal resolves to admin and access is allowed', () => {
     mockedUseAuthorizedPortalContext.mockReturnValue('admin');
-    mockedUseCanAccessAi.mockReturnValue(true);
+    mockSession = {
+      activeTenantId: 'tenant-1',
+      memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT', 'TENANT_ADMIN'] }],
+    };
 
     render(<TenantAiAnalyticsPage />);
 
@@ -222,7 +244,13 @@ describe('TenantAiAnalyticsPage', () => {
     mockedUseTenantId.mockReturnValue('tenant-route');
     mockedUseActiveTenantId.mockReturnValue('tenant-active');
     mockedUseAuthorizedPortalContext.mockReturnValue('admin');
-    mockedUseCanAccessAi.mockReturnValue(true);
+    mockSession = {
+      activeTenantId: 'tenant-active',
+      memberships: [
+        { tenantId: 'tenant-route', roles: ['TENANT_ADMIN'] },
+        { tenantId: 'tenant-active', roles: ['RESIDENT'] },
+      ],
+    };
 
     render(<TenantAiAnalyticsPage />);
 
@@ -235,18 +263,25 @@ describe('TenantAiAnalyticsPage', () => {
     expect(mockedUseAiNudges).not.toHaveBeenCalled();
   });
 
-  it('re-evaluates the tenant and remounts the content when the tenant changes', () => {
+  it('re-evaluates the tenant and blocks the stale admin content when the tenant changes to resident', () => {
     const { rerender } = render(<TenantAiAnalyticsPage />);
 
     expect(mockedUseAiAnalytics).toHaveBeenLastCalledWith('tenant-1');
 
     mockedUseTenantId.mockReturnValue('tenant-2');
-    mockedUseActiveTenantId.mockReturnValue('tenant-2');
+    mockSession = {
+      activeTenantId: 'tenant-2',
+      memberships: [
+        { tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] },
+        { tenantId: 'tenant-2', roles: ['RESIDENT'] },
+      ],
+    };
 
     rerender(<TenantAiAnalyticsPage />);
 
-    expect(mockedUseAiAnalytics).toHaveBeenLastCalledWith('tenant-2');
-    expect(mockedUseAiLimits).toHaveBeenLastCalledWith('tenant-2');
-    expect(mockedUseAiNudges).toHaveBeenLastCalledWith('tenant-2');
+    expect(screen.getByText('No tenés permiso para acceder a las métricas de IA del tenant.')).not.toBeNull();
+    expect(mockedUseAiAnalytics).not.toHaveBeenCalledWith('tenant-2');
+    expect(mockedUseAiLimits).not.toHaveBeenCalledWith('tenant-2');
+    expect(mockedUseAiNudges).not.toHaveBeenCalledWith('tenant-2');
   });
 });

--- a/apps/web/app/(tenant)/[tenantId]/settings/ai/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/settings/ai/page.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+import { useActiveTenantId } from '@/features/auth/useAuthSession';
+import { useCanAccessAi } from '@/features/auth/useUserRoles';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
+import { useTenantId } from '@/features/tenancy/tenant.hooks';
+import { useAiAnalytics } from '@/features/assistant/hooks/useAiAnalytics';
+import { useAiLimits } from '@/features/assistant/hooks/useAiLimits';
+import { useAiNudges } from '@/features/assistant/hooks/useAiNudges';
+import TenantAiAnalyticsPage from './page';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('@/features/auth/useAuthSession', () => ({
+  useActiveTenantId: jest.fn(),
+}));
+
+jest.mock('@/features/auth/useUserRoles', () => ({
+  useCanAccessAi: jest.fn(),
+}));
+
+jest.mock('@/features/auth/useAuthorizedPortalContext', () => ({
+  useAuthorizedPortalContext: jest.fn(),
+}));
+
+jest.mock('@/features/tenancy/tenant.hooks', () => ({
+  useTenantId: jest.fn(),
+}));
+
+jest.mock('@/features/assistant/hooks/useAiAnalytics', () => ({
+  useAiAnalytics: jest.fn(),
+}));
+
+jest.mock('@/features/assistant/hooks/useAiLimits', () => ({
+  useAiLimits: jest.fn(),
+}));
+
+jest.mock('@/features/assistant/hooks/useAiNudges', () => ({
+  useAiNudges: jest.fn(),
+}));
+
+jest.mock('@/features/assistant/components/analytics/AiAnalyticsPanel', () => ({
+  AiAnalyticsPanel: ({ error }: { error: string | null }) => (
+    <div data-testid="ai-analytics-panel">{error ?? 'analytics-ok'}</div>
+  ),
+}));
+
+jest.mock('@/features/assistant/components/limits/AiPlanLimitsCard', () => ({
+  AiPlanLimitsCard: () => <div data-testid="ai-limits-card">limits</div>,
+}));
+
+jest.mock('@/features/assistant/components/limits/AiLimitBanner', () => ({
+  AiLimitBanner: ({ type }: { type: string }) => <div data-testid={`ai-banner-${type}`} />,
+}));
+
+jest.mock('@/features/assistant/components/limits/AiNudgesPanel', () => ({
+  AiNudgesPanel: () => <div data-testid="ai-nudges-panel">nudges</div>,
+}));
+
+jest.mock('@/shared/lib/routes', () => ({
+  routes: {
+    residentDashboard: (tenantId: string) => `/${tenantId}/resident/dashboard`,
+  },
+}));
+
+const mockedUseRouter = jest.mocked(useRouter);
+const mockedUseActiveTenantId = jest.mocked(useActiveTenantId);
+const mockedUseCanAccessAi = jest.mocked(useCanAccessAi);
+const mockedUseAuthorizedPortalContext = jest.mocked(useAuthorizedPortalContext);
+const mockedUseTenantId = jest.mocked(useTenantId);
+const mockedUseAiAnalytics = jest.mocked(useAiAnalytics);
+const mockedUseAiLimits = jest.mocked(useAiLimits);
+const mockedUseAiNudges = jest.mocked(useAiNudges);
+
+describe('TenantAiAnalyticsPage', () => {
+  const replace = jest.fn();
+  const routerMock = {
+    back: jest.fn(),
+    forward: jest.fn(),
+    prefetch: jest.fn().mockResolvedValue(undefined),
+    push: jest.fn(),
+    refresh: jest.fn(),
+    replace,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseRouter.mockReturnValue(routerMock);
+    mockedUseActiveTenantId.mockReturnValue('tenant-1');
+    mockedUseCanAccessAi.mockReturnValue(true);
+    mockedUseAuthorizedPortalContext.mockReturnValue('admin');
+    mockedUseTenantId.mockReturnValue('tenant-1');
+    mockedUseAiAnalytics.mockReturnValue({
+      analytics: null,
+      loading: false,
+      error: null,
+      month: '2026-08',
+      setMonth: jest.fn(),
+      refetch: jest.fn(),
+    });
+    mockedUseAiLimits.mockReturnValue({
+      limits: { budgetCents: 500, callsLimit: 100, allowBigModel: false },
+      usage: {
+        month: '2026-08',
+        budgetCents: 0,
+        calls: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedCostCents: 0,
+        percentUsed: 0,
+        callsPercent: 0,
+      },
+      loading: false,
+      error: undefined,
+    });
+    mockedUseAiNudges.mockReturnValue({
+      nudges: [],
+      loading: false,
+      error: null,
+      submitting: false,
+      hasBlockingNudge: false,
+      dismiss: jest.fn(),
+      requestUpgrade: jest.fn(),
+      reload: jest.fn(),
+    });
+  });
+
+  it('keeps the page gated while the portal context resolves', () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue(null);
+
+    render(<TenantAiAnalyticsPage />);
+
+    expect(document.querySelector('[aria-busy="true"]')).not.toBeNull();
+    expect(screen.queryByTestId('ai-analytics-panel')).toBeNull();
+    expect(mockedUseAiAnalytics).not.toHaveBeenCalled();
+    expect(mockedUseAiLimits).not.toHaveBeenCalled();
+    expect(mockedUseAiNudges).not.toHaveBeenCalled();
+  });
+
+  it('redirects resident portal users and never mounts AI hooks', async () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue('resident');
+
+    render(<TenantAiAnalyticsPage />);
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/tenant-1/resident/dashboard');
+    });
+
+    expect(screen.queryByTestId('ai-analytics-panel')).toBeNull();
+    expect(mockedUseAiAnalytics).not.toHaveBeenCalled();
+    expect(mockedUseAiLimits).not.toHaveBeenCalled();
+    expect(mockedUseAiNudges).not.toHaveBeenCalled();
+  });
+
+  it('renders the AI settings content for tenant owners', () => {
+    mockedUseCanAccessAi.mockReturnValue(true);
+
+    render(<TenantAiAnalyticsPage />);
+
+    expect(screen.getByText('AI Assistant')).not.toBeNull();
+    expect(mockedUseAiAnalytics).toHaveBeenCalledWith('tenant-1');
+    expect(mockedUseAiLimits).toHaveBeenCalledWith('tenant-1');
+    expect(mockedUseAiNudges).toHaveBeenCalledWith('tenant-1');
+  });
+
+  it('renders the AI settings content for tenant admins', () => {
+    mockedUseCanAccessAi.mockReturnValue(true);
+
+    render(<TenantAiAnalyticsPage />);
+
+    expect(screen.getByTestId('ai-analytics-panel').textContent).toBe('analytics-ok');
+  });
+
+  it('renders the AI settings content for operators', () => {
+    mockedUseCanAccessAi.mockReturnValue(true);
+
+    render(<TenantAiAnalyticsPage />);
+
+    expect(screen.getByTestId('ai-nudges-panel')).not.toBeNull();
+  });
+
+  it('shows access denied for admin portal users without AI capability', () => {
+    mockedUseCanAccessAi.mockReturnValue(false);
+
+    render(<TenantAiAnalyticsPage />);
+
+    expect(screen.getByText('No tenés permiso para acceder a las métricas de IA del tenant.')).not.toBeNull();
+    expect(mockedUseAiAnalytics).not.toHaveBeenCalled();
+    expect(mockedUseAiLimits).not.toHaveBeenCalled();
+    expect(mockedUseAiNudges).not.toHaveBeenCalled();
+  });
+
+  it('redirects mixed-role users when the portal resolves to resident', async () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue('resident');
+    mockedUseCanAccessAi.mockReturnValue(true);
+
+    render(<TenantAiAnalyticsPage />);
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/tenant-1/resident/dashboard');
+    });
+
+    expect(mockedUseAiAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('renders mixed-role users when the portal resolves to admin and access is allowed', () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue('admin');
+    mockedUseCanAccessAi.mockReturnValue(true);
+
+    render(<TenantAiAnalyticsPage />);
+
+    expect(screen.getByText('Usage Analytics')).not.toBeNull();
+  });
+
+  it('redirects when the route tenant is stale relative to the active tenant', async () => {
+    mockedUseTenantId.mockReturnValue('tenant-route');
+    mockedUseActiveTenantId.mockReturnValue('tenant-active');
+    mockedUseAuthorizedPortalContext.mockReturnValue('admin');
+    mockedUseCanAccessAi.mockReturnValue(true);
+
+    render(<TenantAiAnalyticsPage />);
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/tenant-active/settings/ai');
+    });
+
+    expect(mockedUseAiAnalytics).not.toHaveBeenCalled();
+    expect(mockedUseAiLimits).not.toHaveBeenCalled();
+    expect(mockedUseAiNudges).not.toHaveBeenCalled();
+  });
+
+  it('re-evaluates the tenant and remounts the content when the tenant changes', () => {
+    const { rerender } = render(<TenantAiAnalyticsPage />);
+
+    expect(mockedUseAiAnalytics).toHaveBeenLastCalledWith('tenant-1');
+
+    mockedUseTenantId.mockReturnValue('tenant-2');
+    mockedUseActiveTenantId.mockReturnValue('tenant-2');
+
+    rerender(<TenantAiAnalyticsPage />);
+
+    expect(mockedUseAiAnalytics).toHaveBeenLastCalledWith('tenant-2');
+    expect(mockedUseAiLimits).toHaveBeenLastCalledWith('tenant-2');
+    expect(mockedUseAiNudges).toHaveBeenLastCalledWith('tenant-2');
+  });
+});

--- a/apps/web/app/(tenant)/[tenantId]/settings/ai/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/settings/ai/page.tsx
@@ -168,13 +168,13 @@ export function TenantAiAnalyticsPage() {
   const routeTenantId = useTenantId();
   const activeTenantId = useActiveTenantId();
   const portalContext = useAuthorizedPortalContext(routeTenantId);
-  const canAccessAi = useCanAccessAi();
 
   const hasMatchingTenant =
     activeTenantId !== null &&
     routeTenantId !== null &&
     activeTenantId === routeTenantId;
   const tenantId = hasMatchingTenant ? activeTenantId : null;
+  const canAccessAi = useCanAccessAi(tenantId ?? undefined);
 
   useEffect(() => {
     if (activeTenantId && routeTenantId && activeTenantId !== routeTenantId) {

--- a/apps/web/app/(tenant)/[tenantId]/settings/ai/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/settings/ai/page.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { useParams } from 'next/navigation';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useActiveTenantId } from '@/features/auth/useAuthSession';
+import { useCanAccessAi } from '@/features/auth/useUserRoles';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
+import { useTenantId } from '@/features/tenancy/tenant.hooks';
 import { useAiAnalytics } from '@/features/assistant/hooks/useAiAnalytics';
 import { useAiLimits } from '@/features/assistant/hooks/useAiLimits';
 import { useAiNudges } from '@/features/assistant/hooks/useAiNudges';
@@ -8,15 +13,13 @@ import { AiAnalyticsPanel } from '@/features/assistant/components/analytics/AiAn
 import { AiPlanLimitsCard } from '@/features/assistant/components/limits/AiPlanLimitsCard';
 import { AiLimitBanner } from '@/features/assistant/components/limits/AiLimitBanner';
 import { AiNudgesPanel } from '@/features/assistant/components/limits/AiNudgesPanel';
+import { routes } from '@/shared/lib/routes';
 
 /**
  * Phase 13: Tenant AI Settings Page
  * Display plan limits, usage, warnings, and analytics
  */
-export default function TenantAiAnalyticsPage() {
-  const params = useParams();
-  const tenantId = params.tenantId as string;
-
+function TenantAiAnalyticsContent({ tenantId }: { tenantId: string }) {
   const { analytics, loading, error, month, setMonth, refetch } =
     useAiAnalytics(tenantId);
 
@@ -26,6 +29,7 @@ export default function TenantAiAnalyticsPage() {
     nudges,
     loading: nudgesLoading,
     submitting: nudgesSubmitting,
+    error: nudgesError,
     dismiss,
     requestUpgrade,
   } = useAiNudges(tenantId);
@@ -40,6 +44,7 @@ export default function TenantAiAnalyticsPage() {
   const showCallsBlocked = limits.callsLimit > 0 && limits.callsLimit < 9999 && callsPercent >= 100;
 
   const upgradeUrl = `/${tenantId}/settings/billing`;
+  const limitsErrorMessage = limitsError;
 
   return (
     <div className="container mx-auto px-4 py-8 max-w-4xl">
@@ -72,6 +77,24 @@ export default function TenantAiAnalyticsPage() {
           onRequestUpgrade={requestUpgrade}
         />
       </div>
+
+      {limitsErrorMessage ? (
+        <div
+          className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700"
+          role="alert"
+        >
+          {limitsErrorMessage}
+        </div>
+      ) : null}
+
+      {nudgesError ? (
+        <div
+          className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-700"
+          role="alert"
+        >
+          {nudgesError}
+        </div>
+      ) : null}
 
       {/* Warning Banners */}
       <div className="space-y-4 mb-8">
@@ -139,3 +162,44 @@ export default function TenantAiAnalyticsPage() {
     </div>
   );
 }
+
+export function TenantAiAnalyticsPage() {
+  const router = useRouter();
+  const routeTenantId = useTenantId();
+  const activeTenantId = useActiveTenantId();
+  const portalContext = useAuthorizedPortalContext(routeTenantId);
+  const canAccessAi = useCanAccessAi();
+
+  const hasMatchingTenant =
+    activeTenantId !== null &&
+    routeTenantId !== null &&
+    activeTenantId === routeTenantId;
+  const tenantId = hasMatchingTenant ? activeTenantId : null;
+
+  useEffect(() => {
+    if (activeTenantId && routeTenantId && activeTenantId !== routeTenantId) {
+      router.replace(`/${activeTenantId}/settings/ai`);
+      return;
+    }
+
+    if (portalContext === 'resident' && tenantId) {
+      router.replace(routes.residentDashboard(tenantId));
+    }
+  }, [activeTenantId, portalContext, routeTenantId, router, tenantId]);
+
+  if (!tenantId || portalContext !== 'admin') {
+    return <div className="min-h-[240px]" aria-busy="true" />;
+  }
+
+  if (!canAccessAi) {
+    return (
+      <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/30 p-6 text-sm text-muted-foreground">
+        No tenés permiso para acceder a las métricas de IA del tenant.
+      </div>
+    );
+  }
+
+  return <TenantAiAnalyticsContent key={tenantId} tenantId={tenantId} />;
+}
+
+export default TenantAiAnalyticsPage;

--- a/apps/web/features/assistant/components/AssistantWidget.tsx
+++ b/apps/web/features/assistant/components/AssistantWidget.tsx
@@ -12,13 +12,12 @@
  */
 
 import { useState, useRef, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { useAssistant } from '../hooks/useAssistant';
 import { SuggestedActionsList } from './SuggestedActionsList';
 import { useAiNudges } from '../hooks/useAiNudges';
 import { useCanAccessAi } from '@/features/auth/useUserRoles';
-import { feedbackApi, FeedbackRequest } from '../services/feedback.api';
+import { feedbackApi } from '../services/feedback.api';
 
 interface AssistantWidgetProps {
   tenantId: string;
@@ -161,12 +160,35 @@ export function AssistantWidget({
   isOpen = true,
   onClose,
 }: AssistantWidgetProps) {
-  const canAccessAi = useCanAccessAi();
+  const canAccessAi = useCanAccessAi(tenantId);
 
   // Hide AI widget from residents - only admins/operators can see it
   if (!canAccessAi) {
     return null;
   }
+
+  return (
+    <AssistantWidgetContent
+      tenantId={tenantId}
+      currentPage={currentPage}
+      buildingId={buildingId}
+      unitId={unitId}
+      permissions={permissions}
+      isOpen={isOpen}
+      onClose={onClose}
+    />
+  );
+}
+
+function AssistantWidgetContent({
+  tenantId,
+  currentPage,
+  buildingId,
+  unitId,
+  permissions = [],
+  isOpen = true,
+  onClose,
+}: AssistantWidgetProps) {
 
   const [message, setMessage] = useState('');
   const [expanded, setExpanded] = useState(isOpen);
@@ -182,7 +204,7 @@ export function AssistantWidget({
     return `sess_${Date.now()}_${Math.random().toString(36).slice(2)}`;
   };
   const [sessionId] = useState(getSessionId);
-  const lastMessageId = useRef<string>('');
+  const [lastMessageId, setLastMessageId] = useState('');
   const { loading, error, answer, suggestedActions, sendMessage, clearError, reset } =
     useAssistant(tenantId);
   const { nudges, submitting, requestUpgrade } = useAiNudges(tenantId);
@@ -203,7 +225,7 @@ export function AssistantWidget({
     setMessage('');
 
     const messageId = `msg_${Date.now()}_${Math.random().toString(36).slice(2)}`;
-    lastMessageId.current = messageId;
+    setLastMessageId(messageId);
 
     await sendMessage(msg, {
       page: currentPage,
@@ -297,7 +319,7 @@ export function AssistantWidget({
                   <p>{answer}</p>
                 </div>
                 <FeedbackControls
-                  messageId={lastMessageId.current}
+                  messageId={lastMessageId}
                   sessionId={sessionId}
                   tenantId={tenantId}
                 />

--- a/apps/web/features/auth/useUserRoles.test.tsx
+++ b/apps/web/features/auth/useUserRoles.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useAuth } from './useAuth';
+import { useCanAccessAi, useUserRoles } from './useUserRoles';
+
+jest.mock('./useAuth', () => ({
+  useAuth: jest.fn(),
+}));
+
+const mockedUseAuth = jest.mocked(useAuth);
+
+describe('useUserRoles', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an empty array when the user has no roles', () => {
+    mockedUseAuth.mockReturnValue({ currentUser: null } as never);
+
+    const { result } = renderHook(() => useUserRoles());
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns the current user roles', () => {
+    mockedUseAuth.mockReturnValue({
+      currentUser: { roles: ['TENANT_ADMIN', 'OPERATOR'] },
+    } as never);
+
+    const { result } = renderHook(() => useUserRoles());
+
+    expect(result.current).toEqual(['TENANT_ADMIN', 'OPERATOR']);
+  });
+});
+
+describe('useCanAccessAi', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    ['TENANT_OWNER'],
+    ['TENANT_ADMIN'],
+    ['OPERATOR'],
+  ])('allows %s', (role) => {
+    mockedUseAuth.mockReturnValue({
+      currentUser: { roles: [role] },
+    } as never);
+
+    const { result } = renderHook(() => useCanAccessAi());
+
+    expect(result.current).toBe(true);
+  });
+
+  it('denies residents', () => {
+    mockedUseAuth.mockReturnValue({
+      currentUser: { roles: ['RESIDENT'] },
+    } as never);
+
+    const { result } = renderHook(() => useCanAccessAi());
+
+    expect(result.current).toBe(false);
+  });
+});

--- a/apps/web/features/auth/useUserRoles.test.tsx
+++ b/apps/web/features/auth/useUserRoles.test.tsx
@@ -5,12 +5,18 @@
 import { renderHook } from '@testing-library/react';
 import { useAuth } from './useAuth';
 import { useCanAccessAi, useUserRoles } from './useUserRoles';
+import { useAuthSession } from './useAuthSession';
 
 jest.mock('./useAuth', () => ({
   useAuth: jest.fn(),
 }));
 
+jest.mock('./useAuthSession', () => ({
+  useAuthSession: jest.fn(),
+}));
+
 const mockedUseAuth = jest.mocked(useAuth);
+const mockedUseAuthSession = jest.mocked(useAuthSession);
 
 describe('useUserRoles', () => {
   beforeEach(() => {
@@ -45,22 +51,49 @@ describe('useCanAccessAi', () => {
     ['TENANT_OWNER'],
     ['TENANT_ADMIN'],
     ['OPERATOR'],
-  ])('allows %s', (role) => {
-    mockedUseAuth.mockReturnValue({
-      currentUser: { roles: [role] },
+  ])('allows %s for the matching tenant membership', (role) => {
+    mockedUseAuthSession.mockReturnValue({
+      activeTenantId: 'tenant-1',
+      memberships: [{ tenantId: 'tenant-1', roles: [role] }],
     } as never);
 
-    const { result } = renderHook(() => useCanAccessAi());
+    const { result } = renderHook(() => useCanAccessAi('tenant-1'));
 
     expect(result.current).toBe(true);
   });
 
-  it('denies residents', () => {
-    mockedUseAuth.mockReturnValue({
-      currentUser: { roles: ['RESIDENT'] },
+  it('denies residents for the matching tenant membership', () => {
+    mockedUseAuthSession.mockReturnValue({
+      activeTenantId: 'tenant-1',
+      memberships: [{ tenantId: 'tenant-1', roles: ['RESIDENT'] }],
     } as never);
 
-    const { result } = renderHook(() => useCanAccessAi());
+    const { result } = renderHook(() => useCanAccessAi('tenant-1'));
+
+    expect(result.current).toBe(false);
+  });
+
+  it('denies a different tenant even when the active tenant has admin access', () => {
+    mockedUseAuthSession.mockReturnValue({
+      activeTenantId: 'tenant-1',
+      memberships: [
+        { tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] },
+        { tenantId: 'tenant-2', roles: ['RESIDENT'] },
+      ],
+    } as never);
+
+    const { result } = renderHook(() => useCanAccessAi('tenant-2'));
+
+    expect(result.current).toBe(false);
+  });
+
+  it('denies when no tenant is provided', () => {
+    mockedUseAuthSession.mockReturnValue({
+      activeTenantId: 'tenant-1',
+      memberships: [{ tenantId: 'tenant-1', roles: ['TENANT_ADMIN'] }],
+    } as never);
+
+    const { result } = renderHook(() => useCanAccessAi(undefined));
 
     expect(result.current).toBe(false);
   });

--- a/apps/web/features/auth/useUserRoles.ts
+++ b/apps/web/features/auth/useUserRoles.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { useAuth } from './useAuth';
+import { useHasAnyRoleInTenant } from '@/features/tenancy/hooks/useEffectiveRole';
 
 /**
  * Hook to get the current user's roles for the active tenant
@@ -25,12 +26,11 @@ export function useUserRoles(): string[] {
 }
 
 /**
- * Helper function to check if user has admin-level access
- * (can see all AI features, not just residents)
+ * Helper function to check if the current tenant membership can access AI settings.
+ *
+ * Only tenant-scoped roles are considered. Global or stale roles from another tenant
+ * are intentionally ignored.
  */
-export function useCanAccessAi(): boolean {
-  const roles = useUserRoles();
-  return roles.some((role) =>
-    ['TENANT_ADMIN', 'TENANT_OWNER', 'OPERATOR', 'SUPER_ADMIN'].includes(role)
-  );
+export function useCanAccessAi(tenantId?: string): boolean {
+  return useHasAnyRoleInTenant(tenantId, ['TENANT_OWNER', 'TENANT_ADMIN', 'OPERATOR']);
 }


### PR DESCRIPTION
Closes #115

## Summary
- Restricts tenant AI settings to authorized tenant roles only.
- Prevents residents from mounting AI analytics, limits, and nudges on the settings page.
- Adds API-side guards so resident traffic is rejected before AI services execute.

## Changes
| File | Change |
|------|--------|
| `apps/web/app/(tenant)/[tenantId]/settings/ai/page.tsx` | Adds portal-aware access control and keeps AI widgets from mounting for unauthorized users. |
| `apps/web/app/(tenant)/[tenantId]/settings/ai/page.test.tsx` | Covers portal resolution, redirects, capability gating, and tenant switching. |
| `apps/web/features/auth/useUserRoles.test.tsx` | Verifies `useCanAccessAi()` only allows tenant owners, admins, and operators. |
| `apps/api/src/assistant/tenant-ai-access.guard.ts` | Adds a tenant-aware guard for AI settings endpoints. |
| `apps/api/src/assistant/assistant.controller.ts` | Applies the guard to tenant AI analytics. |
| `apps/api/src/assistant/ai-budget.controller.ts` | Applies the guard to AI usage endpoints. |
| `apps/api/src/assistant/ai-nudges.controller.ts` | Applies the guard to nudges and upgrade request endpoints. |
| `apps/api/src/assistant/tenant-ai-access.guard.spec.ts` | Covers tenant resolution and role authorization rules. |
| `apps/api/src/assistant/ai-settings-access.integration.spec.ts` | Verifies resident requests are rejected before AI services execute. |

## Test Plan
- [x] `npm run test -w apps/web -- --runInBand --no-coverage --runTestsByPath 'app/(tenant)/[tenantId]/settings/ai/page.test.tsx' 'features/auth/useUserRoles.test.tsx'`
- [x] `npm run test -w apps/api -- --runInBand --no-coverage --runTestsByPath 'src/assistant/tenant-ai-access.guard.spec.ts' 'src/assistant/ai-settings-access.integration.spec.ts'`
- [x] `npm exec --workspace=apps/web -- eslint 'app/(tenant)/[tenantId]/settings/ai/page.tsx' 'app/(tenant)/[tenantId]/settings/ai/page.test.tsx' 'features/auth/useUserRoles.test.tsx'`
- [x] `npm exec --workspace=apps/api -- eslint 'src/assistant/tenant-ai-access.guard.ts' 'src/assistant/tenant-ai-access.guard.spec.ts' 'src/assistant/assistant.controller.ts' 'src/assistant/ai-budget.controller.ts' 'src/assistant/ai-nudges.controller.ts' 'src/assistant/ai-settings-access.integration.spec.ts'`

## Checklist
- [x] Linked approved issue
- [x] Added exactly one `type:*` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
