### PR TITLE
fix(finance): validate runtime inputs for finance endpoints

### DIFF
--- a/apps/api/src/finanzas/expense-import.dto.spec.ts
+++ b/apps/api/src/finanzas/expense-import.dto.spec.ts
@@ -1,0 +1,179 @@
+import 'reflect-metadata';
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { ImportExpensesDto, ExpenseImportRowDto } from './expense-import.dto';
+
+describe('ImportExpensesDto', () => {
+  const validRow = {
+    fecha: '01/05/2026',
+    descripcion: 'Luz',
+    monto: 100,
+    moneda: 'ARS',
+    edificio: 'Edificio A',
+    categoria: 'Servicios',
+  };
+
+  describe('valid payloads', () => {
+    it('accepts a valid period', async () => {
+      const dto = plainToInstance(ImportExpensesDto, { period: '2026-05' });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts period with rows', async () => {
+      const dto = plainToInstance(ImportExpensesDto, {
+        period: '2026-05',
+        rows: [validRow],
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts period with columnMapping', async () => {
+      const dto = plainToInstance(ImportExpensesDto, {
+        period: '2026-05',
+        columnMapping: '{"fecha":0,"descripcion":1}',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts period with optional fields omitted', async () => {
+      const dto = plainToInstance(ImportExpensesDto, { period: '2026-12' });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  describe('invalid payloads', () => {
+    it('rejects missing period', async () => {
+      const dto = plainToInstance(ImportExpensesDto, {});
+      const errors = await validate(dto);
+      expect(errors.length).toBeGreaterThan(0);
+      const periodError = errors.find((e) => e.property === 'period');
+      expect(periodError).toBeDefined();
+    });
+
+    it('rejects empty period', async () => {
+      const dto = plainToInstance(ImportExpensesDto, { period: '' });
+      const errors = await validate(dto);
+      const periodError = errors.find((e) => e.property === 'period');
+      expect(periodError).toBeDefined();
+    });
+
+    it('rejects period without YYYY-MM format', async () => {
+      const dto = plainToInstance(ImportExpensesDto, { period: '2026/05' });
+      const errors = await validate(dto);
+      const periodError = errors.find((e) => e.property === 'period');
+      expect(periodError).toBeDefined();
+    });
+
+    it('rejects period with month 00', async () => {
+      const dto = plainToInstance(ImportExpensesDto, { period: '2026-00' });
+      const errors = await validate(dto);
+      const periodError = errors.find((e) => e.property === 'period');
+      expect(periodError).toBeDefined();
+    });
+
+    it('rejects period with month 13', async () => {
+      const dto = plainToInstance(ImportExpensesDto, { period: '2026-13' });
+      const errors = await validate(dto);
+      const periodError = errors.find((e) => e.property === 'period');
+      expect(periodError).toBeDefined();
+    });
+
+    it('rejects period with wrong separator', async () => {
+      const dto = plainToInstance(ImportExpensesDto, { period: '2026_05' });
+      const errors = await validate(dto);
+      const periodError = errors.find((e) => e.property === 'period');
+      expect(periodError).toBeDefined();
+    });
+  });
+});
+
+describe('ExpenseImportRowDto', () => {
+  const validRow = {
+    fecha: '01/05/2026',
+    descripcion: 'Luz',
+    monto: 100,
+    moneda: 'ARS',
+    edificio: 'Edificio A',
+    categoria: 'Servicios',
+  };
+
+  describe('valid payloads', () => {
+    it('accepts a valid row', async () => {
+      const dto = plainToInstance(ExpenseImportRowDto, validRow);
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts a row with optional proveedor', async () => {
+      const dto = plainToInstance(ExpenseImportRowDto, {
+        ...validRow,
+        proveedor: 'Vendor A',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  describe('invalid payloads', () => {
+    it('rejects missing fecha', async () => {
+      const { fecha, ...rest } = validRow;
+      const dto = plainToInstance(ExpenseImportRowDto, rest);
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'fecha')).toBeDefined();
+    });
+
+    it('rejects empty fecha', async () => {
+      const dto = plainToInstance(ExpenseImportRowDto, { ...validRow, fecha: '' });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'fecha')).toBeDefined();
+    });
+
+    it('rejects missing descripcion', async () => {
+      const { descripcion, ...rest } = validRow;
+      const dto = plainToInstance(ExpenseImportRowDto, rest);
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'descripcion')).toBeDefined();
+    });
+
+    it('rejects missing monto', async () => {
+      const { monto, ...rest } = validRow;
+      const dto = plainToInstance(ExpenseImportRowDto, rest);
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'monto')).toBeDefined();
+    });
+
+    it('rejects non-numeric monto', async () => {
+      const dto = plainToInstance(ExpenseImportRowDto, {
+        ...validRow,
+        monto: 'abc',
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'monto')).toBeDefined();
+    });
+
+    it('rejects missing moneda', async () => {
+      const { moneda, ...rest } = validRow;
+      const dto = plainToInstance(ExpenseImportRowDto, rest);
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'moneda')).toBeDefined();
+    });
+
+    it('rejects missing edificio', async () => {
+      const { edificio, ...rest } = validRow;
+      const dto = plainToInstance(ExpenseImportRowDto, rest);
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'edificio')).toBeDefined();
+    });
+
+    it('rejects missing categoria', async () => {
+      const { categoria, ...rest } = validRow;
+      const dto = plainToInstance(ExpenseImportRowDto, rest);
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'categoria')).toBeDefined();
+    });
+  });
+});

