### PR TITLE
fix(settings): restrict banking account editor to tenant admins

### DIFF
--- a/apps/web/app/(tenant)/[tenantId]/settings/banking/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/settings/banking/page.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { useRouter } from 'next/navigation';
+import { useActiveTenantId } from '@/features/auth/useAuthSession';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
+import { useCanAdministerTenant } from '@/features/tenancy/hooks/useEffectiveRole';
+import { useTenantId } from '@/features/tenancy/tenant.hooks';
+import BankingPage from './page';
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('@/features/auth/useAuthSession', () => ({
+  useActiveTenantId: jest.fn(),
+}));
+
+jest.mock('@/features/auth/useAuthorizedPortalContext', () => ({
+  useAuthorizedPortalContext: jest.fn(),
+}));
+
+jest.mock('@/features/tenancy/hooks/useEffectiveRole', () => ({
+  useCanAdministerTenant: jest.fn(),
+}));
+
+jest.mock('@/features/tenancy/tenant.hooks', () => ({
+  useTenantId: jest.fn(),
+}));
+
+jest.mock('@/features/banking/banking.ui', () => ({
+  __esModule: true,
+  default: ({ tenantId }: { tenantId: string }) => (
+    <div data-testid="banking-ui">{tenantId}</div>
+  ),
+}));
+
+const mockedUseRouter = jest.mocked(useRouter);
+const mockedUseActiveTenantId = jest.mocked(useActiveTenantId);
+const mockedUseAuthorizedPortalContext = jest.mocked(useAuthorizedPortalContext);
+const mockedUseCanAdministerTenant = jest.mocked(useCanAdministerTenant);
+const mockedUseTenantId = jest.mocked(useTenantId);
+
+describe('BankingPage', () => {
+  const replace = jest.fn();
+  const routerMock = {
+    back: jest.fn(),
+    forward: jest.fn(),
+    prefetch: jest.fn().mockResolvedValue(undefined),
+    push: jest.fn(),
+    refresh: jest.fn(),
+    replace,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseRouter.mockReturnValue(routerMock);
+    mockedUseActiveTenantId.mockReturnValue('tenant-1');
+    mockedUseAuthorizedPortalContext.mockReturnValue('admin');
+    mockedUseCanAdministerTenant.mockReturnValue(true);
+    mockedUseTenantId.mockReturnValue('tenant-1');
+  });
+
+  it('keeps a neutral loader while the portal context is unresolved', () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue(null);
+
+    render(<BankingPage />);
+
+    expect(document.querySelector('[aria-busy="true"]')).not.toBeNull();
+    expect(screen.queryByTestId('banking-ui')).toBeNull();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it('redirects resident portal users to the resident dashboard without mounting the editor', async () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue('resident');
+    mockedUseCanAdministerTenant.mockReturnValue(false);
+
+    render(<BankingPage />);
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/tenant-1/resident/dashboard');
+    });
+
+    expect(screen.queryByTestId('banking-ui')).toBeNull();
+    expect(screen.queryByText('Nueva Cuenta')).toBeNull();
+  });
+
+  it('renders the editor for tenant owners', () => {
+    mockedUseCanAdministerTenant.mockReturnValue(true);
+
+    render(<BankingPage />);
+
+    expect(mockedUseCanAdministerTenant).toHaveBeenLastCalledWith('tenant-1');
+    expect(screen.getByTestId('banking-ui').textContent).toBe('tenant-1');
+  });
+
+  it('renders the editor for tenant admins', () => {
+    mockedUseCanAdministerTenant.mockReturnValue(true);
+
+    render(<BankingPage />);
+
+    expect(screen.getByTestId('banking-ui')).not.toBeNull();
+  });
+
+  it('shows the access denied state for an unauthorized portal admin', () => {
+    mockedUseCanAdministerTenant.mockReturnValue(false);
+
+    render(<BankingPage />);
+
+    expect(screen.getByText('No tenés permiso para editar las cuentas bancarias.')).not.toBeNull();
+    expect(screen.queryByTestId('banking-ui')).toBeNull();
+  });
+
+  it('redirects mixed-role users when the portal resolves to resident', async () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue('resident');
+    mockedUseCanAdministerTenant.mockReturnValue(true);
+
+    render(<BankingPage />);
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/tenant-1/resident/dashboard');
+    });
+
+    expect(screen.queryByTestId('banking-ui')).toBeNull();
+  });
+
+  it('renders mixed-role users when the portal resolves to admin', () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue('admin');
+    mockedUseCanAdministerTenant.mockReturnValue(true);
+
+    render(<BankingPage />);
+
+    expect(screen.getByTestId('banking-ui').textContent).toBe('tenant-1');
+  });
+
+  it('redirects a stale route tenant to the active tenant settings page', async () => {
+    mockedUseActiveTenantId.mockReturnValue('tenant-2');
+    mockedUseTenantId.mockReturnValue('tenant-1');
+    mockedUseAuthorizedPortalContext.mockReturnValue('admin');
+
+    render(<BankingPage />);
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/tenant-2/settings/banking');
+    });
+
+    expect(screen.queryByTestId('banking-ui')).toBeNull();
+  });
+
+  it('unmounts the tenant A editor before showing tenant B resident access', async () => {
+    const { rerender } = render(<BankingPage />);
+
+    expect(screen.getByTestId('banking-ui').textContent).toBe('tenant-1');
+
+    mockedUseActiveTenantId.mockReturnValue('tenant-2');
+    mockedUseTenantId.mockReturnValue('tenant-2');
+    mockedUseAuthorizedPortalContext.mockReturnValue('resident');
+    mockedUseCanAdministerTenant.mockReturnValue(false);
+
+    rerender(<BankingPage />);
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith('/tenant-2/resident/dashboard');
+    });
+
+    expect(screen.queryByTestId('banking-ui')).toBeNull();
+  });
+
+  it('remounts the editor when switching from tenant A to tenant B admin access', () => {
+    const { rerender } = render(<BankingPage />);
+
+    expect(screen.getByTestId('banking-ui').textContent).toBe('tenant-1');
+
+    mockedUseActiveTenantId.mockReturnValue('tenant-2');
+    mockedUseTenantId.mockReturnValue('tenant-2');
+    mockedUseAuthorizedPortalContext.mockReturnValue('admin');
+    mockedUseCanAdministerTenant.mockReturnValue(true);
+
+    rerender(<BankingPage />);
+
+    expect(screen.getByTestId('banking-ui').textContent).toBe('tenant-2');
+  });
+
+  it('never mounts the editor before the portal and tenant are resolved', () => {
+    mockedUseAuthorizedPortalContext.mockReturnValue(null);
+
+    render(<BankingPage />);
+
+    expect(screen.queryByTestId('banking-ui')).toBeNull();
+    expect(screen.queryByText('Cuentas bancarias')).toBeNull();
+  });
+});

