### PR TITLE
fix(finance): block mixed-currency liquidations

### DIFF
--- a/apps/api/src/finanzas/liquidation-publication-snapshot.ts
+++ b/apps/api/src/finanzas/liquidation-publication-snapshot.ts
@@ -78,7 +78,7 @@ export function assertLiquidationMovementCurrency(
     });
   }
 
-  const movementCurrency = currencies.values().next().value as string | undefined;
+  const [movementCurrency] = currencies;
   if (movementCurrency !== undefined && movementCurrency !== baseCurrency) {
     throw new UnprocessableEntityException({
       statusCode: 422,

--- a/apps/api/src/finanzas/liquidation-publication-snapshot.ts
+++ b/apps/api/src/finanzas/liquidation-publication-snapshot.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, UnprocessableEntityException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 
 export interface PublishedExpenseSnapshot {
@@ -62,6 +62,30 @@ export interface LiquidationDistributionAllocation {
   unitLabel: string | null;
   areaM2: number;
   amountMinor: number;
+}
+
+export function assertLiquidationMovementCurrency(
+  movements: ReadonlyArray<{ currencyCode: string }>,
+  baseCurrency: string,
+): void {
+  const currencies = new Set(movements.map((movement) => movement.currencyCode));
+
+  if (currencies.size > 1) {
+    throw new UnprocessableEntityException({
+      statusCode: 422,
+      error: 'MIXED_CURRENCY_LIQUIDATION_NOT_SUPPORTED',
+      message: 'No se puede generar una liquidación con movimientos en distintas monedas.',
+    });
+  }
+
+  const movementCurrency = currencies.values().next().value as string | undefined;
+  if (movementCurrency !== undefined && movementCurrency !== baseCurrency) {
+    throw new UnprocessableEntityException({
+      statusCode: 422,
+      error: 'LIQUIDATION_BASE_CURRENCY_MISMATCH',
+      message: `La moneda de los movimientos (${movementCurrency}) no coincide con la moneda base de la liquidación (${baseCurrency}).`,
+    });
+  }
 }
 
 export function buildLiquidationPublicationSnapshot(

--- a/apps/api/src/finanzas/liquidation-publication.use-case.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.ts
@@ -12,6 +12,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { FinanzasValidators } from './finanzas.validators';
 import {
+  assertLiquidationMovementCurrency,
   buildLiquidationPublicationSnapshot,
   type PublishedExpenseSnapshot,
 } from './liquidation-publication-snapshot';
@@ -507,6 +508,9 @@ export class LiquidationPublicationUseCase {
             );
           }
 
+          const publicationExpenses = getPublicationSnapshotExpenses(current.expenseSnapshot);
+          assertLiquidationMovementCurrency(publicationExpenses, current.baseCurrency);
+
           const billableUnits = await tx.unit.findMany({
             where: { tenantId, buildingId: current.buildingId, isBillable: true },
             include: { unitCategory: { select: { coefficient: true, id: true } } },
@@ -537,7 +541,7 @@ export class LiquidationPublicationUseCase {
             baseCurrency: current.baseCurrency,
             totalAmountMinor: current.totalAmountMinor,
             totalsByCurrency: parseTotalsByCurrency(current.totalsByCurrency),
-            expenses: getPublicationSnapshotExpenses(current.expenseSnapshot),
+            expenses: publicationExpenses,
             allocations: distribution.map((item) => ({
               unitId: item.unitId,
               unitCode: item.unitCode,

--- a/apps/api/src/finanzas/liquidations.service.spec.ts
+++ b/apps/api/src/finanzas/liquidations.service.spec.ts
@@ -4,6 +4,7 @@ import {
   ConflictException,
   ForbiddenException,
   NotFoundException,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { LiquidationsService } from './liquidations.service';
@@ -72,6 +73,7 @@ describe('LiquidationsService', () => {
     };
     liquidation: {
       findFirst: jest.Mock;
+      create: jest.Mock;
       updateMany: jest.Mock;
       delete: jest.Mock;
     };
@@ -121,6 +123,12 @@ describe('LiquidationsService', () => {
           return Promise.resolve(baseLiquidation);
         }),
         updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+        create: jest.fn().mockImplementation(({ data }) => Promise.resolve({
+          ...baseLiquidation,
+          ...data,
+          status: 'DRAFT',
+          publicationSnapshot: null,
+        })),
         delete: jest.fn(),
       },
       charge: {
@@ -321,14 +329,116 @@ describe('LiquidationsService', () => {
       { id: 'unit-1', code: '1A', label: '1A', unitCategory: null },
     ]);
 
-    await expect(
-      service.createDraft('tenant-1', 'member-1', {
+    await expect(service.createDraft('tenant-1', 'member-1', {
         buildingId: 'building-1',
         period: '2026-05',
         baseCurrency: 'USD',
-      }),
-    ).rejects.toThrow(BadRequestException);
+      })).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_BASE_CURRENCY_MISMATCH',
+          message: 'La moneda de los movimientos (ARS) no coincide con la moneda base de la liquidación (USD).',
+        },
+      });
 
+    expect(auditService.createLogRequired).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['ARS', ['ARS', 'ARS']],
+    ['USD', ['USD', 'USD']],
+  ])('creates a %s draft when every movement uses the base currency', async (baseCurrency, currencies) => {
+    tx.liquidation.findFirst.mockResolvedValueOnce(null);
+    tx.expense.findMany
+      .mockResolvedValueOnce(currencies.map((currencyCode, index) => ({
+        id: `exp-${index + 1}`,
+        amountMinor: 100 + index,
+        currencyCode,
+        invoiceDate: new Date('2026-05-01T00:00:00.000Z'),
+        description: null,
+        category: { name: 'Water' },
+        vendor: { name: 'Vendor' },
+      })))
+      .mockResolvedValueOnce([]);
+
+    await service.createDraft('tenant-1', 'member-1', {
+      buildingId: 'building-1', period: '2026-05', baseCurrency,
+    });
+
+    expect(tx.liquidation.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        tenantId: 'tenant-1', baseCurrency, totalAmountMinor: 201,
+        totalsByCurrency: { [baseCurrency]: 201 },
+      }),
+    }));
+  });
+
+  it.each([
+    ['MIXED_CURRENCY_LIQUIDATION_NOT_SUPPORTED', ['USD', 'ARS'], 'No se puede generar una liquidación con movimientos en distintas monedas.'],
+    ['LIQUIDATION_BASE_CURRENCY_MISMATCH', ['USD', 'USD'], 'La moneda de los movimientos (USD) no coincide con la moneda base de la liquidación (ARS).'],
+  ])('rejects invalid currencies with %s before financial writes', async (error, currencies, message) => {
+    tx.liquidation.findFirst.mockResolvedValueOnce(null);
+    tx.expense.findMany
+      .mockResolvedValueOnce(currencies.map((currencyCode, index) => ({
+        id: `exp-${index + 1}`, amountMinor: 100, currencyCode,
+        invoiceDate: new Date('2026-05-01T00:00:00.000Z'), description: null,
+        category: { name: 'Water' }, vendor: { name: 'Vendor' },
+      })))
+      .mockResolvedValueOnce([]);
+
+    const promise = service.createDraft('tenant-1', 'member-1', {
+      buildingId: 'building-1', period: '2026-05', baseCurrency: 'ARS',
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(UnprocessableEntityException);
+    await expect(promise).rejects.toMatchObject({ response: { statusCode: 422, error, message } });
+    expect(tx.unit.findMany).not.toHaveBeenCalled();
+    expect(tx.liquidation.create).not.toHaveBeenCalled();
+    expect(tx.charge.createMany).not.toHaveBeenCalled();
+    expect(tx.liquidation.updateMany).not.toHaveBeenCalled();
+    expect(auditService.createLogRequired).not.toHaveBeenCalled();
+  });
+
+  it('guards included adjustments and preserves the existing empty behavior', async () => {
+    tx.liquidation.findFirst.mockResolvedValueOnce(null);
+    tx.adjustment.findMany.mockResolvedValueOnce([{
+      id: 'adj-1', amountMinor: 100, currencyCode: 'USD',
+      sourceInvoiceDate: new Date('2026-04-01T00:00:00.000Z'), sourcePeriod: '2026-04',
+      reason: 'Correction', category: { name: 'Water' },
+    }]);
+
+    await expect(service.createDraft('tenant-1', 'member-1', {
+      buildingId: 'building-1', period: '2026-05', baseCurrency: 'ARS',
+    })).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_BASE_CURRENCY_MISMATCH' },
+    });
+    expect(tx.liquidation.create).not.toHaveBeenCalled();
+
+    tx.liquidation.findFirst.mockResolvedValueOnce(null);
+    tx.adjustment.findMany.mockResolvedValueOnce([]);
+    await expect(service.createDraft('tenant-1', 'member-1', {
+      buildingId: 'building-1', period: '2026-05', baseCurrency: 'ARS',
+    })).rejects.toThrow('No hay gastos VALIDADOS ni ajustes');
+  });
+
+  it('rejects a legacy mixed-currency draft before publication writes', async () => {
+    tx.liquidation.findFirst.mockResolvedValueOnce({
+      ...baseLiquidation,
+      totalsByCurrency: { ARS: 100, USD: 100 },
+      expenseSnapshot: [
+        { ...baseLiquidation.expenseSnapshot[0], amountMinor: 100 },
+        { ...baseLiquidation.expenseSnapshot[0], expenseId: 'exp-2', amountMinor: 100, currencyCode: 'USD' },
+      ],
+    });
+
+    await expect(service.publishLiquidation('tenant-1', 'liq-1', 'member-1', {
+      dueDate: '2026-06-10',
+    })).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'MIXED_CURRENCY_LIQUIDATION_NOT_SUPPORTED' },
+    });
+    expect(tx.unit.findMany).not.toHaveBeenCalled();
+    expect(tx.charge.createMany).not.toHaveBeenCalled();
+    expect(tx.liquidation.updateMany).not.toHaveBeenCalled();
     expect(auditService.createLogRequired).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/finanzas/liquidations.service.ts
+++ b/apps/api/src/finanzas/liquidations.service.ts
@@ -16,6 +16,7 @@ import {
 } from './expense-ledger.dto';
 import { FinanzasValidators } from './finanzas.validators';
 import {
+  assertLiquidationMovementCurrency,
   parseLiquidationPublicationSnapshot,
   type PublishedExpenseSnapshot,
 } from './liquidation-publication-snapshot';
@@ -245,12 +246,6 @@ export class LiquidationsService {
         },
       });
 