--- a/apps/api/src/finanzas/expense-import.dto.ts
+++ b/apps/api/src/finanzas/expense-import.dto.ts
@@ -1,22 +1,76 @@
-export interface ImportExpensesDto {
-  period: string; // YYYY-MM — si no viene en el Excel, usar este
-  columnMapping?: string; // JSON stringificado { fecha: 0, descripcion: 1, ... }
+import { Type } from 'class-transformer';
+import {
+  IsString,
+  IsNotEmpty,
+  IsOptional,
+  Matches,
+  IsArray,
+  ValidateNested,
+  IsNumber,
+} from 'class-validator';
+
+export class ImportExpensesDto {
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^\d{4}-(0[1-9]|1[0-2])$/, {
+    message: 'period must be in YYYY-MM format',
+  })
+  period!: string;
+
+  @IsOptional()
+  @IsString()
+  columnMapping?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => ExpenseImportRowDto)
+  rows?: ExpenseImportRowDto[];
+}
+
+export class ExpenseImportRowDto {
+  @IsString()
+  @IsNotEmpty()
+  fecha!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  descripcion!: string;
+
+  @IsNumber()
+  monto!: number;
+
+  @IsString()
+  @IsNotEmpty()
+  moneda!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  edificio!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  categoria!: string;
+
+  @IsOptional()
+  @IsString()
+  proveedor?: string;
 }
 
 export interface ExpenseImportRow {
-  fecha: string;          // DD/MM/YYYY or similar
+  fecha: string;
   descripcion: string;
   monto: number;
-  moneda: string;         // USD, VES, ARS
-  edificio: string;       // "Torre A" o "Comunes"
-  categoria: string;      // "Electricidad", "Agua", etc.
-  proveedor?: string;     // opcional
+  moneda: string;
+  edificio: string;
+  categoria: string;
+  proveedor?: string;
 }
 
 export interface ExpenseImportResult {
   totalRows: number;
   successCount: number;
   failureCount: number;
-  createdExpenses: string[]; // Array de IDs creados
+  createdExpenses: string[];
   errors: { rowIndex: number; reason: string }[];
 }

