### PR TITLE
feat(finance): integrate multicurrency income snapshots

### DIFF
--- a/apps/api/prisma/migrations/20260810000000_add_expense_multicurrency_snapshot/migration.sql
+++ b/apps/api/prisma/migrations/20260810000000_add_expense_multicurrency_snapshot/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "Expense" ADD COLUMN     "conversionDate" TIMESTAMP(3),
+ADD COLUMN     "exchangeRateDirection" TEXT,
+ADD COLUMN     "exchangeRateEffectiveAt" TIMESTAMP(3),
+ADD COLUMN     "exchangeRateId" TEXT,
+ADD COLUMN     "exchangeRateValue" DECIMAL(28,12),
+ADD COLUMN     "functionalAmountMinor" INTEGER,
+ADD COLUMN     "functionalCurrencyCode" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Expense_tenantId_exchangeRateId_idx" ON "Expense"("tenantId", "exchangeRateId");
+
+-- AddForeignKey
+ALTER TABLE "Expense" ADD CONSTRAINT "Expense_exchangeRateId_fkey" FOREIGN KEY ("exchangeRateId") REFERENCES "ExchangeRate"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/migrations/20260810010000_add_income_multicurrency_snapshot/migration.sql
+++ b/apps/api/prisma/migrations/20260810010000_add_income_multicurrency_snapshot/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "Income" ADD COLUMN     "conversionDate" TIMESTAMP(3),
+ADD COLUMN     "exchangeRateDirection" TEXT,
+ADD COLUMN     "exchangeRateEffectiveAt" TIMESTAMP(3),
+ADD COLUMN     "exchangeRateId" TEXT,
+ADD COLUMN     "exchangeRateValue" DECIMAL(28,12),
+ADD COLUMN     "functionalAmountMinor" INTEGER,
+ADD COLUMN     "functionalCurrencyCode" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Income_tenantId_exchangeRateId_idx" ON "Income"("tenantId", "exchangeRateId");
+
+-- AddForeignKey
+ALTER TABLE "Income" ADD CONSTRAINT "Income_exchangeRateId_fkey" FOREIGN KEY ("exchangeRateId") REFERENCES "ExchangeRate"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -355,6 +355,7 @@ model ExchangeRate {
   tenant              Tenant      @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   createdByMembership Membership? @relation("ExchangeRateCreatedBy", fields: [createdByMembershipId], references: [id], onDelete: SetNull)
   expenses            Expense[]
+  incomes             Income[]
 
   @@unique([tenantId, baseCurrency, quoteCurrency, effectiveAt], map: "ExchangeRate_tenant_pair_effective_key")
   @@index([tenantId, baseCurrency, quoteCurrency, effectiveAt(sort: Desc)], map: "ExchangeRate_tenant_pair_effective_idx")
@@ -1928,6 +1929,13 @@ model Income {
   recordedAt               DateTime?
   voidedByMembershipId     String?
   voidedAt                 DateTime?
+  functionalAmountMinor    Int?           // Snapshot: monto en moneda funcional (minor units) al momento de registro
+  functionalCurrencyCode   String?        // Snapshot: moneda funcional del tenant
+  exchangeRateId           String?        // Snapshot: FK a la tasa usada (null si IDENTITY)
+  exchangeRateValue        Decimal?       @db.Decimal(28, 12) // Snapshot numérico de la tasa aplicada (nunca derivar solo de la fila)
+  exchangeRateDirection    String?        // Snapshot: IDENTITY | DIRECT | INVERSE
+  exchangeRateEffectiveAt  DateTime?      // Snapshot: efectividad de la tasa fuente
+  conversionDate           DateTime?      // Snapshot: fecha de conversión (receivedDate, UTC date-only)
   createdAt                DateTime            @default(now())
   updatedAt                DateTime            @updatedAt
 
@@ -1935,6 +1943,7 @@ model Income {
   building    Building?             @relation(fields: [buildingId], references: [id], onDelete: SetNull)
   category    ExpenseLedgerCategory @relation(fields: [categoryId], references: [id], onDelete: Restrict)
   unitGroup   UnitGroup?            @relation(fields: [unitGroupId], references: [id], onDelete: SetNull)
+  exchangeRate ExchangeRate?        @relation(fields: [exchangeRateId], references: [id], onDelete: SetNull)
   allocations MovementAllocation[]
 
   @@index([tenantId, period])
@@ -1943,6 +1952,7 @@ model Income {
   @@index([tenantId, categoryId])
   @@index([tenantId, scopeType])
   @@index([tenantId, destination])
+  @@index([tenantId, exchangeRateId])
 }
 
 // ============================================================================

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -354,6 +354,7 @@ model ExchangeRate {
 
   tenant              Tenant      @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   createdByMembership Membership? @relation("ExchangeRateCreatedBy", fields: [createdByMembershipId], references: [id], onDelete: SetNull)
+  expenses            Expense[]
 
   @@unique([tenantId, baseCurrency, quoteCurrency, effectiveAt], map: "ExchangeRate_tenant_pair_effective_key")
   @@index([tenantId, baseCurrency, quoteCurrency, effectiveAt(sort: Desc)], map: "ExchangeRate_tenant_pair_effective_idx")
@@ -1830,6 +1831,13 @@ model Expense {
   validatedAt              DateTime?
   voidedByMembershipId     String?
   voidedAt                 DateTime?
+  functionalAmountMinor    Int?           // Snapshot: monto en moneda funcional (minor units) al momento de validación
+  functionalCurrencyCode   String?        // Snapshot: moneda funcional del tenant
+  exchangeRateId           String?        // Snapshot: FK a la tasa usada (null si IDENTITY)
+  exchangeRateValue        Decimal?       @db.Decimal(28, 12) // Snapshot numérico de la tasa aplicada (nunca derivar solo de la fila)
+  exchangeRateDirection    String?        // Snapshot: IDENTITY | DIRECT | INVERSE
+  exchangeRateEffectiveAt  DateTime?      // Snapshot: efectividad de la tasa fuente
+  conversionDate           DateTime?      // Snapshot: fecha de conversión (invoiceDate, UTC date-only)
   createdAt                DateTime       @default(now())
   updatedAt                DateTime       @updatedAt
 
@@ -1838,6 +1846,7 @@ model Expense {
   category    ExpenseLedgerCategory @relation(fields: [categoryId], references: [id], onDelete: Restrict)
   vendor      Vendor?               @relation(fields: [vendorId], references: [id], onDelete: SetNull)
   unitGroup   UnitGroup?           @relation(fields: [unitGroupId], references: [id], onDelete: SetNull)
+  exchangeRate ExchangeRate?        @relation(fields: [exchangeRateId], references: [id], onDelete: SetNull)
   allocations MovementAllocation[]
 
   @@index([tenantId, buildingId, period])
@@ -1845,6 +1854,7 @@ model Expense {
   @@index([tenantId, period, categoryId])
   @@index([tenantId, scopeType])
   @@index([tenantId, buildingId, liquidationPeriod, status])
+  @@index([tenantId, exchangeRateId])
 }
 
 // ============================================================================

--- a/apps/api/src/finanzas/currency-conversion.service.spec.ts
+++ b/apps/api/src/finanzas/currency-conversion.service.spec.ts
@@ -1,0 +1,345 @@
+import {
+  BadRequestException,
+  UnprocessableEntityException,
+} from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import type { CanonicalCurrency } from "@buildingos/contracts";
+import type { PrismaService } from "../prisma/prisma.service";
+import { CurrencyConversionService } from "./currency-conversion.service";
+
+describe("CurrencyConversionService", () => {
+  const exchangeRate = { findFirst: jest.fn() };
+  const prisma = { exchangeRate } as unknown as PrismaService;
+  const service = new CurrencyConversionService(prisma);
+  const conversionDate = "2026-08-09";
+
+  const rate = (
+    overrides: Partial<{
+      id: string;
+      baseCurrency: string;
+      quoteCurrency: string;
+      rate: string;
+      effectiveAt: Date;
+    }> = {},
+  ) => ({
+    id: overrides.id ?? "rate-1",
+    rate: new Prisma.Decimal(overrides.rate ?? "36.500000000001"),
+    effectiveAt: overrides.effectiveAt ?? new Date("2026-08-08T00:00:00.000Z"),
+  });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  it.each(["USD", "VES", "ARS", "COP"] as const)(
+    "returns IDENTITY for %s without querying rates",
+    async (currency) => {
+      await expect(
+        service.convert({
+          tenantId: "tenant-1",
+          amount: 125,
+          originalCurrency: currency,
+          functionalCurrency: currency,
+          conversionDate,
+        }),
+      ).resolves.toEqual({
+        originalAmount: 125,
+        originalCurrency: currency,
+        functionalAmount: 125,
+        functionalCurrency: currency,
+        sourceExchangeRateId: null,
+        appliedRate: "1",
+        direction: "IDENTITY",
+        sourceEffectiveAt: null,
+        conversionDate: new Date("2026-08-09T00:00:00.000Z"),
+      });
+      expect(exchangeRate.findFirst).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ["same day", "2026-08-09T00:00:00.000Z"],
+    ["prior day", "2026-08-08T00:00:00.000Z"],
+  ])(
+    "uses a DIRECT %s rate and returns snapshot metadata",
+    async (_label, effectiveAt) => {
+      exchangeRate.findFirst.mockResolvedValue(
+        rate({ effectiveAt: new Date(effectiveAt) }),
+      );
+
+      await expect(
+        service.convert(input({ amount: 100 })),
+      ).resolves.toMatchObject({
+        functionalAmount: 3650,
+        sourceExchangeRateId: "rate-1",
+        appliedRate: "36.500000000001",
+        direction: "DIRECT",
+        sourceEffectiveAt: new Date(effectiveAt),
+        conversionDate: new Date("2026-08-09T00:00:00.000Z"),
+      });
+      expect(exchangeRate.findFirst).toHaveBeenCalledWith({
+        where: {
+          tenantId: "tenant-1",
+          baseCurrency: "USD",
+          quoteCurrency: "VES",
+          effectiveAt: { lte: new Date("2026-08-09T00:00:00.000Z") },
+        },
+        orderBy: { effectiveAt: "desc" },
+        select: { id: true, rate: true, effectiveAt: true },
+      });
+    },
+  );
+
+  it("requests the latest eligible rate and excludes future rates in the database filter", async () => {
+    exchangeRate.findFirst.mockResolvedValue(rate());
+    await service.convert(input());
+    expect(exchangeRate.findFirst.mock.calls[0][0]).toMatchObject({
+      where: {
+        tenantId: "tenant-1",
+        effectiveAt: { lte: new Date("2026-08-09T00:00:00.000Z") },
+      },
+      orderBy: { effectiveAt: "desc" },
+    });
+  });
+
+  it("uses the exact Decimal reciprocal only when no direct rate exists", async () => {
+    exchangeRate.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(
+        rate({ rate: "4", baseCurrency: "VES", quoteCurrency: "USD" }),
+      );
+
+    await expect(
+      service.convert(input({ amount: 100 })),
+    ).resolves.toMatchObject({
+      functionalAmount: 25,
+      sourceExchangeRateId: "rate-1",
+      appliedRate: "0.25",
+      direction: "INVERSE",
+    });
+    expect(exchangeRate.findFirst).toHaveBeenNthCalledWith(2, {
+      where: {
+        tenantId: "tenant-1",
+        baseCurrency: "VES",
+        quoteCurrency: "USD",
+        effectiveAt: { lte: new Date("2026-08-09T00:00:00.000Z") },
+      },
+      orderBy: { effectiveAt: "desc" },
+      select: { id: true, rate: true, effectiveAt: true },
+    });
+  });
+
+  it("does not query inverse when a direct rate exists", async () => {
+    exchangeRate.findFirst.mockResolvedValue(rate({ rate: "2" }));
+    await expect(
+      service.convert(input({ amount: 100 })),
+    ).resolves.toMatchObject({ functionalAmount: 200, direction: "DIRECT" });
+    expect(exchangeRate.findFirst).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["0", "0.0", "0.000000000000"])(
+    "rejects an INVERSE zero source rate %s before dividing",
+    async (zeroRate) => {
+      exchangeRate.findFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(rate({ rate: zeroRate }));
+      const error = await service
+        .convert(input())
+        .catch((caught: unknown) => caught);
+      expect(error).toBeInstanceOf(UnprocessableEntityException);
+      expect((error as UnprocessableEntityException).getResponse()).toEqual({
+        code: "INVALID_EXCHANGE_RATE",
+        baseCurrency: "VES",
+        quoteCurrency: "USD",
+        effectiveAt: "2026-08-08T00:00:00.000Z",
+      });
+      expect(exchangeRate.findFirst).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each(["-1", "-36.5"])(
+    "rejects a negative INVERSE source rate %s before dividing",
+    async (negativeRate) => {
+      exchangeRate.findFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(rate({ rate: negativeRate }));
+      const error = await service
+        .convert(input())
+        .catch((caught: unknown) => caught);
+      expect(error).toBeInstanceOf(UnprocessableEntityException);
+      expect((error as UnprocessableEntityException).getResponse()).toEqual({
+        code: "INVALID_EXCHANGE_RATE",
+        baseCurrency: "VES",
+        quoteCurrency: "USD",
+        effectiveAt: "2026-08-08T00:00:00.000Z",
+      });
+    },
+  );
+
+  it.each(["0", "0.0", "0.000000000000"])(
+    "rejects a DIRECT zero source rate %s before multiplying",
+    async (zeroRate) => {
+      exchangeRate.findFirst.mockResolvedValue(rate({ rate: zeroRate }));
+      const error = await service
+        .convert(input())
+        .catch((caught: unknown) => caught);
+      expect(error).toBeInstanceOf(UnprocessableEntityException);
+      expect((error as UnprocessableEntityException).getResponse()).toEqual({
+        code: "INVALID_EXCHANGE_RATE",
+        baseCurrency: "USD",
+        quoteCurrency: "VES",
+        effectiveAt: "2026-08-08T00:00:00.000Z",
+      });
+      expect(exchangeRate.findFirst).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each(["-1", "-36.5"])(
+    "rejects a negative DIRECT source rate %s before multiplying",
+    async (negativeRate) => {
+      exchangeRate.findFirst.mockResolvedValue(rate({ rate: negativeRate }));
+      const error = await service
+        .convert(input())
+        .catch((caught: unknown) => caught);
+      expect(error).toBeInstanceOf(UnprocessableEntityException);
+      expect((error as UnprocessableEntityException).getResponse()).toEqual({
+        code: "INVALID_EXCHANGE_RATE",
+        baseCurrency: "USD",
+        quoteCurrency: "VES",
+        effectiveAt: "2026-08-08T00:00:00.000Z",
+      });
+      expect(exchangeRate.findFirst).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("returns a stable sanitized missing-rate error", async () => {
+    exchangeRate.findFirst.mockResolvedValue(null);
+    const error = await service
+      .convert(input())
+      .catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(UnprocessableEntityException);
+    expect((error as UnprocessableEntityException).getResponse()).toEqual({
+      code: "EXCHANGE_RATE_NOT_FOUND",
+      originalCurrency: "USD",
+      functionalCurrency: "VES",
+      conversionDate,
+    });
+  });
+
+  it("never uses another tenant rate because both lookups include tenantId", async () => {
+    exchangeRate.findFirst.mockResolvedValue(null);
+    await expect(
+      service.convert(input({ tenantId: "tenant-b" })),
+    ).rejects.toBeInstanceOf(UnprocessableEntityException);
+    expect(exchangeRate.findFirst.mock.calls).toHaveLength(2);
+    expect(
+      exchangeRate.findFirst.mock.calls.every(
+        ([query]) => query.where.tenantId === "tenant-b",
+      ),
+    ).toBe(true);
+  });
+
+  it("uses the supplied date only and supports the day before an effective rate as missing", async () => {
+    exchangeRate.findFirst.mockResolvedValue(null);
+    await expect(
+      service.convert(input({ conversionDate: "2026-08-07" })),
+    ).rejects.toBeInstanceOf(UnprocessableEntityException);
+    expect(exchangeRate.findFirst.mock.calls[0][0].where.effectiveAt).toEqual({
+      lte: new Date("2026-08-07T00:00:00.000Z"),
+    });
+  });
+
+  it.each(["USD", "VES", "ARS", "COP"] as const)(
+    "accepts canonical original currency %s",
+    async (currency) => {
+      await expect(
+        service.convert(
+          input({ originalCurrency: currency, functionalCurrency: currency }),
+        ),
+      ).resolves.toMatchObject({ direction: "IDENTITY" });
+    },
+  );
+
+  it.each([{ originalCurrency: "EUR" }, { functionalCurrency: "EUR" }])(
+    "rejects invalid currencies before querying",
+    async (override) => {
+      await expect(service.convert(input(override))).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(exchangeRate.findFirst).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["2026-8-09", "2026-02-30", " 2026-08-09", "2026-08-09T00:00:00Z"])(
+    "rejects non-strict conversion date %s",
+    async (date) => {
+      await expect(
+        service.convert(input({ conversionDate: date })),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(exchangeRate.findFirst).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    ["12-decimal rate", "1.123456789012", 100, 112],
+    ["small rate", "0.000000000001", 2_000_000_000, 0],
+    ["large admitted result", "1", 2_147_483_647, 2_147_483_647],
+  ])(
+    "converts %s with fixed-point applied rate",
+    async (_label, sourceRate, amount, expected) => {
+      exchangeRate.findFirst.mockResolvedValue(rate({ rate: sourceRate }));
+      const result = await service.convert(input({ amount }));
+      expect(result.functionalAmount).toBe(expected);
+      expect(result.appliedRate).toBe(new Prisma.Decimal(sourceRate).toFixed());
+      expect(result.appliedRate).not.toMatch(/[eE]/);
+    },
+  );
+
+  it.each([
+    ["even-down", 1, "2.5", 2],
+    ["odd-up", 1, "3.5", 4],
+  ])(
+    "uses ROUND_HALF_EVEN for a positive %s tie",
+    async (_label, amount, sourceRate, expected) => {
+      exchangeRate.findFirst.mockResolvedValue(rate({ rate: sourceRate }));
+      await expect(service.convert(input({ amount }))).resolves.toMatchObject({
+        functionalAmount: expected,
+      });
+    },
+  );
+
+  it.each([
+    [2_147_483_647, "1", 2_147_483_647],
+    [-2_147_483_648, "1", -2_147_483_648],
+  ])(
+    "accepts current Int storage boundary %s",
+    async (amount, sourceRate, expected) => {
+      exchangeRate.findFirst.mockResolvedValue(rate({ rate: sourceRate }));
+      await expect(service.convert(input({ amount }))).resolves.toMatchObject({
+        functionalAmount: expected,
+      });
+    },
+  );
+
+  it.each([
+    [2_147_483_647, "1.000000001"],
+    [-2_147_483_648, "1.000000001"],
+  ])(
+    "rejects converted current Int overflow for %s",
+    async (amount, sourceRate) => {
+      exchangeRate.findFirst.mockResolvedValue(rate({ rate: sourceRate }));
+      await expect(service.convert(input({ amount }))).rejects.toMatchObject({
+        response: { code: "CONVERTED_AMOUNT_OUT_OF_RANGE" },
+      });
+    },
+  );
+
+  function input(overrides: Record<string, unknown> = {}) {
+    return {
+      tenantId: "tenant-1",
+      amount: 100,
+      originalCurrency: "USD",
+      functionalCurrency: "VES",
+      conversionDate,
+      ...overrides,
+    } as Parameters<CurrencyConversionService["convert"]>[0];
+  }
+});

--- a/apps/api/src/finanzas/currency-conversion.service.ts
+++ b/apps/api/src/finanzas/currency-conversion.service.ts
@@ -1,0 +1,242 @@
+import {
+  BadRequestException,
+  Injectable,
+  UnprocessableEntityException,
+} from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import {
+  isCanonicalCurrency,
+  type CanonicalCurrency,
+} from "@buildingos/contracts";
+import { PrismaService } from "../prisma/prisma.service";
+
+const INT_MIN = new Prisma.Decimal("-2147483648");
+const INT_MAX = new Prisma.Decimal("2147483647");
+
+export type CurrencyConversionDirection = "IDENTITY" | "DIRECT" | "INVERSE";
+
+export interface CurrencyConversionInput {
+  readonly tenantId: string;
+  readonly amount: number;
+  readonly originalCurrency: CanonicalCurrency;
+  readonly functionalCurrency: CanonicalCurrency;
+  readonly conversionDate: string;
+}
+
+export interface CurrencyConversionResult {
+  readonly originalAmount: number;
+  readonly originalCurrency: CanonicalCurrency;
+  readonly functionalAmount: number;
+  readonly functionalCurrency: CanonicalCurrency;
+  readonly sourceExchangeRateId: string | null;
+  readonly appliedRate: string;
+  readonly direction: CurrencyConversionDirection;
+  readonly sourceEffectiveAt: Date | null;
+  readonly conversionDate: Date;
+}
+
+interface RateSnapshot {
+  readonly id: string;
+  readonly rate: Prisma.Decimal;
+  readonly effectiveAt: Date;
+}
+
+@Injectable()
+export class CurrencyConversionService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async convert(
+    input: CurrencyConversionInput,
+  ): Promise<CurrencyConversionResult> {
+    this.assertInput(input);
+    const conversionDate = this.normalizeDate(input.conversionDate);
+
+    if (input.originalCurrency === input.functionalCurrency) {
+      return this.result(
+        input,
+        input.amount,
+        new Prisma.Decimal(1),
+        "IDENTITY",
+        null,
+        conversionDate,
+      );
+    }
+
+    const direct = await this.findRate(
+      input.tenantId,
+      input.originalCurrency,
+      input.functionalCurrency,
+      conversionDate,
+    );
+    if (direct) {
+      this.assertPositiveRate(
+        direct,
+        input.originalCurrency,
+        input.functionalCurrency,
+      );
+      return this.convertWithRate(
+        input,
+        direct,
+        direct.rate,
+        "DIRECT",
+        conversionDate,
+      );
+    }
+
+    const inverse = await this.findRate(
+      input.tenantId,
+      input.functionalCurrency,
+      input.originalCurrency,
+      conversionDate,
+    );
+    if (inverse) {
+      this.assertPositiveRate(
+        inverse,
+        input.functionalCurrency,
+        input.originalCurrency,
+      );
+      return this.convertWithRate(
+        input,
+        inverse,
+        new Prisma.Decimal(1).div(inverse.rate),
+        "INVERSE",
+        conversionDate,
+      );
+    }
+
+    throw new UnprocessableEntityException({
+      code: "EXCHANGE_RATE_NOT_FOUND",
+      originalCurrency: input.originalCurrency,
+      functionalCurrency: input.functionalCurrency,
+      conversionDate: input.conversionDate,
+    });
+  }
+
+  private async findRate(
+    tenantId: string,
+    baseCurrency: CanonicalCurrency,
+    quoteCurrency: CanonicalCurrency,
+    conversionDate: Date,
+  ): Promise<RateSnapshot | null> {
+    return this.prisma.exchangeRate.findFirst({
+      where: {
+        tenantId,
+        baseCurrency,
+        quoteCurrency,
+        effectiveAt: { lte: conversionDate },
+      },
+      orderBy: { effectiveAt: "desc" },
+      select: { id: true, rate: true, effectiveAt: true },
+    });
+  }
+
+  private assertPositiveRate(
+    source: RateSnapshot,
+    baseCurrency: CanonicalCurrency,
+    quoteCurrency: CanonicalCurrency,
+  ): void {
+    if (!source.rate.greaterThan(0)) {
+      throw new UnprocessableEntityException({
+        code: "INVALID_EXCHANGE_RATE",
+        baseCurrency,
+        quoteCurrency,
+        effectiveAt: source.effectiveAt.toISOString(),
+      });
+    }
+  }
+
+  private convertWithRate(
+    input: CurrencyConversionInput,
+    source: RateSnapshot,
+    appliedRate: Prisma.Decimal,
+    direction: Exclude<CurrencyConversionDirection, "IDENTITY">,
+    conversionDate: Date,
+  ): CurrencyConversionResult {
+    const converted = new Prisma.Decimal(input.amount)
+      .mul(appliedRate)
+      .toDecimalPlaces(0, Prisma.Decimal.ROUND_HALF_EVEN);
+    this.assertStorageRange(converted);
+    return this.result(
+      input,
+      converted.toNumber(),
+      appliedRate,
+      direction,
+      source,
+      conversionDate,
+    );
+  }
+
+  private result(
+    input: CurrencyConversionInput,
+    functionalAmount: number,
+    appliedRate: Prisma.Decimal,
+    direction: CurrencyConversionDirection,
+    source: RateSnapshot | null,
+    conversionDate: Date,
+  ): CurrencyConversionResult {
+    return {
+      originalAmount: input.amount,
+      originalCurrency: input.originalCurrency,
+      functionalAmount,
+      functionalCurrency: input.functionalCurrency,
+      sourceExchangeRateId: source?.id ?? null,
+      appliedRate: appliedRate.toFixed(),
+      direction,
+      sourceEffectiveAt: source?.effectiveAt ?? null,
+      conversionDate,
+    };
+  }
+
+  private assertInput(input: CurrencyConversionInput): void {
+    if (
+      !isCanonicalCurrency(input.originalCurrency) ||
+      !isCanonicalCurrency(input.functionalCurrency)
+    ) {
+      throw new BadRequestException(
+        "Currency must be one of USD, VES, ARS, or COP",
+      );
+    }
+    if (
+      !Number.isInteger(input.amount) ||
+      !Number.isSafeInteger(input.amount)
+    ) {
+      throw new BadRequestException("Amount must be an integer in minor units");
+    }
+    this.assertStorageRange(new Prisma.Decimal(input.amount));
+    this.normalizeDate(input.conversionDate);
+  }
+
+  private assertStorageRange(amount: Prisma.Decimal): void {
+    if (
+      !amount.isInteger() ||
+      amount.lessThan(INT_MIN) ||
+      amount.greaterThan(INT_MAX)
+    ) {
+      throw new UnprocessableEntityException({
+        code: "CONVERTED_AMOUNT_OUT_OF_RANGE",
+      });
+    }
+  }
+
+  private normalizeDate(value: string): Date {
+    if (
+      typeof value !== "string" ||
+      value.trim() !== value ||
+      !/^\d{4}-\d{2}-\d{2}$/.test(value)
+    ) {
+      throw new BadRequestException(
+        "conversionDate must be a valid YYYY-MM-DD date",
+      );
+    }
+    const date = new Date(`${value}T00:00:00.000Z`);
+    if (
+      Number.isNaN(date.getTime()) ||
+      date.toISOString().slice(0, 10) !== value
+    ) {
+      throw new BadRequestException(
+        "conversionDate must be a valid YYYY-MM-DD date",
+      );
+    }
+    return date;
+  }
+}

--- a/apps/api/src/finanzas/expense-ledger.dto.ts
+++ b/apps/api/src/finanzas/expense-ledger.dto.ts
@@ -216,6 +216,13 @@ export interface ExpenseResponseDto {
   status: 'DRAFT' | 'VALIDATED' | 'VOID';
   scopeType: 'BUILDING' | 'TENANT_SHARED' | 'UNIT_GROUP';
   unitGroupId: string | null;
+  functionalAmountMinor?: number | null;
+  functionalCurrencyCode?: string | null;
+  exchangeRateId?: string | null;
+  exchangeRateValue?: string | null;
+  exchangeRateDirection?: string | null;
+  exchangeRateEffectiveAt?: Date | null;
+  conversionDate?: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/apps/api/src/finanzas/expense-ledger.dto.ts
+++ b/apps/api/src/finanzas/expense-ledger.dto.ts
@@ -410,6 +410,13 @@ export interface IncomeResponseDto {
   scopeType: 'BUILDING' | 'TENANT_SHARED' | 'UNIT_GROUP';
   destination: 'APPLY_TO_EXPENSES' | 'RESERVE_FUND' | 'SPECIAL_FUND';
   unitGroupId: string | null;
+  functionalAmountMinor?: number | null;
+  functionalCurrencyCode?: string | null;
+  exchangeRateId?: string | null;
+  exchangeRateValue?: string | null;
+  exchangeRateDirection?: string | null;
+  exchangeRateEffectiveAt?: Date | null;
+  conversionDate?: Date | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/apps/api/src/finanzas/expenses.multicurrency.spec.ts
+++ b/apps/api/src/finanzas/expenses.multicurrency.spec.ts
@@ -1,0 +1,645 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { ExpensesService } from './expenses.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { MovementAllocationService } from './movement-allocation.service';
+import { CurrencyConversionService } from './currency-conversion.service';
+
+const makeExpense = (overrides: Record<string, unknown> = {}) => ({
+  id: 'expense-1',
+  tenantId: 'tenant-1',
+  buildingId: 'building-1',
+  period: '2026-08',
+  liquidationPeriod: '2026-08',
+  categoryId: 'cat-1',
+  vendorId: 'vendor-1',
+  amountMinor: 1000,
+  currencyCode: 'ARS',
+  invoiceDate: new Date('2026-08-09T00:00:00.000Z'),
+  description: null,
+  attachmentFileKey: null,
+  status: 'DRAFT',
+  scopeType: 'BUILDING',
+  unitGroupId: null,
+  functionalAmountMinor: null,
+  functionalCurrencyCode: null,
+  exchangeRateId: null,
+  exchangeRateValue: null,
+  exchangeRateDirection: null,
+  exchangeRateEffectiveAt: null,
+  conversionDate: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  category: { name: 'Maintenance' },
+  vendor: { name: 'Vendor' },
+  ...overrides,
+});
+
+const validatedExpense = (snapshot: Record<string, unknown>) =>
+  makeExpense({ status: 'VALIDATED', ...snapshot });
+
+describe('ExpensesService multicurrency snapshot', () => {
+  let service: ExpensesService;
+  let prisma: PrismaService;
+  let exchangeRateFindFirst: jest.Mock;
+
+  const rate = (
+    overrides: Partial<{
+      id: string;
+      rate: string;
+      effectiveAt: Date;
+    }> = {},
+  ) => ({
+    id: overrides.id ?? 'rate-1',
+    rate: new Prisma.Decimal(overrides.rate ?? '36.500000000001'),
+    effectiveAt: overrides.effectiveAt ?? new Date('2026-08-08T00:00:00.000Z'),
+  });
+
+  beforeEach(async () => {
+    exchangeRateFindFirst = jest.fn();
+
+    const prismaValue = {
+      expense: {
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      tenant: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'tenant-1',
+          functionalCurrency: 'VES',
+        }),
+      },
+      exchangeRate: { findFirst: exchangeRateFindFirst },
+      liquidation: { findFirst: jest.fn() },
+      expenseLedgerCategory: { findFirst: jest.fn() },
+      vendor: { findFirst: jest.fn() },
+      unitGroup: { findFirst: jest.fn() },
+      adjustment: { findFirst: jest.fn(), create: jest.fn(), update: jest.fn() },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExpensesService,
+        { provide: PrismaService, useValue: prismaValue },
+        { provide: AuditService, useValue: { createLog: jest.fn() } },
+        {
+          provide: FinanzasValidators,
+          useValue: { isAdminOrOperator: jest.fn().mockReturnValue(true) },
+        },
+        {
+          provide: MovementAllocationService,
+          useValue: { createForExpense: jest.fn() },
+        },
+        {
+          provide: CurrencyConversionService,
+          useFactory: (prismaService: PrismaService) =>
+            new CurrencyConversionService(prismaService),
+          inject: [PrismaService],
+        },
+      ],
+    }).compile();
+
+    service = module.get<ExpensesService>(ExpensesService);
+    prisma = module.get<PrismaService>(PrismaService);
+  });
+
+  const validate = () =>
+    service.validateExpense('tenant-1', 'expense-1', 'member-1', ['TENANT_ADMIN']);
+
+  const validateFromBulk = () =>
+    service.validateExpenseFromBulk('tenant-1', 'expense-1', 'member-1');
+
+  const lastUpdateData = (): Record<string, unknown> => {
+    expect(prisma.expense.update).toHaveBeenCalledTimes(1);
+    const call = (prisma.expense.update as jest.Mock).mock.calls[0] as [
+      { data: Record<string, unknown> },
+    ];
+    return call[0].data;
+  };
+
+  const expectTenantScopedLookups = (tenantId: string) => {
+    expect(
+      (prisma.tenant.findFirst as jest.Mock).mock.calls.every(
+        ([query]) => query.where.id === tenantId,
+      ),
+    ).toBe(true);
+    expect(
+      exchangeRateFindFirst.mock.calls.every(
+        ([query]) => query.where.tenantId === tenantId,
+      ),
+    ).toBe(true);
+  };
+
+  describe('IDENTITY (original === functional)', () => {
+    beforeEach(() => {
+      (prisma.tenant.findFirst as jest.Mock).mockResolvedValue({
+        id: 'tenant-1',
+        functionalCurrency: 'ARS',
+      });
+      (prisma.expense.findFirst as jest.Mock).mockResolvedValue(
+        makeExpense({ currencyCode: 'ARS', amountMinor: 1250 }) as never,
+      );
+      (prisma.expense.update as jest.Mock).mockResolvedValue(
+        validatedExpense({
+          currencyCode: 'ARS',
+          amountMinor: 1250,
+          functionalAmountMinor: 1250,
+          functionalCurrencyCode: 'ARS',
+          exchangeRateId: null,
+          exchangeRateValue: '1',
+          exchangeRateDirection: 'IDENTITY',
+          exchangeRateEffectiveAt: null,
+          conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+        }) as never,
+      );
+    });
+
+    it('persists an identity snapshot in the same update that validates, without rate lookups', async () => {
+      const result = await validate();
+
+      expect(result.status).toBe('VALIDATED');
+      expect(result.functionalAmountMinor).toBe(1250);
+      expect(result.functionalCurrencyCode).toBe('ARS');
+      expect(result.exchangeRateValue).toBe('1');
+      expect(result.exchangeRateDirection).toBe('IDENTITY');
+      expect(result.exchangeRateId).toBeNull();
+      expect(result.exchangeRateEffectiveAt).toBeNull();
+      expect(result.conversionDate?.toISOString()).toBe('2026-08-09T00:00:00.000Z');
+
+      expect(lastUpdateData()).toMatchObject({
+        status: 'VALIDATED',
+        validatedByMembershipId: 'member-1',
+        functionalAmountMinor: 1250,
+        functionalCurrencyCode: 'ARS',
+        exchangeRateValue: '1',
+        exchangeRateDirection: 'IDENTITY',
+        exchangeRateId: null,
+        exchangeRateEffectiveAt: null,
+      });
+      expect(exchangeRateFindFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DIRECT', () => {
+    beforeEach(() => {
+      exchangeRateFindFirst.mockResolvedValue(rate());
+      (prisma.expense.findFirst as jest.Mock).mockResolvedValue(
+        makeExpense({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+      (prisma.expense.update as jest.Mock).mockResolvedValue(
+        validatedExpense({
+          currencyCode: 'USD',
+          amountMinor: 100,
+          functionalAmountMinor: 3650,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'rate-1',
+          exchangeRateValue: '36.500000000001',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+          conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+        }) as never,
+      );
+    });
+
+    it('converts with the source rate and persists applied rate, source id, effectiveAt and date', async () => {
+      const result = await validate();
+
+      expect(result.functionalAmountMinor).toBe(3650);
+      expect(result.functionalCurrencyCode).toBe('VES');
+      expect(result.exchangeRateId).toBe('rate-1');
+      expect(result.exchangeRateValue).toBe('36.500000000001');
+      expect(result.exchangeRateDirection).toBe('DIRECT');
+      expect(result.exchangeRateEffectiveAt?.toISOString()).toBe(
+        '2026-08-08T00:00:00.000Z',
+      );
+      expect(result.conversionDate?.toISOString()).toBe('2026-08-09T00:00:00.000Z');
+
+      expect(lastUpdateData()).toMatchObject({
+        status: 'VALIDATED',
+        functionalAmountMinor: 3650,
+        functionalCurrencyCode: 'VES',
+        exchangeRateId: 'rate-1',
+        exchangeRateValue: '36.500000000001',
+        exchangeRateDirection: 'DIRECT',
+      });
+      expect(exchangeRateFindFirst).toHaveBeenCalledWith({
+        where: {
+          tenantId: 'tenant-1',
+          baseCurrency: 'USD',
+          quoteCurrency: 'VES',
+          effectiveAt: { lte: new Date('2026-08-09T00:00:00.000Z') },
+        },
+        orderBy: { effectiveAt: 'desc' },
+        select: { id: true, rate: true, effectiveAt: true },
+      });
+      expect(exchangeRateFindFirst).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('INVERSE', () => {
+    beforeEach(() => {
+      exchangeRateFindFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(
+          rate({ id: 'inverse-rate-1', rate: '4' }),
+        );
+      (prisma.expense.findFirst as jest.Mock).mockResolvedValue(
+        makeExpense({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+      (prisma.expense.update as jest.Mock).mockResolvedValue(
+        validatedExpense({
+          currencyCode: 'USD',
+          amountMinor: 100,
+          functionalAmountMinor: 25,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'inverse-rate-1',
+          exchangeRateValue: '0.25',
+          exchangeRateDirection: 'INVERSE',
+          exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+          conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+        }) as never,
+      );
+    });
+
+    it('falls back to the reciprocal rate and persists applied reciprocal + source row id', async () => {
+      const result = await validate();
+
+      expect(result.functionalAmountMinor).toBe(25);
+      expect(result.exchangeRateId).toBe('inverse-rate-1');
+      expect(result.exchangeRateValue).toBe('0.25');
+      expect(result.exchangeRateDirection).toBe('INVERSE');
+
+      expect(lastUpdateData()).toMatchObject({
+        functionalAmountMinor: 25,
+        exchangeRateId: 'inverse-rate-1',
+        exchangeRateValue: '0.25',
+        exchangeRateDirection: 'INVERSE',
+      });
+      expect(exchangeRateFindFirst).toHaveBeenNthCalledWith(2, {
+        where: {
+          tenantId: 'tenant-1',
+          baseCurrency: 'VES',
+          quoteCurrency: 'USD',
+          effectiveAt: { lte: new Date('2026-08-09T00:00:00.000Z') },
+        },
+        orderBy: { effectiveAt: 'desc' },
+        select: { id: true, rate: true, effectiveAt: true },
+      });
+    });
+  });
+
+  describe('missing rate', () => {
+    let draftExpense: Record<string, unknown>;
+
+    beforeEach(() => {
+      exchangeRateFindFirst.mockResolvedValue(null);
+      draftExpense = makeExpense({ currencyCode: 'USD', amountMinor: 100 });
+      (prisma.expense.findFirst as jest.Mock).mockResolvedValue(draftExpense);
+    });
+
+    it('propagates EXCHANGE_RATE_NOT_FOUND 422 and never calls expense.update (stays DRAFT)', async () => {
+      const error = await validate().catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(UnprocessableEntityException);
+      expect((error as UnprocessableEntityException).getResponse()).toEqual({
+        code: 'EXCHANGE_RATE_NOT_FOUND',
+        originalCurrency: 'USD',
+        functionalCurrency: 'VES',
+        conversionDate: '2026-08-09',
+      });
+      expect(prisma.expense.update).not.toHaveBeenCalled();
+    });
+
+    it('keeps the expense DRAFT with no partial snapshot through the bulk path', async () => {
+      const error = await validateFromBulk().catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(UnprocessableEntityException);
+      expect(prisma.expense.update).not.toHaveBeenCalled();
+      expect(draftExpense.status).toBe('DRAFT');
+    });
+  });
+
+  describe('invalid rate', () => {
+    beforeEach(() => {
+      exchangeRateFindFirst.mockResolvedValue(rate({ rate: '0' }));
+      (prisma.expense.findFirst as jest.Mock).mockResolvedValue(
+        makeExpense({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+    });
+
+    it('propagates INVALID_EXCHANGE_RATE 422 without updating the expense', async () => {
+      const error = await validate().catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(UnprocessableEntityException);
+      expect((error as UnprocessableEntityException).getResponse()).toMatchObject({
+        code: 'INVALID_EXCHANGE_RATE',
+      });
+      expect(prisma.expense.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tenant isolation', () => {
+    beforeEach(() => {
+      (prisma.expense.findFirst as jest.Mock).mockResolvedValue(
+        makeExpense({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+      (prisma.expense.update as jest.Mock).mockResolvedValue(
+        validatedExpense({
+          currencyCode: 'USD',
+          amountMinor: 100,
+          functionalAmountMinor: 1000,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'other-tenant-rate',
+          exchangeRateValue: '10',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+          conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+        }) as never,
+      );
+    });
+
+    it('never uses a rate that belongs to another tenant', async () => {
+      exchangeRateFindFirst.mockImplementation(
+        async ({ where }: { where: { tenantId: string } }) =>
+          where.tenantId === 'tenant-other' ? rate() : null,
+      );
+
+      const error = await validate().catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(UnprocessableEntityException);
+      expect(prisma.expense.update).not.toHaveBeenCalled();
+      expectTenantScopedLookups('tenant-1');
+    });
+
+    it('scopes tenant lookup and every rate query by the acting tenantId', async () => {
+      exchangeRateFindFirst.mockResolvedValue(rate({ id: 'tenant-1-rate' }));
+      (prisma.expense.update as jest.Mock).mockResolvedValue(
+        validatedExpense({
+          currencyCode: 'USD',
+          amountMinor: 100,
+          functionalAmountMinor: 3650,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'tenant-1-rate',
+          exchangeRateValue: '36.500000000001',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+          conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+        }) as never,
+      );
+
+      await validate();
+
+      expectTenantScopedLookups('tenant-1');
+    });
+
+    it('fails with NotFound when the tenant does not exist', async () => {
+      (prisma.tenant.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const error = await validate().catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(NotFoundException);
+      expect(prisma.expense.update).not.toHaveBeenCalled();
+      expect(exchangeRateFindFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('conversion date', () => {
+    beforeEach(() => {
+      (prisma.expense.update as jest.Mock).mockResolvedValue(
+        validatedExpense({}) as never,
+      );
+    });
+
+    it('derives the UTC date-only from invoiceDate regardless of time-of-day', async () => {
+      exchangeRateFindFirst.mockResolvedValue(rate());
+      (prisma.expense.findFirst as jest.Mock).mockResolvedValue(
+        makeExpense({
+          currencyCode: 'USD',
+          amountMinor: 100,
+          invoiceDate: new Date('2026-08-09T23:45:00.000Z'),
+        }) as never,
+      );
+
+      await validate();
+
+      expect(exchangeRateFindFirst.mock.calls[0][0].where.effectiveAt).toEqual({
+        lte: new Date('2026-08-09T00:00:00.000Z'),
+      });
+      expect(lastUpdateData()).toMatchObject({
+        conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+      });
+    });
+
+    it('uses same-day rate, prior rate, and never a future rate', async () => {
+      exchangeRateFindFirst
+        .mockResolvedValueOnce(rate({ id: 'same-day' }))
+        .mockResolvedValueOnce(rate({ id: 'future' }));
+      (prisma.expense.findFirst as jest.Mock).mockResolvedValue(
+        makeExpense({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+
+      await validate();
+
+      expect(exchangeRateFindFirst.mock.calls[0][0].where).toMatchObject({
+        effectiveAt: { lte: new Date('2026-08-09T00:00:00.000Z') },
+      });
+      expect(exchangeRateFindFirst.mock.calls[0][0].orderBy).toEqual({
+        effectiveAt: 'desc',
+      });
+    });
+  });
+
+  describe('immutability', () => {
+    it('stores the snapshot as a value: later ExchangeRate edits do not change the persisted snapshot', async () => {
+      exchangeRateFindFirst
+        .mockResolvedValueOnce(
+          rate({ id: 'rate-1', rate: '36.5', effectiveAt: new Date('2026-08-08T00:00:00.000Z') }),
+        )
+        .mockResolvedValueOnce(
+          rate({ id: 'rate-2', rate: '1000', effectiveAt: new Date('2026-08-10T00:00:00.000Z') }),
+        );
+      (prisma.expense.findFirst as jest.Mock).mockResolvedValue(
+        makeExpense({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+      (prisma.expense.update as jest.Mock).mockResolvedValue(
+        validatedExpense({
+          currencyCode: 'USD',
+          amountMinor: 100,
+          functionalAmountMinor: 3650,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'rate-1',
+          exchangeRateValue: '36.5',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+          conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+        }) as never,
+      );
+
+      const persisted = await validate();
+
+      expect(exchangeRateFindFirst).toHaveBeenCalledTimes(1);
+      expect(persisted.exchangeRateId).toBe('rate-1');
+      expect(persisted.exchangeRateValue).toBe('36.5');
+      expect(persisted.functionalAmountMinor).toBe(3650);
+      expect(lastUpdateData()).toMatchObject({ exchangeRateValue: '36.5' });
+    });
+
+    it('rejects updating a VALIDATED expense through the existing DRAFT-only lifecycle', async () => {
+      (prisma.expense.findFirst as jest.Mock).mockResolvedValue(
+        makeExpense({ status: 'VALIDATED' }) as never,
+      );
+
+      await expect(
+        service.updateExpense(
+          'tenant-1',
+          'expense-1',
+          'member-1',
+          ['TENANT_ADMIN'],
+          { description: 'late edit' },
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.expense.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('precision', () => {
+    beforeEach(() => {
+      (prisma.expense.findFirst as jest.Mock).mockResolvedValue(
+        makeExpense({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+    });
+
+    it.each([
+      ['12-decimal rate', '1.123456789012', 112],
+      ['small rate', '0.000000000001', 0],
+    ])(
+      'converts %s exactly and persists the fixed-point applied rate without exponent',
+      async (_label, sourceRate, expectedFunctionalAmount) => {
+        exchangeRateFindFirst.mockResolvedValue(rate({ rate: sourceRate }));
+        (prisma.expense.update as jest.Mock).mockResolvedValue(
+          validatedExpense({
+            currencyCode: 'USD',
+            amountMinor: 100,
+            functionalAmountMinor: expectedFunctionalAmount,
+            functionalCurrencyCode: 'VES',
+            exchangeRateId: 'rate-1',
+            exchangeRateValue: sourceRate,
+            exchangeRateDirection: 'DIRECT',
+            exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+            conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+          }) as never,
+        );
+
+        const result = await validate();
+
+        expect(result.functionalAmountMinor).toBe(expectedFunctionalAmount);
+        expect(result.exchangeRateValue).toBe(sourceRate);
+        expect(result.exchangeRateValue).not.toMatch(/[eE]/);
+        expect(lastUpdateData()).toMatchObject({ exchangeRateValue: sourceRate });
+      },
+    );
+
+    it.each([
+      ['even-down tie', '2.5', 1, 2],
+      ['odd-up tie', '3.5', 1, 4],
+    ])(
+      'uses ROUND_HALF_EVEN for %s',
+      async (_label, sourceRate, amountMinor, expectedFunctionalAmount) => {
+        exchangeRateFindFirst.mockResolvedValue(rate({ rate: sourceRate }));
+        (prisma.expense.findFirst as jest.Mock).mockResolvedValue(
+          makeExpense({ currencyCode: 'USD', amountMinor }) as never,
+        );
+        (prisma.expense.update as jest.Mock).mockResolvedValue(
+          validatedExpense({
+            currencyCode: 'USD',
+            amountMinor,
+            functionalAmountMinor: expectedFunctionalAmount,
+            functionalCurrencyCode: 'VES',
+            exchangeRateId: 'rate-1',
+            exchangeRateValue: sourceRate,
+            exchangeRateDirection: 'DIRECT',
+            exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+            conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+          }) as never,
+        );
+
+        const result = await validate();
+
+        expect(result.functionalAmountMinor).toBe(expectedFunctionalAmount);
+      },
+    );
+  });
+
+  describe('legacy expenses', () => {
+    it('maps an expense without snapshot fields through toDto with nulls (no speculative backfill)', async () => {
+      (prisma.expense.findFirst as jest.Mock).mockResolvedValue(
+        makeExpense({
+          status: 'VALIDATED',
+          functionalAmountMinor: undefined,
+          functionalCurrencyCode: undefined,
+          exchangeRateId: undefined,
+          exchangeRateValue: undefined,
+          exchangeRateDirection: undefined,
+          exchangeRateEffectiveAt: undefined,
+          conversionDate: undefined,
+        }) as never,
+      );
+
+      const result = await service.getExpense(
+        'tenant-1',
+        'expense-1',
+        ['TENANT_ADMIN'],
+      );
+
+      expect(result.status).toBe('VALIDATED');
+      expect(result.functionalAmountMinor).toBeNull();
+      expect(result.functionalCurrencyCode).toBeNull();
+      expect(result.exchangeRateId).toBeNull();
+      expect(result.exchangeRateValue).toBeNull();
+      expect(result.exchangeRateDirection).toBeNull();
+      expect(result.exchangeRateEffectiveAt).toBeNull();
+      expect(result.conversionDate).toBeNull();
+      expect(prisma.expense.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('bulk validation', () => {
+    it('persists the snapshot in the same update that validates from bulk', async () => {
+      exchangeRateFindFirst.mockResolvedValue(rate({ rate: '2' }));
+      (prisma.expense.findFirst as jest.Mock).mockResolvedValue(
+        makeExpense({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+      (prisma.expense.update as jest.Mock).mockResolvedValue(
+        validatedExpense({
+          currencyCode: 'USD',
+          amountMinor: 100,
+          functionalAmountMinor: 200,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'rate-1',
+          exchangeRateValue: '2',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+          conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+        }) as never,
+      );
+
+      const result = await validateFromBulk();
+
+      expect(result.status).toBe('VALIDATED');
+      expect(result.functionalAmountMinor).toBe(200);
+      expect(lastUpdateData()).toMatchObject({
+        status: 'VALIDATED',
+        validatedByMembershipId: 'member-1',
+        functionalAmountMinor: 200,
+        exchangeRateDirection: 'DIRECT',
+      });
+    });
+  });
+});

--- a/apps/api/src/finanzas/expenses.service.spec.ts
+++ b/apps/api/src/finanzas/expenses.service.spec.ts
@@ -10,6 +10,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { FinanzasValidators } from './finanzas.validators';
 import { MovementAllocationService } from './movement-allocation.service';
+import { CurrencyConversionService } from './currency-conversion.service';
 import { CreateExpenseDto } from './expense-ledger.dto';
 
 const makeExpense = (overrides: Record<string, unknown> = {}) => ({
@@ -28,12 +29,31 @@ const makeExpense = (overrides: Record<string, unknown> = {}) => ({
   status: 'DRAFT',
   scopeType: 'BUILDING',
   unitGroupId: null,
+  functionalAmountMinor: null,
+  functionalCurrencyCode: null,
+  exchangeRateId: null,
+  exchangeRateValue: null,
+  exchangeRateDirection: null,
+  exchangeRateEffectiveAt: null,
+  conversionDate: null,
   createdAt: new Date(),
   updatedAt: new Date(),
   category: { name: 'Maintenance' },
   vendor: { name: 'Vendor' },
   ...overrides,
 });
+
+const identityConversionResult = {
+  originalAmount: 1000,
+  originalCurrency: 'ARS',
+  functionalAmount: 1000,
+  functionalCurrency: 'ARS',
+  sourceExchangeRateId: null,
+  appliedRate: '1',
+  direction: 'IDENTITY',
+  sourceEffectiveAt: null,
+  conversionDate: new Date('2026-05-01T00:00:00.000Z'),
+};
 
 const defaultCreateDto: CreateExpenseDto = {
   buildingId: 'building-1',
@@ -51,6 +71,7 @@ describe('ExpensesService', () => {
   let validators: FinanzasValidators;
   let movementAllocation: MovementAllocationService;
   let audit: AuditService;
+  let currencyConversion: CurrencyConversionService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -65,6 +86,13 @@ describe('ExpensesService', () => {
               findFirst: jest.fn(),
               update: jest.fn(),
             },
+            tenant: {
+              findFirst: jest.fn().mockResolvedValue({
+                id: 'tenant-1',
+                functionalCurrency: 'ARS',
+              }),
+            },
+            exchangeRate: { findFirst: jest.fn() },
             liquidation: { findFirst: jest.fn() },
             expenseLedgerCategory: { findFirst: jest.fn() },
             vendor: { findFirst: jest.fn() },
@@ -84,6 +112,12 @@ describe('ExpensesService', () => {
           provide: MovementAllocationService,
           useValue: { createForExpense: jest.fn() },
         },
+        {
+          provide: CurrencyConversionService,
+          useValue: {
+            convert: jest.fn().mockResolvedValue(identityConversionResult),
+          },
+        },
       ],
     }).compile();
 
@@ -92,6 +126,7 @@ describe('ExpensesService', () => {
     validators = module.get<FinanzasValidators>(FinanzasValidators);
     movementAllocation = module.get<MovementAllocationService>(MovementAllocationService);
     audit = module.get<AuditService>(AuditService);
+    currencyConversion = module.get<CurrencyConversionService>(CurrencyConversionService);
   });
 
   // ── CREATE EXPENSE ─────────────────────────────────────────────────────

--- a/apps/api/src/finanzas/expenses.service.ts
+++ b/apps/api/src/finanzas/expenses.service.ts
@@ -14,6 +14,7 @@ import {
 } from './expense-ledger.dto';
 import { FinanzasValidators } from './finanzas.validators';
 import { MovementAllocationService } from './movement-allocation.service';
+import { CurrencyConversionService } from './currency-conversion.service';
 
 @Injectable()
 export class ExpensesService {
@@ -22,12 +23,64 @@ export class ExpensesService {
     private readonly auditService: AuditService,
     private readonly validators: FinanzasValidators,
     private readonly movementAllocationService: MovementAllocationService,
+    private readonly currencyConversionService: CurrencyConversionService,
   ) {}
 
   private getAccountingPeriodFromInvoiceDate(invoiceDate: Date): string {
     const year = invoiceDate.getUTCFullYear();
     const month = String(invoiceDate.getUTCMonth() + 1).padStart(2, '0');
     return `${year}-${month}`;
+  }
+
+  private toConversionDate(invoiceDate: Date): string {
+    const year = invoiceDate.getUTCFullYear();
+    const month = String(invoiceDate.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(invoiceDate.getUTCDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  private async buildExpenseConversionSnapshot(
+    tenantId: string,
+    expense: { amountMinor: number; currencyCode: string; invoiceDate: Date },
+  ): Promise<{
+    functionalAmountMinor: number;
+    functionalCurrencyCode: string;
+    exchangeRateId: string | null;
+    exchangeRateValue: string;
+    exchangeRateDirection: 'IDENTITY' | 'DIRECT' | 'INVERSE';
+    exchangeRateEffectiveAt: Date | null;
+    conversionDate: Date;
+  }> {
+    const tenant = await this.prisma.tenant.findFirst({
+      where: { id: tenantId },
+      select: { id: true, functionalCurrency: true },
+    });
+
+    if (!tenant) {
+      throw new NotFoundException(`Tenant no encontrado: ${tenantId}`);
+    }
+
+    const result = await this.currencyConversionService.convert({
+      tenantId,
+      amount: expense.amountMinor,
+      originalCurrency: expense.currencyCode as Parameters<
+        typeof this.currencyConversionService.convert
+      >[0]['originalCurrency'],
+      functionalCurrency: tenant.functionalCurrency as Parameters<
+        typeof this.currencyConversionService.convert
+      >[0]['functionalCurrency'],
+      conversionDate: this.toConversionDate(expense.invoiceDate),
+    });
+
+    return {
+      functionalAmountMinor: result.functionalAmount,
+      functionalCurrencyCode: result.functionalCurrency,
+      exchangeRateId: result.sourceExchangeRateId,
+      exchangeRateValue: result.appliedRate,
+      exchangeRateDirection: result.direction,
+      exchangeRateEffectiveAt: result.sourceEffectiveAt,
+      conversionDate: result.conversionDate,
+    };
   }
 
   private accountingPeriodWhere(period?: string):
@@ -419,12 +472,24 @@ export class ExpensesService {
 
     this.assertExpenseCanBeValidated(expense);
 
+    const conversionSnapshot = await this.buildExpenseConversionSnapshot(
+      tenantId,
+      expense,
+    );
+
     const updated = await this.prisma.expense.update({
       where: { id: expenseId },
       data: {
         status: 'VALIDATED',
         validatedByMembershipId: membershipId,
         validatedAt: new Date(),
+        functionalAmountMinor: conversionSnapshot.functionalAmountMinor,
+        functionalCurrencyCode: conversionSnapshot.functionalCurrencyCode,
+        exchangeRateId: conversionSnapshot.exchangeRateId,
+        exchangeRateValue: conversionSnapshot.exchangeRateValue,
+        exchangeRateDirection: conversionSnapshot.exchangeRateDirection,
+        exchangeRateEffectiveAt: conversionSnapshot.exchangeRateEffectiveAt,
+        conversionDate: conversionSnapshot.conversionDate,
       },
       include: {
         category: { select: { name: true } },
@@ -463,12 +528,24 @@ export class ExpensesService {
 
     this.assertExpenseCanBeValidated(expense);
 
+    const conversionSnapshot = await this.buildExpenseConversionSnapshot(
+      tenantId,
+      expense,
+    );
+
     const updated = await this.prisma.expense.update({
       where: { id: expenseId },
       data: {
         status: 'VALIDATED',
         validatedByMembershipId: membershipId ?? null,
         validatedAt: new Date(),
+        functionalAmountMinor: conversionSnapshot.functionalAmountMinor,
+        functionalCurrencyCode: conversionSnapshot.functionalCurrencyCode,
+        exchangeRateId: conversionSnapshot.exchangeRateId,
+        exchangeRateValue: conversionSnapshot.exchangeRateValue,
+        exchangeRateDirection: conversionSnapshot.exchangeRateDirection,
+        exchangeRateEffectiveAt: conversionSnapshot.exchangeRateEffectiveAt,
+        conversionDate: conversionSnapshot.conversionDate,
       },
       include: {
         category: { select: { name: true } },
@@ -558,6 +635,13 @@ export class ExpensesService {
       status: 'DRAFT' | 'VALIDATED' | 'VOID';
       scopeType: 'BUILDING' | 'TENANT_SHARED' | 'UNIT_GROUP';
       unitGroupId: string | null;
+      functionalAmountMinor?: number | null;
+      functionalCurrencyCode?: string | null;
+      exchangeRateId?: string | null;
+      exchangeRateValue?: { toString(): string } | string | null;
+      exchangeRateDirection?: string | null;
+      exchangeRateEffectiveAt?: Date | null;
+      conversionDate?: Date | null;
       createdAt: Date;
       updatedAt: Date;
       category: { name: string };
@@ -582,6 +666,16 @@ export class ExpensesService {
       status: expense.status,
       scopeType: expense.scopeType,
       unitGroupId: expense.unitGroupId,
+      functionalAmountMinor: expense.functionalAmountMinor ?? null,
+      functionalCurrencyCode: expense.functionalCurrencyCode ?? null,
+      exchangeRateId: expense.exchangeRateId ?? null,
+      exchangeRateValue:
+        expense.exchangeRateValue === null || expense.exchangeRateValue === undefined
+          ? null
+          : expense.exchangeRateValue.toString(),
+      exchangeRateDirection: expense.exchangeRateDirection ?? null,
+      exchangeRateEffectiveAt: expense.exchangeRateEffectiveAt ?? null,
+      conversionDate: expense.conversionDate ?? null,
       createdAt: expense.createdAt,
       updatedAt: expense.updatedAt,
     };

--- a/apps/api/src/finanzas/finanzas.module.ts
+++ b/apps/api/src/finanzas/finanzas.module.ts
@@ -39,6 +39,7 @@ import { PaymentGatewayModule } from './payment-gateway/payment-gateway.module';
 import { ConfigService } from '../config/config.service';
 import { MulticurrencyController } from './multicurrency.controller';
 import { MulticurrencyService } from './multicurrency.service';
+import { CurrencyConversionService } from './currency-conversion.service';
 import { AppConfigModule } from '../config/config.module';
 
 import { VendorPreferenceController } from './vendor-preference.controller';
@@ -125,6 +126,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     PaymentReceiptService,
     SignatureGuard,
     MulticurrencyService,
+    CurrencyConversionService,
   ],
   exports: [
     FinanzasService,
@@ -142,6 +144,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     RecurringExpenseService,
     FinanceSummaryService,
     PaymentReceiptService,
+    CurrencyConversionService,
   ],
 })
 export class FinanzasModule {}

--- a/apps/api/src/finanzas/incomes.multicurrency.spec.ts
+++ b/apps/api/src/finanzas/incomes.multicurrency.spec.ts
@@ -1,0 +1,753 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+import { IncomesService } from './incomes.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { MovementAllocationService } from './movement-allocation.service';
+import { CurrencyConversionService } from './currency-conversion.service';
+
+const makeIncome = (overrides: Record<string, unknown> = {}) => ({
+  id: 'income-1',
+  tenantId: 'tenant-1',
+  buildingId: 'building-1',
+  period: '2026-08',
+  categoryId: 'cat-1',
+  amountMinor: 1000,
+  currencyCode: 'ARS',
+  receivedDate: new Date('2026-08-09T00:00:00.000Z'),
+  description: null,
+  attachmentFileKey: null,
+  status: 'DRAFT',
+  scopeType: 'BUILDING',
+  destination: 'APPLY_TO_EXPENSES',
+  unitGroupId: null,
+  functionalAmountMinor: null,
+  functionalCurrencyCode: null,
+  exchangeRateId: null,
+  exchangeRateValue: null,
+  exchangeRateDirection: null,
+  exchangeRateEffectiveAt: null,
+  conversionDate: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  category: { name: 'Parking' },
+  ...overrides,
+});
+
+const recordedIncome = (snapshot: Record<string, unknown>) =>
+  makeIncome({ status: 'RECORDED', ...snapshot });
+
+describe('IncomesService multicurrency snapshot', () => {
+  let service: IncomesService;
+  let prisma: PrismaService;
+  let exchangeRateFindFirst: jest.Mock;
+
+  const rate = (
+    overrides: Partial<{
+      id: string;
+      rate: string;
+      effectiveAt: Date;
+    }> = {},
+  ) => ({
+    id: overrides.id ?? 'rate-1',
+    rate: new Prisma.Decimal(overrides.rate ?? '36.500000000001'),
+    effectiveAt: overrides.effectiveAt ?? new Date('2026-08-08T00:00:00.000Z'),
+  });
+
+  beforeEach(async () => {
+    exchangeRateFindFirst = jest.fn();
+
+    const prismaValue = {
+      income: {
+        findFirst: jest.fn(),
+        findMany: jest.fn(),
+        update: jest.fn(),
+      },
+      tenant: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'tenant-1',
+          functionalCurrency: 'VES',
+        }),
+      },
+      exchangeRate: { findFirst: exchangeRateFindFirst },
+      expenseLedgerCategory: { findFirst: jest.fn() },
+      unitGroup: { findFirst: jest.fn() },
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IncomesService,
+        { provide: PrismaService, useValue: prismaValue },
+        { provide: AuditService, useValue: { createLog: jest.fn() } },
+        {
+          provide: FinanzasValidators,
+          useValue: { isAdminOrOperator: jest.fn().mockReturnValue(true) },
+        },
+        {
+          provide: MovementAllocationService,
+          useValue: { createForIncome: jest.fn() },
+        },
+        {
+          provide: CurrencyConversionService,
+          useFactory: (prismaService: PrismaService) =>
+            new CurrencyConversionService(prismaService),
+          inject: [PrismaService],
+        },
+      ],
+    }).compile();
+
+    service = module.get<IncomesService>(IncomesService);
+    prisma = module.get<PrismaService>(PrismaService);
+  });
+
+  const record = () =>
+    service.recordIncome('tenant-1', 'income-1', 'member-1', ['TENANT_ADMIN']);
+
+  const lastUpdateData = (): Record<string, unknown> => {
+    expect(prisma.income.update).toHaveBeenCalledTimes(1);
+    const call = (prisma.income.update as jest.Mock).mock.calls[0] as [
+      { data: Record<string, unknown> },
+    ];
+    return call[0].data;
+  };
+
+  const expectTenantScopedLookups = (tenantId: string) => {
+    expect(
+      (prisma.tenant.findFirst as jest.Mock).mock.calls.every(
+        ([query]) => query.where.id === tenantId,
+      ),
+    ).toBe(true);
+    expect(
+      exchangeRateFindFirst.mock.calls.every(
+        ([query]) => query.where.tenantId === tenantId,
+      ),
+    ).toBe(true);
+  };
+
+  describe('lifecycle', () => {
+    it('creates incomes as DRAFT without any snapshot', async () => {
+      expect(makeIncome().functionalAmountMinor).toBeNull();
+      expect(makeIncome().exchangeRateId).toBeNull();
+      expect(makeIncome().exchangeRateDirection).toBeNull();
+    });
+
+    it('writes the full snapshot in the SAME update that records, never a second update', async () => {
+      exchangeRateFindFirst.mockResolvedValue(rate({ rate: '2' }));
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+      (prisma.income.update as jest.Mock).mockResolvedValue(
+        recordedIncome({
+          currencyCode: 'USD',
+          amountMinor: 100,
+          functionalAmountMinor: 200,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'rate-1',
+          exchangeRateValue: '2',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+          conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+        }) as never,
+      );
+
+      const result = await record();
+
+      expect(result.status).toBe('RECORDED');
+      expect(prisma.income.update).toHaveBeenCalledTimes(1);
+      expect(lastUpdateData()).toMatchObject({
+        status: 'RECORDED',
+        recordedByMembershipId: 'member-1',
+        functionalAmountMinor: 200,
+        functionalCurrencyCode: 'VES',
+        exchangeRateId: 'rate-1',
+        exchangeRateValue: '2',
+        exchangeRateDirection: 'DIRECT',
+        exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+        conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+      });
+    });
+
+    it('rejects recording a non-DRAFT income', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({ status: 'RECORDED' }) as never,
+      );
+
+      await expect(record()).rejects.toThrow(BadRequestException);
+      expect(prisma.income.update).not.toHaveBeenCalled();
+      expect(exchangeRateFindFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('IDENTITY (original === functional)', () => {
+    beforeEach(() => {
+      (prisma.tenant.findFirst as jest.Mock).mockResolvedValue({
+        id: 'tenant-1',
+        functionalCurrency: 'ARS',
+      });
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({ currencyCode: 'ARS', amountMinor: 1250 }) as never,
+      );
+      (prisma.income.update as jest.Mock).mockResolvedValue(
+        recordedIncome({
+          currencyCode: 'ARS',
+          amountMinor: 1250,
+          functionalAmountMinor: 1250,
+          functionalCurrencyCode: 'ARS',
+          exchangeRateId: null,
+          exchangeRateValue: '1',
+          exchangeRateDirection: 'IDENTITY',
+          exchangeRateEffectiveAt: null,
+          conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+        }) as never,
+      );
+    });
+
+    it('persists an identity snapshot in the same update that records, without rate lookups', async () => {
+      const result = await record();
+
+      expect(result.status).toBe('RECORDED');
+      expect(result.functionalAmountMinor).toBe(1250);
+      expect(result.functionalCurrencyCode).toBe('ARS');
+      expect(result.exchangeRateValue).toBe('1');
+      expect(result.exchangeRateDirection).toBe('IDENTITY');
+      expect(result.exchangeRateId).toBeNull();
+      expect(result.exchangeRateEffectiveAt).toBeNull();
+      expect(result.conversionDate?.toISOString()).toBe('2026-08-09T00:00:00.000Z');
+
+      expect(lastUpdateData()).toMatchObject({
+        status: 'RECORDED',
+        recordedByMembershipId: 'member-1',
+        functionalAmountMinor: 1250,
+        functionalCurrencyCode: 'ARS',
+        exchangeRateValue: '1',
+        exchangeRateDirection: 'IDENTITY',
+        exchangeRateId: null,
+        exchangeRateEffectiveAt: null,
+        conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+      });
+      expect(exchangeRateFindFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('DIRECT', () => {
+    beforeEach(() => {
+      exchangeRateFindFirst.mockResolvedValue(rate());
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+      (prisma.income.update as jest.Mock).mockResolvedValue(
+        recordedIncome({
+          currencyCode: 'USD',
+          amountMinor: 100,
+          functionalAmountMinor: 3650,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'rate-1',
+          exchangeRateValue: '36.500000000001',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+          conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+        }) as never,
+      );
+    });
+
+    it('converts with the source rate and persists applied rate, source id, effectiveAt and date', async () => {
+      const result = await record();
+
+      expect(result.functionalAmountMinor).toBe(3650);
+      expect(result.functionalCurrencyCode).toBe('VES');
+      expect(result.exchangeRateId).toBe('rate-1');
+      expect(result.exchangeRateValue).toBe('36.500000000001');
+      expect(result.exchangeRateDirection).toBe('DIRECT');
+      expect(result.exchangeRateEffectiveAt?.toISOString()).toBe(
+        '2026-08-08T00:00:00.000Z',
+      );
+      expect(result.conversionDate?.toISOString()).toBe('2026-08-09T00:00:00.000Z');
+
+      expect(lastUpdateData()).toMatchObject({
+        status: 'RECORDED',
+        functionalAmountMinor: 3650,
+        functionalCurrencyCode: 'VES',
+        exchangeRateId: 'rate-1',
+        exchangeRateValue: '36.500000000001',
+        exchangeRateDirection: 'DIRECT',
+      });
+      expect(exchangeRateFindFirst).toHaveBeenCalledWith({
+        where: {
+          tenantId: 'tenant-1',
+          baseCurrency: 'USD',
+          quoteCurrency: 'VES',
+          effectiveAt: { lte: new Date('2026-08-09T00:00:00.000Z') },
+        },
+        orderBy: { effectiveAt: 'desc' },
+        select: { id: true, rate: true, effectiveAt: true },
+      });
+      expect(exchangeRateFindFirst).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('INVERSE', () => {
+    beforeEach(() => {
+      exchangeRateFindFirst
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(
+          rate({ id: 'inverse-rate-1', rate: '4' }),
+        );
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+      (prisma.income.update as jest.Mock).mockResolvedValue(
+        recordedIncome({
+          currencyCode: 'USD',
+          amountMinor: 100,
+          functionalAmountMinor: 25,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'inverse-rate-1',
+          exchangeRateValue: '0.25',
+          exchangeRateDirection: 'INVERSE',
+          exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+          conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+        }) as never,
+      );
+    });
+
+    it('falls back to the reciprocal rate and persists applied reciprocal + source row id', async () => {
+      const result = await record();
+
+      expect(result.functionalAmountMinor).toBe(25);
+      expect(result.exchangeRateId).toBe('inverse-rate-1');
+      expect(result.exchangeRateValue).toBe('0.25');
+      expect(result.exchangeRateDirection).toBe('INVERSE');
+
+      expect(lastUpdateData()).toMatchObject({
+        functionalAmountMinor: 25,
+        exchangeRateId: 'inverse-rate-1',
+        exchangeRateValue: '0.25',
+        exchangeRateDirection: 'INVERSE',
+      });
+      expect(exchangeRateFindFirst).toHaveBeenNthCalledWith(2, {
+        where: {
+          tenantId: 'tenant-1',
+          baseCurrency: 'VES',
+          quoteCurrency: 'USD',
+          effectiveAt: { lte: new Date('2026-08-09T00:00:00.000Z') },
+        },
+        orderBy: { effectiveAt: 'desc' },
+        select: { id: true, rate: true, effectiveAt: true },
+      });
+    });
+  });
+
+  describe('priority', () => {
+    it('uses the direct rate when both direct and inverse rates exist', async () => {
+      exchangeRateFindFirst
+        .mockResolvedValueOnce(rate({ id: 'direct-rate', rate: '36.5' }))
+        .mockResolvedValueOnce(rate({ id: 'inverse-rate', rate: '0.02' }));
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+      (prisma.income.update as jest.Mock).mockResolvedValue(
+        recordedIncome({
+          currencyCode: 'USD',
+          amountMinor: 100,
+          functionalAmountMinor: 3650,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'direct-rate',
+          exchangeRateValue: '36.5',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+          conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+        }) as never,
+      );
+
+      const result = await record();
+
+      expect(result.exchangeRateId).toBe('direct-rate');
+      expect(result.exchangeRateDirection).toBe('DIRECT');
+      expect(result.functionalAmountMinor).toBe(3650);
+      expect(exchangeRateFindFirst).toHaveBeenCalledTimes(1);
+      expect(exchangeRateFindFirst.mock.calls[0][0].where).toMatchObject({
+        baseCurrency: 'USD',
+        quoteCurrency: 'VES',
+      });
+    });
+  });
+
+  describe('missing rate', () => {
+    let draftIncome: Record<string, unknown>;
+
+    beforeEach(() => {
+      exchangeRateFindFirst.mockResolvedValue(null);
+      draftIncome = makeIncome({ currencyCode: 'USD', amountMinor: 100 });
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(draftIncome);
+    });
+
+    it('propagates EXCHANGE_RATE_NOT_FOUND 422 and never calls income.update (stays DRAFT)', async () => {
+      const error = await record().catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(UnprocessableEntityException);
+      expect((error as UnprocessableEntityException).getResponse()).toEqual({
+        code: 'EXCHANGE_RATE_NOT_FOUND',
+        originalCurrency: 'USD',
+        functionalCurrency: 'VES',
+        conversionDate: '2026-08-09',
+      });
+      expect(prisma.income.update).not.toHaveBeenCalled();
+    });
+
+    it('keeps the income DRAFT with no partial snapshot', async () => {
+      const error = await record().catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(UnprocessableEntityException);
+      expect(prisma.income.update).not.toHaveBeenCalled();
+      expect(draftIncome.status).toBe('DRAFT');
+      expect(draftIncome.functionalAmountMinor).toBeNull();
+    });
+  });
+
+  describe('invalid rate', () => {
+    beforeEach(() => {
+      exchangeRateFindFirst.mockResolvedValue(rate({ rate: '0' }));
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+    });
+
+    it('propagates INVALID_EXCHANGE_RATE 422 without updating the income', async () => {
+      const error = await record().catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(UnprocessableEntityException);
+      expect((error as UnprocessableEntityException).getResponse()).toMatchObject({
+        code: 'INVALID_EXCHANGE_RATE',
+      });
+      expect(prisma.income.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tenant isolation', () => {
+    beforeEach(() => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+    });
+
+    it('never uses a rate that belongs to another tenant', async () => {
+      exchangeRateFindFirst.mockImplementation(
+        async ({ where }: { where: { tenantId: string } }) =>
+          where.tenantId === 'tenant-other' ? rate() : null,
+      );
+
+      const error = await record().catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(UnprocessableEntityException);
+      expect(prisma.income.update).not.toHaveBeenCalled();
+      expectTenantScopedLookups('tenant-1');
+    });
+
+    it('scopes tenant lookup and every rate query by the acting tenantId', async () => {
+      exchangeRateFindFirst.mockResolvedValue(rate({ id: 'tenant-1-rate' }));
+      (prisma.income.update as jest.Mock).mockResolvedValue(
+        recordedIncome({
+          currencyCode: 'USD',
+          amountMinor: 100,
+          functionalAmountMinor: 3650,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'tenant-1-rate',
+          exchangeRateValue: '36.500000000001',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+          conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+        }) as never,
+      );
+
+      await record();
+
+      expectTenantScopedLookups('tenant-1');
+    });
+
+    it('fails with NotFound when the tenant does not exist', async () => {
+      (prisma.tenant.findFirst as jest.Mock).mockResolvedValue(null);
+
+      const error = await record().catch((caught: unknown) => caught);
+
+      expect(error).toBeInstanceOf(NotFoundException);
+      expect(prisma.income.update).not.toHaveBeenCalled();
+      expect(exchangeRateFindFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('functional currency', () => {
+    it('derives the snapshot functional currency from Tenant.functionalCurrency, never Tenant.currency', async () => {
+      exchangeRateFindFirst.mockResolvedValue(rate({ rate: '10' }));
+      (prisma.tenant.findFirst as jest.Mock).mockResolvedValue({
+        id: 'tenant-1',
+        functionalCurrency: 'COP',
+        currency: 'USD',
+      });
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+      (prisma.income.update as jest.Mock).mockResolvedValue(
+        recordedIncome({
+          currencyCode: 'USD',
+          amountMinor: 100,
+          functionalAmountMinor: 1000,
+          functionalCurrencyCode: 'COP',
+          exchangeRateId: 'rate-1',
+          exchangeRateValue: '10',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+          conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+        }) as never,
+      );
+
+      const result = await record();
+
+      expect(result.functionalCurrencyCode).toBe('COP');
+      expect(exchangeRateFindFirst.mock.calls[0][0].where).toMatchObject({
+        baseCurrency: 'USD',
+        quoteCurrency: 'COP',
+      });
+    });
+  });
+
+  describe('conversion date', () => {
+    beforeEach(() => {
+      (prisma.income.update as jest.Mock).mockResolvedValue(
+        recordedIncome({}) as never,
+      );
+    });
+
+    it('derives the UTC date-only from receivedDate regardless of time-of-day', async () => {
+      exchangeRateFindFirst.mockResolvedValue(rate());
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({
+          currencyCode: 'USD',
+          amountMinor: 100,
+          receivedDate: new Date('2026-08-09T23:45:00.000Z'),
+        }) as never,
+      );
+
+      await record();
+
+      expect(exchangeRateFindFirst.mock.calls[0][0].where.effectiveAt).toEqual({
+        lte: new Date('2026-08-09T00:00:00.000Z'),
+      });
+      expect(lastUpdateData()).toMatchObject({
+        conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+      });
+    });
+
+    it('uses same-day rate, prior rate, and never a future rate', async () => {
+      exchangeRateFindFirst
+        .mockResolvedValueOnce(rate({ id: 'same-day' }))
+        .mockResolvedValueOnce(rate({ id: 'future' }));
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+
+      await record();
+
+      expect(exchangeRateFindFirst.mock.calls[0][0].where).toMatchObject({
+        effectiveAt: { lte: new Date('2026-08-09T00:00:00.000Z') },
+      });
+      expect(exchangeRateFindFirst.mock.calls[0][0].orderBy).toEqual({
+        effectiveAt: 'desc',
+      });
+    });
+  });
+
+  describe('immutability', () => {
+    it('stores the snapshot as a value: later ExchangeRate edits do not change the persisted snapshot', async () => {
+      exchangeRateFindFirst
+        .mockResolvedValueOnce(
+          rate({ id: 'rate-1', rate: '36.5', effectiveAt: new Date('2026-08-08T00:00:00.000Z') }),
+        )
+        .mockResolvedValueOnce(
+          rate({ id: 'rate-2', rate: '1000', effectiveAt: new Date('2026-08-10T00:00:00.000Z') }),
+        );
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+      (prisma.income.update as jest.Mock).mockResolvedValue(
+        recordedIncome({
+          currencyCode: 'USD',
+          amountMinor: 100,
+          functionalAmountMinor: 3650,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'rate-1',
+          exchangeRateValue: '36.5',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+          conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+        }) as never,
+      );
+
+      const persisted = await record();
+
+      expect(exchangeRateFindFirst).toHaveBeenCalledTimes(1);
+      expect(persisted.exchangeRateId).toBe('rate-1');
+      expect(persisted.exchangeRateValue).toBe('36.5');
+      expect(persisted.functionalAmountMinor).toBe(3650);
+      expect(lastUpdateData()).toMatchObject({ exchangeRateValue: '36.5' });
+    });
+
+    it('rejects editing a RECORDED income through the DRAFT-only update guard', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({ status: 'RECORDED' }) as never,
+      );
+
+      await expect(
+        service.updateIncome(
+          'tenant-1',
+          'income-1',
+          'member-1',
+          ['TENANT_ADMIN'],
+          { description: 'late edit' },
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.income.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects editing a VOID income through the DRAFT-only update guard', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({ status: 'VOID' }) as never,
+      );
+
+      await expect(
+        service.updateIncome(
+          'tenant-1',
+          'income-1',
+          'member-1',
+          ['TENANT_ADMIN'],
+          { amountMinor: 500 },
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.income.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('precision', () => {
+    beforeEach(() => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({ currencyCode: 'USD', amountMinor: 100 }) as never,
+      );
+    });
+
+    it.each([
+      ['12-decimal rate', '1.123456789012', 112],
+      ['small rate', '0.000000000001', 0],
+    ])(
+      'converts %s exactly and persists the fixed-point applied rate without exponent',
+      async (_label, sourceRate, expectedFunctionalAmount) => {
+        exchangeRateFindFirst.mockResolvedValue(rate({ rate: sourceRate }));
+        (prisma.income.update as jest.Mock).mockResolvedValue(
+          recordedIncome({
+            currencyCode: 'USD',
+            amountMinor: 100,
+            functionalAmountMinor: expectedFunctionalAmount,
+            functionalCurrencyCode: 'VES',
+            exchangeRateId: 'rate-1',
+            exchangeRateValue: sourceRate,
+            exchangeRateDirection: 'DIRECT',
+            exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+            conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+          }) as never,
+        );
+
+        const result = await record();
+
+        expect(result.functionalAmountMinor).toBe(expectedFunctionalAmount);
+        expect(result.exchangeRateValue).toBe(sourceRate);
+        expect(result.exchangeRateValue).not.toMatch(/[eE]/);
+        expect(lastUpdateData()).toMatchObject({ exchangeRateValue: sourceRate });
+      },
+    );
+
+    it.each([
+      ['even-down tie', '2.5', 1, 2],
+      ['odd-up tie', '3.5', 1, 4],
+    ])(
+      'uses ROUND_HALF_EVEN for %s',
+      async (_label, sourceRate, amountMinor, expectedFunctionalAmount) => {
+        exchangeRateFindFirst.mockResolvedValue(rate({ rate: sourceRate }));
+        (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+          makeIncome({ currencyCode: 'USD', amountMinor }) as never,
+        );
+        (prisma.income.update as jest.Mock).mockResolvedValue(
+          recordedIncome({
+            currencyCode: 'USD',
+            amountMinor,
+            functionalAmountMinor: expectedFunctionalAmount,
+            functionalCurrencyCode: 'VES',
+            exchangeRateId: 'rate-1',
+            exchangeRateValue: sourceRate,
+            exchangeRateDirection: 'DIRECT',
+            exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+            conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+          }) as never,
+        );
+
+        const result = await record();
+
+        expect(result.functionalAmountMinor).toBe(expectedFunctionalAmount);
+      },
+    );
+  });
+
+  describe('legacy incomes', () => {
+    it('maps an income without snapshot fields through toDto with nulls (no speculative backfill)', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(
+        makeIncome({
+          status: 'RECORDED',
+          functionalAmountMinor: undefined,
+          functionalCurrencyCode: undefined,
+          exchangeRateId: undefined,
+          exchangeRateValue: undefined,
+          exchangeRateDirection: undefined,
+          exchangeRateEffectiveAt: undefined,
+          conversionDate: undefined,
+        }) as never,
+      );
+
+      const result = await service.getIncome(
+        'tenant-1',
+        'income-1',
+        ['TENANT_ADMIN'],
+      );
+
+      expect(result.status).toBe('RECORDED');
+      expect(result.functionalAmountMinor).toBeNull();
+      expect(result.functionalCurrencyCode).toBeNull();
+      expect(result.exchangeRateId).toBeNull();
+      expect(result.exchangeRateValue).toBeNull();
+      expect(result.exchangeRateDirection).toBeNull();
+      expect(result.exchangeRateEffectiveAt).toBeNull();
+      expect(result.conversionDate).toBeNull();
+      expect(prisma.income.update).not.toHaveBeenCalled();
+    });
+
+    it('exposes a DRAFT income without a snapshot through listIncomes with nulls', async () => {
+      (prisma.income.findMany as jest.Mock).mockResolvedValue([
+        makeIncome({ status: 'DRAFT' }),
+      ]);
+
+      const results = await service.listIncomes(
+        'tenant-1',
+        ['TENANT_ADMIN'],
+        {},
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe('DRAFT');
+      expect(results[0].functionalAmountMinor).toBeNull();
+      expect(results[0].exchangeRateValue).toBeNull();
+      expect(results[0].conversionDate).toBeNull();
+    });
+  });
+});

--- a/apps/api/src/finanzas/incomes.service.ts
+++ b/apps/api/src/finanzas/incomes.service.ts
@@ -8,6 +8,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { FinanzasValidators } from './finanzas.validators';
 import { MovementAllocationService } from './movement-allocation.service';
+import { CurrencyConversionService } from './currency-conversion.service';
 import {
   CreateIncomeDto,
   UpdateIncomeDto,
@@ -21,6 +22,7 @@ export class IncomesService {
     private readonly auditService: AuditService,
     private readonly validators: FinanzasValidators,
     private readonly movementAllocationService: MovementAllocationService,
+    private readonly currencyConversionService: CurrencyConversionService,
   ) {}
 
   async listIncomes(
@@ -204,6 +206,12 @@ export class IncomesService {
       throw new NotFoundException(`Ingreso no encontrado: ${incomeId}`);
     }
 
+    if (income.status !== 'DRAFT') {
+      throw new BadRequestException(
+        `Solo se pueden editar ingresos en DRAFT. Estado actual: ${income.status}`,
+      );
+    }
+
     // If changing category, validate it's INCOME type
     if (dto.categoryId && dto.categoryId !== income.categoryId) {
       const newCategory = await this.prisma.expenseLedgerCategory.findFirst({
@@ -252,6 +260,57 @@ export class IncomesService {
     return this.toDto(updated);
   }
 
+  private toConversionDate(receivedDate: Date): string {
+    const year = receivedDate.getUTCFullYear();
+    const month = String(receivedDate.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(receivedDate.getUTCDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  private async buildIncomeConversionSnapshot(
+    tenantId: string,
+    income: { amountMinor: number; currencyCode: string; receivedDate: Date },
+  ): Promise<{
+    functionalAmountMinor: number;
+    functionalCurrencyCode: string;
+    exchangeRateId: string | null;
+    exchangeRateValue: string;
+    exchangeRateDirection: 'IDENTITY' | 'DIRECT' | 'INVERSE';
+    exchangeRateEffectiveAt: Date | null;
+    conversionDate: Date;
+  }> {
+    const tenant = await this.prisma.tenant.findFirst({
+      where: { id: tenantId },
+      select: { id: true, functionalCurrency: true },
+    });
+
+    if (!tenant) {
+      throw new NotFoundException(`Tenant no encontrado: ${tenantId}`);
+    }
+
+    const result = await this.currencyConversionService.convert({
+      tenantId,
+      amount: income.amountMinor,
+      originalCurrency: income.currencyCode as Parameters<
+        typeof this.currencyConversionService.convert
+      >[0]['originalCurrency'],
+      functionalCurrency: tenant.functionalCurrency as Parameters<
+        typeof this.currencyConversionService.convert
+      >[0]['functionalCurrency'],
+      conversionDate: this.toConversionDate(income.receivedDate),
+    });
+
+    return {
+      functionalAmountMinor: result.functionalAmount,
+      functionalCurrencyCode: result.functionalCurrency,
+      exchangeRateId: result.sourceExchangeRateId,
+      exchangeRateValue: result.appliedRate,
+      exchangeRateDirection: result.direction,
+      exchangeRateEffectiveAt: result.sourceEffectiveAt,
+      conversionDate: result.conversionDate,
+    };
+  }
+
   async recordIncome(
     tenantId: string,
     incomeId: string,
@@ -277,12 +336,24 @@ export class IncomesService {
       );
     }
 
+    const conversionSnapshot = await this.buildIncomeConversionSnapshot(
+      tenantId,
+      income,
+    );
+
     const updated = await this.prisma.income.update({
       where: { id: incomeId },
       data: {
         status: 'RECORDED',
         recordedByMembershipId: membershipId,
         recordedAt: new Date(),
+        functionalAmountMinor: conversionSnapshot.functionalAmountMinor,
+        functionalCurrencyCode: conversionSnapshot.functionalCurrencyCode,
+        exchangeRateId: conversionSnapshot.exchangeRateId,
+        exchangeRateValue: conversionSnapshot.exchangeRateValue,
+        exchangeRateDirection: conversionSnapshot.exchangeRateDirection,
+        exchangeRateEffectiveAt: conversionSnapshot.exchangeRateEffectiveAt,
+        conversionDate: conversionSnapshot.conversionDate,
       },
       include: { category: true },
     });
@@ -355,6 +426,13 @@ export class IncomesService {
     scopeType: 'BUILDING' | 'TENANT_SHARED' | 'UNIT_GROUP';
     destination: 'APPLY_TO_EXPENSES' | 'RESERVE_FUND' | 'SPECIAL_FUND';
     unitGroupId: string | null;
+    functionalAmountMinor?: number | null;
+    functionalCurrencyCode?: string | null;
+    exchangeRateId?: string | null;
+    exchangeRateValue?: { toString(): string } | string | null;
+    exchangeRateDirection?: string | null;
+    exchangeRateEffectiveAt?: Date | null;
+    conversionDate?: Date | null;
     createdAt: Date;
     updatedAt: Date;
     category: { name: string };
@@ -375,6 +453,16 @@ export class IncomesService {
       scopeType: income.scopeType,
       destination: income.destination,
       unitGroupId: income.unitGroupId,
+      functionalAmountMinor: income.functionalAmountMinor ?? null,
+      functionalCurrencyCode: income.functionalCurrencyCode ?? null,
+      exchangeRateId: income.exchangeRateId ?? null,
+      exchangeRateValue:
+        income.exchangeRateValue === null || income.exchangeRateValue === undefined
+          ? null
+          : income.exchangeRateValue.toString(),
+      exchangeRateDirection: income.exchangeRateDirection ?? null,
+      exchangeRateEffectiveAt: income.exchangeRateEffectiveAt ?? null,
+      conversionDate: income.conversionDate ?? null,
       createdAt: income.createdAt,
       updatedAt: income.updatedAt,
     };

--- a/apps/api/src/observability/sentry-exception.filter.spec.ts
+++ b/apps/api/src/observability/sentry-exception.filter.spec.ts
@@ -3,6 +3,7 @@ import {
   ForbiddenException,
   InternalServerErrorException,
   UnauthorizedException,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { SentryExceptionFilter } from './sentry-exception.filter';
 import { SentryService } from './sentry.service';
@@ -169,5 +170,165 @@ describe('SentryExceptionFilter', () => {
       }),
     );
     expect(response.status).toHaveBeenCalledWith(500);
+  });
+
+  it('preserves the structured business code and safe metadata for EXCHANGE_RATE_NOT_FOUND', () => {
+    const filter = new SentryExceptionFilter(sentryService, loggerService);
+    const response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const host = createHost(
+      {
+        id: 'req-4',
+        routePath: '/tenants/t-1/finance/incomes/i-1/record',
+        path: '/tenants/t-1/finance/incomes/i-1/record',
+        method: 'POST',
+      },
+      response,
+    );
+
+    filter.catch(
+      new UnprocessableEntityException({
+        code: 'EXCHANGE_RATE_NOT_FOUND',
+        originalCurrency: 'USD',
+        functionalCurrency: 'VES',
+        conversionDate: '2026-08-09',
+      }),
+      host,
+    );
+
+    expect(response.status).toHaveBeenCalledWith(422);
+    const body = response.json.mock.calls[0][0];
+    expect(body.statusCode).toBe(422);
+    expect(body.code).toBe('EXCHANGE_RATE_NOT_FOUND');
+    expect(body.originalCurrency).toBe('USD');
+    expect(body.functionalCurrency).toBe('VES');
+    expect(body.conversionDate).toBe('2026-08-09');
+    expect(body.requestId).toBe('req-4');
+    expect(body.timestamp).toBeDefined();
+    expect(JSON.stringify(body)).not.toContain('stack');
+  });
+
+  it('preserves the structured business code for INVALID_EXCHANGE_RATE', () => {
+    const filter = new SentryExceptionFilter(sentryService, loggerService);
+    const response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const host = createHost(
+      {
+        id: 'req-5',
+        routePath: '/tenants/t-1/finance/incomes/i-1/record',
+        path: '/tenants/t-1/finance/incomes/i-1/record',
+        method: 'POST',
+      },
+      response,
+    );
+
+    filter.catch(
+      new UnprocessableEntityException({
+        code: 'INVALID_EXCHANGE_RATE',
+        baseCurrency: 'VES',
+        quoteCurrency: 'USD',
+        effectiveAt: '2026-08-08T00:00:00.000Z',
+      }),
+      host,
+    );
+
+    expect(response.status).toHaveBeenCalledWith(422);
+    const body = response.json.mock.calls[0][0];
+    expect(body.code).toBe('INVALID_EXCHANGE_RATE');
+    expect(body.baseCurrency).toBe('VES');
+    expect(body.quoteCurrency).toBe('USD');
+    expect(body.effectiveAt).toBe('2026-08-08T00:00:00.000Z');
+    expect(JSON.stringify(body)).not.toContain('stack');
+  });
+
+  it('keeps compatible shape for a plain-string HttpException', () => {
+    const filter = new SentryExceptionFilter(sentryService, loggerService);
+    const response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const host = createHost(
+      {
+        id: 'req-6',
+        routePath: '/finance',
+        path: '/finance',
+        method: 'GET',
+      },
+      response,
+    );
+
+    filter.catch(new UnauthorizedException('Sesión expirada'), host);
+
+    expect(response.status).toHaveBeenCalledWith(401);
+    const body = response.json.mock.calls[0][0];
+    expect(body.statusCode).toBe(401);
+    expect(body.message).toBe('Sesión expirada');
+    expect(body.requestId).toBe('req-6');
+    expect(body.timestamp).toBeDefined();
+    expect(body.code).toBeUndefined();
+  });
+
+  it('does not expose stack or internals for unexpected errors', () => {
+    const filter = new SentryExceptionFilter(sentryService, loggerService);
+    const response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const host = createHost(
+      {
+        id: 'req-7',
+        routePath: '/finance',
+        path: '/finance',
+        method: 'POST',
+      },
+      response,
+    );
+
+    const boom = new Error('boom');
+    boom.stack = 'at internal/path.js:1:1';
+    filter.catch(boom, host);
+
+    expect(response.status).toHaveBeenCalledWith(500);
+    const body = response.json.mock.calls[0][0];
+    expect(body.statusCode).toBe(500);
+    expect(JSON.stringify(body)).not.toContain('boom');
+    expect(JSON.stringify(body)).not.toContain('stack');
+    expect(JSON.stringify(body)).not.toContain('internal/path.js');
+  });
+
+  it('does not expose Prisma internals for Prisma-style errors', () => {
+    const filter = new SentryExceptionFilter(sentryService, loggerService);
+    const response = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+    const host = createHost(
+      {
+        id: 'req-8',
+        routePath: '/finance',
+        path: '/finance',
+        method: 'POST',
+      },
+      response,
+    );
+
+    const prismaError = new Error('PrismaClientKnownRequestError');
+    (prismaError as Error & { code?: string; meta?: unknown }).code = 'P2002';
+    (prismaError as Error & { meta?: unknown }).meta = {
+      target: ['tenantId', 'code'],
+      modelName: 'Expense',
+    };
+    filter.catch(prismaError, host);
+
+    expect(response.status).toHaveBeenCalledWith(500);
+    const body = response.json.mock.calls[0][0];
+    const bodyText = JSON.stringify(body);
+    expect(bodyText).not.toContain('P2002');
+    expect(bodyText).not.toContain('Expense');
+    expect(bodyText).not.toContain('stack');
   });
 });

--- a/apps/api/src/observability/sentry-exception.filter.ts
+++ b/apps/api/src/observability/sentry-exception.filter.ts
@@ -24,6 +24,28 @@ interface HttpExceptionResponseBody {
   message?: string | string[];
 }
 
+const SAFE_BODY_KEYS = new Set([
+  'statusCode',
+  'message',
+  'error',
+  'code',
+  'originalCurrency',
+  'functionalCurrency',
+  'conversionDate',
+  'baseCurrency',
+  'quoteCurrency',
+  'effectiveAt',
+]);
+
+function isSafeResponseValue(value: unknown): boolean {
+  return (
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    value === null
+  );
+}
+
 @Catch()
 export class SentryExceptionFilter implements ExceptionFilter {
   constructor(
@@ -48,7 +70,10 @@ export class SentryExceptionFilter implements ExceptionFilter {
 
     let statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
     let message = 'Internal Server Error';
+    let responseMessage = 'Internal Server Error';
     let error: Error | null = null;
+    const structuredFields: Record<string, string | number | boolean | null> =
+      {};
 
     // Handle HttpException
     if (exception instanceof HttpException) {
@@ -58,12 +83,23 @@ export class SentryExceptionFilter implements ExceptionFilter {
         typeof exceptionResponse === 'string'
           ? exceptionResponse
           : this.getHttpExceptionMessage(exceptionResponse);
+      responseMessage = message;
       error = exception as Error;
+
+      // Preserve structured safe fields (business codes and authorized metadata)
+      if (typeof exceptionResponse === 'object' && exceptionResponse !== null) {
+        for (const [key, value] of Object.entries(exceptionResponse)) {
+          if (SAFE_BODY_KEYS.has(key) && isSafeResponseValue(value)) {
+            structuredFields[key] = value;
+          }
+        }
+      }
     }
     // Handle regular errors
     else if (exception instanceof Error) {
       error = exception;
       message = exception.message;
+      // Do not echo unexpected error internals to the client
     }
     // Handle unknown exceptions
     else {
@@ -108,7 +144,8 @@ export class SentryExceptionFilter implements ExceptionFilter {
     // Send response
     response.status(statusCode).json({
       statusCode,
-      message,
+      message: responseMessage,
+      ...structuredFields,
       requestId: context.requestId,
       timestamp: new Date().toISOString(),
     });

--- a/apps/web/features/finance/components/ExpensesList.tsx
+++ b/apps/web/features/finance/components/ExpensesList.tsx
@@ -241,6 +241,17 @@ export function ExpensesList({
                   </td>
                   <td className="px-4 py-3 text-right font-mono">
                     {formatCurrency(expense.amountMinor, expense.currencyCode)}
+                    {expense.functionalAmountMinor != null &&
+                      expense.functionalCurrencyCode &&
+                      expense.functionalCurrencyCode !== expense.currencyCode && (
+                        <p className="text-xs text-muted-foreground">
+                          ≈{' '}
+                          {formatCurrency(
+                            expense.functionalAmountMinor,
+                            expense.functionalCurrencyCode,
+                          )}
+                        </p>
+                      )}
                   </td>
                   <td className="px-4 py-3 text-center">
                     <span

--- a/apps/web/features/finance/components/TenantExpensesList.tsx
+++ b/apps/web/features/finance/components/TenantExpensesList.tsx
@@ -193,6 +193,17 @@ export function TenantExpensesList({
                   </td>
                   <td className="px-4 py-3 text-right font-mono">
                     {formatCurrency(expense.amountMinor, expense.currencyCode)}
+                    {expense.functionalAmountMinor != null &&
+                      expense.functionalCurrencyCode &&
+                      expense.functionalCurrencyCode !== expense.currencyCode && (
+                        <p className="text-xs text-muted-foreground">
+                          ≈{' '}
+                          {formatCurrency(
+                            expense.functionalAmountMinor,
+                            expense.functionalCurrencyCode,
+                          )}
+                        </p>
+                      )}
                   </td>
                   <td className="px-4 py-3 text-center">
                     <span

--- a/apps/web/features/finance/services/expense-ledger.api.ts
+++ b/apps/web/features/finance/services/expense-ledger.api.ts
@@ -39,6 +39,13 @@ export interface Expense {
   status: ExpenseStatus;
   scopeType: ExpenseScopeType;
   unitGroupId: string | null;
+  functionalAmountMinor?: number | null;
+  functionalCurrencyCode?: string | null;
+  exchangeRateId?: string | null;
+  exchangeRateValue?: string | null;
+  exchangeRateDirection?: string | null;
+  exchangeRateEffectiveAt?: string | null;
+  conversionDate?: string | null;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary

- **3B — Multicurrency conversion engine**: tenant-scoped `CurrencyConversionService` with IDENTITY → DIRECT → INVERSE resolution, Prisma.Decimal arithmetic, ROUND_HALF_EVEN final posting, Int range guards, and stable sanitized errors.
- **3C1 — Expense multicurrency snapshots**: additive `functionalAmountMinor` / `functionalCurrencyCode` / exchange-rate snapshot fields written in the same update that validates an expense; migration `20260810000000_add_expense_multicurrency_snapshot`.
- **3C2 — Income multicurrency snapshots**: same snapshot contract applied at DRAFT→RECORDED via `recordIncome`, with a DRAFT-only update guard added for immutability; migration `20260810010000_add_income_multicurrency_snapshot`.
- **Structured 422 business error preservation**: `SentryExceptionFilter` now preserves safe business fields (`code`, currency/date metadata) while never leaking stack/Prisma/SQL internals.

## Migrations included

- `20260810000000_add_expense_multicurrency_snapshot` (additive, nullable)
- `20260810010000_add_income_multicurrency_snapshot` (additive, nullable)

No speculative historical backfill (owned by Phase 3G). Legacy rows remain readable with NULL snapshots.

## Local validation

- Focused: 93 tests (conversion 41, expenses 19, incomes 25, filter 8) — all pass.
- Finance API suite: 774 passed, 11 skipped (pre-existing env-gated).
- API typecheck, touched lint, Prisma validate, API build: pass.
- Web typecheck and finance suite (85): pass.
- Isolated DB acceptance: 86 migrations applied; functional smoke covered IDENTITY, DIRECT, INVERSE, missing-rate 422 with `code: EXCHANGE_RATE_NOT_FOUND` preserved, DRAFT + NULL snapshot on failure (DB-verified), and Expense DIRECT regression.

## Scope

No Phase 3C3 (Adjustment), no liquidation/charge/payment/report changes in this PR.