### PR TITLE
Fix mixed-role resident context reconciliation by portal

### DIFF
--- a/apps/api/src/context/context.controller.ts
+++ b/apps/api/src/context/context.controller.ts
@@ -1,10 +1,26 @@
-import { Controller, Get, Post, Body, UseGuards, Req } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  UseGuards,
+  Req,
+  Headers,
+  BadRequestException,
+} from '@nestjs/common';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { ContextService, UserContextData, ContextOptions } from './context.service';
 import type { AuthenticatedRequest } from '../common/types/request.types';
+import { normalizePortalContextHeader } from '../common/portal-context';
+import { IsOptional, IsString } from 'class-validator';
 
-export interface SetContextDto {
+export class SetContextDto {
+  @IsOptional()
+  @IsString()
   activeBuildingId?: string | null;
+
+  @IsOptional()
+  @IsString()
   activeUnitId?: string | null;
 }
 
@@ -25,7 +41,7 @@ export class ContextController {
     const tenantId = req.tenantId || req.headers['x-tenant-id'];
 
     if (!tenantId || typeof tenantId !== 'string') {
-      throw new Error('Tenant ID is required (X-Tenant-Id header)');
+      throw new BadRequestException('Tenant ID is required (X-Tenant-Id header)');
     }
 
     return tenantId;
@@ -36,11 +52,18 @@ export class ContextController {
    * Get current active building/unit for user in active tenant
    */
   @Get()
-  async getContext(@Req() req: AuthenticatedRequest): Promise<UserContextData> {
+  async getContext(
+    @Req() req: AuthenticatedRequest,
+    @Headers('x-portal-context') portalContext?: string,
+  ): Promise<UserContextData> {
     const userId = req.user.id;
     const tenantId = this.getTenantId(req);
 
-    return this.contextService.getContext(userId, tenantId);
+    return this.contextService.getContext(
+      userId,
+      tenantId,
+      normalizePortalContextHeader(portalContext),
+    );
   }
 
   /**
@@ -57,6 +80,7 @@ export class ContextController {
   async setContext(
     @Req() req: AuthenticatedRequest,
     @Body() dto: SetContextDto,
+    @Headers('x-portal-context') portalContext?: string,
   ): Promise<UserContextData> {
     const userId = req.user.id;
     const tenantId = this.getTenantId(req);
@@ -66,6 +90,7 @@ export class ContextController {
       tenantId,
       dto.activeBuildingId,
       dto.activeUnitId,
+      normalizePortalContextHeader(portalContext),
     );
   }
 
@@ -80,10 +105,17 @@ export class ContextController {
    * }
    */
   @Get('options')
-  async getContextOptions(@Req() req: AuthenticatedRequest): Promise<ContextOptions> {
+  async getContextOptions(
+    @Req() req: AuthenticatedRequest,
+    @Headers('x-portal-context') portalContext?: string,
+  ): Promise<ContextOptions> {
     const userId = req.user.id;
     const tenantId = this.getTenantId(req);
 
-    return this.contextService.getContextOptions(userId, tenantId);
+    return this.contextService.getContextOptions(
+      userId,
+      tenantId,
+      normalizePortalContextHeader(portalContext),
+    );
   }
 }

--- a/apps/api/src/context/context.service.spec.ts
+++ b/apps/api/src/context/context.service.spec.ts
@@ -21,11 +21,11 @@ describe('ContextService', () => {
       findFirst: jest.fn(),
       findMany: jest.fn(),
     },
-  } as unknown as PrismaService;
+  } as PrismaService;
 
   const authorize = {
     authorize: jest.fn(),
-  } as unknown as AuthorizeService;
+  } as AuthorizeService;
 
   const residentAccess = {
     shouldEnforce: jest.fn(),
@@ -34,7 +34,7 @@ describe('ContextService', () => {
     getActiveBuildingIds: jest.fn(),
     assertUnitAccess: jest.fn(),
     assertBuildingAccess: jest.fn(),
-  } as unknown as ResidentAccessService;
+  } as ResidentAccessService;
 
   const service = new ContextService(prisma, authorize, residentAccess);
 
@@ -52,7 +52,7 @@ describe('ContextService', () => {
         activeUnitId: 'unit-stale',
       },
       roles: [{ role: 'RESIDENT' }],
-    } as never);
+    });
     jest.spyOn(residentAccess, 'shouldEnforce').mockReturnValue(true);
     jest.spyOn(residentAccess, 'resolveActiveResidentOccupancy')
       .mockResolvedValueOnce(null)
@@ -72,7 +72,7 @@ describe('ContextService', () => {
       tenantId: 'tenant-1',
       activeBuildingId: 'building-1',
       activeUnitId: 'unit-1',
-    } as never);
+    });
 
     await expect(service.getContext('user-1', 'tenant-1')).resolves.toEqual({
       tenantId: 'tenant-1',
@@ -96,6 +96,65 @@ describe('ContextService', () => {
     });
   });
 
+  it('reconciles mixed-role resident context when the resident portal is explicit', async () => {
+    jest.spyOn(prisma.membership, 'findUnique').mockResolvedValue({
+      id: 'membership-1',
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      userContext: {
+        activeBuildingId: 'building-archived',
+        activeUnitId: 'unit-archived',
+      },
+      roles: [
+        { role: 'RESIDENT' },
+        { role: 'TENANT_ADMIN', scopeType: 'TENANT', scopeBuildingId: null },
+      ],
+    });
+    jest.spyOn(residentAccess, 'resolveActiveResidentOccupancy')
+      .mockResolvedValueOnce({
+        occupancyId: 'occupancy-1',
+        tenantId: 'tenant-1',
+        buildingId: 'building-1',
+        buildingName: 'Edificio A',
+        buildingAlias: 'A',
+        unitId: 'unit-1',
+        unitCode: 'A-01',
+        unitLabel: 'Unidad 1',
+        memberId: 'member-1',
+      });
+    jest.spyOn(prisma.userContext, 'upsert').mockResolvedValue({
+      tenantId: 'tenant-1',
+      activeBuildingId: 'building-1',
+      activeUnitId: 'unit-1',
+    });
+
+    await expect(service.getContext('user-1', 'tenant-1', 'resident')).resolves.toEqual({
+      tenantId: 'tenant-1',
+      activeBuildingId: 'building-1',
+      activeUnitId: 'unit-1',
+    });
+
+    expect(residentAccess.resolveActiveResidentOccupancy).toHaveBeenCalledWith({
+      tenantId: 'tenant-1',
+      userId: 'user-1',
+      unitId: 'unit-archived',
+    });
+    expect(prisma.userContext.upsert).toHaveBeenCalledWith({
+      where: { membershipId: 'membership-1' },
+      update: {
+        tenantId: 'tenant-1',
+        activeBuildingId: 'building-1',
+        activeUnitId: 'unit-1',
+      },
+      create: {
+        tenantId: 'tenant-1',
+        membershipId: 'membership-1',
+        activeBuildingId: 'building-1',
+        activeUnitId: 'unit-1',
+      },
+    });
+  });
+
   it('omits archived buildings and their units from tenant-scoped context options', async () => {
     jest.spyOn(prisma.membership, 'findUnique').mockResolvedValue({
       id: 'membership-1',
@@ -103,14 +162,14 @@ describe('ContextService', () => {
       userId: 'user-1',
       userContext: null,
       roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT', scopeBuildingId: null }],
-    } as never);
+    });
     jest.spyOn(residentAccess, 'shouldEnforce').mockReturnValue(false);
     jest.spyOn(prisma.building, 'findMany').mockResolvedValue([
       { id: 'building-active', name: 'Edificio Activo' },
-    ] as never);
+    ]);
     jest.spyOn(prisma.unit, 'findMany').mockResolvedValue([
       { id: 'unit-1', code: 'A-01', label: 'Unidad 1' },
-    ] as never);
+    ]);
 
     await expect(service.getContextOptions('user-1', 'tenant-1')).resolves.toEqual({
       buildings: [
@@ -143,7 +202,7 @@ describe('ContextService', () => {
       userId: 'user-1',
       userContext: null,
       roles: [{ role: 'RESIDENT' }],
-    } as never);
+    });
     jest.spyOn(residentAccess, 'shouldEnforce').mockReturnValue(true);
     jest.spyOn(residentAccess, 'resolveActiveResidentOccupancy').mockResolvedValue({
       occupancyId: 'occupancy-1',
@@ -160,12 +219,12 @@ describe('ContextService', () => {
       id: 'building-1',
       tenantId: 'tenant-1',
       name: 'Edificio A',
-    } as never);
+    });
     jest.spyOn(prisma.userContext, 'upsert').mockResolvedValue({
       tenantId: 'tenant-1',
       activeBuildingId: 'building-1',
       activeUnitId: 'unit-1',
-    } as never);
+    });
 
     await expect(service.setContext('user-1', 'tenant-1', 'building-1', null)).resolves.toEqual({
       tenantId: 'tenant-1',
@@ -187,7 +246,7 @@ describe('ContextService', () => {
       userId: 'user-1',
       userContext: null,
       roles: [{ role: 'RESIDENT' }],
-    } as never);
+    });
     jest.spyOn(residentAccess, 'shouldEnforce').mockReturnValue(true);
     jest.spyOn(residentAccess, 'resolveActiveResidentOccupancy').mockResolvedValue(null);
 