--- a/apps/api/src/finanzas/expenses.controller.ts
+++ b/apps/api/src/finanzas/expenses.controller.ts
@@ -1,3 +1,4 @@
+import { Type } from 'class-transformer';
 import {
   Controller,
   Get,
@@ -12,6 +13,13 @@ import {
   HttpStatus,
   BadRequestException,
 } from '@nestjs/common';
+import {
+  IsString,
+  IsOptional,
+  IsInt,
+  Min,
+  Matches,
+} from 'class-validator';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
 import { AuthenticatedRequest } from '../common/types/request.types';
@@ -24,12 +32,37 @@ import {
 import { ImportExpensesDto, ExpenseImportResult } from './expense-import.dto';
 
 class ListExpensesQuery {
+  @IsOptional()
+  @IsString()
   buildingId?: string;
+
+  @IsOptional()
+  @IsString()
+  @Matches(/^\d{4}-(0[1-9]|1[0-2])$/)
   period?: string;
+
+  @IsOptional()
+  @IsString()
   status?: string;
+
+  @IsOptional()
+  @IsString()
   categoryId?: string;
+
+  @IsOptional()
+  @IsString()
   scopeType?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
   limit?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
   offset?: number;
 }
 
@@ -133,23 +166,11 @@ export class ExpensesController {
   @Post('import/from-excel')
   @HttpCode(HttpStatus.OK)
   async importFromExcel(
-    @Body()
-    body: {
-      period: string; // YYYY-MM
-      rows: Array<{
-        fecha: string;
-        descripcion: string;
-        monto: number;
-        moneda: string;
-        edificio: string;
-        categoria: string;
-        proveedor?: string;
-      }>;
-    },
+    @Body() body: ImportExpensesDto,
     @Request() req: AuthenticatedRequest,
   ): Promise<ExpenseImportResult> {
-    if (!body.period || !body.rows || !Array.isArray(body.rows)) {
-      throw new BadRequestException('period y rows (array) son requeridos');
+    if (!body.rows || !Array.isArray(body.rows) || body.rows.length === 0) {
+      throw new BadRequestException('rows (array) son requeridos');
     }
 
     const result = await this.expensesService.importExpensesFromExcel(

--- a/apps/api/src/finanzas/finanzas-validation.integration.spec.ts
+++ b/apps/api/src/finanzas/finanzas-validation.integration.spec.ts
@@ -1,0 +1,320 @@
+import { CanActivate, INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request = require('supertest');
+import { ExpensesController } from './expenses.controller';
+import { ExpensesService } from './expenses.service';
+import { RecurringExpenseController } from './recurring-expense.controller';
+import { RecurringExpenseService } from './recurring-expense.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
+import { BuildingAccessGuard } from '../tenancy/building-access.guard';
+
+const mockExpensesService = {
+  listExpenses: jest.fn().mockResolvedValue([]),
+  importExpensesFromExcel: jest.fn().mockResolvedValue({
+    successCount: 0,
+    failureCount: 0,
+    errors: [],
+  }),
+};
+
+const mockRecurringExpenseService = {
+  createRecurringExpense: jest.fn().mockResolvedValue({
+    id: 're-1',
+    categoryId: 'cat-1',
+    amount: 5000,
+    currency: 'ARS',
+    concept: 'Test',
+    frequency: 'MONTHLY',
+    isActive: true,
+  }),
+  listRecurringExpenses: jest.fn().mockResolvedValue([]),
+  updateRecurringExpense: jest.fn().mockResolvedValue({
+    id: 're-1',
+    categoryId: 'cat-1',
+    amount: 5000,
+    currency: 'ARS',
+    concept: 'Test',
+    frequency: 'MONTHLY',
+    isActive: true,
+  }),
+};
+
+const alwaysPass: CanActivate = { canActivate: () => true };
+
+describe('Finance ValidationPipe integration', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [ExpensesController, RecurringExpenseController],
+      providers: [
+        { provide: ExpensesService, useValue: mockExpensesService },
+        { provide: RecurringExpenseService, useValue: mockRecurringExpenseService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(alwaysPass)
+      .overrideGuard(TenantAccessGuard)
+      .useValue(alwaysPass)
+      .overrideGuard(BuildingAccessGuard)
+      .useValue(alwaysPass)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.use((req: any, _res: any, next: any) => {
+      req.tenantId = 't-1';
+      req.user = { id: 'user-1', roles: ['TENANT_ADMIN'], membershipId: 'member-1' };
+      next();
+    });
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: false,
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+      }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('ExpensesController — import/from-excel', () => {
+    const baseUrl = '/tenants/t-1/finance/expenses/import/from-excel';
+
+    it('rejects invalid period format', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({ period: '2026/05', rows: [] });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toEqual(
+        expect.arrayContaining([expect.stringMatching(/period/i)]),
+      );
+    });
+
+    it('rejects rows missing required fields', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({ period: '2026-05', rows: [{ fecha: '01/05/2026' }] });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects empty rows array (controller manual check)', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({ period: '2026-05', rows: [] });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/rows/i);
+    });
+
+    it('rejects missing rows', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({ period: '2026-05' });
+      expect(res.status).toBe(400);
+    });
+
+    it('does not call service when validation fails', async () => {
+      await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({ period: 'bad' });
+      expect(mockExpensesService.importExpensesFromExcel).not.toHaveBeenCalled();
+    });
+
+    it('calls service for valid payload', async () => {
+      await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          period: '2026-05',
+          rows: [
+            {
+              fecha: '01/05/2026',
+              descripcion: 'Luz',
+              monto: 100,
+              moneda: 'ARS',
+              edificio: 'Edificio A',
+              categoria: 'Servicios',
+            },
+          ],
+        });
+      expect(mockExpensesService.importExpensesFromExcel).toHaveBeenCalled();
+    });
+  });
+
+  describe('ExpensesController — listExpenses', () => {
+    const baseUrl = '/tenants/t-1/finance/expenses';
+
+    it('rejects invalid period format', async () => {
+      const res = await request(app.getHttpServer())
+        .get(baseUrl)
+        .query({ period: '2026-13' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects limit of 0', async () => {
+      const res = await request(app.getHttpServer())
+        .get(baseUrl)
+        .query({ limit: 0 });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects decimal limit', async () => {
+      const res = await request(app.getHttpServer())
+        .get(baseUrl)
+        .query({ limit: 10.5 });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects negative offset', async () => {
+      const res = await request(app.getHttpServer())
+        .get(baseUrl)
+        .query({ offset: -1 });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects non-numeric limit', async () => {
+      const res = await request(app.getHttpServer())
+        .get(baseUrl)
+        .query({ limit: 'abc' });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('RecurringExpenseController — create', () => {
+    const baseUrl = '/buildings/b-1/recurring-expenses';
+
+    it('rejects decimal amount', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          categoryId: 'cat-1',
+          amount: 10.5,
+          currency: 'ARS',
+          concept: 'Test',
+          frequency: 'MONTHLY',
+        });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toEqual(
+        expect.arrayContaining([expect.stringMatching(/amount/i)]),
+      );
+    });
+
+    it('rejects invalid currency', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          categoryId: 'cat-1',
+          amount: 5000,
+          currency: 'EUR',
+          concept: 'Test',
+          frequency: 'MONTHLY',
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects invalid frequency', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          categoryId: 'cat-1',
+          amount: 5000,
+          currency: 'ARS',
+          concept: 'Test',
+          frequency: 'WEEKLY',
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects empty categoryId', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          categoryId: '',
+          amount: 5000,
+          currency: 'ARS',
+          concept: 'Test',
+          frequency: 'MONTHLY',
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects empty concept', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          categoryId: 'cat-1',
+          amount: 5000,
+          currency: 'ARS',
+          concept: '',
+          frequency: 'MONTHLY',
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it('does not call service when validation fails', async () => {
+      await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({ categoryId: '', amount: -1, currency: 'X', concept: '', frequency: 'Y' });
+      expect(mockRecurringExpenseService.createRecurringExpense).not.toHaveBeenCalled();
+    });
+
+    it('calls service for valid payload', async () => {
+      await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          categoryId: 'cat-1',
+          amount: 5000,
+          currency: 'ARS',
+          concept: 'Expensas mensuales',
+          frequency: 'MONTHLY',
+        });
+      expect(mockRecurringExpenseService.createRecurringExpense).toHaveBeenCalled();
+    });
+  });
+
+  describe('RecurringExpenseController — update', () => {
+    const baseUrl = '/buildings/b-1/recurring-expenses/re-1';
+
+    it('coerces isActive via enableImplicitConversion (pipe is permissive for booleans)', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ isActive: 0 });
+      expect(res.status).toBe(200);
+    });
+
+    it('rejects decimal amount', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ amount: 10.5 });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects empty concept', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ concept: '' });
+      expect(res.status).toBe(400);
+    });
+
+    it('does not call service when validation fails', async () => {
+      await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ isActive: { invalid: true }, amount: 1.5, concept: '' });
+      expect(mockRecurringExpenseService.updateRecurringExpense).not.toHaveBeenCalled();
+    });
+
+    it('calls service for valid payload', async () => {
+      await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ amount: 7500, concept: 'Updated' });
+      expect(mockRecurringExpenseService.updateRecurringExpense).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/finanzas/finanzas-validation.integration.spec.ts
+++ b/apps/api/src/finanzas/finanzas-validation.integration.spec.ts
@@ -282,11 +282,74 @@ describe('Finance ValidationPipe integration', () => {
   describe('RecurringExpenseController — update', () => {
     const baseUrl = '/buildings/b-1/recurring-expenses/re-1';
 
-    it('coerces isActive via enableImplicitConversion (pipe is permissive for booleans)', async () => {
+    it('accepts true as isActive', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ isActive: true });
+      expect(res.status).toBe(200);
+    });
+
+    it('accepts false as isActive', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ isActive: false });
+      expect(res.status).toBe(200);
+    });
+
+    it('rejects 0 as isActive', async () => {
       const res = await request(app.getHttpServer())
         .patch(baseUrl)
         .send({ isActive: 0 });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects 1 as isActive', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ isActive: 1 });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects "true" as isActive', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ isActive: 'true' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects "false" as isActive', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ isActive: 'false' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects "yes" as isActive', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ isActive: 'yes' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects object as isActive', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ isActive: { invalid: true } });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects array as isActive', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ isActive: [1] });
