### PR TITLE
feat(finance): add tenant shared recurring expenses

### DIFF
--- a/apps/api/prisma/migrations/20260807000000_add_recurring_expense_tenant_shared/migration.sql
+++ b/apps/api/prisma/migrations/20260807000000_add_recurring_expense_tenant_shared/migration.sql
@@ -1,0 +1,42 @@
+-- CreateEnum: RecurringExpenseAllocationMode
+CREATE TYPE "RecurringExpenseAllocationMode" AS ENUM ('MANUAL', 'EQUAL_SHARE', 'BUILDING_TOTAL_M2');
+
+-- AlterTable: Make buildingId nullable and add scopeType/allocationMode to RecurringExpense
+ALTER TABLE "RecurringExpense" ALTER COLUMN "buildingId" DROP NOT NULL;
+ALTER TABLE "RecurringExpense" ADD COLUMN "scopeType" "MovementScope" NOT NULL DEFAULT 'BUILDING';
+ALTER TABLE "RecurringExpense" ADD COLUMN "allocationMode" "RecurringExpenseAllocationMode";
+
+-- CreateTable: RecurringExpenseAllocation (percentage-only template for MANUAL mode)
+CREATE TABLE "RecurringExpenseAllocation" (
+    "id" TEXT NOT NULL,
+    "recurringExpenseId" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "buildingId" TEXT NOT NULL,
+    "percentage" DOUBLE PRECISION NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RecurringExpenseAllocation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex: Unique constraint for building per recurring expense
+CREATE UNIQUE INDEX "RecurringExpenseAllocation_recurringExpenseId_buildingId_key" ON "RecurringExpenseAllocation"("recurringExpenseId", "buildingId");
+
+-- CreateIndex: Index for tenant lookups
+CREATE INDEX "RecurringExpenseAllocation_tenantId_recurringExpenseId_idx" ON "RecurringExpenseAllocation"("tenantId", "recurringExpenseId");
+
+-- CreateIndex: Scope type index for RecurringExpense
+CREATE INDEX "RecurringExpense_tenantId_scopeType_idx" ON "RecurringExpense"("tenantId", "scopeType");
+
+-- AddForeignKey: RecurringExpenseAllocation -> RecurringExpense
+ALTER TABLE "RecurringExpenseAllocation" ADD CONSTRAINT "RecurringExpenseAllocation_recurringExpenseId_fkey" FOREIGN KEY ("recurringExpenseId") REFERENCES "RecurringExpense"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey: RecurringExpenseAllocation -> Tenant
+ALTER TABLE "RecurringExpenseAllocation" ADD CONSTRAINT "RecurringExpenseAllocation_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey: RecurringExpenseAllocation -> Building
+ALTER TABLE "RecurringExpenseAllocation" ADD CONSTRAINT "RecurringExpenseAllocation_buildingId_fkey" FOREIGN KEY ("buildingId") REFERENCES "Building"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- UpdateForeignKey: RecurringExpense -> Building (now nullable, CASCADE on delete)
+ALTER TABLE "RecurringExpense" DROP CONSTRAINT "RecurringExpense_buildingId_fkey";
+ALTER TABLE "RecurringExpense" ADD CONSTRAINT "RecurringExpense_buildingId_fkey" FOREIGN KEY ("buildingId") REFERENCES "Building"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -123,6 +123,12 @@ enum MovementScope {
   UNIT_GROUP      // Se reparte solo entre un grupo de unidades
 }
 
+enum RecurringExpenseAllocationMode {
+  MANUAL            // Porcentajes fijos en RecurringExpenseAllocation
+  EQUAL_SHARE       // Reparto igualitario dinámico
+  BUILDING_TOTAL_M2 // Proporcional a m² totales dinámico
+}
+
 enum IncomeDestination {
   APPLY_TO_EXPENSES  // Baja el neto a prorratear
   RESERVE_FUND       // Va a fondo de reserva (no afecta liquidación)
@@ -234,6 +240,7 @@ model Tenant {
   expenseLedgerCategories  ExpenseLedgerCategory[]
   expenses                 Expense[]
   recurringExpenses        RecurringExpense[]
+  recurringExpenseAllocations RecurringExpenseAllocation[]
   incomes                  Income[]
   movementAllocations      MovementAllocation[]
   unitGroups               UnitGroup[]
@@ -426,6 +433,7 @@ model Building {
   expensePeriods       ExpensePeriod[]
   expenses             Expense[]
   recurringExpenses    RecurringExpense[]
+  recurringExpenseAllocations RecurringExpenseAllocation[]
   incomes              Income[]
   movementAllocations  MovementAllocation[]
   unitGroups           UnitGroup[]
@@ -1759,26 +1767,47 @@ model Expense {
 // FINANZAS: RecurringExpense (Templates for auto-generated DRAFT expenses)
 // ============================================================================
 model RecurringExpense {
-  id            String   @id @default(cuid())
+  id            String        @id @default(cuid())
   tenantId      String
-  buildingId    String
+  buildingId    String?
+  scopeType     MovementScope @default(BUILDING)
+  allocationMode RecurringExpenseAllocationMode? // Solo para TENANT_SHARED
   categoryId    String
-  amount        Int      // En centavos
-  currency      String   // ISO: ARS, VES, USD
-  concept       String   // Descripción del gasto (ej: "Electricidad Base")
-  frequency     String   // MONTHLY, QUARTERLY, YEARLY
-  nextRunDate   DateTime // Próxima fecha de ejecución
-  isActive      Boolean  @default(true)
-  createdAt     DateTime @default(now())
-  updatedAt     DateTime @updatedAt
+  amount        Int           // En centavos
+  currency      String        // ISO: ARS, VES, USD
+  concept       String        // Descripción del gasto (ej: "Electricidad Base")
+  frequency     String        // MONTHLY, QUARTERLY, YEARLY
+  nextRunDate   DateTime      // Próxima fecha de ejecución
+  isActive      Boolean       @default(true)
+  createdAt     DateTime      @default(now())
+  updatedAt     DateTime      @updatedAt
 
-  tenant   Tenant                @relation(fields: [tenantId], references: [id], onDelete: Cascade)
-  building Building              @relation(fields: [buildingId], references: [id], onDelete: Cascade)
-  category ExpenseLedgerCategory @relation(fields: [categoryId], references: [id], onDelete: Restrict)
+  tenant      Tenant                @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  building    Building?             @relation(fields: [buildingId], references: [id], onDelete: Cascade)
+  category    ExpenseLedgerCategory @relation(fields: [categoryId], references: [id], onDelete: Restrict)
+  allocations RecurringExpenseAllocation[]
 
   @@index([tenantId, buildingId, nextRunDate])
   @@index([isActive, nextRunDate])
   @@index([tenantId, isActive])
+  @@index([tenantId, scopeType])
+}
+
+model RecurringExpenseAllocation {
+  id                 String   @id @default(cuid())
+  recurringExpenseId String
+  tenantId           String
+  buildingId         String
+  percentage         Float
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+
+  recurringExpense RecurringExpense @relation(fields: [recurringExpenseId], references: [id], onDelete: Cascade)
+  tenant           Tenant           @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  building         Building         @relation(fields: [buildingId], references: [id], onDelete: Restrict)
+
+  @@unique([recurringExpenseId, buildingId])
+  @@index([tenantId, recurringExpenseId])
 }
 
 // ============================================================================

--- a/apps/api/src/finanzas/finanzas-validation.integration.spec.ts
+++ b/apps/api/src/finanzas/finanzas-validation.integration.spec.ts
@@ -4,6 +4,7 @@ import request = require('supertest');
 import { ExpensesController } from './expenses.controller';
 import { ExpensesService } from './expenses.service';
 import { RecurringExpenseController } from './recurring-expense.controller';
+import { TenantRecurringExpenseController } from './tenant-recurring-expense.controller';
 import { RecurringExpenseService } from './recurring-expense.service';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
@@ -47,7 +48,7 @@ describe('Finance ValidationPipe integration', () => {
 
   beforeAll(async () => {
     const moduleFixture: TestingModule = await Test.createTestingModule({
-      controllers: [ExpensesController, RecurringExpenseController],
+      controllers: [ExpensesController, RecurringExpenseController, TenantRecurringExpenseController],
       providers: [
         { provide: ExpensesService, useValue: mockExpensesService },
         { provide: RecurringExpenseService, useValue: mockRecurringExpenseService },
@@ -377,7 +378,200 @@ describe('Finance ValidationPipe integration', () => {
       await request(app.getHttpServer())
         .patch(baseUrl)
         .send({ amount: 7500, concept: 'Updated' });
-      expect(mockRecurringExpenseService.updateRecurringExpense).toHaveBeenCalled();
+      expect(mockRecurringExpenseService.updateRecurringExpense).toHaveBeenCalledWith(
+        't-1',
+        're-1',
+        expect.objectContaining({ amount: 7500, concept: 'Updated' }),
+        { scopeType: 'BUILDING', buildingId: 'b-1' },
+      );
+    });
+  });
+
+  describe('RecurringExpenseController — create with scopeType', () => {
+    const baseUrl = '/buildings/b-1/recurring-expenses';
+
+    it('rejects invalid scopeType', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          categoryId: 'cat-1',
+          amount: 5000,
+          currency: 'ARS',
+          concept: 'Test',
+          frequency: 'MONTHLY',
+          scopeType: 'UNIT_GROUP',
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects invalid allocationMode', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          categoryId: 'cat-1',
+          amount: 5000,
+          currency: 'ARS',
+          concept: 'Test',
+          frequency: 'MONTHLY',
+          scopeType: 'TENANT_SHARED',
+          allocationMode: 'INVALID',
+          allocations: [{ buildingId: 'bld-1', percentage: 100 }],
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects empty allocations for TENANT_SHARED', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          categoryId: 'cat-1',
+          amount: 5000,
+          currency: 'ARS',
+          concept: 'Test',
+          frequency: 'MONTHLY',
+          scopeType: 'TENANT_SHARED',
+          allocationMode: 'EQUAL_SHARE',
+          allocations: [],
+        });
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe('TenantRecurringExpenseController — create', () => {
+    const baseUrl = '/tenants/t-1/recurring-expenses';
+
+    it('rejects decimal amount', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          categoryId: 'cat-1',
+          amount: 10.5,
+          currency: 'ARS',
+          concept: 'Test',
+          frequency: 'MONTHLY',
+          allocationMode: 'EQUAL_SHARE',
+          allocations: [{ buildingId: 'bld-1', percentage: 100 }],
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects invalid currency', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          categoryId: 'cat-1',
+          amount: 5000,
+          currency: 'EUR',
+          concept: 'Test',
+          frequency: 'MONTHLY',
+          allocationMode: 'EQUAL_SHARE',
+          allocations: [{ buildingId: 'bld-1', percentage: 100 }],
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects invalid frequency', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          categoryId: 'cat-1',
+          amount: 5000,
+          currency: 'ARS',
+          concept: 'Test',
+          frequency: 'WEEKLY',
+          allocationMode: 'EQUAL_SHARE',
+          allocations: [{ buildingId: 'bld-1', percentage: 100 }],
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects empty allocations for TENANT_SHARED', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          categoryId: 'cat-1',
+          amount: 5000,
+          currency: 'ARS',
+          concept: 'Test',
+          frequency: 'MONTHLY',
+          allocationMode: 'EQUAL_SHARE',
+          allocations: [],
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects empty concept', async () => {
+      const res = await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          categoryId: 'cat-1',
+          amount: 5000,
+          currency: 'ARS',
+          concept: '',
+          frequency: 'MONTHLY',
+          allocationMode: 'EQUAL_SHARE',
+          allocations: [{ buildingId: 'bld-1', percentage: 100 }],
+        });
+      expect(res.status).toBe(400);
+    });
+
+    it('calls service for valid TENANT_SHARED payload', async () => {
+      await request(app.getHttpServer())
+        .post(baseUrl)
+        .send({
+          categoryId: 'cat-1',
+          amount: 5000,
+          currency: 'ARS',
+          concept: 'Expensas compartidas',
+          frequency: 'MONTHLY',
+          allocationMode: 'EQUAL_SHARE',
+          allocations: [{ buildingId: 'bld-1', percentage: 100 }],
+        });
+      expect(mockRecurringExpenseService.createRecurringExpense).toHaveBeenCalled();
+    });
+  });
+
+  describe('TenantRecurringExpenseController — update', () => {
+    const baseUrl = '/tenants/t-1/recurring-expenses/re-1';
+
+    it('accepts true as isActive', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ isActive: true });
+      expect(res.status).toBe(200);
+    });
+
+    it('rejects 0 as isActive', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ isActive: 0 });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects invalid allocationMode', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ allocationMode: 'INVALID' });
+      expect(res.status).toBe(400);
+    });
+
+    it('rejects empty allocations', async () => {
+      const res = await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ allocations: [] });
+      expect(res.status).toBe(400);
+    });
+
+    it('calls service for valid update', async () => {
+      await request(app.getHttpServer())
+        .patch(baseUrl)
+        .send({ amount: 7500, concept: 'Updated' });
+      expect(mockRecurringExpenseService.updateRecurringExpense).toHaveBeenCalledWith(
+        't-1',
+        're-1',
+        expect.objectContaining({ amount: 7500, concept: 'Updated' }),
+        { scopeType: 'TENANT_SHARED', buildingId: null },
+      );
     });
   });
 });

--- a/apps/api/src/finanzas/finanzas.module.ts
+++ b/apps/api/src/finanzas/finanzas.module.ts
@@ -45,6 +45,7 @@ import { ExpenseReportsController } from './expense-reports.controller';
 import { ExpenseReportsService } from './expense-reports.service';
 import { ExpenseImportService } from './expense-import.service';
 import { RecurringExpenseController } from './recurring-expense.controller';
+import { TenantRecurringExpenseController } from './tenant-recurring-expense.controller';
 import { RecurringExpenseService } from './recurring-expense.service';
 import { FinanceSummaryService } from './finance-summary.service';
 import { PaymentReceiptService } from '../receipts/payment-receipt.service';
@@ -79,6 +80,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     VendorPreferenceController,
     ExpenseReportsController,
     RecurringExpenseController,