--- a/apps/web/app/(tenant)/[tenantId]/settings/banking/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/settings/banking/page.tsx
@@ -1,15 +1,74 @@
-import BankingUI from "@/features/banking/banking.ui";
+'use client';
 
-export default function BankingPage() {
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useActiveTenantId } from '@/features/auth/useAuthSession';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
+import { useCanAdministerTenant } from '@/features/tenancy/hooks/useEffectiveRole';
+import { useTenantId } from '@/features/tenancy/tenant.hooks';
+import BankingUI from '@/features/banking/banking.ui';
+import { routes } from '@/shared/lib/routes';
+
+interface BankingSettingsContentProps {
+  readonly tenantId: string;
+}
+
+function BankingSettingsContent({ tenantId }: BankingSettingsContentProps) {
   return (
     <div className="max-w-4xl mx-auto py-8">
       <div className="mb-8">
         <h1 className="text-3xl font-bold tracking-tight text-foreground">Cuentas bancarias</h1>
-        <p className="text-muted-foreground mt-2">
+        <p className="mt-2 text-muted-foreground">
           Estas cuentas se mostrarán a residentes para reportar pagos.
         </p>
       </div>
-      <BankingUI />
+
+      <BankingUI key={tenantId} tenantId={tenantId} />
     </div>
   );
+}
+
+export default function BankingPage() {
+  const router = useRouter();
+  const routeTenantId = useTenantId();
+  const activeTenantId = useActiveTenantId();
+  const portalContext = useAuthorizedPortalContext(routeTenantId);
+
+  const hasMatchingTenant =
+    activeTenantId !== null &&
+    routeTenantId !== null &&
+    activeTenantId === routeTenantId;
+  const tenantId = hasMatchingTenant ? activeTenantId : null;
+  const canAdministerTenant = useCanAdministerTenant(tenantId ?? undefined);
+
+  useEffect(() => {
+    if (activeTenantId && routeTenantId && activeTenantId !== routeTenantId) {
+      router.replace(`/${activeTenantId}/settings/banking`);
+      return;
+    }
+
+    if (portalContext === 'resident' && tenantId) {
+      router.replace(routes.residentDashboard(tenantId));
+    }
+  }, [activeTenantId, portalContext, routeTenantId, router, tenantId]);
+
+  if (!tenantId || portalContext === null) {
+    return <div className="max-w-4xl mx-auto py-8" aria-busy="true" />;
+  }
+
+  if (portalContext === 'resident') {
+    return <div className="max-w-4xl mx-auto py-8" aria-busy="true" />;
+  }
+
+  if (!canAdministerTenant) {
+    return (
+      <div className="max-w-4xl mx-auto py-8">
+        <div className="rounded-lg border border-dashed border-muted-foreground/30 bg-muted/30 p-6 text-sm text-muted-foreground">
+          No tenés permiso para editar las cuentas bancarias.
+        </div>
+      </div>
+    );
+  }
+
+  return <BankingSettingsContent key={tenantId} tenantId={tenantId} />;
 }