+      expect(res.status).toBe(400);
+    });
+
+    it('does not call service when isActive validation fails', async () => {
+      await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ isActive: 0 });
+      expect(mockRecurringExpenseService.updateRecurringExpense).not.toHaveBeenCalled();
     });
 
     it('rejects decimal amount', async () => {

--- a/apps/api/src/finanzas/finanzas.controller.ts
+++ b/apps/api/src/finanzas/finanzas.controller.ts
@@ -62,7 +62,6 @@ import {
 } from './finanzas.dto';
 import {
   ImportExpensesDto,
-  ExpenseImportRow,
   ExpenseImportResult,
 } from './expense-import.dto';
 
@@ -515,7 +514,7 @@ export class FinanzasController {
   @Post('expenses/import')
   async importExpenses(
     @Param('buildingId') buildingId: string,
-    @Body() importDto: ImportExpensesDto & { rows: ExpenseImportRow[] },
+    @Body() importDto: ImportExpensesDto,
     @Request() req: AuthenticatedRequest,
   ): Promise<ExpenseImportResult> {
     const tenantId = req.tenantId!;

--- a/apps/api/src/finanzas/get-payment-audit-log-query.dto.spec.ts
+++ b/apps/api/src/finanzas/get-payment-audit-log-query.dto.spec.ts
@@ -1,0 +1,66 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { GetPaymentAuditLogQuery } from './tenant-finance.controller';
+
+describe('GetPaymentAuditLogQuery validation', () => {
+  it('accepts empty query (optional fields)', async () => {
+    const q = plainToInstance(GetPaymentAuditLogQuery, {});
+    const errors = await validate(q);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts valid limit', async () => {
+    const q = plainToInstance(GetPaymentAuditLogQuery, { limit: 50 });
+    const errors = await validate(q);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts limit = 1 (minimum)', async () => {
+    const q = plainToInstance(GetPaymentAuditLogQuery, { limit: 1 });
+    const errors = await validate(q);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts limit = 200 (maximum)', async () => {
+    const q = plainToInstance(GetPaymentAuditLogQuery, { limit: 200 });
+    const errors = await validate(q);
+    expect(errors).toHaveLength(0);
+  });
+
+  it('transforms string limit to number', async () => {
+    const q = plainToInstance(GetPaymentAuditLogQuery, { limit: '30' });
+    const errors = await validate(q);
+    expect(errors).toHaveLength(0);
+    expect(q.limit).toBe(30);
+  });
+
+  it('rejects limit = 0', async () => {
+    const q = plainToInstance(GetPaymentAuditLogQuery, { limit: 0 });
+    const errors = await validate(q);
+    expect(errors.find((e) => e.property === 'limit')).toBeDefined();
+  });
+
+  it('rejects limit > 200', async () => {
+    const q = plainToInstance(GetPaymentAuditLogQuery, { limit: 201 });
+    const errors = await validate(q);
+    expect(errors.find((e) => e.property === 'limit')).toBeDefined();
+  });
+
+  it('rejects negative limit', async () => {
+    const q = plainToInstance(GetPaymentAuditLogQuery, { limit: -5 });
+    const errors = await validate(q);
+    expect(errors.find((e) => e.property === 'limit')).toBeDefined();
+  });
+
+  it('rejects decimal limit', async () => {
+    const q = plainToInstance(GetPaymentAuditLogQuery, { limit: 10.5 });
+    const errors = await validate(q);
+    expect(errors.find((e) => e.property === 'limit')).toBeDefined();
+  });
+
+  it('rejects non-numeric limit', async () => {
+    const q = plainToInstance(GetPaymentAuditLogQuery, { limit: 'abc' });
+    const errors = await validate(q);
+    expect(errors.find((e) => e.property === 'limit')).toBeDefined();
+  });
+});

--- a/apps/api/src/finanzas/recurring-expense.controller.ts
+++ b/apps/api/src/finanzas/recurring-expense.controller.ts
@@ -7,6 +7,7 @@ import {
   Body,
   Param,
   UseGuards,
+  UseInterceptors,
   Request,
   ForbiddenException,
 } from '@nestjs/common';
@@ -14,6 +15,7 @@ import type { Role } from '@buildingos/contracts';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { BuildingAccessGuard } from '../tenancy/building-access.guard';
 import { RecurringExpenseService } from './recurring-expense.service';
+import { StrictBooleanInterceptor } from './strict-boolean.interceptor';
 import { AuthenticatedRequest } from '../common/types/request.types';
 import {
   CreateRecurringExpenseDto,
@@ -83,6 +85,7 @@ export class RecurringExpenseController {
    * Update a recurring expense template (enable/disable or modify)
    */
   @Patch(':id')
+  @UseInterceptors(new StrictBooleanInterceptor())
   async updateRecurringExpense(
     @Param('buildingId') buildingId: string,
     @Param('id') recurringId: string,

--- a/apps/api/src/finanzas/recurring-expense.dto.spec.ts
+++ b/apps/api/src/finanzas/recurring-expense.dto.spec.ts
@@ -210,10 +210,44 @@ describe('UpdateRecurringExpenseDto', () => {
   });
 
   describe('invalid payloads', () => {
-    it('rejects non-boolean isActive', async () => {
-      const dto = plainToInstance(UpdateRecurringExpenseDto, {
-        isActive: 'yes',
-      });
+    it('rejects 0 as isActive', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, { isActive: 0 });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'isActive')).toBeDefined();
+    });
+
+    it('rejects 1 as isActive', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, { isActive: 1 });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'isActive')).toBeDefined();
+    });
+
+    it('rejects "true" as isActive', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, { isActive: 'true' });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'isActive')).toBeDefined();
+    });
+
+    it('rejects "false" as isActive', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, { isActive: 'false' });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'isActive')).toBeDefined();
+    });
+
+    it('rejects "yes" as isActive', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, { isActive: 'yes' });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'isActive')).toBeDefined();
+    });
+
+    it('rejects object as isActive', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, { isActive: { a: 1 } });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'isActive')).toBeDefined();
+    });
+
+    it('rejects array as isActive', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, { isActive: [1] });
       const errors = await validate(dto);
       expect(errors.find((e) => e.property === 'isActive')).toBeDefined();
     });

