### PR TITLE
fix(api): exclude archived buildings from active flows

### DIFF
--- a/apps/api/src/context/context.service.spec.ts
+++ b/apps/api/src/context/context.service.spec.ts
@@ -96,6 +96,46 @@ describe('ContextService', () => {
     });
   });
 
+  it('omits archived buildings and their units from tenant-scoped context options', async () => {
+    jest.spyOn(prisma.membership, 'findUnique').mockResolvedValue({
+      id: 'membership-1',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      userContext: null,
+      roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT', scopeBuildingId: null }],
+    } as never);
+    jest.spyOn(residentAccess, 'shouldEnforce').mockReturnValue(false);
+    jest.spyOn(prisma.building, 'findMany').mockResolvedValue([
+      { id: 'building-active', name: 'Edificio Activo' },
+    ] as never);
+    jest.spyOn(prisma.unit, 'findMany').mockResolvedValue([
+      { id: 'unit-1', code: 'A-01', label: 'Unidad 1' },
+    ] as never);
+
+    await expect(service.getContextOptions('user-1', 'tenant-1')).resolves.toEqual({
+      buildings: [
+        { id: 'building-active', name: 'Edificio Activo' },
+      ],
+      unitsByBuilding: {
+        'building-active': [
+          { id: 'unit-1', code: 'A-01', label: 'Unidad 1' },
+        ],
+      },
+    });
+
+    expect(prisma.building.findMany).toHaveBeenCalledWith({
+      where: { tenantId: 'tenant-1', deletedAt: null },
+      select: { id: true, name: true },
+    });
+    expect(prisma.unit.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: expect.objectContaining({
+        tenantId: 'tenant-1',
+        buildingId: 'building-active',
+        building: { deletedAt: null },
+      }),
+    }));
+  });
+
   it('normalizes a resident building-only selection to the first active unit in that building', async () => {
     jest.spyOn(prisma.membership, 'findUnique').mockResolvedValue({
       id: 'membership-1',
@@ -156,6 +196,26 @@ describe('ContextService', () => {
     );
   });
 
+  it('rejects archived buildings when setting a tenant-scoped context', async () => {
+    jest.spyOn(prisma.membership, 'findUnique').mockResolvedValue({
+      id: 'membership-1',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      userContext: null,
+      roles: [{ role: 'TENANT_ADMIN' }],
+    } as never);
+    jest.spyOn(residentAccess, 'shouldEnforce').mockReturnValue(false);
+    jest.spyOn(prisma.building, 'findFirst').mockResolvedValue(null);
+
+    await expect(
+      service.setContext('user-1', 'tenant-1', 'building-archived', null),
+    ).rejects.toBeInstanceOf(NotFoundException);
+
+    expect(prisma.building.findFirst).toHaveBeenCalledWith({
+      where: { id: 'building-archived', tenantId: 'tenant-1', deletedAt: null },
+    });
+  });
+
   it('keeps the resident context empty when there are no active occupancies', async () => {
     jest.spyOn(prisma.membership, 'findUnique').mockResolvedValue({
       id: 'membership-1',
@@ -177,5 +237,33 @@ describe('ContextService', () => {
       activeBuildingId: null,
       activeUnitId: null,
     });
+  });
+
+  it('omits archived buildings from tenant-wide context options', async () => {
+    jest.spyOn(prisma.membership, 'findUnique').mockResolvedValue({
+      id: 'membership-1',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      userContext: null,
+      roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+    } as never);
+    jest.spyOn(prisma.building, 'findMany').mockResolvedValue([
+      { id: 'building-active', name: 'Edificio Activo' },
+    ] as never);
+    jest.spyOn(prisma.unit, 'findMany').mockResolvedValue([] as never);
+    jest.spyOn(residentAccess, 'shouldEnforce').mockReturnValue(false);
+
+    await expect(service.getContextOptions('user-1', 'tenant-1')).resolves.toEqual({
+      buildings: [{ id: 'building-active', name: 'Edificio Activo' }],
+      unitsByBuilding: {
+        'building-active': [],
+      },
+    });
+
+    expect(prisma.building.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { tenantId: 'tenant-1', deletedAt: null },
+      }),
+    );
   });
 });

--- a/apps/api/src/context/context.service.ts
+++ b/apps/api/src/context/context.service.ts
@@ -201,7 +201,7 @@ export class ContextService {
     // If unit is specified, derive/validate building
     if (effectiveUnitId) {
       const unit = await this.prisma.unit.findFirst({
-        where: { id: effectiveUnitId, tenantId },
+        where: { id: effectiveUnitId, tenantId, building: { deletedAt: null } },
         include: { building: true },
       });
 
@@ -251,7 +251,7 @@ export class ContextService {
     // Validate building if specified
     if (effectiveBuildingId) {
       const building = await this.prisma.building.findFirst({
-        where: { id: effectiveBuildingId, tenantId },
+        where: { id: effectiveBuildingId, tenantId, deletedAt: null },
       });
 
       if (!building) {
@@ -387,7 +387,7 @@ export class ContextService {
     const hasTenantScope = roles.some((r: MembershipRoleShape) => r.scopeType === 'TENANT');
     if (hasTenantScope) {
       const buildings = await this.prisma.building.findMany({
-        where: { tenantId },
+        where: { tenantId, deletedAt: null },
         select: { id: true, name: true },
       });
       return buildings.sort((a, b) =>
@@ -403,7 +403,7 @@ export class ContextService {
 
     if (buildingIds.length > 0) {
       const buildings = await this.prisma.building.findMany({
-        where: { tenantId, id: { in: buildingIds } },
+        where: { tenantId, id: { in: buildingIds }, deletedAt: null },
         select: { id: true, name: true },
       });
       return buildings.sort((a, b) =>
@@ -438,7 +438,12 @@ export class ContextService {
       const unitIds = await this.residentAccess.getActiveUnitIds(_tenantId, userId, buildingId);
       if (unitIds.length === 0) return [];
       const units = await this.prisma.unit.findMany({
-        where: { tenantId: _tenantId, buildingId, id: { in: unitIds } },
+        where: {
+          tenantId: _tenantId,
+          buildingId,
+          building: { deletedAt: null },
+          id: { in: unitIds },
+        },
         select: { id: true, code: true, label: true },
       });
       return units.sort((a, b) =>
@@ -451,7 +456,11 @@ export class ContextService {
     // If TENANT or BUILDING scoped: return all units in building
     if (hasTenantScope || hasBuildingScope) {
       const units = await this.prisma.unit.findMany({
-        where: { tenantId: _tenantId, buildingId },
+        where: {
+          tenantId: _tenantId,
+          buildingId,
+          building: { deletedAt: null },
+        },
         select: { id: true, code: true, label: true },
       });
       return units.sort((a, b) =>
@@ -472,6 +481,7 @@ export class ContextService {
         where: {
           tenantId: _tenantId,
           buildingId,
+          building: { deletedAt: null },
           id: { in: unitIds },
         },
         select: { id: true, code: true, label: true },

--- a/apps/api/src/occupants/occupants.service.spec.ts
+++ b/apps/api/src/occupants/occupants.service.spec.ts
@@ -108,7 +108,7 @@ describe('OccupantsService', () => {
 
     expect(prisma.unitOccupant.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
-        where: { unitId: 'unit-1' },
+        where: { tenantId: 'tenant-1', unitId: 'unit-1' },
         include: {
           member: {
             include: {
@@ -137,7 +137,7 @@ describe('OccupantsService', () => {
 
     expect(result).toEqual([]);
     expect(prisma.unit.findFirst).toHaveBeenCalledWith({
-      where: { id: 'unit-1', building: { id: 'building-1', tenantId: 'tenant-1' } },
+      where: { id: 'unit-1', building: { id: 'building-1', tenantId: 'tenant-1', deletedAt: null } },
     });
     expectNoPasswordHashDeep(result);
   });
@@ -150,5 +150,30 @@ describe('OccupantsService', () => {
     ).rejects.toBeInstanceOf(NotFoundException);
 
     expect(prisma.unitOccupant.findMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects assigning occupants to archived buildings', async () => {
+    authorizeService.authorize.mockResolvedValue(true);
+    planEntitlements.assertLimit.mockResolvedValue(undefined);
+    prisma.tenantMember.findFirst.mockResolvedValue({ id: 'member-1' } as never);
+    prisma.unit.findFirst.mockResolvedValueOnce(null);
+
+    await expect(
+      service.assignOccupant(
+        'tenant-1',
+        'building-archived',
+        'unit-1',
+        { memberId: 'member-1', role: 'RESIDENT' } as never,
+        'user-1',
+      ),
+    ).rejects.toBeInstanceOf(NotFoundException);
+
+    expect(prisma.unit.findFirst).toHaveBeenCalledWith({
+      where: {
+        id: 'unit-1',
+        building: { id: 'building-archived', tenantId: 'tenant-1', deletedAt: null },
+      },
+    });
+    expect(prisma.unitOccupant.create).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/occupants/occupants.service.ts
+++ b/apps/api/src/occupants/occupants.service.ts
@@ -27,7 +27,7 @@ interface OccupantUserWithPublicFields {
   name: string;
 }
 
-interface OccupantWithPublicMemberUser extends UnitOccupant {
+export interface OccupantWithPublicMemberUser extends UnitOccupant {
   member?: {
     user?: OccupantUserWithPublicFields | null;
   } | null;

--- a/apps/api/src/occupants/occupants.service.ts
+++ b/apps/api/src/occupants/occupants.service.ts
@@ -8,30 +8,30 @@ import { AuthorizeService } from '../rbac/authorize.service';
 import { CreateOccupantDto } from './dto/create-occupant.dto';
 import { publicUserSelect, toPublicUser } from '../common/public-user';
 
-type OccupantNotificationUnit = {
+interface OccupantNotificationUnit {
   id: string;
   label: string | null;
   buildingId: string;
   building?: {
     name: string;
   } | null;
-};
+}
 
-type OccupantWithRelations = UnitOccupant & {
+interface OccupantWithRelations extends UnitOccupant {
   unit?: OccupantNotificationUnit | null;
-};
+}
 
-type OccupantUserWithPublicFields = {
+interface OccupantUserWithPublicFields {
   id: string;
   email: string;
   name: string;
-};
+}
 
-type OccupantWithPublicMemberUser = UnitOccupant & {
+interface OccupantWithPublicMemberUser extends UnitOccupant {
   member?: {
     user?: OccupantUserWithPublicFields | null;
   } | null;
-};
+}
 
 @Injectable()
 export class OccupantsService {
@@ -69,7 +69,7 @@ export class OccupantsService {
 
     // Verify unit exists and belongs to building/tenant
     const unit = await this.prisma.unit.findFirst({
-      where: { id: unitId, building: { id: buildingId, tenantId } },
+      where: { id: unitId, building: { id: buildingId, tenantId, deletedAt: null } },
     });
 
     if (!unit) {
@@ -144,7 +144,7 @@ export class OccupantsService {
   async findOccupants(tenantId: string, buildingId: string, unitId: string): Promise<UnitOccupant[]> {
     // Verify unit exists and belongs to building/tenant
     const unit = await this.prisma.unit.findFirst({
-      where: { id: unitId, building: { id: buildingId, tenantId } },
+      where: { id: unitId, building: { id: buildingId, tenantId, deletedAt: null } },
     });
 
     if (!unit) {
@@ -154,7 +154,7 @@ export class OccupantsService {
     }
 
     return await this.prisma.unitOccupant.findMany({
-      where: { unitId },
+      where: { tenantId, unitId },
       include: {
         member: {
           include: {
@@ -192,7 +192,7 @@ export class OccupantsService {
 
     // Verify unit exists and belongs to building/tenant
     const unit = await this.prisma.unit.findFirst({
-      where: { id: unitId, building: { id: buildingId, tenantId } },
+      where: { id: unitId, building: { id: buildingId, tenantId, deletedAt: null } },
     });
 
     if (!unit) {
@@ -203,7 +203,7 @@ export class OccupantsService {
 
     // Verify occupant exists and belongs to this unit
     const occupant = await this.prisma.unitOccupant.findFirst({
-      where: { id: occupantId, unitId },
+      where: { id: occupantId, tenantId, unitId },
     });
 
     if (!occupant) {
@@ -212,8 +212,8 @@ export class OccupantsService {
       );
     }
 
-    const deleted = await this.prisma.unitOccupant.delete({
-      where: { id: occupantId },
+    await this.prisma.unitOccupant.deleteMany({
+      where: { id: occupantId, tenantId },
     });
 
     // Audit: OCCUPANT_REMOVE
@@ -232,7 +232,7 @@ export class OccupantsService {
       });
     }
 
-    return deleted;
+    return occupant;
   }
 
   /**
@@ -246,8 +246,8 @@ export class OccupantsService {
   ): Promise<void> {
     try {
       // Load fresh member data to get user ID
-      const member = await this.prisma.tenantMember.findUnique({
-        where: { id: occupant.memberId },
+      const member = await this.prisma.tenantMember.findFirst({
+        where: { id: occupant.memberId, tenantId },
         include: { user: { select: { id: true } } },
       });
 
@@ -292,6 +292,6 @@ export class OccupantsService {
         ...occupant.member,
         user: toPublicUser(occupant.member.user) ?? null,
       },
-    } as unknown as UnitOccupant;
+    };
   }
 }

--- a/apps/api/src/occupants/occupants.service.ts
+++ b/apps/api/src/occupants/occupants.service.ts
@@ -141,7 +141,7 @@ export class OccupantsService {
   /**
    * List all occupants for a unit
    */
-  async findOccupants(tenantId: string, buildingId: string, unitId: string): Promise<UnitOccupant[]> {
+  async findOccupants(tenantId: string, buildingId: string, unitId: string): Promise<OccupantWithPublicMemberUser[]> {
     // Verify unit exists and belongs to building/tenant
     const unit = await this.prisma.unit.findFirst({
       where: { id: unitId, building: { id: buildingId, tenantId, deletedAt: null } },
@@ -281,7 +281,7 @@ export class OccupantsService {
     }
   }
 
-  private sanitizeOccupantUser(occupant: OccupantWithPublicMemberUser): UnitOccupant {
+  private sanitizeOccupantUser(occupant: OccupantWithPublicMemberUser): OccupantWithPublicMemberUser {
     if (!occupant.member) {
       return occupant;
     }

--- a/apps/api/src/resident-access/resident-access.service.spec.ts
+++ b/apps/api/src/resident-access/resident-access.service.spec.ts
@@ -49,7 +49,13 @@ describe('ResidentAccessService', () => {
 
     await expect(service.getActiveUnitIds('tenant-1', 'user-1')).resolves.toEqual(['unit-1', 'unit-2']);
     expect(prisma.unitOccupant.findMany).toHaveBeenCalledWith(expect.objectContaining({
-      where: expect.objectContaining({ tenantId: 'tenant-1', endDate: null }),
+      where: expect.objectContaining({
+        tenantId: 'tenant-1',
+        endDate: null,
+        unit: expect.objectContaining({
+          building: expect.objectContaining({ deletedAt: null }),
+        }),
+      }),
     }));
   });
 

--- a/apps/api/src/resident-access/resident-access.service.ts
+++ b/apps/api/src/resident-access/resident-access.service.ts
@@ -44,7 +44,11 @@ export class ResidentAccessService {
         tenantId,
         endDate: null,
         member: { tenantId, userId, disabledAt: null },
-        unit: { tenantId, ...(buildingId ? { buildingId } : {}) },
+        unit: {
+          tenantId,
+          ...(buildingId ? { buildingId } : {}),
+          building: { deletedAt: null },
+        },
       },
       select: {
         id: true,

--- a/apps/api/src/tenancy/building-access.guard.spec.ts
+++ b/apps/api/src/tenancy/building-access.guard.spec.ts
@@ -1,0 +1,65 @@
+import { BadRequestException, ExecutionContext, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { BuildingAccessGuard, RequestWithUser } from './building-access.guard';
+import { PrismaService } from '../prisma/prisma.service';
+
+describe('BuildingAccessGuard', () => {
+  const prisma = {
+    building: {
+      findFirst: jest.fn(),
+    },
+    membership: {
+      findUnique: jest.fn(),
+    },
+  } as unknown as PrismaService;
+
+  const guard = new BuildingAccessGuard(prisma);
+
+  const createContext = (request: Partial<RequestWithUser> = {}): ExecutionContext =>
+    ({
+      switchToHttp: () => ({
+        getRequest: () =>
+          ({
+            params: { buildingId: 'building-1', tenantId: 'tenant-1' },
+            user: { id: 'user-1', memberships: [{ tenantId: 'tenant-1' }] },
+            ...request,
+          }) as RequestWithUser,
+      }),
+    }) as unknown as ExecutionContext;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects archived buildings as not found', async () => {
+    jest.spyOn(prisma.building, 'findFirst').mockResolvedValue({
+      id: 'building-1',
+      tenantId: 'tenant-1',
+      deletedAt: new Date('2026-08-01T00:00:00.000Z'),
+    } as never);
+
+    await expect(guard.canActivate(createContext())).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('rejects requests without a buildingId', async () => {
+    await expect(
+      guard.canActivate(
+        createContext({
+          params: {},
+        }),
+      ),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects users without a tenant membership role for the building', async () => {
+    jest.spyOn(prisma.building, 'findFirst').mockResolvedValue({
+      id: 'building-1',
+      tenantId: 'tenant-1',
+      deletedAt: null,
+    } as never);
+    jest.spyOn(prisma.membership, 'findUnique').mockResolvedValue({
+      roles: [],
+    } as never);
+
+    await expect(guard.canActivate(createContext())).rejects.toBeInstanceOf(ForbiddenException);
+  });
+});

--- a/apps/api/src/tenancy/building-access.guard.ts
+++ b/apps/api/src/tenancy/building-access.guard.ts
@@ -65,13 +65,15 @@ export class BuildingAccessGuard implements CanActivate {
     const paramTenantId = request.params.tenantId as string | undefined;
 
     // 3. Buscar el building en la BD
-    const building = await this.prisma.building.findUnique({
-      where: { id: buildingId },
-      select: { id: true, tenantId: true },
+    const building = await this.prisma.building.findFirst({
+      where: paramTenantId
+        ? { id: buildingId, tenantId: paramTenantId, deletedAt: null }
+        : { id: buildingId, deletedAt: null },
+      select: { id: true, tenantId: true, deletedAt: true },
     });
 
     // 4. Si el building no existe, responder 404 (no filtrar existencia)
-    if (!building) {
+    if (!building || building.deletedAt !== null) {
       throw new NotFoundException(
         `Building not found or does not belong to this tenant`,
       );
@@ -130,7 +132,14 @@ export class BuildingAccessGuard implements CanActivate {
     // Los controllers usan req.user.roles para validar permisos (RBAC)
     const tenantRoles = membership.roles
       .filter(r => r.scopeType === 'TENANT' || (r.scopeType === 'BUILDING' && r.scopeBuildingId === buildingId))
-      .map(r => r.role as Role);
+      .map((r) => r.role)
+      .filter((role): role is Role =>
+        role === 'SUPER_ADMIN' ||
+        role === 'TENANT_OWNER' ||
+        role === 'TENANT_ADMIN' ||
+        role === 'OPERATOR' ||
+        role === 'RESIDENT',
+      );
     request.user.roles = tenantRoles;
 
     return true;

--- a/apps/api/src/units/units.service.spec.ts
+++ b/apps/api/src/units/units.service.spec.ts
@@ -35,8 +35,8 @@ describe('UnitsService', () => {
               create: jest.fn(),
               findMany: jest.fn(),
               findFirst: jest.fn(),
-              update: jest.fn(),
-              delete: jest.fn(),
+              updateMany: jest.fn(),
+              deleteMany: jest.fn(),
               count: jest.fn(),
             },
             charge: {
@@ -116,9 +116,9 @@ describe('UnitsService', () => {
         updatedAt: new Date(),
       };
 
-      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as any);
+      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as never);
       jest.spyOn(planEntitlementsService, 'assertLimit').mockResolvedValue(undefined);
-      jest.spyOn(prismaService.unit, 'create').mockResolvedValue(expectedUnit as any);
+      jest.spyOn(prismaService.unit, 'create').mockResolvedValue(expectedUnit as never);
       jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
 
       // ACT
@@ -164,9 +164,9 @@ describe('UnitsService', () => {
         updatedAt: new Date(),
       };
 
-      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as any);
+      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as never);
       jest.spyOn(planEntitlementsService, 'assertLimit').mockResolvedValue(undefined);
-      jest.spyOn(prismaService.unit, 'create').mockResolvedValue(expectedUnit as any);
+      jest.spyOn(prismaService.unit, 'create').mockResolvedValue(expectedUnit as never);
 
       // ACT
       const result = await service.create(tenantId, buildingId, 'user-123', dto);
@@ -217,7 +217,7 @@ describe('UnitsService', () => {
         meta: { target: ['code'] },
       };
 
-      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as any);
+      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as never);
       jest.spyOn(planEntitlementsService, 'assertLimit').mockResolvedValue(undefined);
       jest.spyOn(prismaService.unit, 'create').mockRejectedValue(error);
 
@@ -248,7 +248,7 @@ describe('UnitsService', () => {
       };
       const limitError = new BadRequestException('Unit limit exceeded');
 
-      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as any);
+      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as never);
       jest.spyOn(planEntitlementsService, 'assertLimit').mockRejectedValue(limitError);
 
       // ACT & ASSERT
@@ -290,7 +290,7 @@ describe('UnitsService', () => {
         },
       ];
 
-      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue(expectedUnits as any);
+      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue(expectedUnits as never);
 
       // ACT
       const result = await service.findAllByTenant(tenantId);
@@ -324,7 +324,7 @@ describe('UnitsService', () => {
         },
       ];
 
-      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue(expectedUnits as any);
+      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue(expectedUnits as never);
 
       // ACT
       const result = await service.findAllByTenant(tenantId, buildingId);
@@ -342,7 +342,7 @@ describe('UnitsService', () => {
     it('should return empty array when tenant has no units', async () => {
       // ARRANGE
       const tenantId = 'tenant-empty';
-      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue([]);
+      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue([] as never);
 
       // ACT
       const result = await service.findAllByTenant(tenantId);
@@ -380,8 +380,8 @@ describe('UnitsService', () => {
         },
       ];
 
-      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as any);
-      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue(expectedUnits as any);
+      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as never);
+      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue(expectedUnits as never);
 
       // ACT
       const result = await service.findAll(tenantId, buildingId);
@@ -455,8 +455,8 @@ describe('UnitsService', () => {
         ],
       };
 
-      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as any);
-      jest.spyOn(prismaService.unit, 'findFirst').mockResolvedValue(expectedUnit as any);
+      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as never);
+      jest.spyOn(prismaService.unit, 'findFirst').mockResolvedValue(expectedUnit as never);
 
       // ACT
       const result = await service.findOne(tenantId, buildingId, unitId);
@@ -500,7 +500,7 @@ describe('UnitsService', () => {
         updatedAt: new Date(),
       };
 
-      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as any);
+      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as never);
       jest.spyOn(prismaService.unit, 'findFirst').mockResolvedValue(null);
 
       // ACT & ASSERT
@@ -550,9 +550,9 @@ describe('UnitsService', () => {
         occupancyStatus: 'OCCUPIED',
       };
 
-      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as any);
-      jest.spyOn(prismaService.unit, 'findFirst').mockResolvedValue(existingUnit as any);
-      jest.spyOn(prismaService.unit, 'update').mockResolvedValue(updatedUnit as any);
+      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as never);
+      jest.spyOn(prismaService.unit, 'updateMany').mockResolvedValue({ count: 1 } as never);
+      jest.spyOn(prismaService.unit, 'findFirst').mockResolvedValue(updatedUnit as never);
       jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
 
       // ACT
@@ -563,7 +563,17 @@ describe('UnitsService', () => {
         ...updatedUnit,
         displayCode: 'A01-NEW',
       });
-      expect(prismaService.unit.update).toHaveBeenCalled();
+      expect(prismaService.unit.updateMany).toHaveBeenCalledWith({
+        where: { id: unitId, tenantId, buildingId },
+        data: {
+          code: 'A01-NEW',
+          label: 'Updated Unit',
+          unitType: 'PENTHOUSE',
+          occupancyStatus: 'OCCUPIED',
+          m2: undefined,
+          unitCategoryId: undefined,
+        },
+      });
       expect(auditService.createLog).toHaveBeenCalled();
     });
 
@@ -602,9 +612,8 @@ describe('UnitsService', () => {
         meta: { target: ['code'] },
       };
 
-      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as any);
-      jest.spyOn(prismaService.unit, 'findFirst').mockResolvedValue(existingUnit as any);
-      jest.spyOn(prismaService.unit, 'update').mockRejectedValue(error);
+      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as never);
+      jest.spyOn(prismaService.unit, 'updateMany').mockRejectedValue(error);
 
       // ACT & ASSERT
       await expect(service.update(tenantId, buildingId, unitId, 'user-123', dto)).rejects.toThrow(
@@ -640,9 +649,9 @@ describe('UnitsService', () => {
         unitOccupants: [],
       };
 
-      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as any);
-      jest.spyOn(prismaService.unit, 'findFirst').mockResolvedValue(existingUnit as any);
-      jest.spyOn(prismaService.unit, 'delete').mockResolvedValue(existingUnit as any);
+      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as never);
+      jest.spyOn(prismaService.unit, 'findFirst').mockResolvedValueOnce(existingUnit as never).mockResolvedValueOnce(existingUnit as never);
+      jest.spyOn(prismaService.unit, 'deleteMany').mockResolvedValue({ count: 1 } as never);
       jest.spyOn(auditService, 'createLog').mockResolvedValue(undefined);
 
       // ACT
@@ -653,8 +662,8 @@ describe('UnitsService', () => {
         ...existingUnit,
         displayCode: 'A01',
       });
-      expect(prismaService.unit.delete).toHaveBeenCalledWith({
-        where: { id: unitId },
+      expect(prismaService.unit.deleteMany).toHaveBeenCalledWith({
+        where: { id: unitId, tenantId, buildingId },
       });
       expect(auditService.createLog).toHaveBeenCalledWith({
         tenantId,
@@ -684,7 +693,7 @@ describe('UnitsService', () => {
         updatedAt: new Date(),
       };
 
-      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as any);
+      jest.spyOn(prismaService.building, 'findFirst').mockResolvedValue(building as never);
       jest.spyOn(prismaService.unit, 'findFirst').mockResolvedValue(null);
 
       // ACT & ASSERT

--- a/apps/api/src/units/units.service.ts
+++ b/apps/api/src/units/units.service.ts
@@ -124,6 +124,7 @@ export class UnitsService {
   async findAllByTenant(tenantId: string, buildingId?: string, unitIds?: string[]): Promise<UnitWithDisplayCode[]> {
     const where: Prisma.UnitWhereInput = {
       tenantId,
+      building: { deletedAt: null },
     };
 
     if (buildingId) {
@@ -216,7 +217,7 @@ export class UnitsService {
     unitId: string,
     userId: string,
     dto: UpdateUnitDto,
-  ): Promise<Unit> {
+  ): Promise<UnitWithDisplayCode> {
     // RBAC: check permission
     const hasAccess = await this.authorizeService.authorize({
       userId,
@@ -229,12 +230,9 @@ export class UnitsService {
       throw new ForbiddenException('No tiene permiso para modificar unidades');
     }
 
-    // Verify building belongs to tenant and unit belongs to building
-    await this.findOne(tenantId, buildingId, unitId);
-
     try {
-      const updatedUnit = await this.prisma.unit.update({
-        where: { id: unitId },
+      const updatedUnit = await this.prisma.unit.updateMany({
+        where: { id: unitId, tenantId, buildingId },
         data: {
           code: dto.code,
           label: dto.label,
@@ -243,12 +241,15 @@ export class UnitsService {
           m2: dto.m2,
           unitCategoryId: dto.unitCategoryId,
         },
-        include: {
-          building: { select: { id: true, name: true, alias: true } },
-          unitCategory: { select: { id: true, name: true } },
-          unitOccupants: { include: { member: true } },
-        },
       });
+
+      if (updatedUnit.count === 0) {
+        throw new NotFoundException(
+          `Unit not found or does not belong to this building`,
+        );
+      }
+
+      const refreshedUnit = await this.findOne(tenantId, buildingId, unitId);
 
       // Audit: UNIT_UPDATE
       void this.auditService.createLog({
@@ -259,14 +260,14 @@ export class UnitsService {
         entityId: unitId,
         metadata: {
           buildingId,
-          code: updatedUnit.code,
-          label: updatedUnit.label,
-          unitType: updatedUnit.unitType,
-          occupancyStatus: updatedUnit.occupancyStatus,
+          code: refreshedUnit.code,
+          label: refreshedUnit.label,
+          unitType: refreshedUnit.unitType,
+          occupancyStatus: refreshedUnit.occupancyStatus,
         },
       });
 
-      return addDisplayCode(updatedUnit);
+      return refreshedUnit;
     } catch (error: unknown) {
       if (
         typeof error === 'object' &&
@@ -290,7 +291,7 @@ export class UnitsService {
     buildingId: string,
     unitId: string,
     userId: string,
-  ): Promise<Unit> {
+  ): Promise<UnitWithDisplayCode> {
     // RBAC: check permission
     const hasAccess = await this.authorizeService.authorize({
       userId,
@@ -352,23 +353,23 @@ export class UnitsService {
       );
     }
 
-    const deletedUnit = await this.prisma.unit.delete({
-      where: { id: unitId },
+    await this.prisma.unit.deleteMany({
+      where: { id: unitId, tenantId, buildingId },
     });
 
     // Audit: UNIT_DELETE
     void this.auditService.createLog({
       tenantId,
       actorUserId: userId,
-      action: AuditAction.UNIT_DELETE,
-      entityType: 'Unit',
-      entityId: unitId,
-      metadata: {
-        buildingId,
-        code: deletedUnit.code,
-        label: deletedUnit.label,
-      },
-    });
+        action: AuditAction.UNIT_DELETE,
+        entityType: 'Unit',
+        entityId: unitId,
+        metadata: {
+          buildingId,
+          code: unitToDelete.code,
+          label: unitToDelete.label,
+        },
+      });
 
     return addDisplayCode(unitToDelete);
   }


### PR DESCRIPTION
Fixes #119\n\n### Summary\n- Excludes archived buildings from resident active occupancy resolution.\n- Blocks occupant assignment and occupant lookup/removal on archived buildings.\n- Filters archived buildings from tenant context options and tenant-wide unit listings.\n- Rejects archived buildings in the building access guard.\n\n### Verification\n- npm test --workspace apps/api -- --runInBand src/resident-access/resident-access.service.spec.ts src/context/context.service.spec.ts src/occupants/occupants.service.spec.ts src/units/units.service.spec.ts src/tenancy/building-access.guard.spec.ts