### PR TITLE
fix(web): add polling for cross-session resident payment refresh

### DIFF
--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
@@ -573,6 +573,7 @@ export const ResidentPaymentsPage = () => {
     },
     enabled: !!tenantId && !!userId && !!buildingId && !!unitId,
     staleTime: 5 * 60 * 1000,
+    refetchInterval: 10_000,
   });
 
   const [showForm, setShowForm] = useState(false);


### PR DESCRIPTION
## Problema

Cuando el admin aprueba un pago, el residente no ve el cambio a Conciliado hasta recargar manualmente la página.

La invalidación `queryClient.invalidateQueries` solo afecta al `QueryClient` del navegador donde se ejecuta (el admin). El residente tiene su propio `QueryClient` en otra sesión/pestaña que no recibe la invalidación.

## Causa raíz

- `QueryClient` es una instancia en memoria por navegador (`QueryProvider.tsx:6`)
- `invalidateQueries` solo invalida la instancia local
- La query residente tiene `staleTime: 5min` y sin `refetchInterval`
- No existe infraestructura realtime (WebSocket, Socket.IO, SSE) en el proyecto

## Solución

Agrega `refetchInterval: 10_000` a la query `residentPayments` en el componente residente.

- Polling cada 10 segundos mientras la query esté habilitada
- React Query detiene automáticamente el polling al desmontar
- React Query pausa cuando la pestaña no está visible
- Respeta `enabled` — no polla si faltan datos de contexto
- No introduce dependencias nuevas

## Validación

- Frontend tests: 32 passed
- Typecheck Web: no errors
- Lint: 2 pre-existing errors (no introduced)
- `git diff --check`: clean
- 1 archivo, 1 línea agregada
- Staging no utilizado

> **Nota**: La validación manual con dos sesiones separadas (admin + residente) debe realizarse después del merge con API y web corriendo localmente.