--- a/apps/api/src/finanzas/recurring-expense.dto.spec.ts
+++ b/apps/api/src/finanzas/recurring-expense.dto.spec.ts
@@ -109,6 +109,15 @@ describe('CreateRecurringExpenseDto', () => {
       expect(errors.find((e) => e.property === 'amount')).toBeDefined();
     });
 
+    it('rejects decimal amount (must be integer cents)', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        amount: 10.5,
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'amount')).toBeDefined();
+    });
+
     it('rejects missing currency', async () => {
       const { currency, ...rest } = validPayload;
       const dto = plainToInstance(CreateRecurringExpenseDto, rest);
@@ -225,6 +234,12 @@ describe('UpdateRecurringExpenseDto', () => {
       const dto = plainToInstance(UpdateRecurringExpenseDto, {
         amount: 'invalid',
       });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'amount')).toBeDefined();
+    });
+
+    it('rejects decimal amount (must be integer cents)', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, { amount: 10.5 });
       const errors = await validate(dto);
       expect(errors.find((e) => e.property === 'amount')).toBeDefined();
     });

--- a/apps/api/src/finanzas/recurring-expense.dto.spec.ts
+++ b/apps/api/src/finanzas/recurring-expense.dto.spec.ts
@@ -1,0 +1,238 @@
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import {
+  CreateRecurringExpenseDto,
+  UpdateRecurringExpenseDto,
+} from './recurring-expense.dto';
+
+describe('CreateRecurringExpenseDto', () => {
+  const validPayload = {
+    categoryId: 'cat-1',
+    amount: 5000,
+    currency: 'ARS',
+    concept: 'Expensas mensuales',
+    frequency: 'MONTHLY',
+  };
+
+  describe('valid payloads', () => {
+    it('accepts a complete valid payload', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, validPayload);
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts QUARTERLY frequency', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        frequency: 'QUARTERLY',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts YEARLY frequency', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        frequency: 'YEARLY',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts USD currency', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        currency: 'USD',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts VES currency', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        currency: 'VES',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  describe('invalid payloads', () => {
+    it('rejects missing categoryId', async () => {
+      const { categoryId, ...rest } = validPayload;
+      const dto = plainToInstance(CreateRecurringExpenseDto, rest);
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'categoryId')).toBeDefined();
+    });
+
+    it('rejects empty categoryId', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        categoryId: '',
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'categoryId')).toBeDefined();
+    });
+
+    it('rejects missing amount', async () => {
+      const { amount, ...rest } = validPayload;
+      const dto = plainToInstance(CreateRecurringExpenseDto, rest);
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'amount')).toBeDefined();
+    });
+
+    it('rejects zero amount', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        amount: 0,
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'amount')).toBeDefined();
+    });
+
+    it('rejects negative amount', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        amount: -100,
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'amount')).toBeDefined();
+    });
+
+    it('rejects non-numeric amount', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        amount: 'abc',
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'amount')).toBeDefined();
+    });
+
+    it('rejects missing currency', async () => {
+      const { currency, ...rest } = validPayload;
+      const dto = plainToInstance(CreateRecurringExpenseDto, rest);
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'currency')).toBeDefined();
+    });
+
+    it('rejects invalid currency', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        currency: 'EUR',
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'currency')).toBeDefined();
+    });
+
+    it('rejects missing concept', async () => {
+      const { concept, ...rest } = validPayload;
+      const dto = plainToInstance(CreateRecurringExpenseDto, rest);
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'concept')).toBeDefined();
+    });
+
+    it('rejects empty concept', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        concept: '',
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'concept')).toBeDefined();
+    });
+
+    it('rejects missing frequency', async () => {
+      const { frequency, ...rest } = validPayload;
+      const dto = plainToInstance(CreateRecurringExpenseDto, rest);
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'frequency')).toBeDefined();
+    });
+
+    it('rejects invalid frequency', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        frequency: 'WEEKLY',
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'frequency')).toBeDefined();
+    });
+  });
+});
+
+describe('UpdateRecurringExpenseDto', () => {
+  describe('valid payloads', () => {
+    it('accepts updating only isActive', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, {
+        isActive: false,
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts updating only amount', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, { amount: 7500 });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts updating only concept', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, {
+        concept: 'New concept',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts combining multiple optional fields', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, {
+        isActive: true,
+        amount: 10000,
+        concept: 'Updated concept',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts empty payload (no changes)', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, {});
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  describe('invalid payloads', () => {
+    it('rejects non-boolean isActive', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, {
+        isActive: 'yes',
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'isActive')).toBeDefined();
+    });
+
+    it('rejects zero amount', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, { amount: 0 });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'amount')).toBeDefined();
+    });
+
+    it('rejects negative amount', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, { amount: -50 });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'amount')).toBeDefined();
+    });
+
+    it('rejects non-numeric amount', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, {
+        amount: 'invalid',
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'amount')).toBeDefined();
+    });
+
+    it('rejects empty concept', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, { concept: '' });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'concept')).toBeDefined();
+    });
+  });
+});

