### PR TITLE
docs(workflow): enforce local-first staging process

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,33 @@
+## Descripción
+
+<!-- Describe brevemente el problema y la solución -->
+
+## Tipo de cambio
+
+- [ ] Bug fix
+- [ ] Nueva funcionalidad
+- [ ] Refactor
+- [ ] Cambio de documentación
+- [ ] Otro: ___
+
+## Checklist de validación local obligatoria
+
+Antes de abrir este PR, se completó localmente:
+
+- [ ] Tests unitarios pasan
+- [ ] Tests de integración pasan
+- [ ] Tests E2E pasan (si aplica)
+- [ ] Typecheck (`tsc --noEmit`) sin errores
+- [ ] Lint sin errores nuevos
+- [ ] Build exitoso
+- [ ] `git diff --check` limpio
+- [ ] Confirmé que todos los cambios fueron implementados y probados localmente
+- [ ] Confirmé que el merge a main activará automáticamente el deploy a staging
+- [ ] El despliegue automático a staging está autorizado para este PR
+- [ ] Las migraciones incluidas fueron validadas localmente
+- [ ] No se requiere preservar ningún archivo temporal dentro del checkout de staging
+- [ ] La validación funcional en staging está definida para después del merge
+
+## Notas
+
+<!-- Agrega notas para el revisor, screenshhots, o contexto adicional -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,64 @@
 - Never say "listo" without validation, or clarify that validation was not performed.
 - GitHub Actions build, lint, test, and E2E jobs declared in `.github/workflows/` are preauthorized quality gates for CI alignment work. This does not authorize deploys, VPS access, staging, production, or remote migrations.
 
+## Regla obligatoria: desarrollo local antes de staging
+
+Todo desarrollo en BuildingOS se realiza localmente antes de cualquier interacción con staging.
+
+- **Reproducción**: todo bug o funcionalidad se reproduce primero en el entorno local.
+- **Implementación**: el código se escribe, ajusta y valida exclusivamente en local.
+- **Validación local obligatoria**: antes de cualquier PR o deploy, se ejecutan localmente según corresponda:
+  - tests unitarios y de integración
+  - tests E2E
+  - typecheck (`tsc --noEmit`)
+  - lint
+  - build
+  - `git diff --check`
+- **Staging no es entorno de desarrollo**: staging no se utiliza como entorno principal de desarrollo, diagnóstico o experimentación.
+- **No modificar staging directamente**: no se aplica ningún cambio a staging antes de completar la validación local con tests verdes.
+- **Staging solo post-validación**: staging se utiliza únicamente después de pruebas locales verdes y autorización explícita del responsable.
+- **Hotfix excepcional**: si un hotfix en staging es estrictamente necesario, debe quedar reproducido, versionado y probado localmente después de aplicado.
+- **Autorización requerida**: merge, deploy y cambios de base de datos (migraciones, seeds, datos) requieren autorización explícita.
+
+### Limpieza del repositorio de staging
+
+El checkout de staging debe permanecer siempre limpio.
+
+- **Prohibido en staging**: no se deben crear scripts temporales, fixtures de diagnóstico, dumps, logs, archivos de bootstrap, archivos de prueba o archivos auxiliares no versionados dentro del checkout de staging.
+- **Archivos temporales**: deben guardarse en `/tmp`, el home del usuario, o una ubicación externa al repositorio.
+
+### Deploy automático a staging
+
+En BuildingOS, fusionar cambios hacia `main` activa automáticamente el workflow `Deploy main to staging`.
+
+- Autorizar un merge hacia `main` implica también autorizar el despliegue automático a staging, salvo que el workflow haya sido deshabilitado explícitamente antes del merge.
+- Antes de autorizar un merge, se debe confirmar:
+  - validaciones locales verdes
+  - checks del PR verdes
+  - migraciones revisadas
+  - staging preparado para recibir el cambio
+  - ausencia de archivos temporales dentro del checkout remoto
+
+### Protección del checkout remoto
+
+- Si el deploy detecta archivos tracked, staged o untracked en el checkout remoto, debe detenerse.
+- **Prohibido**: solucionar automáticamente esa situación mediante `git clean`, `git reset --hard`, borrado automático, sobrescritura forzada o eliminación de archivos sin inspección.
+- Los archivos encontrados deben inspeccionarse primero y, si son necesarios, preservarse fuera del repositorio antes de limpiar el checkout.
+
+### Flujo oficial
+
+```
+Trabajo local
+→ pruebas locales verdes
+→ commit
+→ PR
+→ checks verdes
+→ autorización de merge
+→ merge a main
+→ deploy automático a staging
+→ validación funcional en staging
+```
+
 ## RTK Usage
 When working with AI coding agents such as Codex or OpenCode, prefer RTK commands to reduce token usage and keep command outputs compact.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing a BuildingOS