+    TenantRecurringExpenseController,
     PaymentWebhookController,
   ],
   providers: [

--- a/apps/api/src/finanzas/movement-allocation.service.ts
+++ b/apps/api/src/finanzas/movement-allocation.service.ts
@@ -30,11 +30,11 @@ type MovementAllocationWithBuilding = Prisma.MovementAllocationGetPayload<{
 const PERCENTAGE_SCALE = 10_000;
 const TOTAL_PERCENTAGE_BASIS_POINTS = 100 * PERCENTAGE_SCALE;
 
-function toBasisPoints(percentage: number): number {
+export function toBasisPoints(percentage: number): number {
   return Math.round(percentage * PERCENTAGE_SCALE);
 }
 
-function allocateByLargestRemainder(
+export function allocateByLargestRemainder(
   totalAmountMinor: number,
   allocations: CreateAllocationInput[],
 ): number[] {
@@ -214,6 +214,35 @@ export class MovementAllocationService {
       entityType: 'MovementAllocation',
       entityId: expenseId,
       metadata: { allocationCount: allocations.length, totalAmount: amountMinor },
+    });
+  }
+
+  /**
+   * Creates MovementAllocations inside an existing Prisma transaction.
+   * Does NOT validate (caller must validate beforehand).
+   * Does NOT audit (caller handles audit after commit).
+   */
+  async createForExpenseInTx(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    expenseId: string,
+    amountMinor: number,
+    currencyCode: string,
+    allocations: CreateAllocationInput[],
+  ): Promise<void> {
+    const allocatedAmounts = allocations.some((alloc) => alloc.percentage !== undefined && alloc.percentage !== null)
+      ? allocateByLargestRemainder(amountMinor, allocations)
+      : allocations.map((alloc) => alloc.amountMinor!);
+
+    await tx.movementAllocation.createMany({
+      data: allocations.map((alloc, index) => ({
+        tenantId,
+        expenseId,
+        buildingId: alloc.buildingId,
+        percentage: alloc.percentage ?? null,
+        amountMinor: allocatedAmounts[index],
+        currencyCode,
+      })),
     });
   }
 

--- a/apps/api/src/finanzas/recurring-expense.controller.spec.ts
+++ b/apps/api/src/finanzas/recurring-expense.controller.spec.ts
@@ -1,0 +1,149 @@
+import { ForbiddenException } from '@nestjs/common';
+import { RecurringExpenseController } from './recurring-expense.controller';
+import { TenantRecurringExpenseController } from './tenant-recurring-expense.controller';
+import type { AuthenticatedRequest } from '../common/types/request.types';
+
+const stubReq = (
+  roles: string[],
+  tenantId = 'tenant-1',
+): AuthenticatedRequest =>
+  ({
+    tenantId,
+    user: {
+      id: 'user-1',
+      email: 'admin@test.com',
+      membershipId: 'member-1',
+      roles,
+    },
+  }) as AuthenticatedRequest;
+
+describe('RecurringExpenseController — role access', () => {
+  let controller: RecurringExpenseController;
+  let service: {
+    createRecurringExpense: jest.Mock;
+    listRecurringExpenses: jest.Mock;
+    updateRecurringExpense: jest.Mock;
+  };
+
+  beforeEach(() => {
+    service = {
+      createRecurringExpense: jest.fn().mockResolvedValue({ id: 're-1' }),
+      listRecurringExpenses: jest.fn().mockResolvedValue([]),
+      updateRecurringExpense: jest.fn().mockResolvedValue({ id: 're-1' }),
+    };
+    controller = new RecurringExpenseController(service as never);
+  });
+
+  it('fails closed for residents, empty roles and unknown roles on create/update', async () => {
+    const baseDto = {
+      categoryId: 'cat-1',
+      amount: 5000,
+      currency: 'ARS',
+      concept: 'Test',
+      frequency: 'MONTHLY',
+    };
+
+    for (const roles of [[], ['RESIDENT'], ['UNKNOWN_ROLE']]) {
+      await expect(
+        controller.createRecurringExpense('b-1', baseDto, stubReq(roles)),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      await expect(
+        controller.updateRecurringExpense('b-1', 're-1', { amount: 1 }, stubReq(roles)),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    }
+
+    expect(service.createRecurringExpense).not.toHaveBeenCalled();
+    expect(service.updateRecurringExpense).not.toHaveBeenCalled();
+  });
+
+  it('allows TENANT_ADMIN and passes BUILDING scope context with buildingId to the service', async () => {
+    const admin = stubReq(['TENANT_ADMIN']);
+    const baseDto = {
+      categoryId: 'cat-1',
+      amount: 5000,
+      currency: 'ARS',
+      concept: 'Test',
+      frequency: 'MONTHLY',
+    };
+
+    await controller.createRecurringExpense('b-1', baseDto, admin);
+    expect(service.createRecurringExpense).toHaveBeenCalledWith(
+      'tenant-1',
+      baseDto,
+      'b-1',
+    );
+
+    await controller.updateRecurringExpense('b-1', 're-1', { amount: 1 }, admin);
+    expect(service.updateRecurringExpense).toHaveBeenCalledWith(
+      'tenant-1',
+      're-1',
+      { amount: 1 },
+      { scopeType: 'BUILDING', buildingId: 'b-1' },
+    );
+  });
+});
+
+describe('TenantRecurringExpenseController — role access', () => {
+  let controller: TenantRecurringExpenseController;
+  let service: {
+    createRecurringExpense: jest.Mock;
+    listRecurringExpenses: jest.Mock;
+    updateRecurringExpense: jest.Mock;
+  };
+
+  beforeEach(() => {
+    service = {
+      createRecurringExpense: jest.fn().mockResolvedValue({ id: 're-1' }),
+      listRecurringExpenses: jest.fn().mockResolvedValue([]),
+      updateRecurringExpense: jest.fn().mockResolvedValue({ id: 're-1' }),
+    };
+    controller = new TenantRecurringExpenseController(service as never);
+  });
+
+  it('fails closed for residents, empty roles and unknown roles on create/update', async () => {
+    const baseDto = {
+      categoryId: 'cat-1',
+      amount: 5000,
+      currency: 'ARS',
+      concept: 'Test',
+      frequency: 'MONTHLY',
+    };
+
+    for (const roles of [[], ['RESIDENT'], ['UNKNOWN_ROLE']]) {
+      await expect(
+        controller.createRecurringExpense('tenant-1', baseDto, stubReq(roles)),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      await expect(
+        controller.updateRecurringExpense('tenant-1', 're-1', { amount: 1 }, stubReq(roles)),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    }
+
+    expect(service.createRecurringExpense).not.toHaveBeenCalled();
+    expect(service.updateRecurringExpense).not.toHaveBeenCalled();
+  });
+
+  it('allows TENANT_OWNER and passes TENANT_SHARED scope context with buildingId null to the service', async () => {
+    const owner = stubReq(['TENANT_OWNER']);
+    const baseDto = {
+      categoryId: 'cat-1',
+      amount: 5000,
+      currency: 'ARS',
+      concept: 'Test',
+      frequency: 'MONTHLY',
+    };
+
+    await controller.createRecurringExpense('tenant-1', baseDto, owner);
+    expect(service.createRecurringExpense).toHaveBeenCalledWith(
+      'tenant-1',
+      baseDto,
+    );
+
+    await controller.updateRecurringExpense('tenant-1', 're-1', { amount: 1 }, owner);
+    expect(service.updateRecurringExpense).toHaveBeenCalledWith(
+      'tenant-1',
+      're-1',
+      { amount: 1 },
+      { scopeType: 'TENANT_SHARED', buildingId: null },
+    );
+  });
+});

--- a/apps/api/src/finanzas/recurring-expense.dto.spec.ts
+++ b/apps/api/src/finanzas/recurring-expense.dto.spec.ts
@@ -1,9 +1,96 @@
+import 'reflect-metadata';
 import { validate } from 'class-validator';
 import { plainToInstance } from 'class-transformer';
 import {
   CreateRecurringExpenseDto,
   UpdateRecurringExpenseDto,
+  RecurringExpenseAllocationInputDto,
 } from './recurring-expense.dto';
+
+describe('RecurringExpenseAllocationInputDto', () => {
+  describe('valid payloads', () => {
+    it('accepts buildingId with percentage', async () => {
+      const dto = plainToInstance(RecurringExpenseAllocationInputDto, {
+        buildingId: 'bld-1',
+        percentage: 50,
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('rejects allocation with amountMinor only (percentage is required)', async () => {
+      const dto = plainToInstance(RecurringExpenseAllocationInputDto, {
+        buildingId: 'bld-1',
+        amountMinor: 5000,
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'percentage')).toBeDefined();
+    });
+
+    it('rejects missing percentage', async () => {
+      const dto = plainToInstance(RecurringExpenseAllocationInputDto, {
+        buildingId: 'bld-1',
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'percentage')).toBeDefined();
+    });
+  });
+
+  describe('invalid payloads', () => {
+    it('rejects missing buildingId', async () => {
+      const dto = plainToInstance(RecurringExpenseAllocationInputDto, {
+        percentage: 50,
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'buildingId')).toBeDefined();
+    });
+
+    it('rejects empty buildingId', async () => {
+      const dto = plainToInstance(RecurringExpenseAllocationInputDto, {
+        buildingId: '',
+        percentage: 50,
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'buildingId')).toBeDefined();
+    });
+
+    it('rejects negative percentage', async () => {
+      const dto = plainToInstance(RecurringExpenseAllocationInputDto, {
+        buildingId: 'bld-1',
+        percentage: -10,
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'percentage')).toBeDefined();
+    });
+
+    it('rejects decimal percentage (must be integer)', async () => {
+      const dto = plainToInstance(RecurringExpenseAllocationInputDto, {
+        buildingId: 'bld-1',
+        percentage: 50.5,
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'percentage')).toBeDefined();
+    });
+
+    it('rejects non-numeric percentage', async () => {
+      const dto = plainToInstance(RecurringExpenseAllocationInputDto, {
+        buildingId: 'bld-1',
+        percentage: 'abc',
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'percentage')).toBeDefined();
+    });
+
+    it('rejects percentage above 100', async () => {
+      const dto = plainToInstance(RecurringExpenseAllocationInputDto, {
+        buildingId: 'bld-1',
+        percentage: 150,
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'percentage')).toBeDefined();
+    });
+  });
+});
 
 describe('CreateRecurringExpenseDto', () => {
   const validPayload = {
@@ -53,6 +140,71 @@ describe('CreateRecurringExpenseDto', () => {
         ...validPayload,
         currency: 'VES',
       });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts BUILDING scopeType', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        scopeType: 'BUILDING',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts TENANT_SHARED scopeType with allocations', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'EQUAL_SHARE',
+        allocations: [
+          { buildingId: 'bld-1', percentage: 50 },
+          { buildingId: 'bld-2', percentage: 50 },
+        ],
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts allocationMode EQUAL_SHARE', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'EQUAL_SHARE',
+        allocations: [{ buildingId: 'bld-1', percentage: 100 }],
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts allocationMode BUILDING_TOTAL_M2', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'BUILDING_TOTAL_M2',
+        allocations: [{ buildingId: 'bld-1', percentage: 100 }],
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts allocationMode MANUAL with percentage allocations', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'MANUAL',
+        allocations: [
+          { buildingId: 'bld-1', percentage: 50 },
+          { buildingId: 'bld-2', percentage: 50 },
+        ],
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts optional scopeType (defaults to BUILDING at service level)', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, validPayload);
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);
     });
@@ -165,6 +317,37 @@ describe('CreateRecurringExpenseDto', () => {
       const errors = await validate(dto);
       expect(errors.find((e) => e.property === 'frequency')).toBeDefined();
     });
+
+    it('rejects invalid scopeType', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        scopeType: 'UNIT_GROUP',
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'scopeType')).toBeDefined();
+    });
+
+    it('rejects invalid allocationMode', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'INVALID',
+        allocations: [{ buildingId: 'bld-1', percentage: 100 }],
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'allocationMode')).toBeDefined();
+    });
+
+    it('rejects empty allocations array', async () => {
+      const dto = plainToInstance(CreateRecurringExpenseDto, {
+        ...validPayload,
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'EQUAL_SHARE',
+        allocations: [],
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'allocations')).toBeDefined();
+    });
   });
 });
 
@@ -204,6 +387,37 @@ describe('UpdateRecurringExpenseDto', () => {
 
     it('accepts empty payload (no changes)', async () => {
       const dto = plainToInstance(UpdateRecurringExpenseDto, {});
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts updating allocationMode', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, {
+        allocationMode: 'BUILDING_TOTAL_M2',
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts updating allocations', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, {
+        allocations: [
+          { buildingId: 'bld-1', percentage: 60 },
+          { buildingId: 'bld-2', percentage: 40 },
+        ],
+      });
+      const errors = await validate(dto);
+      expect(errors).toHaveLength(0);
+    });
+
+    it('accepts updating both allocationMode and allocations', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, {
+        allocationMode: 'MANUAL',
+        allocations: [
+          { buildingId: 'bld-1', percentage: 60 },
+          { buildingId: 'bld-2', percentage: 40 },
+        ],
+      });
       const errors = await validate(dto);
       expect(errors).toHaveLength(0);
     });
@@ -282,6 +496,22 @@ describe('UpdateRecurringExpenseDto', () => {
       const dto = plainToInstance(UpdateRecurringExpenseDto, { concept: '' });
       const errors = await validate(dto);
       expect(errors.find((e) => e.property === 'concept')).toBeDefined();
+    });
+
+    it('rejects invalid allocationMode', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, {
+        allocationMode: 'INVALID',
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'allocationMode')).toBeDefined();
+    });
+
+    it('rejects empty allocations array', async () => {
+      const dto = plainToInstance(UpdateRecurringExpenseDto, {
+        allocations: [],
+      });
+      const errors = await validate(dto);
+      expect(errors.find((e) => e.property === 'allocations')).toBeDefined();
     });
   });
 });

--- a/apps/api/src/finanzas/recurring-expense.dto.ts
+++ b/apps/api/src/finanzas/recurring-expense.dto.ts
@@ -1,3 +1,4 @@
+import { Type } from 'class-transformer';
 import {
   IsString,
   IsNotEmpty,
@@ -5,10 +6,42 @@ import {
   IsOptional,
   IsBoolean,
   Min,
+  Max,
   IsIn,
+  IsArray,
+  ValidateNested,
+  ArrayMinSize,
 } from 'class-validator';
 
+export class RecurringExpenseAllocationInputDto {
+  @IsString()
+  @IsNotEmpty()
+  buildingId!: string;
+
+  @IsInt()
+  @Min(0)
+  @Max(100)
+  percentage!: number;
+}
+
 export class CreateRecurringExpenseDto {
+  @IsOptional()
+  @IsString()
+  @IsIn(['BUILDING', 'TENANT_SHARED'])
+  scopeType?: 'BUILDING' | 'TENANT_SHARED';
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['MANUAL', 'EQUAL_SHARE', 'BUILDING_TOTAL_M2'])
+  allocationMode?: 'MANUAL' | 'EQUAL_SHARE' | 'BUILDING_TOTAL_M2';
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => RecurringExpenseAllocationInputDto)
+  allocations?: RecurringExpenseAllocationInputDto[];
+
   @IsString()
   @IsNotEmpty()
   categoryId!: string;
