### PR TITLE
feat(finance): value liquidations in functional currency

### DIFF
--- a/apps/api/prisma/migrations/20260810030000_add_liquidation_functional_valuation/migration.sql
+++ b/apps/api/prisma/migrations/20260810030000_add_liquidation_functional_valuation/migration.sql
@@ -1,0 +1,9 @@
+-- CreateEnum
+CREATE TYPE "LiquidationValuationMode" AS ENUM ('FUNCTIONAL', 'LEGACY_NOMINAL');
+
+-- AlterTable
+ALTER TABLE "Liquidation" ADD COLUMN     "valuationMode" "LiquidationValuationMode";
+
+-- AlterTable
+ALTER TABLE "MovementAllocation" ADD COLUMN     "functionalAmountMinor" INTEGER,
+ADD COLUMN     "functionalCurrencyCode" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -142,6 +142,11 @@ enum LiquidationStatus {
   CANCELED
 }
 
+enum LiquidationValuationMode {
+  FUNCTIONAL
+  LEGACY_NOMINAL
+}
+
 enum LeadStatus {
   NEW
   CONTACTED
@@ -1960,16 +1965,18 @@ model Income {
 // FINANZAS: MovementAllocation (Distribución de Expense/Income TENANT_SHARED)
 // ============================================================================
 model MovementAllocation {
-  id           String   @id @default(cuid())
-  tenantId     String
-  expenseId    String?  // XOR con incomeId
-  incomeId     String?  // XOR con expenseId
-  buildingId   String
-  percentage   Float?   // % del total (0–100), si se distribuye por %
-  amountMinor  Int?     // monto fijo en esa moneda
-  currencyCode String?
-  createdAt    DateTime @default(now())
-  updatedAt    DateTime @updatedAt
+  id                      String   @id @default(cuid())
+  tenantId                String
+  expenseId               String?  // XOR con incomeId
+  incomeId                String?  // XOR con expenseId
+  buildingId              String
+  percentage              Float?   // % del total (0–100), si se distribuye por %
+  amountMinor             Int?     // monto fijo en esa moneda
+  currencyCode            String?
+  functionalAmountMinor   Int?     // Snapshot: porción en moneda funcional al validar el Expense
+  functionalCurrencyCode  String?  // Snapshot: moneda funcional del tenant al validar el Expense
+  createdAt               DateTime @default(now())
+  updatedAt               DateTime @updatedAt
 
   tenant   Tenant    @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   expense  Expense?  @relation(fields: [expenseId], references: [id], onDelete: Cascade)
@@ -2035,6 +2042,7 @@ model Liquidation {
   period                   String            // YYYY-MM format - período de devengo
   chargePeriod             String?           // YYYY-MM - período de cobro (default: period + 1 mes)
   status                   LiquidationStatus @default(DRAFT)
+  valuationMode            LiquidationValuationMode? // NULL = histórico pre-3D / legacy
   baseCurrency             String            // Moneda base de liquidación
   totalAmountMinor         Int               // Total en centavos derivado de gastos VALIDATED
   totalsByCurrency         Json              // Snapshot: { "ARS": 150000, "USD": 5000 }

--- a/apps/api/src/finanzas/expense-ledger.dto.ts
+++ b/apps/api/src/finanzas/expense-ledger.dto.ts
@@ -284,6 +284,7 @@ export interface LiquidationResponseDto {
   period: string;
   chargePeriod?: string | null;
   status: 'DRAFT' | 'REVIEWED' | 'PUBLISHED' | 'CANCELED';
+  valuationMode?: 'FUNCTIONAL' | 'LEGACY_NOMINAL' | null;
   baseCurrency: string;
   totalAmountMinor: number;
   totalsByCurrency: Record<string, number>;

--- a/apps/api/src/finanzas/expenses.service.ts
+++ b/apps/api/src/finanzas/expenses.service.ts
@@ -13,7 +13,10 @@ import {
   ExpenseResponseDto,
 } from './expense-ledger.dto';
 import { FinanzasValidators } from './finanzas.validators';
-import { MovementAllocationService } from './movement-allocation.service';
+import {
+  MovementAllocationService,
+  allocateFunctionalByLargestRemainder,
+} from './movement-allocation.service';
 import { CurrencyConversionService } from './currency-conversion.service';
 
 @Injectable()
@@ -30,6 +33,92 @@ export class ExpensesService {
     const year = invoiceDate.getUTCFullYear();
     const month = String(invoiceDate.getUTCMonth() + 1).padStart(2, '0');
     return `${year}-${month}`;
+  }
+
+  private async persistValidatedExpense(
+    expense: {
+      id: string;
+      tenantId: string;
+      scopeType: 'BUILDING' | 'TENANT_SHARED' | 'UNIT_GROUP';
+    },
+    snapshot: {
+      functionalAmountMinor: number;
+      functionalCurrencyCode: string;
+      exchangeRateId: string | null;
+      exchangeRateValue: string;
+      exchangeRateDirection: 'IDENTITY' | 'DIRECT' | 'INVERSE';
+      exchangeRateEffectiveAt: Date | null;
+      conversionDate: Date;
+    },
+    validatedByMembershipId: string | null,
+  ) {
+    const baseData = {
+      status: 'VALIDATED' as const,
+      validatedByMembershipId,
+      validatedAt: new Date(),
+      functionalAmountMinor: snapshot.functionalAmountMinor,
+      functionalCurrencyCode: snapshot.functionalCurrencyCode,
+      exchangeRateId: snapshot.exchangeRateId,
+      exchangeRateValue: snapshot.exchangeRateValue,
+      exchangeRateDirection: snapshot.exchangeRateDirection,
+      exchangeRateEffectiveAt: snapshot.exchangeRateEffectiveAt,
+      conversionDate: snapshot.conversionDate,
+    };
+
+    if (expense.scopeType !== 'TENANT_SHARED') {
+      return this.prisma.expense.update({
+        where: { id: expense.id },
+        data: baseData,
+        include: {
+          category: { select: { name: true } },
+          vendor: { select: { name: true } },
+        },
+      });
+    }
+
+    const allocations = await this.prisma.movementAllocation.findMany({
+      where: { tenantId: expense.tenantId, expenseId: expense.id },
+      select: { id: true, amountMinor: true },
+    });
+
+    if (allocations.length === 0) {
+      return this.prisma.expense.update({
+        where: { id: expense.id },
+        data: baseData,
+        include: {
+          category: { select: { name: true } },
+          vendor: { select: { name: true } },
+        },
+      });
+    }
+
+    const shares = allocateFunctionalByLargestRemainder(
+      snapshot.functionalAmountMinor,
+      allocations.map((allocation) => allocation.amountMinor ?? 0),
+    );
+
+    return this.prisma.$transaction(async (tx) => {
+      const updated = await tx.expense.update({
+        where: { id: expense.id },
+        data: baseData,
+        include: {
+          category: { select: { name: true } },
+          vendor: { select: { name: true } },
+        },
+      });
+
+      for (const [index, allocation] of allocations.entries()) {
+        await tx.movementAllocation.update({
+          where: { id: allocation.id },
+          data: {
+            functionalAmountMinor: shares[index],
+            functionalCurrencyCode: snapshot.functionalCurrencyCode,
+          },
+        });
+      }
+
+      return updated;
+    });
   }
 
   private toConversionDate(invoiceDate: Date): string {
@@ -477,25 +566,11 @@ export class ExpensesService {
       expense,
     );
 
-    const updated = await this.prisma.expense.update({
-      where: { id: expenseId },
-      data: {
-        status: 'VALIDATED',
-        validatedByMembershipId: membershipId,
-        validatedAt: new Date(),
-        functionalAmountMinor: conversionSnapshot.functionalAmountMinor,
-        functionalCurrencyCode: conversionSnapshot.functionalCurrencyCode,
-        exchangeRateId: conversionSnapshot.exchangeRateId,
-        exchangeRateValue: conversionSnapshot.exchangeRateValue,
-        exchangeRateDirection: conversionSnapshot.exchangeRateDirection,
-        exchangeRateEffectiveAt: conversionSnapshot.exchangeRateEffectiveAt,
-        conversionDate: conversionSnapshot.conversionDate,
-      },
-      include: {
-        category: { select: { name: true } },
-        vendor: { select: { name: true } },
-      },
-    });
+    const updated = await this.persistValidatedExpense(
+      expense,
+      conversionSnapshot,
+      membershipId,
+    );
 
     void this.auditService.createLog({
       tenantId,
@@ -533,25 +608,11 @@ export class ExpensesService {
       expense,
     );
 
-    const updated = await this.prisma.expense.update({
-      where: { id: expenseId },
-      data: {
-        status: 'VALIDATED',
-        validatedByMembershipId: membershipId ?? null,
-        validatedAt: new Date(),
-        functionalAmountMinor: conversionSnapshot.functionalAmountMinor,
-        functionalCurrencyCode: conversionSnapshot.functionalCurrencyCode,
-        exchangeRateId: conversionSnapshot.exchangeRateId,
-        exchangeRateValue: conversionSnapshot.exchangeRateValue,
-        exchangeRateDirection: conversionSnapshot.exchangeRateDirection,
-        exchangeRateEffectiveAt: conversionSnapshot.exchangeRateEffectiveAt,
-        conversionDate: conversionSnapshot.conversionDate,
-      },
-      include: {
-        category: { select: { name: true } },
-        vendor: { select: { name: true } },
-      },
-    });
+    const updated = await this.persistValidatedExpense(
+      expense,
+      conversionSnapshot,
+      membershipId ?? null,
+    );
 
     void this.auditService.createLog({
       tenantId,
@@ -561,10 +622,8 @@ export class ExpensesService {
       entityId: expenseId,
       metadata: {
         period: expense.period,
-        liquidationPeriod: expense.liquidationPeriod,
         amountMinor: expense.amountMinor,
         currencyCode: expense.currencyCode,
-        bulkOperation: true,
       },
     });
 

--- a/apps/api/src/finanzas/expenses.tenant-shared-functional.spec.ts
+++ b/apps/api/src/finanzas/expenses.tenant-shared-functional.spec.ts
@@ -1,0 +1,195 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Prisma } from '@prisma/client';
+import { ExpensesService } from './expenses.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { MovementAllocationService } from './movement-allocation.service';
+import { CurrencyConversionService } from './currency-conversion.service';
+
+const makeSharedExpense = (overrides: Record<string, unknown> = {}) => ({
+  id: 'exp-shared-1',
+  tenantId: 'tenant-1',
+  buildingId: null,
+  period: '2026-08',
+  liquidationPeriod: '2026-08',
+  categoryId: 'cat-1',
+  vendorId: 'vendor-1',
+  amountMinor: 1000,
+  currencyCode: 'USD',
+  invoiceDate: new Date('2026-08-09T00:00:00.000Z'),
+  description: null,
+  attachmentFileKey: null,
+  status: 'DRAFT',
+  scopeType: 'TENANT_SHARED',
+  unitGroupId: null,
+  functionalAmountMinor: null,
+  functionalCurrencyCode: null,
+  exchangeRateId: null,
+  exchangeRateValue: null,
+  exchangeRateDirection: null,
+  exchangeRateEffectiveAt: null,
+  conversionDate: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  category: { name: 'Shared' },
+  vendor: { name: 'Vendor' },
+  ...overrides,
+});
+
+describe('ExpensesService TENANT_SHARED functional allocation', () => {
+  let service: ExpensesService;
+  let prisma: PrismaService;
+  let exchangeRateFindFirst: jest.Mock;
+  let allocationUpdates: Array<{ id: string; data: Record<string, unknown> }>;
+
+  beforeEach(async () => {
+    exchangeRateFindFirst = jest.fn();
+    allocationUpdates = [];
+
+    const prismaValue = {
+      expense: {
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      tenant: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'tenant-1',
+          functionalCurrency: 'VES',
+        }),
+      },
+      exchangeRate: { findFirst: exchangeRateFindFirst },
+      liquidation: { findFirst: jest.fn() },
+      expenseLedgerCategory: { findFirst: jest.fn() },
+      vendor: { findFirst: jest.fn() },
+      unitGroup: { findFirst: jest.fn() },
+      adjustment: { findFirst: jest.fn(), create: jest.fn(), update: jest.fn() },
+      movementAllocation: {
+        findMany: jest.fn(),
+        update: jest.fn().mockImplementation(({ where, data }: { where: { id: string }; data: Record<string, unknown> }) => {
+          allocationUpdates.push({ id: where.id, data });
+          return Promise.resolve({ id: where.id, ...data });
+        }),
+      },
+      $transaction: jest.fn((callback: (client: typeof prismaValue) => unknown) =>
+        callback(prismaValue),
+      ),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ExpensesService,
+        { provide: PrismaService, useValue: prismaValue },
+        { provide: AuditService, useValue: { createLog: jest.fn() } },
+        {
+          provide: FinanzasValidators,
+          useValue: { isAdminOrOperator: jest.fn().mockReturnValue(true) },
+        },
+        {
+          provide: MovementAllocationService,
+          useValue: { createForExpense: jest.fn() },
+        },
+        {
+          provide: CurrencyConversionService,
+          useFactory: (prismaService: PrismaService) =>
+            new CurrencyConversionService(prismaService),
+          inject: [PrismaService],
+        },
+      ],
+    }).compile();
+
+    service = module.get<ExpensesService>(ExpensesService);
+    prisma = module.get<PrismaService>(PrismaService);
+  });
+
+  const validate = () =>
+    service.validateExpense('tenant-1', 'exp-shared-1', 'member-1', ['TENANT_ADMIN']);
+
+  const setup = (allocations: Array<{ id: string; amountMinor: number; percentage: number | null }>) => {
+    (prisma.expense.findFirst as jest.Mock).mockResolvedValue(makeSharedExpense());
+    exchangeRateFindFirst.mockResolvedValue({
+      id: 'rate-1',
+      rate: new Prisma.Decimal('36.5'),
+      effectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+    });
+    (prisma.movementAllocation.findMany as jest.Mock).mockResolvedValue(allocations);
+    (prisma.expense.update as jest.Mock).mockResolvedValue(
+      makeSharedExpense({
+        status: 'VALIDATED',
+        functionalAmountMinor: 36500,
+        functionalCurrencyCode: 'VES',
+        exchangeRateId: 'rate-1',
+        exchangeRateValue: new Prisma.Decimal('36.5'),
+        exchangeRateDirection: 'DIRECT',
+        exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+        conversionDate: new Date('2026-08-09T00:00:00.000Z'),
+      }),
+    );
+  };
+
+  it('distributes the functional amount by percentage-created nominal weights (60/40)', async () => {
+    setup([
+      { id: 'alloc-1', amountMinor: 600, percentage: 60 },
+      { id: 'alloc-2', amountMinor: 400, percentage: 40 },
+    ]);
+
+    const result = await validate();
+
+    expect(result.functionalAmountMinor).toBe(36500);
+    expect(allocationUpdates).toHaveLength(2);
+    const shares = allocationUpdates.map((update) => update.data.functionalAmountMinor);
+    expect(shares).toEqual([21900, 14600]);
+    expect(
+      allocationUpdates.every((update) => update.data.functionalCurrencyCode === 'VES'),
+    ).toBe(true);
+    expect(shares.reduce((sum, share) => sum + (share as number), 0)).toBe(36500);
+  });
+
+  it('distributes by amount-mode nominal weights and preserves exact sum', async () => {
+    setup([
+      { id: 'alloc-1', amountMinor: 250, percentage: null },
+      { id: 'alloc-2', amountMinor: 750, percentage: null },
+    ]);
+
+    await validate();
+
+    const shares = allocationUpdates.map((update) => update.data.functionalAmountMinor);
+    expect(shares).toEqual([9125, 27375]);
+    expect(shares.reduce((sum, share) => sum + (share as number), 0)).toBe(36500);
+  });
+
+  it('handles thirds with a deterministic residual and exact total', async () => {
+    setup([
+      { id: 'alloc-1', amountMinor: 333, percentage: 33.3 },
+      { id: 'alloc-2', amountMinor: 333, percentage: 33.3 },
+      { id: 'alloc-3', amountMinor: 334, percentage: 33.4 },
+    ]);
+
+    await validate();
+
+    const shares = allocationUpdates.map((update) => update.data.functionalAmountMinor);
+    const total = (shares as number[]).reduce((sum, share) => sum + share, 0);
+    expect(total).toBe(36500);
+    expect(shares.every((share) => Number.isSafeInteger(share))).toBe(true);
+  });
+
+  it('leaves allocations untouched for BUILDING scope expenses', async () => {
+    (prisma.expense.findFirst as jest.Mock).mockResolvedValue(
+      makeSharedExpense({ id: 'exp-building', scopeType: 'BUILDING', buildingId: 'building-1' }),
+    );
+    exchangeRateFindFirst.mockResolvedValue({
+      id: 'rate-1',
+      rate: new Prisma.Decimal('36.5'),
+      effectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+    });
+    (prisma.expense.update as jest.Mock).mockResolvedValue(
+      makeSharedExpense({ scopeType: 'BUILDING', buildingId: 'building-1', status: 'VALIDATED' }),
+    );
+
+    await service.validateExpense('tenant-1', 'exp-building', 'member-1', ['TENANT_ADMIN']);
+
+    expect(prisma.movementAllocation.findMany).not.toHaveBeenCalled();
+    expect(prisma.movementAllocation.update).not.toHaveBeenCalled();
+    expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/finanzas/finanzas.module.spec.ts
+++ b/apps/api/src/finanzas/finanzas.module.spec.ts
@@ -4,7 +4,7 @@ import { LiquidationEngineController } from './liquidation-engine.controller';
 import { LiquidationsController } from './liquidations.controller';
 
 describe('FinanzasModule', () => {
-  it('registers only the hardened liquidation controller route', () => {
+  it('registers the liquidation controllers with the same hardened engine behind both routes', () => {
     const controllersMetadata = Reflect.getMetadata(
       MODULE_METADATA.CONTROLLERS,
       FinanzasModule,
@@ -17,6 +17,6 @@ describe('FinanzasModule', () => {
     const controllers = controllersMetadata;
 
     expect(controllers).toContain(LiquidationsController);
-    expect(controllers).not.toContain(LiquidationEngineController);
+    expect(controllers).toContain(LiquidationEngineController);
   });
 });

--- a/apps/api/src/finanzas/finanzas.module.ts
+++ b/apps/api/src/finanzas/finanzas.module.ts
@@ -23,9 +23,10 @@ import { ExpenseLedgerCategoriesService } from './expense-ledger-categories.serv
 import { ExpensesService } from './expenses.service';
 import { IncomesService } from './incomes.service';
 import { LiquidationsService } from './liquidations.service';
+import { LiquidationEngineService } from './liquidation-engine.service';
+import { LiquidationEngineController } from './liquidation-engine.controller';
 import { MovementAllocationService } from './movement-allocation.service';
 import { UnitGroupService } from './unit-group.service';
-import { LiquidationEngineService } from './liquidation-engine.service';
 import { AdjustmentsService } from './adjustments.service';
 import { PrismaModule } from '../prisma/prisma.module';
 import { ResidentAccessModule } from '../resident-access/resident-access.module';
@@ -77,6 +78,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     ExpensesController,
     IncomesController,
     LiquidationsController,
+    LiquidationEngineController,
     UnitGroupController,
     MovementAllocationController,
     AdjustmentsController,

--- a/apps/api/src/finanzas/liquidation-engine.controller.spec.ts
+++ b/apps/api/src/finanzas/liquidation-engine.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException, UnauthorizedException } from '@nestjs/common';
 import { LiquidationEngineController } from './liquidation-engine.controller';
 import { LiquidationEngineService } from './liquidation-engine.service';
+import { PrismaService } from '../prisma/prisma.service';
 import type { AuthenticatedRequest } from '../common/types/request.types';
 
 describe('LiquidationEngineController', () => {
@@ -47,6 +48,14 @@ describe('LiquidationEngineController', () => {
         {
           provide: LiquidationEngineService,
           useValue: service,
+        },
+        {
+          provide: 'APP_CONFIG',
+          useValue: { jwtSecret: 'test-secret-at-least-32-chars' },
+        },
+        {
+          provide: PrismaService,
+          useValue: { membership: { findFirst: jest.fn() } },
         },
       ],
     }).compile();

--- a/apps/api/src/finanzas/liquidation-engine.controller.ts
+++ b/apps/api/src/finanzas/liquidation-engine.controller.ts
@@ -12,6 +12,7 @@ import {
 } from '@nestjs/common';
 import { IsISO8601, IsString } from 'class-validator';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
 import { AuthenticatedRequest } from '../common/types/request.types';
 import { LiquidationEngineService } from './liquidation-engine.service';
 
@@ -32,7 +33,7 @@ export class PublishLiquidationDto {
 }
 
 @Controller('tenants/:tenantId/liquidations')
-@UseGuards(JwtAuthGuard)
+@UseGuards(JwtAuthGuard, TenantAccessGuard)
 export class LiquidationEngineController {
   constructor(private readonly liquidationEngine: LiquidationEngineService) {}
 

--- a/apps/api/src/finanzas/liquidation-engine.service.spec.ts
+++ b/apps/api/src/finanzas/liquidation-engine.service.spec.ts
@@ -1,901 +1,113 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { BadRequestException, NotFoundException } from '@nestjs/common';
-import { PrismaService } from '../prisma/prisma.service';
-import { AuditService } from '../audit/audit.service';
-import { FinanzasValidators } from './finanzas.validators';
 import { LiquidationEngineService } from './liquidation-engine.service';
+import { LiquidationsService } from './liquidations.service';
 
-describe('LiquidationEngineService', () => {
+describe('LiquidationEngineService (wrapper over LiquidationsService)', () => {
   let service: LiquidationEngineService;
-  let prisma: PrismaService;
-  let auditService: AuditService;
-  let validators: FinanzasValidators;
-
-  const tenantId = 'tenant-123';
-  const buildingId = 'building-456';
-  const membershipId = 'member-789';
+  let m1: {
+    createDraft: jest.Mock;
+    getLiquidation: jest.Mock;
+    reviewLiquidation: jest.Mock;
+    publishLiquidation: jest.Mock;
+    cancelLiquidation: jest.Mock;
+  };
 
   beforeEach(async () => {
+    m1 = {
+      createDraft: jest.fn(),
+      getLiquidation: jest.fn(),
+      reviewLiquidation: jest.fn(),
+      publishLiquidation: jest.fn(),
+      cancelLiquidation: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         LiquidationEngineService,
-        {
-          provide: PrismaService,
-          useValue: {
-            expense: { findMany: jest.fn() },
-            unit: { findMany: jest.fn() },
-            liquidation: {
-              findFirst: jest.fn(),
-              create: jest.fn(),
-              update: jest.fn(),
-              updateMany: jest.fn(),
-              delete: jest.fn(),
-              deleteMany: jest.fn(),
-            },
-            charge: {
-              createMany: jest.fn(),
-              findMany: jest.fn(),
-              deleteMany: jest.fn(),
-            },
-            membership: {
-              findFirst: jest.fn(),
-            },
-            $transaction: jest.fn(),
-          },
-        },
-        {
-          provide: AuditService,
-          useValue: { createLog: jest.fn(), createLogRequired: jest.fn().mockResolvedValue(undefined) },
-        },
-        {
-          provide: FinanzasValidators,
-          useValue: {
-            isAdminOrOperator: jest.fn().mockReturnValue(true),
-            validateBuildingBelongsToTenant: jest.fn().mockResolvedValue(true),
-          },
-        },
+        { provide: LiquidationsService, useValue: m1 },
       ],
     }).compile();
 
     service = module.get<LiquidationEngineService>(LiquidationEngineService);
-    prisma = module.get<PrismaService>(PrismaService);
-    auditService = module.get<AuditService>(AuditService);
-    validators = module.get<FinanzasValidators>(FinanzasValidators);
-    jest.spyOn(prisma, '$transaction').mockImplementation(
-      async (callback) => callback(prisma),
+  });
+
+  it('createLiquidationDraft delegates to M1 with a plain DTO', async () => {
+    m1.createDraft.mockResolvedValue({ id: 'liq-1' });
+
+    const result = await service.createLiquidationDraft(
+      'tenant-1',
+      'building-1',
+      '2026-08',
+      'VES',
+      'member-1',
     );
-    jest.spyOn(prisma.membership, 'findFirst').mockResolvedValue({
-      id: membershipId,
-      tenantId,
-      roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
-    } as never);
+
+    expect(m1.createDraft).toHaveBeenCalledTimes(1);
+    expect(m1.createDraft).toHaveBeenCalledWith('tenant-1', 'member-1', {
+      buildingId: 'building-1',
+      period: '2026-08',
+      baseCurrency: 'VES',
+    });
+    expect(result).toEqual({ id: 'liq-1' });
   });
 
-  describe('createLiquidationDraft', () => {
-    it('debería crear liquidación draft con expenses validadas', async () => {
-      const expenses = [
-        {
-          id: 'exp-1',
-          amountMinor: 100000,
-          currencyCode: 'ARS',
-          category: { name: 'Electricidad' },
-          vendor: { name: 'EDENOR' },
-          allocations: [],
-        },
-        {
-          id: 'exp-2',
-          amountMinor: 50000,
-          currencyCode: 'ARS',
-          category: { name: 'Agua' },
-          vendor: null,
-          allocations: [],
-        },
-      ];
+  it('getLiquidationDetail delegates tenant scoping to M1', async () => {
+    m1.getLiquidation.mockResolvedValue({ id: 'liq-1' });
 
-      const units = [
-        { id: 'unit-1', code: 'A-101', label: '101', m2: 100 },
-        { id: 'unit-2', code: 'A-102', label: '102', m2: 150 },
-      ];
+    const result = await service.getLiquidationDetail('tenant-1', 'liq-1', 'member-1');
 
-      const persistedMembershipId = 'member-persisted-create';
-      jest.spyOn(prisma.membership, 'findFirst').mockResolvedValueOnce({
-        id: persistedMembershipId,
-        tenantId,
-        roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
-      } as never);
-      jest
-        .spyOn(prisma.expense, 'findMany')
-        .mockResolvedValueOnce(expenses as never)
-        .mockResolvedValueOnce([] as never);
-      jest.spyOn(prisma.unit, 'findMany').mockResolvedValue(units as never);
-      const createSpy = jest.spyOn(prisma.liquidation, 'create').mockResolvedValue({
-        id: 'liq-1',
-        tenantId,
-        buildingId,
-        period: '2026-04',
-        status: 'DRAFT',
-        baseCurrency: 'ARS',
-        totalAmountMinor: 150000,
-        totalsByCurrency: { ARS: 150000 },
-        unitCount: 2,
-      } as never);
-
-      const result = await service.createLiquidationDraft(
-        tenantId,
-        buildingId,
-        '2026-04',
-        'ARS',
-        membershipId,
-      );
-
-      expect(result.liquidation.id).toBe('liq-1');
-      expect(result.liquidation.status).toBe('DRAFT');
-      expect(result.chargesPreview.length).toBe(2);
-      expect(createSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({
-            generatedByMembershipId: persistedMembershipId,
-          }),
-        }),
-      );
-      expect(auditService.createLogRequired).toHaveBeenCalledWith(
-        expect.objectContaining({
-          action: 'LIQUIDATION_DRAFT',
-          actorMembershipId: persistedMembershipId,
-        }),
-        prisma,
-      );
-    });
-
-    it('debería lanzar error si no hay gastos validados', async () => {
-      jest
-        .spyOn(prisma.expense, 'findMany')
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([]);
-
-      await expect(
-        service.createLiquidationDraft(
-          tenantId,
-          buildingId,
-          '2026-04',
-          'ARS',
-          membershipId,
-        ),
-      ).rejects.toThrow(BadRequestException);
-    });
-
-    it('debería lanzar error si no hay unidades billables', async () => {
-      const expenses = [
-        {
-          id: 'exp-1',
-          amountMinor: 100000,
-          currencyCode: 'ARS',
-          category: { name: 'Electricidad' },
-          vendor: { name: 'EDENOR' },
-          allocations: [],
-          scopeType: 'BUILDING',
-        },
-      ];
-
-      jest
-        .spyOn(prisma.expense, 'findMany')
-        .mockResolvedValueOnce(expenses as never)
-        .mockResolvedValueOnce([]);
-      jest.spyOn(prisma.unit, 'findMany').mockResolvedValue([]);
-
-      await expect(
-        service.createLiquidationDraft(
-          tenantId,
-          buildingId,
-          '2026-04',
-          'ARS',
-          membershipId,
-        ),
-      ).rejects.toThrow(BadRequestException);
-    });
-
-    it('debería rechazar una membresía inexistente aunque el JWT tenga rol ADMIN', async () => {
-      jest.spyOn(prisma.membership, 'findFirst').mockResolvedValueOnce(null);
-
-      await expect(
-        service.createLiquidationDraft(
-          tenantId,
-          buildingId,
-          '2026-04',
-          'ARS',
-          membershipId,
-        ),
-      ).rejects.toThrow('No se encontró una membresía válida para el tenant');
-    });
-
-    it('debería rechazar una membresía de otro tenant', async () => {
-      jest.spyOn(prisma.membership, 'findFirst').mockResolvedValueOnce(null);
-
-      await expect(
-        service.createLiquidationDraft(
-          'tenant-other',
-          buildingId,
-          '2026-04',
-          'ARS',
-          membershipId,
-        ),
-      ).rejects.toThrow('No se encontró una membresía válida para el tenant');
-    });
-
-    it('debería rechazar una membresía sin rol TENANT autorizado', async () => {
-      jest.spyOn(validators, 'isAdminOrOperator').mockReturnValueOnce(false);
-      jest.spyOn(prisma.membership, 'findFirst').mockResolvedValueOnce({
-        id: membershipId,
-        tenantId,
-        roles: [{ role: 'TENANT_ADMIN', scopeType: 'BUILDING' }],
-      } as never);
-
-      await expect(
-        service.createLiquidationDraft(
-          tenantId,
-          buildingId,
-          '2026-04',
-          'ARS',
-          membershipId,
-        ),
-      ).rejects.toThrow('Solo administradores pueden gestionar liquidaciones');
-    });
+    expect(m1.getLiquidation).toHaveBeenCalledWith('tenant-1', 'liq-1', 'member-1');
+    expect(result).toEqual({ id: 'liq-1' });
   });
 
-  describe('reviewLiquidation', () => {
-    it('debería cambiar estado DRAFT → REVIEWED y persistir reviewedByMembershipId', async () => {
-      const liquidation = {
-        id: 'liq-1',
-        status: 'DRAFT',
-        period: '2026-04',
-      };
-      const reviewedLiquidation = {
-        ...liquidation,
-        status: 'REVIEWED',
-        reviewedByMembershipId: membershipId,
-      };
+  it('reviewLiquidation delegates to M1', async () => {
+    m1.reviewLiquidation.mockResolvedValue({ id: 'liq-1', status: 'REVIEWED' });
 
-      jest.spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValueOnce(liquidation as never)
-        .mockResolvedValueOnce(reviewedLiquidation as never);
-      const updateManySpy = jest
-        .spyOn(prisma.liquidation, 'updateMany')
-        .mockResolvedValue({ count: 1 });
+    const result = await service.reviewLiquidation('tenant-1', 'liq-1', 'member-1');
 
-      const result = await service.reviewLiquidation(
-        tenantId,
-        'liq-1',
-        membershipId
-      );
-
-      expect(result.status).toBe('REVIEWED');
-      expect(result.reviewedByMembershipId).toBe(membershipId);
-      expect(updateManySpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: {
-            id: 'liq-1',
-            tenantId,
-            status: 'DRAFT',
-          },
-        }),
-      );
-
-      const updateArgs = updateManySpy.mock.calls[0][0];
-      expect(updateArgs.data.reviewedAt).toBeInstanceOf(Date);
-      expect(updateArgs.data.updatedAt).toBe(updateArgs.data.reviewedAt);
-      expect(updateArgs.data.reviewedByMembershipId).toBe(membershipId);
-      expect(auditService.createLogRequired).toHaveBeenCalledWith(
-        expect.objectContaining({
-          action: 'LIQUIDATION_REVIEW',
-          actorMembershipId: membershipId,
-          metadata: expect.objectContaining({
-            period: '2026-04',
-            previousStatus: 'DRAFT',
-          }),
-        }),
-        prisma,
-      );
-    });
-
-    it('debería lanzar error si liquidación no existe', async () => {
-      jest.spyOn(prisma.liquidation, 'findFirst').mockResolvedValueOnce(null);
-
-      await expect(
-        service.reviewLiquidation(
-          tenantId,
-          'liq-not-found',
-          membershipId
-        ),
-      ).rejects.toThrow(NotFoundException);
-    });
-
-    it('debería lanzar error si status no es DRAFT', async () => {
-      jest
-        .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValueOnce({ id: 'liq-1', status: 'PUBLISHED', period: '2026-04' } as never);
-
-      await expect(
-        service.reviewLiquidation(
-          tenantId,
-          'liq-1',
-          membershipId
-        ),
-      ).rejects.toThrow(BadRequestException);
-    });
-
-    it('debería lanzar error si la carrera deja la liquidación sin actualizar', async () => {
-      jest
-        .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValueOnce({ id: 'liq-1', status: 'DRAFT', period: '2026-04' } as never);
-      jest.spyOn(prisma.liquidation, 'updateMany').mockResolvedValue({ count: 0 });
-
-      await expect(
-        service.reviewLiquidation(
-          tenantId,
-          'liq-1',
-          membershipId
-        ),
-      ).rejects.toThrow('No fue posible revisar la liquidación porque cambió de estado');
-    });
-
-    it('debería revertir la revisión si falla la auditoría obligatoria', async () => {
-      const liquidation = {
-        id: 'liq-1',
-        status: 'DRAFT',
-        period: '2026-04',
-      };
-      let persistedStatus = 'DRAFT';
-      const transactionClient = {
-        ...prisma,
-        liquidation: {
-          ...prisma.liquidation,
-          findFirst: jest.fn().mockImplementation(async () => (
-            persistedStatus === 'REVIEWED'
-              ? {
-                ...liquidation,
-                status: 'REVIEWED',
-                reviewedByMembershipId: membershipId,
-              }
-              : liquidation
-          )),
-          updateMany: jest.fn().mockImplementation(async ({ data }) => {
-            persistedStatus = data.status;
-            return { count: 1 };
-          }),
-        },
-      };
-
-      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback) => {
-        const snapshot = persistedStatus;
-        try {
-          return await callback(transactionClient);
-        } catch (error) {
-          persistedStatus = snapshot;
-          throw error;
-        }
-      });
-      jest.spyOn(auditService, 'createLogRequired').mockRejectedValueOnce(new Error('audit failed'));
-      jest.spyOn(prisma.liquidation, 'findFirst').mockResolvedValueOnce(liquidation as never);
-
-      await expect(
-        service.reviewLiquidation(
-          tenantId,
-          'liq-1',
-          membershipId
-        ),
-      ).rejects.toThrow('audit failed');
-
-      expect(persistedStatus).toBe('DRAFT');
-    });
+    expect(m1.reviewLiquidation).toHaveBeenCalledWith('tenant-1', 'liq-1', 'member-1');
+    expect(result.status).toBe('REVIEWED');
   });
 
-  describe('publishLiquidation', () => {
-    it('debería cambiar estado REVIEWED → PUBLISHED y crear charges', async () => {
-      const liquidation = {
-        id: 'liq-1',
-        status: 'REVIEWED',
-        buildingId,
-        period: '2026-04',
-        baseCurrency: 'ARS',
-      };
+  it('publishLiquidation delegates with an ISO due date', async () => {
+    m1.publishLiquidation.mockResolvedValue({ id: 'liq-1', status: 'PUBLISHED' });
+    const dueDate = new Date('2026-09-15T00:00:00.000Z');
 
-      const expenses = [
-        {
-          id: 'exp-1',
-          amountMinor: 120000,
-          currencyCode: 'ARS',
-          category: { name: 'Electricidad' },
-          vendor: { name: 'EDENOR' },
-          invoiceDate: new Date('2026-04-10'),
-          description: 'Servicio eléctrico',
-          allocations: [],
-          scopeType: 'BUILDING',
-        },
-      ];
+    const result = await service.publishLiquidation(
+      'tenant-1',
+      'liq-1',
+      dueDate,
+      'member-1',
+    );
 
-      const units = [
-        { id: 'unit-1', code: 'A-101', label: '101', m2: 100 },
-        { id: 'unit-2', code: 'A-102', label: '102', m2: 200 },
-      ];
-
-      const persistedMembershipId = 'member-persisted-publish';
-      jest.spyOn(prisma.membership, 'findFirst').mockResolvedValueOnce({
-        id: persistedMembershipId,
-        tenantId,
-        roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
-      } as never);
-      jest
-        .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValue(liquidation as never);
-      jest
-        .spyOn(prisma.expense, 'findMany')
-        .mockResolvedValueOnce(expenses as never)
-        .mockResolvedValueOnce([] as never);
-      jest.spyOn(prisma.unit, 'findMany').mockResolvedValue(units as never);
-      jest
-        .spyOn(prisma.charge, 'createMany')
-        .mockResolvedValue({ count: 2 });
-      jest
-        .spyOn(prisma.liquidation, 'update')
-        .mockResolvedValue({
-          ...liquidation,
-          status: 'PUBLISHED',
-        } as never);
-
-      const dueDate = new Date('2026-05-30');
-      const result = await service.publishLiquidation(
-        tenantId,
-        'liq-1',
-        dueDate,
-        membershipId,
-      );
-
-      expect(result.status).toBe('PUBLISHED');
-      expect(prisma.charge.createMany).toHaveBeenCalled();
-      expect(prisma.liquidation.update).toHaveBeenCalledWith(
-        expect.objectContaining({
-          data: expect.objectContaining({
-            publicationSnapshot: expect.objectContaining({
-              version: 1,
-              liquidationId: 'liq-1',
-              totalAmountMinor: 120000,
-              publishedAt: expect.any(String),
-              allocations: expect.arrayContaining([
-                expect.objectContaining({ unitId: 'unit-1' }),
-              ]),
-            }),
-            publishedAt: expect.any(Date),
-            publishedByMembershipId: persistedMembershipId,
-          }),
-        }),
-      );
-      expect(auditService.createLogRequired).toHaveBeenCalledWith(
-        expect.objectContaining({
-          action: 'LIQUIDATION_PUBLISH',
-          actorMembershipId: persistedMembershipId,
-        }),
-        prisma,
-      );
+    expect(m1.publishLiquidation).toHaveBeenCalledWith('tenant-1', 'liq-1', 'member-1', {
+      dueDate: '2026-09-15T00:00:00.000Z',
     });
-
-    it('debería distribuir centavos exactos con Largest Remainder y reflejarlos en la snapshot', async () => {
-      const liquidation = {
-        id: 'liq-1',
-        status: 'REVIEWED',
-        buildingId,
-        period: '2026-04',
-        baseCurrency: 'ARS',
-      };
-
-      const expenses = [
-        {
-          id: 'exp-1',
-          amountMinor: 100,
-          currencyCode: 'ARS',
-          category: { name: 'Electricidad' },
-          vendor: { name: 'EDENOR' },
-          invoiceDate: new Date('2026-04-10'),
-          description: 'Servicio eléctrico',
-          allocations: [],
-          scopeType: 'BUILDING',
-        },
-      ];
-
-      const units = [
-        { id: 'unit-c', code: 'C-103', label: '103', m2: 1 },
-        { id: 'unit-a', code: 'A-101', label: '101', m2: 1 },
-        { id: 'unit-b', code: 'B-102', label: '102', m2: 1 },
-      ];
-
-      jest.spyOn(prisma.membership, 'findFirst').mockResolvedValueOnce({
-        id: 'member-persisted-publish',
-        tenantId,
-        roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
-      } as never);
-      jest
-        .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValueOnce(liquidation as never);
-      jest
-        .spyOn(prisma.expense, 'findMany')
-        .mockResolvedValueOnce(expenses as never)
-        .mockResolvedValueOnce([] as never);
-      jest.spyOn(prisma.unit, 'findMany').mockResolvedValue(units as never);
-      const createManySpy = jest
-        .spyOn(prisma.charge, 'createMany')
-        .mockResolvedValue({ count: 3 });
-      jest.spyOn(prisma.liquidation, 'update').mockImplementation(async ({ data }) => ({
-        ...liquidation,
-        status: 'PUBLISHED',
-        publicationSnapshot: data.publicationSnapshot,
-        publishedAt: data.publishedAt,
-        publishedByMembershipId: data.publishedByMembershipId,
-      }) as never);
-
-      const result = await service.publishLiquidation(
-        tenantId,
-        'liq-1',
-        new Date('2026-05-30'),
-        membershipId,
-      );
-
-      expect(result.status).toBe('PUBLISHED');
-
-      const chargeAmounts = createManySpy.mock.calls[0][0].data.map(
-        (charge) => charge.amount,
-      );
-      expect(chargeAmounts).toEqual([34, 33, 33]);
-
-      expect(
-        (result.publicationSnapshot as {
-          allocations: Array<{ unitId: string; amountMinor: number }>;
-        }).allocations.map((allocation) => allocation.amountMinor),
-      ).toEqual([34, 33, 33]);
-      expect(
-        (result.publicationSnapshot as {
-          allocations: Array<{ unitId: string; amountMinor: number }>;
-        }).allocations.reduce((sum, allocation) => sum + allocation.amountMinor, 0),
-      ).toBe(100);
-    });
-
-    it('rolls back publication when required audit logging fails', async () => {
-      const liquidation = {
-        id: 'liq-1',
-        status: 'REVIEWED',
-        buildingId,
-        period: '2026-04',
-        baseCurrency: 'ARS',
-      };
-      const expenses = [{
-        id: 'exp-1',
-        amountMinor: 120000,
-        currencyCode: 'ARS',
-        category: { name: 'Electricidad' },
-        vendor: { name: 'EDENOR' },
-        invoiceDate: new Date('2026-04-10'),
-        description: 'Servicio eléctrico',
-        allocations: [],
-        scopeType: 'BUILDING',
-      }];
-      const units = [
-        { id: 'unit-1', code: 'A-101', label: '101', m2: 100 },
-        { id: 'unit-2', code: 'A-102', label: '102', m2: 200 },
-      ];
-      let persistedStatus = 'REVIEWED';
-      const transactionClient = {
-        ...prisma,
-        charge: {
-          ...prisma.charge,
-          createMany: jest.fn().mockResolvedValue({ count: 2 }),
-        },
-        liquidation: {
-          ...prisma.liquidation,
-          update: jest.fn().mockImplementation(async () => ({
-            ...liquidation,
-            status: 'PUBLISHED',
-          })),
-        },
-      };
-
-      jest.spyOn(prisma.liquidation, 'findFirst').mockResolvedValue(liquidation as never);
-      jest.spyOn(prisma.expense, 'findMany')
-        .mockResolvedValueOnce(expenses as never)
-        .mockResolvedValueOnce([] as never);
-      jest.spyOn(prisma.unit, 'findMany').mockResolvedValue(units as never);
-      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback) => {
-        try {
-          const result = await callback(transactionClient);
-          persistedStatus = 'PUBLISHED';
-          return result;
-        } catch (error) {
-          throw error;
-        }
-      });
-      jest.spyOn(auditService, 'createLogRequired').mockRejectedValueOnce(new Error('audit failed'));
-
-      await expect(
-        service.publishLiquidation(
-          tenantId,
-          liquidation.id,
-          new Date('2026-05-30'),
-          membershipId,
-        ),
-      ).rejects.toThrow('audit failed');
-
-      expect(persistedStatus).toBe('REVIEWED');
-      expect(transactionClient.charge.createMany).toHaveBeenCalledTimes(1);
-      expect(transactionClient.liquidation.update).toHaveBeenCalledTimes(1);
-      expect(auditService.createLogRequired).toHaveBeenCalledWith(
-        expect.objectContaining({ action: 'LIQUIDATION_PUBLISH' }),
-        transactionClient,
-      );
-    });
-
-    it('debería lanzar error si status no es REVIEWED', async () => {
-      jest
-        .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValue({ id: 'liq-1', status: 'DRAFT' } as never);
-
-      await expect(
-        service.publishLiquidation(
-          tenantId,
-          'liq-1',
-          new Date(),
-          membershipId,
-        ),
-      ).rejects.toThrow(BadRequestException);
-    });
+    expect(result.status).toBe('PUBLISHED');
   });
 
-  describe('cancelLiquidation', () => {
-    it('debería cambiar estado DRAFT → CANCELED sin borrar la liquidación ni los cargos', async () => {
-      const liquidation = {
-        id: 'liq-1',
-        status: 'DRAFT',
-        period: '2026-04',
-      };
-      const canceledLiquidation = {
-        ...liquidation,
-        status: 'CANCELED',
-        canceledByMembershipId: membershipId,
-      };
+  it('cancelLiquidation delegates to M1', async () => {
+    m1.cancelLiquidation.mockResolvedValue({ id: 'liq-1', status: 'CANCELED' });
 
-      jest
-        .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValueOnce(liquidation as never)
-        .mockResolvedValueOnce(canceledLiquidation as never);
-      const updateManySpy = jest
-        .spyOn(prisma.liquidation, 'updateMany')
-        .mockResolvedValue({ count: 1 });
+    const result = await service.cancelLiquidation('tenant-1', 'liq-1', 'member-1');
 
-      const result = await service.cancelLiquidation(
-        tenantId,
-        'liq-1',
-        membershipId
-      );
-
-      expect(result.status).toBe('CANCELED');
-      expect(result.canceledByMembershipId).toBe(membershipId);
-      expect(prisma.charge.deleteMany).not.toHaveBeenCalled();
-      expect(prisma.liquidation.delete).not.toHaveBeenCalled();
-      expect(updateManySpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: {
-            id: 'liq-1',
-            tenantId,
-            status: { in: ['DRAFT', 'REVIEWED'] },
-          },
-        }),
-      );
-      const updateArgs = updateManySpy.mock.calls[0][0];
-      expect(updateArgs.data.canceledAt).toBeInstanceOf(Date);
-      expect(updateArgs.data.updatedAt).toBe(updateArgs.data.canceledAt);
-      expect(updateArgs.data.canceledByMembershipId).toBe(membershipId);
-      expect(auditService.createLogRequired).toHaveBeenCalledWith(
-        expect.objectContaining({
-          action: 'LIQUIDATION_CANCEL',
-          actorMembershipId: membershipId,
-          metadata: expect.objectContaining({
-            period: '2026-04',
-            previousStatus: 'DRAFT',
-          }),
-        }),
-        prisma,
-      );
-    });
-
-    it('debería permitir cancelar una liquidación REVIEWED', async () => {
-      jest
-        .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValueOnce({ id: 'liq-1', status: 'REVIEWED', period: '2026-04' } as never)
-        .mockResolvedValueOnce({
-          id: 'liq-1',
-          status: 'CANCELED',
-          period: '2026-04',
-        } as never);
-      jest.spyOn(prisma.liquidation, 'updateMany').mockResolvedValue({ count: 1 });
-
-      const result = await service.cancelLiquidation(
-        tenantId,
-        'liq-1',
-        membershipId
-      );
-
-      expect(result.status).toBe('CANCELED');
-    });
-
-    it('debería rechazar cancelación directa de liquidaciones PUBLISHED', async () => {
-      jest
-        .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValueOnce({ id: 'liq-1', status: 'PUBLISHED', period: '2026-04' } as never);
-
-      await expect(
-        service.cancelLiquidation(
-          tenantId,
-          'liq-1',
-          membershipId
-        ),
-      ).rejects.toThrow('La liquidación publicada no se puede cancelar directamente');
-    });
-
-    it('debería rechazar una liquidación ya CANCELED', async () => {
-      jest
-        .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValueOnce({ id: 'liq-1', status: 'CANCELED', period: '2026-04' } as never);
-
-      await expect(
-        service.cancelLiquidation(
-          tenantId,
-          'liq-1',
-          membershipId
-        ),
-      ).rejects.toThrow(BadRequestException);
-    });
-
-    it('debería lanzar error si la carrera deja la liquidación sin actualizar', async () => {
-      jest
-        .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValueOnce({ id: 'liq-1', status: 'DRAFT', period: '2026-04' } as never);
-      jest.spyOn(prisma.liquidation, 'updateMany').mockResolvedValue({ count: 0 });
-
-      await expect(
-        service.cancelLiquidation(
-          tenantId,
-          'liq-1',
-          membershipId
-        ),
-      ).rejects.toThrow('No fue posible cancelar la liquidación porque cambió de estado');
-    });
-
-    it('debería revertir la cancelación si falla la auditoría obligatoria', async () => {
-      const liquidation = {
-        id: 'liq-1',
-        status: 'DRAFT',
-        period: '2026-04',
-      };
-      let persistedStatus = 'DRAFT';
-      const transactionClient = {
-        ...prisma,
-        liquidation: {
-          ...prisma.liquidation,
-          findFirst: jest.fn().mockImplementation(async () => (
-            persistedStatus === 'CANCELED'
-              ? {
-                ...liquidation,
-                status: 'CANCELED',
-                canceledByMembershipId: membershipId,
-              }
-              : liquidation
-          )),
-          updateMany: jest.fn().mockImplementation(async ({ data }) => {
-            persistedStatus = data.status;
-            return { count: 1 };
-          }),
-        },
-      };
-
-      jest.spyOn(prisma, '$transaction').mockImplementation(async (callback) => {
-        const snapshot = persistedStatus;
-        try {
-          return await callback(transactionClient);
-        } catch (error) {
-          persistedStatus = snapshot;
-          throw error;
-        }
-      });
-      jest.spyOn(auditService, 'createLogRequired').mockRejectedValueOnce(new Error('audit failed'));
-      jest.spyOn(prisma.liquidation, 'findFirst').mockResolvedValueOnce(liquidation as never);
-
-      await expect(
-        service.cancelLiquidation(
-          tenantId,
-          'liq-1',
-          membershipId
-        ),
-      ).rejects.toThrow('audit failed');
-
-      expect(persistedStatus).toBe('DRAFT');
-    });
+    expect(m1.cancelLiquidation).toHaveBeenCalledWith('tenant-1', 'liq-1', 'member-1');
+    expect(result.status).toBe('CANCELED');
   });
 
-  describe('getLiquidationDetail', () => {
-    it('debería retornar liquidación con expenses y charges', async () => {
-      const liquidation = {
-        id: 'liq-1',
-        status: 'PUBLISHED',
-        buildingId,
-        period: '2026-04',
-      };
+  it('cannot bypass M1 rules: baseCurrency is always forwarded to M1', async () => {
+    m1.createDraft.mockRejectedValue(
+      new Error('LIQUIDATION_BASE_CURRENCY_MISMATCH'),
+    );
 
-      const expenses = [
-        {
-          id: 'exp-1',
-          amountMinor: 100000,
-          currencyCode: 'ARS',
-          category: { name: 'Electricidad' },
-          vendor: { name: 'EDENOR' },
-        },
-      ];
+    await expect(
+      service.createLiquidationDraft('tenant-1', 'building-1', '2026-08', 'ARS', 'member-1'),
+    ).rejects.toThrow('LIQUIDATION_BASE_CURRENCY_MISMATCH');
 
-      const charges = [
-        {
-          unitId: 'unit-1',
-          amount: 40000,
-          unit: { code: 'A-101', label: '101', m2: 100 },
-        },
-        {
-          unitId: 'unit-2',
-          amount: 60000,
-          unit: { code: 'A-102', label: '102', m2: 150 },
-        },
-      ];
-
-      jest
-        .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValue(liquidation as never);
-      jest.spyOn(prisma.expense, 'findMany').mockResolvedValue(expenses as never);
-      jest.spyOn(prisma.charge, 'findMany').mockResolvedValue(charges as never);
-
-      const result = await service.getLiquidationDetail(
-        tenantId,
-        'liq-1',
-        membershipId,
-      );
-
-      expect(result.id).toBe('liq-1');
-      expect(result.expenses.length).toBe(1);
-      expect(result.chargesPreview.length).toBe(2);
-    });
-
-    it('debería retornar chargesPreview vacío si DRAFT', async () => {
-      jest
-        .spyOn(prisma.liquidation, 'findFirst')
-        .mockResolvedValue({
-          id: 'liq-1',
-          status: 'DRAFT',
-          buildingId,
-          period: '2026-04',
-        } as never);
-      jest.spyOn(prisma.expense, 'findMany').mockResolvedValue([]);
-
-      const result = await service.getLiquidationDetail(
-        tenantId,
-        'liq-1',
-        membershipId,
-      );
-
-      expect(result.chargesPreview).toEqual([]);
-    });
-
-    it('debería rechazar detail si la membresía no existe o no pertenece al tenant', async () => {
-      jest.spyOn(prisma.membership, 'findFirst').mockResolvedValueOnce(null);
-
-      await expect(
-        service.getLiquidationDetail(
-          tenantId,
-          'liq-1',
-          'member-missing',
-        ),
-      ).rejects.toThrow('No se encontró una membresía válida para el tenant');
-    });
+    expect(m1.createDraft).toHaveBeenCalledWith(
+      'tenant-1',
+      'member-1',
+      expect.objectContaining({ baseCurrency: 'ARS' }),
+    );
   });
 });

--- a/apps/api/src/finanzas/liquidation-engine.service.ts
+++ b/apps/api/src/finanzas/liquidation-engine.service.ts
@@ -1,69 +1,23 @@
-import {
-  Injectable,
-  BadRequestException,
-  NotFoundException,
-  ForbiddenException,
-} from '@nestjs/common';
-import { Prisma } from '@prisma/client';
-import { PrismaService } from '../prisma/prisma.service';
-import { AuditService } from '../audit/audit.service';
-import { FinanzasValidators } from './finanzas.validators';
-import {
-  buildLiquidationPublicationSnapshot,
-  distributeLiquidationAmountByLargestRemainder,
-} from './liquidation-publication-snapshot';
+import { Injectable } from '@nestjs/common';
+import { LiquidationsService } from './liquidations.service';
 
-export interface LiquidationCalculationInput {
-  buildingId: string;
-  period: string; // YYYY-MM
-  baseCurrency: string;
-}
-
-export interface ChargeAllocation {
-  unitId: string;
-  unitCode: string;
-  unitLabel: string | null;
-  areaM2: number;
-  amountMinor: number; // prorrateo o monto fijo
-}
-
-type LiquidationExpense = Prisma.ExpenseGetPayload<{
-  include: {
-    category: {
-      select: {
-        name: true;
-      };
-    };
-    vendor: {
-      select: {
-        name: true;
-      };
-    };
-    allocations: true;
-  };
-}>;
-
-type LiquidationUnit = Prisma.UnitGetPayload<{
-  select: {
-    id: true;
-    code: true;
-    label: true;
-    m2: true;
-  };
-}>;
-
+/**
+ * Thin facade over LiquidationsService (M1).
+ *
+ * Keeps the legacy route `/tenants/:tenantId/liquidations` working while
+ * guaranteeing that every write operation goes through the exact same
+ * invariants as the active engine: tenant/building scoping, membership and
+ * role checks, valuation mode determination, mixed-currency guards and
+ * publication snapshot reconciliation.
+ *
+ * No monetary logic lives here; baseCurrency is always resolved by M1 rules
+ * (functional currency validation for FUNCTIONAL drafts, single-currency
+ * match for LEGACY_NOMINAL drafts).
+ */
 @Injectable()
 export class LiquidationEngineService {
-  constructor(
-    private readonly prisma: PrismaService,
-    private readonly auditService: AuditService,
-    private readonly validators: FinanzasValidators,
-  ) {}
+  constructor(private readonly liquidations: LiquidationsService) {}
 
-  /**
-   * Create a draft liquidation for a building/period
-   * Aggregates all VALIDATED expenses, allocates to units using prorrateo or allocation rules
-   */
   async createLiquidationDraft(
     tenantId: string,
     buildingId: string,
@@ -71,616 +25,60 @@ export class LiquidationEngineService {
     baseCurrency: string,
     membershipId: string,
   ) {
-    const membership = await this.requireFinanceMembership(
-      this.prisma,
+    return this.liquidations.createDraft(tenantId, membershipId, {
+      buildingId,
+      period,
+      baseCurrency,
+    });
+  }
+
+  async getLiquidationDetail(
+    tenantId: string,
+    liquidationId: string,
+    membershipId: string,
+  ) {
+    return this.liquidations.getLiquidation(
       tenantId,
+      liquidationId,
       membershipId,
     );
-
-    await this.validators.validateBuildingBelongsToTenant(tenantId, buildingId);
-
-    // Verificar que no exista liquidación en DRAFT/PUBLISHED para este período
-    const existing = await this.prisma.liquidation.findFirst({
-      where: {
-        tenantId,
-        buildingId,
-        period,
-        status: { not: 'CANCELED' },
-      },
-    });
-
-    if (existing) {
-      throw new BadRequestException(
-        `Ya existe una liquidación en estado ${existing.status} para ${period}`,
-      );
-    }
-
-    // 1. Gastos propios del edificio (scopeType BUILDING)
-    const buildingExpenses = await this.prisma.expense.findMany({
-      where: { tenantId, buildingId, period, status: 'VALIDATED' },
-      include: {
-        category: { select: { name: true } },
-        vendor: { select: { name: true } },
-        allocations: true,
-      },
-    });
-
-    // 2. Gastos de condominio (TENANT_SHARED) con allocation para este edificio
-    const sharedExpenses = await this.prisma.expense.findMany({
-      where: {
-        tenantId,
-        period,
-        status: 'VALIDATED',
-        scopeType: 'TENANT_SHARED',
-        allocations: { some: { buildingId } },
-      },
-      include: {
-        category: { select: { name: true } },
-        vendor: { select: { name: true } },
-        allocations: { where: { buildingId } },
-      },
-    });
-
-    const allExpenses = [...buildingExpenses, ...sharedExpenses];
-
-    if (allExpenses.length === 0) {
-      throw new BadRequestException(
-        `No hay gastos validados para ${period} en este edificio`,
-      );
-    }
-
-    // Calcular totales: BUILDING usa monto completo, TENANT_SHARED usa la porción de este edificio
-    const buildingTotal = buildingExpenses.reduce((s, e) => s + e.amountMinor, 0);
-    const sharedTotal = sharedExpenses.reduce((s, e) => {
-      const alloc = e.allocations[0];
-      if (!alloc) return s;
-      const amount = alloc.amountMinor ?? Math.floor(e.amountMinor * (alloc.percentage ?? 0) / 100);
-      return s + amount;
-    }, 0);
-    const totalAmountMinor = buildingTotal + sharedTotal;
-
-    const totalsByCurrency: Record<string, number> = {};
-    buildingExpenses.forEach((exp) => {
-      totalsByCurrency[exp.currencyCode] =
-        (totalsByCurrency[exp.currencyCode] ?? 0) + exp.amountMinor;
-    });
-    sharedExpenses.forEach((exp) => {
-      const alloc = exp.allocations[0];
-      if (!alloc) return;
-      const amount = alloc.amountMinor ?? Math.floor(exp.amountMinor * (alloc.percentage ?? 0) / 100);
-      totalsByCurrency[exp.currencyCode] = (totalsByCurrency[exp.currencyCode] ?? 0) + amount;
-    });
-
-    // Obtener unidades del building (solo billables)
-    const units = await this.prisma.unit.findMany({
-      where: { tenantId, buildingId, isBillable: true },
-      select: { id: true, code: true, label: true, m2: true },
-    });
-
-    if (units.length === 0) {
-      throw new BadRequestException(
-        'El edificio no tiene unidades billables registradas',
-      );
-    }
-
-    // Calcular allocations: prorrateo por m2 del total combinado
-    const chargesPreview = this.calculateCharges(
-      allExpenses,
-      units,
-      totalAmountMinor,
-    );
-
-    // Crear liquidación en DRAFT
-    const liquidation = await this.prisma.$transaction(async (tx) => {
-      const created = await tx.liquidation.create({
-        data: {
-        tenantId,
-        buildingId,
-        period,
-        status: 'DRAFT',
-        baseCurrency,
-        totalAmountMinor,
-        totalsByCurrency,
-        expenseSnapshot: allExpenses.map((e) => {
-          const isShared = e.scopeType === 'TENANT_SHARED';
-          const alloc = isShared ? e.allocations[0] : null;
-          const amount = isShared && alloc
-            ? (alloc.amountMinor ?? Math.floor(e.amountMinor * (alloc.percentage ?? 0) / 100))
-            : e.amountMinor;
-          return {
-            expenseId: e.id,
-            amountMinor: amount,
-            currencyCode: e.currencyCode,
-            scopeType: e.scopeType,
-          };
-        }),
-        unitCount: units.length,
-        generatedByMembershipId: membership.id,
-        },
-      });
-
-      await this.auditService.createLogRequired({
-        tenantId,
-        actorMembershipId: membership.id,
-        action: 'LIQUIDATION_DRAFT',
-        entityType: 'Liquidation',
-        entityId: created.id,
-        metadata: {
-          period,
-          buildingId,
-          expenseCount: allExpenses.length,
-          buildingExpenseCount: buildingExpenses.length,
-          sharedExpenseCount: sharedExpenses.length,
-          totalAmountMinor,
-        },
-      }, tx);
-
-      return created;
-    });
-
-    return {
-      liquidation,
-      expenses: allExpenses.map((e) => {
-        const isShared = e.scopeType === 'TENANT_SHARED';
-        const alloc = isShared ? e.allocations[0] : null;
-        const amount = isShared && alloc
-          ? (alloc.amountMinor ?? Math.floor(e.amountMinor * (alloc.percentage ?? 0) / 100))
-          : e.amountMinor;
-        return {
-          id: e.id,
-          categoryName: e.category.name,
-          vendorName: e.vendor?.name ?? null,
-          amountMinor: amount,
-          currencyCode: e.currencyCode,
-          invoiceDate: e.invoiceDate,
-          description: e.description,
-          scopeType: e.scopeType,
-        };
-      }),
-      chargesPreview,
-    };
   }
 
-  /**
-   * Calculate charge allocations for units
-   * Rules:
-   * - BUILDING scope: prorrateo por m2
-   * - TENANT_SHARED scope: usar MovementAllocation % o amounts
-   * - UNIT_GROUP scope: prorrateo solo dentro del grupo
-   */
-  private calculateCharges(
-    _expenses: ReadonlyArray<unknown>,
-    units: LiquidationUnit[],
-    totalAmountMinor: number,
-  ): ChargeAllocation[] {
-    // Por ahora: prorrateo simple por m2 para BUILDING scope
-    // TODO: soporte para TENANT_SHARED y UNIT_GROUP scopes
-
-    return distributeLiquidationAmountByLargestRemainder(
-      units.map((unit) => ({
-        id: unit.id,
-        code: unit.code,
-        label: unit.label,
-        areaM2: unit.m2 ?? 0,
-      })),
-      totalAmountMinor,
-    );
-  }
-
-  /**
-   * Publish a draft liquidation → status REVIEWED
-   * This locks the liquidation for review before final publication
-   */
   async reviewLiquidation(
     tenantId: string,
     liquidationId: string,
     membershipId: string,
   ) {
-    return this.prisma.$transaction(async (tx) => {
-      const membership = await this.requireFinanceMembership(tx, tenantId, membershipId);
-      const liquidation = await tx.liquidation.findFirst({
-        where: { id: liquidationId, tenantId },
-        select: {
-          id: true,
-          status: true,
-          period: true,
-        },
-      });
-
-      if (!liquidation) {
-        throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-      }
-
-      if (liquidation.status !== 'DRAFT') {
-        throw new BadRequestException(
-          `La liquidación debe estar en DRAFT. Estado actual: ${liquidation.status}`,
-        );
-      }
-
-      const reviewedAt = new Date();
-      const updateResult = await tx.liquidation.updateMany({
-        where: { id: liquidationId, tenantId, status: 'DRAFT' },
-        data: {
-          status: 'REVIEWED',
-          reviewedAt,
-          reviewedByMembershipId: membership.id,
-          updatedAt: reviewedAt,
-        },
-      });
-
-      if (updateResult.count !== 1) {
-        throw new BadRequestException(
-          'No fue posible revisar la liquidación porque cambió de estado',
-        );
-      }
-
-      const updated = await tx.liquidation.findFirst({
-        where: { id: liquidationId, tenantId },
-      });
-
-      if (!updated) {
-        throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-      }
-
-      await this.auditService.createLogRequired({
-        tenantId,
-        actorMembershipId: membership.id,
-        action: 'LIQUIDATION_REVIEW',
-        entityType: 'Liquidation',
-        entityId: liquidationId,
-        metadata: { period: liquidation.period, previousStatus: 'DRAFT' },
-      }, tx);
-
-      return updated;
-    });
+    return this.liquidations.reviewLiquidation(
+      tenantId,
+      liquidationId,
+      membershipId,
+    );
   }
 
-  /**
-   * Publish a reviewed liquidation → status PUBLISHED
-   * Creates charges for all units based on calculated allocations
-   */
   async publishLiquidation(
     tenantId: string,
     liquidationId: string,
     dueDate: Date,
     membershipId: string,
   ) {
-    return this.prisma.$transaction(async (tx) => {
-      const membership = await this.requireFinanceMembership(tx, tenantId, membershipId);
-      const liquidation = await tx.liquidation.findFirst({
-        where: { id: liquidationId, tenantId },
-      });
-
-      if (!liquidation) {
-        throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-      }
-
-      if (liquidation.status !== 'REVIEWED') {
-        throw new BadRequestException(
-          `La liquidación debe estar en REVIEWED. Estado actual: ${liquidation.status}`,
-        );
-      }
-
-      const buildingExpenses = await tx.expense.findMany({
-        where: {
-          tenantId,
-          buildingId: liquidation.buildingId,
-          period: liquidation.period,
-          status: 'VALIDATED',
-        },
-        include: {
-          category: { select: { name: true } },
-          vendor: { select: { name: true } },
-          allocations: true,
-        },
-      });
-
-      const sharedExpenses = await tx.expense.findMany({
-        where: {
-          tenantId,
-          period: liquidation.period,
-          status: 'VALIDATED',
-          scopeType: 'TENANT_SHARED',
-          allocations: { some: { buildingId: liquidation.buildingId } },
-        },
-        include: {
-          category: { select: { name: true } },
-          vendor: { select: { name: true } },
-          allocations: { where: { buildingId: liquidation.buildingId } },
-        },
-      });
-
-      const units = await tx.unit.findMany({
-        where: { tenantId, buildingId: liquidation.buildingId, isBillable: true },
-        select: { id: true, code: true, label: true, m2: true },
-      });
-
-      const buildingTotal = buildingExpenses.reduce(
-        (sum, expense) => sum + expense.amountMinor,
-        0,
-      );
-      const sharedTotal = sharedExpenses.reduce((sum, expense) => {
-        const allocation = expense.allocations[0];
-        if (!allocation) {
-          return sum;
-        }
-
-        return sum + (
-          allocation.amountMinor
-          ?? Math.floor(expense.amountMinor * (allocation.percentage ?? 0) / 100)
-        );
-      }, 0);
-      const totalAmountMinor = buildingTotal + sharedTotal;
-      const allExpenses = [...buildingExpenses, ...sharedExpenses];
-      const charges = this.calculateCharges(allExpenses, units, totalAmountMinor);
-      const totalsByCurrency: Record<string, number> = {};
-      const publicationExpenses = allExpenses.map((expense) => {
-        const allocation = expense.scopeType === 'TENANT_SHARED'
-          ? expense.allocations[0]
-          : undefined;
-        const amountMinor = allocation
-          ? (
-            allocation.amountMinor
-            ?? Math.floor(expense.amountMinor * (allocation.percentage ?? 0) / 100)
-          )
-          : expense.amountMinor;
-
-        totalsByCurrency[expense.currencyCode] =
-          (totalsByCurrency[expense.currencyCode] ?? 0) + amountMinor;
-
-        return {
-          expenseId: expense.id,
-          categoryName: expense.category.name,
-          vendorName: expense.vendor?.name ?? null,
-          amountMinor,
-          currencyCode: expense.currencyCode,
-          invoiceDate: expense.invoiceDate.toISOString(),
-          description: expense.description,
-          type: 'EXPENSE' as const,
-        };
-      });
-      const publishedAt = new Date();
-      const publicationSnapshot = buildLiquidationPublicationSnapshot({
-        liquidationId: liquidation.id,
-        tenantId,
-        buildingId: liquidation.buildingId,
-        period: liquidation.period,
-        baseCurrency: liquidation.baseCurrency,
-        totalAmountMinor,
-        totalsByCurrency,
-        expenses: publicationExpenses,
-        allocations: charges.map((charge) => ({
-          unitId: charge.unitId,
-          unitCode: charge.unitCode,
-          unitLabel: charge.unitLabel,
-          amountMinor: charge.amountMinor,
-        })),
-        dueDate,
-        publishedAt,
-      });
-
-      const chargeRecords = await tx.charge.createMany({
-        data: charges.map((charge) => ({
-        tenantId,
-        buildingId: liquidation.buildingId,
-        unitId: charge.unitId,
-        period: liquidation.period,
-        concept: `Expensas Comunes - ${liquidation.period}`,
-        amount: charge.amountMinor,
-        currency: liquidation.baseCurrency,
-        dueDate,
-        status: 'PENDING',
-        liquidationId: liquidation.id,
-        })),
-      });
-
-      const updated = await tx.liquidation.update({
-        where: { id: liquidationId },
-        data: {
-          status: 'PUBLISHED',
-          publicationSnapshot,
-          publishedByMembershipId: membership.id,
-          publishedAt,
-        },
-      });
-
-      await this.auditService.createLogRequired({
-        tenantId,
-        actorMembershipId: membership.id,
-        action: 'LIQUIDATION_PUBLISH',
-        entityType: 'Liquidation',
-        entityId: liquidationId,
-        metadata: {
-          period: liquidation.period,
-          chargeCount: chargeRecords.count,
-          totalAmountMinor,
-          dueDate: dueDate.toISOString(),
-        },
-      }, tx);
-
-      return updated;
-    });
+    return this.liquidations.publishLiquidation(
+      tenantId,
+      liquidationId,
+      membershipId,
+      { dueDate: dueDate.toISOString() },
+    );
   }
 
-  /**
-   * Cancel a liquidation (DRAFT or REVIEWED)
-   * Publishes a terminal CANCELED state without deleting financial history
-   */
   async cancelLiquidation(
     tenantId: string,
     liquidationId: string,
     membershipId: string,
   ) {
-    return this.prisma.$transaction(async (tx) => {
-      const membership = await this.requireFinanceMembership(tx, tenantId, membershipId);
-      const liquidation = await tx.liquidation.findFirst({
-        where: { id: liquidationId, tenantId },
-        select: {
-          id: true,
-          status: true,
-          period: true,
-        },
-      });
-
-      if (!liquidation) {
-        throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-      }
-
-      if (liquidation.status === 'PUBLISHED') {
-        throw new BadRequestException('La liquidación publicada no se puede cancelar directamente');
-      }
-
-      if (liquidation.status === 'CANCELED') {
-        throw new BadRequestException('La liquidación ya está cancelada');
-      }
-
-      const canceledAt = new Date();
-      const updateResult = await tx.liquidation.updateMany({
-        where: {
-          id: liquidationId,
-          tenantId,
-          status: { in: ['DRAFT', 'REVIEWED'] },
-        },
-        data: {
-          status: 'CANCELED',
-          canceledAt,
-          canceledByMembershipId: membership.id,
-          updatedAt: canceledAt,
-        },
-      });
-
-      if (updateResult.count !== 1) {
-        throw new BadRequestException(
-          'No fue posible cancelar la liquidación porque cambió de estado',
-        );
-      }
-
-      const canceled = await tx.liquidation.findFirst({
-        where: { id: liquidationId, tenantId },
-      });
-
-      if (!canceled) {
-        throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-      }
-
-      await this.auditService.createLogRequired({
-        tenantId,
-        actorMembershipId: membership.id,
-        action: 'LIQUIDATION_CANCEL',
-        entityType: 'Liquidation',
-        entityId: liquidationId,
-        metadata: {
-          period: liquidation.period,
-          previousStatus: liquidation.status,
-          canceledAt: canceledAt.toISOString(),
-        },
-      }, tx);
-
-      return canceled;
-    });
-  }
-
-  /**
-   * Get liquidation detail with expenses and charges preview
-   */
-  async getLiquidationDetail(
-    tenantId: string,
-    liquidationId: string,
-    membershipId: string,
-  ) {
-    await this.requireFinanceMembership(this.prisma, tenantId, membershipId);
-
-    const liquidation = await this.prisma.liquidation.findFirst({
-      where: { id: liquidationId, tenantId },
-    });
-
-    if (!liquidation) {
-      throw new NotFoundException(`Liquidación no encontrada: ${liquidationId}`);
-    }
-
-    const expenses = await this.prisma.expense.findMany({
-      where: {
-        tenantId,
-        buildingId: liquidation.buildingId,
-        period: liquidation.period,
-        status: 'VALIDATED',
-      },
-      include: {
-        category: { select: { name: true } },
-        vendor: { select: { name: true } },
-      },
-    });
-
-    // Obtener charges si PUBLISHED
-    const charges =
-      liquidation.status === 'PUBLISHED'
-        ? await this.prisma.charge.findMany({
-            where: {
-              tenantId,
-              liquidationId,
-            },
-            include: {
-              unit: { select: { code: true, label: true, m2: true } },
-            },
-          })
-        : [];
-
-    return {
-      ...liquidation,
-      expenses: expenses.map((e) => ({
-        id: e.id,
-        categoryName: e.category.name,
-        vendorName: e.vendor?.name ?? null,
-        amountMinor: e.amountMinor,
-        currencyCode: e.currencyCode,
-        invoiceDate: e.invoiceDate,
-        description: e.description,
-      })),
-      chargesPreview: charges.map((c) => ({
-        unitId: c.unitId,
-        unitCode: c.unit.code,
-        unitLabel: c.unit.label,
-        areaM2: c.unit.m2,
-        amountMinor: c.amount,
-      })),
-    };
-  }
-
-  private async requireFinanceMembership(
-    client: PrismaService | Prisma.TransactionClient,
-    tenantId: string,
-    membershipId: string,
-  ): Promise<{ id: string; tenantId: string; roles: string[] }> {
-    const membership = await client.membership.findFirst({
-      where: { id: membershipId, tenantId },
-      select: {
-        id: true,
-        tenantId: true,
-        roles: {
-          select: {
-            role: true,
-            scopeType: true,
-          },
-        },
-      },
-    });
-
-    if (!membership) {
-      throw new ForbiddenException('No se encontró una membresía válida para el tenant');
-    }
-
-    const tenantRoles = membership.roles
-      .filter((role) => role.scopeType === 'TENANT')
-      .map((role) => role.role);
-
-    if (!this.validators.isAdminOrOperator(tenantRoles)) {
-      throw new ForbiddenException('Solo administradores pueden gestionar liquidaciones');
-    }
-
-    return {
-      id: membership.id,
-      tenantId: membership.tenantId,
-      roles: tenantRoles,
-    };
+    return this.liquidations.cancelLiquidation(
+      tenantId,
+      liquidationId,
+      membershipId,
+    );
   }
 }

--- a/apps/api/src/finanzas/liquidation-publication-snapshot.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication-snapshot.spec.ts
@@ -1,5 +1,6 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, UnprocessableEntityException } from '@nestjs/common';
 import {
+  assertLiquidationMovementCurrency,
   buildLiquidationPublicationSnapshot,
   distributeLiquidationAmountByLargestRemainder,
   parseLiquidationPublicationSnapshot,
@@ -14,6 +15,7 @@ describe('liquidation publication snapshot', () => {
     baseCurrency: 'ARS',
     totalAmountMinor: 100,
     totalsByCurrency: { ARS: 100 },
+    valuationMode: 'LEGACY_NOMINAL' as const,
     expenses: [
       {
         expenseId: 'exp-1',
@@ -261,5 +263,184 @@ describe('liquidation publication snapshot', () => {
         ],
       }),
     ).toThrow(BadRequestException);
+  });
+
+  describe('valuation mode aware guards', () => {
+    it('FUNCTIONAL allows different original currencies converging to base', () => {
+      expect(() =>
+        assertLiquidationMovementCurrency(
+          [
+            { currencyCode: 'USD', functionalAmountMinor: 36500, functionalCurrencyCode: 'VES' },
+            { currencyCode: 'COP', functionalAmountMinor: 125, functionalCurrencyCode: 'VES' },
+          ],
+          'VES',
+          'FUNCTIONAL',
+        ),
+      ).not.toThrow();
+    });
+
+    it('FUNCTIONAL rejects a movement without functional amount', () => {
+      expect(() =>
+        assertLiquidationMovementCurrency(
+          [{ currencyCode: 'USD', functionalAmountMinor: null, functionalCurrencyCode: null }],
+          'VES',
+          'FUNCTIONAL',
+        ),
+      ).toThrow(UnprocessableEntityException);
+    });
+
+    it('FUNCTIONAL rejects a movement that does not converge to base currency', () => {
+      expect(() =>
+        assertLiquidationMovementCurrency(
+          [{ currencyCode: 'USD', functionalAmountMinor: 100, functionalCurrencyCode: 'ARS' }],
+          'VES',
+          'FUNCTIONAL',
+        ),
+      ).toThrow(UnprocessableEntityException);
+    });
+
+    it('LEGACY_NOMINAL keeps the mixed currency behavior', () => {
+      expect(() =>
+        assertLiquidationMovementCurrency(
+          [{ currencyCode: 'USD' }, { currencyCode: 'ARS' }],
+          'VES',
+          'LEGACY_NOMINAL',
+        ),
+      ).toThrow(UnprocessableEntityException);
+    });
+  });
+
+  describe('publication snapshot v2', () => {
+    const functionalInput = {
+      ...baseInput,
+      baseCurrency: 'VES',
+      totalAmountMinor: 36625,
+      totalsByCurrency: { USD: 1000, COP: 200 },
+      valuationMode: 'FUNCTIONAL' as const,
+      allocations: [
+        { unitId: 'unit-1', unitCode: '1A', unitLabel: '1A', amountMinor: 36625 },
+      ],
+      expenses: [
+        {
+          expenseId: 'exp-1',
+          categoryName: 'Maintenance',
+          vendorName: 'Vendor',
+          amountMinor: 1000,
+          currencyCode: 'USD',
+          invoiceDate: '2026-08-05T00:00:00.000Z',
+          description: null,
+          type: 'EXPENSE' as const,
+          functionalAmountMinor: 36500,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'rate-1',
+          exchangeRateValue: '36.5',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: '2026-08-04T00:00:00.000Z',
+          conversionDate: '2026-08-05T00:00:00.000Z',
+        },
+        {
+          expenseId: 'ADJ-adj-1',
+          categoryName: 'Water',
+          vendorName: null,
+          amountMinor: 200,
+          currencyCode: 'COP',
+          invoiceDate: '2026-08-01T00:00:00.000Z',
+          description: 'Ajuste retroactivo: correction',
+          type: 'ADJUSTMENT' as const,
+          sourcePeriod: '2026-08',
+          functionalAmountMinor: 125,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'rate-inv',
+          exchangeRateValue: '25',
+          exchangeRateDirection: 'INVERSE',
+          exchangeRateEffectiveAt: '2026-07-20T00:00:00.000Z',
+          conversionDate: '2026-08-01T00:00:00.000Z',
+        },
+      ],
+    };
+
+    it('builds version 2 with functional provenance per source', () => {
+      const snapshot = buildLiquidationPublicationSnapshot(functionalInput);
+
+      expect(snapshot).toMatchObject({
+        version: 2,
+        valuationMode: 'FUNCTIONAL',
+        totalAmountMinor: 36625,
+      });
+      expect(snapshot.expenses[0]).toMatchObject({
+        functionalAmountMinor: 36500,
+        exchangeRateValue: '36.5',
+        exchangeRateDirection: 'DIRECT',
+      });
+      expect(snapshot.expenses[1]).toMatchObject({
+        functionalAmountMinor: 125,
+        exchangeRateDirection: 'INVERSE',
+        exchangeRateId: 'rate-inv',
+      });
+    });
+
+    it('parses version 2 back with functional provenance', () => {
+      const snapshot = buildLiquidationPublicationSnapshot(functionalInput);
+      const parsed = parseLiquidationPublicationSnapshot(snapshot);
+
+      expect(parsed).toMatchObject({
+        version: 2,
+        valuationMode: 'FUNCTIONAL',
+        totalAmountMinor: 36625,
+      });
+      expect(parsed?.expenses[0]).toMatchObject({
+        functionalAmountMinor: 36500,
+        exchangeRateValue: '36.5',
+      });
+    });
+
+    it('rejects a v2 snapshot whose functional sum does not match the total', () => {
+      expect(() =>
+        buildLiquidationPublicationSnapshot({
+          ...functionalInput,
+          totalAmountMinor: 36626,
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('parses a legacy v2 snapshot as version 1 for compatibility', () => {
+      const snapshot = buildLiquidationPublicationSnapshot(baseInput);
+      const parsed = parseLiquidationPublicationSnapshot(snapshot);
+
+      expect(parsed).toMatchObject({ version: 1 });
+    });
+
+    it('still parses a raw historical v1 snapshot', () => {
+      const legacyV1 = {
+        version: 1,
+        liquidationId: 'liq-historic',
+        tenantId: 'tenant-1',
+        buildingId: 'building-1',
+        period: '2026-04',
+        baseCurrency: 'ARS',
+        totalAmountMinor: 50,
+        totalsByCurrency: { ARS: 50 },
+        expenses: [
+          {
+            expenseId: 'exp-9',
+            categoryName: 'Water',
+            vendorName: null,
+            amountMinor: 50,
+            currencyCode: 'ARS',
+            invoiceDate: '2026-04-01T00:00:00.000Z',
+            description: null,
+            type: 'EXPENSE',
+          },
+        ],
+        allocations: [
+          { unitId: 'unit-1', unitCode: '1A', unitLabel: '1A', amountMinor: 50 },
+        ],
+        dueDate: '2026-05-10T00:00:00.000Z',
+        publishedAt: '2026-06-01T00:00:00.000Z',
+      };
+
+      const parsed = parseLiquidationPublicationSnapshot(legacyV1);
+      expect(parsed).toMatchObject({ version: 1, totalAmountMinor: 50 });
+    });
   });
 });

--- a/apps/api/src/finanzas/liquidation-publication-snapshot.ts
+++ b/apps/api/src/finanzas/liquidation-publication-snapshot.ts
@@ -11,6 +11,13 @@ export interface PublishedExpenseSnapshot {
   description: string | null;
   type: 'EXPENSE' | 'ADJUSTMENT';
   sourcePeriod?: string;
+  functionalAmountMinor?: number | null;
+  functionalCurrencyCode?: string | null;
+  exchangeRateId?: string | null;
+  exchangeRateValue?: string | null;
+  exchangeRateDirection?: string | null;
+  exchangeRateEffectiveAt?: string | null;
+  conversionDate?: string | null;
 }
 
 export interface PublishedAllocationSnapshot {
@@ -35,6 +42,26 @@ export interface LiquidationPublicationSnapshotV1 {
   publishedAt: string;
 }
 
+export interface LiquidationPublicationSnapshotV2 {
+  version: 2;
+  valuationMode: 'FUNCTIONAL' | 'LEGACY_NOMINAL';
+  liquidationId: string;
+  tenantId: string;
+  buildingId: string;
+  period: string;
+  baseCurrency: string;
+  totalAmountMinor: number;
+  totalsByCurrency: Record<string, number>;
+  expenses: readonly PublishedExpenseSnapshot[];
+  allocations: readonly PublishedAllocationSnapshot[];
+  dueDate: string;
+  publishedAt: string;
+}
+
+export type LiquidationPublicationSnapshot =
+  | LiquidationPublicationSnapshotV1
+  | LiquidationPublicationSnapshotV2;
+
 export interface BuildLiquidationPublicationSnapshotInput {
   liquidationId: string;
   tenantId: string;
@@ -47,6 +74,7 @@ export interface BuildLiquidationPublicationSnapshotInput {
   allocations: readonly PublishedAllocationSnapshot[];
   dueDate: Date;
   publishedAt: Date;
+  valuationMode: 'FUNCTIONAL' | 'LEGACY_NOMINAL';
 }
 
 export interface LiquidationDistributionUnit {
@@ -65,9 +93,37 @@ export interface LiquidationDistributionAllocation {
 }
 
 export function assertLiquidationMovementCurrency(
-  movements: ReadonlyArray<{ currencyCode: string }>,
+  movements: ReadonlyArray<{
+    currencyCode: string;
+    functionalAmountMinor?: number | null;
+    functionalCurrencyCode?: string | null;
+  }>,
   baseCurrency: string,
+  valuationMode: 'FUNCTIONAL' | 'LEGACY_NOMINAL' = 'LEGACY_NOMINAL',
 ): void {
+  if (valuationMode === 'FUNCTIONAL') {
+    for (const movement of movements) {
+      if (movement.functionalAmountMinor === null || movement.functionalAmountMinor === undefined) {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+          message:
+            'La liquidación FUNCTIONAL incluye un movimiento sin snapshot funcional',
+        });
+      }
+      if (
+        movement.functionalCurrencyCode !== baseCurrency
+      ) {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+          message: `El movimiento en ${movement.currencyCode} no converge a la moneda base (${baseCurrency})`,
+        });
+      }
+    }
+    return;
+  }
+
   const currencies = new Set(movements.map((movement) => movement.currencyCode));
 
   if (currencies.size > 1) {
@@ -109,15 +165,18 @@ export function buildLiquidationPublicationSnapshot(
       safeAddMinor(sum, allocation.amountMinor, 'allocations.totalAmountMinor'),
     0,
   );
-  const baseCurrencyTotal = totalsByCurrency[input.baseCurrency];
+  const valuedTotal =
+    input.valuationMode === 'FUNCTIONAL'
+      ? sumFunctionalAmount(expenses, input.valuationMode)
+      : expenseTotalsByCurrency[input.baseCurrency];
 
-  if (baseCurrencyTotal === undefined) {
+  if (valuedTotal === undefined) {
     throw new BadRequestException(
       'Liquidation publication snapshot must include the base currency total',
     );
   }
 
-  if (baseCurrencyTotal !== input.totalAmountMinor) {
+  if (valuedTotal !== input.totalAmountMinor) {
     throw new BadRequestException(
       'Liquidation publication snapshot totals must match the liquidation total',
     );
@@ -132,7 +191,8 @@ export function buildLiquidationPublicationSnapshot(
   assertCurrencyTotalsMatch(totalsByCurrency, expenseTotalsByCurrency);
 
   return createJsonObject({
-    version: 1,
+    version: 2,
+    valuationMode: input.valuationMode,
     liquidationId: input.liquidationId,
     tenantId: input.tenantId,
     buildingId: input.buildingId,
@@ -260,7 +320,7 @@ export function distributeLiquidationAmountByLargestRemainder(
 
 export function parseLiquidationPublicationSnapshot(
   value: unknown,
-): LiquidationPublicationSnapshotV1 | null {
+): LiquidationPublicationSnapshot | null {
   if (value === null) {
     return null;
   }
@@ -269,7 +329,7 @@ export function parseLiquidationPublicationSnapshot(
     throw new BadRequestException('Liquidation publication snapshot is invalid');
   }
 
-  if (value.version !== 1) {
+  if (value.version !== 1 && value.version !== 2) {
     throw new BadRequestException('Liquidation publication snapshot version is invalid');
   }
 
@@ -282,6 +342,10 @@ export function parseLiquidationPublicationSnapshot(
   const totalsByCurrency = parseTotalsByCurrency(value.totalsByCurrency);
   const dueDate = parseIsoDateString(value.dueDate, 'dueDate');
   const publishedAt = parseIsoDateString(value.publishedAt, 'publishedAt');
+  const valuationMode =
+    value.version === 2
+      ? parseValuationMode(value.valuationMode)
+      : ('LEGACY_NOMINAL' as const);
 
   if (!Array.isArray(value.expenses)) {
     throw new BadRequestException('Liquidation publication snapshot expenses are invalid');
@@ -299,14 +363,18 @@ export function parseLiquidationPublicationSnapshot(
       safeAddMinor(sum, allocation.amountMinor, 'allocations.totalAmountMinor'),
     0,
   );
+  const valuedTotal =
+    valuationMode === 'FUNCTIONAL'
+      ? sumFunctionalAmount(expenses, valuationMode)
+      : totalsByCurrency[baseCurrency];
 
-  if (totalsByCurrency[baseCurrency] === undefined) {
+  if (valuedTotal === undefined) {
     throw new BadRequestException(
       'Liquidation publication snapshot must include the base currency total',
     );
   }
 
-  if (totalsByCurrency[baseCurrency] !== totalAmountMinor) {
+  if (valuedTotal !== totalAmountMinor) {
     throw new BadRequestException(
       'Liquidation publication snapshot totals must match the liquidation total',
     );
@@ -320,8 +388,26 @@ export function parseLiquidationPublicationSnapshot(
 
   assertCurrencyTotalsMatch(totalsByCurrency, expenseTotalsByCurrency);
 
+  if (valuationMode === 'LEGACY_NOMINAL') {
+    return {
+      version: 1,
+      liquidationId,
+      tenantId,
+      buildingId,
+      period,
+      baseCurrency,
+      totalAmountMinor,
+      totalsByCurrency,
+      expenses,
+      allocations,
+      dueDate,
+      publishedAt,
+    };
+  }
+
   return {
-    version: 1,
+    version: 2,
+    valuationMode,
     liquidationId,
     tenantId,
     buildingId,
@@ -334,6 +420,35 @@ export function parseLiquidationPublicationSnapshot(
     dueDate,
     publishedAt,
   };
+}
+
+function parseValuationMode(value: unknown): 'FUNCTIONAL' | 'LEGACY_NOMINAL' {
+  if (value === 'FUNCTIONAL' || value === 'LEGACY_NOMINAL') {
+    return value;
+  }
+  throw new BadRequestException('Liquidation publication snapshot valuationMode is invalid');
+}
+
+function sumFunctionalAmount(
+  items: readonly PublishedExpenseSnapshot[],
+  valuationMode: 'FUNCTIONAL' | 'LEGACY_NOMINAL',
+): number | undefined {
+  if (valuationMode === 'LEGACY_NOMINAL') {
+    return undefined;
+  }
+
+  return items.reduce((sum, item) => {
+    if (item.functionalAmountMinor === null || item.functionalAmountMinor === undefined) {
+      throw new BadRequestException(
+        'Liquidation publication snapshot functional amount is invalid',
+      );
+    }
+    return safeAddMinor(
+      sum,
+      item.functionalAmountMinor,
+      `functionalAmountMinor:${item.expenseId}`,
+    );
+  }, 0);
 }
 
 function normalizeExpenseSnapshot(value: PublishedExpenseSnapshot): PublishedExpenseSnapshot {
@@ -370,6 +485,27 @@ function normalizeExpenseSnapshot(value: PublishedExpenseSnapshot): PublishedExp
     description: value.description,
     type: value.type,
     ...(sourcePeriod ? { sourcePeriod } : {}),
+    ...(value.functionalAmountMinor !== null && value.functionalAmountMinor !== undefined
+      ? { functionalAmountMinor: value.functionalAmountMinor }
+      : {}),
+    ...(value.functionalCurrencyCode !== null && value.functionalCurrencyCode !== undefined
+      ? { functionalCurrencyCode: value.functionalCurrencyCode }
+      : {}),
+    ...(value.exchangeRateId !== null && value.exchangeRateId !== undefined
+      ? { exchangeRateId: value.exchangeRateId }
+      : {}),
+    ...(value.exchangeRateValue !== null && value.exchangeRateValue !== undefined
+      ? { exchangeRateValue: value.exchangeRateValue }
+      : {}),
+    ...(value.exchangeRateDirection !== null && value.exchangeRateDirection !== undefined
+      ? { exchangeRateDirection: value.exchangeRateDirection }
+      : {}),
+    ...(value.exchangeRateEffectiveAt !== null && value.exchangeRateEffectiveAt !== undefined
+      ? { exchangeRateEffectiveAt: value.exchangeRateEffectiveAt }
+      : {}),
+    ...(value.conversionDate !== null && value.conversionDate !== undefined
+      ? { conversionDate: value.conversionDate }
+      : {}),
   };
 }
 
@@ -420,6 +556,27 @@ function toExpenseJsonObject(value: PublishedExpenseSnapshot): Prisma.InputJsonO
     description: value.description,
     type: value.type,
     ...(value.sourcePeriod ? { sourcePeriod: value.sourcePeriod } : {}),
+    ...(value.functionalAmountMinor !== null && value.functionalAmountMinor !== undefined
+      ? { functionalAmountMinor: value.functionalAmountMinor }
+      : {}),
+    ...(value.functionalCurrencyCode !== null && value.functionalCurrencyCode !== undefined
+      ? { functionalCurrencyCode: value.functionalCurrencyCode }
+      : {}),
+    ...(value.exchangeRateId !== null && value.exchangeRateId !== undefined
+      ? { exchangeRateId: value.exchangeRateId }
+      : {}),
+    ...(value.exchangeRateValue !== null && value.exchangeRateValue !== undefined
+      ? { exchangeRateValue: value.exchangeRateValue }
+      : {}),
+    ...(value.exchangeRateDirection !== null && value.exchangeRateDirection !== undefined
+      ? { exchangeRateDirection: value.exchangeRateDirection }
+      : {}),
+    ...(value.exchangeRateEffectiveAt !== null && value.exchangeRateEffectiveAt !== undefined
+      ? { exchangeRateEffectiveAt: value.exchangeRateEffectiveAt }
+      : {}),
+    ...(value.conversionDate !== null && value.conversionDate !== undefined
+      ? { conversionDate: value.conversionDate }
+      : {}),
   });
 }
 
@@ -455,6 +612,35 @@ function parseExpenseSnapshot(value: unknown): PublishedExpenseSnapshot {
       ? undefined
       : parseNonEmptyString(value.sourcePeriod, 'sourcePeriod');
 
+  const functionalAmountMinor =
+    value.functionalAmountMinor === undefined || value.functionalAmountMinor === null
+      ? undefined
+      : parseSafeIntegerNonNegative(value.functionalAmountMinor, 'functionalAmountMinor');
+  const functionalCurrencyCode =
+    value.functionalCurrencyCode === undefined || value.functionalCurrencyCode === null
+      ? undefined
+      : parseNonEmptyString(value.functionalCurrencyCode, 'functionalCurrencyCode');
+  const exchangeRateId =
+    value.exchangeRateId === undefined || value.exchangeRateId === null
+      ? undefined
+      : parseNonEmptyString(value.exchangeRateId, 'exchangeRateId');
+  const exchangeRateValue =
+    value.exchangeRateValue === undefined || value.exchangeRateValue === null
+      ? undefined
+      : parseNonEmptyString(String(value.exchangeRateValue), 'exchangeRateValue');
+  const exchangeRateDirection =
+    value.exchangeRateDirection === undefined || value.exchangeRateDirection === null
+      ? undefined
+      : parseNonEmptyString(value.exchangeRateDirection, 'exchangeRateDirection');
+  const exchangeRateEffectiveAt =
+    value.exchangeRateEffectiveAt === undefined || value.exchangeRateEffectiveAt === null
+      ? undefined
+      : parseIsoDateString(value.exchangeRateEffectiveAt, 'exchangeRateEffectiveAt');
+  const conversionDate =
+    value.conversionDate === undefined || value.conversionDate === null
+      ? undefined
+      : parseIsoDateString(value.conversionDate, 'conversionDate');
+
   return {
     expenseId,
     categoryName,
@@ -465,6 +651,13 @@ function parseExpenseSnapshot(value: unknown): PublishedExpenseSnapshot {
     description,
     type,
     ...(sourcePeriod ? { sourcePeriod } : {}),
+    ...(functionalAmountMinor !== undefined ? { functionalAmountMinor } : {}),
+    ...(functionalCurrencyCode !== undefined ? { functionalCurrencyCode } : {}),
+    ...(exchangeRateId !== undefined ? { exchangeRateId } : {}),
+    ...(exchangeRateValue !== undefined ? { exchangeRateValue } : {}),
+    ...(exchangeRateDirection !== undefined ? { exchangeRateDirection } : {}),
+    ...(exchangeRateEffectiveAt !== undefined ? { exchangeRateEffectiveAt } : {}),
+    ...(conversionDate !== undefined ? { conversionDate } : {}),
   };
 }
 

--- a/apps/api/src/finanzas/liquidation-publication.use-case.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.spec.ts
@@ -16,6 +16,7 @@ const baseLiquidation = {
   period: '2026-05',
   chargePeriod: '2026-06',
   status: 'REVIEWED' as const,
+  valuationMode: null,
   baseCurrency: 'ARS',
   totalAmountMinor: 101,
   totalsByCurrency: { ARS: 101 },
@@ -146,7 +147,8 @@ describe('LiquidationPublicationUseCase', () => {
         data: expect.objectContaining({
           status: 'PUBLISHED',
           publicationSnapshot: expect.objectContaining({
-            version: 1,
+            version: 2,
+            valuationMode: 'LEGACY_NOMINAL',
             totalAmountMinor: 101,
             dueDate: '2026-06-10T00:00:00.000Z',
           }),
@@ -348,5 +350,160 @@ describe('LiquidationPublicationUseCase', () => {
     expect(notificationsService.createNotification).not.toHaveBeenCalledWith(expect.objectContaining({
       userId: 'user-1',
     }));
+  });
+
+  describe('FUNCTIONAL valuation publication', () => {
+    const functionalLiquidation = {
+      ...baseLiquidation,
+      valuationMode: 'FUNCTIONAL' as const,
+      baseCurrency: 'VES',
+      totalAmountMinor: 36625,
+      totalsByCurrency: { USD: 1000, COP: 200 },
+      expenseSnapshot: [
+        {
+          expenseId: 'exp-1',
+          categoryName: 'Maintenance',
+          vendorName: 'Vendor',
+          amountMinor: 1000,
+          currencyCode: 'USD',
+          invoiceDate: '2026-08-05T00:00:00.000Z',
+          description: null,
+          type: 'EXPENSE',
+          functionalAmountMinor: 36500,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'rate-1',
+          exchangeRateValue: '36.5',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: '2026-08-04T00:00:00.000Z',
+          conversionDate: '2026-08-05T00:00:00.000Z',
+        },
+        {
+          expenseId: 'ADJ-adj-1',
+          categoryName: 'Water',
+          vendorName: null,
+          amountMinor: 200,
+          currencyCode: 'COP',
+          invoiceDate: '2026-08-01T00:00:00.000Z',
+          description: 'Ajuste retroactivo: correction',
+          type: 'ADJUSTMENT',
+          sourcePeriod: '2026-08',
+          functionalAmountMinor: 125,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'rate-inv',
+          exchangeRateValue: '25',
+          exchangeRateDirection: 'INVERSE',
+          exchangeRateEffectiveAt: '2026-07-20T00:00:00.000Z',
+          conversionDate: '2026-08-01T00:00:00.000Z',
+        },
+      ],
+    };
+
+    const mockFunctionalPublish = () => {
+      tx.liquidation.findFirst
+        .mockReset()
+        .mockResolvedValueOnce(functionalLiquidation)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          ...functionalLiquidation,
+          status: 'PUBLISHED',
+          publishedAt: new Date('2026-08-10T00:00:00.000Z'),
+        })
+        .mockResolvedValueOnce({
+          ...functionalLiquidation,
+          status: 'PUBLISHED',
+          publishedAt: new Date('2026-08-10T00:00:00.000Z'),
+        });
+      tx.unit.findMany.mockResolvedValue([
+        { id: 'unit-1', code: '1A', label: '1A', unitCategory: null },
+      ]);
+      tx.charge.findMany.mockResolvedValue([]);
+    };
+
+    it('publishes a FUNCTIONAL liquidation and writes a version 2 snapshot', async () => {
+      mockFunctionalPublish();
+
+      const result = await useCase.execute(
+        'tenant-1',
+        'liq-1',
+        'member-1',
+        { dueDate: '2026-09-10' },
+        'post-commit',
+      );
+
+      expect(result.status).toBe('PUBLISHED');
+      const snapshotUpdate = (tx.liquidation.updateMany as jest.Mock).mock.calls.find(
+        (call) => (call[0].data?.publicationSnapshot as { version?: number })?.version === 2,
+      );
+      expect(snapshotUpdate).toBeDefined();
+      expect(snapshotUpdate[0].data.publicationSnapshot).toMatchObject({
+        version: 2,
+        valuationMode: 'FUNCTIONAL',
+        totalAmountMinor: 36625,
+      });
+      expect(snapshotUpdate[0].data.publicationSnapshot.expenses[1]).toMatchObject({
+        expenseId: 'ADJ-adj-1',
+        functionalAmountMinor: 125,
+        exchangeRateDirection: 'INVERSE',
+      });
+    });
+
+    it('charges equal the functional total exactly', async () => {
+      mockFunctionalPublish();
+
+      await useCase.execute(
+        'tenant-1',
+        'liq-1',
+        'member-1',
+        { dueDate: '2026-09-10' },
+        'post-commit',
+      );
+
+      const chargeCreate = (tx.charge.createMany as jest.Mock).mock.calls[0] as [
+        { data: Array<{ amount: number; currency: string }> },
+      ];
+      const totalCharges = chargeCreate[0].data.reduce(
+        (sum, charge) => sum + charge.amount,
+        0,
+      );
+      expect(totalCharges).toBe(36625);
+      expect(chargeCreate[0].data.every((charge) => charge.currency === 'VES')).toBe(true);
+    });
+
+    it('blocks publication when the source snapshot drifts from the total', async () => {
+      mockFunctionalPublish();
+      tx.liquidation.findFirst
+        .mockReset()
+        .mockResolvedValueOnce({
+          ...functionalLiquidation,
+          totalAmountMinor: 36626,
+        })
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          ...functionalLiquidation,
+          status: 'PUBLISHED',
+          publishedAt: new Date('2026-08-10T00:00:00.000Z'),
+        })
+        .mockResolvedValueOnce({
+          ...functionalLiquidation,
+          status: 'PUBLISHED',
+          publishedAt: new Date('2026-08-10T00:00:00.000Z'),
+        });
+
+      await expect(
+        useCase.execute(
+          'tenant-1',
+          'liq-1',
+          'member-1',
+          { dueDate: '2026-09-10' },
+          'post-commit',
+        ),
+      ).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_PUBLICATION_SOURCE_DRIFT',
+        },
+      });
+      expect(tx.charge.createMany).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/finanzas/liquidation-publication.use-case.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.ts
@@ -5,6 +5,7 @@ import {
   Injectable,
   Logger,
   NotFoundException,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { ChargeStatus, Prisma } from '@prisma/client';
 import { AuditService } from '../audit/audit.service';
@@ -138,6 +139,7 @@ type LiquidationRecord = {
   period: string;
   chargePeriod: string | null;
   status: 'DRAFT' | 'REVIEWED' | 'PUBLISHED' | 'CANCELED';
+  valuationMode: 'FUNCTIONAL' | 'LEGACY_NOMINAL' | null;
   baseCurrency: string;
   totalAmountMinor: number;
   totalsByCurrency: unknown;
@@ -158,6 +160,7 @@ export interface DraftLiquidationInput {
   readonly buildingId: string;
   readonly period: string;
   readonly chargePeriod?: string | null;
+  readonly valuationMode?: 'FUNCTIONAL' | 'LEGACY_NOMINAL' | null;
   readonly baseCurrency: string;
   readonly totalAmountMinor: number;
   readonly totalsByCurrency: Prisma.InputJsonObject;
@@ -351,6 +354,7 @@ export async function createLiquidationDraftRecord(
       buildingId: input.buildingId,
       period: input.period,
       chargePeriod: input.chargePeriod ?? null,
+      valuationMode: input.valuationMode ?? null,
       baseCurrency: input.baseCurrency,
       totalAmountMinor: input.totalAmountMinor,
       totalsByCurrency: input.totalsByCurrency,
@@ -509,7 +513,32 @@ export class LiquidationPublicationUseCase {
           }
 
           const publicationExpenses = getPublicationSnapshotExpenses(current.expenseSnapshot);
-          assertLiquidationMovementCurrency(publicationExpenses, current.baseCurrency);
+          const valuationMode = current.valuationMode ?? 'LEGACY_NOMINAL';
+          assertLiquidationMovementCurrency(
+            publicationExpenses,
+            current.baseCurrency,
+            valuationMode,
+          );
+
+          const valuedSourceTotal =
+            valuationMode === 'FUNCTIONAL'
+              ? publicationExpenses.reduce(
+                  (sum, expense) => sum + (expense.functionalAmountMinor ?? NaN),
+                  0,
+                )
+              : publicationExpenses.reduce((sum, expense) => sum + expense.amountMinor, 0);
+
+          if (
+            !Number.isSafeInteger(valuedSourceTotal) ||
+            valuedSourceTotal !== current.totalAmountMinor
+          ) {
+            throw new UnprocessableEntityException({
+              statusCode: 422,
+              error: 'LIQUIDATION_PUBLICATION_SOURCE_DRIFT',
+              message:
+                'El snapshot de fuentes de la liquidación no reconcilia con su total; no se publica',
+            });
+          }
 
           const billableUnits = await tx.unit.findMany({
             where: { tenantId, buildingId: current.buildingId, isBillable: true },
@@ -538,6 +567,7 @@ export class LiquidationPublicationUseCase {
             tenantId,
             buildingId: current.buildingId,
             period: current.period,
+            valuationMode,
             baseCurrency: current.baseCurrency,
             totalAmountMinor: current.totalAmountMinor,
             totalsByCurrency: parseTotalsByCurrency(current.totalsByCurrency),
@@ -809,7 +839,26 @@ function isSerializationConflict(
   return error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2034';
 }
 
-function parseExpenseSnapshot(value: unknown): LiquidationExpenseSnapshotItem[] {
+interface ParsedLiquidationExpenseItem {
+  expenseId: string;
+  categoryName: string;
+  vendorName: string | null;
+  amountMinor: number;
+  currencyCode: string;
+  invoiceDate: string;
+  description: string | null;
+  type: 'EXPENSE' | 'ADJUSTMENT';
+  sourcePeriod?: string;
+  functionalAmountMinor?: number;
+  functionalCurrencyCode?: string;
+  exchangeRateId?: string;
+  exchangeRateValue?: string;
+  exchangeRateDirection?: string;
+  exchangeRateEffectiveAt?: string;
+  conversionDate?: string;
+}
+
+function parseExpenseSnapshot(value: unknown): ParsedLiquidationExpenseItem[] {
   if (!Array.isArray(value)) {
     throw new BadRequestException('Liquidation expense snapshot is invalid');
   }
@@ -829,6 +878,13 @@ function parseExpenseSnapshot(value: unknown): LiquidationExpenseSnapshotItem[] 
     const description = snapshot.description;
     const type = snapshot.type;
     const sourcePeriod = snapshot.sourcePeriod;
+    const functionalAmountMinor = snapshot.functionalAmountMinor;
+    const functionalCurrencyCode = snapshot.functionalCurrencyCode;
+    const exchangeRateId = snapshot.exchangeRateId;
+    const exchangeRateValue = snapshot.exchangeRateValue;
+    const exchangeRateDirection = snapshot.exchangeRateDirection;
+    const exchangeRateEffectiveAt = snapshot.exchangeRateEffectiveAt;
+    const conversionDate = snapshot.conversionDate;
 
     if (typeof expenseId !== 'string') {
       throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid expenseId`);
@@ -863,6 +919,56 @@ function parseExpenseSnapshot(value: unknown): LiquidationExpenseSnapshotItem[] 
       throw new BadRequestException(`Liquidation expense snapshot item ${index} has invalid invoiceDate`);
     }
 
+    const parseOptionalInt = (value: unknown, field: string): number | undefined => {
+      if (value === null || value === undefined) {
+        return undefined;
+      }
+      if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+        throw new BadRequestException(
+          `Liquidation expense snapshot item ${index} has invalid ${field}`,
+        );
+      }
+      return value;
+    };
+
+    const parseOptionalString = (value: unknown, field: string): string | undefined => {
+      if (value === null || value === undefined) {
+        return undefined;
+      }
+      if (typeof value !== 'string' || value.length === 0) {
+        throw new BadRequestException(
+          `Liquidation expense snapshot item ${index} has invalid ${field}`,
+        );
+      }
+      return value;
+    };
+
+    const parseOptionalIsoDate = (value: unknown, field: string): string | undefined => {
+      if (value === null || value === undefined) {
+        return undefined;
+      }
+      const parsed = new Date(String(value));
+      if (Number.isNaN(parsed.getTime())) {
+        throw new BadRequestException(
+          `Liquidation expense snapshot item ${index} has invalid ${field}`,
+        );
+      }
+      return parsed.toISOString();
+    };
+
+    const parsedFunctionalAmountMinor = parseOptionalInt(functionalAmountMinor, 'functionalAmountMinor');
+    const parsedFunctionalCurrencyCode = parseOptionalString(functionalCurrencyCode, 'functionalCurrencyCode');
+    const parsedExchangeRateId = parseOptionalString(exchangeRateId, 'exchangeRateId');
+    const parsedExchangeRateValue = parseOptionalString(
+      exchangeRateValue === null || exchangeRateValue === undefined
+        ? undefined
+        : String(exchangeRateValue),
+      'exchangeRateValue',
+    );
+    const parsedExchangeRateDirection = parseOptionalString(exchangeRateDirection, 'exchangeRateDirection');
+    const parsedExchangeRateEffectiveAt = parseOptionalIsoDate(exchangeRateEffectiveAt, 'exchangeRateEffectiveAt');
+    const parsedConversionDate = parseOptionalIsoDate(conversionDate, 'conversionDate');
+
     return {
       expenseId,
       categoryName,
@@ -873,6 +979,13 @@ function parseExpenseSnapshot(value: unknown): LiquidationExpenseSnapshotItem[] 
       description,
       type,
       sourcePeriod: sourcePeriod ?? undefined,
+      functionalAmountMinor: parsedFunctionalAmountMinor,
+      functionalCurrencyCode: parsedFunctionalCurrencyCode,
+      exchangeRateId: parsedExchangeRateId,
+      exchangeRateValue: parsedExchangeRateValue,
+      exchangeRateDirection: parsedExchangeRateDirection,
+      exchangeRateEffectiveAt: parsedExchangeRateEffectiveAt,
+      conversionDate: parsedConversionDate,
     };
   });
 }
@@ -890,6 +1003,27 @@ function getPublicationSnapshotExpenses(
     description: expense.description,
     type: expense.type,
     ...(expense.sourcePeriod ? { sourcePeriod: expense.sourcePeriod } : {}),
+    ...(expense.functionalAmountMinor !== null && expense.functionalAmountMinor !== undefined
+      ? { functionalAmountMinor: expense.functionalAmountMinor }
+      : {}),
+    ...(expense.functionalCurrencyCode !== null && expense.functionalCurrencyCode !== undefined
+      ? { functionalCurrencyCode: expense.functionalCurrencyCode }
+      : {}),
+    ...(expense.exchangeRateId !== null && expense.exchangeRateId !== undefined
+      ? { exchangeRateId: expense.exchangeRateId }
+      : {}),
+    ...(expense.exchangeRateValue !== null && expense.exchangeRateValue !== undefined
+      ? { exchangeRateValue: expense.exchangeRateValue }
+      : {}),
+    ...(expense.exchangeRateDirection !== null && expense.exchangeRateDirection !== undefined
+      ? { exchangeRateDirection: expense.exchangeRateDirection }
+      : {}),
+    ...(expense.exchangeRateEffectiveAt !== null && expense.exchangeRateEffectiveAt !== undefined
+      ? { exchangeRateEffectiveAt: expense.exchangeRateEffectiveAt }
+      : {}),
+    ...(expense.conversionDate !== null && expense.conversionDate !== undefined
+      ? { conversionDate: expense.conversionDate }
+      : {}),
   }));
 }
 

--- a/apps/api/src/finanzas/liquidation-publication.use-case.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.ts
@@ -215,6 +215,7 @@ export function toLiquidationResponseDto(
     period: liquidation.period,
     chargePeriod: liquidation.chargePeriod,
     status: liquidation.status,
+    valuationMode: liquidation.valuationMode,
     baseCurrency: liquidation.baseCurrency,
     totalAmountMinor: liquidation.totalAmountMinor,
     totalsByCurrency: parseTotalsByCurrency(liquidation.totalsByCurrency),

--- a/apps/api/src/finanzas/liquidation-valuation.ts
+++ b/apps/api/src/finanzas/liquidation-valuation.ts
@@ -1,0 +1,198 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+
+export type LiquidationValuationMode = 'FUNCTIONAL' | 'LEGACY_NOMINAL';
+
+export interface LiquidationValuationSource {
+  id: string;
+  type: 'EXPENSE' | 'ADJUSTMENT';
+  amountMinor: number;
+  currencyCode: string;
+  functionalAmountMinor: number | null;
+  functionalCurrencyCode: string | null;
+  exchangeRateId: string | null;
+  exchangeRateValue: string | number | { toString(): string } | null;
+  exchangeRateDirection: string | null;
+  exchangeRateEffectiveAt: Date | string | null;
+  conversionDate: Date | string | null;
+}
+
+const VALID_DIRECTIONS = new Set(['IDENTITY', 'DIRECT', 'INVERSE']);
+
+function functionalSnapshotRequired(message: string): never {
+  throw new UnprocessableEntityException({
+    statusCode: 422,
+    error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+    message,
+  });
+}
+
+function rateToString(
+  value: string | number | { toString(): string } | null,
+): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return value.toString();
+}
+
+export function isFunctionalSnapshotPresent(
+  source: LiquidationValuationSource,
+): boolean {
+  return (
+    source.functionalAmountMinor != null ||
+    source.functionalCurrencyCode != null ||
+    source.exchangeRateId != null ||
+    rateToString(source.exchangeRateValue) != null ||
+    source.exchangeRateDirection != null ||
+    source.exchangeRateEffectiveAt != null ||
+    source.conversionDate != null
+  );
+}
+
+export function assertFunctionalSnapshotComplete(
+  source: LiquidationValuationSource,
+  baseCurrency: string,
+): void {
+  const rate = rateToString(source.exchangeRateValue);
+
+  if (source.functionalAmountMinor === null) {
+    functionalSnapshotRequired(
+      `La fuente ${source.type}:${source.id} no posee functionalAmountMinor`,
+    );
+  }
+  if (source.functionalCurrencyCode === null) {
+    functionalSnapshotRequired(
+      `La fuente ${source.type}:${source.id} no posee functionalCurrencyCode`,
+    );
+  }
+  if (source.functionalCurrencyCode !== baseCurrency) {
+    functionalSnapshotRequired(
+      `La fuente ${source.type}:${source.id} está en ${source.functionalCurrencyCode}, ` +
+        `se esperaba la moneda base de la liquidación (${baseCurrency})`,
+    );
+  }
+  if (rate === null) {
+    functionalSnapshotRequired(
+      `La fuente ${source.type}:${source.id} no posee exchangeRateValue`,
+    );
+  }
+  if (
+    source.exchangeRateDirection === null ||
+    !VALID_DIRECTIONS.has(source.exchangeRateDirection)
+  ) {
+    functionalSnapshotRequired(
+      `La fuente ${source.type}:${source.id} no posee una dirección de conversión válida`,
+    );
+  }
+  if (source.conversionDate === null) {
+    functionalSnapshotRequired(
+      `La fuente ${source.type}:${source.id} no posee conversionDate`,
+    );
+  }
+
+  const rateDecimal = new Prisma.Decimal(rate);
+
+  if (source.exchangeRateDirection === 'IDENTITY') {
+    if (!rateDecimal.equals(1)) {
+      functionalSnapshotRequired(
+        `La fuente ${source.type}:${source.id} es IDENTITY pero su tasa no es 1`,
+      );
+    }
+    if (source.exchangeRateId !== null || source.exchangeRateEffectiveAt !== null) {
+      functionalSnapshotRequired(
+        `La fuente ${source.type}:${source.id} es IDENTITY pero referencia una tasa`,
+      );
+    }
+    return;
+  }
+
+  if (source.exchangeRateDirection === 'DIRECT' || source.exchangeRateDirection === 'INVERSE') {
+    if (!rateDecimal.greaterThan(0)) {
+      functionalSnapshotRequired(
+        `La fuente ${source.type}:${source.id} posee una tasa no positiva`,
+      );
+    }
+    if (source.exchangeRateId === null) {
+      functionalSnapshotRequired(
+        `La fuente ${source.type}:${source.id} no referencia la tasa fuente`,
+      );
+    }
+    if (source.exchangeRateEffectiveAt === null) {
+      functionalSnapshotRequired(
+        `La fuente ${source.type}:${source.id} no posee la efectividad de la tasa`,
+      );
+    }
+    return;
+  }
+}
+
+export function determineLiquidationValuationMode(
+  sources: readonly LiquidationValuationSource[],
+  baseCurrency: string,
+): LiquidationValuationMode {
+  if (sources.length === 0) {
+    throw new UnprocessableEntityException({
+      statusCode: 422,
+      error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+      message: 'La liquidación no posee fuentes valorables',
+    });
+  }
+
+  let functionalCount = 0;
+  for (const source of sources) {
+    if (isFunctionalSnapshotPresent(source)) {
+      functionalCount += 1;
+    }
+  }
+
+  if (functionalCount === 0) {
+    const currencies = new Set(sources.map((source) => source.currencyCode));
+    if (currencies.size > 1) {
+      throw new UnprocessableEntityException({
+        statusCode: 422,
+        error: 'MIXED_CURRENCY_LIQUIDATION_NOT_SUPPORTED',
+        message:
+          'No se puede generar una liquidación con movimientos en distintas monedas.',
+      });
+    }
+    const [movementCurrency] = currencies;
+    if (movementCurrency !== undefined && movementCurrency !== baseCurrency) {
+      throw new UnprocessableEntityException({
+        statusCode: 422,
+        error: 'LIQUIDATION_BASE_CURRENCY_MISMATCH',
+        message: `La moneda de los movimientos (${movementCurrency}) no coincide con la moneda base de la liquidación (${baseCurrency}).`,
+      });
+    }
+    return 'LEGACY_NOMINAL';
+  }
+
+  if (functionalCount !== sources.length) {
+    functionalSnapshotRequired(
+      'La liquidación mezcla fuentes con snapshot funcional y fuentes legacy; ' +
+        'no se permite un modo parcial',
+    );
+  }
+
+  for (const source of sources) {
+    assertFunctionalSnapshotComplete(source, baseCurrency);
+  }
+
+  return 'FUNCTIONAL';
+}
+
+export function sumValuationAmounts(
+  sources: readonly LiquidationValuationSource[],
+  mode: LiquidationValuationMode,
+): number {
+  return sources.reduce((sum, source) => {
+    const amount =
+      mode === 'FUNCTIONAL' ? source.functionalAmountMinor : source.amountMinor;
+    if (amount === null || amount === undefined) {
+      functionalSnapshotRequired(
+        `La fuente ${source.type}:${source.id} no aporta monto valorable`,
+      );
+    }
+    return sum + amount;
+  }, 0);
+}

--- a/apps/api/src/finanzas/liquidations.multicurrency.spec.ts
+++ b/apps/api/src/finanzas/liquidations.multicurrency.spec.ts
@@ -1,0 +1,468 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UnprocessableEntityException } from '@nestjs/common';
+import { LiquidationsService } from './liquidations.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { NotificationsService } from '../notifications/notifications.service';
+import {
+  createLiquidationWorkflowDependencies,
+  LiquidationPublicationUseCase,
+} from './liquidation-publication.use-case';
+
+const legacyExpense = (overrides: Record<string, unknown> = {}) => ({
+  id: 'exp-1',
+  tenantId: 'tenant-1',
+  buildingId: 'building-1',
+  period: '2026-08',
+  liquidationPeriod: '2026-08',
+  category: { name: 'Maintenance' },
+  vendor: { name: 'Vendor' },
+  amountMinor: 1000,
+  currencyCode: 'ARS',
+  invoiceDate: new Date('2026-08-05T00:00:00.000Z'),
+  description: null,
+  status: 'VALIDATED',
+  scopeType: 'BUILDING',
+  ...overrides,
+});
+
+const functionalExpense = (overrides: Record<string, unknown> = {}) =>
+  legacyExpense({
+    currencyCode: 'USD',
+    functionalAmountMinor: 36500,
+    functionalCurrencyCode: 'VES',
+    exchangeRateId: 'rate-1',
+    exchangeRateValue: '36.5',
+    exchangeRateDirection: 'DIRECT',
+    exchangeRateEffectiveAt: new Date('2026-08-04T00:00:00.000Z'),
+    conversionDate: new Date('2026-08-05T00:00:00.000Z'),
+    ...overrides,
+  });
+
+const identityExpense = (overrides: Record<string, unknown> = {}) =>
+  legacyExpense({
+    currencyCode: 'VES',
+    amountMinor: 500,
+    functionalAmountMinor: 500,
+    functionalCurrencyCode: 'VES',
+    exchangeRateId: null,
+    exchangeRateValue: '1',
+    exchangeRateDirection: 'IDENTITY',
+    exchangeRateEffectiveAt: null,
+    conversionDate: new Date('2026-08-05T00:00:00.000Z'),
+    ...overrides,
+  });
+
+const legacyAdjustment = (overrides: Record<string, unknown> = {}) => ({
+  id: 'adj-1',
+  amountMinor: 200,
+  currencyCode: 'ARS',
+  sourceInvoiceDate: new Date('2026-08-01T00:00:00.000Z'),
+  sourcePeriod: '2026-08',
+  reason: 'Correction',
+  category: { name: 'Water' },
+  ...overrides,
+});
+
+const functionalAdjustment = (overrides: Record<string, unknown> = {}) =>
+  legacyAdjustment({
+    currencyCode: 'COP',
+    functionalAmountMinor: 125,
+    functionalCurrencyCode: 'VES',
+    exchangeRateId: 'rate-inv',
+    exchangeRateValue: '25',
+    exchangeRateDirection: 'INVERSE',
+    exchangeRateEffectiveAt: new Date('2026-07-20T00:00:00.000Z'),
+    conversionDate: new Date('2026-08-01T00:00:00.000Z'),
+    ...overrides,
+  });
+
+describe('LiquidationsService multicurrency valuation', () => {
+  let service: LiquidationsService;
+  let prisma: PrismaService;
+  let tx: {
+    tenant: { findFirst: jest.Mock };
+    membership: { findFirst: jest.Mock };
+    building: { findFirst: jest.Mock };
+    expense: { count: jest.Mock; findMany: jest.Mock };
+    adjustment: { findMany: jest.Mock };
+    unit: { findMany: jest.Mock };
+    liquidation: {
+      findFirst: jest.Mock;
+      create: jest.Mock;
+      updateMany: jest.Mock;
+    };
+    charge: {
+      count: jest.Mock;
+      findMany: jest.Mock;
+      createMany: jest.Mock;
+      updateMany: jest.Mock;
+    };
+    paymentAllocation: { count: jest.Mock };
+    auditLog: { create: jest.Mock };
+  };
+
+  const setupPrisma = () => {
+    prisma = {
+      $transaction: jest.fn((fn: (client: typeof tx) => unknown) => fn(tx)),
+    } as unknown as PrismaService;
+  };
+
+  beforeEach(async () => {
+    tx = {
+      tenant: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'tenant-1', functionalCurrency: 'VES' }),
+      },
+      membership: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'member-1',
+          tenantId: 'tenant-1',
+          userId: 'user-1',
+          roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+        }),
+      },
+      building: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'building-1' }),
+      },
+      expense: {
+        count: jest.fn().mockResolvedValue(0),
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      adjustment: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      unit: {
+        findMany: jest.fn().mockResolvedValue([
+          { id: 'unit-1', code: '1A', label: '1A', unitCategory: null },
+          { id: 'unit-2', code: '1B', label: '1B', unitCategory: null },
+        ]),
+      },
+      liquidation: {
+        findFirst: jest.fn().mockImplementation(({ where }: { where?: { status?: string } }) => {
+          if (where?.status === 'PUBLISHED') {
+            return Promise.resolve(null);
+          }
+          const createdData =
+            (tx.liquidation.create as jest.Mock).mock.calls[0]?.[0]?.data ?? {};
+          return Promise.resolve({
+            id: 'liq-created',
+            tenantId: 'tenant-1',
+            buildingId: 'building-1',
+            period: '2026-08',
+            chargePeriod: null,
+            status: 'DRAFT',
+            valuationMode: createdData.valuationMode ?? 'LEGACY_NOMINAL',
+            baseCurrency: createdData.baseCurrency ?? 'VES',
+            totalAmountMinor: 0,
+            totalsByCurrency: {},
+            expenseSnapshot: [],
+            publicationSnapshot: null,
+            unitCount: 2,
+            generatedAt: new Date(),
+            reviewedAt: null,
+            publishedAt: null,
+            canceledAt: null,
+            createdAt: new Date(),
+          });
+        }),
+        create: jest.fn().mockImplementation(({ data }: { data: Record<string, unknown> }) =>
+          Promise.resolve({ id: 'liq-created', ...data, createdAt: new Date(), updatedAt: new Date() }),
+        ),
+        updateMany: jest.fn().mockResolvedValue({ count: 1 }),
+      },
+      charge: {
+        count: jest.fn().mockResolvedValue(0),
+        findMany: jest.fn().mockResolvedValue([]),
+        createMany: jest.fn().mockResolvedValue({ count: 2 }),
+        updateMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      paymentAllocation: { count: jest.fn().mockResolvedValue(0) },
+      auditLog: { create: jest.fn().mockResolvedValue({}) },
+    };
+
+    setupPrisma();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LiquidationsService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: AuditService, useValue: { createLog: jest.fn(), createLogRequired: jest.fn() } },
+        {
+          provide: FinanzasValidators,
+          useValue: { isAdminOrOperator: jest.fn().mockReturnValue(true) },
+        },
+        { provide: NotificationsService, useValue: { createNotification: jest.fn() } },
+        {
+          provide: LiquidationPublicationUseCase,
+          useFactory: () =>
+            new LiquidationPublicationUseCase(
+              createLiquidationWorkflowDependencies(
+                prisma,
+                { isAdminOrOperator: () => true },
+                jest.fn(),
+              ),
+            ),
+        },
+      ],
+    }).compile();
+
+    service = module.get<LiquidationsService>(LiquidationsService);
+  });
+
+  const createDraft = (baseCurrency = 'VES', period = '2026-08') =>
+    service.createDraft('tenant-1', 'member-1', {
+      buildingId: 'building-1',
+      period,
+      baseCurrency,
+    });
+
+  const lastCreated = () => {
+    expect(tx.liquidation.create).toHaveBeenCalledTimes(1);
+    const call = (tx.liquidation.create as jest.Mock).mock.calls[0] as [
+      { data: Record<string, unknown> },
+    ];
+    return call[0].data;
+  };
+
+  describe('FUNCTIONAL mode', () => {
+    it('single functional expense in functional currency produces FUNCTIONAL valuation', async () => {
+      tx.expense.findMany
+        .mockResolvedValueOnce([identityExpense()])
+        .mockResolvedValueOnce([]);
+
+      const result = await createDraft();
+
+      const data = lastCreated();
+      expect(data.valuationMode).toBe('FUNCTIONAL');
+      expect(data.baseCurrency).toBe('VES');
+      expect(data.totalAmountMinor).toBe(500);
+      expect(result.valuationMode).toBe('FUNCTIONAL');
+    });
+
+    it('USD + COP sources converge to functional VES total', async () => {
+      tx.expense.findMany
+        .mockResolvedValueOnce([functionalExpense()])
+        .mockResolvedValueOnce([]);
+      tx.adjustment.findMany.mockResolvedValueOnce([functionalAdjustment()]);
+
+      const result = await createDraft();
+
+      const data = lastCreated();
+      expect(data.valuationMode).toBe('FUNCTIONAL');
+      expect(data.baseCurrency).toBe('VES');
+      expect(data.totalAmountMinor).toBe(36500 + 125);
+      expect(data.totalsByCurrency).toEqual({ USD: 1000, COP: 200 });
+      expect(result.valuationMode).toBe('FUNCTIONAL');
+    });
+
+    it('keeps original totals by currency and functional total in the snapshot items', async () => {
+      tx.expense.findMany
+        .mockResolvedValueOnce([functionalExpense(), identityExpense()])
+        .mockResolvedValueOnce([]);
+
+      await createDraft();
+
+      const data = lastCreated();
+      const snapshot = data.expenseSnapshot as Array<Record<string, unknown>>;
+      expect(data.totalAmountMinor).toBe(37000);
+      expect(data.totalsByCurrency).toEqual({ USD: 1000, VES: 500 });
+      expect(snapshot).toHaveLength(2);
+      expect(snapshot[0]).toMatchObject({
+        expenseId: 'exp-1',
+        functionalAmountMinor: 36500,
+        functionalCurrencyCode: 'VES',
+        exchangeRateDirection: 'DIRECT',
+      });
+      expect(snapshot[1]).toMatchObject({
+        exchangeRateDirection: 'IDENTITY',
+        exchangeRateId: null,
+      });
+    });
+
+    it('rejects a base currency that differs from the tenant functional currency', async () => {
+      tx.expense.findMany
+        .mockResolvedValueOnce([functionalExpense()])
+        .mockResolvedValueOnce([]);
+
+      await expect(createDraft('USD')).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_BASE_CURRENCY_MISMATCH',
+        },
+      });
+      expect(tx.liquidation.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('LEGACY_NOMINAL mode', () => {
+    it('all legacy sources with single currency equal to base produce LEGACY_NOMINAL', async () => {
+      tx.expense.findMany
+        .mockResolvedValueOnce([legacyExpense()])
+        .mockResolvedValueOnce([]);
+      tx.adjustment.findMany.mockResolvedValueOnce([legacyAdjustment()]);
+
+      const result = await createDraft('ARS');
+
+      const data = lastCreated();
+      expect(data.valuationMode).toBe('LEGACY_NOMINAL');
+      expect(data.baseCurrency).toBe('ARS');
+      expect(data.totalAmountMinor).toBe(1200);
+      expect(result.valuationMode).toBe('LEGACY_NOMINAL');
+    });
+
+    it('blocks legacy single currency different from base currency', async () => {
+      tx.expense.findMany
+        .mockResolvedValueOnce([legacyExpense()])
+        .mockResolvedValueOnce([]);
+
+      await expect(createDraft('USD')).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_BASE_CURRENCY_MISMATCH',
+        },
+      });
+    });
+
+    it('blocks legacy mixed currencies', async () => {
+      tx.expense.findMany
+        .mockResolvedValueOnce([legacyExpense(), legacyExpense({ id: 'exp-2', currencyCode: 'USD' })])
+        .mockResolvedValueOnce([]);
+
+      await expect(createDraft('ARS')).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'MIXED_CURRENCY_LIQUIDATION_NOT_SUPPORTED',
+        },
+      });
+    });
+  });
+
+  describe('HYBRID / PARTIAL blocks', () => {
+    it('blocks functional expense + legacy adjustment', async () => {
+      tx.expense.findMany
+        .mockResolvedValueOnce([functionalExpense()])
+        .mockResolvedValueOnce([]);
+      tx.adjustment.findMany.mockResolvedValueOnce([legacyAdjustment()]);
+
+      await expect(createDraft()).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+        },
+      });
+      expect(tx.liquidation.create).not.toHaveBeenCalled();
+    });
+
+    it('blocks legacy expense + functional adjustment', async () => {
+      tx.expense.findMany
+        .mockResolvedValueOnce([legacyExpense()])
+        .mockResolvedValueOnce([]);
+      tx.adjustment.findMany.mockResolvedValueOnce([functionalAdjustment()]);
+
+      await expect(createDraft('VES')).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+        },
+      });
+    });
+
+    it('blocks a corrupted IDENTITY snapshot (rate present, direction missing)', async () => {
+      tx.expense.findMany
+        .mockResolvedValueOnce([
+          identityExpense({
+            exchangeRateDirection: null,
+            exchangeRateId: 'rate-x',
+          }),
+        ])
+        .mockResolvedValueOnce([]);
+
+      await expect(createDraft()).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+        },
+      });
+    });
+
+    it('blocks a DIRECT snapshot with non-positive rate', async () => {
+      tx.expense.findMany
+        .mockResolvedValueOnce([
+          functionalExpense({ exchangeRateValue: '0' }),
+        ])
+        .mockResolvedValueOnce([]);
+
+      await expect(createDraft()).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+        },
+      });
+    });
+
+    it('blocks a snapshot with missing provenance (no exchangeRateId on DIRECT)', async () => {
+      tx.expense.findMany
+        .mockResolvedValueOnce([
+          functionalExpense({ exchangeRateId: null }),
+        ])
+        .mockResolvedValueOnce([]);
+
+      await expect(createDraft()).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+        },
+      });
+    });
+
+    it('blocks a snapshot whose functional currency differs from base currency', async () => {
+      tx.expense.findMany
+        .mockResolvedValueOnce([
+          functionalExpense({ functionalCurrencyCode: 'ARS' }),
+        ])
+        .mockResolvedValueOnce([]);
+
+      await expect(createDraft()).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+        },
+      });
+    });
+  });
+
+  describe('functional currency changed before draft', () => {
+    it('blocks when the frozen functional snapshot predates a tenant currency change', async () => {
+      tx.expense.findMany
+        .mockResolvedValueOnce([functionalExpense()])
+        .mockResolvedValueOnce([]);
+      tx.tenant.findFirst.mockResolvedValueOnce({
+        id: 'tenant-1',
+        functionalCurrency: 'USD',
+      });
+
+      await expect(createDraft('USD')).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+        },
+      });
+      expect(tx.liquidation.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tenant isolation', () => {
+    it('does not leak rates or sources across tenants (membership scoped)', async () => {
+      tx.membership.findFirst.mockResolvedValueOnce(null);
+
+      await expect(
+        service.createDraft('other-tenant', 'member-1', {
+          buildingId: 'building-1',
+          period: '2026-08',
+          baseCurrency: 'VES',
+        }),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/apps/api/src/finanzas/liquidations.service.spec.ts
+++ b/apps/api/src/finanzas/liquidations.service.spec.ts
@@ -90,6 +90,9 @@ describe('LiquidationsService', () => {
 
   beforeEach(async () => {
     tx = {
+      tenant: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'tenant-1', functionalCurrency: 'ARS' }),
+      },
       membership: {
       findFirst: jest.fn().mockResolvedValue({
         id: 'member-1',

--- a/apps/api/src/finanzas/liquidations.service.ts
+++ b/apps/api/src/finanzas/liquidations.service.ts
@@ -4,6 +4,7 @@ import {
   BadRequestException,
   ConflictException,
   ForbiddenException,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { ChargeStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
@@ -15,6 +16,11 @@ import {
   LiquidationDetailDto,
 } from './expense-ledger.dto';
 import { FinanzasValidators } from './finanzas.validators';
+import {
+  determineLiquidationValuationMode,
+  isFunctionalSnapshotPresent,
+  sumValuationAmounts,
+} from './liquidation-valuation';
 import {
   assertLiquidationMovementCurrency,
   parseLiquidationPublicationSnapshot,
@@ -38,6 +44,13 @@ interface LiquidationExpenseSnapshotItem extends Prisma.InputJsonObject {
   description: string | null;
   type: 'EXPENSE' | 'ADJUSTMENT';
   sourcePeriod?: string;
+  functionalAmountMinor?: number | null;
+  functionalCurrencyCode?: string | null;
+  exchangeRateId?: string | null;
+  exchangeRateValue?: string | null;
+  exchangeRateDirection?: string | null;
+  exchangeRateEffectiveAt?: string | null;
+  conversionDate?: string | null;
 }
 
 interface LiquidationExpenseSnapshotRow {
@@ -50,6 +63,13 @@ interface LiquidationExpenseSnapshotRow {
   description: string | null;
   type: 'EXPENSE' | 'ADJUSTMENT';
   sourcePeriod?: string;
+  functionalAmountMinor: number | null;
+  functionalCurrencyCode: string | null;
+  exchangeRateId: string | null;
+  exchangeRateValue: string | null;
+  exchangeRateDirection: string | null;
+  exchangeRateEffectiveAt: Date | null;
+  conversionDate: Date | null;
 }
 
 interface CancelLiquidationOptions {
@@ -255,6 +275,16 @@ export class LiquidationsService {
         invoiceDate: expense.invoiceDate,
         description: expense.description,
         type: 'EXPENSE',
+        functionalAmountMinor: expense.functionalAmountMinor,
+        functionalCurrencyCode: expense.functionalCurrencyCode,
+        exchangeRateId: expense.exchangeRateId,
+        exchangeRateValue:
+          expense.exchangeRateValue === null || expense.exchangeRateValue === undefined
+            ? null
+            : expense.exchangeRateValue.toString(),
+        exchangeRateDirection: expense.exchangeRateDirection,
+        exchangeRateEffectiveAt: expense.exchangeRateEffectiveAt,
+        conversionDate: expense.conversionDate,
       }));
 
       for (const expense of allocatedSharedExpenses) {
@@ -269,6 +299,17 @@ export class LiquidationsService {
             invoiceDate: expense.invoiceDate,
             description: expense.description,
             type: 'EXPENSE',
+            functionalAmountMinor: allocation.functionalAmountMinor,
+            functionalCurrencyCode:
+              allocation.functionalCurrencyCode ?? expense.functionalCurrencyCode,
+            exchangeRateId: expense.exchangeRateId,
+            exchangeRateValue:
+              expense.exchangeRateValue === null || expense.exchangeRateValue === undefined
+                ? null
+                : expense.exchangeRateValue.toString(),
+            exchangeRateDirection: expense.exchangeRateDirection,
+            exchangeRateEffectiveAt: expense.exchangeRateEffectiveAt,
+            conversionDate: expense.conversionDate,
           });
         }
       }
@@ -282,6 +323,13 @@ export class LiquidationsService {
         invoiceDate: expense.invoiceDate.toISOString(),
         description: expense.description,
         type: expense.type,
+        functionalAmountMinor: expense.functionalAmountMinor,
+        functionalCurrencyCode: expense.functionalCurrencyCode,
+        exchangeRateId: expense.exchangeRateId,
+        exchangeRateValue: expense.exchangeRateValue,
+        exchangeRateDirection: expense.exchangeRateDirection,
+        exchangeRateEffectiveAt: expense.exchangeRateEffectiveAt?.toISOString() ?? null,
+        conversionDate: expense.conversionDate?.toISOString() ?? null,
       }));
 
       const totalsByCurrency: Record<string, number> = {};
@@ -304,6 +352,17 @@ export class LiquidationsService {
           description: `Ajuste retroactivo: ${adjustment.reason}`,
           type: 'ADJUSTMENT',
           sourcePeriod: adjustment.sourcePeriod,
+          functionalAmountMinor: adjustment.functionalAmountMinor,
+          functionalCurrencyCode: adjustment.functionalCurrencyCode,
+          exchangeRateId: adjustment.exchangeRateId,
+          exchangeRateValue:
+            adjustment.exchangeRateValue === null || adjustment.exchangeRateValue === undefined
+              ? null
+              : adjustment.exchangeRateValue.toString(),
+          exchangeRateDirection: adjustment.exchangeRateDirection,
+          exchangeRateEffectiveAt:
+            adjustment.exchangeRateEffectiveAt?.toISOString() ?? null,
+          conversionDate: adjustment.conversionDate?.toISOString() ?? null,
         });
 
         totalsByCurrency[adjustment.currencyCode] = this.safeAddAmountMinor(
@@ -320,7 +379,50 @@ export class LiquidationsService {
         );
       }
 
-      assertLiquidationMovementCurrency(expenseSnapshotItems, dto.baseCurrency);
+      const tenant = await tx.tenant.findFirst({
+        where: { id: tenantId },
+        select: { functionalCurrency: true },
+      });
+
+      if (!tenant) {
+        throw new NotFoundException(`Tenant no encontrado: ${tenantId}`);
+      }
+
+      const valuationSources = expenseSnapshotItems.map((item) => ({
+        id: item.expenseId,
+        type: item.type,
+        amountMinor: item.amountMinor,
+        currencyCode: item.currencyCode,
+        functionalAmountMinor: item.functionalAmountMinor ?? null,
+        functionalCurrencyCode: item.functionalCurrencyCode ?? null,
+        exchangeRateId: item.exchangeRateId ?? null,
+        exchangeRateValue: item.exchangeRateValue ?? null,
+        exchangeRateDirection: item.exchangeRateDirection ?? null,
+        exchangeRateEffectiveAt: item.exchangeRateEffectiveAt ?? null,
+        conversionDate: item.conversionDate ?? null,
+      }));
+
+      const hasFunctionalSources = valuationSources.some(
+        (source) => isFunctionalSnapshotPresent(source),
+      );
+
+      if (hasFunctionalSources && dto.baseCurrency !== tenant.functionalCurrency) {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'LIQUIDATION_BASE_CURRENCY_MISMATCH',
+          message: `La moneda base solicitada (${dto.baseCurrency}) no coincide con la moneda funcional del tenant (${tenant.functionalCurrency})`,
+        });
+      }
+
+      const valuationMode = determineLiquidationValuationMode(
+        valuationSources,
+        dto.baseCurrency,
+      );
+      assertLiquidationMovementCurrency(
+        expenseSnapshotItems,
+        dto.baseCurrency,
+        valuationMode,
+      );
 
       const billableUnits = await tx.unit.findMany({
         where: { tenantId, buildingId: dto.buildingId, isBillable: true },
@@ -328,7 +430,7 @@ export class LiquidationsService {
         orderBy: { code: 'asc' },
       });
 
-      const totalAmountMinor = this.requireCurrencyTotal(totalsByCurrency, dto.baseCurrency);
+      const totalAmountMinor = sumValuationAmounts(valuationSources, valuationMode);
       const chargesPreview = this.calculateDistribution(
         billableUnits,
         totalAmountMinor,
@@ -341,6 +443,7 @@ export class LiquidationsService {
         tenantId,
         buildingId: dto.buildingId,
         period: dto.period,
+        valuationMode,
         baseCurrency: dto.baseCurrency,
         totalAmountMinor,
         totalsByCurrency,
@@ -614,6 +717,7 @@ export class LiquidationsService {
     period: string;
     chargePeriod: string | null;
     status: 'DRAFT' | 'REVIEWED' | 'PUBLISHED' | 'CANCELED';
+    valuationMode: 'FUNCTIONAL' | 'LEGACY_NOMINAL' | null;
     baseCurrency: string;
     totalAmountMinor: number;
     totalsByCurrency: unknown;
@@ -633,6 +737,7 @@ export class LiquidationsService {
       period: liq.period,
       chargePeriod: liq.chargePeriod,
       status: liq.status,
+      valuationMode: liq.valuationMode,
       baseCurrency: liq.baseCurrency,
       totalAmountMinor: liq.totalAmountMinor,
       totalsByCurrency,
@@ -653,6 +758,7 @@ export class LiquidationsService {
       period: string;
       chargePeriod: string | null;
       status: 'DRAFT' | 'REVIEWED' | 'PUBLISHED' | 'CANCELED';
+      valuationMode: 'FUNCTIONAL' | 'LEGACY_NOMINAL' | null;
       baseCurrency: string;
       totalAmountMinor: number;
       totalsByCurrency: unknown;

--- a/apps/api/src/finanzas/movement-allocation.service.ts
+++ b/apps/api/src/finanzas/movement-allocation.service.ts
@@ -79,6 +79,75 @@ export function allocateByLargestRemainder(
   return allocatedAmounts;
 }
 
+/**
+ * Distribuye un total funcional (minor units) entre pesos nominales enteros
+ * usando largest remainder con aritmética decimal exacta.
+ *
+ * Garantiza: SUM(resultado) === totalFunctionalMinor exactamente.
+ */
+export function allocateFunctionalByLargestRemainder(
+  totalFunctionalMinor: number,
+  weights: readonly number[],
+): number[] {
+  if (weights.length === 0) {
+    throw new BadRequestException('No hay pesos para distribuir el monto funcional');
+  }
+
+  const totalDecimal = new Prisma.Decimal(totalFunctionalMinor);
+  const weightDecimals = weights.map((weight) => new Prisma.Decimal(weight ?? 0));
+  const totalWeight = weightDecimals.reduce(
+    (sum, weight) => sum.add(weight),
+    new Prisma.Decimal(0),
+  );
+
+  const exactShares = weightDecimals.map((weight, index) => {
+    const raw = totalDecimal.mul(weight).div(totalWeight);
+    const floor = raw.toDecimalPlaces(0, Prisma.Decimal.ROUND_DOWN);
+    return {
+      index,
+      amountMinor: floor.toNumber(),
+      remainder: raw.sub(floor),
+    };
+  });
+
+  const allocatedAmount = exactShares.reduce(
+    (sum, share) => sum + share.amountMinor,
+    0,
+  );
+  const missingCents = totalFunctionalMinor - allocatedAmount;
+
+  if (missingCents < 0 || !Number.isSafeInteger(missingCents)) {
+    throw new BadRequestException(
+      `Error de redondeo al distribuir el monto funcional ${totalFunctionalMinor}`,
+    );
+  }
+
+  exactShares
+    .slice()
+    .sort(
+      (a, b) =>
+        b.remainder.comparedTo(a.remainder) || a.index - b.index,
+    )
+    .slice(0, missingCents)
+    .forEach((share) => {
+      const target = exactShares[share.index];
+      if (target) {
+        target.amountMinor += 1;
+      }
+    });
+
+  const allocatedAmounts = exactShares.map((share) => share.amountMinor);
+  const finalAmount = allocatedAmounts.reduce((sum, amount) => sum + amount, 0);
+
+  if (finalAmount !== totalFunctionalMinor) {
+    throw new BadRequestException(
+      `Error de redondeo: las allocations funcionales suman ${finalAmount}, esperado ${totalFunctionalMinor}`,
+    );
+  }
+
+  return allocatedAmounts;
+}
+
 @Injectable()
 export class MovementAllocationService {
   constructor(

--- a/apps/web/features/finance/services/expense-ledger.api.ts
+++ b/apps/web/features/finance/services/expense-ledger.api.ts
@@ -5,6 +5,7 @@ import { apiClient } from '@/shared/lib/http/client';
 export type ExpenseStatus = 'DRAFT' | 'VALIDATED' | 'VOID';
 export type IncomeStatus = 'DRAFT' | 'RECORDED' | 'VOID';
 export type LiquidationStatus = 'DRAFT' | 'REVIEWED' | 'PUBLISHED' | 'CANCELED';
+export type LiquidationValuationMode = 'FUNCTIONAL' | 'LEGACY_NOMINAL';
 export type CatalogScope = 'BUILDING' | 'CONDOMINIUM_COMMON';
 
 export interface ExpenseLedgerCategory {
@@ -90,6 +91,7 @@ export interface Liquidation {
   buildingId: string;
   period: string;
   status: LiquidationStatus;
+  valuationMode?: LiquidationValuationMode | null;
   baseCurrency: string;
   totalAmountMinor: number;
   totalsByCurrency: Record<string, number>;


### PR DESCRIPTION
## PHASE 3D — Liquidations multicurrency

- `Liquidation.totalAmountMinor` semánticamente expresado en `baseCurrency` (funcional o nominal)
- `valuationMode`: **FUNCTIONAL** / **LEGACY_NOMINAL** (enum Prisma, NULL = histórico)
- Hybrid/partial snapshots **bloqueados** (`LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED`)
- `Tenant.functionalCurrency` congelada en el draft (baseCurrency validada)
- Los snapshots de fuentes (3C1/3C3) **nunca se reconvierten**
- Publication snapshot **V2** (original + functional + FX provenance por item) con **backward compatibility V1**
- Reconciliación exacta: SUM sources == totalAmountMinor == SUM allocations == SUM charges
- TENANT_SHARED: allocations funcionales exactas (largest remainder, suma == Expense.functionalAmountMinor)
- Source freeze: publish usa el snapshot del draft; drift → `LIQUIDATION_PUBLICATION_SOURCE_DRIFT`
- M2 (liquidation-engine) **delega en M1**; su controller **ahora registrado y protegido** con `TenantAccessGuard` (+JwtAuthGuard)
- Migration `20260810030000_add_liquidation_functional_valuation` **aditiva** (enum + 3 columnas nullable, sin backfill)
- Aceptación funcional local real pasada (HTTP + DB)

Explicitamente NO incluido: Payments multicurrency, Reports, Dashboard, 3E, producción.

Deuda/futuro: M3 ExpensePeriod legacy queda intacto.