### PR TITLE
test(api): cover resident cross-unit access denial

### DIFF
--- a/apps/api/src/resident-access/resident-access.service.spec.ts
+++ b/apps/api/src/resident-access/resident-access.service.spec.ts
@@ -124,6 +124,29 @@ describe('ResidentAccessService', () => {
     }));
   });
 
+  it('denies access to a different unit in the same building when resident only occupies one unit', async () => {
+    jest.spyOn(prisma.unitOccupant, 'findMany').mockResolvedValue([
+      {
+        id: 'occupancy-1',
+        memberId: 'member-1',
+        unitId: 'unit-own',
+        unit: {
+          id: 'unit-own',
+          code: 'A-01',
+          label: 'Unidad Propia',
+          building: {
+            id: 'building-1',
+            name: 'Edificio A',
+            alias: 'A',
+          },
+        },
+      },
+    ] as never);
+
+    await expect(service.assertUnitAccess('tenant-1', 'user-1', 'unit-neighbor', 'building-1'))
+      .rejects.toBeInstanceOf(NotFoundException);
+  });
+
   it('does not self-scope a resident who also has a privileged tenant role', () => {
     expect(service.shouldEnforce(['RESIDENT'])).toBe(true);
     expect(service.shouldEnforce(['RESIDENT', 'TENANT_ADMIN'])).toBe(false);


### PR DESCRIPTION
## Root cause

The staging E2E fixture (`bootstrap-adm-fin-01.js`) associated `residentB` with **both** units in the same building (`E2E-UNIT-A` and `E2E-UNIT-B`). The E2E smoke test found `otherUnit` as "any unit in the same building ≠ resident's unit", then expected `assertUnitAccess` to deny access. But since `residentB` had an active occupancy on both units, the authorization check correctly returned HTTP 200.

## Authorization code was correct

The service path `assertUnitLedgerAccess → validateResidentUnitAccess → assertUnitAccess → resolveActiveResidentOccupancy` was correct and did not require changes.

## What was fixed (out of scope of this PR)

- The bootstrap script was corrected to assign `residentB` to only `E2E-UNIT-A`.
- The orphaned `UnitOccupant` record was deleted directly from the staging database.

## This PR adds

A regression test in `resident-access.service.spec.ts` that exercises the full `findMany` → filter occupancy path: when a resident occupies one unit in a building, `assertUnitAccess` must throw `NotFoundException` for a different unit in the same building.

## Verifications

- Unit tests: **6 passed, 0 failed**
- E2E smoke (staging): **1 passed, 0 failed**
- `git diff --check`: clean

## Notes

- E2E fixtures remain on staging intentionally.
- No productive authorization code was changed.