+
+## Regla obligatoria: desarrollo local antes de staging
+
+Todo desarrollo se realiza localmente antes de cualquier interacción con staging.
+
+### Flujo
+
+1. **Reproducir** el bug o funcionalidad en local.
+2. **Implementar** el cambio exclusivamente en local.
+3. **Validar** localmente antes de cualquier PR:
+   - tests unitarios y de integración
+   - tests E2E (si aplica)
+   - typecheck (`tsc --noEmit`)
+   - lint
+   - build
+   - `git diff --check`
+4. **Crear PR** solo después de validación local exitosa.
+5. **Staging** se utiliza solo después de merge a main y autorización explícita.
+
+### Reglas
+
+- Staging no es entorno de desarrollo ni diagnóstico.
+- No se modifica staging directamente sin validación local previa.
+- Hotfixes en staging deben quedar reproducidos y versionados localmente.
+- Merge, deploy y cambios de base de datos requieren autorización explícita.
+
+## Merge y despliegue automático a staging
+
+En BuildingOS, fusionar cambios hacia `main` activa automáticamente el workflow `Deploy main to staging`.
+
+- Un merge no es únicamente una integración de código: autorizar un merge implica autorizar el despliegue automático a staging.
+- El checkout remoto de staging debe permanecer limpio. No se deben crear scripts temporales, fixtures, dumps, logs, archivos de bootstrap o archivos auxiliares no versionados dentro del checkout.
+- Los archivos temporales deben guardarse en `/tmp`, el home del usuario, o una ubicación externa al repositorio.
+- Nunca se deben limpiar archivos encontrados en el checkout remoto sin inspección previa. `git clean`, `git reset --hard` y borrado automático están prohibidos.
+- La validación funcional de staging ocurre después del deploy exitoso, no antes.
+
+### Flujo oficial
+
+```
+Local
+→ pruebas
+→ commit
+→ PR
+→ checks
+→ merge autorizado
+→ deploy automático
+→ smoke y validación funcional en staging
+```
+
+## Commits
+
+- Conventional commits: `feat`, `fix`, `refactor`, `test`, `docs`, etc.
+- Mensajes claros y accionables.
+- Un feature por commit.
+- Incluir contexto del por qué, no solo el qué.
+
+## Pull Requests
+
+- Un PR por feature o fix.
+- Descripción clra del problema y la solución.
+- Checklist de validación local completado.
+- Tests incluidos para cambios de lógica de negocio.
+- No incluir cambios fuera del alcance.
+
+## Ramas
+
+- `main` siempre deployable.
+- Feature branches: `feat/nombre-descriptivo`.
+- Fix branches: `fix/nombre-descriptivo`.
+- Eliminar ramas después de merge.


### PR DESCRIPTION
## Objetivo

Formalizar el flujo obligatorio local-first de BuildingOS y documentar el comportamiento real del despliegue automático a staging.

## Cambios

- Agrega la regla principal en AGENTS.md.
- Agrega CONTRIBUTING.md con el flujo para colaboradores.
- Agrega el checklist obligatorio al template de pull requests.
- Documenta que los merges a main activan Deploy main to staging.
- Exige mantener limpio el checkout remoto.
- Prohíbe git clean, git reset --hard y borrados automáticos sin inspección.
- Exige guardar scripts y archivos temporales fuera del repositorio.

## Flujo oficial

```
Trabajo local
→ pruebas locales verdes
→ commit
→ PR
→ checks verdes
→ autorización de merge
→ merge a main
→ deploy automático a staging
→ validación funcional en staging
```

## Validación

- `git diff --check`: limpio.
- Solo se modificaron archivos documentales.
- No se utilizó staging, producción ni VPS.
- No se modificaron workflows ni código productivo.

> **Nota**: Este PR es documental, pero su futuro merge hacia main activará automáticamente el deploy a staging. Debe quedar explícitamente pendiente de autorización antes del merge.