@@ -46,12 +79,35 @@ export class UpdateRecurringExpenseDto {
   @IsString()
   @IsNotEmpty()
   concept?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsIn(['MANUAL', 'EQUAL_SHARE', 'BUILDING_TOTAL_M2'])
+  allocationMode?: 'MANUAL' | 'EQUAL_SHARE' | 'BUILDING_TOTAL_M2';
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMinSize(1)
+  @ValidateNested({ each: true })
+  @Type(() => RecurringExpenseAllocationInputDto)
+  allocations?: RecurringExpenseAllocationInputDto[];
+}
+
+export interface RecurringExpenseAllocationDto {
+  id: string;
+  recurringExpenseId: string;
+  buildingId: string;
+  percentage: number;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface RecurringExpenseDto {
   id: string;
   tenantId: string;
-  buildingId: string;
+  buildingId: string | null;
+  scopeType: string;
+  allocationMode: string | null;
   categoryId: string;
   amount: number;
   currency: string;

--- a/apps/api/src/finanzas/recurring-expense.service.spec.ts
+++ b/apps/api/src/finanzas/recurring-expense.service.spec.ts
@@ -1,0 +1,1365 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BadRequestException, Logger, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { MovementAllocationService } from './movement-allocation.service';
+import { RecurringExpenseService } from './recurring-expense.service';
+import {
+  CreateRecurringExpenseDto,
+  UpdateRecurringExpenseDto,
+} from './recurring-expense.dto';
+
+describe('RecurringExpenseService', () => {
+  let service: RecurringExpenseService;
+  let prisma: PrismaService;
+  let auditService: AuditService;
+  let movementAllocationService: MovementAllocationService;
+  let tx: Record<string, any>;
+  let loggerErrorSpy: jest.SpyInstance;
+
+  const tenantId = 'tenant-1';
+  const buildingId = 'building-1';
+  const recurringId = 'recurring-1';
+  const categoryId = 'category-1';
+
+  const baseCreateDto: CreateRecurringExpenseDto = {
+    categoryId,
+    amount: 10000,
+    currency: 'ARS',
+    concept: 'Expensas mensuales',
+    frequency: 'MONTHLY',
+  };
+
+  const makeRecurring = (overrides: Record<string, unknown> = {}) => ({
+    id: recurringId,
+    tenantId,
+    buildingId: null,
+    scopeType: 'BUILDING',
+    allocationMode: null,
+    categoryId,
+    amount: 10000,
+    currency: 'ARS',
+    concept: 'Expensas mensuales',
+    frequency: 'MONTHLY',
+    nextRunDate: new Date('2026-09-01'),
+    isActive: true,
+    createdAt: new Date('2026-08-01'),
+    updatedAt: new Date('2026-08-01'),
+    allocations: [],
+    ...overrides,
+  });
+
+  const makeCategory = (catalogScope: string) => ({
+    id: categoryId,
+    tenantId,
+    name: 'Rubro',
+    catalogScope,
+    isActive: true,
+  });
+
+  beforeEach(async () => {
+    tx = {
+      recurringExpense: {
+        create: jest.fn(),
+        updateMany: jest.fn(),
+        findFirst: jest.fn(),
+      },
+      recurringExpenseAllocation: {
+        createMany: jest.fn(),
+        deleteMany: jest.fn(),
+      },
+      expense: {
+        create: jest.fn(),
+      },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RecurringExpenseService,
+        {
+          provide: PrismaService,
+          useValue: {
+            recurringExpense: {
+              findFirst: jest.fn(),
+              findMany: jest.fn(),
+              create: jest.fn(),
+              updateMany: jest.fn(),
+            },
+            recurringExpenseAllocation: {
+              createMany: jest.fn(),
+              deleteMany: jest.fn(),
+            },
+            expenseLedgerCategory: {
+              findFirst: jest.fn(),
+            },
+            building: {
+              findFirst: jest.fn(),
+              findMany: jest.fn(),
+            },
+            expense: {
+              create: jest.fn(),
+            },
+            $transaction: jest.fn((callback: (client: Record<string, any>) => Promise<unknown>) =>
+              callback(tx),
+            ),
+          },
+        },
+        {
+          provide: AuditService,
+          useValue: { createLog: jest.fn().mockResolvedValue(undefined) },
+        },
+        {
+          provide: MovementAllocationService,
+          useValue: {
+            validateAllocations: jest.fn().mockResolvedValue(undefined),
+            suggestAllocationsByMode: jest.fn(),
+            createForExpenseInTx: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<RecurringExpenseService>(RecurringExpenseService);
+    prisma = module.get<PrismaService>(PrismaService);
+    auditService = module.get<AuditService>(AuditService);
+    movementAllocationService = module.get<MovementAllocationService>(MovementAllocationService);
+
+    jest.spyOn(prisma.building, 'findFirst').mockResolvedValue({
+      id: buildingId,
+      tenantId,
+    } as any);
+    jest.spyOn(prisma.expenseLedgerCategory, 'findFirst').mockResolvedValue(
+      makeCategory('BUILDING') as any,
+    );
+    jest.spyOn(prisma.recurringExpense, 'create').mockResolvedValue(
+      makeRecurring({ buildingId, scopeType: 'BUILDING' }) as any,
+    );
+    (prisma.$transaction as jest.Mock).mockImplementation(
+      (callback: (client: Record<string, any>) => Promise<unknown>) => callback(tx),
+    );
+
+    loggerErrorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    loggerErrorSpy.mockRestore();
+  });
+
+  // ========== CREATE — BUILDING ==========
+  describe('createRecurringExpense — BUILDING', () => {
+    it('crea RecurringExpense BUILDING con scopeType omitido, buildingId de la ruta, allocationMode null y sin template allocations', async () => {
+      const result = await service.createRecurringExpense(tenantId, baseCreateDto, buildingId);
+
+      expect(prisma.building.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: buildingId, tenantId } }),
+      );
+      expect(prisma.recurringExpense.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            tenantId,
+            buildingId,
+            scopeType: 'BUILDING',
+            allocationMode: null,
+          }),
+        }),
+      );
+      expect(prisma.recurringExpenseAllocation.createMany).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(result.scopeType).toBe('BUILDING');
+    });
+
+    it('acepta scopeType BUILDING explícito', async () => {
+      const dto = { ...baseCreateDto, scopeType: 'BUILDING' as const };
+      await service.createRecurringExpense(tenantId, dto, buildingId);
+
+      expect(prisma.recurringExpense.create).toHaveBeenCalled();
+    });
+
+    it('rechaza con 400 scopeType TENANT_SHARED en ruta building y no crea RecurringExpense', async () => {
+      const dto = { ...baseCreateDto, scopeType: 'TENANT_SHARED' as const };
+
+      await expect(service.createRecurringExpense(tenantId, dto, buildingId)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(prisma.recurringExpense.create).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('rechaza con 400 allocationMode en scope BUILDING', async () => {
+      const dto = { ...baseCreateDto, allocationMode: 'MANUAL' as const };
+
+      await expect(service.createRecurringExpense(tenantId, dto, buildingId)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(prisma.recurringExpense.create).not.toHaveBeenCalled();
+    });
+
+    it('rechaza con 400 allocations en scope BUILDING', async () => {
+      const dto = {
+        ...baseCreateDto,
+        allocations: [{ buildingId: 'b-9', percentage: 100 }],
+      };
+
+      await expect(service.createRecurringExpense(tenantId, dto, buildingId)).rejects.toThrow(
+        BadRequestException,
+      );
+      expect(prisma.recurringExpense.create).not.toHaveBeenCalled();
+    });
+
+    it('rechaza building que no pertenece al tenant y no crea RecurringExpense', async () => {
+      jest.spyOn(prisma.building, 'findFirst').mockResolvedValue(null);
+
+      await expect(service.createRecurringExpense(tenantId, baseCreateDto, buildingId)).rejects.toThrow(
+        NotFoundException,
+      );
+      expect(prisma.recurringExpense.create).not.toHaveBeenCalled();
+    });
+
+    it('rechaza con 422 CATEGORY_SCOPE_MISMATCH rubro CONDOMINIUM_COMMON en BUILDING', async () => {
+      jest.spyOn(prisma.expenseLedgerCategory, 'findFirst').mockResolvedValue(
+        makeCategory('CONDOMINIUM_COMMON') as any,
+      );
+
+      const error = await service
+        .createRecurringExpense(tenantId, baseCreateDto, buildingId)
+        .catch((e: UnprocessableEntityException) => e);
+
+      expect(error).toBeInstanceOf(UnprocessableEntityException);
+      expect((error as any)?.getResponse?.()).toEqual(
+        expect.objectContaining({ error: 'CATEGORY_SCOPE_MISMATCH' }),
+      );
+      expect(prisma.recurringExpense.create).not.toHaveBeenCalled();
+    });
+
+    it('audit de create BUILDING NO incluye la propiedad allocationMode', async () => {
+      await service.createRecurringExpense(tenantId, baseCreateDto, buildingId);
+
+      expect(auditService.createLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.not.objectContaining({ allocationMode: expect.anything() }),
+        }),
+      );
+      const metadata = (auditService.createLog as jest.Mock).mock.calls[0][0].metadata;
+      expect(metadata).not.toHaveProperty('allocationMode');
+    });
+  });
+
+  // ========== CREATE — TENANT_SHARED MANUAL ==========
+  describe('createRecurringExpense — TENANT_SHARED MANUAL', () => {
+    const manualDto: CreateRecurringExpenseDto = {
+      ...baseCreateDto,
+      scopeType: 'TENANT_SHARED',
+      allocationMode: 'MANUAL',
+      allocations: [
+        { buildingId: 'building-1', percentage: 60 },
+        { buildingId: 'building-2', percentage: 40 },
+      ],
+    };
+
+    beforeEach(() => {
+      jest.spyOn(prisma.expenseLedgerCategory, 'findFirst').mockResolvedValue(
+        makeCategory('CONDOMINIUM_COMMON') as any,
+      );
+      tx.recurringExpense.create.mockResolvedValue(
+        makeRecurring({ scopeType: 'TENANT_SHARED', allocationMode: 'MANUAL' }),
+      );
+      tx.recurringExpenseAllocation.createMany.mockResolvedValue({ count: 2 });
+    });
+
+    it('crea RecurringExpense + RecurringExpenseAllocation[] dentro de la misma $transaction, validando vía validateAllocations', async () => {
+      const result = await service.createRecurringExpense(tenantId, manualDto);
+
+      expect(movementAllocationService.validateAllocations).toHaveBeenCalledWith(
+        tenantId,
+        manualDto.allocations,
+        manualDto.amount,
+        manualDto.currency,
+      );
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(tx.recurringExpense.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            tenantId,
+            buildingId: null,
+            scopeType: 'TENANT_SHARED',
+            allocationMode: 'MANUAL',
+          }),
+        }),
+      );
+      expect(tx.recurringExpenseAllocation.createMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.arrayContaining([
+            expect.objectContaining({
+              tenantId,
+              recurringExpenseId: recurringId,
+              buildingId: 'building-1',
+              percentage: 60,
+            }),
+            expect.objectContaining({
+              tenantId,
+              recurringExpenseId: recurringId,
+              buildingId: 'building-2',
+              percentage: 40,
+            }),
+          ]),
+        }),
+      );
+      expect(result.scopeType).toBe('TENANT_SHARED');
+    });
+
+    it('rechaza con 400 MANUAL sin allocations', async () => {
+      const dto = { ...baseCreateDto, scopeType: 'TENANT_SHARED' as const, allocationMode: 'MANUAL' as const };
+
+      await expect(service.createRecurringExpense(tenantId, dto)).rejects.toThrow(BadRequestException);
+      expect(movementAllocationService.validateAllocations).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('propaga error de validateAllocations sin abrir mutación parcial', async () => {
+      (movementAllocationService.validateAllocations as jest.Mock).mockRejectedValueOnce(
+        new BadRequestException('Los porcentajes deben sumar 100%'),
+      );
+
+      await expect(service.createRecurringExpense(tenantId, manualDto)).rejects.toThrow(BadRequestException);
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(tx.recurringExpense.create).not.toHaveBeenCalled();
+    });
+
+    it('rechaza con 422 CATEGORY_SCOPE_MISMATCH rubro BUILDING para TENANT_SHARED', async () => {
+      jest.spyOn(prisma.expenseLedgerCategory, 'findFirst').mockResolvedValue(
+        makeCategory('BUILDING') as any,
+      );
+
+      const error = await service
+        .createRecurringExpense(tenantId, manualDto)
+        .catch((e: UnprocessableEntityException) => e);
+
+      expect(error).toBeInstanceOf(UnprocessableEntityException);
+      expect((error as any)?.getResponse?.()).toEqual(
+        expect.objectContaining({ error: 'CATEGORY_SCOPE_MISMATCH' }),
+      );
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('no considera la regla creada si falla createMany de templates', async () => {
+      tx.recurringExpenseAllocation.createMany.mockRejectedValueOnce(new Error('createMany failed'));
+
+      await expect(service.createRecurringExpense(tenantId, manualDto)).rejects.toThrow('createMany failed');
+      expect(auditService.createLog).not.toHaveBeenCalled();
+    });
+
+    it('dispara el audit solo después de resolver correctamente la transacción', async () => {
+      await service.createRecurringExpense(tenantId, manualDto);
+
+      const txCallOrder = (prisma.$transaction as jest.Mock).mock.invocationCallOrder[0];
+      const auditCallOrder = (auditService.createLog as jest.Mock).mock.invocationCallOrder[0];
+
+      expect(auditService.createLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId,
+          action: 'EXPENSE_CREATE',
+          entityType: 'RecurringExpense',
+          entityId: recurringId,
+        }),
+      );
+      expect(txCallOrder).toBeLessThan(auditCallOrder);
+    });
+
+    it('audit de create TENANT_SHARED MANUAL incluye allocationMode MANUAL', async () => {
+      await service.createRecurringExpense(tenantId, manualDto);
+
+      const metadata = (auditService.createLog as jest.Mock).mock.calls[0][0].metadata;
+      expect(metadata).toHaveProperty('allocationMode', 'MANUAL');
+    });
+  });
+
+  // ========== CREATE — MODOS DINÁMICOS ==========
+  describe('createRecurringExpense — EQUAL_SHARE / BUILDING_TOTAL_M2', () => {
+    beforeEach(() => {
+      jest.spyOn(prisma.expenseLedgerCategory, 'findFirst').mockResolvedValue(
+        makeCategory('CONDOMINIUM_COMMON') as any,
+      );
+      jest.spyOn(prisma.recurringExpense, 'create').mockResolvedValue(
+        makeRecurring({ scopeType: 'TENANT_SHARED', allocationMode: 'EQUAL_SHARE' }) as any,
+      );
+    });
+
+    it('EQUAL_SHARE válido sin allocations: crea regla sin persistir templates', async () => {
+      const dto: CreateRecurringExpenseDto = {
+        ...baseCreateDto,
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'EQUAL_SHARE',
+      };
+
+      const result = await service.createRecurringExpense(tenantId, dto);
+
+      expect(prisma.recurringExpense.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            scopeType: 'TENANT_SHARED',
+            allocationMode: 'EQUAL_SHARE',
+            buildingId: null,
+          }),
+        }),
+      );
+      expect(prisma.recurringExpenseAllocation.createMany).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(result.scopeType).toBe('TENANT_SHARED');
+    });
+
+    it('BUILDING_TOTAL_M2 válido sin allocations: crea regla sin persistir templates', async () => {
+      jest.spyOn(prisma.recurringExpense, 'create').mockResolvedValue(
+        makeRecurring({ scopeType: 'TENANT_SHARED', allocationMode: 'BUILDING_TOTAL_M2' }) as any,
+      );
+      const dto: CreateRecurringExpenseDto = {
+        ...baseCreateDto,
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'BUILDING_TOTAL_M2',
+      };
+
+      const result = await service.createRecurringExpense(tenantId, dto);
+
+      expect(prisma.recurringExpense.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            allocationMode: 'BUILDING_TOTAL_M2',
+          }),
+        }),
+      );
+      expect(prisma.recurringExpenseAllocation.createMany).not.toHaveBeenCalled();
+      expect(result.allocationMode).toBe('BUILDING_TOTAL_M2');
+    });
+
+    it('rechaza con 400 EQUAL_SHARE con allocations manuales', async () => {
+      const dto: CreateRecurringExpenseDto = {
+        ...baseCreateDto,
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'EQUAL_SHARE',
+        allocations: [{ buildingId: 'b-1', percentage: 100 }],
+      };
+
+      await expect(service.createRecurringExpense(tenantId, dto)).rejects.toThrow(BadRequestException);
+      expect(prisma.recurringExpense.create).not.toHaveBeenCalled();
+    });
+
+    it('rechaza con 400 BUILDING_TOTAL_M2 con allocations', async () => {
+      const dto: CreateRecurringExpenseDto = {
+        ...baseCreateDto,
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'BUILDING_TOTAL_M2',
+        allocations: [{ buildingId: 'b-1', percentage: 100 }],
+      };
+
+      await expect(service.createRecurringExpense(tenantId, dto)).rejects.toThrow(BadRequestException);
+      expect(prisma.recurringExpense.create).not.toHaveBeenCalled();
+    });
+
+    it('rechaza con 400 ruta tenant con scopeType BUILDING, sin reinterpretar', async () => {
+      const dto = { ...baseCreateDto, scopeType: 'BUILDING' as const };
+
+      await expect(service.createRecurringExpense(tenantId, dto)).rejects.toThrow(BadRequestException);
+      expect(prisma.expenseLedgerCategory.findFirst).not.toHaveBeenCalled();
+      expect(prisma.recurringExpense.create).not.toHaveBeenCalled();
+    });
+  });
+
+  // ========== LIST ==========
+  describe('listRecurringExpenses', () => {
+    beforeEach(() => {
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([] as any);
+    });
+
+    it('lista BUILDING filtrando tenantId, buildingId y scopeType', async () => {
+      await service.listRecurringExpenses(tenantId, buildingId, false, 'BUILDING');
+
+      expect(prisma.recurringExpense.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            tenantId,
+            isActive: true,
+            scopeType: 'BUILDING',
+            buildingId,
+          },
+          orderBy: { nextRunDate: 'asc' },
+        }),
+      );
+    });
+
+    it('lista tenant/shared con buildingId null y scope TENANT_SHARED', async () => {
+      await service.listRecurringExpenses(tenantId, undefined, false, 'TENANT_SHARED');
+
+      expect(prisma.recurringExpense.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            tenantId,
+            isActive: true,
+            scopeType: 'TENANT_SHARED',
+            buildingId: null,
+          },
+        }),
+      );
+    });
+
+    it('includeInactive true omite el filtro isActive', async () => {
+      await service.listRecurringExpenses(tenantId, undefined, true, 'TENANT_SHARED');
+
+      expect(prisma.recurringExpense.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.not.objectContaining({ isActive: true }),
+        }),
+      );
+    });
+  });
+
+  // ========== PATCH — BUILDING ==========
+  describe('updateRecurringExpense — BUILDING', () => {
+    const expectedScope = { scopeType: 'BUILDING' as const, buildingId };
+
+    beforeEach(() => {
+      jest.spyOn(prisma.recurringExpense, 'findFirst').mockResolvedValue(
+        makeRecurring({ buildingId, scopeType: 'BUILDING' }) as any,
+      );
+      jest.spyOn(prisma.recurringExpense, 'updateMany').mockResolvedValue({ count: 1 } as any);
+    });
+
+    it('actualiza amount/concept/isActive válido de forma tenant-scoped', async () => {
+      (prisma.recurringExpense.findFirst as jest.Mock)
+        .mockResolvedValueOnce(makeRecurring({ buildingId, scopeType: 'BUILDING' }))
+        .mockResolvedValueOnce(makeRecurring({ buildingId, scopeType: 'BUILDING', amount: 7500 }));
+
+      const result = await service.updateRecurringExpense(tenantId, recurringId, {
+        amount: 7500,
+        concept: 'Nuevo concepto',
+        isActive: false,
+      }, expectedScope);
+
+      expect(prisma.recurringExpense.findFirst).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ where: { id: recurringId, tenantId, scopeType: 'BUILDING', buildingId } }),
+      );
+      expect(prisma.recurringExpense.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: recurringId, tenantId },
+          data: expect.objectContaining({ amount: 7500, concept: 'Nuevo concepto', isActive: false }),
+        }),
+      );
+      expect(result.amount).toBe(7500);
+    });
+
+    it('rechaza con 400 allocationMode en BUILDING', async () => {
+      await expect(
+        service.updateRecurringExpense(tenantId, recurringId, { allocationMode: 'MANUAL' }, expectedScope),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.recurringExpense.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('rechaza con 400 allocations en BUILDING', async () => {
+      await expect(
+        service.updateRecurringExpense(tenantId, recurringId, {
+          allocations: [{ buildingId: 'b-1', percentage: 100 }],
+        }, expectedScope),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.recurringExpense.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('lanza NotFound para recurringId de otro tenant sin mutación', async () => {
+      jest.spyOn(prisma.recurringExpense, 'findFirst').mockResolvedValue(null);
+
+      await expect(
+        service.updateRecurringExpense(tenantId, 'recurring-other', { amount: 1 }, expectedScope),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.recurringExpense.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('regla BUILDING de otro edificio: NotFound porque el where exige buildingId de la ruta', async () => {
+      // Simula que la regla existe pero pertenece a building-2: el findFirst
+      // con buildingId de la ruta (building-1) no la encuentra.
+      jest.spyOn(prisma.recurringExpense, 'findFirst').mockResolvedValue(null);
+
+      await expect(
+        service.updateRecurringExpense(tenantId, recurringId, { amount: 1 }, expectedScope),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.recurringExpense.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: recurringId, tenantId, scopeType: 'BUILDING', buildingId },
+        }),
+      );
+      expect(prisma.recurringExpense.updateMany).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  // ========== PATCH — TENANT_SHARED MANUAL ==========
+  describe('updateRecurringExpense — TENANT_SHARED MANUAL', () => {
+    const expectedScope = { scopeType: 'TENANT_SHARED' as const, buildingId: null };
+    const manualExisting = (overrides: Record<string, unknown> = {}) =>
+      makeRecurring({
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'MANUAL',
+        allocations: [
+          { id: 'a1', recurringExpenseId: recurringId, tenantId, buildingId: 'building-1', percentage: 60, createdAt: new Date(), updatedAt: new Date() },
+          { id: 'a2', recurringExpenseId: recurringId, tenantId, buildingId: 'building-2', percentage: 40, createdAt: new Date(), updatedAt: new Date() },
+        ],
+        ...overrides,
+      });
+
+    beforeEach(() => {
+      jest.spyOn(prisma.recurringExpense, 'findFirst').mockResolvedValue(manualExisting() as any);
+      jest.spyOn(prisma.recurringExpense, 'updateMany').mockResolvedValue({ count: 1 } as any);
+      tx.recurringExpenseAllocation.deleteMany.mockResolvedValue({ count: 2 });
+      tx.recurringExpenseAllocation.createMany.mockResolvedValue({ count: 2 });
+      tx.recurringExpense.updateMany.mockResolvedValue({ count: 1 });
+      tx.recurringExpense.findFirst.mockResolvedValue(manualExisting());
+    });
+
+    it('reemplazo MANUAL válido: validateAllocations ANTES de deleteMany, delete+create+update en transacción', async () => {
+      const newAllocations = [
+        { buildingId: 'building-1', percentage: 70 },
+        { buildingId: 'building-3', percentage: 30 },
+      ];
+      tx.recurringExpense.findFirst.mockResolvedValue(
+        manualExisting({ allocations: newAllocations }),
+      );
+
+      await service.updateRecurringExpense(tenantId, recurringId, { allocations: newAllocations }, expectedScope);
+
+      const validateOrder = (movementAllocationService.validateAllocations as jest.Mock).mock.invocationCallOrder[0];
+      const deleteOrder = (tx.recurringExpenseAllocation.deleteMany as jest.Mock).mock.invocationCallOrder[0];
+      const createOrder = (tx.recurringExpenseAllocation.createMany as jest.Mock).mock.invocationCallOrder[0];
+
+      expect(movementAllocationService.validateAllocations).toHaveBeenCalledWith(
+        tenantId,
+        newAllocations,
+        10000,
+        'ARS',
+      );
+      expect(validateOrder).toBeLessThan(deleteOrder);
+      expect(deleteOrder).toBeLessThan(createOrder);
+      expect(prisma.$transaction).toHaveBeenCalledTimes(1);
+      expect(tx.recurringExpenseAllocation.deleteMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { recurringExpenseId: recurringId, tenantId } }),
+      );
+      expect(tx.recurringExpense.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: recurringId, tenantId } }),
+      );
+    });
+
+    it('si validateAllocations falla, no ejecuta deleteMany ni createMany', async () => {
+      (movementAllocationService.validateAllocations as jest.Mock).mockRejectedValueOnce(
+        new BadRequestException('invalid'),
+      );
+
+      await expect(
+        service.updateRecurringExpense(tenantId, recurringId, {
+          allocations: [{ buildingId: 'building-1', percentage: 50 }],
+        }, expectedScope),
+      ).rejects.toThrow(BadRequestException);
+
+      expect(tx.recurringExpenseAllocation.deleteMany).not.toHaveBeenCalled();
+      expect(tx.recurringExpenseAllocation.createMany).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+    });
+
+    it('si createMany falla dentro de transacción, la operación es rechazada sin retorno de éxito', async () => {
+      tx.recurringExpenseAllocation.createMany.mockRejectedValueOnce(new Error('createMany failed'));
+
+      await expect(
+        service.updateRecurringExpense(tenantId, recurringId, {
+          allocations: [{ buildingId: 'building-1', percentage: 100 }],
+        }, expectedScope),
+      ).rejects.toThrow('createMany failed');
+    });
+
+    it('cambio EQUAL_SHARE -> MANUAL exige allocations, valida y crea templates', async () => {
+      const existing = makeRecurring({
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'EQUAL_SHARE',
+        allocations: [],
+      });
+      (prisma.recurringExpense.findFirst as jest.Mock).mockResolvedValueOnce(existing);
+      tx.recurringExpense.findFirst.mockResolvedValue(
+        makeRecurring({ scopeType: 'TENANT_SHARED', allocationMode: 'MANUAL' }),
+      );
+      const newAllocations = [
+        { buildingId: 'building-1', percentage: 60 },
+        { buildingId: 'building-2', percentage: 40 },
+      ];
+
+      const result = await service.updateRecurringExpense(tenantId, recurringId, {
+        allocationMode: 'MANUAL',
+        allocations: newAllocations,
+      }, expectedScope);
+
+      expect(movementAllocationService.validateAllocations).toHaveBeenCalled();
+      expect(tx.recurringExpenseAllocation.deleteMany).toHaveBeenCalled();
+      expect(tx.recurringExpenseAllocation.createMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.arrayContaining([
+            expect.objectContaining({ buildingId: 'building-1', percentage: 60 }),
+            expect.objectContaining({ buildingId: 'building-2', percentage: 40 }),
+          ]),
+        }),
+      );
+      expect(result.allocationMode).toBe('MANUAL');
+    });
+
+    it('cambio MANUAL -> EQUAL_SHARE elimina templates en transacción y cambia allocationMode', async () => {
+      const existing = manualExisting();
+      (prisma.recurringExpense.findFirst as jest.Mock).mockResolvedValueOnce(existing);
+      tx.recurringExpense.findFirst.mockResolvedValue(
+        makeRecurring({ scopeType: 'TENANT_SHARED', allocationMode: 'EQUAL_SHARE', allocations: [] }),
+      );
+
+      const result = await service.updateRecurringExpense(tenantId, recurringId, {
+        allocationMode: 'EQUAL_SHARE',
+      }, expectedScope);
+
+      expect(tx.recurringExpenseAllocation.deleteMany).toHaveBeenCalled();
+      expect(tx.recurringExpenseAllocation.createMany).not.toHaveBeenCalled();
+      expect(tx.recurringExpense.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: recurringId, tenantId },
+          data: expect.objectContaining({ allocationMode: 'EQUAL_SHARE' }),
+        }),
+      );
+      expect(result.allocationMode).toBe('EQUAL_SHARE');
+    });
+
+    it('cambio MANUAL -> BUILDING_TOTAL_M2 elimina templates en transacción', async () => {
+      const existing = manualExisting();
+      (prisma.recurringExpense.findFirst as jest.Mock).mockResolvedValueOnce(existing);
+      tx.recurringExpense.findFirst.mockResolvedValue(
+        makeRecurring({ scopeType: 'TENANT_SHARED', allocationMode: 'BUILDING_TOTAL_M2', allocations: [] }),
+      );
+
+      const result = await service.updateRecurringExpense(tenantId, recurringId, {
+        allocationMode: 'BUILDING_TOTAL_M2',
+      }, expectedScope);
+
+      expect(tx.recurringExpenseAllocation.deleteMany).toHaveBeenCalled();
+      expect(tx.recurringExpense.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ allocationMode: 'BUILDING_TOTAL_M2' }) }),
+      );
+      expect(result.allocationMode).toBe('BUILDING_TOTAL_M2');
+    });
+
+    it('rechaza con 400 cambio a MANUAL sin allocations', async () => {
+      const existing = makeRecurring({
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'EQUAL_SHARE',
+        allocations: [],
+      });
+      (prisma.recurringExpense.findFirst as jest.Mock).mockResolvedValueOnce(existing);
+
+      const error = await service
+        .updateRecurringExpense(tenantId, recurringId, { allocationMode: 'MANUAL' }, expectedScope)
+        .catch((e: Error) => e);
+
+      expect(error).toBeInstanceOf(BadRequestException);
+      expect(tx.recurringExpenseAllocation.deleteMany).not.toHaveBeenCalled();
+      expect(tx.recurringExpenseAllocation.createMany).not.toHaveBeenCalled();
+    });
+
+    it('rechaza con 400 cambio BUILDING_TOTAL_M2 -> MANUAL sin allocations', async () => {
+      const existing = makeRecurring({
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'BUILDING_TOTAL_M2',
+        allocations: [],
+      });
+      (prisma.recurringExpense.findFirst as jest.Mock).mockResolvedValueOnce(existing);
+
+      const error = await service
+        .updateRecurringExpense(tenantId, recurringId, { allocationMode: 'MANUAL' }, expectedScope)
+        .catch((e: Error) => e);
+
+      expect(error).toBeInstanceOf(BadRequestException);
+      expect(prisma.recurringExpense.updateMany).not.toHaveBeenCalled();
+      expect(tx.recurringExpenseAllocation.deleteMany).not.toHaveBeenCalled();
+      expect(tx.recurringExpenseAllocation.createMany).not.toHaveBeenCalled();
+    });
+
+    it('MANUAL existente con templates + update amount sin allocations: válido y conserva templates', async () => {
+      const existing = manualExisting();
+      (prisma.recurringExpense.findFirst as jest.Mock)
+        .mockResolvedValueOnce(existing)
+        .mockResolvedValueOnce(manualExisting({ amount: 12500 }));
+
+      const result = await service.updateRecurringExpense(tenantId, recurringId, {
+        amount: 12500,
+      }, expectedScope);
+
+      expect(prisma.recurringExpense.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: recurringId, tenantId },
+          data: expect.objectContaining({ amount: 12500 }),
+        }),
+      );
+      expect(tx.recurringExpenseAllocation.deleteMany).not.toHaveBeenCalled();
+      expect(tx.recurringExpenseAllocation.createMany).not.toHaveBeenCalled();
+      expect(result.amount).toBe(12500);
+      expect(result.allocationMode).toBe('MANUAL');
+    });
+
+    it('MANUAL -> MANUAL con allocations nuevas: reemplazo válido y atómico', async () => {
+      const existing = manualExisting();
+      (prisma.recurringExpense.findFirst as jest.Mock).mockResolvedValueOnce(existing);
+      tx.recurringExpense.findFirst.mockResolvedValue(
+        manualExisting({ allocations: [
+          { id: 'a9', recurringExpenseId: recurringId, tenantId, buildingId: 'building-1', percentage: 100, createdAt: new Date(), updatedAt: new Date() },
+        ] }),
+      );
+      const newAllocations = [{ buildingId: 'building-1', percentage: 100 }];
+
+      const result = await service.updateRecurringExpense(tenantId, recurringId, {
+        allocationMode: 'MANUAL',
+        allocations: newAllocations,
+      }, expectedScope);
+
+      expect(movementAllocationService.validateAllocations).toHaveBeenCalledWith(
+        tenantId,
+        newAllocations,
+        10000,
+        'ARS',
+      );
+      expect(tx.recurringExpenseAllocation.deleteMany).toHaveBeenCalled();
+      expect(tx.recurringExpenseAllocation.createMany).toHaveBeenCalled();
+      expect(tx.recurringExpense.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: recurringId, tenantId } }),
+      );
+      expect(result.allocationMode).toBe('MANUAL');
+    });
+
+    it('rechaza con 400 cambio a MANUAL con allocations vacías', async () => {
+      const existing = makeRecurring({
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'EQUAL_SHARE',
+        allocations: [],
+      });
+      (prisma.recurringExpense.findFirst as jest.Mock).mockResolvedValueOnce(existing);
+      (movementAllocationService.validateAllocations as jest.Mock).mockRejectedValueOnce(
+        new BadRequestException('Las allocations no pueden estar vacías'),
+      );
+
+      const error = await service
+        .updateRecurringExpense(tenantId, recurringId, { allocationMode: 'MANUAL', allocations: [] }, expectedScope)
+        .catch((e: Error) => e);
+
+      expect(error).toBeInstanceOf(BadRequestException);
+      expect(tx.recurringExpenseAllocation.deleteMany).not.toHaveBeenCalled();
+      expect(tx.recurringExpenseAllocation.createMany).not.toHaveBeenCalled();
+    });
+
+    it('comprueba explícitamente que updateMany contiene id + tenantId en where', async () => {
+      await service.updateRecurringExpense(tenantId, recurringId, { amount: 500 }, expectedScope);
+
+      expect(prisma.recurringExpense.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: recurringId, tenantId },
+        }),
+      );
+    });
+
+    it('lanza NotFound cuando updateMany retorna count=0', async () => {
+      (prisma.recurringExpense.updateMany as jest.Mock).mockResolvedValueOnce({ count: 0 });
+
+      await expect(
+        service.updateRecurringExpense(tenantId, recurringId, { amount: 500 }, expectedScope),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ========== CRON — BUILDING ==========
+  describe('processRecurringExpenses — BUILDING', () => {
+    const buildingRule = () =>
+      makeRecurring({
+        id: 're-b1',
+        buildingId,
+        scopeType: 'BUILDING',
+        allocationMode: null,
+        nextRunDate: new Date('2020-01-01'),
+      });
+
+    beforeEach(() => {
+      tx.expense.create.mockResolvedValue({
+        id: 'expense-1',
+        tenantId,
+        buildingId,
+        scopeType: 'BUILDING',
+      });
+      tx.recurringExpense.updateMany.mockResolvedValue({ count: 1 });
+    });
+
+    it('regla BUILDING due válida: crea Expense BUILDING DRAFT, update nextRunDate tenant-scoped, createdCount=1', async () => {
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([buildingRule()] as any);
+
+      const result = await service.processRecurringExpenses();
+
+      expect(tx.expense.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            tenantId,
+            buildingId,
+            scopeType: 'BUILDING',
+            status: 'DRAFT',
+            amountMinor: 10000,
+            currencyCode: 'ARS',
+          }),
+        }),
+      );
+      expect(tx.recurringExpense.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 're-b1', tenantId },
+          data: expect.objectContaining({ nextRunDate: expect.any(Date) }),
+        }),
+      );
+      expect(result.createdCount).toBe(1);
+    });
+
+    it('BUILDING sin buildingId: falla la regla sin Expense ni nextRunDate, y no incrementa createdCount', async () => {
+      const rule = buildingRule();
+      rule.buildingId = null;
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([rule] as any);
+
+      const result = await service.processRecurringExpenses();
+
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(tx.expense.create).not.toHaveBeenCalled();
+      expect(result.createdCount).toBe(0);
+      expect(loggerErrorSpy).toHaveBeenCalled();
+    });
+
+    it('fallo en expense.create: sin nextRunDate ni audit exitoso', async () => {
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([buildingRule()] as any);
+      tx.expense.create.mockRejectedValueOnce(new Error('expense create failed'));
+
+      const result = await service.processRecurringExpenses();
+
+      expect(tx.recurringExpense.updateMany).not.toHaveBeenCalled();
+      expect(auditService.createLog).not.toHaveBeenCalled();
+      expect(result.createdCount).toBe(0);
+    });
+
+    it('fallo en updateMany: transacción falla, sin audit, createdCount no incrementa', async () => {
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([buildingRule()] as any);
+      tx.recurringExpense.updateMany.mockResolvedValueOnce({ count: 0 });
+
+      const result = await service.processRecurringExpenses();
+
+      expect(auditService.createLog).not.toHaveBeenCalled();
+      expect(result.createdCount).toBe(0);
+    });
+
+    it('audit post-transacción: entityType Expense, entityId = expense.id, recurringId en metadata', async () => {
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([buildingRule()] as any);
+
+      await service.processRecurringExpenses();
+
+      const txCallOrder = (prisma.$transaction as jest.Mock).mock.invocationCallOrder[0];
+      const auditCallOrder = (auditService.createLog as jest.Mock).mock.invocationCallOrder[0];
+
+      expect(auditService.createLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId,
+          action: 'EXPENSE_CREATE',
+          entityType: 'Expense',
+          entityId: 'expense-1',
+          metadata: expect.objectContaining({
+            source: 'RECURRING_CRONJOB',
+            recurringId: 're-b1',
+            scopeType: 'BUILDING',
+          }),
+        }),
+      );
+      expect(txCallOrder).toBeLessThan(auditCallOrder);
+    });
+
+    it('audit de cron BUILDING NO incluye allocationMode', async () => {
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([buildingRule()] as any);
+
+      await service.processRecurringExpenses();
+
+      const metadata = (auditService.createLog as jest.Mock).mock.calls[0][0].metadata;
+      expect(metadata).not.toHaveProperty('allocationMode');
+    });
+  });
+
+  // ========== CRON — TENANT_SHARED MANUAL ==========
+  describe('processRecurringExpenses — TENANT_SHARED MANUAL', () => {
+    const manualRule = () =>
+      makeRecurring({
+        id: 're-t1',
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'MANUAL',
+        nextRunDate: new Date('2020-01-01'),
+        allocations: [
+          { buildingId: 'building-1', percentage: 60 },
+          { buildingId: 'building-2', percentage: 40 },
+        ],
+      });
+
+    beforeEach(() => {
+      tx.expense.create.mockResolvedValue({
+        id: 'expense-t1',
+        tenantId,
+        buildingId: null,
+        scopeType: 'TENANT_SHARED',
+      });
+      tx.recurringExpense.updateMany.mockResolvedValue({ count: 1 });
+    });
+
+    it('MANUAL válido: usa allocations almacenadas, valida, crea Expense TENANT_SHARED con buildingId null, llama createForExpenseInTx, actualiza nextRunDate, createdCount=1', async () => {
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([manualRule()] as any);
+
+      const result = await service.processRecurringExpenses();
+
+      const expectedAllocations = manualRule().allocations;
+      expect(movementAllocationService.validateAllocations).toHaveBeenCalledWith(
+        tenantId,
+        expectedAllocations,
+        10000,
+        'ARS',
+      );
+      expect(tx.expense.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            tenantId,
+            buildingId: null,
+            scopeType: 'TENANT_SHARED',
+            status: 'DRAFT',
+          }),
+        }),
+      );
+      expect(movementAllocationService.createForExpenseInTx).toHaveBeenCalledWith(
+        tx,
+        tenantId,
+        'expense-t1',
+        10000,
+        'ARS',
+        expectedAllocations,
+      );
+      expect(tx.recurringExpense.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 're-t1', tenantId },
+        }),
+      );
+      expect(result.createdCount).toBe(1);
+    });
+
+    it('MANUAL sin template allocations: falla sin Expense ni nextRunDate', async () => {
+      const rule = manualRule();
+      rule.allocations = [];
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([rule] as any);
+
+      const result = await service.processRecurringExpenses();
+
+      expect(movementAllocationService.validateAllocations).not.toHaveBeenCalled();
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(result.createdCount).toBe(0);
+    });
+
+    it('MANUAL con reparto inválido: validateAllocations falla, no entra en mutaciones', async () => {
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([manualRule()] as any);
+      (movementAllocationService.validateAllocations as jest.Mock).mockRejectedValueOnce(
+        new BadRequestException('invalid reparto'),
+      );
+
+      const result = await service.processRecurringExpenses();
+
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(tx.expense.create).not.toHaveBeenCalled();
+      expect(result.createdCount).toBe(0);
+      expect(loggerErrorSpy).toHaveBeenCalled();
+    });
+
+    it('createForExpenseInTx falla: transacción rechazada, sin nextRunDate ni audit, createdCount no incrementa', async () => {
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([manualRule()] as any);
+      (movementAllocationService.createForExpenseInTx as jest.Mock).mockRejectedValueOnce(
+        new Error('allocation tx failed'),
+      );
+
+      const result = await service.processRecurringExpenses();
+
+      expect(tx.recurringExpense.updateMany).not.toHaveBeenCalled();
+      expect(auditService.createLog).not.toHaveBeenCalled();
+      expect(result.createdCount).toBe(0);
+    });
+
+    it('audit de cron TENANT_SHARED incluye allocationMode MANUAL', async () => {
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([manualRule()] as any);
+
+      await service.processRecurringExpenses();
+
+      const metadata = (auditService.createLog as jest.Mock).mock.calls[0][0].metadata;
+      expect(metadata).toHaveProperty('allocationMode', 'MANUAL');
+    });
+  });
+
+  // ========== CRON — EQUAL_SHARE ==========
+  describe('processRecurringExpenses — EQUAL_SHARE', () => {
+    const equalRule = () =>
+      makeRecurring({
+        id: 're-e1',
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'EQUAL_SHARE',
+        nextRunDate: new Date('2020-01-01'),
+        allocations: [],
+      });
+
+    const suggestions = [
+      { buildingId: 'building-1', buildingName: 'A', totalM2: 0, percentage: 50 },
+      { buildingId: 'building-2', buildingName: 'B', totalM2: 0, percentage: 50 },
+    ];
+
+    beforeEach(() => {
+      (movementAllocationService.suggestAllocationsByMode as jest.Mock).mockResolvedValue(suggestions);
+      tx.expense.create.mockResolvedValue({ id: 'expense-e1', tenantId, scopeType: 'TENANT_SHARED' });
+      tx.recurringExpense.updateMany.mockResolvedValue({ count: 1 });
+    });
+
+    it('llama suggestAllocationsByMode con tenantId y EQUAL_SHARE, valida sugerencias y usa createForExpenseInTx', async () => {
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([equalRule()] as any);
+
+      const result = await service.processRecurringExpenses();
+
+      expect(movementAllocationService.suggestAllocationsByMode).toHaveBeenCalledWith(
+        tenantId,
+        'EQUAL_SHARE',
+      );
+      expect(movementAllocationService.validateAllocations).toHaveBeenCalledWith(
+        tenantId,
+        [
+          { buildingId: 'building-1', percentage: 50 },
+          { buildingId: 'building-2', percentage: 50 },
+        ],
+        10000,
+        'ARS',
+      );
+      expect(movementAllocationService.createForExpenseInTx).toHaveBeenCalledWith(
+        tx,
+        tenantId,
+        'expense-e1',
+        10000,
+        'ARS',
+        [
+          { buildingId: 'building-1', percentage: 50 },
+          { buildingId: 'building-2', percentage: 50 },
+        ],
+      );
+      expect(result.createdCount).toBe(1);
+    });
+
+    it('sugerencias []: no Expense, no nextRunDate, createdCount no incrementa', async () => {
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([equalRule()] as any);
+      (movementAllocationService.suggestAllocationsByMode as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.processRecurringExpenses();
+
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(tx.expense.create).not.toHaveBeenCalled();
+      expect(result.createdCount).toBe(0);
+    });
+  });
+
+  // ========== CRON — BUILDING_TOTAL_M2 ==========
+  describe('processRecurringExpenses — BUILDING_TOTAL_M2', () => {
+    const m2Rule = () =>
+      makeRecurring({
+        id: 're-m1',
+        scopeType: 'TENANT_SHARED',
+        allocationMode: 'BUILDING_TOTAL_M2',
+        nextRunDate: new Date('2020-01-01'),
+        allocations: [],
+      });
+
+    beforeEach(() => {
+      (movementAllocationService.suggestAllocationsByMode as jest.Mock).mockResolvedValue([
+        { buildingId: 'building-1', buildingName: 'A', totalM2: 100, percentage: 100 },
+      ]);
+      tx.expense.create.mockResolvedValue({ id: 'expense-m1', tenantId, scopeType: 'TENANT_SHARED' });
+      tx.recurringExpense.updateMany.mockResolvedValue({ count: 1 });
+    });
+
+    it('llama suggestAllocationsByMode con BUILDING_TOTAL_M2, valida y crea Expense + allocations vía createForExpenseInTx', async () => {
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([m2Rule()] as any);
+
+      const result = await service.processRecurringExpenses();
+
+      expect(movementAllocationService.suggestAllocationsByMode).toHaveBeenCalledWith(
+        tenantId,
+        'BUILDING_TOTAL_M2',
+      );
+      expect(movementAllocationService.validateAllocations).toHaveBeenCalled();
+      expect(movementAllocationService.createForExpenseInTx).toHaveBeenCalled();
+      expect(result.createdCount).toBe(1);
+    });
+
+    it('cero edificios: falla de forma segura sin mutaciones', async () => {
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([m2Rule()] as any);
+      (movementAllocationService.suggestAllocationsByMode as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.processRecurringExpenses();
+
+      expect(prisma.$transaction).not.toHaveBeenCalled();
+      expect(tx.expense.create).not.toHaveBeenCalled();
+      expect(result.createdCount).toBe(0);
+    });
+  });
+
+  // ========== AISLAMIENTO MULTITENANT ==========
+  describe('aislamiento multitenant', () => {
+    const buildingScope = { scopeType: 'BUILDING' as const, buildingId };
+    const tenantScope = { scopeType: 'TENANT_SHARED' as const, buildingId: null };
+
+    it('findFirst de update incorpora tenantId, scopeType y buildingId', async () => {
+      (prisma.recurringExpense.findFirst as jest.Mock)
+        .mockResolvedValueOnce(
+          makeRecurring({ buildingId, scopeType: 'BUILDING' }),
+        )
+        .mockResolvedValueOnce(
+          makeRecurring({ buildingId, scopeType: 'BUILDING', amount: 500 }),
+        );
+      (prisma.recurringExpense.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await service.updateRecurringExpense(tenantId, recurringId, { amount: 500 }, buildingScope);
+
+      expect(prisma.recurringExpense.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: recurringId, tenantId, scopeType: 'BUILDING', buildingId },
+        }),
+      );
+      expect(prisma.recurringExpense.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: recurringId, tenantId } }),
+      );
+    });
+
+    it('no permite actualizar una regla de otro tenant (NotFound sin mutación)', async () => {
+      (prisma.recurringExpense.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        service.updateRecurringExpense('tenant-other', recurringId, { amount: 1 }, buildingScope),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.recurringExpense.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('contexto BUILDING no puede modificar una regla TENANT_SHARED (NotFound)', async () => {
+      (prisma.recurringExpense.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        service.updateRecurringExpense(tenantId, recurringId, { amount: 1 }, buildingScope),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.recurringExpense.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: recurringId, tenantId, scopeType: 'BUILDING', buildingId },
+        }),
+      );
+      expect(prisma.recurringExpense.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('contexto TENANT_SHARED no puede modificar una regla BUILDING (NotFound)', async () => {
+      (prisma.recurringExpense.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        service.updateRecurringExpense(tenantId, recurringId, { amount: 1 }, tenantScope),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.recurringExpense.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: recurringId, tenantId, scopeType: 'TENANT_SHARED', buildingId: null },
+        }),
+      );
+      expect(prisma.recurringExpense.updateMany).not.toHaveBeenCalled();
+    });
+
+    it('TENANT_SHARED correcto: find incluye tenantId + scopeType TENANT_SHARED + buildingId null', async () => {
+      (prisma.recurringExpense.findFirst as jest.Mock)
+        .mockResolvedValueOnce(
+          makeRecurring({ scopeType: 'TENANT_SHARED', allocationMode: 'EQUAL_SHARE' }),
+        )
+        .mockResolvedValueOnce(
+          makeRecurring({ scopeType: 'TENANT_SHARED', allocationMode: 'EQUAL_SHARE', amount: 500 }),
+        );
+      (prisma.recurringExpense.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+
+      await service.updateRecurringExpense(tenantId, recurringId, { amount: 500 }, tenantScope);
+
+      expect(prisma.recurringExpense.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: recurringId, tenantId, scopeType: 'TENANT_SHARED', buildingId: null },
+        }),
+      );
+    });
+
+    it('no permite usar rubro de otro tenant', async () => {
+      jest.spyOn(prisma.expenseLedgerCategory, 'findFirst').mockResolvedValue(null);
+
+      await expect(
+        service.createRecurringExpense('tenant-1', baseCreateDto, buildingId),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.recurringExpense.create).not.toHaveBeenCalled();
+    });
+
+    it('no permite usar building de otro tenant', async () => {
+      jest.spyOn(prisma.building, 'findFirst').mockResolvedValue(null);
+
+      await expect(
+        service.createRecurringExpense('tenant-1', baseCreateDto, buildingId),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.recurringExpense.create).not.toHaveBeenCalled();
+    });
+
+    it('cron updateMany incluye id + tenantId en where', async () => {
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([
+        makeRecurring({
+          id: 're-c1',
+          tenantId,
+          buildingId,
+          scopeType: 'BUILDING',
+          nextRunDate: new Date('2020-01-01'),
+        }),
+      ] as any);
+      tx.expense.create.mockResolvedValue({ id: 'expense-c1', tenantId, buildingId });
+      tx.recurringExpense.updateMany.mockResolvedValue({ count: 1 });
+
+      await service.processRecurringExpenses();
+
+      expect(tx.recurringExpense.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 're-c1', tenantId },
+        }),
+      );
+    });
+  });
+
+  // ========== PROCESS CONTINÚA TRAS FALLO ==========
+  describe('processRecurringExpenses — continúa tras fallo', () => {
+    it('regla A falla, regla B válida: A se registra en error, B se procesa, createdCount=1', async () => {
+      const ruleA = makeRecurring({
+        id: 're-a',
+        buildingId: null,
+        scopeType: 'BUILDING',
+        nextRunDate: new Date('2020-01-01'),
+      });
+      const ruleB = makeRecurring({
+        id: 're-b',
+        buildingId,
+        scopeType: 'BUILDING',
+        nextRunDate: new Date('2020-01-01'),
+      });
+      jest.spyOn(prisma.recurringExpense, 'findMany').mockResolvedValue([ruleA, ruleB] as any);
+      tx.expense.create.mockResolvedValue({ id: 'expense-b', tenantId, buildingId });
+      tx.recurringExpense.updateMany.mockResolvedValue({ count: 1 });
+
+      const result = await service.processRecurringExpenses();
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to process recurring expense re-a'),
+        expect.any(String),
+      );
+      expect(tx.expense.create).toHaveBeenCalledTimes(1);
+      expect(tx.recurringExpense.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 're-b', tenantId } }),
+      );
+      expect(result.createdCount).toBe(1);
+    });
+  });
+});