@@ -203,7 +262,7 @@ describe('ContextService', () => {
       userId: 'user-1',
       userContext: null,
       roles: [{ role: 'TENANT_ADMIN' }],
-    } as never);
+    });
     jest.spyOn(residentAccess, 'shouldEnforce').mockReturnValue(false);
     jest.spyOn(prisma.building, 'findFirst').mockResolvedValue(null);
 
@@ -223,14 +282,14 @@ describe('ContextService', () => {
       userId: 'user-1',
       userContext: null,
       roles: [{ role: 'RESIDENT' }],
-    } as never);
+    });
     jest.spyOn(residentAccess, 'shouldEnforce').mockReturnValue(true);
     jest.spyOn(residentAccess, 'resolveActiveResidentOccupancy').mockResolvedValue(null);
     jest.spyOn(prisma.userContext, 'upsert').mockResolvedValue({
       tenantId: 'tenant-1',
       activeBuildingId: null,
       activeUnitId: null,
-    } as never);
+    });
 
     await expect(service.getContext('user-1', 'tenant-1')).resolves.toEqual({
       tenantId: 'tenant-1',
@@ -246,11 +305,11 @@ describe('ContextService', () => {
       userId: 'user-1',
       userContext: null,
       roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
-    } as never);
+    });
     jest.spyOn(prisma.building, 'findMany').mockResolvedValue([
       { id: 'building-active', name: 'Edificio Activo' },
-    ] as never);
-    jest.spyOn(prisma.unit, 'findMany').mockResolvedValue([] as never);
+    ]);
+    jest.spyOn(prisma.unit, 'findMany').mockResolvedValue([]);
     jest.spyOn(residentAccess, 'shouldEnforce').mockReturnValue(false);
 
     await expect(service.getContextOptions('user-1', 'tenant-1')).resolves.toEqual({

--- a/apps/api/src/context/context.service.ts
+++ b/apps/api/src/context/context.service.ts
@@ -5,6 +5,11 @@ import {
   ResidentAccessService,
   type ActiveResidentOccupancy,
 } from '../resident-access/resident-access.service';
+import {
+  normalizePortalContextHeader,
+  resolveNotificationPortalContext,
+} from '../common/portal-context';
+import type { PortalContext } from '../common/types/request.types';
 
 interface MembershipRoleShape {
   role: string;
@@ -12,6 +17,13 @@ interface MembershipRoleShape {
   scopeBuildingId: string | null;
   scopeUnitId?: string | null;
 }
+
+const membershipRoleSelect = {
+  role: true,
+  scopeType: true,
+  scopeBuildingId: true,
+  scopeUnitId: true,
+} as const;
 
 export interface UserContextData {
   tenantId: string;
@@ -38,6 +50,16 @@ export class ContextService {
     private readonly authorize: AuthorizeService,
     private readonly residentAccess: ResidentAccessService,
   ) {}
+
+  private resolvePortalContext(
+    userRoles: readonly string[],
+    portalContext?: string | null,
+  ): PortalContext {
+    return resolveNotificationPortalContext(
+      userRoles,
+      normalizePortalContextHeader(portalContext),
+    );
+  }
 
   private async persistContext(
     membershipId: string,
@@ -108,12 +130,16 @@ export class ContextService {
   /**
    * Get current context for user/tenant
    */
-  async getContext(userId: string, tenantId: string): Promise<UserContextData> {
+  async getContext(
+    userId: string,
+    tenantId: string,
+    portalContext?: string | null,
+  ): Promise<UserContextData> {
     const membership = await this.prisma.membership.findUnique({
       where: { userId_tenantId: { userId, tenantId } },
       include: {
         userContext: true,
-        roles: { where: { tenantId } },
+        roles: { where: { tenantId }, select: membershipRoleSelect },
       },
     });
 
@@ -122,9 +148,12 @@ export class ContextService {
     }
 
     const roles = membership.roles || [];
-    const isResident = this.residentAccess.shouldEnforce(roles.map((role) => role.role));
+    const isResidentPortal = this.resolvePortalContext(
+      roles.map((role) => role.role),
+      portalContext,
+    ) === 'resident';
 
-    if (isResident) {
+    if (isResidentPortal) {
       const resolvedOccupancy = await this.resolveResidentContextState(
         tenantId,
         userId,
@@ -159,7 +188,7 @@ export class ContextService {
     // Auto-initialize if no context exists OR if context is empty (both null — never properly initialized)
     const ctx = membership.userContext;
     if (!ctx || (!ctx.activeBuildingId && !ctx.activeUnitId)) {
-      return this.initializeContext(userId, tenantId);
+      return this.initializeContext(userId, tenantId, portalContext);
     }
 
     return {
@@ -183,11 +212,12 @@ export class ContextService {
     tenantId: string,
     activeBuildingId?: string | null,
     activeUnitId?: string | null,
+    portalContext?: string | null,
   ): Promise<UserContextData> {
     // Get membership
     const membership = await this.prisma.membership.findUnique({
       where: { userId_tenantId: { userId, tenantId } },
-      include: { userContext: true, user: true, roles: { where: { tenantId } } },
+      include: { userContext: true, roles: { where: { tenantId }, select: membershipRoleSelect } },
     });
 
     if (!membership) {
@@ -215,9 +245,10 @@ export class ContextService {
 
     // Determine if user is RESIDENT (skip buildings.read check — they validate via UnitOccupant)
     const rolesForCheck = membership.roles || [];
-    const isResidentForBuildingCheck = this.residentAccess.shouldEnforce(rolesForCheck.map((role) => role.role));
+    const isResidentPortal =
+      this.resolvePortalContext(rolesForCheck.map((role) => role.role), portalContext) === 'resident';
 
-    if (isResidentForBuildingCheck) {
+    if (isResidentPortal) {
       if (effectiveUnitId) {
         const occupancy = await this.residentAccess.resolveActiveResidentOccupancy({
           tenantId,
@@ -258,11 +289,11 @@ export class ContextService {
         throw new NotFoundException('Building not found or does not belong to this tenant');
       }
 
-      if (isResidentForBuildingCheck && !effectiveUnitId) {
+      if (isResidentPortal && !effectiveUnitId) {
         await this.residentAccess.assertBuildingAccess(tenantId, userId, effectiveBuildingId);
       }
 
-      if (!isResidentForBuildingCheck) {
+      if (!isResidentPortal) {
         const hasAccess = await this.authorize.authorize({
           userId,
           tenantId,
@@ -280,7 +311,10 @@ export class ContextService {
     if (effectiveUnitId) {
       // Get user's roles to check if RESIDENT
       const roles = membership.roles || [];
-      const isResident = this.residentAccess.shouldEnforce(roles.map((role) => role.role));
+      const isResident = this.resolvePortalContext(
+        roles.map((role) => role.role),
+        portalContext,
+      ) === 'resident';
 
       if (isResident) {
         await this.residentAccess.assertUnitAccess(
@@ -323,12 +357,12 @@ export class ContextService {
   async getContextOptions(
     userId: string,
     tenantId: string,
+    portalContext?: string | null,
   ): Promise<ContextOptions> {
     const membership = await this.prisma.membership.findUnique({
       where: { userId_tenantId: { userId, tenantId } },
       include: {
-        roles: true,
-        user: true,
+        roles: { where: { tenantId }, select: membershipRoleSelect },
       },
     });
 
@@ -336,11 +370,18 @@ export class ContextService {
       throw new NotFoundException('Membership not found');
     }
 
+    const isResidentPortal =
+      this.resolvePortalContext(
+        (membership.roles || []).map((role) => role.role),
+        portalContext,
+      ) === 'resident';
+
     // Get buildings user can access
     const buildings = await this.getAccessibleBuildings(
       membership.roles || [],
       userId,
       tenantId,
+      isResidentPortal,
     );
 
     // Get units per building
@@ -351,6 +392,7 @@ export class ContextService {
         userId,
         tenantId,
         building.id,
+        isResidentPortal,
       );
     }
 
@@ -367,10 +409,10 @@ export class ContextService {
     roles: MembershipRoleShape[],
     userId: string,
     tenantId: string,
+    isResidentPortal: boolean,
   ): Promise<ContextOption[]> {
     // RESIDENT always derives buildings from their UnitOccupant records (regardless of scopeType)
-    const isResident = this.residentAccess.shouldEnforce(roles.map((role) => role.role));
-    if (isResident) {
+    if (isResidentPortal) {
       const buildingIds = await this.residentAccess.getActiveBuildingIds(tenantId, userId);
       if (buildingIds.length === 0) return [];
       const buildings = await this.prisma.building.findMany({
@@ -412,6 +454,34 @@ export class ContextService {
       );
     }
 
+    const unitScopedRoles = roles.filter((r: MembershipRoleShape) => r.scopeType === 'UNIT');
+    const unitIds = unitScopedRoles
+      .map((r: MembershipRoleShape) => r.scopeUnitId)
+      .filter((id: string | null | undefined): id is string => typeof id === 'string' && id.length > 0);
+
+    if (unitIds.length > 0) {
+      const units = await this.prisma.unit.findMany({
+        where: {
+          tenantId,
+          id: { in: unitIds },
+          building: { deletedAt: null },
+        },
+        select: { buildingId: true },
+      });
+      const derivedBuildingIds = [...new Set(units.map((unit) => unit.buildingId))];
+
+      if (derivedBuildingIds.length > 0) {
+        const buildings = await this.prisma.building.findMany({
+          where: { tenantId, id: { in: derivedBuildingIds }, deletedAt: null },
+          select: { id: true, name: true },
+        });
+        return buildings.sort((a, b) =>
+          a.name.localeCompare(b.name, 'es', { numeric: true, sensitivity: 'base' }) ||
+          a.id.localeCompare(b.id, 'es', { numeric: true, sensitivity: 'base' }),
+        );
+      }
+    }
+
     return [];
   }
 
@@ -423,6 +493,7 @@ export class ContextService {
     userId: string,
     _tenantId: string,
     buildingId: string,
+    isResidentPortal: boolean,
   ): Promise<ContextOption[]> {
 
     // Check role scopes
@@ -433,8 +504,7 @@ export class ContextService {
     const hasUnitScope = roles.some((r: MembershipRoleShape) => r.scopeType === 'UNIT');
 
     // RESIDENT always sees only units where they are an occupant — regardless of scope
-    const isResident = this.residentAccess.shouldEnforce(roles.map((role) => role.role));
-    if (isResident) {
+    if (isResidentPortal) {
       const unitIds = await this.residentAccess.getActiveUnitIds(_tenantId, userId, buildingId);
       if (unitIds.length === 0) return [];
       const units = await this.prisma.unit.findMany({
@@ -500,10 +570,14 @@ export class ContextService {
    * Auto-initialize context for new user
    * Called after first login to set default active building/unit
    */
-  async initializeContext(userId: string, tenantId: string): Promise<UserContextData> {
+  async initializeContext(
+    userId: string,
+    tenantId: string,
+    portalContext?: string | null,
+  ): Promise<UserContextData> {
     const membership = await this.prisma.membership.findUnique({
       where: { userId_tenantId: { userId, tenantId } },
-      include: { userContext: true, roles: { where: { tenantId } }, user: true },
+      include: { userContext: true, roles: { where: { tenantId }, select: membershipRoleSelect } },
     });
 
     if (!membership || membership.userContext) {
@@ -516,9 +590,12 @@ export class ContextService {
     }
 
     const roles = membership.roles || [];
-    const isResident = this.residentAccess.shouldEnforce(roles.map((role) => role.role));
+    const isResidentPortal = this.resolvePortalContext(
+      roles.map((role) => role.role),
+      portalContext,
+    ) === 'resident';
 
-    if (isResident) {
+    if (isResidentPortal) {
       const resolvedOccupancy = await this.resolveResidentContextState(tenantId, userId, null);
 
       return this.persistContext(
@@ -534,6 +611,7 @@ export class ContextService {
       membership.roles || [],
       userId,
       tenantId,
+      false,
     );
     if (buildings.length === 1) {
       // Auto-select this building
@@ -545,6 +623,7 @@ export class ContextService {
         userId,
         tenantId,
         building.id,
+        false,
       );
       if (units.length === 1) {
         return this.setContext(userId, tenantId, building.id, units[0]!.id);

--- a/apps/web/app/(tenant)/[tenantId]/resident/dashboard/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/dashboard/page.tsx
@@ -85,7 +85,6 @@ const ResidentDashboardPage = () => {
   const userName = session?.user?.name?.trim() ?? '';
   const userId = session?.user?.id ?? null;
   const activeTenantId = session?.activeTenantId ?? null;
-  const isActiveTenant = activeTenantId === tenantId;
   const { profileQuery: residentProfileQuery } = useResidentProfile(tenantId ?? null);
   const residentProfileName = residentProfileQuery.data?.name?.trim() ?? '';
   const greetingName = residentProfileName || userName;
@@ -141,7 +140,7 @@ const ResidentDashboardPage = () => {
 
       return getResidentTickets(tenantId, buildingId, unitId, 3);
     },
-    enabled: isActiveTenant && !!buildingId && !!unitId && !!userId,
+    enabled: !!buildingId && !!unitId && !!userId,
     staleTime: 2 * 60 * 1000,
     gcTime: 5 * 60 * 1000,
     retry: 1,
@@ -163,22 +162,6 @@ const ResidentDashboardPage = () => {
     .sort((a, b) => new Date(String(a.dueDate)).getTime() - new Date(String(b.dueDate)).getTime())[0];
 
   const isLoading = contextLoading || ledgerLoading;
-
-  if (!isActiveTenant) {
-    return (
-      <Card className="border-yellow-200 bg-yellow-50 p-6 dark:border-yellow-900/50 dark:bg-yellow-950/30">
-        <div className="flex items-start gap-3">
-          <AlertCircle className="mt-0.5 text-yellow-600 dark:text-yellow-400" size={24} />
-          <div className="space-y-1">
-            <p className="font-medium text-yellow-800 dark:text-yellow-200">Seleccioná el tenant activo</p>
-            <p className="text-sm text-yellow-700 dark:text-yellow-300">
-              Este panel residente solo carga datos cuando coincide con el tenant activo de tu sesión.
-            </p>
-          </div>
-        </div>
-      </Card>
-    );
-  }
 
   if (isLoading || commsLoading || ticketsLoading) {
     return (

--- a/apps/web/app/(tenant)/[tenantId]/resident/dashboard/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/dashboard/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ReactNode } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
@@ -50,7 +51,7 @@ interface KPICardProps {
   value: string;
   subValue?: string;
   color: string;
-  icon: React.ReactNode;
+  icon: ReactNode;
   cta?: string;
   onClick?: () => void;
 }
@@ -83,6 +84,8 @@ const ResidentDashboardPage = () => {
   const session = useAuthSession();
   const userName = session?.user?.name?.trim() ?? '';
   const userId = session?.user?.id ?? null;
+  const activeTenantId = session?.activeTenantId ?? null;
+  const isActiveTenant = activeTenantId === tenantId;
   const { profileQuery: residentProfileQuery } = useResidentProfile(tenantId ?? null);
   const residentProfileName = residentProfileQuery.data?.name?.trim() ?? '';
   const greetingName = residentProfileName || userName;
@@ -130,9 +133,15 @@ const ResidentDashboardPage = () => {
     isError: ticketsError,
     error: ticketsErrorValue,
   } = useQuery<Ticket[]>({
-    queryKey: ['residentTickets', tenantId, userId, buildingId, unitId],
-    queryFn: () => getResidentTickets(buildingId!, unitId!, 3),
-    enabled: !!buildingId && !!unitId && !!userId,
+    queryKey: ['residentTickets', tenantId, activeTenantId, userId, buildingId, unitId],
+    queryFn: () => {
+      if (!tenantId || !buildingId || !unitId) {
+        throw new Error('Tenant, building and unit context are required');
+      }
+
+      return getResidentTickets(tenantId, buildingId, unitId, 3);
+    },
+    enabled: isActiveTenant && !!buildingId && !!unitId && !!userId,
     staleTime: 2 * 60 * 1000,
     gcTime: 5 * 60 * 1000,
     retry: 1,
@@ -154,6 +163,22 @@ const ResidentDashboardPage = () => {
     .sort((a, b) => new Date(String(a.dueDate)).getTime() - new Date(String(b.dueDate)).getTime())[0];
 
   const isLoading = contextLoading || ledgerLoading;
+
+  if (!isActiveTenant) {
+    return (
+      <Card className="border-yellow-200 bg-yellow-50 p-6 dark:border-yellow-900/50 dark:bg-yellow-950/30">
+        <div className="flex items-start gap-3">
+          <AlertCircle className="mt-0.5 text-yellow-600 dark:text-yellow-400" size={24} />
+          <div className="space-y-1">
+            <p className="font-medium text-yellow-800 dark:text-yellow-200">Seleccioná el tenant activo</p>
+            <p className="text-sm text-yellow-700 dark:text-yellow-300">
+              Este panel residente solo carga datos cuando coincide con el tenant activo de tu sesión.
+            </p>
+          </div>
+        </div>
+      </Card>
+    );
+  }
 
   if (isLoading || commsLoading || ticketsLoading) {
     return (

--- a/apps/web/app/(tenant)/[tenantId]/resident/tickets/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/tickets/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
@@ -24,6 +24,20 @@ import Card from '../../../../../shared/components/ui/Card';
 import Badge, { type BadgeVariant } from '../../../../../shared/components/ui/Badge';
 import Skeleton from '../../../../../shared/components/ui/Skeleton';
 import { residentTicketDetailPath } from '../../../../../shared/lib/routes';
+
+const RESIDENT_TICKET_CATEGORIES = [
+  'MAINTENANCE',
+  'REPAIR',
+  'CLEANING',
+  'COMPLAINT',
+  'SAFETY',
+  'BILLING',
+  'OTHER',
+] as const satisfies readonly Ticket['category'][];
+
+function isResidentTicketCategory(value: string): value is Ticket['category'] {
+  return RESIDENT_TICKET_CATEGORIES.includes(value as Ticket['category']);
+}
 
 function ticketStatusLabel(status: Ticket['status']): string {
   const labels: Record<Ticket['status'], string> = {
@@ -86,7 +100,7 @@ export default function ResidentTicketsPage() {
   const [newTicket, setNewTicket] = useState({
     title: '',
     description: '',
-    category: 'OTHER',
+    category: 'OTHER' as Ticket['category'],
   });
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
@@ -118,13 +132,19 @@ export default function ResidentTicketsPage() {
     refetch,
   } = useQuery<Ticket[]>({
     queryKey: ['residentTickets', tenantId, userId, buildingId, unitId],
-    queryFn: () => getResidentTickets(buildingId!, unitId!, 50),
+    queryFn: () => {
+      if (!tenantId || !buildingId || !unitId) {
+        throw new Error('Tenant, building and unit context are required');
+      }
+
+      return getResidentTickets(tenantId, buildingId, unitId, 50);
+    },
     enabled: identityMatchesRoute && !!buildingId && !!unitId && !contextLoading,
     staleTime: 30_000,
     refetchOnWindowFocus: true,
   });
 
-  const handleCreate = async (e: React.FormEvent) => {
+  const handleCreate = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (!identityMatchesRoute || !buildingId || !unitId || contextLoading) return;
 
@@ -143,7 +163,7 @@ export default function ResidentTicketsPage() {
       await createTicket(buildingId, {
         title,
         description,
-        category: newTicket.category as Ticket['category'],
+        category: newTicket.category,
         unitId,
       }, 'resident');
       setSuccess('Reclamo creado correctamente');
@@ -263,7 +283,14 @@ export default function ResidentTicketsPage() {
                 <select
                   id="resident-ticket-category"
                   value={newTicket.category}
-                  onChange={(e) => setNewTicket({ ...newTicket, category: e.target.value })}
+                  onChange={(e) =>
+                    setNewTicket({
+                      ...newTicket,
+                      category: isResidentTicketCategory(e.target.value)
+                        ? e.target.value
+                        : 'OTHER',
+                    })
+                  }
                   className="w-full px-3 py-2 border rounded-md"
                 >
                   <option value="MAINTENANCE">Mantenimiento</option>

--- a/apps/web/app/(tenant)/[tenantId]/resident/tickets/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/tickets/page.tsx
@@ -112,7 +112,7 @@ export default function ResidentTicketsPage() {
   const buildingId = context?.activeBuildingId;
   const unitId = context?.activeUnitId;
   const identityMatchesRoute = Boolean(
-    userId && tenantId && session?.activeTenantId === tenantId && context?.tenantId === tenantId,
+    userId && tenantId && context?.tenantId === tenantId,
   );
 
   useEffect(() => {
@@ -182,8 +182,8 @@ export default function ResidentTicketsPage() {
   };
 
   const statusFilter = 'all';
-  const filteredTickets = statusFilter === 'all' 
-    ? tickets 
+  const filteredTickets = statusFilter === 'all'
+    ? tickets
     : tickets.filter(t => t.status === statusFilter);
 
   if (contextLoading) {
@@ -207,8 +207,8 @@ export default function ResidentTicketsPage() {
           Mis reclamos
         </h1>
         <p className="text-muted-foreground mt-1">{tenantName}</p>
-        
-      <Card className="p-4 mt-6 border-yellow-300 bg-yellow-50 dark:border-yellow-900/60 dark:bg-yellow-950/40">
+
+        <Card className="p-4 mt-6 border-yellow-300 bg-yellow-50 dark:border-yellow-900/60 dark:bg-yellow-950/40">
         <div className="flex items-center gap-2">
           <AlertCircle className="text-yellow-600 dark:text-yellow-400" size={20} />
           <div>
@@ -216,7 +216,7 @@ export default function ResidentTicketsPage() {
             <p className="text-sm text-yellow-700 dark:text-yellow-300">Comunicate con la administración para que te asignen una unidad.</p>
           </div>
         </div>
-      </Card>
+        </Card>
       </div>
     );
   }

--- a/apps/web/features/context/context.api.test.ts
+++ b/apps/web/features/context/context.api.test.ts
@@ -1,0 +1,66 @@
+import { apiClient } from '@/shared/lib/http/client';
+import { getContext, getContextOptions, setContext } from './context.api';
+
+jest.mock('@/shared/lib/http/client', () => ({
+  apiClient: jest.fn(),
+}));
+
+const mockedApiClient = jest.mocked(apiClient);
+
+describe('context.api', () => {
+  beforeEach(() => {
+    mockedApiClient.mockReset();
+  });
+
+  it('sends the resident portal context when loading resident context data', async () => {
+    mockedApiClient.mockResolvedValue({
+      tenantId: 'tenant-1',
+      activeBuildingId: 'building-1',
+      activeUnitId: 'unit-1',
+    });
+
+    await getContext('tenant-1', 'resident');
+    await getContextOptions('tenant-1', 'resident');
+
+    expect(mockedApiClient).toHaveBeenNthCalledWith(1, {
+      path: '/me/context',
+      method: 'GET',
+      headers: {
+        'X-Tenant-Id': 'tenant-1',
+        'X-Portal-Context': 'resident',
+      },
+    });
+
+    expect(mockedApiClient).toHaveBeenNthCalledWith(2, {
+      path: '/me/context/options',
+      method: 'GET',
+      headers: {
+        'X-Tenant-Id': 'tenant-1',
+        'X-Portal-Context': 'resident',
+      },
+    });
+  });
+
+  it('sends the admin portal context when setting admin context data', async () => {
+    mockedApiClient.mockResolvedValue({
+      tenantId: 'tenant-1',
+      activeBuildingId: 'building-1',
+      activeUnitId: 'unit-1',
+    });
+
+    await setContext('tenant-1', 'building-1', 'unit-1', 'admin');
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/me/context',
+      method: 'POST',
+      headers: {
+        'X-Tenant-Id': 'tenant-1',
+        'X-Portal-Context': 'admin',
+      },
+      body: {
+        activeBuildingId: 'building-1',
+        activeUnitId: 'unit-1',
+      },
+    });
+  });
+});

--- a/apps/web/features/context/context.api.ts
+++ b/apps/web/features/context/context.api.ts
@@ -1,16 +1,33 @@
 import { UserContext, ContextOptions } from './context.types';
 import { apiClient } from '@/shared/lib/http/client';
+import type { PortalContext } from '@/features/auth/landing-route';
+
+function buildContextHeaders(
+  tenantId: string,
+  portalContext?: PortalContext | null,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    'X-Tenant-Id': tenantId,
+  };
+
+  if (portalContext) {
+    headers['X-Portal-Context'] = portalContext;
+  }
+
+  return headers;
+}
 
 /**
  * Get current user context for active tenant
  */
-export async function getContext(tenantId: string): Promise<UserContext> {
+export async function getContext(
+  tenantId: string,
+  portalContext?: PortalContext | null,
+): Promise<UserContext> {
   return apiClient<UserContext>({
     path: '/me/context',
     method: 'GET',
-    headers: {
-      'X-Tenant-Id': tenantId,
-    },
+    headers: buildContextHeaders(tenantId, portalContext),
   });
 }
 
@@ -21,13 +38,12 @@ export async function setContext(
   tenantId: string,
   activeBuildingId?: string | null,
   activeUnitId?: string | null,
+  portalContext?: PortalContext | null,
 ): Promise<UserContext> {
   return apiClient<UserContext, { activeBuildingId: string | null; activeUnitId: string | null }>({
     path: '/me/context',
     method: 'POST',
-    headers: {
-      'X-Tenant-Id': tenantId,
-    },
+    headers: buildContextHeaders(tenantId, portalContext),
     body: {
       activeBuildingId: activeBuildingId || null,
       activeUnitId: activeUnitId || null,
@@ -38,12 +54,13 @@ export async function setContext(
 /**
  * Get available buildings and units for context selection
  */
-export async function getContextOptions(tenantId: string): Promise<ContextOptions> {
+export async function getContextOptions(
+  tenantId: string,
+  portalContext?: PortalContext | null,
+): Promise<ContextOptions> {
   return apiClient<ContextOptions>({
     path: '/me/context/options',
     method: 'GET',
-    headers: {
-      'X-Tenant-Id': tenantId,
-    },
+    headers: buildContextHeaders(tenantId, portalContext),
   });
 }

--- a/apps/web/features/context/useContext.test.tsx
+++ b/apps/web/features/context/useContext.test.tsx
@@ -1,11 +1,16 @@
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { useAuthSession } from '@/features/auth/useAuthSession';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
 import { getContext, getContextOptions } from './context.api';
 import type { ContextOptions, UserContext } from './context.types';
 import { useContextManager } from './useContext';
 
 jest.mock('@/features/auth/useAuthSession', () => ({
   useAuthSession: jest.fn(),
+}));
+
+jest.mock('@/features/auth/useAuthorizedPortalContext', () => ({
+  useAuthorizedPortalContext: jest.fn(),
 }));
 
 jest.mock('./context.api', () => ({
@@ -15,6 +20,7 @@ jest.mock('./context.api', () => ({
 }));
 
 const mockedUseAuthSession = jest.mocked(useAuthSession);
+const mockedUseAuthorizedPortalContext = jest.mocked(useAuthorizedPortalContext);
 const mockedGetContext = jest.mocked(getContext);
 const mockedGetContextOptions = jest.mocked(getContextOptions);
 
@@ -30,6 +36,7 @@ function createDeferred<T>() {
 describe('useContextManager', () => {
   beforeEach(() => {
     mockedUseAuthSession.mockReset();
+    mockedUseAuthorizedPortalContext.mockReset();
     mockedGetContext.mockReset();
     mockedGetContextOptions.mockReset();
   });
@@ -45,6 +52,7 @@ describe('useContextManager', () => {
       memberships: [],
       activeTenantId: 'tenant-1',
     });
+    mockedUseAuthorizedPortalContext.mockReturnValue('resident');
     mockedGetContext.mockImplementationOnce(() => context1.promise);
     mockedGetContextOptions.mockImplementationOnce(() => options1.promise);
     mockedGetContext.mockImplementationOnce(() => context2.promise);
@@ -60,6 +68,9 @@ describe('useContextManager', () => {
       expect(mockedGetContextOptions).toHaveBeenCalledTimes(1);
     });
 
+    expect(mockedGetContext).toHaveBeenNthCalledWith(1, 'tenant-1', 'resident');
+    expect(mockedGetContextOptions).toHaveBeenNthCalledWith(1, 'tenant-1', 'resident');
+
     mockedUseAuthSession.mockReturnValue({
       user: { id: 'user-2', email: 'resident2@buildingos.test', name: 'Resident 2' },
       memberships: [],
@@ -72,6 +83,9 @@ describe('useContextManager', () => {
       expect(mockedGetContext).toHaveBeenCalledTimes(2);
       expect(mockedGetContextOptions).toHaveBeenCalledTimes(2);
     });
+
+    expect(mockedGetContext).toHaveBeenNthCalledWith(2, 'tenant-1', 'resident');
+    expect(mockedGetContextOptions).toHaveBeenNthCalledWith(2, 'tenant-1', 'resident');
 
     await act(async () => {
       context2.resolve({

--- a/apps/web/features/context/useContext.ts
+++ b/apps/web/features/context/useContext.ts
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useAuthSession } from '@/features/auth/useAuthSession';
 import { UserContext, ContextOptions } from './context.types';
 import { getContext, setContext, getContextOptions } from './context.api';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
 
 interface UseContextState {
   context: UserContext | null;
@@ -29,6 +30,8 @@ interface UseContextState {
 export function useContextManager(tenantId: string | null) {
   const session = useAuthSession();
   const userId = session?.user.id ?? null;
+  const activeTenantId = session?.activeTenantId ?? null;
+  const portalContext = useAuthorizedPortalContext(tenantId);
   const [state, setState] = useState<UseContextState>({
     context: null,
     options: null,
@@ -38,18 +41,28 @@ export function useContextManager(tenantId: string | null) {
 
   // Load context and options on mount or when tenantId changes
   useEffect(() => {
-    if (!tenantId || !userId) {
-      setState({
-        context: null,
-        options: null,
-        loading: false,
-        error: null,
-      });
-      return;
-    }
-
     let isActive = true;
     const loadData = async () => {
+      if (!tenantId || !userId) {
+        setState({
+          context: null,
+          options: null,
+          loading: false,
+          error: null,
+        });
+        return;
+      }
+
+      if (activeTenantId !== tenantId) {
+        setState({
+          context: null,
+          options: null,
+          loading: false,
+          error: null,
+        });
+        return;
+      }
+
       setState({
         context: null,
         options: null,
@@ -58,8 +71,8 @@ export function useContextManager(tenantId: string | null) {
       });
       try {
         const [context, options] = await Promise.all([
-          getContext(tenantId),
-          getContextOptions(tenantId),
+          getContext(tenantId, portalContext),
+          getContextOptions(tenantId, portalContext),
         ]);
 
         if (!isActive) return;
@@ -81,14 +94,14 @@ export function useContextManager(tenantId: string | null) {
     return () => {
       isActive = false;
     };
-  }, [tenantId, userId]);
+  }, [tenantId, userId, activeTenantId, portalContext]);
 
   const setActiveBuilding = useCallback(
     async (buildingId: string | null) => {
       if (!tenantId || !state.context) return;
 
       try {
-        const newContext = await setContext(tenantId, buildingId, null);
+        const newContext = await setContext(tenantId, buildingId, null, portalContext);
         setState((prev) => ({
           ...prev,
           context: newContext,
@@ -99,7 +112,7 @@ export function useContextManager(tenantId: string | null) {
         throw error;
       }
     },
-    [tenantId, state.context],
+    [tenantId, state.context, portalContext],
   );
 
   const setActiveUnit = useCallback(
@@ -107,7 +120,7 @@ export function useContextManager(tenantId: string | null) {
       if (!tenantId) return;
 
       try {
-        const newContext = await setContext(tenantId, buildingId, unitId);
+        const newContext = await setContext(tenantId, buildingId, unitId, portalContext);
         setState((prev) => ({
           ...prev,
           context: newContext,
@@ -118,11 +131,11 @@ export function useContextManager(tenantId: string | null) {
         throw error;
       }
     },
-    [tenantId],
+    [tenantId, portalContext],
   );
 
   const refetch = useCallback(async () => {
-    if (!tenantId || !userId) return;
+    if (!tenantId || !userId || activeTenantId !== tenantId) return;
 
     setState({
       context: null,
@@ -132,8 +145,8 @@ export function useContextManager(tenantId: string | null) {
     });
     try {
       const [context, options] = await Promise.all([
-        getContext(tenantId),
-        getContextOptions(tenantId),
+        getContext(tenantId, portalContext),
+        getContextOptions(tenantId, portalContext),
       ]);
 
       setState((prev) => ({
@@ -146,7 +159,7 @@ export function useContextManager(tenantId: string | null) {
       const message = error instanceof Error ? error.message : 'Unknown error';
       setState((prev) => ({ ...prev, loading: false, error: message }));
     }
-  }, [tenantId, userId]);
+  }, [tenantId, userId, activeTenantId, portalContext]);
 
   return {
     ...state,

--- a/apps/web/features/context/useContextOptions.ts
+++ b/apps/web/features/context/useContextOptions.ts
@@ -21,13 +21,13 @@ export function useContextOptions(tenantId: string | null) {
   return useQuery<ContextOptions>({
     queryKey: ['contextOptions', tenantId, activeTenantId, userId, portalContext],
     queryFn: () => {
-      if (!tenantId || !userId || activeTenantId !== tenantId) {
+      if (!tenantId || !userId || !portalContext) {
         throw new Error('Tenant and user context are required');
       }
 
       return getContextOptions(tenantId, portalContext);
     },
-    enabled: !!tenantId && !!userId && activeTenantId === tenantId,
+    enabled: !!tenantId && !!userId && !!portalContext,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
     retry: 1,

--- a/apps/web/features/context/useContextOptions.ts
+++ b/apps/web/features/context/useContextOptions.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { useAuthSession } from '@/features/auth/useAuthSession';
+import { useAuthorizedPortalContext } from '@/features/auth/useAuthorizedPortalContext';
 import { getContextOptions } from './context.api';
 import type { ContextOptions } from './context.types';
 
@@ -14,17 +15,19 @@ import type { ContextOptions } from './context.types';
 export function useContextOptions(tenantId: string | null) {
   const session = useAuthSession();
   const userId = session?.user.id ?? null;
+  const activeTenantId = session?.activeTenantId ?? null;
+  const portalContext = useAuthorizedPortalContext(tenantId);
 
   return useQuery<ContextOptions>({
-    queryKey: ['contextOptions', tenantId, userId],
+    queryKey: ['contextOptions', tenantId, activeTenantId, userId, portalContext],
     queryFn: () => {
-      if (!tenantId || !userId) {
+      if (!tenantId || !userId || activeTenantId !== tenantId) {
         throw new Error('Tenant and user context are required');
       }
 
-      return getContextOptions(tenantId);
+      return getContextOptions(tenantId, portalContext);
     },
-    enabled: !!tenantId && !!userId,
+    enabled: !!tenantId && !!userId && activeTenantId === tenantId,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
     retry: 1,

--- a/apps/web/features/resident/api/resident-context.api.test.ts
+++ b/apps/web/features/resident/api/resident-context.api.test.ts
@@ -1,5 +1,10 @@
 import { apiClient } from '@/shared/lib/http/client';
-import { getResidentCommunications } from './resident-context.api';
+import {
+  getResidentCommunications,
+  getResidentContext,
+  getResidentTickets,
+  getResidentLedger,
+} from './resident-context.api';
 
 jest.mock('@/shared/lib/http/client', () => ({
   apiClient: jest.fn(),
@@ -19,6 +24,67 @@ describe('resident-context.api', () => {
 
     expect(mockedApiClient).toHaveBeenCalledWith({
       path: '/me/communications?limit=5',
+      method: 'GET',
+      headers: {
+        'X-Tenant-Id': 'tenant-1',
+        'X-Portal-Context': 'resident',
+      },
+    });
+  });
+
+  it('sends the active tenant and resident portal context for resident context requests', async () => {
+    mockedApiClient.mockResolvedValue({
+      tenantId: 'tenant-1',
+      activeBuildingId: 'building-1',
+      activeUnitId: 'unit-1',
+    });
+
+    await getResidentContext('tenant-1');
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/me/context',
+      method: 'GET',
+      headers: {
+        'X-Tenant-Id': 'tenant-1',
+        'X-Portal-Context': 'resident',
+      },
+    });
+  });
+
+  it('sends the active tenant and resident portal context for resident ticket requests', async () => {
+    mockedApiClient.mockResolvedValue({
+      tickets: [],
+    });
+
+    await getResidentTickets('tenant-1', 'building-1', 'unit-1', 50);
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/buildings/building-1/tickets?unitId=unit-1&limit=50',
+      method: 'GET',
+      headers: {
+        'X-Tenant-Id': 'tenant-1',
+        'X-Portal-Context': 'resident',
+      },
+    });
+  });
+
+  it('sends the active tenant and resident portal context for resident ledger requests', async () => {
+    mockedApiClient.mockResolvedValue({
+      charges: [],
+      payments: [],
+      totals: {
+        balance: 0,
+        currency: 'ARS',
+        charges: 0,
+        payments: 0,
+        credits: 0,
+      },
+    });
+
+    await getResidentLedger('tenant-1', 'unit-1');
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/units/unit-1/ledger',
       method: 'GET',
       headers: {
         'X-Tenant-Id': 'tenant-1',

--- a/apps/web/features/resident/api/resident-context.api.ts
+++ b/apps/web/features/resident/api/resident-context.api.ts
@@ -37,7 +37,7 @@ export async function getResidentContext(tenantId: string): Promise<ResidentCont
   return apiClient<ResidentContext>({
     path: '/me/context',
     method: 'GET',
-    headers: { 'X-Tenant-Id': tenantId },
+    headers: buildResidentHeaders(tenantId),
   });
 }
 
@@ -52,7 +52,7 @@ export async function getResidentLedger(
   return apiClient<UnitLedger>({
     path: `/units/${unitId}/ledger`,
     method: 'GET',
-    headers: { 'X-Tenant-Id': tenantId },
+    headers: buildResidentHeaders(tenantId),
   });
 }
 
@@ -79,6 +79,7 @@ export async function getResidentCommunications(
  * @param limit - Max items to return
  */
 export async function getResidentTickets(
+  tenantId: string,
   buildingId: string,
   unitId: string,
   limit = 3,
@@ -87,6 +88,7 @@ export async function getResidentTickets(
   const response = await apiClient<{ tickets: Ticket[] }>({
     path: `/buildings/${buildingId}/tickets?${params.toString()}`,
     method: 'GET',
+    headers: buildResidentHeaders(tenantId),
   });
   return Array.isArray(response) ? response : response?.tickets ?? [];
 }

--- a/apps/web/features/resident/hooks/useResidentCommunications.test.tsx
+++ b/apps/web/features/resident/hooks/useResidentCommunications.test.tsx
@@ -55,19 +55,23 @@ describe('useResidentCommunications', () => {
     expect(mockedGetResidentCommunications).toHaveBeenCalledWith('tenant-1', 7);
   });
 
-  it('does not fetch when the route tenant differs from the active tenant', () => {
+  it('fetches communications for the resident route even when activeTenantId points elsewhere', async () => {
     mockedUseAuthSession.mockReturnValue({
       user: { id: 'user-1', email: 'resident@buildingos.test', name: 'Resident' },
       memberships: [],
       activeTenantId: 'tenant-current',
     });
+    mockedGetResidentCommunications.mockResolvedValue([]);
 
     const wrapper = createWrapper();
     const { result } = renderHook(() => useResidentCommunications('tenant-previous', 3), {
       wrapper,
     });
 
-    expect(result.current.fetchStatus).toBe('idle');
-    expect(mockedGetResidentCommunications).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(mockedGetResidentCommunications).toHaveBeenCalledWith('tenant-previous', 3);
   });
 });

--- a/apps/web/features/resident/hooks/useResidentCommunications.ts
+++ b/apps/web/features/resident/hooks/useResidentCommunications.ts
@@ -14,11 +14,17 @@ export function useResidentCommunications(tenantId: string | null, limit = 3) {
   const session = useAuthSession();
   const userId = session?.user.id ?? null;
   const activeTenantId = session?.activeTenantId ?? null;
-  const shouldFetch = !!tenantId && !!userId && tenantId === activeTenantId;
+  const shouldFetch = !!tenantId && !!userId;
 
   return useQuery<InboxCommunication[]>({
     queryKey: ['residentCommunications', tenantId, activeTenantId, userId, limit],
-    queryFn: () => getResidentCommunications(activeTenantId!, limit),
+    queryFn: () => {
+      if (!tenantId) {
+        throw new Error('Tenant context is required');
+      }
+
+      return getResidentCommunications(tenantId, limit);
+    },
     enabled: shouldFetch,
     staleTime: 2 * 60 * 1000,
     gcTime: 5 * 60 * 1000,

--- a/apps/web/features/resident/hooks/useResidentContext.test.tsx
+++ b/apps/web/features/resident/hooks/useResidentContext.test.tsx
@@ -90,17 +90,29 @@ describe('useResidentContext', () => {
     expect(mockedGetResidentContext).toHaveBeenNthCalledWith(2, 'tenant-1');
   });
 
-  it('does not fetch a resident context for a route outside the active session tenant', async () => {
+  it('fetches a resident context for a valid resident route even when activeTenantId points elsewhere', async () => {
     mockedUseAuthSession.mockReturnValue({
       user: { id: 'user-1', email: 'resident@buildingos.test', name: 'Resident' },
       memberships: [],
       activeTenantId: 'tenant-current',
     });
+    mockedGetResidentContext.mockResolvedValue({
+      tenantId: 'tenant-previous',
+      activeBuildingId: 'building-1',
+      activeUnitId: 'unit-1',
+    });
 
     const wrapper = createWrapper();
     const { result } = renderHook(() => useResidentContext('tenant-previous'), { wrapper });
 
-    expect(result.current.fetchStatus).toBe('idle');
-    expect(mockedGetResidentContext).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(result.current.data).toEqual({
+        tenantId: 'tenant-previous',
+        activeBuildingId: 'building-1',
+        activeUnitId: 'unit-1',
+      });
+    });
+
+    expect(mockedGetResidentContext).toHaveBeenCalledWith('tenant-previous');
   });
 });

--- a/apps/web/features/resident/hooks/useResidentContext.ts
+++ b/apps/web/features/resident/hooks/useResidentContext.ts
@@ -14,11 +14,16 @@ export function useResidentContext(tenantId: string | null) {
 
   return useQuery<ResidentContext>({
     queryKey: ['residentContext', tenantId, userId],
-    queryFn: () => getResidentContext(tenantId!),
-    // A resident route must match the tenant selected by the authenticated
-    // session. This prevents a previous route/context from being reused while
-    // a different account or tenant is still settling.
-    enabled: !!tenantId && !!userId && session?.activeTenantId === tenantId,
+    queryFn: () => {
+      if (!tenantId) {
+        throw new Error('Tenant context is required');
+      }
+
+      return getResidentContext(tenantId);
+    },
+    // Resident routes are authorized by the layout and must keep working even
+    // when the session's active tenant points to a different admin context.
+    enabled: !!tenantId && !!userId,
     staleTime: 2 * 60 * 1000, // 2 minutes
     gcTime: 5 * 60 * 1000,
     retry: 1,

--- a/apps/web/features/resident/hooks/useResidentLedger.test.tsx
+++ b/apps/web/features/resident/hooks/useResidentLedger.test.tsx
@@ -1,10 +1,11 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useAuthSession } from '@/features/auth/useAuthSession';
-import { getResidentLedger } from '../api/resident-context.api';
+import type { AuthSession } from '@/features/auth/auth.types';
+import { getResidentLedger, type UnitLedger } from '../api/resident-context.api';
 import { useResidentLedger } from './useResidentLedger';
 
-type MockSession = NonNullable<ReturnType<typeof useAuthSession>>;
+type MockSession = AuthSession;
 
 jest.mock('@/features/auth/useAuthSession', () => ({
   useAuthSession: jest.fn(),
@@ -31,7 +32,7 @@ function makeSession(userId = 'user-1'): MockSession {
       },
     ],
     activeTenantId: 'tenant-2',
-  } as MockSession;
+  };
 }
 
 function createWrapper() {
@@ -52,9 +53,11 @@ function createWrapper() {
   return { Wrapper, queryClient };
 }
 
-function ledger(balance: number) {
+function ledger(balance: number): UnitLedger {
   return {
+    unitId: 'unit-1',
     totals: {
+      totalCharges: balance,
       balance,
       currency: 'ARS',
     },
@@ -66,7 +69,7 @@ function ledger(balance: number) {
 describe('useResidentLedger', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedUseAuthSession.mockReturnValue(makeSession() as never);
+    mockedUseAuthSession.mockReturnValue(makeSession());
   });
 
   it.each([
@@ -101,8 +104,8 @@ describe('useResidentLedger', () => {
     expect(mockedGetResidentLedger).not.toHaveBeenCalled();
   });
 
-  it('fetches the ledger using the route tenant and active unit', async () => {
-    mockedGetResidentLedger.mockResolvedValue(ledger(1250) as never);
+  it('fetches the ledger using the route tenant and active unit even when activeTenantId points elsewhere', async () => {
+    mockedGetResidentLedger.mockResolvedValue(ledger(1250));
 
     const { Wrapper, queryClient } = createWrapper();
 
@@ -124,6 +127,7 @@ describe('useResidentLedger', () => {
       queryClient.getQueryState([
         'residentLedger',
         'tenant-1',
+        'tenant-2',
         'user-1',
         'unit-1',
       ]),
@@ -132,8 +136,8 @@ describe('useResidentLedger', () => {
 
   it('uses separate cache entries when the authenticated user changes', async () => {
     mockedGetResidentLedger
-      .mockResolvedValueOnce(ledger(100) as never)
-      .mockResolvedValueOnce(ledger(200) as never);
+      .mockResolvedValueOnce(ledger(100))
+      .mockResolvedValueOnce(ledger(200));
 
     const { Wrapper, queryClient } = createWrapper();
 
@@ -146,7 +150,7 @@ describe('useResidentLedger', () => {
       expect(result.current.data?.totals.balance).toBe(100);
     });
 
-    mockedUseAuthSession.mockReturnValue(makeSession('user-2') as never);
+    mockedUseAuthSession.mockReturnValue(makeSession('user-2'));
     rerender();
 
     await waitFor(() => {
@@ -158,6 +162,7 @@ describe('useResidentLedger', () => {
       queryClient.getQueryState([
         'residentLedger',
         'tenant-1',
+        'tenant-2',
         'user-1',
         'unit-1',
       ]),
@@ -166,6 +171,7 @@ describe('useResidentLedger', () => {
       queryClient.getQueryState([
         'residentLedger',
         'tenant-1',
+        'tenant-2',
         'user-2',
         'unit-1',
       ]),
@@ -174,8 +180,8 @@ describe('useResidentLedger', () => {
 
   it('loads a separate ledger when the active unit changes', async () => {
     mockedGetResidentLedger
-      .mockResolvedValueOnce(ledger(300) as never)
-      .mockResolvedValueOnce(ledger(450) as never);
+      .mockResolvedValueOnce(ledger(300))
+      .mockResolvedValueOnce(ledger(450));
 
     const { Wrapper } = createWrapper();
 

--- a/apps/web/features/resident/hooks/useResidentLedger.ts
+++ b/apps/web/features/resident/hooks/useResidentLedger.ts
@@ -25,7 +25,7 @@ export function useResidentLedger(
 
       return getResidentLedger(tenantId, unitId);
     },
-    enabled: !!tenantId && !!unitId && !!userId && activeTenantId === tenantId,
+    enabled: !!tenantId && !!unitId && !!userId,
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000,
     retry: 1,

--- a/apps/web/features/resident/hooks/useResidentLedger.ts
+++ b/apps/web/features/resident/hooks/useResidentLedger.ts
@@ -14,11 +14,18 @@ export function useResidentLedger(
 ) {
   const session = useAuthSession();
   const userId = session?.user.id ?? null;
+  const activeTenantId = session?.activeTenantId ?? null;
 
   return useQuery<UnitLedger>({
-    queryKey: ['residentLedger', tenantId, userId, unitId],
-    queryFn: () => getResidentLedger(tenantId!, unitId!),
-    enabled: !!tenantId && !!unitId && !!userId,
+    queryKey: ['residentLedger', tenantId, activeTenantId, userId, unitId],
+    queryFn: () => {
+      if (!tenantId || !unitId) {
+        throw new Error('Tenant and unit context are required');
+      }
+
+      return getResidentLedger(tenantId, unitId);
+    },
+    enabled: !!tenantId && !!unitId && !!userId && activeTenantId === tenantId,
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 10 * 60 * 1000,
     retry: 1,


### PR DESCRIPTION
## Summary
- Make `/me/context` and resident-scoped frontend data calls honor explicit portal context
- Reconcile mixed-role resident context back to active occupancy when the resident portal is active
- Add regression coverage for resident context, options, and ticket/ledger API headers

## Related
Closes #121