--- a/apps/web/features/banking/banking.ui.test.tsx
+++ b/apps/web/features/banking/banking.ui.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import type { ButtonHTMLAttributes, InputHTMLAttributes, ReactNode } from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import BankingUI from './banking.ui';
+import { addBankAccount, listBankAccounts, removeBankAccount } from './banking.storage';
+import type { BankAccount } from './banking.types';
+
+let accountsByTenant: Record<string, BankAccount[]> = {};
+
+jest.mock('./banking.storage', () => ({
+  listBankAccounts: jest.fn(),
+  addBankAccount: jest.fn(),
+  removeBankAccount: jest.fn(),
+}));
+
+jest.mock('@/shared/components/ui/Card', () => ({
+  __esModule: true,
+  default: ({ children, className }: { children: ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+}));
+
+jest.mock('@/shared/components/ui/Button', () => ({
+  __esModule: true,
+  default: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button type="button" {...props}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock('@/shared/components/ui/Input', () => ({
+  __esModule: true,
+  default: (() => {
+    const React = jest.requireActual('react') as typeof import('react');
+    const MockInput = React.forwardRef<HTMLInputElement, InputHTMLAttributes<HTMLInputElement>>(
+      (props, ref) => <input ref={ref} {...props} />,
+    );
+    MockInput.displayName = 'MockInput';
+    return MockInput;
+  })(),
+}));
+
+jest.mock('@/shared/components/ui/Table', () => ({
+  Table: ({ children }: { children: ReactNode }) => <table>{children}</table>,
+}));
+
+const mockedListBankAccounts = jest.mocked(listBankAccounts);
+const mockedAddBankAccount = jest.mocked(addBankAccount);
+const mockedRemoveBankAccount = jest.mocked(removeBankAccount);
+
+describe('BankingUI', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    accountsByTenant = {
+      'tenant-a': [
+        {
+          id: 'acc-a-1',
+          bankName: 'Banco A',
+          accountHolder: 'Consorcio A',
+          accountNumber: '111',
+          notes: 'Tenant A',
+          createdAt: '2026-08-04T00:00:00.000Z',
+        },
+      ],
+      'tenant-b': [
+        {
+          id: 'acc-b-1',
+          bankName: 'Banco B',
+          accountHolder: 'Consorcio B',
+          accountNumber: '222',
+          notes: 'Tenant B',
+          createdAt: '2026-08-04T00:00:00.000Z',
+        },
+      ],
+    };
+
+    mockedListBankAccounts.mockImplementation((tenantId: string) => accountsByTenant[tenantId] ?? []);
+    mockedAddBankAccount.mockImplementation(
+      (tenantId: string, account: Omit<BankAccount, 'id' | 'createdAt'>) => {
+        const newAccount: BankAccount = {
+          ...account,
+          id: `${tenantId}-new`,
+          createdAt: '2026-08-04T00:00:00.000Z',
+        };
+
+        accountsByTenant[tenantId] = [...(accountsByTenant[tenantId] ?? []), newAccount];
+        window.dispatchEvent(new Event('bo:storage'));
+        return newAccount;
+      },
+    );
+    mockedRemoveBankAccount.mockImplementation((tenantId: string, id: string) => {
+      accountsByTenant[tenantId] = (accountsByTenant[tenantId] ?? []).filter(
+        (account) => account.id !== id,
+      );
+      window.dispatchEvent(new Event('bo:storage'));
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('lists accounts for the provided tenant only', () => {
+    render(<BankingUI tenantId="tenant-a" />);
+
+    expect(mockedListBankAccounts).toHaveBeenCalledWith('tenant-a');
+    expect(screen.getByText('Banco A')).not.toBeNull();
+    expect(screen.queryByText('Banco B')).toBeNull();
+  });
+
+  it('creates an account for the provided tenant', async () => {
+    render(<BankingUI tenantId="tenant-a" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Nueva Cuenta' }));
+    fireEvent.change(screen.getByPlaceholderText('Ej: Banco Nacional'), {
+      target: { value: 'Banco Nuevo' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Ej: Consorcio Torre A'), {
+      target: { value: 'Consorcio Nuevo' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('0000...'), {
+      target: { value: '999' },
+    });
+    fireEvent.change(screen.getByPlaceholderText('Cuenta principal...'), {
+      target: { value: 'Cuenta de prueba' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Guardar Cuenta' }));
+
+    await waitFor(() => {
+      expect(mockedAddBankAccount).toHaveBeenCalledWith('tenant-a', {
+        bankName: 'Banco Nuevo',
+        accountHolder: 'Consorcio Nuevo',
+        accountNumber: '999',
+        notes: 'Cuenta de prueba',
+      });
+    });
+
+    expect(screen.getByText('Banco Nuevo')).not.toBeNull();
+  });
+
+  it('deletes an account for the provided tenant', async () => {
+    jest.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<BankingUI tenantId="tenant-a" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Eliminar' }));
+
+    await waitFor(() => {
+      expect(mockedRemoveBankAccount).toHaveBeenCalledWith('tenant-a', 'acc-a-1');
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Banco A')).toBeNull();
+    });
+  });
+
+  it('remounts cleanly when the tenant prop changes from A to B', () => {
+    const { rerender } = render(<BankingUI tenantId="tenant-a" />);
+
+    expect(screen.getByText('Banco A')).not.toBeNull();
+
+    rerender(<BankingUI tenantId="tenant-b" />);
+
+    expect(mockedListBankAccounts).toHaveBeenCalledWith('tenant-b');
+    expect(screen.getByText('Banco B')).not.toBeNull();
+    expect(screen.queryByText('Banco A')).toBeNull();
+  });
+});

--- a/apps/web/features/banking/banking.ui.tsx
+++ b/apps/web/features/banking/banking.ui.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -8,8 +8,7 @@ import Card from "@/shared/components/ui/Card";
 import Button from "@/shared/components/ui/Button";
 import Input from "@/shared/components/ui/Input";
 import { Table } from "@/shared/components/ui/Table";
-import { useTenantId } from "@/features/tenancy/tenant.hooks";
-import { BankAccount } from "./banking.types";
+import { useBoStorageTick } from "@/shared/lib/storage/useBoStorage";
 import { listBankAccounts, addBankAccount, removeBankAccount } from "./banking.storage";
 
 const schema = z.object({
@@ -21,10 +20,14 @@ const schema = z.object({
 
 type FormData = z.infer<typeof schema>;
 
-export default function BankingUI() {
-  const tenantId = useTenantId();
-  const [accounts, setAccounts] = useState<BankAccount[]>([]);
+export interface BankingUIProps {
+  readonly tenantId: string;
+}
+
+export default function BankingUI({ tenantId }: BankingUIProps) {
   const [isCreating, setIsCreating] = useState(false);
+  useBoStorageTick();
+  const accounts = listBankAccounts(tenantId);
 
   const {
     register,
@@ -35,30 +38,15 @@ export default function BankingUI() {
     resolver: zodResolver(schema),
   });
 
-  const refresh = () => {
-    if (tenantId) {
-      setAccounts(listBankAccounts(tenantId));
-    }
-  };
-
-  useEffect(() => {
-    refresh();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tenantId]);
-
   const onSubmit = (data: FormData) => {
-    if (!tenantId) return;
     addBankAccount(tenantId, data);
     reset();
     setIsCreating(false);
-    refresh();
   };
 
   const handleDelete = (id: string) => {
-    if (!tenantId) return;
     if (confirm("¿Estás seguro de eliminar esta cuenta?")) {
       removeBankAccount(tenantId, id);
-      refresh();
     }
   };
 
@@ -74,36 +62,36 @@ export default function BankingUI() {
       {isCreating && (
         <Card className="p-6">
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               <div>
-                <label className="block text-sm font-medium text-foreground mb-1">
+                <label className="mb-1 block text-sm font-medium text-foreground">
                   Banco
                 </label>
                 <Input {...register("bankName")} placeholder="Ej: Banco Nacional" />
                 {errors.bankName && (
-                  <p className="text-sm text-red-500 mt-1">{errors.bankName.message}</p>
+                  <p className="mt-1 text-sm text-red-500">{errors.bankName.message}</p>
                 )}
               </div>
               <div>
-                <label className="block text-sm font-medium text-foreground mb-1">
+                <label className="mb-1 block text-sm font-medium text-foreground">
                   Titular
                 </label>
                 <Input {...register("accountHolder")} placeholder="Ej: Consorcio Torre A" />
                 {errors.accountHolder && (
-                  <p className="text-sm text-red-500 mt-1">{errors.accountHolder.message}</p>
+                  <p className="mt-1 text-sm text-red-500">{errors.accountHolder.message}</p>
                 )}
               </div>
               <div>
-                <label className="block text-sm font-medium text-foreground mb-1">
+                <label className="mb-1 block text-sm font-medium text-foreground">
                   Número de Cuenta / CBU / IBAN
                 </label>
                 <Input {...register("accountNumber")} placeholder="0000..." />
                 {errors.accountNumber && (
-                  <p className="text-sm text-red-500 mt-1">{errors.accountNumber.message}</p>
+                  <p className="mt-1 text-sm text-red-500">{errors.accountNumber.message}</p>
                 )}
               </div>
               <div>
-                <label className="block text-sm font-medium text-foreground mb-1">
+                <label className="mb-1 block text-sm font-medium text-foreground">
                   Notas (Opcional)
                 </label>
                 <Input {...register("notes")} placeholder="Cuenta principal..." />
@@ -145,9 +133,9 @@ export default function BankingUI() {
             <tbody>
               {accounts.map((acc) => (
                 <tr key={acc.id} className="border-b border-border last:border-0 hover:bg-muted/50">
-                  <td className="px-4 py-3 text-sm text-foreground font-medium">{acc.bankName}</td>
+                  <td className="px-4 py-3 text-sm font-medium text-foreground">{acc.bankName}</td>
                   <td className="px-4 py-3 text-sm text-muted-foreground">{acc.accountHolder}</td>
-                  <td className="px-4 py-3 text-sm text-muted-foreground font-mono">{acc.accountNumber}</td>
+                  <td className="px-4 py-3 font-mono text-sm text-muted-foreground">{acc.accountNumber}</td>
                   <td className="px-4 py-3 text-sm text-muted-foreground">{acc.notes || "-"}</td>
                   <td className="px-4 py-3 text-right">
                     <Button

--- a/apps/web/shared/components/layout/Sidebar.test.tsx
+++ b/apps/web/shared/components/layout/Sidebar.test.tsx
@@ -2,11 +2,13 @@
  * @jest-environment jsdom
  */
 
+import type { ReactNode } from "react";
 import { render, screen } from "@testing-library/react";
 import { Sidebar } from "./Sidebar";
 
 let pathname = "/tenant-1/tickets/ticket-1";
 let currentSearch = "";
+let tenantId = "tenant-1";
 let session: {
   user: { id: string; email: string; name: string };
   memberships: Array<{ tenantId: string; roles: string[] }>;
@@ -15,7 +17,11 @@ let session: {
 
 jest.mock("next/link", () => ({
   __esModule: true,
-  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => <a href={href} {...props}>{children}</a>,
+  default: ({ href, children, ...props }: { href: string; children: ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
 }));
 
 jest.mock("next/navigation", () => ({
@@ -24,7 +30,7 @@ jest.mock("next/navigation", () => ({
 }));
 
 jest.mock("../../../features/tenancy/tenant.hooks", () => ({
-  useTenantId: () => "tenant-1",
+  useTenantId: () => tenantId,
 }));
 
 jest.mock("../../../features/auth/useAuthSession", () => ({
@@ -41,22 +47,33 @@ jest.mock("../../../features/tenants/tenants.hooks", () => ({
 }));
 
 jest.mock("@/i18n", () => ({
-  t: (key: string) => ({
-    "common.condominium": "Condominio",
-    "navigation.dashboard": "Panel",
-    "navigation.myProfile": "Mi perfil",
-    "navigation.payments": "Pagos",
-    "navigation.communications": "Comunicados",
-    "navigation.tickets": "Solicitudes",
-    "navigation.myUnit": "Mi unidad",
-    "navigation.documents": "Documentos",
-  })[key] ?? key,
+  t: (key: string) =>
+    ({
+      "common.condominium": "Condominio",
+      "navigation.dashboard": "Panel",
+      "navigation.myProfile": "Mi perfil",
+      "navigation.payments": "Pagos",
+      "navigation.communications": "Comunicados",
+      "navigation.tickets": "Solicitudes",
+      "navigation.myUnit": "Mi unidad",
+      "navigation.documents": "Documentos",
+      "navigation.buildings": "Edificios",
+      "navigation.units": "Unidades",
+      "navigation.finanzas": "Finanzas",
+      "navigation.rubros": "Rubros",
+      "navigation.reports": "Reportes",
+      "navigation.settings": "Configuración",
+      "settings.general": "Configuración general",
+      "navigation.residents": "Residentes",
+      "sidebar.team": "Equipo",
+    })[key] ?? key,
 }));
 
 describe("Sidebar", () => {
   beforeEach(() => {
     pathname = "/tenant-1/tickets/ticket-1";
     currentSearch = "";
+    tenantId = "tenant-1";
     window.history.pushState({}, "", pathname);
     session = {
       user: { id: "user-1", email: "test@test.com", name: "Test User" },
@@ -72,7 +89,7 @@ describe("Sidebar", () => {
     expect(aside?.className).toContain("hidden");
     expect(aside?.className).toContain("w-64");
     expect(aside?.className).toContain("lg:block");
-    expect(screen.getByRole("link", { name: "navigation.buildings" }).className).not.toContain("min-h-11");
+    expect(screen.getByRole("link", { name: "Edificios" }).className).not.toContain("min-h-11");
   });
 
   it("uses visible touch-sized links without a fixed desktop width in the drawer variant", () => {
@@ -93,8 +110,11 @@ describe("Sidebar", () => {
 
     render(<Sidebar variant="drawer" />);
 
-    expect(screen.getByRole("link", { name: "Panel" }).getAttribute("href")).toBe("/tenant-1/resident/dashboard");
+    expect(screen.getByRole("link", { name: "Panel" }).getAttribute("href")).toBe(
+      "/tenant-1/resident/dashboard",
+    );
     expect(screen.getByRole("link", { name: "Mi perfil" }).className).toContain("bg-primary");
+    expect(screen.queryByRole("link", { name: "Cuentas bancarias" })).toBeNull();
   });
 
   it("renders admin navigation on admin routes for mixed-role users", () => {
@@ -104,7 +124,11 @@ describe("Sidebar", () => {
     render(<Sidebar variant="drawer" />);
 
     expect(screen.getByRole("link", { name: "Panel" }).getAttribute("href")).toBe("/tenant-1/dashboard");
-    expect(screen.getByRole("link", { name: "navigation.buildings" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Edificios" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Configuración general" })).toBeTruthy();
+    expect(screen.getByRole("link", { name: "Cuentas bancarias" }).getAttribute("href")).toBe(
+      "/tenant-1/settings/banking",
+    );
     expect(screen.queryByRole("link", { name: "Mi perfil" })).toBeNull();
   });
 
@@ -115,6 +139,7 @@ describe("Sidebar", () => {
     render(<Sidebar variant="drawer" />);
 
     expect(screen.getByRole("link", { name: "Solicitudes" }).className).toContain("bg-primary");
+    expect(screen.queryByRole("link", { name: "Cuentas bancarias" })).toBeNull();
   });
 
   it("falls back to resident navigation for resident-only users on admin routes", () => {
@@ -128,8 +153,85 @@ describe("Sidebar", () => {
 
     render(<Sidebar variant="drawer" />);
 
-    expect(screen.getByRole("link", { name: "Panel" }).getAttribute("href")).toBe("/tenant-1/resident/dashboard");
+    expect(screen.getByRole("link", { name: "Panel" }).getAttribute("href")).toBe(
+      "/tenant-1/resident/dashboard",
+    );
     expect(screen.getByRole("link", { name: "Mi perfil" })).toBeTruthy();
-    expect(screen.queryByRole("link", { name: "navigation.buildings" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Edificios" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "Cuentas bancarias" })).toBeNull();
+  });
+
+  it("hides banking navigation for operator users", () => {
+    pathname = "/tenant-1/dashboard";
+    session = {
+      user: { id: "operator-1", email: "operator@test.com", name: "Operator User" },
+      memberships: [{ tenantId: "tenant-1", roles: ["OPERATOR"] }],
+      activeTenantId: "tenant-1",
+    };
+
+    render(<Sidebar variant="drawer" />);
+
+    expect(screen.queryByRole("link", { name: "Cuentas bancarias" })).toBeNull();
+  });
+
+  it("hides banking navigation for mixed-role users when the portal resolves to resident", () => {
+    pathname = "/tenant-1/resident/profile";
+    currentSearch = "portal=resident";
+    session = {
+      user: { id: "mixed-1", email: "mixed@test.com", name: "Mixed Resident" },
+      memberships: [{ tenantId: "tenant-1", roles: ["RESIDENT", "TENANT_ADMIN"] }],
+      activeTenantId: "tenant-1",
+    };
+
+    render(<Sidebar variant="drawer" />);
+
+    expect(screen.queryByRole("link", { name: "Cuentas bancarias" })).toBeNull();
+  });
+
+  it("shows banking navigation for mixed-role users when the portal resolves to admin", () => {
+    pathname = "/tenant-1/dashboard";
+    session = {
+      user: { id: "mixed-2", email: "mixed@test.com", name: "Mixed Admin" },
+      memberships: [{ tenantId: "tenant-1", roles: ["RESIDENT", "TENANT_ADMIN"] }],
+      activeTenantId: "tenant-1",
+    };
+
+    render(<Sidebar variant="drawer" />);
+
+    expect(screen.getByRole("link", { name: "Cuentas bancarias" }).getAttribute("href")).toBe(
+      "/tenant-1/settings/banking",
+    );
+  });
+
+  it("does not leak tenant A admin permissions when evaluating tenant B", () => {
+    tenantId = "tenant-2";
+    pathname = "/tenant-2/dashboard";
+    session = {
+      user: { id: "user-2", email: "test2@test.com", name: "Test User 2" },
+      memberships: [
+        { tenantId: "tenant-1", roles: ["TENANT_ADMIN"] },
+        { tenantId: "tenant-2", roles: ["RESIDENT"] },
+      ],
+      activeTenantId: "tenant-2",
+    };
+
+    render(<Sidebar variant="drawer" />);
+
+    expect(screen.queryByRole("link", { name: "Cuentas bancarias" })).toBeNull();
+  });
+
+  it("marks the banking link as active on the banking settings route", () => {
+    pathname = "/tenant-1/settings/banking";
+    session = {
+      user: { id: "owner-1", email: "owner@test.com", name: "Owner User" },
+      memberships: [{ tenantId: "tenant-1", roles: ["TENANT_OWNER"] }],
+      activeTenantId: "tenant-1",
+    };
+
+    render(<Sidebar variant="drawer" />);
+
+    expect(screen.getByRole("link", { name: "Cuentas bancarias" }).className).toContain(
+      "bg-primary",
+    );
   });
 });

--- a/apps/web/shared/components/layout/Sidebar.tsx
+++ b/apps/web/shared/components/layout/Sidebar.tsx
@@ -9,6 +9,7 @@ import { useAuthSession, useIsSuperAdmin } from "../../../features/auth/useAuthS
 import { getLastPortal } from "../../../features/auth/session.storage";
 import { useImpersonation } from "../../../features/impersonation/useImpersonation";
 import { useTenants } from "../../../features/tenants/tenants.hooks";
+import { useCanAdministerTenant } from "../../../features/tenancy/hooks/useEffectiveRole";
 import { resolveAuthorizedPortalContext } from "../../../features/auth/landing-route";
 import { t } from "@/i18n";
 
@@ -54,6 +55,7 @@ export const Sidebar = ({ className, footer, id, onNavigate, variant = "desktop"
   const tenantName = tenants?.find((tenant) => tenant.id === tenantId)?.name;
   const isSuperAdmin = useIsSuperAdmin();
   const { isImpersonating } = useImpersonation();
+  const canAdministerTenant = useCanAdministerTenant(tenantId ?? undefined);
 
   if ((isSuperAdmin && !isImpersonating) || !tenantId) return null;
 
@@ -129,6 +131,7 @@ export const Sidebar = ({ className, footer, id, onNavigate, variant = "desktop"
               {t("navigation.settings")}
             </div>
             {navItem(`/${tenantId}/settings/general`, t("settings.general"))}
+            {canAdministerTenant && navItem(`/${tenantId}/settings/banking`, "Cuentas bancarias")}
             {navItem(routes.onboardingImport(tenantId), "Onboarding import")}
             {navItem(`/${tenantId}/settings/members`, t("navigation.residents"))}
             {navItem(`/${tenantId}/settings/team`, t("sidebar.team"))}


### PR DESCRIPTION
Closes #117

## Summary
- Guards the banking account editor by active portal and tenant-specific roles.
- Prevents residents and operators from mounting administrative banking controls.
- Binds local banking state to the validated tenant and prevents stale editor state across tenant changes.
- Adds the administrative sidebar entry for authorized banking access.

## Changes Table
| File | Change |
|------|--------|
| `apps/web/app/(tenant)/[tenantId]/settings/banking/page.tsx` | Added tenant-aware, portal-aware admin gating with redirect and access-denied states. |
| `apps/web/app/(tenant)/[tenantId]/settings/banking/page.test.tsx` | Added coverage for loading, resident redirect, role gating, tenant mismatch, and tenant switching. |
| `apps/web/features/banking/banking.ui.tsx` | Bound the editor to the validated tenant prop and removed independent tenant resolution. |
| `apps/web/features/banking/banking.ui.test.tsx` | Added focused coverage for tenant-specific listing, create, delete, and remount behavior. |
| `apps/web/shared/components/layout/Sidebar.tsx` | Adds the authorized banking settings navigation entry. |
| `apps/web/shared/components/layout/Sidebar.test.tsx` | Verifies owner/admin visibility and operator/resident hiding. |

## Test Plan
- [x] `git diff --check`
- [x] `npm run test -w apps/web -- --runInBand --no-coverage --runTestsByPath 'app/(tenant)/[tenantId]/settings/banking/page.test.tsx' 'features/banking/banking.ui.test.tsx' 'shared/components/layout/Sidebar.test.tsx'`
- [x] `npm run lint -w apps/web -- --max-warnings=0 'app/(tenant)/[tenantId]/settings/banking/page.tsx' 'app/(tenant)/[tenantId]/settings/banking/page.test.tsx' 'features/banking/banking.ui.tsx' 'features/banking/banking.ui.test.tsx' 'shared/components/layout/Sidebar.tsx' 'shared/components/layout/Sidebar.test.tsx'`
- [ ] `npx tsc --noEmit` — fails in pre-existing workspace imports for `@buildingos/contracts` / `@buildingos/permissions`
- [ ] `npm run build -w apps/web` — fails in pre-existing workspace imports for `@buildingos/contracts` / `@buildingos/permissions`

## Scope
- frontend authorization only
- existing localStorage persistence preserved
- no backend
- no schema or migrations
- no seeds
- no deployment