--- a/apps/api/src/finanzas/recurring-expense.service.ts
+++ b/apps/api/src/finanzas/recurring-expense.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, BadRequestException, NotFoundException, UnprocessableEntityException } from '@nestjs/common';
+import { Prisma, RecurringExpenseAllocationMode } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
-import { RecurringExpense, AuditAction } from '@prisma/client';
+import { MovementAllocationService } from './movement-allocation.service';
 import {
   CreateRecurringExpenseDto,
   UpdateRecurringExpenseDto,
@@ -9,10 +10,22 @@ import {
 } from './recurring-expense.dto';
 
 /**
- * [PHASE 4 HARD #14] RecurringExpenseService
- * Manages recurring expense templates that auto-generate DRAFT expenses
- * - Create/update/delete recurring expense rules
- * - Daily cronjob processes due rules and creates DRAFT expenses
+ * Contexto de scope esperado para operaciones de actualización.
+ * BUILDING: buildingId de la ruta (nunca null).
+ * TENANT_SHARED: buildingId null obligatoriamente.
+ */
+export interface RecurringExpenseUpdateScope {
+  scopeType: 'BUILDING' | 'TENANT_SHARED';
+  buildingId: string | null;
+}
+
+/**
+ * RecurringExpenseService — canonical, transactional recurring expense templates.
+ *
+ * BUILDING scope: single building, buildingId from route, no allocations.
+ * TENANT_SHARED scope: multi-building, allocationMode required.
+ *   - MANUAL: percentage templates stored in RecurringExpenseAllocation.
+ *   - EQUAL_SHARE / BUILDING_TOTAL_M2: computed dynamically at execution time.
  */
 @Injectable()
 export class RecurringExpenseService {
@@ -21,22 +34,171 @@ export class RecurringExpenseService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly auditService: AuditService,
+    private readonly movementAllocationService: MovementAllocationService,
   ) {}
 
   /**
-   * Create a new recurring expense template
+   * Create a new recurring expense template.
+   * BUILDING: requires buildingId from route param, no allocations.
+   * TENANT_SHARED MANUAL: requires allocations (percentage only), atomic create.
+   * TENANT_SHARED EQUAL_SHARE / BUILDING_TOTAL_M2: no allocations stored.
    */
   async createRecurringExpense(
     tenantId: string,
-    buildingId: string,
     createDto: CreateRecurringExpenseDto,
+    buildingId?: string,
   ): Promise<RecurringExpenseDto> {
+    // --- Scope resolution from the ORIGINAL payload (before resolving scope) ---
+    const isBuildingRoute = !!buildingId;
+
+    // Building route: scopeType must be omitted or BUILDING
+    if (isBuildingRoute && createDto.scopeType === 'TENANT_SHARED') {
+      throw new BadRequestException(
+        'Los endpoints /buildings/:buildingId solo permiten scopeType BUILDING',
+      );
+    }
+    // Tenant route: scopeType must be omitted or TENANT_SHARED
+    if (!isBuildingRoute && createDto.scopeType === 'BUILDING') {
+      throw new BadRequestException(
+        'scopeType BUILDING requiere la ruta /buildings/:buildingId',
+      );
+    }
+
+    const scopeType = isBuildingRoute
+      ? 'BUILDING'
+      : (createDto.scopeType ?? 'TENANT_SHARED');
+
+    // --- BUILDING invariants ---
+    if (scopeType === 'BUILDING') {
+      await this.validateBuildingBelongsToTenant(tenantId, buildingId!);
+
+      // Reject allocations and allocationMode on BUILDING scope
+      if (createDto.allocations && createDto.allocations.length > 0) {
+        throw new BadRequestException(
+          'No se pueden enviar allocations para scope BUILDING',
+        );
+      }
+      if (createDto.allocationMode) {
+        throw new BadRequestException(
+          'No se puede enviar allocationMode para scope BUILDING',
+        );
+      }
+    }
+
+    // --- TENANT_SHARED invariants ---
+    let allocationMode: RecurringExpenseAllocationMode | null = null;
+    if (scopeType === 'TENANT_SHARED') {
+      if (!createDto.allocationMode) {
+        throw new BadRequestException('allocationMode es requerido para scope TENANT_SHARED');
+      }
+      allocationMode = createDto.allocationMode;
+
+      if (allocationMode === RecurringExpenseAllocationMode.MANUAL) {
+        if (!createDto.allocations || createDto.allocations.length === 0) {
+          throw new BadRequestException(
+            'allocations es requerido para allocationMode MANUAL',
+          );
+        }
+        // Canonical allocation validation: tenant ownership, duplicates,
+        // percentage range and sum=100% (percentage mode, no amountMinor)
+        await this.movementAllocationService.validateAllocations(
+          tenantId,
+          createDto.allocations,
+          createDto.amount,
+          createDto.currency,
+        );
+      } else {
+        // EQUAL_SHARE / BUILDING_TOTAL_M2: reject allocations if provided
+        if (createDto.allocations && createDto.allocations.length > 0) {
+          throw new BadRequestException(
+            `allocationMode ${allocationMode} no acepta allocations manuales. Use EQUAL_SHARE o BUILDING_TOTAL_M2 sin allocations.`,
+          );
+        }
+      }
+    }
+
+    // --- Category scope validation ---
+    const category = await this.prisma.expenseLedgerCategory.findFirst({
+      where: { id: createDto.categoryId, tenantId, isActive: true },
+    });
+    if (!category) {
+      throw new NotFoundException(`Rubro de gasto no encontrado: ${createDto.categoryId}`);
+    }
+
+    if (scopeType === 'BUILDING' && category.catalogScope !== 'BUILDING') {
+      throw new UnprocessableEntityException({
+        statusCode: 422,
+        error: 'CATEGORY_SCOPE_MISMATCH',
+        message: `El rubro "${category.name}" es de scope CONDOMINIUM_COMMON y no puede usarse para gastos recurrentes BUILDING.`,
+      });
+    }
+    if (scopeType === 'TENANT_SHARED' && category.catalogScope !== 'CONDOMINIUM_COMMON') {
+      throw new UnprocessableEntityException({
+        statusCode: 422,
+        error: 'CATEGORY_SCOPE_MISMATCH',
+        message: `El rubro "${category.name}" es de scope BUILDING y no puede usarse para gastos recurrentes TENANT_SHARED.`,
+      });
+    }
+
     const nextRunDate = this.calculateNextRunDate(new Date(), createDto.frequency);
 
+    if (scopeType === 'TENANT_SHARED' && allocationMode === RecurringExpenseAllocationMode.MANUAL) {
+      // Atomic: create RecurringExpense + RecurringExpenseAllocation[] in one transaction
+      const result = await this.prisma.$transaction(async (tx) => {
+        const recurring = await tx.recurringExpense.create({
+          data: {
+            tenantId,
+            buildingId: null,
+            scopeType,
+            allocationMode,
+            categoryId: createDto.categoryId,
+            amount: createDto.amount,
+            currency: createDto.currency,
+            concept: createDto.concept,
+            frequency: createDto.frequency,
+            nextRunDate,
+            isActive: true,
+          },
+        });
+
+        await tx.recurringExpenseAllocation.createMany({
+          data: createDto.allocations!.map((alloc) => ({
+            tenantId,
+            recurringExpenseId: recurring.id,
+            buildingId: alloc.buildingId,
+            percentage: alloc.percentage,
+          })),
+        });
+
+        return recurring;
+      });
+
+      void this.auditService.createLog({
+        tenantId,
+        action: 'EXPENSE_CREATE',
+        entityType: 'RecurringExpense',
+        entityId: result.id,
+        metadata: {
+          scopeType,
+          ...(allocationMode ? { allocationMode } : {}),
+          frequency: createDto.frequency,
+          amount: createDto.amount,
+          concept: createDto.concept,
+          nextRunDate: nextRunDate.toISOString(),
+          allocationCount: createDto.allocations!.length,
+        },
+      });
+
+      return result as RecurringExpenseDto;
+    }
+
+    // BUILDING or TENANT_SHARED with EQUAL_SHARE/BUILDING_TOTAL_M2
     const recurring = await this.prisma.recurringExpense.create({
       data: {
         tenantId,
-        buildingId,
+        buildingId: scopeType === 'BUILDING' ? buildingId! : null,
+        scopeType,
+        allocationMode,
         categoryId: createDto.categoryId,
         amount: createDto.amount,
         currency: createDto.currency,
@@ -47,13 +209,14 @@ export class RecurringExpenseService {
       },
     });
 
-    // Audit creation
     void this.auditService.createLog({
       tenantId,
-      action: AuditAction.EXPENSE_CREATE,
+      action: 'EXPENSE_CREATE',
       entityType: 'RecurringExpense',
       entityId: recurring.id,
       metadata: {
+        scopeType,
+        ...(allocationMode ? { allocationMode } : {}),
         frequency: createDto.frequency,
         amount: createDto.amount,
         concept: createDto.concept,
@@ -65,64 +228,256 @@ export class RecurringExpenseService {
   }
 
   /**
-   * List recurring expenses for a building
+   * List recurring expenses for a building or tenant.
    */
   async listRecurringExpenses(
     tenantId: string,
-    buildingId: string,
+    buildingId: string | undefined,
     includeInactive: boolean = false,
+    scopeType?: 'BUILDING' | 'TENANT_SHARED',
   ): Promise<RecurringExpenseDto[]> {
+    const where: Record<string, unknown> = {
+      tenantId,
+      ...(includeInactive ? {} : { isActive: true }),
+    };
+
+    if (scopeType) {
+      where.scopeType = scopeType;
+    }
+
+    if (buildingId) {
+      where.buildingId = buildingId;
+    } else {
+      where.buildingId = null;
+    }
+
     return this.prisma.recurringExpense.findMany({
-      where: {
-        tenantId,
-        buildingId,
-        ...(includeInactive ? {} : { isActive: true }),
-      },
+      where,
       orderBy: { nextRunDate: 'asc' },
     }) as Promise<RecurringExpenseDto[]>;
   }
 
   /**
-   * Update a recurring expense template
+   * Update a recurring expense template.
+   * Allocation replacement for TENANT_SHARED MANUAL is transactional.
+   * Changing allocationMode to EQUAL_SHARE/BUILDING_TOTAL_M2 removes templates.
+   * Changing to MANUAL requires new allocations.
+   * BUILDING scope rejects allocationMode and allocations.
+   * All mutations are tenant-scoped (updateMany with id+tenantId).
+   * The initial lookup enforces the expected scope: a rule outside the
+   * requested scope (wrong building or wrong scopeType) is a 404.
    */
   async updateRecurringExpense(
     tenantId: string,
     recurringId: string,
     updateDto: UpdateRecurringExpenseDto,
+    expectedScope: RecurringExpenseUpdateScope,
   ): Promise<RecurringExpenseDto> {
-    // Verify ownership
     const existing = await this.prisma.recurringExpense.findFirst({
-      where: { id: recurringId, tenantId },
+      where: {
+        id: recurringId,
+        tenantId,
+        scopeType: expectedScope.scopeType,
+        buildingId: expectedScope.buildingId,
+      },
+      include: { allocations: true },
     });
 
     if (!existing) {
-      throw new Error(`RecurringExpense not found: ${recurringId}`);
+      throw new NotFoundException(`RecurringExpense not found: ${recurringId}`);
     }
 
-    const updated = await this.prisma.recurringExpense.update({
-      where: { id: recurringId },
-      data: updateDto,
-    });
+    // BUILDING scope: reject allocationMode and allocations
+    if (existing.scopeType === 'BUILDING') {
+      if (updateDto.allocationMode) {
+        throw new BadRequestException(
+          'No se puede cambiar allocationMode en scope BUILDING',
+        );
+      }
+      if (updateDto.allocations && updateDto.allocations.length > 0) {
+        throw new BadRequestException(
+          'No se pueden enviar allocations en scope BUILDING',
+        );
+      }
+    }
 
-    return updated as RecurringExpenseDto;
+    // Determine effective allocationMode after update
+    const effectiveMode = updateDto.allocationMode ?? existing.allocationMode;
+    // Effective amount/currency after the update, for allocation validation
+    const effectiveAmount = updateDto.amount ?? existing.amount;
+    const effectiveCurrency = existing.currency;
+
+    if (existing.scopeType === 'TENANT_SHARED') {
+      if (effectiveMode === RecurringExpenseAllocationMode.MANUAL) {
+        if (updateDto.allocations) {
+          // Validate fully BEFORE replacing templates
+          await this.movementAllocationService.validateAllocations(
+            tenantId,
+            updateDto.allocations,
+            effectiveAmount,
+            effectiveCurrency,
+          );
+
+          // Replacement: delete+create atomically, tenant-scoped
+          return await this.prisma.$transaction(async (tx) => {
+            await tx.recurringExpenseAllocation.deleteMany({
+              where: { recurringExpenseId: recurringId, tenantId },
+            });
+
+            await tx.recurringExpenseAllocation.createMany({
+              data: updateDto.allocations!.map((alloc) => ({
+                tenantId,
+                recurringExpenseId: recurringId,
+                buildingId: alloc.buildingId,
+                percentage: alloc.percentage,
+              })),
+            });
+
+            const updateResult = await tx.recurringExpense.updateMany({
+              where: { id: recurringId, tenantId },
+              data: {
+                ...(updateDto.isActive !== undefined && { isActive: updateDto.isActive }),
+                ...(updateDto.amount !== undefined && { amount: updateDto.amount }),
+                ...(updateDto.concept !== undefined && { concept: updateDto.concept }),
+                ...(updateDto.allocationMode !== undefined && { allocationMode: updateDto.allocationMode }),
+              },
+            });
+            if (updateResult.count !== 1) {
+              throw new NotFoundException(`RecurringExpense not found: ${recurringId}`);
+            }
+
+            const updated = await tx.recurringExpense.findFirst({
+              where: { id: recurringId, tenantId },
+              include: { allocations: true },
+            });
+            if (!updated) {
+              throw new NotFoundException(`RecurringExpense not found: ${recurringId}`);
+            }
+
+            return updated as unknown as RecurringExpenseDto;
+          });
+        }
+
+        // No new allocations: only valid when the rule already is MANUAL
+        // with persisted templates; transitioning from a dynamic mode to
+        // MANUAL without new allocations would violate the model invariant.
+        if (
+          existing.allocationMode !== RecurringExpenseAllocationMode.MANUAL ||
+          existing.allocations.length === 0
+        ) {
+          throw new BadRequestException(
+            'Para allocationMode MANUAL se requieren allocations',
+          );
+        }
+
+        // No allocations change, just update fields (tenant-scoped)
+        const updated = await this.prisma.recurringExpense.updateMany({
+          where: { id: recurringId, tenantId },
+          data: {
+            ...(updateDto.isActive !== undefined && { isActive: updateDto.isActive }),
+            ...(updateDto.amount !== undefined && { amount: updateDto.amount }),
+            ...(updateDto.concept !== undefined && { concept: updateDto.concept }),
+            ...(updateDto.allocationMode !== undefined && { allocationMode: updateDto.allocationMode }),
+          },
+        });
+        if (updated.count !== 1) {
+          throw new NotFoundException(`RecurringExpense not found: ${recurringId}`);
+        }
+
+        const refreshed = await this.prisma.recurringExpense.findFirst({
+          where: { id: recurringId, tenantId },
+          include: { allocations: true },
+        });
+        if (!refreshed) {
+          throw new NotFoundException(`RecurringExpense not found: ${recurringId}`);
+        }
+
+        return refreshed as unknown as RecurringExpenseDto;
+      }
+
+      // Switching to EQUAL_SHARE or BUILDING_TOTAL_M2
+      if (updateDto.allocationMode && updateDto.allocationMode !== RecurringExpenseAllocationMode.MANUAL) {
+        // Reject allocations if provided
+        if (updateDto.allocations && updateDto.allocations.length > 0) {
+          throw new BadRequestException(
+            `allocationMode ${updateDto.allocationMode} no acepta allocations manuales`,
+          );
+        }
+
+        return await this.prisma.$transaction(async (tx) => {
+          // Delete template allocations (tenant-scoped)
+          await tx.recurringExpenseAllocation.deleteMany({
+            where: { recurringExpenseId: recurringId, tenantId },
+          });
+
+          const updateResult = await tx.recurringExpense.updateMany({
+            where: { id: recurringId, tenantId },
+            data: {
+              ...(updateDto.isActive !== undefined && { isActive: updateDto.isActive }),
+              ...(updateDto.amount !== undefined && { amount: updateDto.amount }),
+              ...(updateDto.concept !== undefined && { concept: updateDto.concept }),
+              allocationMode: updateDto.allocationMode,
+            },
+          });
+          if (updateResult.count !== 1) {
+            throw new NotFoundException(`RecurringExpense not found: ${recurringId}`);
+          }
+
+          const updated = await tx.recurringExpense.findFirst({
+            where: { id: recurringId, tenantId },
+            include: { allocations: true },
+          });
+          if (!updated) {
+            throw new NotFoundException(`RecurringExpense not found: ${recurringId}`);
+          }
+
+          return updated as unknown as RecurringExpenseDto;
+        });
+      }
+    }
+
+    // Default: just update fields (tenant-scoped)
+    const updated = await this.prisma.recurringExpense.updateMany({
+      where: { id: recurringId, tenantId },
+      data: {
+        ...(updateDto.isActive !== undefined && { isActive: updateDto.isActive }),
+        ...(updateDto.amount !== undefined && { amount: updateDto.amount }),
+        ...(updateDto.concept !== undefined && { concept: updateDto.concept }),
+        ...(updateDto.allocationMode !== undefined && { allocationMode: updateDto.allocationMode }),
+      },
+    });
+    if (updated.count !== 1) {
+      throw new NotFoundException(`RecurringExpense not found: ${recurringId}`);
+    }
+
+    const refreshed = await this.prisma.recurringExpense.findFirst({
+      where: { id: recurringId, tenantId },
+      include: { allocations: true },
+    });
+    if (!refreshed) {
+      throw new NotFoundException(`RecurringExpense not found: ${recurringId}`);
+    }
+
+    return refreshed as unknown as RecurringExpenseDto;
   }
 
   /**
-   * [PHASE 4 HARD #14 CRONJOB] Process all due recurring expenses
-   * Runs daily: creates DRAFT expenses for any recurring rules past nextRunDate
+   * Process all due recurring expenses.
+   * Each rule is executed inside a single transaction:
+   *   create Expense + create MovementAllocation[] + update nextRunDate
+   * If any step fails, the entire rule rolls back.
+   * Audit is fired AFTER the transaction commits.
    */
   async processRecurringExpenses(): Promise<{ createdCount: number }> {
     const now = new Date();
 
-    // Find all active recurring expenses due today or past
     const due = await this.prisma.recurringExpense.findMany({
       where: {
         isActive: true,
         nextRunDate: { lte: now },
       },
       include: {
-        building: { select: { id: true, name: true } },
-        category: { select: { id: true, name: true } },
+        allocations: { select: { buildingId: true, percentage: true } },
       },
     });
 
@@ -130,49 +485,7 @@ export class RecurringExpenseService {
 
     for (const recurring of due) {
       try {
-        const period = this.getCurrentPeriod();
-
-        // Create DRAFT expense
-        await this.prisma.expense.create({
-          data: {
-            tenantId: recurring.tenantId,
-            buildingId: recurring.buildingId,
-            period,
-            categoryId: recurring.categoryId,
-            description: `[Recurrente] ${recurring.concept}`,
-            amountMinor: recurring.amount,
-            currencyCode: recurring.currency,
-            invoiceDate: now,
-            status: 'DRAFT',
-            scopeType: 'BUILDING',
-            createdByMembershipId: 'system-recurring-cronjob',
-            postedAt: now,
-          },
-        });
-
-        // Calculate next run date
-        const nextRun = this.calculateNextRunDate(now, recurring.frequency);
-
-        // Update nextRunDate
-        await this.prisma.recurringExpense.update({
-          where: { id: recurring.id },
-          data: { nextRunDate: nextRun },
-        });
-
-        // Audit the creation (fire-and-forget)
-        void this.auditService.createLog({
-          tenantId: recurring.tenantId,
-          action: AuditAction.EXPENSE_CREATE,
-          entityType: 'Expense',
-          entityId: recurring.id,
-          metadata: {
-            source: 'RECURRING_CRONJOB',
-            recurringId: recurring.id,
-            frequency: recurring.frequency,
-            nextRunDate: nextRun.toISOString(),
-          },
-        });
-
+        await this.processOneRecurringExpense(recurring, now);
         createdCount++;
       } catch (error) {
         this.logger.error(
@@ -186,8 +499,186 @@ export class RecurringExpenseService {
   }
 
   /**
-   * Calculate next run date based on frequency
+   * Process a single recurring expense rule.
+   * The transaction only performs the atomic mutations and returns minimal data;
+   * the audit log is fired AFTER the transaction resolves (post-commit).
    */
+  private async processOneRecurringExpense(
+    recurring: {
+      id: string;
+      tenantId: string;
+      buildingId: string | null;
+      scopeType: string;
+      allocationMode: RecurringExpenseAllocationMode | null;
+      categoryId: string;
+      amount: number;
+      currency: string;
+      concept: string;
+      frequency: string;
+      allocations: Array<{ buildingId: string; percentage: number }>;
+    },
+    now: Date,
+  ): Promise<void> {
+    const period = this.getCurrentPeriod();
+    const nextRun = this.calculateNextRunDate(now, recurring.frequency);
+
+    if (recurring.scopeType === 'BUILDING') {
+      if (!recurring.buildingId) {
+        throw new Error(`RecurringExpense ${recurring.id} has BUILDING scope but no buildingId`);
+      }
+
+      const expenseId = await this.prisma.$transaction(async (tx) => {
+        const expense = await tx.expense.create({
+          data: {
+            tenantId: recurring.tenantId,
+            buildingId: recurring.buildingId!,
+            period,
+            categoryId: recurring.categoryId,
+            description: `[Recurrente] ${recurring.concept}`,
+            amountMinor: recurring.amount,
+            currencyCode: recurring.currency,
+            invoiceDate: now,
+            status: 'DRAFT',
+            scopeType: 'BUILDING',
+            createdByMembershipId: 'system-recurring-cronjob',
+            postedAt: now,
+          },
+        });
+
+        const nextRunResult = await tx.recurringExpense.updateMany({
+          where: { id: recurring.id, tenantId: recurring.tenantId },
+          data: { nextRunDate: nextRun },
+        });
+        if (nextRunResult.count !== 1) {
+          throw new Error(
+            `RecurringExpense ${recurring.id} no encontrado para actualizar nextRunDate`,
+          );
+        }
+
+        return expense.id;
+      });
+
+      // Post-commit audit
+      void this.auditService.createLog({
+        tenantId: recurring.tenantId,
+        action: 'EXPENSE_CREATE',
+        entityType: 'Expense',
+        entityId: expenseId,
+        metadata: {
+          source: 'RECURRING_CRONJOB',
+          recurringId: recurring.id,
+          scopeType: recurring.scopeType,
+          frequency: recurring.frequency,
+          nextRunDate: nextRun.toISOString(),
+        },
+      });
+      return;
+    }
+
+    // --- TENANT_SHARED ---
+    let percentageAllocations: Array<{ buildingId: string; percentage: number }>;
+
+    if (recurring.allocationMode === RecurringExpenseAllocationMode.MANUAL) {
+      if (recurring.allocations.length === 0) {
+        throw new Error(
+          `RecurringExpense ${recurring.id} is MANUAL but has no allocations`,
+        );
+      }
+      percentageAllocations = recurring.allocations;
+    } else if (
+      recurring.allocationMode === RecurringExpenseAllocationMode.EQUAL_SHARE ||
+      recurring.allocationMode === RecurringExpenseAllocationMode.BUILDING_TOTAL_M2
+    ) {
+      const suggestions = await this.movementAllocationService.suggestAllocationsByMode(
+        recurring.tenantId,
+        recurring.allocationMode,
+      );
+      if (suggestions.length === 0) {
+        throw new Error(
+          `RecurringExpense ${recurring.id} mode ${recurring.allocationMode} produced zero buildings`,
+        );
+      }
+      percentageAllocations = suggestions.map((s) => ({
+        buildingId: s.buildingId,
+        percentage: s.percentage,
+      }));
+    } else {
+      throw new Error(
+        `RecurringExpense ${recurring.id} has invalid allocationMode: ${recurring.allocationMode}`,
+      );
+    }
+
+    // Validate resolved allocations (manual or dynamic) before creating anything.
+    // Protects against deleted/foreign buildings, duplicates, wrong sum,
+    // and invalid dynamic distributions.
+    await this.movementAllocationService.validateAllocations(
+      recurring.tenantId,
+      percentageAllocations,
+      recurring.amount,
+      recurring.currency,
+    );
+
+    // Atomic: create Expense + MovementAllocations (canonical, largest remainder)
+    // + update nextRunDate. No audit inside the transaction.
+    const expenseId = await this.prisma.$transaction(async (tx) => {
+      const expense = await tx.expense.create({
+        data: {
+          tenantId: recurring.tenantId,
+          buildingId: null,
+          period,
+          categoryId: recurring.categoryId,
+          description: `[Recurrente] ${recurring.concept}`,
+          amountMinor: recurring.amount,
+          currencyCode: recurring.currency,
+          invoiceDate: now,
+          status: 'DRAFT',
+          scopeType: 'TENANT_SHARED',
+          createdByMembershipId: 'system-recurring-cronjob',
+          postedAt: now,
+        },
+      });
+
+      await this.movementAllocationService.createForExpenseInTx(
+        tx,
+        recurring.tenantId,
+        expense.id,
+        recurring.amount,
+        recurring.currency,
+        percentageAllocations,
+      );
+
+      const nextRunResult = await tx.recurringExpense.updateMany({
+        where: { id: recurring.id, tenantId: recurring.tenantId },
+        data: { nextRunDate: nextRun },
+      });
+      if (nextRunResult.count !== 1) {
+        throw new Error(
+          `RecurringExpense ${recurring.id} no encontrado para actualizar nextRunDate`,
+        );
+      }
+
+      return expense.id;
+    });
+
+    // Post-commit audit
+    void this.auditService.createLog({
+      tenantId: recurring.tenantId,
+      action: 'EXPENSE_CREATE',
+      entityType: 'Expense',
+      entityId: expenseId,
+      metadata: {
+        source: 'RECURRING_CRONJOB',
+        recurringId: recurring.id,
+        scopeType: recurring.scopeType,
+        allocationMode: recurring.allocationMode,
+        frequency: recurring.frequency,
+        nextRunDate: nextRun.toISOString(),
+      },
+    });
+  }
+
+  // --- Private helpers ---
+
   private calculateNextRunDate(from: Date, frequency: string): Date {
     const next = new Date(from);
     switch (frequency) {
@@ -204,13 +695,19 @@ export class RecurringExpenseService {
     return next;
   }
 
-  /**
-   * Get current period in YYYY-MM format
-   */
   private getCurrentPeriod(): string {
     const now = new Date();
     const year = now.getFullYear();
     const month = String(now.getMonth() + 1).padStart(2, '0');
     return `${year}-${month}`;
+  }
+
+  private async validateBuildingBelongsToTenant(tenantId: string, buildingId: string): Promise<void> {
+    const building = await this.prisma.building.findFirst({
+      where: { id: buildingId, tenantId },
+    });
+    if (!building) {
+      throw new NotFoundException(`Building not found: ${buildingId}`);
+    }
   }
 }

--- a/apps/api/src/finanzas/tenant-recurring-expense.controller.ts
+++ b/apps/api/src/finanzas/tenant-recurring-expense.controller.ts
@@ -13,7 +13,7 @@ import {
 } from '@nestjs/common';
 import type { Role } from '@buildingos/contracts';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
-import { BuildingAccessGuard } from '../tenancy/building-access.guard';
+import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
 import { RecurringExpenseService } from './recurring-expense.service';
 import { StrictBooleanInterceptor } from './strict-boolean.interceptor';
 import { AuthenticatedRequest } from '../common/types/request.types';
@@ -24,13 +24,13 @@ import {
 } from './recurring-expense.dto';
 
 /**
- * RecurringExpenseController: CRUD of BUILDING-scoped recurring expense templates.
- * Only admins/operators can create/update recurring expenses.
- * This controller only handles BUILDING scope (buildingId from the route).
+ * TenantRecurringExpenseController: CRUD for tenant-shared recurring expense templates
+ * Only admins/operators can create/update recurring expenses
+ * Handles TENANT_SHARED scope (multi-building expenses with allocations)
  */
-@Controller('buildings/:buildingId/recurring-expenses')
-@UseGuards(JwtAuthGuard, BuildingAccessGuard)
-export class RecurringExpenseController {
+@Controller('tenants/:tenantId/recurring-expenses')
+@UseGuards(JwtAuthGuard, TenantAccessGuard)
+export class TenantRecurringExpenseController {
   private readonly adminRoles: readonly Role[] = [
     'TENANT_ADMIN',
     'TENANT_OWNER',
@@ -40,16 +40,15 @@ export class RecurringExpenseController {
   constructor(private recurringExpenseService: RecurringExpenseService) {}
 
   /**
-   * POST /buildings/:buildingId/recurring-expenses
-   * Create a new recurring expense template
+   * POST /tenants/:tenantId/recurring-expenses
+   * Create a new tenant-shared recurring expense template
    */
   @Post()
   async createRecurringExpense(
-    @Param('buildingId') buildingId: string,
+    @Param('tenantId') tenantId: string,
     @Body() createDto: CreateRecurringExpenseDto,
     @Request() req: AuthenticatedRequest,
   ): Promise<RecurringExpenseDto> {
-    const tenantId = req.tenantId!;
     const userRoles = req.user?.roles || [];
 
     // Only TENANT_ADMIN, TENANT_OWNER, OPERATOR can create
@@ -60,43 +59,42 @@ export class RecurringExpenseController {
     return this.recurringExpenseService.createRecurringExpense(
       tenantId,
       createDto,
-      buildingId,
     );
   }
 
   /**
-   * GET /buildings/:buildingId/recurring-expenses
-   * List recurring expense templates for a building
+   * GET /tenants/:tenantId/recurring-expenses
+   * List tenant-shared recurring expense templates
    */
   @Get()
   async listRecurringExpenses(
-    @Param('buildingId') buildingId: string,
+    @Param('tenantId') tenantId: string,
     @Query('includeInactive') includeInactive: string,
     @Request() req: AuthenticatedRequest,
   ): Promise<RecurringExpenseDto[]> {
-    const tenantId = req.tenantId!;
     const shouldIncludeInactive = includeInactive === 'true';
 
+    // List TENANT_SHARED scope only
     return this.recurringExpenseService.listRecurringExpenses(
       tenantId,
-      buildingId,
+      undefined,
       shouldIncludeInactive,
+      'TENANT_SHARED',
     );
   }
 
   /**
-   * PATCH /buildings/:buildingId/recurring-expenses/:id
-   * Update a recurring expense template (enable/disable or modify)
+   * PATCH /tenants/:tenantId/recurring-expenses/:id
+   * Update a tenant-shared recurring expense template
    */
   @Patch(':id')
   @UseInterceptors(new StrictBooleanInterceptor())
   async updateRecurringExpense(
-    @Param('buildingId') buildingId: string,
+    @Param('tenantId') tenantId: string,
     @Param('id') recurringId: string,
     @Body() updateDto: UpdateRecurringExpenseDto,
     @Request() req: AuthenticatedRequest,
   ): Promise<RecurringExpenseDto> {
-    const tenantId = req.tenantId!;
     const userRoles = req.user?.roles || [];
 
     // Only TENANT_ADMIN, TENANT_OWNER, OPERATOR can update
@@ -108,7 +106,7 @@ export class RecurringExpenseController {
       tenantId,
       recurringId,
       updateDto,
-      { scopeType: 'BUILDING', buildingId },
+      { scopeType: 'TENANT_SHARED', buildingId: null },
     );
   }
 }


### PR DESCRIPTION
## Resumen

Agrega soporte backend para gastos recurrentes compartidos a nivel tenant, manteniendo separado el flujo existente por edificio.

### Alcance
- `BUILDING`: regla recurrente para un edificio específico.
- `TENANT_SHARED / MANUAL`: reparto porcentual persistido por edificio.
- `TENANT_SHARED / EQUAL_SHARE`: reparto dinámico igualitario al ejecutar.
- `TENANT_SHARED / BUILDING_TOTAL_M2`: reparto dinámico según m² totales por edificio.
- Nuevo controller tenant-scoped para `/tenants/:tenantId/recurring-expenses`.
- Aislamiento estricto entre endpoints BUILDING y TENANT_SHARED.
- Creación transaccional de Expense + MovementAllocation + avance de `nextRunDate`.
- Reutilización del motor canónico de allocations y largest remainder.
- Auditoría post-commit y sin `allocationMode: null` para reglas BUILDING.

### Prisma
- `RecurringExpense.buildingId` pasa a nullable.
- Se agrega `scopeType` con default `BUILDING`.
- Se agrega enum `RecurringExpenseAllocationMode` (`MANUAL`, `EQUAL_SHARE`, `BUILDING_TOTAL_M2`).
- Se agrega `RecurringExpenseAllocation` con templates porcentuales para modo MANUAL.
- FK `RecurringExpenseAllocation -> Building` usa `ON DELETE RESTRICT`.
- FK `RecurringExpense -> Building` mantiene `ON DELETE CASCADE`.

### Validación local
- Suite API completa: **156 passed / 2 skipped suites**, **2080 passed / 13 skipped tests**, **0 failed**.
- TypeScript: 0 errores.
- Prisma validate: OK.
- Migraciones aplicadas desde cero sobre DB local aislada y `migrate status` en up to date.
- Acceptance funcional real con API + PostgreSQL + cron:
  - BUILDING ✅
  - MANUAL 60/40: `6001 + 4000 = 10001` ✅
  - EQUAL_SHARE 50/50: `5001 + 5000 = 10001` ✅
  - BUILDING_TOTAL_M2: `27500 + 18000 = 45500` ✅
  - 4 Expenses creados, 6 MovementAllocation, sin duplicados ✅
  - `nextRunDate` avanzado correctamente ✅
  - aislamiento BUILDING/TENANT_SHARED ✅
  - audit BUILDING verificado ✅

### Nota de migraciones
Durante la acceptance se detectó un drift histórico entre `schema.prisma` y el historial de migraciones de `main`. Se reprodujo también en un worktree limpio de `main`, y se verificó que esta feature **no introduce divergencias adicionales**. Ese problema queda fuera del alcance de este PR y debe tratarse separadamente.

Commit validado: `76b178ed69e1181174aa583a5d249095d34ea7d7`.