### PR TITLE
fix(finance): harden receipt generation and refresh payments

### DIFF
--- a/apps/api/prisma/migrations/20260805000000_add_receipt_generated_to_payment_audit_action/migration.sql
+++ b/apps/api/prisma/migrations/20260805000000_add_receipt_generated_to_payment_audit_action/migration.sql
@@ -1,0 +1,2 @@
+-- Add RECEIPT_GENERATED to PaymentAuditAction enum
+ALTER TYPE "PaymentAuditAction" ADD VALUE IF NOT EXISTS 'RECEIPT_GENERATED';

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -559,6 +559,49 @@ describe('PaymentReceiptService', () => {
     }));
   });
 
+  it('stores a safe error message instead of raw error when receipt generation fails', async () => {
+    let paymentState = {
+      id: 'payment-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      amount: 4050000,
+      currency: 'ARS',
+      method: 'TRANSFER',
+      createdByUserId: 'resident-1',
+      approvedByUserId: 'admin-1',
+      approvedAt: '2026-07-24T12:00:00.000Z',
+      reference: 'TRX-001',
+      paymentAllocations: [{
+        chargeId: 'charge-1',
+        amount: 4050000,
+        charge: {
+          period: '2025-10',
+          concept: 'Condominio ordinario 2025-10',
+          expensePeriod: { year: 2025, month: 10 },
+        },
+      }],
+      unit: { label: 'TN-01-01' },
+      building: { name: 'Complejo Horizonte' },
+      receiptDocumentId: null,
+      receiptNumber: null,
+      receiptStatus: ReceiptStatus.PENDING,
+      receiptError: null,
+    } as never;
+
+    prisma.payment.findUnique.mockImplementation(async () => paymentState as never);
+    prisma.payment.update.mockImplementation(async ({ data }) => {
+      paymentState = { ...paymentState, ...data } as never;
+      return paymentState as never;
+    });
+    minio.uploadBuffer.mockRejectedValueOnce(new Error('Invalid `prisma.paymentAuditLog.create()` invocation'));
+
+    await service.ensureReceiptForPayment('tenant-1', 'payment-1');
+
+    expect(paymentState.receiptStatus).toBe(ReceiptStatus.FAILED);
+    expect(paymentState.receiptError).toBe('No pudimos generar el comprobante. Intenta nuevamente más tarde.');
+  });
+
   it('does not notify the receipt owner when excluded from the approval flow', async () => {
     const notifyResidentReceiptReady = Reflect.get(service, 'notifyResidentReceiptReady') as (
       payment: { tenantId: string; createdByUserId: string; amount: number; currency: string; id: string },

--- a/apps/api/src/receipts/payment-receipt.service.ts
+++ b/apps/api/src/receipts/payment-receipt.service.ts
@@ -5,6 +5,8 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { DocumentCategory, DocumentVisibility, Prisma, ReceiptStatus } from '@prisma/client';
 import { acquirePaymentReceiptLock } from '../common/payment-linked-document-lock';
 
+const RECEIPT_GENERATION_SAFE_ERROR = 'No pudimos generar el comprobante. Intenta nuevamente más tarde.';
+
 export interface GenerateReceiptInput {
   paymentId: string;
   tenantId: string;
@@ -187,14 +189,14 @@ export class PaymentReceiptService {
         url,
       };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.error(`Failed to generate receipt for payment ${paymentId}: ${errorMessage}`);
+      const rawMessage = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Failed to generate receipt for payment ${paymentId}: ${rawMessage}`);
 
       if (uploadedReceiptObject && preparedReceipt && !preparedReceipt.reuseExisting && !receiptFinalized) {
         await this.cleanupUploadedReceiptObjectIfSafe(tenantId, preparedReceipt);
       }
 
-      await this.markReceiptGenerationFailedIfNeeded(tenantId, paymentId, errorMessage);
+      await this.markReceiptGenerationFailedIfNeeded(tenantId, paymentId, RECEIPT_GENERATION_SAFE_ERROR);
 
       return null;
     }

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
@@ -434,8 +434,8 @@ describe('ResidentPaymentsPage', () => {
     const Wrapper = createWrapper();
     render(<ResidentPaymentsPage />, { wrapper: Wrapper });
 
-    expect(await screen.findByText('Error al generar el recibo aprobado')).toBeTruthy();
-    expect(screen.getByText('Error al generar el recibo conciliado')).toBeTruthy();
+    const safeMessage = 'No pudimos generar el recibo. La administración ya fue notificada.';
+    expect(await screen.findAllByText(safeMessage)).toHaveLength(2);
 
     fireEvent.click(screen.getByRole('button', { name: /ver recibo del pago de/i }));
 

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
@@ -38,6 +38,15 @@ const CIVIL_DATE_OR_TIMESTAMP_PATTERN = /^(\d{4}-\d{2}-\d{2})(?:T.*)?$/;
 const MONTH_SHORT_LABELS = ['ene.', 'feb.', 'mar.', 'abr.', 'may.', 'jun.', 'jul.', 'ago.', 'sep.', 'oct.', 'nov.', 'dic.'] as const;
 const MONTH_SHORT_UPPER_LABELS = ['ENE', 'FEB', 'MAR', 'ABR', 'MAY', 'JUN', 'JUL', 'AGO', 'SEP', 'OCT', 'NOV', 'DIC'] as const;
 
+const SAFE_RECEIPT_ERROR = 'No pudimos generar el recibo. La administración ya fue notificada.';
+
+function safeReceiptError(error?: string | null): string {
+  if (!error) return SAFE_RECEIPT_ERROR;
+  if (error.includes('prisma') || error.includes('Prisma') || error.includes('Invalid')) return SAFE_RECEIPT_ERROR;
+  if (error.includes('CREATE') || error.includes('constraint') || error.includes('violates')) return SAFE_RECEIPT_ERROR;
+  return SAFE_RECEIPT_ERROR;
+}
+
 function useMediaQuery(query: string): boolean {
   const getInitialMatch = () => {
     if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
@@ -1604,7 +1613,7 @@ export const ResidentPaymentsPage = () => {
                               )}
                               {showReceiptErrorState && (
                                 <p className="text-sm text-red-700 dark:text-red-300">
-                                  {payment.receiptError || 'No pudimos generar el recibo. La administración ya fue notificada.'}
+                                  {safeReceiptError(payment.receiptError)}
                                 </p>
                               )}
                             </div>
@@ -1803,7 +1812,7 @@ export const ResidentPaymentsPage = () => {
                           )}
                           {showReceiptErrorState && (
                             <p className="text-sm text-red-700 dark:text-red-300">
-                              {payment.receiptError || 'No pudimos generar el recibo. La administración ya fue notificada.'}
+                              {safeReceiptError(payment.receiptError)}
                             </p>
                           )}
                         </div>
@@ -2106,7 +2115,7 @@ export const ResidentPaymentsPage = () => {
                     )}
                     {showReceiptErrorState && (
                       <p className="text-sm text-red-700">
-                        {payment.receiptError || 'No pudimos generar el recibo. La administración ya fue notificada.'}
+                        {safeReceiptError(payment.receiptError)}
                       </p>
                     )}
                   </div>

--- a/apps/web/features/finance/components/PaymentsReviewList.tsx
+++ b/apps/web/features/finance/components/PaymentsReviewList.tsx
@@ -40,7 +40,7 @@ export function PaymentsReviewList({
   onRefresh,
 }: PaymentsReviewListProps) {
   const { toast } = useToast();
-  const approveMutation = useApprovePayment(buildingId, 'SUBMITTED');
+  const approveMutation = useApprovePayment(buildingId, 'SUBMITTED', tenantId);
   const rejectMutation = useRejectPayment(buildingId, 'SUBMITTED');
   const [selectedPaymentId, setSelectedPaymentId] = useState<string | null>(null);
   const [downloadingId, setDownloadingId] = useState<string | null>(null);

--- a/apps/web/features/finance/components/TenantFinanceDashboard.tsx
+++ b/apps/web/features/finance/components/TenantFinanceDashboard.tsx
@@ -90,6 +90,7 @@ export const TenantFinanceDashboard = () => {
     onSuccess: () => {
       setSelectedPaymentId(null);
       queryClient.invalidateQueries({ queryKey: ['tenantPayments', tenantId] });
+      queryClient.invalidateQueries({ queryKey: ['residentPayments', tenantId], exact: false });
     },
   });
 

--- a/apps/web/features/finance/hooks/usePaymentsReview.ts
+++ b/apps/web/features/finance/hooks/usePaymentsReview.ts
@@ -21,9 +21,11 @@ export function usePaymentsReview(buildingId: string, status?: string) {
 /**
  * Hook to approve a payment
  * @param buildingId - Building ID
+ * @param status - Payment status filter
+ * @param tenantId - Optional tenant ID to invalidate resident payments query
  * @returns Mutation result with approve function
  */
-export function useApprovePayment(buildingId: string, status?: string) {
+export function useApprovePayment(buildingId: string, status?: string, tenantId?: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -31,6 +33,9 @@ export function useApprovePayment(buildingId: string, status?: string) {
       approvePayment(buildingId, params.paymentId, params.paidAt),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['payments', buildingId, status] });
+      if (tenantId) {
+        queryClient.invalidateQueries({ queryKey: ['residentPayments', tenantId], exact: false });
+      }
     },
   });
 }

--- a/apps/web/features/payments/payments.review.ui.tsx
+++ b/apps/web/features/payments/payments.review.ui.tsx
@@ -48,7 +48,6 @@ const REJECTION_REASONS = [
 export const PaymentsReviewUI = () => {
   const params = useParams();
   const tenantId = params?.tenantId as string | undefined;
-
   const canReview = useCan('payments.review');
   const { format } = useTenantCurrency();
 


### PR DESCRIPTION
## Problema

`PaymentAuditAction.RECEIPT_GENERATED` existía en schema.prisma, pero no había una migración PostgreSQL que agregara ese valor al enum.

La conciliación del pago finalizaba correctamente, pero la generación posterior del recibo fallaba. El mensaje crudo de Prisma se almacenaba en `receiptError` y terminaba visible para el residente.

Además, la caché de `residentPayments` no se invalidaba después de aprobar el pago, por lo que el badge Conciliado solo se actualizaba al recargar.

## Solución

- Agrega la migración:
  `20260805000000_add_receipt_generated_to_payment_audit_action`.
- Sanitiza el error almacenado en `receiptError`.
- Conserva el error técnico completo únicamente en el logger interno.
- Agrega defensa frontend para no mostrar errores históricos crudos.
- Invalida las queries `["residentPayments", tenantId, ...]` después de aprobar.
- Mantiene la conciliación financiera independiente del fallo secundario del recibo.
- Conserva la limpieza de `receiptError` cuando la generación termina correctamente.

## Validación local

- Receipt service: 14 passed.
- Finanzas: 79 passed.
- Página de pagos residente: 32 passed.
- Prisma validate: passed.
- Prisma generate: passed.
- Migración temporal con `prisma migrate deploy`: 82 migraciones aplicadas.
- Migración registrada con `finished_at` y sin `rolled_back_at`.
- Enum final: 7 valores, incluyendo `RECEIPT_GENERATED`.
- Typecheck API: passed.
- Typecheck Web: passed.
- Lint focalizado: passed.
- `git diff --check`: limpio.

## Seguridad y alcance

- No se exponen mensajes de Prisma o PostgreSQL al residente.
- No se utilizó staging.
- No se modificó producción.
- No se ejecutaron migraciones contra el VPS.
- No incluye ADM-FIN-01 ni el commit 138ab793.