-      const billableUnits = await tx.unit.findMany({
-        where: { tenantId, buildingId: dto.buildingId, isBillable: true },
-        include: { unitCategory: { select: { coefficient: true, id: true } } },
-        orderBy: { code: 'asc' },
-      });
-
       const allExpenses: LiquidationExpenseSnapshotRow[] = buildingExpenses.map((expense) => ({
         expenseId: expense.id,
         categoryName: expense.category.name,
@@ -324,6 +319,14 @@ export class LiquidationsService {
             `Registrá gastos propios del edificio o verificá que los gastos comunes tengan asignación a este edificio.`,
         );
       }
+
+      assertLiquidationMovementCurrency(expenseSnapshotItems, dto.baseCurrency);
+
+      const billableUnits = await tx.unit.findMany({
+        where: { tenantId, buildingId: dto.buildingId, isBillable: true },
+        include: { unitCategory: { select: { coefficient: true, id: true } } },
+        orderBy: { code: 'asc' },
+      });
 
       const totalAmountMinor = this.requireCurrencyTotal(totalsByCurrency, dto.baseCurrency);
       const chargesPreview = this.calculateDistribution(


### PR DESCRIPTION
Closes #137

## Resumen
Impide generar o publicar liquidaciones que mezclen monedas sin conversión.

## Reglas
- mixed currency => `422 MIXED_CURRENCY_LIQUIDATION_NOT_SUPPORTED`
- single currency distinta de `baseCurrency` => `422 LIQUIDATION_BASE_CURRENCY_MISMATCH`

## Atomicidad
El guard ocurre antes de:
- persistir liquidación inválida
- crear snapshot
- crear cargos
- cambiar estado
- registrar auditoría derivada

## Validación
- 57 tests focalizados
- 626 finance
- 2086 API completa
- TypeScript ✅
- Prisma validate ✅
- diff-check ✅

## Riesgo conocido
Drafts históricos incompatibles quedan bloqueados al publicar. No se convierten automáticamente; eso queda para la Fase 3.