--- a/apps/api/src/finanzas/recurring-expense.dto.ts
+++ b/apps/api/src/finanzas/recurring-expense.dto.ts
@@ -1,7 +1,7 @@
 import {
   IsString,
   IsNotEmpty,
-  IsNumber,
+  IsInt,
   IsOptional,
   IsBoolean,
   Min,
@@ -13,7 +13,7 @@ export class CreateRecurringExpenseDto {
   @IsNotEmpty()
   categoryId!: string;
 
-  @IsNumber()
+  @IsInt()
   @Min(1)
   amount!: number;
 
@@ -38,7 +38,7 @@ export class UpdateRecurringExpenseDto {
   isActive?: boolean;
 
   @IsOptional()
-  @IsNumber()
+  @IsInt()
   @Min(1)
   amount?: number;
 

--- a/apps/api/src/finanzas/recurring-expense.dto.ts
+++ b/apps/api/src/finanzas/recurring-expense.dto.ts
@@ -1,14 +1,50 @@
-export interface CreateRecurringExpenseDto {
-  categoryId: string;
-  amount: number; // in cents
-  currency: string; // ISO: ARS, VES, USD
-  concept: string;
-  frequency: 'MONTHLY' | 'QUARTERLY' | 'YEARLY';
+import {
+  IsString,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsBoolean,
+  Min,
+  IsIn,
+} from 'class-validator';
+
+export class CreateRecurringExpenseDto {
+  @IsString()
+  @IsNotEmpty()
+  categoryId!: string;
+
+  @IsNumber()
+  @Min(1)
+  amount!: number;
+
+  @IsString()
+  @IsNotEmpty()
+  @IsIn(['ARS', 'VES', 'USD'])
+  currency!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  concept!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @IsIn(['MONTHLY', 'QUARTERLY', 'YEARLY'])
+  frequency!: 'MONTHLY' | 'QUARTERLY' | 'YEARLY';
 }
 
-export interface UpdateRecurringExpenseDto {
+export class UpdateRecurringExpenseDto {
+  @IsOptional()
+  @IsBoolean()
   isActive?: boolean;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
   amount?: number;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
   concept?: string;
 }
 

--- a/apps/api/src/finanzas/strict-boolean.interceptor.ts
+++ b/apps/api/src/finanzas/strict-boolean.interceptor.ts
@@ -1,0 +1,40 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  BadRequestException,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { Request } from 'express';
+
+/**
+ * Interceptor that validates boolean fields in the raw request body BEFORE
+ * the global ValidationPipe runs.
+ *
+ * Why interceptor and not pipe? The global ValidationPipe uses
+ * `enableImplicitConversion: true`, which causes class-transformer to convert
+ * `0` → `false`, `"true"` → `true`, etc. BEFORE class-validator decorators
+ * execute. A handler-level `@UsePipes()` runs AFTER global pipes, so by the
+ * time a custom pipe sees the value, it's already been converted.
+ *
+ * Interceptors execute before pipes in the NestJS lifecycle:
+ * Middleware → Guards → Interceptors → Pipes → Handler
+ */
+@Injectable()
+export class StrictBooleanInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const req = context.switchToHttp().getRequest<Request>();
+    const body = req.body as Record<string, unknown> | undefined;
+
+    if (body && 'isActive' in body && typeof body.isActive !== 'boolean') {
+      throw new BadRequestException({
+        statusCode: 400,
+        message: ['isActive must be a boolean (true or false)'],
+        error: 'Bad Request',
+      });
+    }
+
+    return next.handle();
+  }
+}

--- a/apps/api/src/finanzas/tenant-finance.controller.ts
+++ b/apps/api/src/finanzas/tenant-finance.controller.ts
@@ -39,7 +39,7 @@ import {
 } from './finanzas.dto';
 import { Payment } from '@prisma/client';
 
-class GetPaymentAuditLogQuery {
+export class GetPaymentAuditLogQuery {
   @IsOptional()
   @Type(() => Number)
   @IsInt()

--- a/apps/api/src/finanzas/tenant-finance.controller.ts
+++ b/apps/api/src/finanzas/tenant-finance.controller.ts
@@ -1,3 +1,10 @@
+import { Type } from 'class-transformer';
+import {
+  IsOptional,
+  IsInt,
+  Min,
+  Max,
+} from 'class-validator';
 import {
   Controller,
   Get,
@@ -32,7 +39,14 @@ import {
 } from './finanzas.dto';
 import { Payment } from '@prisma/client';
 
-interface GetPaymentAuditLogQuery { limit?: number }
+class GetPaymentAuditLogQuery {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number;
+}
 
 /**
  * TenantFinanceController: Tenant-level (aggregated) finance endpoints

--- a/apps/api/src/finanzas/tenant-finance.http.spec.ts
+++ b/apps/api/src/finanzas/tenant-finance.http.spec.ts
@@ -1,0 +1,140 @@
+import { CanActivate, INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request = require('supertest');
+import { TenantFinanceController } from './tenant-finance.controller';
+import { FinanzasService } from './finanzas.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
+
+const mockFinanzasService = {
+  getPaymentAuditLog: jest.fn().mockResolvedValue([]),
+};
+
+const alwaysPass: CanActivate = { canActivate: () => true };
+
+describe('TenantFinanceController — getPaymentAuditLog HTTP', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [TenantFinanceController],
+      providers: [
+        { provide: FinanzasService, useValue: mockFinanzasService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(alwaysPass)
+      .overrideGuard(TenantAccessGuard)
+      .useValue(alwaysPass)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.use((req: any, _res: any, next: any) => {
+      req.tenantId = 't-1';
+      req.user = {
+        id: 'user-1',
+        roles: ['TENANT_ADMIN'],
+        membershipId: 'member-1',
+      };
+      next();
+    });
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: false,
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+      }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const baseUrl = '/tenants/t-1/finance/payments/p-1/audit';
+
+  it('returns 200 with valid limit', async () => {
+    const res = await request(app.getHttpServer())
+      .get(baseUrl)
+      .query({ limit: 20 });
+    expect(res.status).toBe(200);
+  });
+
+  it('passes limit as number to the service', async () => {
+    await request(app.getHttpServer())
+      .get(baseUrl)
+      .query({ limit: 20 });
+    expect(mockFinanzasService.getPaymentAuditLog).toHaveBeenCalledWith(
+      't-1',
+      'p-1',
+      expect.objectContaining({ limit: 20 }),
+    );
+  });
+
+  it('returns 200 when limit is absent (optional field)', async () => {
+    const res = await request(app.getHttpServer()).get(baseUrl);
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 200 when limit is 1 (minimum)', async () => {
+    const res = await request(app.getHttpServer())
+      .get(baseUrl)
+      .query({ limit: 1 });
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 200 when limit is 200 (maximum)', async () => {
+    const res = await request(app.getHttpServer())
+      .get(baseUrl)
+      .query({ limit: 200 });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects limit=0 with 400', async () => {
+    const res = await request(app.getHttpServer())
+      .get(baseUrl)
+      .query({ limit: 0 });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects limit=-1 with 400', async () => {
+    const res = await request(app.getHttpServer())
+      .get(baseUrl)
+      .query({ limit: -1 });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects decimal limit with 400', async () => {
+    const res = await request(app.getHttpServer())
+      .get(baseUrl)
+      .query({ limit: 10.5 });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects non-numeric limit with 400', async () => {
+    const res = await request(app.getHttpServer())
+      .get(baseUrl)
+      .query({ limit: 'abc' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects limit>200 with 400', async () => {
+    const res = await request(app.getHttpServer())
+      .get(baseUrl)
+      .query({ limit: 201 });
+    expect(res.status).toBe(400);
+  });
+
+  it('does not call service when limit validation fails', async () => {
+    await request(app.getHttpServer())
+      .get(baseUrl)
+      .query({ limit: 0 });
+    expect(mockFinanzasService.getPaymentAuditLog).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #131

## Problema

Varios endpoints financieros activos reciben payloads definidos como interfaces TypeScript o clases sin decoradores de `class-validator`.

Las interfaces desaparecen en runtime, por lo que el `ValidationPipe` global no puede validar ni transformar esos payloads antes de que lleguen a la capa de servicios. Esto significa que inputs inválidos (períos malformados, montos no numéricos, monedas/frecuencias no válidas, IDs vacíos) pasan directamente al service layer sin validación runtime.

## Solución

Convertir DTOs financieros activos de `interface` o tipos planos a clases concretas con decoradores de `class-validator` y `class-transformer`:

| DTO | Archivo | Cambio |
|---|---|---|
| `ImportExpensesDto` | `expense-import.dto.ts` | Interface → class con `@IsString`, `@IsNotEmpty`, `@Matches` (YYYY-MM) |
| `ExpenseImportRowDto` | `expense-import.dto.ts` | Nuevo class para validar cada fila de importación |
| `CreateRecurringExpenseDto` | `recurring-expense.dto.ts` | Interface → class con `@IsInt` para montos (enteros), `@IsIn` para currency y frequency |
| `UpdateRecurringExpenseDto` | `recurring-expense.dto.ts` | Interface → class con `@IsBoolean`, `@IsInt`, `@Min(1)` |
| `ListExpensesQuery` | `expenses.controller.ts` | Plain class → decorated class con `@Matches` para period, `@Type(() => Number)` para limit/offset |
| `GetPaymentAuditLogQuery` | `tenant-finance.controller.ts` | Interface → class con `@Type(() => Number)`, `@IsInt`, `@Min(1)`, `@Max(200)` |

Reglas de validación agregadas:
- Períodos: formato `YYYY-MM` con mes entre 01-12
- IDs requeridos: `@IsString()` + `@IsNotEmpty()`
- Montos: `@IsInt()` + `@Min(1)` — enteros estrictos (centavos), rechaza decimales
- Monedas: `@IsIn([ARS, VES, USD])` — solo monedas admitidas por el contrato actual
- Frecuencias: `@IsIn([MONTHLY, QUARTERLY, YEARLY])` — solo valores vigentes
- Conceptos: `@IsString()` + `@IsNotEmpty()`
- Booleanos: `@IsBoolean()` con `@IsOptional()` + `StrictBooleanInterceptor` para rechazar `0`, `1`, `"true"`, `"false"`, `"yes"`, objects, arrays en el body raw ANTES del ValidationPipe
- Límites de query: `@Type(() => Number)` + `@IsInt()` + `@Min()` / `@Max()`

### StrictBooleanInterceptor

El ValidationPipe global usa `enableImplicitConversion: true`, que convierte `0` → `false`, `"true"` → `true` ANTES de que `@IsBoolean()` ejecute. Esto significa que `@IsBoolean()` solo ve valores ya convertidos, making strict rejection impossible at the validator level.

**Solución**: `StrictBooleanInterceptor` — un NestJS interceptor que valida el body raw en `req.body` ANTES de que los pipes ejecuten (el orden de ejecución NestJS es: Middleware → Guards → **Interceptors** → Pipes → Handler). Rechaza `isActive` que no sea un booleano JSON literal (`true`/`false`) con HTTP 400.

## Contrato preservado

- Los payloads válidos actuales del frontend (period YYYY-MM, montos numéricos, monedas ARS/VES/USD, frecuencias MONTHLY/QUARTERLY/YEARLY) continúan siendo aceptados.
- Los campos opcionales (`columnMapping`, `proveedor`, `limit`, `offset`, `isActive`, etc.) siguen siendo opcionales.
- `ExpenseImportRow` y `ExpenseImportResult` se mantienen como interfaces (son tipos de respuesta, no de entrada).
- `RecurringExpenseDto` se mantiene como interface (tipo de respuesta).

## Pruebas

### DTO unit tests (65 tests)
- `expense-import.dto.spec.ts` — 20 tests: period format, row required fields, empty values
- `recurring-expense.dto.spec.ts` — 35 tests: currency, frequency, amount integer, categoryId, concept, strict boolean rejection (0, 1, "true", "false", "yes", object, array)
- `get-payment-audit-log-query.dto.spec.ts` — 10 tests: limit min/max, transform, decimal rejection

### Controller + ValidationPipe integration tests (32 tests)
- `finanzas-validation.integration.spec.ts` — NestJS TestingModule with real ValidationPipe config matching `main.ts`:
  - ExpensesController `import/from-excel`: period format, rows missing/empty, service delegation
  - ExpensesController `listExpenses`: period format, limit/offset validation
  - RecurringExpenseController `create`: decimal amount rejection, currency, frequency, categoryId, concept
  - RecurringExpenseController `update`: strict boolean isActive (true→200, false→200, 0→400, 1→400, "true"→400, "false"→400, "yes"→400, object→400, array→400), decimal amount, concept, service delegation

### TenantFinanceController HTTP tests (11 tests)
- `tenant-finance.http.spec.ts` — NestJS TestingModule with real ValidationPipe for `GetPaymentAuditLogQuery`:
  - limit=20 → 200, service receives number 20
  - limit absent → 200
  - limit=1, limit=200 → 200 (boundary)
  - limit=0, -1, 10.5, "abc", 201 → 400
  - Service not called on validation failure

### Totales
- **154 suites, 1974 tests passing**
- `tsc --noEmit` limpio
- `git diff --check` limpio

## Alcance

Backend financiero focalizado: DTOs, controllers, interceptors y tests.

## Exclusiones

- No LiquidationEngineController
- No issue #126
- No FinanzasService refactor
- No frontend
- No Prisma schema
- No migraciones
- No seeds
- No staging
- No producción

## Checklist local-first

- [x] Pruebas locales verdes
- [x] Lint focalizado
- [x] Typecheck (`tsc --noEmit`)