### PR TITLE
feat(finance): add multicurrency foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       - name: 📦 Install dependencies
         run: npm ci
 
+      - name: 🏗️ Build internal packages
+        run: npm run build:packages
+
       - name: 🧬 Generate Prisma client
         run: npm run prisma:generate -w apps/api
 

--- a/apps/api/prisma/migrations/20260809000000_add_multicurrency_foundation/migration.sql
+++ b/apps/api/prisma/migrations/20260809000000_add_multicurrency_foundation/migration.sql
@@ -1,0 +1,36 @@
+ALTER TABLE "Tenant" ADD COLUMN "functionalCurrency" TEXT;
+
+UPDATE "Tenant" SET "functionalCurrency" = "currency"
+WHERE "currency" IN ('USD', 'VES', 'ARS', 'COP');
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM "Tenant" WHERE "functionalCurrency" IS NULL) THEN
+    RAISE EXCEPTION 'Multicurrency migration blocked: Tenant.currency contains non-canonical values';
+  END IF;
+END $$;
+
+ALTER TABLE "Tenant" ALTER COLUMN "functionalCurrency" SET NOT NULL;
+ALTER TABLE "Tenant" ALTER COLUMN "functionalCurrency" SET DEFAULT 'ARS';
+
+CREATE TABLE "ExchangeRate" (
+  "id" TEXT NOT NULL,
+  "tenantId" TEXT NOT NULL,
+  "baseCurrency" TEXT NOT NULL,
+  "quoteCurrency" TEXT NOT NULL,
+  "rate" DECIMAL(28,12) NOT NULL,
+  "effectiveAt" TIMESTAMP(3) NOT NULL,
+  "source" TEXT,
+  "createdByMembershipId" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL,
+  CONSTRAINT "ExchangeRate_pkey" PRIMARY KEY ("id"),
+  CONSTRAINT "ExchangeRate_rate_positive_check" CHECK ("rate" > 0),
+  CONSTRAINT "ExchangeRate_distinct_currency_check" CHECK ("baseCurrency" <> "quoteCurrency")
+);
+
+CREATE UNIQUE INDEX "ExchangeRate_tenant_pair_effective_key" ON "ExchangeRate"("tenantId", "baseCurrency", "quoteCurrency", "effectiveAt");
+CREATE INDEX "ExchangeRate_tenant_pair_effective_idx" ON "ExchangeRate"("tenantId", "baseCurrency", "quoteCurrency", "effectiveAt" DESC);
+CREATE INDEX "ExchangeRate_createdByMembershipId_idx" ON "ExchangeRate"("createdByMembershipId");
+ALTER TABLE "ExchangeRate" ADD CONSTRAINT "ExchangeRate_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "ExchangeRate" ADD CONSTRAINT "ExchangeRate_createdByMembershipId_fkey" FOREIGN KEY ("createdByMembershipId") REFERENCES "Membership"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -190,6 +190,7 @@ model Tenant {
 
   // Localization & Currency
   currency              String @default("ARS") // ARS (Argentina), VES (Venezuela), USD
+  functionalCurrency    String @default("ARS")
   locale                String @default("es-AR") // es-AR, es-VE, en-US
 
   // Building alias generation sequence
