### PR TITLE
feat(web): add tenant shared recurring expenses ui

### DIFF
--- a/apps/web/features/finance/components/TenantFinanceDashboard.test.tsx
+++ b/apps/web/features/finance/components/TenantFinanceDashboard.test.tsx
@@ -14,6 +14,10 @@ const useQueryClientMock = jest.fn();
 const useTenantFinanceSummaryMock = jest.fn();
 const useBuildingsMock = jest.fn();
 const useExpensesMock = jest.fn();
+const useTenantRecurringExpensesMock = jest.fn();
+const useCreateTenantRecurringExpenseMock = jest.fn();
+const useUpdateTenantRecurringExpenseMock = jest.fn();
+const useExpenseLedgerCategoriesMock = jest.fn();
 let searchParams = new URLSearchParams();
 
 jest.mock('next/navigation', () => ({
@@ -43,6 +47,10 @@ jest.mock('@/features/buildings/hooks', () => ({
 
 jest.mock('../hooks/useExpenseLedger', () => ({
   useExpenses: (...args: unknown[]) => useExpensesMock(...args),
+  useTenantRecurringExpenses: (...args: unknown[]) => useTenantRecurringExpensesMock(...args),
+  useCreateTenantRecurringExpense: (...args: unknown[]) => useCreateTenantRecurringExpenseMock(...args),
+  useUpdateTenantRecurringExpense: (...args: unknown[]) => useUpdateTenantRecurringExpenseMock(...args),
+  useExpenseLedgerCategories: (...args: unknown[]) => useExpenseLedgerCategoriesMock(...args),
 }));
 
 jest.mock('../services/finance.api', () => ({
@@ -97,6 +105,12 @@ jest.mock('./NotasRevelatoriasPanel', () => ({
   NotasRevelatoriasPanel: () => <div>Notas Revelatorias panel</div>,
 }));
 
+jest.mock('./TenantRecurringExpensesTab', () => ({
+  TenantRecurringExpensesTab: ({ tenantId }: { tenantId: string }) => (
+    <div data-testid="tenant-recurring-tab">Tenant recurring tab {tenantId}</div>
+  ),
+}));
+
 jest.mock('@/shared/lib/format/money', () => ({
   formatCurrency: (value: number) => `$${value.toLocaleString('es-AR')}`,
 }));
@@ -138,6 +152,21 @@ describe('TenantFinanceDashboard', () => {
       error: null,
       refetch: jest.fn(),
     });
+    useTenantRecurringExpensesMock.mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+    useCreateTenantRecurringExpenseMock.mockReturnValue({
+      mutateAsync: jest.fn(),
+      isPending: false,
+    });
+    useUpdateTenantRecurringExpenseMock.mockReturnValue({
+      mutateAsync: jest.fn(),
+      isPending: false,
+    });
+    useExpenseLedgerCategoriesMock.mockReturnValue({ data: [] });
   });
 
   it('opens the payments tab from the query string and updates when navigation changes', () => {
@@ -171,5 +200,26 @@ describe('TenantFinanceDashboard', () => {
 
     expect(routerReplace).toHaveBeenCalledWith('/tenant-1/finanzas?foo=bar&tab=payments', { scroll: false });
     expect(periodInput.value).toBe('2026-08');
+  });
+
+  it('shows the recurring rules tab', () => {
+    render(<TenantFinanceDashboard />);
+
+    expect(screen.getByText('Reglas recurrentes')).toBeTruthy();
+  });
+
+  it('selects the recurring tab from ?tab=recurring', () => {
+    searchParams = new URLSearchParams('tab=recurring');
+    render(<TenantFinanceDashboard />);
+
+    expect(screen.getByTestId('tenant-recurring-tab').textContent).toContain(
+      'Tenant recurring tab tenant-1',
+    );
+  });
+
+  it('does not render the recurring tab by default', () => {
+    render(<TenantFinanceDashboard />);
+
+    expect(screen.queryByTestId('tenant-recurring-tab')).toBeNull();
   });
 });

--- a/apps/web/features/finance/components/TenantFinanceDashboard.tsx
+++ b/apps/web/features/finance/components/TenantFinanceDashboard.tsx
@@ -19,13 +19,14 @@ import { ExpenseLedgerCategoriesManager } from './ExpenseLedgerCategoriesManager
 import { TenantExpensesList } from './TenantExpensesList';
 import { ExpenseHistoryReport } from './ExpenseHistoryReport';
 import { NotasRevelatoriasPanel } from './NotasRevelatoriasPanel';
+import { TenantRecurringExpensesTab } from './TenantRecurringExpensesTab';
 import { useExpenses } from '../hooks/useExpenseLedger';
 import { formatCurrency } from '@/shared/lib/format/money';
 import { getDownloadUrl } from '@/features/buildings/services/documents.api';
 import { FileText, Loader2 } from 'lucide-react';
 import { useToast } from '@/shared/components/ui/Toast';
 
-type Tab = 'overview' | 'rubros' | 'expenses' | 'payments' | 'charges' | 'delinquent' | 'reports' | 'notas';
+type Tab = 'overview' | 'rubros' | 'expenses' | 'recurring' | 'payments' | 'charges' | 'delinquent' | 'reports' | 'notas';
 
 interface Params {
   tenantId: string;
@@ -43,7 +44,7 @@ export const TenantFinanceDashboard = () => {
   const searchParams = useSearchParams();
   const tenantId = params?.tenantId;
   const currentMonth = new Date().toISOString().slice(0, 7);
-  const allowedTabs: readonly Tab[] = ['overview', 'rubros', 'expenses', 'payments', 'charges', 'delinquent', 'reports', 'notas'];
+  const allowedTabs: readonly Tab[] = ['overview', 'rubros', 'expenses', 'recurring', 'payments', 'charges', 'delinquent', 'reports', 'notas'];
   const activeTab = (() => {
     const tabParam = searchParams.get('tab');
     if (tabParam && allowedTabs.includes(tabParam as Tab)) {
@@ -169,16 +170,17 @@ export const TenantFinanceDashboard = () => {
         {/* Tabs */}
         <div className="space-y-4">
            <div className="flex flex-wrap gap-2">
-             {[
-               { id: 'overview', label: 'Resumen' },
-               { id: 'expenses', label: `Gastos comunes (${visibleTenantExpenses.length})` },
-               { id: 'rubros', label: 'Rubros' },
-               { id: 'payments', label: `Pagos (${payments.length})` },
-               { id: 'charges', label: 'Cargos' },
-               { id: 'delinquent', label: `Morosos (${summary?.delinquentUnitsCount || 0})` },
-               { id: 'reports', label: 'Historial de gastos' },
-               { id: 'notas', label: 'Notas Revelatorias' },
-             ].map((tab) => (
+              {[
+                { id: 'overview', label: 'Resumen' },
+                { id: 'expenses', label: `Gastos comunes (${visibleTenantExpenses.length})` },
+                { id: 'rubros', label: 'Rubros' },
+                { id: 'recurring', label: 'Reglas recurrentes' },
+                { id: 'payments', label: `Pagos (${payments.length})` },
+                { id: 'charges', label: 'Cargos' },
+                { id: 'delinquent', label: `Morosos (${summary?.delinquentUnitsCount || 0})` },
+                { id: 'reports', label: 'Historial de gastos' },
+                { id: 'notas', label: 'Notas Revelatorias' },
+              ].map((tab) => (
              <button
                key={tab.id}
                onClick={() => updateTab(tab.id as Tab)}
@@ -237,6 +239,9 @@ export const TenantFinanceDashboard = () => {
             tenantId={tenantId || ''}
             defaultScopeFilter="CONDOMINIUM_COMMON"
           />
+        )}
+        {activeTab === 'recurring' && (
+          <TenantRecurringExpensesTab tenantId={tenantId || ''} />
         )}
         {activeTab === 'payments' && (
           <>

--- a/apps/web/features/finance/components/TenantRecurringExpenseModal.tsx
+++ b/apps/web/features/finance/components/TenantRecurringExpenseModal.tsx
@@ -1,0 +1,395 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Loader2, X } from 'lucide-react';
+import Card from '@/shared/components/ui/Card';
+import Button from '@/shared/components/ui/Button';
+import Input from '@/shared/components/ui/Input';
+import Select from '@/shared/components/ui/Select';
+import { toCents, formatCurrency } from '@/shared/lib/format/money';
+import type { Building } from '@/features/units/units.types';
+import type {
+  CreateTenantRecurringExpenseData,
+  RecurringExpense,
+  RecurringExpenseAllocationInput,
+  RecurringExpenseAllocationMode,
+} from '../services/expense-ledger.api';
+
+interface CategoryOption {
+  id: string;
+  name: string;
+}
+
+interface TenantRecurringExpenseModalProps {
+  isOpen: boolean;
+  categoryOptions: CategoryOption[];
+  buildings: Building[];
+  initialValue?: RecurringExpense;
+  onClose: () => void;
+  onSubmit: (data: CreateTenantRecurringExpenseData) => Promise<void>;
+  isSubmitting?: boolean;
+}
+
+const MODE_OPTIONS: Array<{ value: RecurringExpenseAllocationMode; label: string }> = [
+  { value: 'MANUAL', label: 'Distribución manual' },
+  { value: 'EQUAL_SHARE', label: 'Partes iguales' },
+  { value: 'BUILDING_TOTAL_M2', label: 'Según m² de los edificios' },
+];
+
+const FREQUENCY_OPTIONS: Array<{ value: 'MONTHLY' | 'QUARTERLY' | 'YEARLY'; label: string }> = [
+  { value: 'MONTHLY', label: 'Mensual' },
+  { value: 'QUARTERLY', label: 'Trimestral' },
+  { value: 'YEARLY', label: 'Anual' },
+];
+
+function allocationModeLabel(mode: RecurringExpenseAllocationMode): string {
+  return MODE_OPTIONS.find((option) => option.value === mode)?.label ?? mode;
+}
+
+export function TenantRecurringExpenseModal({
+  isOpen,
+  categoryOptions,
+  buildings,
+  initialValue,
+  onClose,
+  onSubmit,
+  isSubmitting,
+}: TenantRecurringExpenseModalProps) {
+  const isEditMode = !!initialValue;
+
+  const [categoryId, setCategoryId] = useState(initialValue?.categoryId || '');
+  const [concept, setConcept] = useState(initialValue?.concept || '');
+  const [currency, setCurrency] = useState(initialValue?.currency || 'ARS');
+  const [frequency, setFrequency] = useState<'MONTHLY' | 'QUARTERLY' | 'YEARLY'>(
+    (initialValue?.frequency as 'MONTHLY' | 'QUARTERLY' | 'YEARLY') || 'MONTHLY',
+  );
+  const [allocationMode, setAllocationMode] = useState<RecurringExpenseAllocationMode>(
+    (initialValue?.allocationMode as RecurringExpenseAllocationMode) || 'EQUAL_SHARE',
+  );
+  const [amountInput, setAmountInput] = useState(
+    initialValue ? String(initialValue.amount / 100) : '',
+  );
+  const [percentages, setPercentages] = useState<Record<string, string>>({});
+  const [error, setError] = useState('');
+
+  const amountMinor = useMemo(() => {
+    const amount = Number(amountInput);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      return 0;
+    }
+    return toCents(amount);
+  }, [amountInput]);
+
+  const totalPercentage = useMemo(() => {
+    return Object.values(percentages).reduce((sum, value) => {
+      const parsed = Number(value);
+      return sum + (Number.isFinite(parsed) ? parsed : 0);
+    }, 0);
+  }, [percentages]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleSave = async () => {
+    if (!categoryId) {
+      setError('Selecciona un rubro');
+      return;
+    }
+    if (!concept.trim()) {
+      setError('El concepto es requerido');
+      return;
+    }
+    if (!amountMinor) {
+      setError('Monto inválido');
+      return;
+    }
+
+    if (isEditMode) {
+      setError('');
+      await onSubmit({
+        scopeType: 'TENANT_SHARED',
+        allocationMode: initialValue?.allocationMode || 'EQUAL_SHARE',
+        categoryId,
+        amount: amountMinor,
+        currency,
+        concept: concept.trim(),
+        frequency,
+      });
+      return;
+    }
+
+    if (buildings.length === 0) {
+      setError('El conjunto no tiene edificios para crear una regla recurrente');
+      return;
+    }
+
+    let allocations: RecurringExpenseAllocationInput[] | undefined;
+    if (allocationMode === 'MANUAL') {
+      const parsed: Array<{ buildingId: string; percentage: number }> = buildings.map(
+        (building) => ({
+          buildingId: building.id,
+          percentage: Number(percentages[building.id] ?? 0),
+        }),
+      );
+
+      const invalid = parsed.some(
+        (allocation) =>
+          !Number.isInteger(allocation.percentage) ||
+          allocation.percentage < 0 ||
+          allocation.percentage > 100,
+      );
+      if (invalid) {
+        setError('Los porcentajes deben ser números enteros entre 0 y 100');
+        return;
+      }
+
+      if (totalPercentage !== 100) {
+        setError(`La suma de los porcentajes debe ser exactamente 100% (actual: ${totalPercentage}%)`);
+        return;
+      }
+
+      allocations = parsed.filter((allocation) => allocation.percentage > 0);
+      if (allocations.length === 0) {
+        setError('Debe existir al menos una allocation con porcentaje mayor a 0');
+        return;
+      }
+    }
+
+    setError('');
+    await onSubmit({
+      scopeType: 'TENANT_SHARED',
+      allocationMode,
+      categoryId,
+      amount: amountMinor,
+      currency,
+      concept: concept.trim(),
+      frequency,
+      allocations,
+    });
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <Card className="w-full max-w-lg p-0">
+        <div className="flex items-center justify-between border-b p-4">
+          <h3 className="text-lg font-semibold">
+            {isEditMode ? 'Editar regla recurrente' : 'Nueva regla recurrente'}
+          </h3>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="space-y-4 p-4">
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Rubro</label>
+            <Select
+              aria-label="Rubro"
+              value={categoryId}
+              onChange={(e) => setCategoryId(e.target.value)}
+              disabled={isSubmitting || isEditMode}
+            >
+              <option value="">Selecciona un rubro</option>
+              {categoryOptions.map((cat) => (
+                <option key={cat.id} value={cat.id}>
+                  {cat.name}
+                </option>
+              ))}
+            </Select>
+          </div>
+
+          <Input
+            label="Concepto"
+            aria-label="Concepto"
+            value={concept}
+            onChange={(e) => setConcept(e.target.value)}
+            disabled={isSubmitting}
+            placeholder="Ej. Abono de limpieza mensual"
+          />
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <Input
+              label="Monto"
+              aria-label="Monto"
+              type="number"
+              step="0.01"
+              min="0"
+              value={amountInput}
+              onChange={(e) => setAmountInput(e.target.value)}
+              disabled={isSubmitting}
+              placeholder="0.00"
+            />
+
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Moneda</label>
+              <Select
+                aria-label="Moneda"
+                value={currency}
+                onChange={(e) => setCurrency(e.target.value)}
+                disabled={isSubmitting || isEditMode}
+              >
+                <option value="ARS">ARS</option>
+                <option value="USD">USD</option>
+                <option value="VES">VES</option>
+              </Select>
+            </div>
+          </div>
+
+          <div className="space-y-1">
+            <label className="text-sm font-medium">Frecuencia</label>
+            <Select
+              aria-label="Frecuencia"
+              value={frequency}
+              onChange={(e) =>
+                setFrequency(e.target.value as 'MONTHLY' | 'QUARTERLY' | 'YEARLY')
+              }
+              disabled={isSubmitting || isEditMode}
+            >
+              {FREQUENCY_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </Select>
+          </div>
+
+          {!isEditMode ? (
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Método de distribución</label>
+              <Select
+                aria-label="Método de distribución"
+                value={allocationMode}
+                onChange={(e) =>
+                  setAllocationMode(e.target.value as RecurringExpenseAllocationMode)
+                }
+                disabled={isSubmitting}
+              >
+                {MODE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </Select>
+            </div>
+          ) : (
+            <div className="space-y-1">
+              <label className="text-sm font-medium">Método de distribución</label>
+              <p className="text-sm text-muted-foreground">
+                {initialValue?.allocationMode
+                  ? allocationModeLabel(initialValue.allocationMode)
+                  : 'Sin especificar'}
+              </p>
+            </div>
+          )}
+
+          {!isEditMode && allocationMode === 'MANUAL' && (
+            <div className="space-y-3">
+              <div className="flex items-center justify-between">
+                <p className="text-sm font-medium">Porcentajes por edificio</p>
+                <p
+                  className={`text-sm font-medium ${
+                    totalPercentage === 100 ? 'text-green-600' : 'text-muted-foreground'
+                  }`}
+                >
+                  Total: {totalPercentage}%
+                </p>
+              </div>
+
+              {buildings.length === 0 ? (
+                <p className="text-xs text-amber-600">
+                  El conjunto no tiene edificios. Agrega edificios antes de crear una regla con
+                  distribución manual.
+                </p>
+              ) : (
+                <div className="space-y-2">
+                  {buildings.map((building) => (
+                    <div
+                      key={building.id}
+                      className="flex items-center justify-between gap-3"
+                    >
+                      <span className="text-sm">{building.name}</span>
+                      <Input
+                        type="number"
+                        min={0}
+                        max={100}
+                        step={1}
+                        value={percentages[building.id] ?? ''}
+                        onChange={(e) =>
+                          setPercentages((prev) => ({
+                            ...prev,
+                            [building.id]: e.target.value,
+                          }))
+                        }
+                        disabled={isSubmitting}
+                        className="w-24"
+                        aria-label={`Porcentaje para ${building.name}`}
+                        placeholder="0"
+                      />
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+
+          {!isEditMode && allocationMode === 'EQUAL_SHARE' && (
+            <p className="text-xs text-muted-foreground">
+              El gasto se distribuirá en partes iguales entre los edificios existentes al momento
+              de ejecutar la regla.
+            </p>
+          )}
+
+          {!isEditMode && allocationMode === 'BUILDING_TOTAL_M2' && (
+            <p className="text-xs text-muted-foreground">
+              El gasto se distribuirá proporcionalmente según los m² totales de cada edificio al
+              momento de ejecutar la regla.
+            </p>
+          )}
+
+          {!isEditMode && amountMinor > 0 && (
+            <p className="text-xs text-muted-foreground">
+              Se generarán gastos por {formatCurrency(amountMinor, currency)} según la
+              frecuencia.
+            </p>
+          )}
+
+          {isEditMode ? (
+            <p className="text-xs text-muted-foreground">
+              En edición solo se puede actualizar concepto y monto. El método de distribución no
+              se puede modificar.
+            </p>
+          ) : null}
+
+          {error && <p className="text-sm text-red-600">{error}</p>}
+
+          <div className="flex gap-2 pt-2">
+            <Button
+              type="button"
+              className="flex-1"
+              onClick={() => void handleSave()}
+              disabled={isSubmitting}
+            >
+              {isSubmitting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+              Guardar
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              className="flex-1"
+              onClick={onClose}
+              disabled={isSubmitting}
+            >
+              Cancelar
+            </Button>
+          </div>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/features/finance/components/TenantRecurringExpensesTab.test.tsx
+++ b/apps/web/features/finance/components/TenantRecurringExpensesTab.test.tsx
@@ -1,0 +1,419 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ToastProvider } from '@/shared/components/ui/Toast';
+import { TenantRecurringExpensesTab } from './TenantRecurringExpensesTab';
+import * as useExpenseLedger from '../hooks/useExpenseLedger';
+import * as useBuildingsModule from '@/features/buildings/hooks';
+
+jest.mock('../hooks/useExpenseLedger', () => ({
+  useTenantRecurringExpenses: jest.fn(),
+  useCreateTenantRecurringExpense: jest.fn(),
+  useUpdateTenantRecurringExpense: jest.fn(),
+  useExpenseLedgerCategories: jest.fn(),
+}));
+
+jest.mock('@/features/buildings/hooks', () => ({
+  useBuildings: jest.fn(),
+}));
+
+jest.mock('@/shared/components/ui/Toast', () => ({
+  useToast: () => ({ toast: jest.fn() }),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+const mockedUseTenantRecurringExpenses = jest.mocked(useExpenseLedger.useTenantRecurringExpenses);
+const mockedUseCreate = jest.mocked(useExpenseLedger.useCreateTenantRecurringExpense);
+const mockedUseUpdate = jest.mocked(useExpenseLedger.useUpdateTenantRecurringExpense);
+const mockedUseCategories = jest.mocked(useExpenseLedger.useExpenseLedgerCategories);
+const mockedUseBuildings = jest.mocked(useBuildingsModule.useBuildings);
+
+const mockRule = (overrides: Record<string, unknown> = {}) => ({
+  id: 're-1',
+  tenantId: 'tenant-1',
+  buildingId: null,
+  scopeType: 'TENANT_SHARED',
+  allocationMode: 'MANUAL',
+  categoryId: 'category-1',
+  amount: 10000,
+  currency: 'ARS',
+  concept: 'Limpieza mensual',
+  frequency: 'MONTHLY',
+  nextRunDate: '2026-09-01T00:00:00.000Z',
+  isActive: true,
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+  ...overrides,
+});
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>{ui}</ToastProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function mockMutations() {
+  const createMutate = jest.fn().mockResolvedValue({});
+  const updateMutate = jest.fn().mockResolvedValue({});
+  mockedUseCreate.mockReturnValue({
+    mutateAsync: createMutate,
+    isPending: false,
+  } as never);
+  mockedUseUpdate.mockReturnValue({
+    mutateAsync: updateMutate,
+    isPending: false,
+  } as never);
+  return { createMutate, updateMutate };
+}
+
+describe('TenantRecurringExpensesTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseCategories.mockReturnValue({
+      data: [
+        { id: 'category-1', name: 'Limpieza' },
+        { id: 'category-2', name: 'Seguridad' },
+      ],
+    } as never);
+    mockedUseBuildings.mockReturnValue({
+      buildings: [
+        { id: 'building-1', tenantId: 'tenant-1', name: 'Torre Norte' },
+        { id: 'building-2', tenantId: 'tenant-1', name: 'Torre Sur' },
+      ],
+      loading: false,
+      error: null,
+    } as never);
+  });
+
+  it('muestra empty state cuando no hay reglas', () => {
+    mockedUseTenantRecurringExpenses.mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    mockMutations();
+
+    renderWithProviders(<TenantRecurringExpensesTab tenantId="tenant-1" />);
+
+    expect(screen.getByText(/no hay reglas recurrentes comunes/i)).toBeTruthy();
+  });
+
+  it('lista reglas MANUAL/EQUAL_SHARE/BUILDING_TOTAL_M2 con etiquetas amigables', () => {
+    mockedUseTenantRecurringExpenses.mockReturnValue({
+      data: [
+        mockRule({ allocationMode: 'MANUAL', concept: 'Manual test' }),
+        mockRule({
+          id: 're-2',
+          allocationMode: 'EQUAL_SHARE',
+          concept: 'Iguales test',
+        }),
+        mockRule({
+          id: 're-3',
+          allocationMode: 'BUILDING_TOTAL_M2',
+          concept: 'M2 test',
+        }),
+      ],
+      isPending: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    mockMutations();
+
+    renderWithProviders(<TenantRecurringExpensesTab tenantId="tenant-1" />);
+
+    expect(screen.getByText('Manual test')).toBeTruthy();
+    expect(screen.getByText('Iguales test')).toBeTruthy();
+    expect(screen.getByText('M2 test')).toBeTruthy();
+    expect(screen.getByText('Distribución manual')).toBeTruthy();
+    expect(screen.getByText('Partes iguales')).toBeTruthy();
+    expect(screen.getByText('Según m² de los edificios')).toBeTruthy();
+  });
+
+  it('muestra reglas inactivas con estado Inactiva', () => {
+    mockedUseTenantRecurringExpenses.mockReturnValue({
+      data: [mockRule({ isActive: false })],
+      isPending: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    mockMutations();
+
+    renderWithProviders(<TenantRecurringExpensesTab tenantId="tenant-1" />);
+
+    expect(screen.getByText('Inactiva')).toBeTruthy();
+    expect(screen.getByText('Activar')).toBeTruthy();
+  });
+
+  it('toggle de activación llama PATCH con isActive correcto', async () => {
+    mockedUseTenantRecurringExpenses.mockReturnValue({
+      data: [mockRule({ isActive: true })],
+      isPending: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    const { updateMutate } = mockMutations();
+
+    renderWithProviders(<TenantRecurringExpensesTab tenantId="tenant-1" />);
+
+    fireEvent.click(screen.getByText('Desactivar'));
+
+    await waitFor(() => {
+      expect(updateMutate).toHaveBeenCalledWith({
+        recurringExpenseId: 're-1',
+        data: { isActive: false },
+      });
+    });
+  });
+
+  it('creación EQUAL_SHARE no envía allocations', async () => {
+    mockedUseTenantRecurringExpenses.mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    const { createMutate } = mockMutations();
+
+    renderWithProviders(<TenantRecurringExpensesTab tenantId="tenant-1" />);
+
+    fireEvent.click(screen.getByText('Nueva regla'));
+    await screen.findByText('Nueva regla recurrente');
+
+    fireEvent.change(screen.getByLabelText('Rubro'), { target: { value: 'category-1' } });
+    fireEvent.change(screen.getByLabelText('Concepto'), {
+      target: { value: 'Limpieza' },
+    });
+    fireEvent.change(screen.getByLabelText('Monto'), { target: { value: '100' } });
+
+    fireEvent.click(screen.getByText('Guardar'));
+
+    await waitFor(() => {
+      expect(createMutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allocationMode: 'EQUAL_SHARE',
+          scopeType: 'TENANT_SHARED',
+          allocations: undefined,
+        }),
+      );
+    });
+  });
+
+  it('creación BUILDING_TOTAL_M2 no envía allocations', async () => {
+    mockedUseTenantRecurringExpenses.mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    const { createMutate } = mockMutations();
+
+    renderWithProviders(<TenantRecurringExpensesTab tenantId="tenant-1" />);
+
+    fireEvent.click(screen.getByText('Nueva regla'));
+    await screen.findByText('Nueva regla recurrente');
+
+    fireEvent.change(screen.getByLabelText('Rubro'), { target: { value: 'category-1' } });
+    fireEvent.change(screen.getByLabelText('Concepto'), {
+      target: { value: 'M2 test' },
+    });
+    fireEvent.change(screen.getByLabelText('Monto'), { target: { value: '100' } });
+
+    fireEvent.change(screen.getByLabelText('Método de distribución'), {
+      target: { value: 'BUILDING_TOTAL_M2' },
+    });
+
+    fireEvent.click(screen.getByText('Guardar'));
+
+    await waitFor(() => {
+      expect(createMutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allocationMode: 'BUILDING_TOTAL_M2',
+          allocations: undefined,
+        }),
+      );
+    });
+  });
+
+  it('MANUAL exige suma exactamente 100 y genera allocations con IDs reales', async () => {
+    mockedUseTenantRecurringExpenses.mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    const { createMutate } = mockMutations();
+
+    renderWithProviders(<TenantRecurringExpensesTab tenantId="tenant-1" />);
+
+    fireEvent.click(screen.getByText('Nueva regla'));
+    await screen.findByText('Nueva regla recurrente');
+
+    fireEvent.change(screen.getByLabelText('Rubro'), { target: { value: 'category-1' } });
+    fireEvent.change(screen.getByLabelText('Concepto'), {
+      target: { value: 'Manual test' },
+    });
+    fireEvent.change(screen.getByLabelText('Monto'), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText('Método de distribución'), {
+      target: { value: 'MANUAL' },
+    });
+
+    fireEvent.change(screen.getByLabelText('Porcentaje para Torre Norte'), {
+      target: { value: '50' },
+    });
+    fireEvent.change(screen.getByLabelText('Porcentaje para Torre Sur'), {
+      target: { value: '40' },
+    });
+
+    fireEvent.click(screen.getByText('Guardar'));
+
+    await waitFor(() => {
+      expect(createMutate).not.toHaveBeenCalled();
+    });
+    expect(screen.getByText(/debe ser exactamente 100%/i)).toBeTruthy();
+
+    fireEvent.change(screen.getByLabelText('Porcentaje para Torre Sur'), {
+      target: { value: '50' },
+    });
+    fireEvent.click(screen.getByText('Guardar'));
+
+    await waitFor(() => {
+      expect(createMutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allocationMode: 'MANUAL',
+          allocations: [
+            { buildingId: 'building-1', percentage: 50 },
+            { buildingId: 'building-2', percentage: 50 },
+          ],
+        }),
+      );
+    });
+  });
+
+  it('edición no permite modificar allocationMode', async () => {
+    mockedUseTenantRecurringExpenses.mockReturnValue({
+      data: [mockRule({ allocationMode: 'EQUAL_SHARE' })],
+      isPending: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    const { updateMutate } = mockMutations();
+
+    renderWithProviders(<TenantRecurringExpensesTab tenantId="tenant-1" />);
+
+    fireEvent.click(screen.getByText('Editar'));
+    await screen.findByText('Editar regla recurrente');
+
+    expect(screen.queryByLabelText('Método de distribución')).toBeNull();
+    expect(screen.getAllByText('Partes iguales').length).toBeGreaterThan(0);
+
+    fireEvent.change(screen.getByLabelText('Concepto'), {
+      target: { value: 'Nuevo concepto' },
+    });
+    fireEvent.click(screen.getByText('Guardar'));
+
+    await waitFor(() => {
+      expect(updateMutate).toHaveBeenCalledWith({
+        recurringExpenseId: 're-1',
+        data: { amount: 10000, concept: 'Nuevo concepto' },
+      });
+    });
+  });
+
+  it('muestra loading mientras carga', () => {
+    mockedUseTenantRecurringExpenses.mockReturnValue({
+      data: undefined,
+      isPending: true,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    mockMutations();
+
+    renderWithProviders(<TenantRecurringExpensesTab tenantId="tenant-1" />);
+
+    expect(document.querySelector('.animate-spin')).toBeTruthy();
+  });
+
+  it('bloquea creación sin edificios en el tenant', async () => {
+    mockedUseTenantRecurringExpenses.mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    mockedUseBuildings.mockReturnValue({
+      buildings: [],
+      loading: false,
+      error: null,
+    } as never);
+    const { createMutate } = mockMutations();
+
+    renderWithProviders(<TenantRecurringExpensesTab tenantId="tenant-1" />);
+
+    fireEvent.click(screen.getByText('Nueva regla'));
+    await screen.findByText('Nueva regla recurrente');
+
+    fireEvent.change(screen.getByLabelText('Rubro'), { target: { value: 'category-1' } });
+    fireEvent.change(screen.getByLabelText('Concepto'), {
+      target: { value: 'Sin edificios' },
+    });
+    fireEvent.change(screen.getByLabelText('Monto'), { target: { value: '100' } });
+
+    fireEvent.click(screen.getByText('Guardar'));
+
+    await waitFor(() => {
+      expect(createMutate).not.toHaveBeenCalled();
+    });
+    expect(screen.getByText(/no tiene edificios/i)).toBeTruthy();
+  });
+
+  it('MANUAL no envía allocations con porcentaje 0', async () => {
+    mockedUseTenantRecurringExpenses.mockReturnValue({
+      data: [],
+      isPending: false,
+      error: null,
+      refetch: jest.fn(),
+    } as never);
+    const { createMutate } = mockMutations();
+
+    renderWithProviders(<TenantRecurringExpensesTab tenantId="tenant-1" />);
+
+    fireEvent.click(screen.getByText('Nueva regla'));
+    await screen.findByText('Nueva regla recurrente');
+
+    fireEvent.change(screen.getByLabelText('Rubro'), { target: { value: 'category-1' } });
+    fireEvent.change(screen.getByLabelText('Concepto'), {
+      target: { value: 'Con cero' },
+    });
+    fireEvent.change(screen.getByLabelText('Monto'), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText('Método de distribución'), {
+      target: { value: 'MANUAL' },
+    });
+
+    fireEvent.change(screen.getByLabelText('Porcentaje para Torre Norte'), {
+      target: { value: '100' },
+    });
+    fireEvent.change(screen.getByLabelText('Porcentaje para Torre Sur'), {
+      target: { value: '0' },
+    });
+
+    fireEvent.click(screen.getByText('Guardar'));
+
+    await waitFor(() => {
+      expect(createMutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allocationMode: 'MANUAL',
+          allocations: [{ buildingId: 'building-1', percentage: 100 }],
+        }),
+      );
+    });
+  });
+});

--- a/apps/web/features/finance/components/TenantRecurringExpensesTab.tsx
+++ b/apps/web/features/finance/components/TenantRecurringExpensesTab.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { CalendarClock, Loader2, Plus, RefreshCw } from 'lucide-react';
+import Button from '@/shared/components/ui/Button';
+import Card from '@/shared/components/ui/Card';
+import { useToast } from '@/shared/components/ui/Toast';
+import { formatCurrency } from '@/shared/lib/format/money';
+import { useBuildings } from '@/features/buildings/hooks';
+import {
+  useExpenseLedgerCategories,
+  useTenantRecurringExpenses,
+  useCreateTenantRecurringExpense,
+  useUpdateTenantRecurringExpense,
+} from '../hooks/useExpenseLedger';
+import type {
+  CreateTenantRecurringExpenseData,
+  RecurringExpense,
+  RecurringExpenseAllocationMode,
+} from '../services/expense-ledger.api';
+import { TenantRecurringExpenseModal } from './TenantRecurringExpenseModal';
+
+interface TenantRecurringExpensesTabProps {
+  tenantId: string;
+}
+
+function frequencyLabel(frequency: string): string {
+  const labels: Record<string, string> = {
+    MONTHLY: 'Mensual',
+    QUARTERLY: 'Trimestral',
+    YEARLY: 'Anual',
+  };
+  return labels[frequency] ?? frequency;
+}
+
+function allocationModeLabel(mode: RecurringExpenseAllocationMode | null): string {
+  const labels: Record<RecurringExpenseAllocationMode, string> = {
+    MANUAL: 'Distribución manual',
+    EQUAL_SHARE: 'Partes iguales',
+    BUILDING_TOTAL_M2: 'Según m² de los edificios',
+  };
+  return mode ? labels[mode] : 'Sin especificar';
+}
+
+function formatDate(date: string): string {
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) {
+    return date;
+  }
+  return parsed.toLocaleDateString('es-AR');
+}
+
+export function TenantRecurringExpensesTab({ tenantId }: TenantRecurringExpensesTabProps) {
+  const { toast } = useToast();
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [editingExpense, setEditingExpense] = useState<RecurringExpense | null>(null);
+
+  const { buildings } = useBuildings(tenantId);
+
+  const {
+    data: recurringExpenses = [],
+    isPending,
+    error,
+    refetch,
+  } = useTenantRecurringExpenses(tenantId);
+
+  const { data: categories = [] } = useExpenseLedgerCategories(
+    tenantId,
+    'EXPENSE',
+    'CONDOMINIUM_COMMON',
+  );
+
+  const createMutation = useCreateTenantRecurringExpense(tenantId);
+  const updateMutation = useUpdateTenantRecurringExpense(tenantId);
+
+  const categoryOptions = useMemo(
+    () => categories.map((category) => ({ id: category.id, name: category.name })),
+    [categories],
+  );
+
+  const handleCreate = async (data: CreateTenantRecurringExpenseData) => {
+    try {
+      await createMutation.mutateAsync(data);
+      toast('Regla recurrente creada', 'success');
+      setShowCreateModal(false);
+    } catch {
+      toast('Error al crear regla recurrente', 'error');
+    }
+  };
+
+  const handleEdit = async (data: CreateTenantRecurringExpenseData) => {
+    if (!editingExpense) {
+      return;
+    }
+
+    try {
+      await updateMutation.mutateAsync({
+        recurringExpenseId: editingExpense.id,
+        data: {
+          amount: data.amount,
+          concept: data.concept,
+        },
+      });
+      toast('Regla recurrente actualizada', 'success');
+      setEditingExpense(null);
+    } catch {
+      toast('Error al actualizar regla recurrente', 'error');
+    }
+  };
+
+  const handleToggleActive = async (item: RecurringExpense) => {
+    try {
+      await updateMutation.mutateAsync({
+        recurringExpenseId: item.id,
+        data: { isActive: !item.isActive },
+      });
+      toast(item.isActive ? 'Regla desactivada' : 'Regla activada', 'success');
+    } catch {
+      toast('Error al cambiar estado', 'error');
+    }
+  };
+
+  const isLoadingAction = createMutation.isPending || updateMutation.isPending;
+
+  if (isPending) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-sm font-medium text-muted-foreground">Reglas recurrentes comunes</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Plantillas de gastos comunes que el cron convierte en gastos DRAFT automáticamente.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => void refetch()}
+            disabled={isLoadingAction}
+          >
+            <RefreshCw className="h-4 w-4 mr-1" />
+            Refrescar
+          </Button>
+          <Button size="sm" onClick={() => setShowCreateModal(true)} disabled={isLoadingAction}>
+            <Plus className="h-4 w-4 mr-1" />
+            Nueva regla
+          </Button>
+        </div>
+      </div>
+
+      {error ? (
+        <Card className="border-red-200 bg-red-50 p-4 text-red-700">
+          Error al cargar reglas recurrentes.
+        </Card>
+      ) : recurringExpenses.length === 0 ? (
+        <Card className="border-dashed p-8 text-center text-muted-foreground">
+          <CalendarClock className="mx-auto mb-2 h-8 w-8" />
+          No hay reglas recurrentes comunes configuradas.
+        </Card>
+      ) : (
+        <div className="space-y-3">
+          {recurringExpenses.map((item) => (
+            <Card key={item.id} className="p-4">
+              <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <p className="font-medium">{item.concept}</p>
+                    <span
+                      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+                        item.isActive
+                          ? 'bg-green-100 text-green-700'
+                          : 'bg-gray-100 text-gray-600'
+                      }`}
+                    >
+                      {item.isActive ? 'Activa' : 'Inactiva'}
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <span>{allocationModeLabel(item.allocationMode)}</span>
+                    <span>•</span>
+                    <span>{frequencyLabel(item.frequency)}</span>
+                    <span>•</span>
+                    <span>{formatCurrency(item.amount, item.currency)}</span>
+                    <span>•</span>
+                    <span>Siguiente ejecución: {formatDate(item.nextRunDate)}</span>
+                  </div>
+                </div>
+
+                <div className="flex gap-2">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => setEditingExpense(item)}
+                    disabled={isLoadingAction}
+                  >
+                    Editar
+                  </Button>
+                  <Button
+                    variant={item.isActive ? 'secondary' : 'primary'}
+                    size="sm"
+                    onClick={() => void handleToggleActive(item)}
+                    disabled={isLoadingAction}
+                  >
+                    {item.isActive ? 'Desactivar' : 'Activar'}
+                  </Button>
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {showCreateModal && (
+        <TenantRecurringExpenseModal
+          isOpen={showCreateModal}
+          categoryOptions={categoryOptions}
+          buildings={buildings}
+          onClose={() => setShowCreateModal(false)}
+          onSubmit={handleCreate}
+          isSubmitting={createMutation.isPending}
+        />
+      )}
+
+      {editingExpense && (
+        <TenantRecurringExpenseModal
+          isOpen={!!editingExpense}
+          initialValue={editingExpense}
+          categoryOptions={categoryOptions}
+          buildings={buildings}
+          onClose={() => setEditingExpense(null)}
+          onSubmit={handleEdit}
+          isSubmitting={updateMutation.isPending}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/features/finance/components/index.ts
+++ b/apps/web/features/finance/components/index.ts
@@ -19,3 +19,5 @@ export { LiquidationCard } from './LiquidationCard';
 export { LiquidationPublishModal } from './LiquidationPublishModal';
 export { RecurringExpensesTab } from './RecurringExpensesTab';
 export { RecurringExpenseModal } from './RecurringExpenseModal';
+export { TenantRecurringExpensesTab } from './TenantRecurringExpensesTab';
+export { TenantRecurringExpenseModal } from './TenantRecurringExpenseModal';

--- a/apps/web/features/finance/hooks/useExpenseLedger.ts
+++ b/apps/web/features/finance/hooks/useExpenseLedger.ts
@@ -13,6 +13,9 @@ import {
   listRecurringExpenses,
   createRecurringExpense,
   updateRecurringExpense,
+  listTenantRecurringExpenses,
+  createTenantRecurringExpense,
+  updateTenantRecurringExpense,
   listIncomes,
   createIncome,
   updateIncome,
@@ -30,6 +33,7 @@ import {
   CreateExpenseData,
   CreateRecurringExpenseData,
   UpdateRecurringExpenseData,
+  CreateTenantRecurringExpenseData,
   ListIncomesParams,
   CreateIncomeData,
   createAdjustment,
@@ -211,6 +215,51 @@ export function useUpdateRecurringExpense(buildingId: string) {
     }) => updateRecurringExpense(buildingId, recurringExpenseId, data),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['recurring-expenses', buildingId] });
+      void queryClient.invalidateQueries({ queryKey: ['expenses'] });
+    },
+  });
+}
+
+// ── Tenant-shared RecurringExpenses hooks ───────────────────────────────────
+
+export function useTenantRecurringExpenses(tenantId: string) {
+  return useQuery({
+    queryKey: ['tenant-recurring-expenses', tenantId],
+    queryFn: () => listTenantRecurringExpenses(tenantId, true),
+    enabled: !!tenantId,
+    staleTime: 2 * 60 * 1000,
+    placeholderData: (prev) => prev ?? [],
+  });
+}
+
+export function useCreateTenantRecurringExpense(tenantId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateTenantRecurringExpenseData) =>
+      createTenantRecurringExpense(tenantId, data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ['tenant-recurring-expenses', tenantId],
+      });
+      void queryClient.invalidateQueries({ queryKey: ['expenses'] });
+    },
+  });
+}
+
+export function useUpdateTenantRecurringExpense(tenantId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      recurringExpenseId,
+      data,
+    }: {
+      recurringExpenseId: string;
+      data: UpdateRecurringExpenseData;
+    }) => updateTenantRecurringExpense(tenantId, recurringExpenseId, data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ['tenant-recurring-expenses', tenantId],
+      });
       void queryClient.invalidateQueries({ queryKey: ['expenses'] });
     },
   });

--- a/apps/web/features/finance/services/expense-ledger.api.test.ts
+++ b/apps/web/features/finance/services/expense-ledger.api.test.ts
@@ -4,6 +4,9 @@ import {
   createLiquidationDraft,
   publishLiquidation,
   reviewLiquidation,
+  listTenantRecurringExpenses,
+  createTenantRecurringExpense,
+  updateTenantRecurringExpense,
 } from './expense-ledger.api';
 
 jest.mock('@/shared/lib/http/client', () => ({
@@ -64,5 +67,80 @@ describe('expense ledger liquidation API', () => {
         baseCurrency: 'ARS',
       }),
     ).rejects.toThrow('network down');
+  });
+});
+
+describe('tenant recurring expenses API', () => {
+  beforeEach(() => {
+    mockedApiClient.mockReset();
+    mockedApiClient.mockResolvedValue({});
+  });
+
+  it('lists tenant recurring expenses through the tenant route with includeInactive=true', async () => {
+    await listTenantRecurringExpenses('tenant-1', true);
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/tenants/tenant-1/recurring-expenses?includeInactive=true',
+      method: 'GET',
+    });
+  });
+
+  it('lists tenant recurring expenses without includeInactive when not requested', async () => {
+    await listTenantRecurringExpenses('tenant-1');
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/tenants/tenant-1/recurring-expenses',
+      method: 'GET',
+    });
+  });
+
+  it('creates tenant recurring expenses through the tenant route with the full payload', async () => {
+    const payload = {
+      scopeType: 'TENANT_SHARED' as const,
+      allocationMode: 'MANUAL' as const,
+      categoryId: 'category-1',
+      amount: 10000,
+      currency: 'ARS',
+      concept: 'Limpieza',
+      frequency: 'MONTHLY' as const,
+      allocations: [
+        { buildingId: 'building-1', percentage: 60 },
+        { buildingId: 'building-2', percentage: 40 },
+      ],
+    };
+
+    await createTenantRecurringExpense('tenant-1', payload);
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/tenants/tenant-1/recurring-expenses',
+      method: 'POST',
+      body: payload,
+    });
+  });
+
+  it('updates tenant recurring expenses through the tenant route with id', async () => {
+    await updateTenantRecurringExpense('tenant-1', 're-1', { isActive: false });
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/tenants/tenant-1/recurring-expenses/re-1',
+      method: 'PATCH',
+      body: { isActive: false },
+    });
+  });
+
+  it('does not use the buildings route for tenant-scoped operations', async () => {
+    await listTenantRecurringExpenses('tenant-1', true);
+    await createTenantRecurringExpense('tenant-1', {
+      scopeType: 'TENANT_SHARED',
+      allocationMode: 'EQUAL_SHARE',
+      categoryId: 'category-1',
+      amount: 10000,
+      currency: 'ARS',
+      concept: 'Limpieza',
+      frequency: 'MONTHLY',
+    });
+
+    const calls = mockedApiClient.mock.calls.map((call) => call[0]);
+    expect(calls.every((call) => !String(call.path).startsWith('/buildings/'))).toBe(true);
   });
 });

--- a/apps/web/features/finance/services/expense-ledger.api.ts
+++ b/apps/web/features/finance/services/expense-ledger.api.ts
@@ -104,10 +104,19 @@ export interface BulkValidateExpensesResult {
   errorCount: number;
 }
 
+export type RecurringExpenseAllocationMode =
+  | 'MANUAL'
+  | 'EQUAL_SHARE'
+  | 'BUILDING_TOTAL_M2';
+
+export type RecurringExpenseScopeType = 'BUILDING' | 'TENANT_SHARED';
+
 export interface RecurringExpense {
   id: string;
   tenantId: string;
-  buildingId: string;
+  buildingId: string | null;
+  scopeType: RecurringExpenseScopeType;
+  allocationMode: RecurringExpenseAllocationMode | null;
   categoryId: string;
   amount: number;
   currency: string;
@@ -117,6 +126,22 @@ export interface RecurringExpense {
   isActive: boolean;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface RecurringExpenseAllocationInput {
+  buildingId: string;
+  percentage: number;
+}
+
+export interface CreateTenantRecurringExpenseData {
+  scopeType: 'TENANT_SHARED';
+  allocationMode: RecurringExpenseAllocationMode;
+  categoryId: string;
+  amount: number;
+  currency: string;
+  concept: string;
+  frequency: 'MONTHLY' | 'QUARTERLY' | 'YEARLY';
+  allocations?: RecurringExpenseAllocationInput[];
 }
 
 export interface CreateRecurringExpenseData {
@@ -383,6 +408,46 @@ export async function updateRecurringExpense(
 ): Promise<RecurringExpense> {
   return apiClient<RecurringExpense, UpdateRecurringExpenseData>({
     path: `/buildings/${buildingId}/recurring-expenses/${recurringExpenseId}`,
+    method: 'PATCH',
+    body: data,
+  });
+}
+
+// ── Tenant-shared RecurringExpenses API ─────────────────────────────────────
+// TENANT_SHARED scope: multi-building rules managed at tenant level.
+
+export async function listTenantRecurringExpenses(
+  tenantId: string,
+  includeInactive?: boolean,
+): Promise<RecurringExpense[]> {
+  const qs = new URLSearchParams();
+  if (includeInactive) qs.append('includeInactive', 'true');
+
+  const queryStr = qs.toString();
+  return apiClient<RecurringExpense[]>({
+    path: `/tenants/${tenantId}/recurring-expenses${queryStr ? '?' + queryStr : ''}`,
+    method: 'GET',
+  });
+}
+
+export async function createTenantRecurringExpense(
+  tenantId: string,
+  data: CreateTenantRecurringExpenseData,
+): Promise<RecurringExpense> {
+  return apiClient<RecurringExpense, CreateTenantRecurringExpenseData>({
+    path: `/tenants/${tenantId}/recurring-expenses`,
+    method: 'POST',
+    body: data,
+  });
+}
+
+export async function updateTenantRecurringExpense(
+  tenantId: string,
+  recurringExpenseId: string,
+  data: UpdateRecurringExpenseData,
+): Promise<RecurringExpense> {
+  return apiClient<RecurringExpense, UpdateRecurringExpenseData>({
+    path: `/tenants/${tenantId}/recurring-expenses/${recurringExpenseId}`,
     method: 'PATCH',
     body: data,
   });


### PR DESCRIPTION
## Resumen

Nueva pestaña **Reglas recurrentes** en Administración → Finanzas del conjunto (también accesible con `?tab=recurring`) para administrar gastos recurrentes comunes **TENANT_SHARED**.

## Funcionalidad

- **Creación tenant-scoped** vía `POST /tenants/:tenantId/recurring-expenses` con soporte de los 3 métodos de distribución:
  - **MANUAL**: porcentajes enteros 0-100 por edificio real del tenant, suma exacta 100%, envía solo allocations con percentage > 0
  - **EQUAL_SHARE**: sin allocations (reparto dinámico en ejecución)
  - **BUILDING_TOTAL_M2**: sin allocations (el backend calcula según m² al ejecutar)
- **Lista incluyendo inactivas** (`includeInactive=true`) con estado Activa/Inactiva visible, método, frecuencia, monto y próxima ejecución
- **Activar/desactivar** con `PATCH { isActive }`
- **Edición limitada a concepto y monto** (el GET tenant no devuelve templates MANUAL, por lo que allocationMode/allocation/rubro/moneda/frecuencia quedan en solo lectura)
- **Bloqueo de creación cuando el tenant no tiene edificios**
- **Separación estricta BUILDING vs TENANT_SHARED**: funciones API, hooks y query keys propias (`['tenant-recurring-expenses', tenantId]`), sin contaminar el flujo BUILDING existente

## Calidad

- Tests de API (rutas tenant, includeInactive, payloads, no usa /buildings) y UI (labels amigables, validación suma 100, allocations reales, edición restringida, bloqueo sin edificios, toggle)
- TypeScript: 0 errores
- ESLint: 0 issues
- Build web de producción: exit 0
- Suite finance completa: 58 tests passed