@@ -260,6 +261,7 @@ model Tenant {
   emailDeliveries       EmailDelivery[]
   unitBalanceSnapshots  UnitBalanceMonthlySnapshot[]
   buildingBalanceSnapshots BuildingBalanceMonthlySnapshot[]
+  exchangeRates         ExchangeRate[]
 }
 
 model User {
@@ -330,11 +332,32 @@ model Membership {
   aiInteractionLogs     AiInteractionLog[]
   aiActionEvents        AiActionEvent[]
   planChangeRequests    PlanChangeRequest[]   @relation("PlanRequestRequestedBy")
+  exchangeRatesCreated  ExchangeRate[]        @relation("ExchangeRateCreatedBy")
 
   @@unique([userId, tenantId])
   @@index([tenantId])
   @@index([userId])
   userContext      UserContext?
+}
+
+model ExchangeRate {
+  id                    String   @id @default(cuid())
+  tenantId              String
+  baseCurrency          String
+  quoteCurrency         String
+  rate                  Decimal  @db.Decimal(28, 12)
+  effectiveAt           DateTime
+  source                String?
+  createdByMembershipId String?
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+
+  tenant              Tenant      @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  createdByMembership Membership? @relation("ExchangeRateCreatedBy", fields: [createdByMembershipId], references: [id], onDelete: SetNull)
+
+  @@unique([tenantId, baseCurrency, quoteCurrency, effectiveAt], map: "ExchangeRate_tenant_pair_effective_key")
+  @@index([tenantId, baseCurrency, quoteCurrency, effectiveAt(sort: Desc)], map: "ExchangeRate_tenant_pair_effective_idx")
+  @@index([createdByMembershipId])
 }
 
 model UserContext {

--- a/apps/api/src/finanzas/currencies.contract.spec.ts
+++ b/apps/api/src/finanzas/currencies.contract.spec.ts
@@ -1,0 +1,11 @@
+import { CANONICAL_CURRENCIES, isCanonicalCurrency } from '@buildingos/contracts';
+
+describe('canonical currencies contract', () => {
+  it.each(CANONICAL_CURRENCIES)('accepts %s', (currency) => {
+    expect(isCanonicalCurrency(currency)).toBe(true);
+  });
+
+  it('rejects unknown values', () => {
+    expect(isCanonicalCurrency('EUR')).toBe(false);
+  });
+});

--- a/apps/api/src/finanzas/expense-ledger.dto.ts
+++ b/apps/api/src/finanzas/expense-ledger.dto.ts
@@ -12,12 +12,10 @@ import {
   Length,
   Matches,
   ValidateIf,
-  registerDecorator,
-  ValidationOptions,
-  ValidationArguments,
 } from 'class-validator';
 import { Transform, Type } from 'class-transformer';
 import { MovementType } from '@prisma/client';
+import { IsStrictDateString } from './strict-date.decorator';
 
 export type ExpenseLedgerCategoryMovementType = 'EXPENSE' | 'INCOME';
 export type ExpenseLedgerCategoryCatalogScope = 'BUILDING' | 'CONDOMINIUM_COMMON';
@@ -270,34 +268,6 @@ export class LiquidationParamDto {
   @IsString()
   @Matches(/^c[0-9a-z]{24}$/)
   liquidationId!: string;
-}
-
-function IsStrictDateString(validationOptions?: ValidationOptions) {
-  return (object: object, propertyName: string): void => {
-    registerDecorator({
-      name: 'IsStrictDateString',
-      target: object.constructor,
-      propertyName,
-      options: validationOptions,
-      validator: {
-        validate(value: unknown, args: ValidationArguments): boolean {
-          if (typeof value !== 'string') {
-            return false;
-          }
-
-          if (value.trim() !== value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) {
-            return false;
-          }
-
-          const date = new Date(`${value}T00:00:00.000Z`);
-          return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
-        },
-        defaultMessage(validationArguments?: ValidationArguments): string {
-          return `${validationArguments?.property ?? 'value'} must be a valid YYYY-MM-DD date`;
-        },
-      },
-    });
-  };
 }
 
 export interface LiquidationResponseDto {

--- a/apps/api/src/finanzas/finanzas.module.ts
+++ b/apps/api/src/finanzas/finanzas.module.ts
@@ -37,6 +37,8 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { StorageModule } from '../storage/storage.module';
 import { PaymentGatewayModule } from './payment-gateway/payment-gateway.module';
 import { ConfigService } from '../config/config.service';
+import { MulticurrencyController } from './multicurrency.controller';
+import { MulticurrencyService } from './multicurrency.service';
 import { AppConfigModule } from '../config/config.module';
 
 import { VendorPreferenceController } from './vendor-preference.controller';
@@ -82,6 +84,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     RecurringExpenseController,
     TenantRecurringExpenseController,
     PaymentWebhookController,
+    MulticurrencyController,
   ],
   providers: [
     FinanzasService,
@@ -121,6 +124,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     FinanceSummaryService,
     PaymentReceiptService,
     SignatureGuard,
+    MulticurrencyService,
   ],
   exports: [
     FinanzasService,

--- a/apps/api/src/finanzas/multicurrency.controller.ts
+++ b/apps/api/src/finanzas/multicurrency.controller.ts
@@ -1,0 +1,33 @@
+import { Body, Controller, Get, Param, Patch, Post, Query, Request, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import type { AuthenticatedRequest } from '../common/types/request.types';
+import { RequireTenantPermission } from '../rbac/tenant-permission.guard';
+import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
+import { CreateExchangeRateDto, ExchangeRateQueryDto, UpdateExchangeRateDto, UpdateFinanceSettingsDto } from './multicurrency.dto';
+import { MulticurrencyService } from './multicurrency.service';
+
+@Controller('tenants/:tenantId/finance')
+@UseGuards(JwtAuthGuard, TenantAccessGuard)
+export class MulticurrencyController {
+  constructor(private readonly multicurrency: MulticurrencyService) {}
+
+  @Get('settings')
+  @RequireTenantPermission('finance.settings.read')
+  getSettings(@Param('tenantId') tenantId: string) { return this.multicurrency.getSettings(tenantId); }
+
+  @Patch('settings')
+  @RequireTenantPermission('finance.settings.write')
+  updateSettings(@Param('tenantId') tenantId: string, @Body() dto: UpdateFinanceSettingsDto) { return this.multicurrency.updateSettings(tenantId, dto.functionalCurrency); }
+
+  @Get('exchange-rates')
+  @RequireTenantPermission('finance.settings.read')
+  list(@Param('tenantId') tenantId: string, @Query() query: ExchangeRateQueryDto) { return this.multicurrency.list(tenantId, query); }
+
+  @Post('exchange-rates')
+  @RequireTenantPermission('finance.settings.write')
+  create(@Param('tenantId') tenantId: string, @Body() dto: CreateExchangeRateDto, @Request() req: AuthenticatedRequest) { return this.multicurrency.create(tenantId, req.user.membershipId, dto); }
+
+  @Patch('exchange-rates/:exchangeRateId')
+  @RequireTenantPermission('finance.settings.write')
+  update(@Param('tenantId') tenantId: string, @Param('exchangeRateId') id: string, @Body() dto: UpdateExchangeRateDto) { return this.multicurrency.update(tenantId, id, dto); }
+}

--- a/apps/api/src/finanzas/multicurrency.dto.spec.ts
+++ b/apps/api/src/finanzas/multicurrency.dto.spec.ts
@@ -17,14 +17,21 @@ describe('multicurrency DTO validation', () => {
     ['update', UpdateExchangeRateDto, {}],
   ] as const)('%s exchange rate', (_operation, Dto, additionalFields) => {
     it.each(['1', '36.5', '0.50', '0.000000000001', '9999999999999999', '9999999999999999.123456789012'])('accepts rate %s', async (rate) => {
-      const value = Object.assign(new Dto(), additionalFields, { rate, effectiveAt: '2026-08-09T00:00:00.000Z' });
+      const value = Object.assign(new Dto(), additionalFields, { rate, effectiveAt: '2026-08-09' });
       await expect(validate(value)).resolves.toHaveLength(0);
     });
 
     it.each(['99999999999999999', '1.1234567890123', '0', '-1', '+0'])('rejects rate %s', async (rate) => {
-      const value = Object.assign(new Dto(), additionalFields, { rate, effectiveAt: '2026-08-09T00:00:00.000Z' });
+      const value = Object.assign(new Dto(), additionalFields, { rate, effectiveAt: '2026-08-09' });
       expect(await validate(value)).not.toHaveLength(0);
     });
+  });
+
+  it.each(['2026-08-09T00:00:00.000Z', '2026-02-30', '2026-8-9', 'not-a-date'])('rejects non-canonical effective date %s for create and update', async (effectiveAt) => {
+    const create = Object.assign(new CreateExchangeRateDto(), { baseCurrency: 'USD', quoteCurrency: 'VES', rate: '1', effectiveAt });
+    const update = Object.assign(new UpdateExchangeRateDto(), { rate: '1', effectiveAt });
+    expect(await validate(create)).not.toHaveLength(0);
+    expect(await validate(update)).not.toHaveLength(0);
   });
 
   it('rejects invalid currencies and effective dates', async () => {

--- a/apps/api/src/finanzas/multicurrency.dto.spec.ts
+++ b/apps/api/src/finanzas/multicurrency.dto.spec.ts
@@ -1,0 +1,24 @@
+import { validate } from 'class-validator';
+import { CreateExchangeRateDto, UpdateFinanceSettingsDto } from './multicurrency.dto';
+
+describe('multicurrency DTO validation', () => {
+  it.each(['USD', 'VES', 'ARS', 'COP'])('accepts functional currency %s', async (currency) => {
+    const value = Object.assign(new UpdateFinanceSettingsDto(), { functionalCurrency: currency });
+    await expect(validate(value)).resolves.toHaveLength(0);
+  });
+
+  it('rejects an unknown functional currency', async () => {
+    const value = Object.assign(new UpdateFinanceSettingsDto(), { functionalCurrency: 'EUR' });
+    expect(await validate(value)).not.toHaveLength(0);
+  });
+
+  it.each(['0', '-1', '1.1234567890123'])('rejects invalid rate %s', async (rate) => {
+    const value = Object.assign(new CreateExchangeRateDto(), { baseCurrency: 'USD', quoteCurrency: 'VES', rate, effectiveAt: '2026-08-09T00:00:00.000Z' });
+    expect(await validate(value)).not.toHaveLength(0);
+  });
+
+  it('rejects invalid currencies and effective dates', async () => {
+    const value = Object.assign(new CreateExchangeRateDto(), { baseCurrency: 'EUR', quoteCurrency: 'GBP', rate: '1', effectiveAt: 'not-a-date' });
+    expect(await validate(value)).toHaveLength(3);
+  });
+});

--- a/apps/api/src/finanzas/multicurrency.dto.spec.ts
+++ b/apps/api/src/finanzas/multicurrency.dto.spec.ts
@@ -1,5 +1,5 @@
 import { validate } from 'class-validator';
-import { CreateExchangeRateDto, UpdateFinanceSettingsDto } from './multicurrency.dto';
+import { CreateExchangeRateDto, UpdateExchangeRateDto, UpdateFinanceSettingsDto } from './multicurrency.dto';
 
 describe('multicurrency DTO validation', () => {
   it.each(['USD', 'VES', 'ARS', 'COP'])('accepts functional currency %s', async (currency) => {
@@ -12,9 +12,19 @@ describe('multicurrency DTO validation', () => {
     expect(await validate(value)).not.toHaveLength(0);
   });
 
-  it.each(['0', '-1', '1.1234567890123'])('rejects invalid rate %s', async (rate) => {
-    const value = Object.assign(new CreateExchangeRateDto(), { baseCurrency: 'USD', quoteCurrency: 'VES', rate, effectiveAt: '2026-08-09T00:00:00.000Z' });
-    expect(await validate(value)).not.toHaveLength(0);
+  describe.each([
+    ['create', CreateExchangeRateDto, { baseCurrency: 'USD', quoteCurrency: 'VES' }],
+    ['update', UpdateExchangeRateDto, {}],
+  ] as const)('%s exchange rate', (_operation, Dto, additionalFields) => {
+    it.each(['1', '36.5', '9999999999999999', '9999999999999999.123456789012'])('accepts rate %s', async (rate) => {
+      const value = Object.assign(new Dto(), additionalFields, { rate, effectiveAt: '2026-08-09T00:00:00.000Z' });
+      await expect(validate(value)).resolves.toHaveLength(0);
+    });
+
+    it.each(['99999999999999999', '1.1234567890123', '0', '-1', '+0'])('rejects rate %s', async (rate) => {
+      const value = Object.assign(new Dto(), additionalFields, { rate, effectiveAt: '2026-08-09T00:00:00.000Z' });
+      expect(await validate(value)).not.toHaveLength(0);
+    });
   });
 
   it('rejects invalid currencies and effective dates', async () => {

--- a/apps/api/src/finanzas/multicurrency.dto.spec.ts
+++ b/apps/api/src/finanzas/multicurrency.dto.spec.ts
@@ -16,7 +16,7 @@ describe('multicurrency DTO validation', () => {
     ['create', CreateExchangeRateDto, { baseCurrency: 'USD', quoteCurrency: 'VES' }],
     ['update', UpdateExchangeRateDto, {}],
   ] as const)('%s exchange rate', (_operation, Dto, additionalFields) => {
-    it.each(['1', '36.5', '9999999999999999', '9999999999999999.123456789012'])('accepts rate %s', async (rate) => {
+    it.each(['1', '36.5', '0.50', '0.000000000001', '9999999999999999', '9999999999999999.123456789012'])('accepts rate %s', async (rate) => {
       const value = Object.assign(new Dto(), additionalFields, { rate, effectiveAt: '2026-08-09T00:00:00.000Z' });
       await expect(validate(value)).resolves.toHaveLength(0);
     });

--- a/apps/api/src/finanzas/multicurrency.dto.ts
+++ b/apps/api/src/finanzas/multicurrency.dto.ts
@@ -1,0 +1,51 @@
+import { CANONICAL_CURRENCIES, type CanonicalCurrency } from '@buildingos/contracts';
+import { IsDateString, IsIn, IsOptional, IsString, Matches, MaxLength } from 'class-validator';
+
+export class UpdateFinanceSettingsDto {
+  @IsIn(CANONICAL_CURRENCIES)
+  functionalCurrency!: CanonicalCurrency;
+}
+
+export class ExchangeRateQueryDto {
+  @IsOptional()
+  @IsIn(CANONICAL_CURRENCIES)
+  baseCurrency?: CanonicalCurrency;
+
+  @IsOptional()
+  @IsIn(CANONICAL_CURRENCIES)
+  quoteCurrency?: CanonicalCurrency;
+}
+
+export class CreateExchangeRateDto {
+  @IsIn(CANONICAL_CURRENCIES)
+  baseCurrency!: CanonicalCurrency;
+
+  @IsIn(CANONICAL_CURRENCIES)
+  quoteCurrency!: CanonicalCurrency;
+
+  @IsString()
+  @Matches(/^(?:0*\.\d{0,11}[1-9]|0*[1-9]\d*(?:\.\d{1,12})?)$/, { message: 'rate must be a positive decimal string with at most 12 decimal places' })
+  rate!: string;
+
+  @IsDateString()
+  effectiveAt!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  source?: string;
+}
+
+export class UpdateExchangeRateDto {
+  @IsString()
+  @Matches(/^(?:0*\.\d{0,11}[1-9]|0*[1-9]\d*(?:\.\d{1,12})?)$/, { message: 'rate must be a positive decimal string with at most 12 decimal places' })
+  rate!: string;
+
+  @IsDateString()
+  effectiveAt!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  source?: string;
+}

--- a/apps/api/src/finanzas/multicurrency.dto.ts
+++ b/apps/api/src/finanzas/multicurrency.dto.ts
@@ -1,6 +1,9 @@
 import { CANONICAL_CURRENCIES, type CanonicalCurrency } from '@buildingos/contracts';
 import { IsDateString, IsIn, IsOptional, IsString, Matches, MaxLength } from 'class-validator';
 
+const DECIMAL_28_12_POSITIVE_PATTERN = /^(?!0+(?:\.0+)?$)\d{1,16}(?:\.\d{1,12})?$/;
+const DECIMAL_28_12_POSITIVE_MESSAGE = 'rate must be greater than zero with at most 16 integer and 12 fractional digits';
+
 export class UpdateFinanceSettingsDto {
   @IsIn(CANONICAL_CURRENCIES)
   functionalCurrency!: CanonicalCurrency;
@@ -24,7 +27,7 @@ export class CreateExchangeRateDto {
   quoteCurrency!: CanonicalCurrency;
 
   @IsString()
-  @Matches(/^(?:0*\.\d{0,11}[1-9]|0*[1-9]\d*(?:\.\d{1,12})?)$/, { message: 'rate must be a positive decimal string with at most 12 decimal places' })
+  @Matches(DECIMAL_28_12_POSITIVE_PATTERN, { message: DECIMAL_28_12_POSITIVE_MESSAGE })
   rate!: string;
 
   @IsDateString()
@@ -38,7 +41,7 @@ export class CreateExchangeRateDto {
 
 export class UpdateExchangeRateDto {
   @IsString()
-  @Matches(/^(?:0*\.\d{0,11}[1-9]|0*[1-9]\d*(?:\.\d{1,12})?)$/, { message: 'rate must be a positive decimal string with at most 12 decimal places' })
+  @Matches(DECIMAL_28_12_POSITIVE_PATTERN, { message: DECIMAL_28_12_POSITIVE_MESSAGE })
   rate!: string;
 
   @IsDateString()

--- a/apps/api/src/finanzas/multicurrency.dto.ts
+++ b/apps/api/src/finanzas/multicurrency.dto.ts
@@ -1,5 +1,6 @@
 import { CANONICAL_CURRENCIES, type CanonicalCurrency } from '@buildingos/contracts';
-import { IsDateString, IsIn, IsOptional, IsString, Matches, MaxLength } from 'class-validator';
+import { IsIn, IsOptional, IsString, Matches, MaxLength } from 'class-validator';
+import { IsStrictDateString } from './strict-date.decorator';
 
 const DECIMAL_28_12_POSITIVE_PATTERN = /^(?!0+(?:\.0+)?$)\d{1,16}(?:\.\d{1,12})?$/;
 const DECIMAL_28_12_POSITIVE_MESSAGE = 'rate must be greater than zero with at most 16 integer and 12 fractional digits';
@@ -30,7 +31,7 @@ export class CreateExchangeRateDto {
   @Matches(DECIMAL_28_12_POSITIVE_PATTERN, { message: DECIMAL_28_12_POSITIVE_MESSAGE })
   rate!: string;
 
-  @IsDateString()
+  @IsStrictDateString({ message: 'effectiveAt must be a valid YYYY-MM-DD date' })
   effectiveAt!: string;
 
   @IsOptional()
@@ -44,7 +45,7 @@ export class UpdateExchangeRateDto {
   @Matches(DECIMAL_28_12_POSITIVE_PATTERN, { message: DECIMAL_28_12_POSITIVE_MESSAGE })
   rate!: string;
 
-  @IsDateString()
+  @IsStrictDateString({ message: 'effectiveAt must be a valid YYYY-MM-DD date' })
   effectiveAt!: string;
 
   @IsOptional()

--- a/apps/api/src/finanzas/multicurrency.rbac.spec.ts
+++ b/apps/api/src/finanzas/multicurrency.rbac.spec.ts
@@ -1,0 +1,17 @@
+import { ROLE_PERMISSIONS } from '@buildingos/permissions';
+
+describe('multicurrency RBAC', () => {
+  it.each(['TENANT_OWNER', 'TENANT_ADMIN'] as const)('allows %s to read and write', (role) => {
+    expect(ROLE_PERMISSIONS[role]).toEqual(expect.arrayContaining(['finance.settings.read', 'finance.settings.write']));
+  });
+
+  it('allows OPERATOR to read but denies write', () => {
+    expect(ROLE_PERMISSIONS.OPERATOR).toContain('finance.settings.read');
+    expect(ROLE_PERMISSIONS.OPERATOR).not.toContain('finance.settings.write');
+  });
+
+  it('denies resident access', () => {
+    expect(ROLE_PERMISSIONS.RESIDENT).not.toContain('finance.settings.read');
+    expect(ROLE_PERMISSIONS.RESIDENT).not.toContain('finance.settings.write');
+  });
+});

--- a/apps/api/src/finanzas/multicurrency.service.spec.ts
+++ b/apps/api/src/finanzas/multicurrency.service.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { MulticurrencyService } from './multicurrency.service';
 import type { PrismaService } from '../prisma/prisma.service';
@@ -13,6 +13,21 @@ describe('MulticurrencyService', () => {
   const service = new MulticurrencyService(prisma);
   const dto = { baseCurrency: 'USD' as const, quoteCurrency: 'VES' as const, rate: '36.500000000001', effectiveAt: '2026-08-09T00:00:00.000Z', source: 'Central bank' };
   const record = { id: 'rate-1', tenantId: 'tenant-1', ...dto, rate: new Prisma.Decimal(dto.rate), effectiveAt: new Date(dto.effectiveAt), source: dto.source, createdByMembershipId: 'membership-1', createdAt: new Date(), updatedAt: new Date() };
+  const publicResponseFields = ['id', 'baseCurrency', 'quoteCurrency', 'rate', 'effectiveAt', 'source', 'createdAt', 'updatedAt'];
+
+  function prismaKnownRequestError(code: string): Prisma.PrismaClientKnownRequestError {
+    return new Prisma.PrismaClientKnownRequestError('Sensitive Prisma details', {
+      code,
+      clientVersion: '5.22.0',
+      meta: { target: ['tenantId', 'baseCurrency', 'quoteCurrency', 'effectiveAt'] },
+    });
+  }
+
+  function expectPublicExchangeRate(response: object): void {
+    expect(Object.keys(response).sort()).toEqual([...publicResponseFields].sort());
+    expect(response).not.toHaveProperty('tenantId');
+    expect(response).not.toHaveProperty('createdByMembershipId');
+  }
 
   beforeEach(() => jest.clearAllMocks());
 
@@ -31,6 +46,61 @@ describe('MulticurrencyService', () => {
     expect(exchangeRate.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ tenantId: 'tenant-1', rate: expect.any(Prisma.Decimal) }) }));
   });
 
+  it.each([
+    ['0.000000000001', '0.000000000001'],
+    ['0.50', '0.5'],
+    ['36.5', '36.5'],
+    ['9999999999999999.123456789012', '9999999999999999.123456789012'],
+  ])('serializes %s as canonical fixed point usable unchanged by PATCH', async (storedRate, expectedRate) => {
+    exchangeRate.findMany.mockResolvedValue([{ ...record, rate: new Prisma.Decimal(storedRate) }]);
+
+    const [response] = await service.list('tenant-1', {});
+
+    expect(response.rate).toBe(expectedRate);
+    expect(response.rate).not.toMatch(/[eE]/);
+    exchangeRate.updateMany.mockResolvedValue({ count: 1 });
+    exchangeRate.findFirstOrThrow.mockResolvedValue({ ...record, rate: new Prisma.Decimal(response.rate) });
+    await service.update('tenant-1', 'rate-1', { rate: response.rate, effectiveAt: dto.effectiveAt });
+    expect(exchangeRate.updateMany).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ rate: new Prisma.Decimal(expectedRate) }) }));
+  });
+
+  it('maps create P2002 to a sanitized conflict payload', async () => {
+    exchangeRate.create.mockRejectedValue(prismaKnownRequestError('P2002'));
+
+    const error = await service.create('tenant-1', undefined, dto).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(ConflictException);
+    expect((error as ConflictException).getResponse()).toEqual({
+      code: 'EXCHANGE_RATE_ALREADY_EXISTS',
+      message: 'An exchange rate already exists for this currency pair and effective date',
+    });
+    expect(JSON.stringify((error as ConflictException).getResponse())).not.toContain('Sensitive Prisma details');
+  });
+
+  it('maps update P2002 to a sanitized conflict payload', async () => {
+    exchangeRate.updateMany.mockRejectedValue(prismaKnownRequestError('P2002'));
+
+    const error = await service.update('tenant-1', 'rate-1', { rate: '36.5', effectiveAt: dto.effectiveAt }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(ConflictException);
+    expect((error as ConflictException).getResponse()).toEqual({
+      code: 'EXCHANGE_RATE_ALREADY_EXISTS',
+      message: 'An exchange rate already exists for this currency pair and effective date',
+    });
+  });
+
+  it.each(['create', 'update'] as const)('rethrows non-P2002 errors from %s unchanged', async (operation) => {
+    const error = prismaKnownRequestError('P2024');
+    if (operation === 'create') exchangeRate.create.mockRejectedValue(error);
+    else exchangeRate.updateMany.mockRejectedValue(error);
+
+    const request = operation === 'create'
+      ? service.create('tenant-1', undefined, dto)
+      : service.update('tenant-1', 'rate-1', { rate: '36.5', effectiveAt: dto.effectiveAt });
+
+    await expect(request).rejects.toBe(error);
+  });
+
   it('rejects a creator membership from another tenant', async () => {
     membership.findFirst.mockResolvedValue(null);
     await expect(service.create('tenant-1', 'membership-2', dto)).rejects.toBeInstanceOf(BadRequestException);
@@ -47,15 +117,22 @@ describe('MulticurrencyService', () => {
 
   it('lists only tenant rates ordered by effective date descending', async () => {
     exchangeRate.findMany.mockResolvedValue([record]);
-    await service.list('tenant-1', { baseCurrency: 'USD', quoteCurrency: 'VES' });
+    const [response] = await service.list('tenant-1', { baseCurrency: 'USD', quoteCurrency: 'VES' });
     expect(exchangeRate.findMany).toHaveBeenCalledWith({ where: { tenantId: 'tenant-1', baseCurrency: 'USD', quoteCurrency: 'VES' }, orderBy: { effectiveAt: 'desc' } });
+    expectPublicExchangeRate(response);
+  });
+
+  it('returns every public field and no internal fields from create', async () => {
+    exchangeRate.create.mockResolvedValue(record);
+    expectPublicExchangeRate(await service.create('tenant-1', undefined, dto));
   });
 
   it('updates using both id and tenantId without changing the historical pair', async () => {
     exchangeRate.updateMany.mockResolvedValue({ count: 1 });
     exchangeRate.findFirstOrThrow.mockResolvedValue(record);
-    await service.update('tenant-1', 'rate-1', { rate: '40.25', effectiveAt: dto.effectiveAt, source: 'Market' });
+    const response = await service.update('tenant-1', 'rate-1', { rate: '40.25', effectiveAt: dto.effectiveAt, source: 'Market' });
     expect(exchangeRate.updateMany).toHaveBeenCalledWith({ where: { id: 'rate-1', tenantId: 'tenant-1' }, data: expect.not.objectContaining({ baseCurrency: expect.anything(), quoteCurrency: expect.anything() }) });
+    expectPublicExchangeRate(response);
   });
 
   it('does not update a rate from another tenant', async () => {

--- a/apps/api/src/finanzas/multicurrency.service.spec.ts
+++ b/apps/api/src/finanzas/multicurrency.service.spec.ts
@@ -11,7 +11,7 @@ describe('MulticurrencyService', () => {
   };
   const prisma = { tenant, membership, exchangeRate } as unknown as PrismaService;
   const service = new MulticurrencyService(prisma);
-  const dto = { baseCurrency: 'USD' as const, quoteCurrency: 'VES' as const, rate: '36.500000000001', effectiveAt: '2026-08-09T00:00:00.000Z', source: 'Central bank' };
+  const dto = { baseCurrency: 'USD' as const, quoteCurrency: 'VES' as const, rate: '36.500000000001', effectiveAt: '2026-08-09', source: 'Central bank' };
   const record = { id: 'rate-1', tenantId: 'tenant-1', ...dto, rate: new Prisma.Decimal(dto.rate), effectiveAt: new Date(dto.effectiveAt), source: dto.source, createdByMembershipId: 'membership-1', createdAt: new Date(), updatedAt: new Date() };
   const publicResponseFields = ['id', 'baseCurrency', 'quoteCurrency', 'rate', 'effectiveAt', 'source', 'createdAt', 'updatedAt'];
 
@@ -44,6 +44,7 @@ describe('MulticurrencyService', () => {
     exchangeRate.create.mockResolvedValue(record);
     await expect(service.create('tenant-1', 'membership-1', dto)).resolves.toMatchObject({ rate: '36.500000000001' });
     expect(exchangeRate.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ tenantId: 'tenant-1', rate: expect.any(Prisma.Decimal) }) }));
+    expect(exchangeRate.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ effectiveAt: new Date('2026-08-09T00:00:00.000Z') }) }));
   });
 
   it.each([
@@ -133,6 +134,23 @@ describe('MulticurrencyService', () => {
     const response = await service.update('tenant-1', 'rate-1', { rate: '40.25', effectiveAt: dto.effectiveAt, source: 'Market' });
     expect(exchangeRate.updateMany).toHaveBeenCalledWith({ where: { id: 'rate-1', tenantId: 'tenant-1' }, data: expect.not.objectContaining({ baseCurrency: expect.anything(), quoteCurrency: expect.anything() }) });
     expectPublicExchangeRate(response);
+  });
+
+  it.each([
+    [undefined, undefined],
+    ['  Market  ', 'Market'],
+    ['', null],
+    ['   ', null],
+  ])('maps PATCH source %p to %p without omission ambiguity', async (source, expectedSource) => {
+    exchangeRate.updateMany.mockResolvedValue({ count: 1 });
+    exchangeRate.findFirstOrThrow.mockResolvedValue(record);
+
+    await service.update('tenant-1', 'rate-1', { rate: '40.25', effectiveAt: '2026-08-10', source });
+
+    const data = exchangeRate.updateMany.mock.calls[0][0].data;
+    expect(data.effectiveAt).toEqual(new Date('2026-08-10T00:00:00.000Z'));
+    if (source === undefined) expect(data).not.toHaveProperty('source');
+    else expect(data).toHaveProperty('source', expectedSource);
   });
 
   it('does not update a rate from another tenant', async () => {

--- a/apps/api/src/finanzas/multicurrency.service.spec.ts
+++ b/apps/api/src/finanzas/multicurrency.service.spec.ts
@@ -1,0 +1,65 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { MulticurrencyService } from './multicurrency.service';
+import type { PrismaService } from '../prisma/prisma.service';
+
+describe('MulticurrencyService', () => {
+  const tenant = { findUniqueOrThrow: jest.fn(), update: jest.fn() };
+  const membership = { findFirst: jest.fn() };
+  const exchangeRate = {
+    findMany: jest.fn(), create: jest.fn(), updateMany: jest.fn(), findFirstOrThrow: jest.fn(),
+  };
+  const prisma = { tenant, membership, exchangeRate } as unknown as PrismaService;
+  const service = new MulticurrencyService(prisma);
+  const dto = { baseCurrency: 'USD' as const, quoteCurrency: 'VES' as const, rate: '36.500000000001', effectiveAt: '2026-08-09T00:00:00.000Z', source: 'Central bank' };
+  const record = { id: 'rate-1', tenantId: 'tenant-1', ...dto, rate: new Prisma.Decimal(dto.rate), effectiveAt: new Date(dto.effectiveAt), source: dto.source, createdByMembershipId: 'membership-1', createdAt: new Date(), updatedAt: new Date() };
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it('gets and updates functional currency in the requested tenant', async () => {
+    tenant.findUniqueOrThrow.mockResolvedValue({ functionalCurrency: 'ARS' });
+    tenant.update.mockResolvedValue({ functionalCurrency: 'COP' });
+    await expect(service.getSettings('tenant-1')).resolves.toEqual({ functionalCurrency: 'ARS' });
+    await expect(service.updateSettings('tenant-1', 'COP')).resolves.toEqual({ functionalCurrency: 'COP' });
+    expect(tenant.update).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 'tenant-1' } }));
+  });
+
+  it('creates a tenant-scoped rate and serializes Decimal as a stable string', async () => {
+    membership.findFirst.mockResolvedValue({ id: 'membership-1' });
+    exchangeRate.create.mockResolvedValue(record);
+    await expect(service.create('tenant-1', 'membership-1', dto)).resolves.toMatchObject({ rate: '36.500000000001' });
+    expect(exchangeRate.create).toHaveBeenCalledWith(expect.objectContaining({ data: expect.objectContaining({ tenantId: 'tenant-1', rate: expect.any(Prisma.Decimal) }) }));
+  });
+
+  it('rejects a creator membership from another tenant', async () => {
+    membership.findFirst.mockResolvedValue(null);
+    await expect(service.create('tenant-1', 'membership-2', dto)).rejects.toBeInstanceOf(BadRequestException);
+    expect(membership.findFirst).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 'membership-2', tenantId: 'tenant-1' } }));
+  });
+
+  it.each(['0', '-1'])('rejects non-positive rate %s', async (rate) => {
+    await expect(service.create('tenant-1', undefined, { ...dto, rate })).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('rejects an equal currency pair', async () => {
+    await expect(service.create('tenant-1', undefined, { ...dto, quoteCurrency: 'USD' })).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('lists only tenant rates ordered by effective date descending', async () => {
+    exchangeRate.findMany.mockResolvedValue([record]);
+    await service.list('tenant-1', { baseCurrency: 'USD', quoteCurrency: 'VES' });
+    expect(exchangeRate.findMany).toHaveBeenCalledWith({ where: { tenantId: 'tenant-1', baseCurrency: 'USD', quoteCurrency: 'VES' }, orderBy: { effectiveAt: 'desc' } });
+  });
+
+  it('updates using both id and tenantId without changing the historical pair', async () => {
+    exchangeRate.updateMany.mockResolvedValue({ count: 1 });
+    exchangeRate.findFirstOrThrow.mockResolvedValue(record);
+    await service.update('tenant-1', 'rate-1', { rate: '40.25', effectiveAt: dto.effectiveAt, source: 'Market' });
+    expect(exchangeRate.updateMany).toHaveBeenCalledWith({ where: { id: 'rate-1', tenantId: 'tenant-1' }, data: expect.not.objectContaining({ baseCurrency: expect.anything(), quoteCurrency: expect.anything() }) });
+  });
+
+  it('does not update a rate from another tenant', async () => {
+    exchangeRate.updateMany.mockResolvedValue({ count: 0 });
+    await expect(service.update('tenant-2', 'rate-1', { rate: '40', effectiveAt: dto.effectiveAt })).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/apps/api/src/finanzas/multicurrency.service.ts
+++ b/apps/api/src/finanzas/multicurrency.service.ts
@@ -1,0 +1,69 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import type { CanonicalCurrency } from '@buildingos/contracts';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateExchangeRateDto, ExchangeRateQueryDto, UpdateExchangeRateDto } from './multicurrency.dto';
+
+export interface ExchangeRateResponse {
+  readonly id: string;
+  readonly baseCurrency: string;
+  readonly quoteCurrency: string;
+  readonly rate: string;
+  readonly effectiveAt: Date;
+  readonly source: string | null;
+  readonly createdAt: Date;
+  readonly updatedAt: Date;
+}
+
+@Injectable()
+export class MulticurrencyService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getSettings(tenantId: string): Promise<{ functionalCurrency: string }> {
+    const tenant = await this.prisma.tenant.findUniqueOrThrow({ where: { id: tenantId }, select: { functionalCurrency: true } });
+    return tenant;
+  }
+
+  async updateSettings(tenantId: string, functionalCurrency: CanonicalCurrency): Promise<{ functionalCurrency: string }> {
+    return this.prisma.tenant.update({ where: { id: tenantId }, data: { functionalCurrency }, select: { functionalCurrency: true } });
+  }
+
+  async list(tenantId: string, query: ExchangeRateQueryDto): Promise<ExchangeRateResponse[]> {
+    const rates = await this.prisma.exchangeRate.findMany({
+      where: { tenantId, baseCurrency: query.baseCurrency, quoteCurrency: query.quoteCurrency },
+      orderBy: { effectiveAt: 'desc' },
+    });
+    return rates.map((rate) => this.serialize(rate));
+  }
+
+  async create(tenantId: string, membershipId: string | undefined, dto: CreateExchangeRateDto): Promise<ExchangeRateResponse> {
+    this.assertPair(dto);
+    this.assertRate(dto.rate);
+    if (membershipId) {
+      const membership = await this.prisma.membership.findFirst({ where: { id: membershipId, tenantId }, select: { id: true } });
+      if (!membership) throw new BadRequestException('Creator membership does not belong to tenant');
+    }
+    const rate = await this.prisma.exchangeRate.create({ data: { tenantId, ...dto, rate: new Prisma.Decimal(dto.rate), effectiveAt: new Date(dto.effectiveAt), source: dto.source?.trim() || null, createdByMembershipId: membershipId || null } });
+    return this.serialize(rate);
+  }
+
+  async update(tenantId: string, id: string, dto: UpdateExchangeRateDto): Promise<ExchangeRateResponse> {
+    this.assertRate(dto.rate);
+    const result = await this.prisma.exchangeRate.updateMany({ where: { id, tenantId }, data: { ...dto, rate: new Prisma.Decimal(dto.rate), effectiveAt: new Date(dto.effectiveAt), source: dto.source?.trim() || null } });
+    if (result.count !== 1) throw new NotFoundException('Exchange rate not found');
+    const rate = await this.prisma.exchangeRate.findFirstOrThrow({ where: { id, tenantId } });
+    return this.serialize(rate);
+  }
+
+  private assertPair(dto: CreateExchangeRateDto): void {
+    if (dto.baseCurrency === dto.quoteCurrency) throw new BadRequestException('Base and quote currencies must differ');
+  }
+
+  private assertRate(rate: string): void {
+    if (!new Prisma.Decimal(rate).greaterThan(0)) throw new BadRequestException('Rate must be greater than zero');
+  }
+
+  private serialize(rate: { id: string; baseCurrency: string; quoteCurrency: string; rate: Prisma.Decimal; effectiveAt: Date; source: string | null; createdAt: Date; updatedAt: Date }): ExchangeRateResponse {
+    return { ...rate, rate: rate.rate.toString() };
+  }
+}

--- a/apps/api/src/finanzas/multicurrency.service.ts
+++ b/apps/api/src/finanzas/multicurrency.service.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import type { CanonicalCurrency } from '@buildingos/contracts';
 import { PrismaService } from '../prisma/prisma.service';
@@ -43,13 +43,17 @@ export class MulticurrencyService {
       const membership = await this.prisma.membership.findFirst({ where: { id: membershipId, tenantId }, select: { id: true } });
       if (!membership) throw new BadRequestException('Creator membership does not belong to tenant');
     }
-    const rate = await this.prisma.exchangeRate.create({ data: { tenantId, ...dto, rate: new Prisma.Decimal(dto.rate), effectiveAt: new Date(dto.effectiveAt), source: dto.source?.trim() || null, createdByMembershipId: membershipId || null } });
+    const rate = await this.executeExchangeRateWrite(
+      this.prisma.exchangeRate.create({ data: { tenantId, ...dto, rate: new Prisma.Decimal(dto.rate), effectiveAt: new Date(dto.effectiveAt), source: dto.source?.trim() || null, createdByMembershipId: membershipId || null } }),
+    );
     return this.serialize(rate);
   }
 
   async update(tenantId: string, id: string, dto: UpdateExchangeRateDto): Promise<ExchangeRateResponse> {
     this.assertRate(dto.rate);
-    const result = await this.prisma.exchangeRate.updateMany({ where: { id, tenantId }, data: { ...dto, rate: new Prisma.Decimal(dto.rate), effectiveAt: new Date(dto.effectiveAt), source: dto.source?.trim() || null } });
+    const result = await this.executeExchangeRateWrite(
+      this.prisma.exchangeRate.updateMany({ where: { id, tenantId }, data: { ...dto, rate: new Prisma.Decimal(dto.rate), effectiveAt: new Date(dto.effectiveAt), source: dto.source?.trim() || null } }),
+    );
     if (result.count !== 1) throw new NotFoundException('Exchange rate not found');
     const rate = await this.prisma.exchangeRate.findFirstOrThrow({ where: { id, tenantId } });
     return this.serialize(rate);
@@ -63,7 +67,30 @@ export class MulticurrencyService {
     if (!new Prisma.Decimal(rate).greaterThan(0)) throw new BadRequestException('Rate must be greater than zero');
   }
 
+  private async executeExchangeRateWrite<T>(operation: Promise<T>): Promise<T> {
+    try {
+      return await operation;
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        throw new ConflictException({
+          code: 'EXCHANGE_RATE_ALREADY_EXISTS',
+          message: 'An exchange rate already exists for this currency pair and effective date',
+        });
+      }
+      throw error;
+    }
+  }
+
   private serialize(rate: { id: string; baseCurrency: string; quoteCurrency: string; rate: Prisma.Decimal; effectiveAt: Date; source: string | null; createdAt: Date; updatedAt: Date }): ExchangeRateResponse {
-    return { ...rate, rate: rate.rate.toString() };
+    return {
+      id: rate.id,
+      baseCurrency: rate.baseCurrency,
+      quoteCurrency: rate.quoteCurrency,
+      rate: rate.rate.toFixed(),
+      effectiveAt: rate.effectiveAt,
+      source: rate.source,
+      createdAt: rate.createdAt,
+      updatedAt: rate.updatedAt,
+    };
   }
 }

--- a/apps/api/src/finanzas/multicurrency.service.ts
+++ b/apps/api/src/finanzas/multicurrency.service.ts
@@ -44,15 +44,20 @@ export class MulticurrencyService {
       if (!membership) throw new BadRequestException('Creator membership does not belong to tenant');
     }
     const rate = await this.executeExchangeRateWrite(
-      this.prisma.exchangeRate.create({ data: { tenantId, ...dto, rate: new Prisma.Decimal(dto.rate), effectiveAt: new Date(dto.effectiveAt), source: dto.source?.trim() || null, createdByMembershipId: membershipId || null } }),
+      this.prisma.exchangeRate.create({ data: { tenantId, baseCurrency: dto.baseCurrency, quoteCurrency: dto.quoteCurrency, rate: new Prisma.Decimal(dto.rate), effectiveAt: this.normalizeEffectiveDate(dto.effectiveAt), source: dto.source?.trim() || null, createdByMembershipId: membershipId || null } }),
     );
     return this.serialize(rate);
   }
 
   async update(tenantId: string, id: string, dto: UpdateExchangeRateDto): Promise<ExchangeRateResponse> {
     this.assertRate(dto.rate);
+    const data: Prisma.ExchangeRateUpdateManyMutationInput = {
+      rate: new Prisma.Decimal(dto.rate),
+      effectiveAt: this.normalizeEffectiveDate(dto.effectiveAt),
+      ...(dto.source !== undefined ? { source: dto.source.trim() || null } : {}),
+    };
     const result = await this.executeExchangeRateWrite(
-      this.prisma.exchangeRate.updateMany({ where: { id, tenantId }, data: { ...dto, rate: new Prisma.Decimal(dto.rate), effectiveAt: new Date(dto.effectiveAt), source: dto.source?.trim() || null } }),
+      this.prisma.exchangeRate.updateMany({ where: { id, tenantId }, data }),
     );
     if (result.count !== 1) throw new NotFoundException('Exchange rate not found');
     const rate = await this.prisma.exchangeRate.findFirstOrThrow({ where: { id, tenantId } });
@@ -65,6 +70,10 @@ export class MulticurrencyService {
 
   private assertRate(rate: string): void {
     if (!new Prisma.Decimal(rate).greaterThan(0)) throw new BadRequestException('Rate must be greater than zero');
+  }
+
+  private normalizeEffectiveDate(date: string): Date {
+    return new Date(`${date}T00:00:00.000Z`);
   }
 
   private async executeExchangeRateWrite<T>(operation: Promise<T>): Promise<T> {

--- a/apps/api/src/finanzas/strict-date.decorator.ts
+++ b/apps/api/src/finanzas/strict-date.decorator.ts
@@ -1,0 +1,24 @@
+import { registerDecorator, type ValidationArguments, type ValidationOptions } from 'class-validator';
+
+export function IsStrictDateString(validationOptions?: ValidationOptions) {
+  return (object: object, propertyName: string): void => {
+    registerDecorator({
+      name: 'IsStrictDateString',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: unknown): boolean {
+          if (typeof value !== 'string') return false;
+          if (value.trim() !== value || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+
+          const date = new Date(`${value}T00:00:00.000Z`);
+          return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value;
+        },
+        defaultMessage(validationArguments?: ValidationArguments): string {
+          return `${validationArguments?.property ?? 'value'} must be a valid YYYY-MM-DD date`;
+        },
+      },
+    });
+  };
+}

--- a/apps/web/features/finance/components/MulticurrencySettings.test.tsx
+++ b/apps/web/features/finance/components/MulticurrencySettings.test.tsx
@@ -1,0 +1,85 @@
+/** @jest-environment jsdom */
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MulticurrencySettings } from './MulticurrencySettings';
+import * as api from '../services/multicurrency.api';
+
+jest.mock('../services/multicurrency.api');
+jest.mock('@buildingos/contracts', () => ({ CANONICAL_CURRENCIES: ['USD', 'VES', 'ARS', 'COP'] }));
+const mockedApi = jest.mocked(api);
+
+function renderSubject() {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  return render(<QueryClientProvider client={client}><MulticurrencySettings tenantId="tenant-1" /></QueryClientProvider>);
+}
+
+describe('MulticurrencySettings', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedApi.getFinanceSettings.mockResolvedValue({ functionalCurrency: 'VES' });
+    mockedApi.listExchangeRates.mockResolvedValue([]);
+    mockedApi.updateFinanceSettings.mockResolvedValue({ functionalCurrency: 'COP' });
+    mockedApi.createExchangeRate.mockResolvedValue({ id: 'rate-1', baseCurrency: 'USD', quoteCurrency: 'VES', rate: '36.5', effectiveAt: '2026-08-09T00:00:00.000Z', source: null });
+    mockedApi.updateExchangeRate.mockResolvedValue({ id: 'rate-1', baseCurrency: 'USD', quoteCurrency: 'VES', rate: '40.25', effectiveAt: '2026-08-10T00:00:00.000Z', source: 'Market' });
+  });
+
+  it('shows loading, all four currencies, loaded functional currency and empty rates', async () => {
+    renderSubject();
+    expect(screen.getByText(/Cargando configuración/)).toBeTruthy();
+    await screen.findByText('No hay tasas registradas.');
+    expect((screen.getByLabelText('Moneda funcional') as HTMLSelectElement).value).toBe('VES');
+    for (const currency of ['USD', 'VES', 'ARS', 'COP']) expect(screen.getAllByRole('option', { name: currency }).length).toBeGreaterThan(0);
+  });
+
+  it('updates functional currency and shows success', async () => {
+    renderSubject();
+    await screen.findByText('No hay tasas registradas.');
+    fireEvent.change(screen.getByLabelText('Moneda funcional'), { target: { value: 'COP' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Guardar' }));
+    await waitFor(() => expect(mockedApi.updateFinanceSettings).toHaveBeenCalledWith('tenant-1', 'COP'));
+    expect(await screen.findByText('Moneda funcional actualizada.')).toBeTruthy();
+  });
+
+  it.each([
+    ['same pair', 'Origen y destino deben ser diferentes.', { destination: 'USD', rate: '1' }],
+    ['required rate', 'La tasa es obligatoria.', { destination: 'VES', rate: '' }],
+    ['positive rate', 'La tasa debe ser mayor que cero.', { destination: 'VES', rate: '0' }],
+  ])('validates %s', async (_name, message, values) => {
+    renderSubject();
+    await screen.findByText('No hay tasas registradas.');
+    fireEvent.change(screen.getByLabelText('Destino'), { target: { value: values.destination } });
+    fireEvent.change(screen.getByLabelText('Tasa'), { target: { value: values.rate } });
+    fireEvent.change(screen.getByLabelText('Fecha efectiva'), { target: { value: '2026-08-09' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Agregar tasa' }));
+    expect(screen.getByText(message)).toBeTruthy();
+    expect(mockedApi.createExchangeRate).not.toHaveBeenCalled();
+  });
+
+  it('creates a rate while preserving its decimal string payload', async () => {
+    renderSubject();
+    await screen.findByText('No hay tasas registradas.');
+    fireEvent.change(screen.getByLabelText('Tasa'), { target: { value: '36.500000000001' } });
+    fireEvent.change(screen.getByLabelText('Fecha efectiva'), { target: { value: '2026-08-09' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Agregar tasa' }));
+    await waitFor(() => expect(mockedApi.createExchangeRate).toHaveBeenCalledWith('tenant-1', expect.objectContaining({ rate: '36.500000000001' })));
+  });
+
+  it('shows API loading errors', async () => {
+    mockedApi.getFinanceSettings.mockRejectedValue(new Error('network failed'));
+    renderSubject();
+    expect(await screen.findByText(/network failed/)).toBeTruthy();
+  });
+
+  it('lists and edits history without sending currencies in PATCH', async () => {
+    mockedApi.listExchangeRates.mockResolvedValue([{ id: 'rate-1', baseCurrency: 'USD', quoteCurrency: 'VES', rate: '36.5', effectiveAt: '2026-08-09T00:00:00.000Z', source: 'Central bank' }]);
+    renderSubject();
+    await screen.findByText('Central bank');
+    fireEvent.click(screen.getByRole('button', { name: 'Editar' }));
+    fireEvent.change(screen.getByLabelText('Tasa'), { target: { value: '40.25' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Guardar cambios' }));
+    await waitFor(() => expect(mockedApi.updateExchangeRate).toHaveBeenCalledWith('tenant-1', 'rate-1', expect.objectContaining({ rate: '40.25' })));
+    const payload = mockedApi.updateExchangeRate.mock.calls[0][2];
+    expect(payload).not.toHaveProperty('baseCurrency');
+    expect(payload).not.toHaveProperty('quoteCurrency');
+  });
+});

--- a/apps/web/features/finance/components/MulticurrencySettings.test.tsx
+++ b/apps/web/features/finance/components/MulticurrencySettings.test.tsx
@@ -105,6 +105,18 @@ describe('MulticurrencySettings', () => {
     const payload = mockedApi.updateExchangeRate.mock.calls[0][2];
     expect(payload).not.toHaveProperty('baseCurrency');
     expect(payload).not.toHaveProperty('quoteCurrency');
+    expect(payload).not.toHaveProperty('source');
+    expect(payload.effectiveAt).toBe('2026-08-09');
+  });
+
+  it('sends an empty source only when an existing source is explicitly cleared', async () => {
+    mockedApi.listExchangeRates.mockResolvedValue([{ id: 'rate-1', baseCurrency: 'USD', quoteCurrency: 'VES', rate: '36.5', effectiveAt: '2026-08-09T00:00:00.000Z', source: 'Central bank' }]);
+    renderSubject();
+    await screen.findByText('Central bank');
+    fireEvent.click(screen.getByRole('button', { name: 'Editar' }));
+    fireEvent.change(screen.getByLabelText('Fuente'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Guardar cambios' }));
+    await waitFor(() => expect(mockedApi.updateExchangeRate).toHaveBeenCalledWith('tenant-1', 'rate-1', expect.objectContaining({ source: '' })));
   });
 
   it('shows data without mutation controls for an OPERATOR', async () => {
@@ -117,6 +129,7 @@ describe('MulticurrencySettings', () => {
     expect(screen.queryByRole('button', { name: 'Guardar' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Agregar tasa' })).toBeNull();
     expect(screen.queryByRole('button', { name: 'Editar' })).toBeNull();
+    expect(mockedUseCan).toHaveBeenCalledWith('finance.settings.write', 'tenant-1');
   });
 
   it.each<Role>(['TENANT_ADMIN', 'TENANT_OWNER'])('allows %s to mutate using canonical permissions', async (role) => {

--- a/apps/web/features/finance/components/MulticurrencySettings.test.tsx
+++ b/apps/web/features/finance/components/MulticurrencySettings.test.tsx
@@ -3,12 +3,18 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MulticurrencySettings } from './MulticurrencySettings';
 import * as api from '../services/multicurrency.api';
+import { can } from '@/features/rbac/rbac.permissions';
+import * as rbacHooks from '@/features/rbac/rbac.hooks';
+import type { Role } from '@buildingos/contracts';
 
 jest.mock('../services/multicurrency.api');
+jest.mock('@/features/rbac/rbac.hooks', () => ({ useCan: jest.fn() }));
 jest.mock('@buildingos/contracts', () => ({ CANONICAL_CURRENCIES: ['USD', 'VES', 'ARS', 'COP'] }));
 const mockedApi = jest.mocked(api);
+const mockedUseCan = jest.mocked(rbacHooks.useCan);
 
-function renderSubject() {
+function renderSubject(role: Role = 'TENANT_ADMIN') {
+  mockedUseCan.mockImplementation((permission) => can(role, permission));
   const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
   return render(<QueryClientProvider client={client}><MulticurrencySettings tenantId="tenant-1" /></QueryClientProvider>);
 }
@@ -81,5 +87,26 @@ describe('MulticurrencySettings', () => {
     const payload = mockedApi.updateExchangeRate.mock.calls[0][2];
     expect(payload).not.toHaveProperty('baseCurrency');
     expect(payload).not.toHaveProperty('quoteCurrency');
+  });
+
+  it('shows data without mutation controls for an OPERATOR', async () => {
+    mockedApi.listExchangeRates.mockResolvedValue([{ id: 'rate-1', baseCurrency: 'USD', quoteCurrency: 'VES', rate: '36.5', effectiveAt: '2026-08-09T00:00:00.000Z', source: 'Central bank' }]);
+    renderSubject('OPERATOR');
+    await screen.findByText('Central bank');
+    expect(screen.getAllByText('VES')).not.toHaveLength(0);
+    expect(screen.getByText('09/08/2026')).toBeTruthy();
+    expect(screen.queryByLabelText('Moneda funcional')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Guardar' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Agregar tasa' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Editar' })).toBeNull();
+  });
+
+  it.each<Role>(['TENANT_ADMIN', 'TENANT_OWNER'])('allows %s to mutate using canonical permissions', async (role) => {
+    mockedApi.listExchangeRates.mockResolvedValue([{ id: 'rate-1', baseCurrency: 'USD', quoteCurrency: 'VES', rate: '36.5', effectiveAt: '2026-08-09T00:00:00.000Z', source: null }]);
+    renderSubject(role);
+    await screen.findByText('09/08/2026');
+    expect(screen.getByRole('button', { name: 'Guardar' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Agregar tasa' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Editar' })).toBeTruthy();
   });
 });

--- a/apps/web/features/finance/components/MulticurrencySettings.test.tsx
+++ b/apps/web/features/finance/components/MulticurrencySettings.test.tsx
@@ -46,28 +46,46 @@ describe('MulticurrencySettings', () => {
     expect(await screen.findByText('Moneda funcional actualizada.')).toBeTruthy();
   });
 
-  it.each([
-    ['same pair', 'Origen y destino deben ser diferentes.', { destination: 'USD', rate: '1' }],
-    ['required rate', 'La tasa es obligatoria.', { destination: 'VES', rate: '' }],
-    ['positive rate', 'La tasa debe ser mayor que cero.', { destination: 'VES', rate: '0' }],
-  ])('validates %s', async (_name, message, values) => {
+  it('rejects an exchange rate with the same currency pair', async () => {
     renderSubject();
     await screen.findByText('No hay tasas registradas.');
-    fireEvent.change(screen.getByLabelText('Destino'), { target: { value: values.destination } });
-    fireEvent.change(screen.getByLabelText('Tasa'), { target: { value: values.rate } });
+    fireEvent.change(screen.getByLabelText('Destino'), { target: { value: 'USD' } });
+    fireEvent.change(screen.getByLabelText('Tasa'), { target: { value: '1' } });
+    fireEvent.change(screen.getByLabelText('Fecha efectiva'), { target: { value: '2026-08-09' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Agregar tasa' }));
+    expect(screen.getByText('Origen y destino deben ser diferentes.')).toBeTruthy();
+    expect(mockedApi.createExchangeRate).not.toHaveBeenCalled();
+  });
+
+  it.each(['1', '36.5', '0.50', '0.1', '0.000000000001', '9999999999999999', '9999999999999999.123456789012'])('accepts rate %s and preserves its string payload', async (rate) => {
+    renderSubject();
+    await screen.findByText('No hay tasas registradas.');
+    fireEvent.change(screen.getByLabelText('Tasa'), { target: { value: rate } });
+    fireEvent.change(screen.getByLabelText('Fecha efectiva'), { target: { value: '2026-08-09' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Agregar tasa' }));
+    await waitFor(() => expect(mockedApi.createExchangeRate).toHaveBeenCalledWith('tenant-1', expect.objectContaining({ rate })));
+  });
+
+  it.each([
+    ['0', 'La tasa debe ser mayor que cero.'],
+    ['0.0', 'La tasa debe ser mayor que cero.'],
+    ['0.000000000000', 'La tasa debe ser mayor que cero.'],
+    ['-1', 'La tasa debe ser mayor que cero.'],
+    ['-0.50', 'La tasa debe ser mayor que cero.'],
+    ['+0', 'La tasa debe ser mayor que cero.'],
+    ['99999999999999999', 'La tasa debe ser mayor que cero.'],
+    ['1.1234567890123', 'La tasa debe ser mayor que cero.'],
+    ['abc', 'La tasa debe ser mayor que cero.'],
+    ['', 'La tasa es obligatoria.'],
+    ['.50', 'La tasa debe ser mayor que cero.'],
+  ])('rejects rate %s', async (rate, message) => {
+    renderSubject();
+    await screen.findByText('No hay tasas registradas.');
+    fireEvent.change(screen.getByLabelText('Tasa'), { target: { value: rate } });
     fireEvent.change(screen.getByLabelText('Fecha efectiva'), { target: { value: '2026-08-09' } });
     fireEvent.click(screen.getByRole('button', { name: 'Agregar tasa' }));
     expect(screen.getByText(message)).toBeTruthy();
     expect(mockedApi.createExchangeRate).not.toHaveBeenCalled();
-  });
-
-  it('creates a rate while preserving its decimal string payload', async () => {
-    renderSubject();
-    await screen.findByText('No hay tasas registradas.');
-    fireEvent.change(screen.getByLabelText('Tasa'), { target: { value: '36.500000000001' } });
-    fireEvent.change(screen.getByLabelText('Fecha efectiva'), { target: { value: '2026-08-09' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Agregar tasa' }));
-    await waitFor(() => expect(mockedApi.createExchangeRate).toHaveBeenCalledWith('tenant-1', expect.objectContaining({ rate: '36.500000000001' })));
   });
 
   it('shows API loading errors', async () => {

--- a/apps/web/features/finance/components/MulticurrencySettings.tsx
+++ b/apps/web/features/finance/components/MulticurrencySettings.tsx
@@ -5,11 +5,18 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { FormEvent, useState } from 'react';
 import Button from '@/shared/components/ui/Button';
 import Card from '@/shared/components/ui/Card';
+import { useCan } from '@/features/rbac/rbac.hooks';
 import { createExchangeRate, getFinanceSettings, listExchangeRates, updateExchangeRate, updateFinanceSettings } from '../services/multicurrency.api';
 
 interface Props { readonly tenantId: string }
 
+function formatCalendarDate(value: string) {
+  const [year, month, day] = value.slice(0, 10).split('-');
+  return `${day}/${month}/${year}`;
+}
+
 export function MulticurrencySettings({ tenantId }: Props) {
+  const canWrite = useCan('finance.settings.write');
   const client = useQueryClient();
   const settings = useQuery({ queryKey: ['finance-settings', tenantId], queryFn: () => getFinanceSettings(tenantId) });
   const rates = useQuery({ queryKey: ['exchange-rates', tenantId], queryFn: () => listExchangeRates(tenantId) });
@@ -46,30 +53,30 @@ export function MulticurrencySettings({ tenantId }: Props) {
     <Card className="p-6 space-y-3">
       <h2 className="font-semibold">Moneda funcional</h2>
       <p className="text-sm text-muted-foreground">Moneda de referencia contable del tenant. No convierte movimientos existentes.</p>
-      <div className="flex gap-2">
-        <select aria-label="Moneda funcional" value={selectedFunctionalCurrency} onChange={(event) => setFunctionalCurrency(event.target.value as CanonicalCurrency)} className="border rounded px-3 py-2">
-          {CANONICAL_CURRENCIES.map((currency) => <option key={currency}>{currency}</option>)}
-        </select>
-        <Button onClick={() => saveSettings.mutate()} disabled={saveSettings.isPending}>Guardar</Button>
-      </div>
+      {canWrite ? <div className="flex gap-2">
+          <select aria-label="Moneda funcional" value={selectedFunctionalCurrency} onChange={(event) => setFunctionalCurrency(event.target.value as CanonicalCurrency)} className="border rounded px-3 py-2">
+            {CANONICAL_CURRENCIES.map((currency) => <option key={currency}>{currency}</option>)}
+          </select>
+          <Button onClick={() => saveSettings.mutate()} disabled={saveSettings.isPending}>Guardar</Button>
+        </div> : <p>{selectedFunctionalCurrency}</p>}
       {saveSettings.isSuccess && <p className="text-sm text-green-700">Moneda funcional actualizada.</p>}
       {saveSettings.error && <p className="text-sm text-red-700">{saveSettings.error.message}</p>}
     </Card>
     <Card className="p-6 space-y-4">
       <h2 className="font-semibold">Tasas de cambio</h2>
       <p className="text-sm text-muted-foreground">Semántica: 1 moneda de origen = tasa monedas de destino.</p>
-      <form onSubmit={submitRate} className="grid gap-3 md:grid-cols-5">
+      {canWrite && <form onSubmit={submitRate} className="grid gap-3 md:grid-cols-5">
         <select aria-label="Origen" value={baseCurrency} disabled={editingId !== null} onChange={(event) => setBaseCurrency(event.target.value as CanonicalCurrency)} className="border rounded px-3 py-2">{CANONICAL_CURRENCIES.map((currency) => <option key={currency}>{currency}</option>)}</select>
         <select aria-label="Destino" value={quoteCurrency} disabled={editingId !== null} onChange={(event) => setQuoteCurrency(event.target.value as CanonicalCurrency)} className="border rounded px-3 py-2">{CANONICAL_CURRENCIES.map((currency) => <option key={currency}>{currency}</option>)}</select>
         <input aria-label="Tasa" value={rate} onChange={(event) => setRate(event.target.value)} placeholder="Tasa" inputMode="decimal" className="border rounded px-3 py-2" />
         <input aria-label="Fecha efectiva" type="date" value={effectiveAt} onChange={(event) => setEffectiveAt(event.target.value)} className="border rounded px-3 py-2" />
         <input aria-label="Fuente" value={source} onChange={(event) => setSource(event.target.value)} placeholder="Fuente (opcional)" className="border rounded px-3 py-2" />
         <Button type="submit" disabled={saveRate.isPending}>{editingId ? 'Guardar cambios' : 'Agregar tasa'}</Button>
-      </form>
+      </form>}
       {validationError && <p className="text-sm text-red-700">{validationError}</p>}
       {saveRate.isSuccess && <p className="text-sm text-green-700">Tasa guardada.</p>}
       {saveRate.error && <p className="text-sm text-red-700">{saveRate.error.message}</p>}
-      {!rates.data?.length ? <p className="text-sm text-muted-foreground">No hay tasas registradas.</p> : <div className="overflow-x-auto"><table className="w-full text-sm"><thead><tr><th>Origen</th><th>Destino</th><th>Tasa</th><th>Fecha efectiva</th><th>Fuente</th><th>Acciones</th></tr></thead><tbody>{rates.data.map((item) => <tr key={item.id}><td>{item.baseCurrency}</td><td>{item.quoteCurrency}</td><td>{item.rate}</td><td>{new Date(item.effectiveAt).toLocaleDateString()}</td><td>{item.source || 'Sin fuente'}</td><td><button type="button" onClick={() => { setEditingId(item.id); setBaseCurrency(item.baseCurrency); setQuoteCurrency(item.quoteCurrency); setRate(item.rate); setEffectiveAt(item.effectiveAt.slice(0, 10)); setSource(item.source || ''); }}>Editar</button></td></tr>)}</tbody></table></div>}
+      {!rates.data?.length ? <p className="text-sm text-muted-foreground">No hay tasas registradas.</p> : <div className="overflow-x-auto"><table className="w-full text-sm"><thead><tr><th>Origen</th><th>Destino</th><th>Tasa</th><th>Fecha efectiva</th><th>Fuente</th>{canWrite && <th>Acciones</th>}</tr></thead><tbody>{rates.data.map((item) => <tr key={item.id}><td>{item.baseCurrency}</td><td>{item.quoteCurrency}</td><td>{item.rate}</td><td>{formatCalendarDate(item.effectiveAt)}</td><td>{item.source || 'Sin fuente'}</td>{canWrite && <td><button type="button" onClick={() => { setEditingId(item.id); setBaseCurrency(item.baseCurrency); setQuoteCurrency(item.quoteCurrency); setRate(item.rate); setEffectiveAt(item.effectiveAt.slice(0, 10)); setSource(item.source || ''); }}>Editar</button></td>}</tr>)}</tbody></table></div>}
     </Card>
   </div>;
 }

--- a/apps/web/features/finance/components/MulticurrencySettings.tsx
+++ b/apps/web/features/finance/components/MulticurrencySettings.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { CANONICAL_CURRENCIES, type CanonicalCurrency } from '@buildingos/contracts';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { FormEvent, useState } from 'react';
+import Button from '@/shared/components/ui/Button';
+import Card from '@/shared/components/ui/Card';
+import { createExchangeRate, getFinanceSettings, listExchangeRates, updateExchangeRate, updateFinanceSettings } from '../services/multicurrency.api';
+
+interface Props { readonly tenantId: string }
+
+export function MulticurrencySettings({ tenantId }: Props) {
+  const client = useQueryClient();
+  const settings = useQuery({ queryKey: ['finance-settings', tenantId], queryFn: () => getFinanceSettings(tenantId) });
+  const rates = useQuery({ queryKey: ['exchange-rates', tenantId], queryFn: () => listExchangeRates(tenantId) });
+  const [functionalCurrency, setFunctionalCurrency] = useState<CanonicalCurrency | null>(null);
+  const [baseCurrency, setBaseCurrency] = useState<CanonicalCurrency>('USD');
+  const [quoteCurrency, setQuoteCurrency] = useState<CanonicalCurrency>('VES');
+  const [rate, setRate] = useState('');
+  const [effectiveAt, setEffectiveAt] = useState('');
+  const [source, setSource] = useState('');
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const selectedFunctionalCurrency = functionalCurrency ?? settings.data?.functionalCurrency ?? 'ARS';
+  const saveSettings = useMutation({ mutationFn: () => updateFinanceSettings(tenantId, selectedFunctionalCurrency), onSuccess: () => client.invalidateQueries({ queryKey: ['finance-settings', tenantId] }) });
+  const saveRate = useMutation({ mutationFn: () => {
+    const input = { rate, effectiveAt: new Date(`${effectiveAt}T00:00:00.000Z`).toISOString(), source: source.trim() || undefined };
+    return editingId ? updateExchangeRate(tenantId, editingId, input) : createExchangeRate(tenantId, { baseCurrency, quoteCurrency, ...input });
+  }, onSuccess: () => { setRate(''); setSource(''); setEffectiveAt(''); setEditingId(null); void client.invalidateQueries({ queryKey: ['exchange-rates', tenantId] }); } });
+
+  const submitRate = (event: FormEvent) => {
+    event.preventDefault();
+    if (baseCurrency === quoteCurrency) return setValidationError('Origen y destino deben ser diferentes.');
+    if (!rate) return setValidationError('La tasa es obligatoria.');
+    if (!/^(?:0*\.\d{0,11}[1-9]|0*[1-9]\d*(?:\.\d{1,12})?)$/.test(rate)) return setValidationError('La tasa debe ser mayor que cero.');
+    if (!effectiveAt) return setValidationError('La fecha efectiva es obligatoria.');
+    setValidationError(null);
+    saveRate.mutate();
+  };
+
+  if (settings.isLoading || rates.isLoading) return <Card className="p-6">Cargando configuración monetaria...</Card>;
+  const error = settings.error || rates.error;
+  if (error) return <Card className="p-6 text-red-700">No pudimos cargar la configuración monetaria: {error instanceof Error ? error.message : 'Error desconocido'}</Card>;
+
+  return <div className="space-y-4">
+    <Card className="p-6 space-y-3">
+      <h2 className="font-semibold">Moneda funcional</h2>
+      <p className="text-sm text-muted-foreground">Moneda de referencia contable del tenant. No convierte movimientos existentes.</p>
+      <div className="flex gap-2">
+        <select aria-label="Moneda funcional" value={selectedFunctionalCurrency} onChange={(event) => setFunctionalCurrency(event.target.value as CanonicalCurrency)} className="border rounded px-3 py-2">
+          {CANONICAL_CURRENCIES.map((currency) => <option key={currency}>{currency}</option>)}
+        </select>
+        <Button onClick={() => saveSettings.mutate()} disabled={saveSettings.isPending}>Guardar</Button>
+      </div>
+      {saveSettings.isSuccess && <p className="text-sm text-green-700">Moneda funcional actualizada.</p>}
+      {saveSettings.error && <p className="text-sm text-red-700">{saveSettings.error.message}</p>}
+    </Card>
+    <Card className="p-6 space-y-4">
+      <h2 className="font-semibold">Tasas de cambio</h2>
+      <p className="text-sm text-muted-foreground">Semántica: 1 moneda de origen = tasa monedas de destino.</p>
+      <form onSubmit={submitRate} className="grid gap-3 md:grid-cols-5">
+        <select aria-label="Origen" value={baseCurrency} disabled={editingId !== null} onChange={(event) => setBaseCurrency(event.target.value as CanonicalCurrency)} className="border rounded px-3 py-2">{CANONICAL_CURRENCIES.map((currency) => <option key={currency}>{currency}</option>)}</select>
+        <select aria-label="Destino" value={quoteCurrency} disabled={editingId !== null} onChange={(event) => setQuoteCurrency(event.target.value as CanonicalCurrency)} className="border rounded px-3 py-2">{CANONICAL_CURRENCIES.map((currency) => <option key={currency}>{currency}</option>)}</select>
+        <input aria-label="Tasa" value={rate} onChange={(event) => setRate(event.target.value)} placeholder="Tasa" inputMode="decimal" className="border rounded px-3 py-2" />
+        <input aria-label="Fecha efectiva" type="date" value={effectiveAt} onChange={(event) => setEffectiveAt(event.target.value)} className="border rounded px-3 py-2" />
+        <input aria-label="Fuente" value={source} onChange={(event) => setSource(event.target.value)} placeholder="Fuente (opcional)" className="border rounded px-3 py-2" />
+        <Button type="submit" disabled={saveRate.isPending}>{editingId ? 'Guardar cambios' : 'Agregar tasa'}</Button>
+      </form>
+      {validationError && <p className="text-sm text-red-700">{validationError}</p>}
+      {saveRate.isSuccess && <p className="text-sm text-green-700">Tasa guardada.</p>}
+      {saveRate.error && <p className="text-sm text-red-700">{saveRate.error.message}</p>}
+      {!rates.data?.length ? <p className="text-sm text-muted-foreground">No hay tasas registradas.</p> : <div className="overflow-x-auto"><table className="w-full text-sm"><thead><tr><th>Origen</th><th>Destino</th><th>Tasa</th><th>Fecha efectiva</th><th>Fuente</th><th>Acciones</th></tr></thead><tbody>{rates.data.map((item) => <tr key={item.id}><td>{item.baseCurrency}</td><td>{item.quoteCurrency}</td><td>{item.rate}</td><td>{new Date(item.effectiveAt).toLocaleDateString()}</td><td>{item.source || 'Sin fuente'}</td><td><button type="button" onClick={() => { setEditingId(item.id); setBaseCurrency(item.baseCurrency); setQuoteCurrency(item.quoteCurrency); setRate(item.rate); setEffectiveAt(item.effectiveAt.slice(0, 10)); setSource(item.source || ''); }}>Editar</button></td></tr>)}</tbody></table></div>}
+    </Card>
+  </div>;
+}

--- a/apps/web/features/finance/components/MulticurrencySettings.tsx
+++ b/apps/web/features/finance/components/MulticurrencySettings.tsx
@@ -10,6 +10,8 @@ import { createExchangeRate, getFinanceSettings, listExchangeRates, updateExchan
 
 interface Props { readonly tenantId: string }
 
+const DECIMAL_28_12_POSITIVE_PATTERN = /^(?!0+(?:\.0+)?$)\d{1,16}(?:\.\d{1,12})?$/;
+
 function formatCalendarDate(value: string) {
   const [year, month, day] = value.slice(0, 10).split('-');
   return `${day}/${month}/${year}`;
@@ -39,7 +41,7 @@ export function MulticurrencySettings({ tenantId }: Props) {
     event.preventDefault();
     if (baseCurrency === quoteCurrency) return setValidationError('Origen y destino deben ser diferentes.');
     if (!rate) return setValidationError('La tasa es obligatoria.');
-    if (!/^(?:0*\.\d{0,11}[1-9]|0*[1-9]\d*(?:\.\d{1,12})?)$/.test(rate)) return setValidationError('La tasa debe ser mayor que cero.');
+    if (!DECIMAL_28_12_POSITIVE_PATTERN.test(rate)) return setValidationError('La tasa debe ser mayor que cero.');
     if (!effectiveAt) return setValidationError('La fecha efectiva es obligatoria.');
     setValidationError(null);
     saveRate.mutate();

--- a/apps/web/features/finance/components/MulticurrencySettings.tsx
+++ b/apps/web/features/finance/components/MulticurrencySettings.tsx
@@ -18,7 +18,7 @@ function formatCalendarDate(value: string) {
 }
 
 export function MulticurrencySettings({ tenantId }: Props) {
-  const canWrite = useCan('finance.settings.write');
+  const canWrite = useCan('finance.settings.write', tenantId);
   const client = useQueryClient();
   const settings = useQuery({ queryKey: ['finance-settings', tenantId], queryFn: () => getFinanceSettings(tenantId) });
   const rates = useQuery({ queryKey: ['exchange-rates', tenantId], queryFn: () => listExchangeRates(tenantId) });
@@ -28,14 +28,17 @@ export function MulticurrencySettings({ tenantId }: Props) {
   const [rate, setRate] = useState('');
   const [effectiveAt, setEffectiveAt] = useState('');
   const [source, setSource] = useState('');
+  const [sourceTouched, setSourceTouched] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const selectedFunctionalCurrency = functionalCurrency ?? settings.data?.functionalCurrency ?? 'ARS';
   const saveSettings = useMutation({ mutationFn: () => updateFinanceSettings(tenantId, selectedFunctionalCurrency), onSuccess: () => client.invalidateQueries({ queryKey: ['finance-settings', tenantId] }) });
   const saveRate = useMutation({ mutationFn: () => {
-    const input = { rate, effectiveAt: new Date(`${effectiveAt}T00:00:00.000Z`).toISOString(), source: source.trim() || undefined };
-    return editingId ? updateExchangeRate(tenantId, editingId, input) : createExchangeRate(tenantId, { baseCurrency, quoteCurrency, ...input });
-  }, onSuccess: () => { setRate(''); setSource(''); setEffectiveAt(''); setEditingId(null); void client.invalidateQueries({ queryKey: ['exchange-rates', tenantId] }); } });
+    const input = { rate, effectiveAt };
+    return editingId
+      ? updateExchangeRate(tenantId, editingId, { ...input, ...(sourceTouched ? { source: source.trim() } : {}) })
+      : createExchangeRate(tenantId, { baseCurrency, quoteCurrency, ...input, ...(source.trim() ? { source: source.trim() } : {}) });
+  }, onSuccess: () => { setRate(''); setSource(''); setSourceTouched(false); setEffectiveAt(''); setEditingId(null); void client.invalidateQueries({ queryKey: ['exchange-rates', tenantId] }); } });
 
   const submitRate = (event: FormEvent) => {
     event.preventDefault();
@@ -72,13 +75,13 @@ export function MulticurrencySettings({ tenantId }: Props) {
         <select aria-label="Destino" value={quoteCurrency} disabled={editingId !== null} onChange={(event) => setQuoteCurrency(event.target.value as CanonicalCurrency)} className="border rounded px-3 py-2">{CANONICAL_CURRENCIES.map((currency) => <option key={currency}>{currency}</option>)}</select>
         <input aria-label="Tasa" value={rate} onChange={(event) => setRate(event.target.value)} placeholder="Tasa" inputMode="decimal" className="border rounded px-3 py-2" />
         <input aria-label="Fecha efectiva" type="date" value={effectiveAt} onChange={(event) => setEffectiveAt(event.target.value)} className="border rounded px-3 py-2" />
-        <input aria-label="Fuente" value={source} onChange={(event) => setSource(event.target.value)} placeholder="Fuente (opcional)" className="border rounded px-3 py-2" />
+        <input aria-label="Fuente" value={source} onChange={(event) => { setSource(event.target.value); setSourceTouched(true); }} placeholder="Fuente (opcional)" className="border rounded px-3 py-2" />
         <Button type="submit" disabled={saveRate.isPending}>{editingId ? 'Guardar cambios' : 'Agregar tasa'}</Button>
       </form>}
       {validationError && <p className="text-sm text-red-700">{validationError}</p>}
       {saveRate.isSuccess && <p className="text-sm text-green-700">Tasa guardada.</p>}
       {saveRate.error && <p className="text-sm text-red-700">{saveRate.error.message}</p>}
-      {!rates.data?.length ? <p className="text-sm text-muted-foreground">No hay tasas registradas.</p> : <div className="overflow-x-auto"><table className="w-full text-sm"><thead><tr><th>Origen</th><th>Destino</th><th>Tasa</th><th>Fecha efectiva</th><th>Fuente</th>{canWrite && <th>Acciones</th>}</tr></thead><tbody>{rates.data.map((item) => <tr key={item.id}><td>{item.baseCurrency}</td><td>{item.quoteCurrency}</td><td>{item.rate}</td><td>{formatCalendarDate(item.effectiveAt)}</td><td>{item.source || 'Sin fuente'}</td>{canWrite && <td><button type="button" onClick={() => { setEditingId(item.id); setBaseCurrency(item.baseCurrency); setQuoteCurrency(item.quoteCurrency); setRate(item.rate); setEffectiveAt(item.effectiveAt.slice(0, 10)); setSource(item.source || ''); }}>Editar</button></td>}</tr>)}</tbody></table></div>}
+      {!rates.data?.length ? <p className="text-sm text-muted-foreground">No hay tasas registradas.</p> : <div className="overflow-x-auto"><table className="w-full text-sm"><thead><tr><th>Origen</th><th>Destino</th><th>Tasa</th><th>Fecha efectiva</th><th>Fuente</th>{canWrite && <th>Acciones</th>}</tr></thead><tbody>{rates.data.map((item) => <tr key={item.id}><td>{item.baseCurrency}</td><td>{item.quoteCurrency}</td><td>{item.rate}</td><td>{formatCalendarDate(item.effectiveAt)}</td><td>{item.source || 'Sin fuente'}</td>{canWrite && <td><button type="button" onClick={() => { setEditingId(item.id); setBaseCurrency(item.baseCurrency); setQuoteCurrency(item.quoteCurrency); setRate(item.rate); setEffectiveAt(item.effectiveAt.slice(0, 10)); setSource(item.source || ''); setSourceTouched(false); }}>Editar</button></td>}</tr>)}</tbody></table></div>}
     </Card>
   </div>;
 }

--- a/apps/web/features/finance/components/TenantFinanceDashboard.tsx
+++ b/apps/web/features/finance/components/TenantFinanceDashboard.tsx
@@ -25,8 +25,9 @@ import { formatCurrency } from '@/shared/lib/format/money';
 import { getDownloadUrl } from '@/features/buildings/services/documents.api';
 import { FileText, Loader2 } from 'lucide-react';
 import { useToast } from '@/shared/components/ui/Toast';
+import { MulticurrencySettings } from './MulticurrencySettings';
 
-type Tab = 'overview' | 'rubros' | 'expenses' | 'recurring' | 'payments' | 'charges' | 'delinquent' | 'reports' | 'notas';
+type Tab = 'overview' | 'rubros' | 'expenses' | 'recurring' | 'payments' | 'charges' | 'delinquent' | 'reports' | 'notas' | 'settings';
 
 interface Params {
   tenantId: string;
@@ -44,7 +45,7 @@ export const TenantFinanceDashboard = () => {
   const searchParams = useSearchParams();
   const tenantId = params?.tenantId;
   const currentMonth = new Date().toISOString().slice(0, 7);
-  const allowedTabs: readonly Tab[] = ['overview', 'rubros', 'expenses', 'recurring', 'payments', 'charges', 'delinquent', 'reports', 'notas'];
+  const allowedTabs: readonly Tab[] = ['overview', 'rubros', 'expenses', 'recurring', 'payments', 'charges', 'delinquent', 'reports', 'notas', 'settings'];
   const activeTab = (() => {
     const tabParam = searchParams.get('tab');
     if (tabParam && allowedTabs.includes(tabParam as Tab)) {
@@ -179,7 +180,8 @@ export const TenantFinanceDashboard = () => {
                 { id: 'charges', label: 'Cargos' },
                 { id: 'delinquent', label: `Morosos (${summary?.delinquentUnitsCount || 0})` },
                 { id: 'reports', label: 'Historial de gastos' },
-                { id: 'notas', label: 'Notas Revelatorias' },
+                 { id: 'notas', label: 'Notas Revelatorias' },
+                 { id: 'settings', label: 'Configuración' },
               ].map((tab) => (
              <button
                key={tab.id}
@@ -329,6 +331,7 @@ export const TenantFinanceDashboard = () => {
         {activeTab === 'notas' && (
           <NotasRevelatoriasPanel tenantId={tenantId || ''} />
         )}
+        {activeTab === 'settings' && <MulticurrencySettings tenantId={tenantId || ''} />}
       </div>
 
       {/* Payment Approval Modal */}

--- a/apps/web/features/finance/services/multicurrency.api.ts
+++ b/apps/web/features/finance/services/multicurrency.api.ts
@@ -1,0 +1,30 @@
+import type { CanonicalCurrency } from '@buildingos/contracts';
+import { apiClient } from '@/shared/lib/http/client';
+
+export interface FinanceSettings { readonly functionalCurrency: CanonicalCurrency }
+export interface ExchangeRate {
+  readonly id: string;
+  readonly baseCurrency: CanonicalCurrency;
+  readonly quoteCurrency: CanonicalCurrency;
+  readonly rate: string;
+  readonly effectiveAt: string;
+  readonly source: string | null;
+}
+export interface ExchangeRateInput {
+  readonly baseCurrency: CanonicalCurrency;
+  readonly quoteCurrency: CanonicalCurrency;
+  readonly rate: string;
+  readonly effectiveAt: string;
+  readonly source?: string;
+}
+export interface ExchangeRateUpdateInput {
+  readonly rate: string;
+  readonly effectiveAt: string;
+  readonly source?: string;
+}
+
+export const getFinanceSettings = (tenantId: string) => apiClient<FinanceSettings>({ path: `/tenants/${tenantId}/finance/settings` });
+export const updateFinanceSettings = (tenantId: string, functionalCurrency: CanonicalCurrency) => apiClient<FinanceSettings, FinanceSettings>({ path: `/tenants/${tenantId}/finance/settings`, method: 'PATCH', body: { functionalCurrency } });
+export const listExchangeRates = (tenantId: string) => apiClient<ExchangeRate[]>({ path: `/tenants/${tenantId}/finance/exchange-rates` });
+export const createExchangeRate = (tenantId: string, body: ExchangeRateInput) => apiClient<ExchangeRate, ExchangeRateInput>({ path: `/tenants/${tenantId}/finance/exchange-rates`, method: 'POST', body });
+export const updateExchangeRate = (tenantId: string, id: string, body: ExchangeRateUpdateInput) => apiClient<ExchangeRate, ExchangeRateUpdateInput>({ path: `/tenants/${tenantId}/finance/exchange-rates/${id}`, method: 'PATCH', body });

--- a/apps/web/features/rbac/rbac.hooks.test.tsx
+++ b/apps/web/features/rbac/rbac.hooks.test.tsx
@@ -1,0 +1,36 @@
+/** @jest-environment jsdom */
+import { renderHook } from '@testing-library/react';
+import type { AuthSession, Role } from '../auth/auth.types';
+import { getSession } from '../auth/session.storage';
+import { useCan } from './rbac.hooks';
+
+jest.mock('../auth/session.storage', () => ({ getSession: jest.fn() }));
+
+const mockedGetSession = jest.mocked(getSession);
+
+function session(activeRole: Role, routedRole: Role): AuthSession {
+  return {
+    user: { id: 'user-1', email: 'user@example.com', name: 'User' },
+    activeTenantId: 'tenant-a',
+    memberships: [
+      { tenantId: 'tenant-a', roles: [activeRole] },
+      { tenantId: 'tenant-b', roles: [routedRole] },
+    ],
+  };
+}
+
+describe('useCan', () => {
+  it.each([
+    ['TENANT_ADMIN', 'OPERATOR', false],
+    ['OPERATOR', 'TENANT_ADMIN', true],
+  ] as const)('uses routed tenant membership when active=%s and routed=%s', (activeRole, routedRole, expected) => {
+    mockedGetSession.mockReturnValue(session(activeRole, routedRole));
+    expect(renderHook(() => useCan('finance.settings.write', 'tenant-b')).result.current).toBe(expected);
+  });
+
+  it('retains active tenant behavior when tenant is omitted or matches the route', () => {
+    mockedGetSession.mockReturnValue(session('TENANT_ADMIN', 'OPERATOR'));
+    expect(renderHook(() => useCan('finance.settings.write')).result.current).toBe(true);
+    expect(renderHook(() => useCan('finance.settings.write', 'tenant-a')).result.current).toBe(true);
+  });
+});

--- a/apps/web/features/rbac/rbac.hooks.ts
+++ b/apps/web/features/rbac/rbac.hooks.ts
@@ -4,19 +4,19 @@ import type { Role } from '@buildingos/contracts';
 import { getSession } from '../auth/session.storage';
 import { can as canPermission } from './rbac.permissions';
 
-export function useCan(permission: string) {
+export function useCan(permission: string, tenantId?: string) {
   const session = getSession();
    const allowed = useMemo(() => {
      if (!session) return false;
      // Get roles from active tenant membership
      const activeMembership = session.memberships.find(
-       (m) => m.tenantId === session.activeTenantId,
+       (m) => m.tenantId === (tenantId ?? session.activeTenantId),
      );
      if (!activeMembership || activeMembership.roles.length === 0) return false;
      // Check if any role has permission
      return activeMembership.roles.some((role) =>
        canPermission(role as Role, permission),
      );
-   }, [session, permission]);
+    }, [session, permission, tenantId]);
    return allowed;
  }

--- a/packages/contracts/src/currencies.ts
+++ b/packages/contracts/src/currencies.ts
@@ -1,0 +1,7 @@
+export const CANONICAL_CURRENCIES = ['USD', 'VES', 'ARS', 'COP'] as const;
+
+export type CanonicalCurrency = (typeof CANONICAL_CURRENCIES)[number];
+
+export function isCanonicalCurrency(value: unknown): value is CanonicalCurrency {
+  return typeof value === 'string' && CANONICAL_CURRENCIES.some((currency) => currency === value);
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,2 +1,3 @@
 export * from './rbac';
 export * from './communications';
+export * from './currencies';

--- a/packages/contracts/src/rbac.ts
+++ b/packages/contracts/src/rbac.ts
@@ -21,6 +21,8 @@ export type Permission =
   | "tickets.read"
   | "tickets.write"
   | "tickets.manage"
+  | "finance.settings.read"
+  | "finance.settings.write"
   | "members.manage";
 
 export interface ScopedRole {

--- a/packages/permissions/src/permissions.ts
+++ b/packages/permissions/src/permissions.ts
@@ -6,6 +6,7 @@ export const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
     "units.read","units.write",
     "payments.submit","payments.review",
     "tickets.read","tickets.write","tickets.manage",
+    "finance.settings.read","finance.settings.write",
     "members.manage",
   ],
   TENANT_OWNER: [
@@ -13,6 +14,7 @@ export const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
     "units.read","units.write",
     "payments.submit","payments.review",
     "tickets.read","tickets.write","tickets.manage",
+    "finance.settings.read","finance.settings.write",
     "members.manage",
   ],
   TENANT_ADMIN: [
@@ -20,6 +22,7 @@ export const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
     "units.read","units.write",
     "payments.review",
     "tickets.read","tickets.write","tickets.manage",
+    "finance.settings.read","finance.settings.write",
     "members.manage",
   ],
   OPERATOR: [
@@ -27,6 +30,7 @@ export const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
     "units.read",
     "payments.review",
     "tickets.read","tickets.write","tickets.manage",
+    "finance.settings.read",
   ],
   RESIDENT: [
     "tickets.read","tickets.write",


### PR DESCRIPTION
Closes #139

## Resumen
Agrega la fundación multimoneda para USD, VES, ARS y COP.

## Moneda funcional
Cada tenant dispone de functionalCurrency independiente de Tenant.currency.

## Tipos de cambio
ExchangeRate tenant-scoped con Prisma Decimal(28,12).

Semántica:
1 baseCurrency = rate quoteCurrency.

## Seguridad
- TENANT_OWNER y TENANT_ADMIN pueden administrar configuración/tasas
- OPERATOR no puede escribir
- operaciones tenant-scoped
- updates incluyen tenantId

## UI
Administración de:
- moneda funcional
- histórico de tasas
- alta de tasa
- edición de tasa

## Migración
- agrega functionalCurrency
- backfill seguro
- crea ExchangeRate
- nombres explícitos de índices para evitar truncamiento PostgreSQL
- validada desde cero en DB temporal
- 84/84 migraciones aplicadas
- drift atribuible a 2C = 0

## Fuera de alcance
No se convierten todavía gastos, ingresos, pagos, cargos ni liquidaciones.
El guard mixed-currency permanece activo.

## Calidad
- Tests backend focalizados: 27/27 PASS
- Tests frontend focalizados: 8/8 PASS
- Suite finance API: 653 PASS, 11 skipped
- Suite API completa: 160 suites PASS, 2 skipped; 2113 tests PASS, 13 skipped; 0 failed
- TypeScript API/web: PASS
- Prisma validate/generate: PASS
- ESLint: PASS
- Build web y paquetes: PASS
- git diff --check: PASS
- Gentle AI review: APPROVED; gate pre-commit ALLOW; sin hallazgos bloqueantes

## Riesgo conocido no bloqueante
Existe una sugerencia de endurecimiento adicional sobre la cantidad de dígitos
permitidos en rate. La persistencia actual usa Decimal(28,12) y validación positiva.