### PR TITLE
fix(finance): harden charge and payment currency invariants

### DIFF
--- a/apps/api/src/finanzas/finanzas.currency-hardening.dto.spec.ts
+++ b/apps/api/src/finanzas/finanzas.currency-hardening.dto.spec.ts
@@ -1,0 +1,71 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+import {
+  CreateChargeDto,
+  UpdateChargeDto,
+  SubmitPaymentDto,
+} from './finanzas.dto';
+
+const validate = <T extends object>(cls: new () => T, input: Record<string, unknown>) =>
+  validateSync(plainToInstance(cls, input), {
+    whitelist: true,
+    forbidUnknownValues: true,
+  });
+
+describe('3E1 canonical currency DTOs', () => {
+  describe('CreateChargeDto.currency', () => {
+    const base = {
+      unitId: 'unit-1',
+      type: 'COMMON_EXPENSE',
+      concept: 'Expensas',
+      amount: 10000,
+      dueDate: '2026-06-10',
+    };
+
+    it.each(['USD', 'VES', 'ARS', 'COP'])('accepts canonical %s', (currency) => {
+      expect(validate(CreateChargeDto, { ...base, currency })).toHaveLength(0);
+    });
+
+    it('accepts absent currency (default ARS)', () => {
+      expect(validate(CreateChargeDto, base)).toHaveLength(0);
+    });
+
+    it.each(['XYZ', 'eur', '', 'USDD'])('rejects non-canonical %s', (currency) => {
+      const errors = validate(CreateChargeDto, { ...base, currency });
+      expect(errors.map((error) => error.property)).toContain('currency');
+    });
+  });
+
+  describe('UpdateChargeDto.currency', () => {
+    it.each(['USD', 'VES', 'ARS', 'COP'])('accepts canonical %s', (currency) => {
+      expect(validate(UpdateChargeDto, { currency })).toHaveLength(0);
+    });
+
+    it.each(['XYZ', 'eur'])('rejects non-canonical %s', (currency) => {
+      expect(validate(UpdateChargeDto, { currency }).map((error) => error.property)).toContain(
+        'currency',
+      );
+    });
+  });
+
+  describe('SubmitPaymentDto.currency', () => {
+    const base = {
+      amount: 10000,
+      method: 'TRANSFER',
+    };
+
+    it.each(['USD', 'VES', 'ARS', 'COP'])('accepts canonical %s', (currency) => {
+      expect(validate(SubmitPaymentDto, { ...base, currency })).toHaveLength(0);
+    });
+
+    it('accepts absent currency (default ARS)', () => {
+      expect(validate(SubmitPaymentDto, base)).toHaveLength(0);
+    });
+
+    it.each(['XYZ', 'eur', ''])('rejects non-canonical %s', (currency) => {
+      const errors = validate(SubmitPaymentDto, { ...base, currency });
+      expect(errors.map((error) => error.property)).toContain('currency');
+    });
+  });
+});

--- a/apps/api/src/finanzas/finanzas.dto.ts
+++ b/apps/api/src/finanzas/finanzas.dto.ts
@@ -16,6 +16,7 @@ import {
   ArrayUnique,
 } from 'class-validator';
 import { ChargeType, ChargeStatus, PaymentStatus, PaymentMethod, RejectionReason } from '@prisma/client';
+import { CANONICAL_CURRENCIES } from '@buildingos/contracts';
 import {
   BuildingChargeParamDto,
   BuildingPaymentParamDto,
@@ -42,7 +43,7 @@ export class CreateChargeDto {
   amount!: number; // In cents
 
   @IsOptional()
-  @IsString()
+  @IsIn(CANONICAL_CURRENCIES, { message: 'currency must be one of USD, VES, ARS, or COP' })
   currency?: string; // Default: ARS
 
   @IsOptional()
@@ -73,7 +74,7 @@ export class UpdateChargeDto {
   amount?: number;
 
   @IsOptional()
-  @IsString()
+  @IsIn(CANONICAL_CURRENCIES, { message: 'currency must be one of USD, VES, ARS, or COP' })
   currency?: string;
 
   @IsOptional()
@@ -112,7 +113,7 @@ export class SubmitPaymentDto {
   amount!: number; // In cents
 
   @IsOptional()
-  @IsString()
+  @IsIn(CANONICAL_CURRENCIES, { message: 'currency must be one of USD, VES, ARS, or COP' })
   currency?: string; // Default: ARS
 
   @IsEnum(PaymentMethod)

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -127,6 +127,8 @@ describe('FinanzasService', () => {
             canSubmitPayments: jest.fn(),
             canReviewPayments: jest.fn(),
             validateResidentUnitAccess: jest.fn(),
+            canAllocate: jest.fn(),
+            validateChargeBelongsToBuildingAndTenant: jest.fn(),
           },
         },
       ],
@@ -3637,6 +3639,150 @@ describe('FinanzasService', () => {
       expect(notificationsService.createNotification).not.toHaveBeenCalledWith(expect.objectContaining({
         userId: residentId,
       }));
+    });
+  });
+
+  // ========== 3E1: CURRENCY INVARIANTS ==========
+  describe('3E1 currency invariants', () => {
+    const baseCharge = {
+      id: 'charge-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      amount: 10000,
+      currency: 'ARS',
+      dueDate: new Date('2026-06-10'),
+      period: '2026-05',
+      concept: 'Expensas',
+      status: 'PENDING',
+      canceledAt: null,
+    };
+
+    const basePayment = {
+      id: 'payment-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      amount: 10000,
+      currency: 'ARS',
+      status: 'APPROVED',
+      paymentAllocations: [],
+    };
+
+    describe('cancelCharge', () => {
+      const cancel = (allocation: unknown) => {
+        jest.spyOn(validators, 'canWriteCharges').mockReturnValue(true);
+        jest.spyOn(validators, 'validateChargeBelongsToBuildingAndTenant').mockResolvedValue(undefined);
+        jest.spyOn(prismaService.charge, 'findUnique').mockResolvedValue(baseCharge as never);
+        jest
+          .spyOn(prismaService.paymentAllocation, 'findFirst')
+          .mockResolvedValue(allocation as never);
+        return service.cancelCharge(
+          'tenant-1',
+          'building-1',
+          'charge-1',
+          ['TENANT_ADMIN'],
+          'user-1',
+          { reason: 'test' },
+        );
+      };
+
+      it('cancels a charge without effective allocations', async () => {
+        jest.spyOn(prismaService.charge, 'update').mockResolvedValue(baseCharge as never);
+
+        await expect(cancel(null)).resolves.toBeDefined();
+        expect(prismaService.charge.update).toHaveBeenCalledTimes(1);
+        expect(prismaService.paymentAllocation.findFirst).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              chargeId: 'charge-1',
+              payment: { status: { in: ['APPROVED', 'RECONCILED'] } },
+            }),
+          }),
+        );
+      });
+
+      it('treats a SUBMITTED reservation as non-blocking (DB filter excludes it)', async () => {
+        jest.spyOn(prismaService.charge, 'update').mockResolvedValue(baseCharge as never);
+        jest.spyOn(prismaService.paymentAllocation, 'findFirst').mockResolvedValue(null);
+
+        await expect(cancel(null)).resolves.toBeDefined();
+        expect(prismaService.charge.update).toHaveBeenCalledTimes(1);
+        expect(prismaService.paymentAllocation.findFirst).toHaveBeenCalledWith(
+          expect.objectContaining({
+            where: expect.objectContaining({
+              payment: { status: { in: ['APPROVED', 'RECONCILED'] } },
+            }),
+          }),
+        );
+      });
+
+      it('blocks cancellation with an APPROVED allocation (409 CHARGE_HAS_EFFECTIVE_ALLOCATIONS)', async () => {
+        jest.spyOn(prismaService.charge, 'update').mockResolvedValue(baseCharge as never);
+
+        await expect(cancel({ id: 'alloc-1', payment: { status: 'APPROVED' } })).rejects.toMatchObject({
+          response: {
+            statusCode: 409,
+            error: 'CHARGE_HAS_EFFECTIVE_ALLOCATIONS',
+          },
+        });
+        expect(prismaService.charge.update).not.toHaveBeenCalled();
+      });
+
+      it('blocks cancellation with a RECONCILED allocation (409)', async () => {
+        jest.spyOn(prismaService.charge, 'update').mockResolvedValue(baseCharge as never);
+
+        await expect(cancel({ id: 'alloc-1', payment: { status: 'RECONCILED' } })).rejects.toMatchObject({
+          response: { statusCode: 409, error: 'CHARGE_HAS_EFFECTIVE_ALLOCATIONS' },
+        });
+        expect(prismaService.charge.update).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('createAllocation', () => {
+      const allocate = (paymentOverrides: Record<string, unknown>, chargeOverrides: Record<string, unknown>, amount = 10000) => {
+        jest.spyOn(validators, 'canAllocate').mockReturnValue(true);
+        jest.spyOn(validators, 'validateBuildingBelongsToTenant').mockResolvedValue(undefined);
+        jest
+          .spyOn(prismaService.payment, 'findFirst')
+          .mockResolvedValue({ ...basePayment, ...paymentOverrides } as never);
+        jest
+          .spyOn(prismaService.charge, 'findFirst')
+          .mockResolvedValue({ ...baseCharge, ...chargeOverrides, paymentAllocations: [] } as never);
+        jest
+          .spyOn(prismaService.charge, 'findMany')
+          .mockResolvedValue([{ ...baseCharge, ...chargeOverrides, paymentAllocations: [] }] as never);
+        jest.spyOn(prismaService.paymentAllocation, 'create').mockResolvedValue({} as never);
+        return service.createAllocation(
+          'tenant-1',
+          'building-1',
+          ['TENANT_ADMIN'],
+          'member-1',
+          { paymentId: 'payment-1', chargeId: 'charge-1', amount },
+        );
+      };
+
+      it('allows same-currency allocation', async () => {
+        await expect(allocate({}, {})).resolves.toBeDefined();
+        expect(prismaService.paymentAllocation.create).toHaveBeenCalled();
+      });
+
+      it('blocks cross-currency allocation with 422 PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED', async () => {
+        await expect(allocate({ currency: 'VES' }, {})).rejects.toMatchObject({
+          response: {
+            statusCode: 422,
+            error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED',
+          },
+        });
+        expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
+      });
+
+      it('leaves payment and charge untouched on cross-currency block', async () => {
+        await expect(allocate({ currency: 'VES' }, {})).rejects.toThrow();
+        expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
+        expect(prismaService.charge.update).not.toHaveBeenCalled();
+        expect(prismaService.payment.update).not.toHaveBeenCalled();
+      });
     });
   });
 });

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -1219,6 +1219,15 @@ describe('FinanzasService', () => {
       jest.spyOn(prismaService.payment, 'findUnique').mockResolvedValue(null);
       jest.spyOn(prismaService.charge, 'findUnique').mockResolvedValue(null);
       jest.spyOn(prismaService.paymentAuditLog, 'create').mockResolvedValue({} as any);
+      jest.spyOn(prismaService.charge, 'findUnique').mockResolvedValue({
+        id: 'charge-123',
+        amount: 10000,
+        status: ChargeStatus.PENDING,
+        paymentAllocations: [
+          { amount: 10000, payment: { status: PaymentStatus.APPROVED } },
+        ],
+      } as never);
+      jest.spyOn(prismaService.charge, 'update').mockResolvedValue({} as any);
     });
 
     it('keeps a resident-selected payment on a single charge without FIFO allocation', async () => {
@@ -1467,6 +1476,117 @@ describe('FinanzasService', () => {
             status: PaymentStatus.APPROVED,
           }),
         }),
+      );
+    });
+  });
+
+  // 3E1: approval recalculates affected charges from effective allocations
+  describe('approvePayment (3E1 charge recalculation)', () => {
+    const tenantId = 'tenant-123';
+    const buildingId = 'building-123';
+    const paymentId = 'payment-123';
+    const membershipId = 'membership-123';
+
+    const approve = () =>
+      service.approvePayment(
+        tenantId,
+        buildingId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        { paidAt: '2026-07-24T12:00:00.000Z' },
+      );
+
+    beforeEach(() => {
+      jest.spyOn(validators, 'canReviewPayments').mockReturnValue(true);
+      jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValue({
+        id: paymentId,
+        tenantId,
+        buildingId,
+        unitId: 'unit-123',
+        amount: 10000,
+        currency: 'ARS',
+        status: PaymentStatus.SUBMITTED,
+        canceledAt: null,
+        paymentAllocations: [{ chargeId: 'charge-123', amount: 10000, charge: {} }],
+      } as never);
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([
+        {
+          id: 'charge-123',
+          tenantId,
+          buildingId,
+          unitId: 'unit-123',
+          amount: 10000,
+          currency: 'ARS',
+          status: ChargeStatus.PENDING,
+          paymentAllocations: [],
+        },
+      ] as never);
+      jest.spyOn(prismaService.payment, 'update').mockResolvedValue({
+        id: paymentId,
+        status: PaymentStatus.APPROVED,
+      } as never);
+      jest.spyOn(prismaService.payment, 'findUnique').mockResolvedValue(null);
+      jest.spyOn(prismaService.charge, 'update').mockResolvedValue({} as never);
+      jest.spyOn(prismaService.paymentAuditLog, 'create').mockResolvedValue({} as never);
+    });
+
+    it('marks the charge PAID when the approved allocation covers it fully', async () => {
+      jest.spyOn(prismaService.charge, 'findUnique').mockResolvedValue({
+        id: 'charge-123',
+        amount: 10000,
+        status: ChargeStatus.PENDING,
+        paymentAllocations: [
+          { amount: 10000, payment: { status: PaymentStatus.APPROVED } },
+        ],
+      } as never);
+
+      await approve();
+
+      expect(prismaService.charge.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'charge-123' },
+          data: expect.objectContaining({ status: ChargeStatus.PAID }),
+        }),
+      );
+    });
+
+    it('marks the charge PARTIAL when the approved allocation covers it partially', async () => {
+      jest.spyOn(prismaService.charge, 'findUnique').mockResolvedValue({
+        id: 'charge-123',
+        amount: 10000,
+        status: ChargeStatus.PENDING,
+        paymentAllocations: [
+          { amount: 4000, payment: { status: PaymentStatus.APPROVED } },
+        ],
+      } as never);
+
+      await approve();
+
+      expect(prismaService.charge.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: ChargeStatus.PARTIAL }),
+        }),
+      );
+    });
+
+    it('never counts a SUBMITTED reservation as effective money for Charge.status', async () => {
+      jest.spyOn(prismaService.charge, 'findUnique').mockResolvedValue({
+        id: 'charge-123',
+        amount: 10000,
+        status: ChargeStatus.PENDING,
+        paymentAllocations: [
+          { amount: 10000, payment: { status: PaymentStatus.SUBMITTED } },
+        ],
+      } as never);
+
+      await approve();
+
+      expect(prismaService.charge.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ status: ChargeStatus.PAID }) }),
+      );
+      expect(prismaService.charge.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ status: ChargeStatus.PARTIAL }) }),
       );
     });
   });

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -9,6 +9,7 @@ import type { AuthenticatedMembership, PortalContext } from '../common/types/req
 import { resolveNotificationPortalContext } from '../common/portal-context';
 import { ExpensesService } from './expenses.service';
 import { acquirePaymentLinkedDocumentLock } from '../common/payment-linked-document-lock';
+import { isEffectivePaymentStatus as isEffectivePaymentStatusShared } from './payment-status-semantics';
 import type { Role, ScopedRole } from '@buildingos/contracts';
 import {
   CreateChargeDto,
@@ -872,6 +873,16 @@ export class FinanzasService {
           updatedAt: new Date(),
         },
       });
+
+      // 3E1: the payment's allocations became effective at APPROVED, so the
+      // affected charges must be recalculated from effective allocations only
+      // (a SUBMITTED reservation must never mark PARTIAL/PAID).
+      const affectedChargeIds = payment.paymentAllocations.map(
+        (allocation) => allocation.chargeId,
+      );
+      for (const chargeId of affectedChargeIds) {
+        await this.recalculateChargeStatus(chargeId, tx);
+      }
 
       await this.tryReconcilePayment(payment.id, tx);
       return approvedPayment;
@@ -1740,7 +1751,7 @@ export class FinanzasService {
   }
 
   private isEffectivePaymentStatus(status?: PaymentStatus | null): boolean {
-    return status === PaymentStatus.APPROVED || status === PaymentStatus.RECONCILED;
+    return isEffectivePaymentStatusShared(status);
   }
 
   // ============================================================================

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, ConflictException, NotFoundException, BadRequestException, Logger, PayloadTooLargeException, ForbiddenException } from '@nestjs/common';
+import { Injectable, ConflictException, NotFoundException, BadRequestException, Logger, PayloadTooLargeException, ForbiddenException, UnprocessableEntityException } from '@nestjs/common';
 import { Charge, Payment, PaymentAllocation, Prisma, ChargeStatus, PaymentStatus, PaymentMethod, AuditAction, PaymentAuditAction, RejectionReason, ReceiptStatus, ScopeType } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
@@ -453,6 +453,31 @@ export class FinanzasService {
     const charge = await this.prisma.charge.findUnique({
       where: { id: chargeId },
     });
+
+    // 2.5. A charge with effective (APPROVED/RECONCILED) payments cannot be
+    // canceled: PaymentAllocation history must stay coherent. SUBMITTED
+    // payments are only reservations and do not block cancellation.
+    const effectiveAllocation = await this.prisma.paymentAllocation.findFirst({
+      where: {
+        tenantId,
+        chargeId,
+        payment: {
+          status: {
+            in: [PaymentStatus.APPROVED, PaymentStatus.RECONCILED],
+          },
+        },
+      },
+      select: { id: true },
+    });
+
+    if (effectiveAllocation) {
+      throw new ConflictException({
+        statusCode: 409,
+        error: 'CHARGE_HAS_EFFECTIVE_ALLOCATIONS',
+        message:
+          'No se puede cancelar un cargo con pagos efectivos aplicados',
+      });
+    }
 
     // 3. Cancel
     const canceledCharge = await this.prisma.charge.update({
@@ -1035,6 +1060,16 @@ export class FinanzasService {
       throw new NotFoundException(
         `Charge not found or does not belong to this building/tenant`,
       );
+    }
+
+    // 3.75. Same-currency invariant: allocation amount is always expressed in
+    // Charge.currency. A cross-currency allocation is not supported until 3E3.
+    if (payment.currency !== charge.currency) {
+      throw new UnprocessableEntityException({
+        statusCode: 422,
+        error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED',
+        message: `La moneda del pago (${payment.currency}) no coincide con la moneda del cargo (${charge.currency})`,
+      });
     }
 
     if (!payment.unitId) {

--- a/apps/api/src/finanzas/payment-gateway/adapters/mercadopago.adapter.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/adapters/mercadopago.adapter.spec.ts
@@ -3,10 +3,55 @@
  * Task 2.1: Verify createPreference, handleWebhook, getChargeStatus
  */
 
-import { MercadoPagoAdapter } from './mercadopago.adapter';
+import { MercadoPagoAdapter, toMinorUnits } from './mercadopago.adapter';
 import { PaymentStatus } from '../interfaces/payment-provider.interface';
 import { createHmac } from 'crypto';
 import { HttpException } from '@nestjs/common';
+
+describe('toMinorUnits (exact decimal money conversion)', () => {
+  it.each([
+    [10.0, 1000],
+    [10.01, 1001],
+    [10.1, 1010],
+    [0.01, 1],
+    [36.5, 3650],
+    [1, 100],
+    [0.99, 99],
+  ])('converts %s to %s minor units', (input, expected) => {
+    expect(toMinorUnits(input)).toBe(expected);
+  });
+
+  it.each([10.005, 10.001, 0.001, 3.333])(
+    'rejects excessive decimal precision %s (never rounds silently)',
+    (input) => {
+      expect(toMinorUnits(input)).toBeUndefined();
+    },
+  );
+
+  it.each([NaN, Infinity, -Infinity, -1, -0.01, 0])(
+    'rejects non-positive or non-finite %s',
+    (input) => {
+      expect(toMinorUnits(input)).toBeUndefined();
+    },
+  );
+
+  it.each(['10.00', null, undefined, {}, '10'])(
+    'rejects unexpected value types %s',
+    (input) => {
+      expect(toMinorUnits(input as never)).toBeUndefined();
+    },
+  );
+
+  it('rejects values beyond safe integer range', () => {
+    expect(toMinorUnits(Number.MAX_SAFE_INTEGER / 100 + 10000)).toBeUndefined();
+  });
+
+  it('never uses binary float arithmetic for money', () => {
+    // 0.1 + 0.2 in binary float is 0.30000000000000004 — must be rejected
+    // because the exact decimal representation carries extra precision.
+    expect(toMinorUnits(0.1 + 0.2)).toBeUndefined();
+  });
+});
 
 describe('MercadoPagoAdapter', () => {
   const webhookSecret = 'test-webhook-secret';

--- a/apps/api/src/finanzas/payment-gateway/adapters/mercadopago.adapter.ts
+++ b/apps/api/src/finanzas/payment-gateway/adapters/mercadopago.adapter.ts
@@ -4,6 +4,7 @@
  */
 
 import { BadRequestException, Injectable, Logger, ServiceUnavailableException, UnauthorizedException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { createHmac, timingSafeEqual } from 'crypto';
 import {
   PaymentProvider,
@@ -14,6 +15,41 @@ import {
   PaymentProviderName,
   WebhookSignatureContext,
 } from '../interfaces/payment-provider.interface';
+
+/**
+ * Converts a provider monetary amount (currency units, e.g. 10.10) to minor
+ * units (1010) using exact decimal arithmetic. Binary float paths are never
+ * used for money.
+ *
+ * Returns undefined (and therefore blocks auto-reconciliation) when the value
+ * is not a finite number, is not positive, or carries more precision than the
+ * supported 2-decimal currency contract.
+ */
+export function toMinorUnits(value: unknown): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined;
+  }
+
+  const amount = new Prisma.Decimal(String(value));
+  if (!amount.greaterThan(0)) {
+    return undefined;
+  }
+
+  const scaled = amount.mul(100);
+  if (!scaled.isInteger()) {
+    // More precision than the currency supports: never round silently.
+    return undefined;
+  }
+
+  const maxSafe = new Prisma.Decimal(Number.MAX_SAFE_INTEGER);
+  if (scaled.greaterThan(maxSafe)) {
+    return undefined;
+  }
+
+  return scaled.toNumber();
+}
+
+
 
 @Injectable()
 export class MercadoPagoAdapter implements PaymentProvider {
@@ -87,10 +123,7 @@ export class MercadoPagoAdapter implements PaymentProvider {
       chargeId: externalRef,
       externalId: String(payment.id),
       status,
-      amount:
-        typeof transactionAmount === 'number' && Number.isFinite(transactionAmount)
-          ? Math.round(transactionAmount * 100)
-          : undefined,
+      amount: toMinorUnits(transactionAmount),
       currency: typeof currencyId === 'string' ? currencyId : undefined,
       rawPayload: payload,
     };

--- a/apps/api/src/finanzas/payment-gateway/adapters/mercadopago.adapter.ts
+++ b/apps/api/src/finanzas/payment-gateway/adapters/mercadopago.adapter.ts
@@ -78,12 +78,20 @@ export class MercadoPagoAdapter implements PaymentProvider {
     const status = this.mapStatus(payment.status);
     const externalRef = payment.external_reference;
 
+    const transactionAmount = payment.transaction_amount;
+    const currencyId = payment.currency_id;
+
     return {
       eventId: String(payment.id),
       eventType: webhookData.action || 'payment.updated',
       chargeId: externalRef,
       externalId: String(payment.id),
       status,
+      amount:
+        typeof transactionAmount === 'number' && Number.isFinite(transactionAmount)
+          ? Math.round(transactionAmount * 100)
+          : undefined,
+      currency: typeof currencyId === 'string' ? currencyId : undefined,
       rawPayload: payload,
     };
   }

--- a/apps/api/src/finanzas/payment-gateway/adapters/stripe.adapter.ts
+++ b/apps/api/src/finanzas/payment-gateway/adapters/stripe.adapter.ts
@@ -87,6 +87,11 @@ export class StripeAdapter implements PaymentProvider {
       chargeId,
       externalId: sessionId,
       status,
+      amount:
+        typeof session.amount_total === 'number' && Number.isSafeInteger(session.amount_total)
+          ? session.amount_total
+          : undefined,
+      currency: typeof session.currency === 'string' ? session.currency.toUpperCase() : undefined,
       rawPayload: payload,
     };
   }

--- a/apps/api/src/finanzas/payment-gateway/e2e/payment-e2e.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/e2e/payment-e2e.spec.ts
@@ -46,14 +46,45 @@ describe('E2E Payment Flow', () => {
     mockProvider.handleWebhook = jest.fn().mockResolvedValue({
       eventId: 'mock-evt-1',
       eventType: 'payment.approved',
+      chargeId: 'charge-e2e-1',
+      externalId: 'mock-ext-1',
       status: 'PAID',
+      amount: 10000,
+      currency: 'ARS',
       rawPayload: {},
     });
     mockProvider.getChargeStatus = jest.fn().mockResolvedValue('PAID');
 
     mockPrisma = {
-      charge: { findUnique: jest.fn(), update: jest.fn() },
-      payment: { findFirst: jest.fn(), update: jest.fn() },
+      charge: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'charge-e2e-1',
+          tenantId: 'tenant-e2e',
+          buildingId: 'building-e2e',
+          unitId: 'unit-e2e',
+          amount: 10000,
+          currency: 'ARS',
+          status: 'PENDING',
+          paymentAllocations: [],
+        }),
+        update: jest.fn(),
+      },
+      payment: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'payment-e2e-1',
+          tenantId: 'tenant-e2e',
+          buildingId: 'building-e2e',
+          unitId: 'unit-e2e',
+          amount: 10000,
+          currency: 'ARS',
+          status: 'SUBMITTED',
+          reference: 'mock-ext-1',
+          paymentAllocations: [],
+        }),
+        update: jest.fn(),
+      },
+      paymentAllocation: { create: jest.fn() },
+      $transaction: jest.fn((callback: (client: unknown) => unknown) => callback(mockPrisma)),
     };
     mockIdempotencyService = {
       isProcessed: jest.fn(),
@@ -63,7 +94,7 @@ describe('E2E Payment Flow', () => {
     service = new PaymentGatewayService(mockProvider as any, mockPrisma, mockIdempotencyService);
   });
 
-  it('creates a payment preference and processes webhook to PAID', async () => {
+  it('creates a payment preference and processes webhook to ledger evidence', async () => {
     // Step 1: Create preference
     const preference = await service.createPreference({
       chargeId: 'charge-e2e-1',
@@ -77,10 +108,7 @@ describe('E2E Payment Flow', () => {
     expect(preference.checkoutUrl).toBe('https://mock-pay.com/1');
     expect(preference.provider).toBe('mercadopago');
 
-    // Step 2: Process webhook (charge is PENDING, webhook says PAID)
-    mockPrisma.charge.findUnique.mockResolvedValue({ id: 'charge-e2e-1', status: 'PENDING' });
-    mockPrisma.charge.update.mockResolvedValue({ id: 'charge-e2e-1', status: 'PAID' });
-    mockPrisma.payment.findFirst.mockResolvedValue(null);
+    // Step 2: Process webhook (charge PENDING + local SUBMITTED payment)
     mockIdempotencyService.isProcessed.mockResolvedValue(false);
     mockIdempotencyService.markProcessed.mockResolvedValue(undefined);
 
@@ -90,9 +118,19 @@ describe('E2E Payment Flow', () => {
       'mercadopago',
     );
 
-    // Step 3: Verify charge was processed
+    // Step 3: Ledger evidence was produced
     expect(result.status).toBe('PAID');
-    // Verify IdempotencyService was called correctly
+    expect(result.chargeUpdated).toBe(true);
+    expect(mockPrisma.paymentAllocation.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ paymentId: 'payment-e2e-1', amount: 10000 }),
+      }),
+    );
+    expect(mockPrisma.payment.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ status: 'APPROVED', paymentEventId: 'mock-evt-1' }),
+      }),
+    );
     expect(mockIdempotencyService.isProcessed).toHaveBeenCalledWith('mock-evt-1', 'mercadopago');
     expect(mockIdempotencyService.markProcessed).toHaveBeenCalledWith('mock-evt-1', 'mercadopago');
   });

--- a/apps/api/src/finanzas/payment-gateway/interfaces/payment-provider.interface.ts
+++ b/apps/api/src/finanzas/payment-gateway/interfaces/payment-provider.interface.ts
@@ -27,6 +27,16 @@ export interface WebhookEvent {
   chargeId?: string;
   externalId?: string;
   status: PaymentStatus;
+  /**
+   * Verified financial amount in minor units, as reported by the provider.
+   * Absent when the provider event does not carry verifiable amount evidence.
+   */
+  amount?: number;
+  /**
+   * Verified currency of the payment, as reported by the provider.
+   * Absent when the provider event does not carry verifiable currency evidence.
+   */
+  currency?: string;
   rawPayload: unknown;
 }
 

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
@@ -128,22 +128,39 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
     });
 
     it('uses the real provider amount, never an inferred outstanding', async () => {
-      await run(paidEvent({ amount: 7500 }));
+      await run(paidEvent());
 
       expect(mockPrisma.paymentAllocation.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: expect.objectContaining({ amount: 7500 }),
+          data: expect.objectContaining({ amount: 10000 }),
         }),
       );
-      expect(mockPrisma.charge.update).toHaveBeenCalledWith(
-        expect.objectContaining({ data: expect.objectContaining({ status: 'PARTIAL' }) }),
+    });
+
+    it('provider amount different from the local payment => 422 PAYMENT_PROVIDER_AMOUNT_MISMATCH, no mutation', async () => {
+      await expect(run(paidEvent({ amount: 7500 }))).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'PAYMENT_PROVIDER_AMOUNT_MISMATCH' },
+      });
+
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(mockPrisma.charge.update).not.toHaveBeenCalled();
+      expect(mockPrisma.payment.update).not.toHaveBeenCalled();
+      expect(mockIdempotencyService.markProcessed).not.toHaveBeenCalled();
+    });
+
+    it('recalculates the charge to PAID from the allocation (ledger-derived status)', async () => {
+      await run(paidEvent());
+
+      const paidUpdate = (mockPrisma.charge.update as jest.Mock).mock.calls.find(
+        (call) => call[0].data?.status === 'PAID',
       );
+      expect(paidUpdate).toBeDefined();
     });
 
     it('skips allocation creation when the pair already exists (idempotent ledger)', async () => {
       mockPrisma.payment.findFirst.mockResolvedValue(
         payment({
-          amount: 20000,
+          amount: 10000,
           status: 'APPROVED',
           paymentAllocations: [{ chargeId: 'charge-1', amount: 10000 }],
         }),
@@ -241,17 +258,6 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
   });
 
   describe('amount guards', () => {
-    it('event amount above payment amount => 422, no mutation', async () => {
-      mockPrisma.payment.findFirst.mockResolvedValue(payment({ amount: 5000 }));
-
-      await expect(run(paidEvent({ amount: 7500 }))).rejects.toMatchObject({
-        response: { statusCode: 422, error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_PAYMENT' },
-      });
-
-      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
-      expect(mockIdempotencyService.markProcessed).not.toHaveBeenCalled();
-    });
-
     it('event amount above charge outstanding => 422, no mutation', async () => {
       createdAllocations.push({ amount: 8000 });
 

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
@@ -1,20 +1,66 @@
 /**
- * Tests for PaymentGatewayService
- * Task 2.3: Delegates to active adapter, confirmCharge on webhook
- * Fix 4: Uses IdempotencyService instead of inline Redis/Prisma checks
+ * Tests for PaymentGatewayService — 3E1 ledger contract
+ *
+ * Financial rules under test:
+ * - A charge is NEVER marked PAID directly: gateway events must produce
+ *   Payment + PaymentAllocation ledger evidence and recalculated status.
+ * - Missing/invalid provider amount or currency => no financial mutation.
+ * - 3E1 is same-currency: event.currency must equal Charge.currency.
+ * - Local Payment matched tenant-scoped by reference; absent Payment => no
+ *   mutation (no invented actor).
+ * - Replay is idempotent (IdempotencyService + unique payment/charge pair).
  */
 
 import { PaymentGatewayService } from './payment-gateway.service';
-import { PaymentProvider, PaymentPreference, WebhookEvent, PaymentStatus } from './interfaces/payment-provider.interface';
-import { HttpException } from '@nestjs/common';
+import { PaymentProvider, WebhookEvent } from './interfaces/payment-provider.interface';
+import { UnprocessableEntityException, ServiceUnavailableException } from '@nestjs/common';
 
-describe('PaymentGatewayService', () => {
+describe('PaymentGatewayService (3E1 ledger)', () => {
   let service: PaymentGatewayService;
   let mockProvider: jest.Mocked<PaymentProvider>;
   let mockPrisma: any;
   let mockIdempotencyService: any;
+  let createdAllocations: Array<{ amount: number }>;
+
+  const charge = (overrides: Record<string, unknown> = {}) => ({
+    id: 'charge-1',
+    tenantId: 'tenant-1',
+    buildingId: 'building-1',
+    unitId: 'unit-1',
+    amount: 10000,
+    currency: 'ARS',
+    status: 'PENDING',
+    paymentAllocations: [],
+    ...overrides,
+  });
+
+  const payment = (overrides: Record<string, unknown> = {}) => ({
+    id: 'payment-1',
+    tenantId: 'tenant-1',
+    buildingId: 'building-1',
+    unitId: 'unit-1',
+    amount: 10000,
+    currency: 'ARS',
+    status: 'SUBMITTED',
+    reference: 'ext-1',
+    paymentAllocations: [],
+    ...overrides,
+  });
+
+  const paidEvent = (overrides: Partial<WebhookEvent> = {}): WebhookEvent => ({
+    eventId: 'evt-1',
+    eventType: 'payment.updated',
+    chargeId: 'charge-1',
+    externalId: 'ext-1',
+    status: 'PAID',
+    amount: 10000,
+    currency: 'ARS',
+    rawPayload: {},
+    ...overrides,
+  });
 
   beforeEach(() => {
+    createdAllocations = [];
     mockProvider = {
       providerName: 'mercadopago',
       createPreference: jest.fn(),
@@ -23,13 +69,22 @@ describe('PaymentGatewayService', () => {
     };
     mockPrisma = {
       charge: {
-        findUnique: jest.fn(),
+        findFirst: jest.fn(() =>
+          Promise.resolve(charge({ paymentAllocations: [...createdAllocations] })),
+        ),
         update: jest.fn(),
       },
       payment: {
-        findFirst: jest.fn(),
+        findFirst: jest.fn(() => Promise.resolve(payment())),
         update: jest.fn(),
       },
+      paymentAllocation: {
+        create: jest.fn(({ data }: { data: { amount: number } }) => {
+          createdAllocations.push({ amount: data.amount });
+          return Promise.resolve({ id: 'alloc-1', ...data });
+        }),
+      },
+      $transaction: jest.fn((callback: (client: unknown) => unknown) => callback(mockPrisma)),
     };
     mockIdempotencyService = {
       isProcessed: jest.fn().mockResolvedValue(false),
@@ -38,227 +93,201 @@ describe('PaymentGatewayService', () => {
     service = new PaymentGatewayService(mockProvider, mockPrisma, mockIdempotencyService);
   });
 
-  describe('createPreference', () => {
-    it('delegates to the active provider', async () => {
-      const mockPreference: PaymentPreference = {
-        preferenceId: 'pref-1',
-        checkoutUrl: 'https://pay.example.com/1',
-        provider: 'mercadopago',
-      };
-      mockProvider.createPreference.mockResolvedValue(mockPreference);
+  const run = (event: WebhookEvent) => {
+    mockProvider.handleWebhook.mockResolvedValue(event);
+    return service.processWebhookEvent(event.rawPayload, 'sig', 'mercadopago');
+  };
 
-      const result = await service.createPreference({
-        chargeId: 'charge-1',
-        tenantId: 'tenant-1',
-        amount: 10000,
-        currency: 'ARS',
-        concept: 'Test',
-      });
+  describe('ledger evidence', () => {
+    it('creates PaymentAllocation and recalculates charge status (never direct PAID)', async () => {
+      const result = await run(paidEvent());
 
-      expect(result).toEqual(mockPreference);
-      expect(mockProvider.createPreference).toHaveBeenCalledTimes(1);
+      expect(result.chargeUpdated).toBe(true);
+      expect(mockPrisma.paymentAllocation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            paymentId: 'payment-1',
+            chargeId: 'charge-1',
+            amount: 10000,
+          }),
+        }),
+      );
+      expect(mockPrisma.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: 'APPROVED', paymentEventId: 'evt-1' }),
+        }),
+      );
+      // Charge PAID status derives from allocations (recalc), never a direct mutation:
+      const paidUpdate = (mockPrisma.charge.update as jest.Mock).mock.calls.find(
+        (call) => call[0].data?.status === 'PAID',
+      );
+      expect(paidUpdate).toBeDefined();
+      expect((mockPrisma.paymentAllocation.create as jest.Mock).mock.invocationCallOrder[0])
+        .toBeLessThan((mockPrisma.charge.update as jest.Mock).mock.invocationCallOrder[0]);
+      expect(mockIdempotencyService.markProcessed).toHaveBeenCalledWith('evt-1', 'mercadopago');
+    });
+
+    it('uses the real provider amount, never an inferred outstanding', async () => {
+      await run(paidEvent({ amount: 7500 }));
+
+      expect(mockPrisma.paymentAllocation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ amount: 7500 }),
+        }),
+      );
+      expect(mockPrisma.charge.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ status: 'PARTIAL' }) }),
+      );
+    });
+
+    it('skips allocation creation when the pair already exists (idempotent ledger)', async () => {
+      mockPrisma.payment.findFirst.mockResolvedValue(
+        payment({
+          amount: 20000,
+          status: 'APPROVED',
+          paymentAllocations: [{ chargeId: 'charge-1', amount: 10000 }],
+        }),
+      );
+
+      const result = await run(paidEvent());
+
+      expect(result.chargeUpdated).toBe(true);
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(mockIdempotencyService.markProcessed).toHaveBeenCalled();
     });
   });
 
-  describe('processWebhookEvent', () => {
-    it('exposes the active configured provider', () => {
-      expect(service.getActiveProviderName()).toBe('mercadopago');
-    });
-
-    it('delegates to the provider and confirms charge on PAID', async () => {
-      const webhookEvent: WebhookEvent = {
-        eventId: 'evt-1',
-        eventType: 'payment.approved',
-        chargeId: 'charge-1',
-        externalId: 'pay-1',
-        status: 'PAID',
-        rawPayload: {},
-      };
-      mockProvider.handleWebhook.mockResolvedValue(webhookEvent);
-      mockPrisma.charge.findUnique.mockResolvedValue({ id: 'charge-1', status: 'PENDING' });
-      mockPrisma.charge.update.mockResolvedValue({ id: 'charge-1', status: 'PAID' });
-      mockPrisma.payment.findFirst.mockResolvedValue(null);
-      mockPrisma.payment.update.mockResolvedValue({ id: 'pay-1', paymentEventId: 'evt-1' });
-      mockIdempotencyService.isProcessed.mockResolvedValue(false);
-
-      const signatureContext = { signature: 'sig', requestId: 'req-1', dataId: 'pay-1' };
-
-      const result = await service.processWebhookEvent({}, signatureContext, 'mercadopago');
-
-      expect(result.status).toBe('PAID');
-      expect(mockProvider.handleWebhook).toHaveBeenCalledWith(
-        {},
-        'sig',
-        { ...signatureContext, provider: 'mercadopago' },
+  describe('missing financial evidence', () => {
+    it('missing provider amount => no financial mutation, event left unprocessed', async () => {
+      await expect(run(paidEvent({ amount: undefined }))).rejects.toThrow(
+        ServiceUnavailableException,
       );
-      expect(mockIdempotencyService.isProcessed).toHaveBeenCalledWith('evt-1', 'mercadopago');
-      expect(mockIdempotencyService.markProcessed).toHaveBeenCalledWith('evt-1', 'mercadopago');
-      expect(mockPrisma.charge.update).toHaveBeenCalledWith({
-        where: { id: 'charge-1' },
-        data: { status: 'PAID', paymentExternalId: 'pay-1' },
-      });
-      expect(mockIdempotencyService.markProcessed.mock.invocationCallOrder[0]).toBeGreaterThan(
-        mockPrisma.charge.update.mock.invocationCallOrder[0],
-      );
-    });
 
-    it('processes PAID after an ignored PENDING webhook with the same MercadoPago payment id', async () => {
-      mockProvider.handleWebhook
-        .mockResolvedValueOnce({
-          eventId: 'mp-payment-1',
-          eventType: 'payment.pending',
-          chargeId: 'charge-1',
-          externalId: 'mp-payment-1',
-          status: 'PENDING',
-          rawPayload: {},
-        })
-        .mockResolvedValueOnce({
-          eventId: 'mp-payment-1',
-          eventType: 'payment.approved',
-          chargeId: 'charge-1',
-          externalId: 'mp-payment-1',
-          status: 'PAID',
-          rawPayload: {},
-        });
-      mockPrisma.charge.findUnique.mockResolvedValue({ id: 'charge-1', status: 'PENDING' });
-      mockPrisma.charge.update.mockResolvedValue({ id: 'charge-1', status: 'PAID' });
-      mockPrisma.payment.findFirst.mockResolvedValue(null);
-
-      const pendingResult = await service.processWebhookEvent({}, { signature: 'sig' }, 'mercadopago');
-      const paidResult = await service.processWebhookEvent({}, { signature: 'sig' }, 'mercadopago');
-
-      expect(pendingResult.chargeUpdated).toBe(false);
-      expect(paidResult.chargeUpdated).toBe(true);
-      expect(mockIdempotencyService.isProcessed).toHaveBeenCalledTimes(1);
-      expect(mockIdempotencyService.isProcessed).toHaveBeenCalledWith('mp-payment-1', 'mercadopago');
-      expect(mockIdempotencyService.markProcessed).toHaveBeenCalledTimes(1);
-      expect(mockIdempotencyService.markProcessed).toHaveBeenCalledWith('mp-payment-1', 'mercadopago');
-      expect(mockPrisma.charge.update).toHaveBeenCalledWith({
-        where: { id: 'charge-1' },
-        data: { status: 'PAID', paymentExternalId: 'mp-payment-1' },
-      });
-    });
-
-    it.each(['REJECTED', 'CANCELLED', 'PENDING'] as const)(
-      'acknowledges %s without charge updates or processed markers',
-      async (status) => {
-        const webhookEvent: WebhookEvent = {
-          eventId: `evt-${status.toLowerCase()}`,
-          eventType: `payment.${status.toLowerCase()}`,
-          chargeId: 'charge-2',
-          externalId: 'pay-2',
-          status,
-          rawPayload: {},
-        };
-        mockProvider.handleWebhook.mockResolvedValue(webhookEvent);
-
-        const result = await service.processWebhookEvent({}, { signature: 'sig' });
-
-        expect(result).toMatchObject({ status, chargeUpdated: false });
-        expect(mockIdempotencyService.isProcessed).not.toHaveBeenCalled();
-        expect(mockIdempotencyService.markProcessed).not.toHaveBeenCalled();
-        expect(mockPrisma.charge.findUnique).not.toHaveBeenCalled();
-        expect(mockPrisma.charge.update).not.toHaveBeenCalled();
-        expect(mockPrisma.payment.update).not.toHaveBeenCalled();
-      },
-    );
-
-    it('does not mark PAID as processed when the charge update fails', async () => {
-      const webhookEvent: WebhookEvent = {
-        eventId: 'evt-paid-fail',
-        eventType: 'payment.approved',
-        chargeId: 'charge-fail',
-        externalId: 'pay-fail',
-        status: 'PAID',
-        rawPayload: {},
-      };
-      mockProvider.handleWebhook.mockResolvedValue(webhookEvent);
-      mockPrisma.charge.findUnique.mockResolvedValue({ id: 'charge-fail', status: 'PENDING' });
-      mockPrisma.charge.update.mockRejectedValue(new Error('database timeout'));
-
-      await expect(service.processWebhookEvent({}, { signature: 'sig' })).rejects.toThrow('database timeout');
-
-      expect(mockIdempotencyService.isProcessed).toHaveBeenCalledWith('evt-paid-fail', 'mercadopago');
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(mockPrisma.charge.update).not.toHaveBeenCalled();
+      expect(mockPrisma.payment.update).not.toHaveBeenCalled();
       expect(mockIdempotencyService.markProcessed).not.toHaveBeenCalled();
     });
 
-    it('skips processing for duplicate webhook events', async () => {
-      const webhookEvent: WebhookEvent = {
-        eventId: 'evt-dup',
-        eventType: 'payment.approved',
-        chargeId: 'charge-3',
-        externalId: 'pay-3',
-        status: 'PAID',
-        rawPayload: {},
-      };
-      mockProvider.handleWebhook.mockResolvedValue(webhookEvent);
-      mockIdempotencyService.isProcessed.mockResolvedValue(true);
+    it('missing provider currency => no financial mutation', async () => {
+      await expect(run(paidEvent({ currency: undefined }))).rejects.toThrow(
+        ServiceUnavailableException,
+      );
 
-      const result = await service.processWebhookEvent({}, { signature: 'sig' }, 'mercadopago');
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(mockPrisma.charge.update).not.toHaveBeenCalled();
+      expect(mockIdempotencyService.markProcessed).not.toHaveBeenCalled();
+    });
+
+    it('non-canonical provider currency => no financial mutation', async () => {
+      await expect(run(paidEvent({ currency: 'XYZ' }))).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(mockIdempotencyService.markProcessed).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('same-currency invariant', () => {
+    it('currency mismatch event vs charge => 422 PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED', async () => {
+      mockPrisma.charge.findFirst.mockResolvedValue(charge({ currency: 'VES' }));
+
+      await expect(run(paidEvent({ currency: 'ARS' }))).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED' },
+      });
+
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(mockPrisma.charge.update).not.toHaveBeenCalled();
+      expect(mockIdempotencyService.markProcessed).not.toHaveBeenCalled();
+    });
+
+    it('currency mismatch payment vs event => 422, no allocation', async () => {
+      mockPrisma.payment.findFirst.mockResolvedValue(payment({ currency: 'VES' }));
+
+      await expect(run(paidEvent())).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED' },
+      });
+
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(mockIdempotencyService.markProcessed).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('tenant isolation', () => {
+    it('matches the local payment tenant-scoped by reference', async () => {
+      await run(paidEvent());
+
+      expect(mockPrisma.payment.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tenantId: 'tenant-1',
+            reference: 'ext-1',
+          }),
+        }),
+      );
+    });
+
+    it('no local payment => no mutation and event left unprocessed', async () => {
+      mockPrisma.payment.findFirst.mockResolvedValue(null);
+
+      const result = await run(paidEvent());
 
       expect(result.chargeUpdated).toBe(false);
-      expect(mockIdempotencyService.isProcessed).toHaveBeenCalledWith('evt-dup', 'mercadopago');
-      expect(mockIdempotencyService.markProcessed).not.toHaveBeenCalled();
-      expect(mockPrisma.charge.findUnique).not.toHaveBeenCalled();
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
       expect(mockPrisma.charge.update).not.toHaveBeenCalled();
-      expect(mockPrisma.payment.findFirst).not.toHaveBeenCalled();
-      expect(mockPrisma.payment.update).not.toHaveBeenCalled();
-    });
-
-    it('marks successful PAID events after charge and payment side effects', async () => {
-      const webhookEvent: WebhookEvent = {
-        eventId: 'evt-paid-side-effects',
-        eventType: 'payment.approved',
-        chargeId: 'charge-side-effects',
-        externalId: 'pay-side-effects',
-        status: 'PAID',
-        rawPayload: {},
-      };
-      mockProvider.handleWebhook.mockResolvedValue(webhookEvent);
-      mockPrisma.charge.findUnique.mockResolvedValue({ id: 'charge-side-effects', status: 'PENDING' });
-      mockPrisma.charge.update.mockResolvedValue({ id: 'charge-side-effects', status: 'PAID' });
-      mockPrisma.payment.findFirst.mockResolvedValue({ id: 'payment-1' });
-      mockPrisma.payment.update.mockResolvedValue({ id: 'payment-1', paymentEventId: 'evt-paid-side-effects' });
-
-      await service.processWebhookEvent({}, { signature: 'sig' });
-
-      expect(mockIdempotencyService.markProcessed).toHaveBeenCalledWith('evt-paid-side-effects', 'mercadopago');
-      expect(mockIdempotencyService.markProcessed.mock.invocationCallOrder[0]).toBeGreaterThan(
-        mockPrisma.charge.update.mock.invocationCallOrder[0],
-      );
-      expect(mockIdempotencyService.markProcessed.mock.invocationCallOrder[0]).toBeGreaterThan(
-        mockPrisma.payment.update.mock.invocationCallOrder[0],
-      );
-    });
-
-    it('rejects direct webhook processing when requested provider conflicts with active provider', async () => {
-      await expect(service.processWebhookEvent({}, { signature: 'sig' }, 'stripe')).rejects.toThrow(
-        'Webhook provider mismatch: active provider is mercadopago',
-      );
-
-      expect(mockProvider.handleWebhook).not.toHaveBeenCalled();
-      expect(mockIdempotencyService.isProcessed).not.toHaveBeenCalled();
-    });
-
-    it('rejects direct webhook processing with HTTP 400 when requested provider conflicts with active provider', async () => {
-      await expect(service.processWebhookEvent({}, { signature: 'sig' }, 'stripe')).rejects.toMatchObject({ status: 400 });
-    });
-
-    it('rejects direct webhook processing with HTTP 503 when no provider is configured', async () => {
-      const serviceWithoutProvider = new PaymentGatewayService(null, mockPrisma, mockIdempotencyService);
-
-      await expect(serviceWithoutProvider.processWebhookEvent({}, { signature: 'sig' })).rejects.toBeInstanceOf(HttpException);
-      await expect(serviceWithoutProvider.processWebhookEvent({}, { signature: 'sig' })).rejects.toMatchObject({ status: 503 });
+      expect(mockIdempotencyService.markProcessed).not.toHaveBeenCalled();
     });
   });
 
-  describe('getChargeStatus', () => {
-    it('delegates to the provider', async () => {
-      mockProvider.getChargeStatus.mockResolvedValue('PAID');
+  describe('amount guards', () => {
+    it('event amount above payment amount => 422, no mutation', async () => {
+      mockPrisma.payment.findFirst.mockResolvedValue(payment({ amount: 5000 }));
 
-      const status = await service.getChargeStatus('pay-1');
-      expect(status).toBe('PAID');
-      expect(mockProvider.getChargeStatus).toHaveBeenCalledWith('pay-1');
+      await expect(run(paidEvent({ amount: 7500 }))).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_PAYMENT' },
+      });
+
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(mockIdempotencyService.markProcessed).not.toHaveBeenCalled();
+    });
+
+    it('event amount above charge outstanding => 422, no mutation', async () => {
+      createdAllocations.push({ amount: 8000 });
+
+      await expect(run(paidEvent({ amount: 3000 }))).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_OUTSTANDING' },
+      });
+
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+    });
+
+    it('event amount above charge amount => 422, no mutation', async () => {
+      mockPrisma.charge.findFirst.mockResolvedValue(charge({ amount: 5000 }));
+
+      await expect(run(paidEvent({ amount: 7500 }))).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_CHARGE' },
+      });
+    });
+  });
+
+  describe('idempotency / replay', () => {
+    it('skips processing when the event was already processed', async () => {
+      mockIdempotencyService.isProcessed.mockResolvedValue(true);
+
+      const result = await run(paidEvent());
+
+      expect(result.chargeUpdated).toBe(false);
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(mockIdempotencyService.markProcessed).not.toHaveBeenCalled();
+    });
+
+    it('duplicate event cannot duplicate the allocation (unique payment/charge pair)', async () => {
+      await run(paidEvent());
+      mockIdempotencyService.isProcessed.mockResolvedValue(true);
+      await run(paidEvent());
+
+      expect(mockPrisma.paymentAllocation.create).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
@@ -257,6 +257,43 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
     });
   });
 
+  describe('same-currency provider partial payment', () => {
+    it('charge 10000, payment 4000, event 4000 => allocation 4000, charge PARTIAL, outstanding 6000', async () => {
+      mockPrisma.charge.findFirst.mockImplementation(() =>
+        Promise.resolve(charge({ amount: 10000, paymentAllocations: [...createdAllocations] })),
+      );
+      mockPrisma.payment.findFirst.mockResolvedValue(payment({ amount: 4000 }));
+
+      const result = await run(paidEvent({ amount: 4000 }));
+
+      expect(result.chargeUpdated).toBe(true);
+      expect(mockPrisma.paymentAllocation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ amount: 4000 }),
+        }),
+      );
+      expect(mockPrisma.charge.update).toHaveBeenCalledWith(
+        expect.objectContaining({ data: expect.objectContaining({ status: 'PARTIAL' }) }),
+      );
+      // ledger-derived outstanding
+      expect(createdAllocations).toEqual([{ amount: 4000 }]);
+    });
+
+    it('replay of the partial event does not duplicate the allocation', async () => {
+      mockPrisma.charge.findFirst.mockImplementation(() =>
+        Promise.resolve(charge({ amount: 10000, paymentAllocations: [...createdAllocations] })),
+      );
+      mockPrisma.payment.findFirst.mockResolvedValue(payment({ amount: 4000 }));
+
+      await run(paidEvent({ amount: 4000 }));
+      mockIdempotencyService.isProcessed.mockResolvedValue(true);
+      await run(paidEvent({ amount: 4000 }));
+
+      expect(mockPrisma.paymentAllocation.create).toHaveBeenCalledTimes(1);
+      expect(createdAllocations).toEqual([{ amount: 4000 }]);
+    });
+  });
+
   describe('amount guards', () => {
     it('event amount above charge outstanding => 422, no mutation', async () => {
       createdAllocations.push({ amount: 8000 });

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
@@ -26,6 +26,10 @@ import { PrismaService } from '../../prisma/prisma.service';
 import { IdempotencyService } from './webhooks/idempotency.service';
 import { ChargeStatus } from '@prisma/client';
 import { Inject } from '@nestjs/common';
+import {
+  EFFECTIVE_PAYMENT_STATUSES,
+  isEffectivePaymentStatus,
+} from '../payment-status-semantics';
 
 @Injectable()
 export class PaymentGatewayService {
@@ -130,7 +134,7 @@ export class PaymentGatewayService {
       include: {
         paymentAllocations: {
           where: {
-            payment: { status: { in: ['APPROVED', 'RECONCILED'] } },
+            payment: { status: { in: [...EFFECTIVE_PAYMENT_STATUSES] } },
           },
           select: { amount: true },
         },
@@ -231,15 +235,17 @@ export class PaymentGatewayService {
         });
       }
 
-      const alreadyAllocated = payment.paymentAllocations.reduce(
-        (sum, allocation) => sum + allocation.amount,
-        0,
-      );
-      if (alreadyAllocated + verifiedAmount > payment.amount) {
+      // 3E1 hardening: the provider amount must reconcile EXACTLY with the
+      // local payment amount. Any difference blocks the whole reconciliation
+      // (no allocation, no status mutation) and leaves the event unprocessed.
+      if (verifiedAmount !== payment.amount) {
+        this.logger.error(
+          `Webhook event ${event.eventId}: provider amount ${verifiedAmount} does not match local payment amount ${payment.amount}`,
+        );
         throw new UnprocessableEntityException({
           statusCode: 422,
-          error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_PAYMENT',
-          message: 'El monto del evento supera el monto del pago local',
+          error: 'PAYMENT_PROVIDER_AMOUNT_MISMATCH',
+          message: 'El monto del proveedor no coincide con el monto del pago local',
         });
       }
 
@@ -251,6 +257,18 @@ export class PaymentGatewayService {
           `Webhook event ${event.eventId}: allocation for payment ${payment.id} / charge ${charge.id} already exists`,
         );
         return true;
+      }
+
+      const alreadyAllocated = payment.paymentAllocations.reduce(
+        (sum, allocation) => sum + allocation.amount,
+        0,
+      );
+      if (alreadyAllocated + verifiedAmount > payment.amount) {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_PAYMENT',
+          message: 'El monto del evento supera el monto del pago local',
+        });
       }
 
       let effectivePaymentStatus = payment.status;
@@ -309,7 +327,7 @@ export class PaymentGatewayService {
       include: {
         paymentAllocations: {
           where: {
-            payment: { status: { in: ['APPROVED', 'RECONCILED'] } },
+            payment: { status: { in: [...EFFECTIVE_PAYMENT_STATUSES] } },
           },
           select: { amount: true },
         },
@@ -353,7 +371,7 @@ export class PaymentGatewayService {
       },
     });
 
-    if (!payment || payment.status !== 'APPROVED') {
+    if (!payment || !isEffectivePaymentStatus(payment.status)) {
       return;
     }
 

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
@@ -3,7 +3,15 @@
  * Task 2.3: Orchestrates payment creation, webhook handling, and charge confirmation
  */
 
-import { BadRequestException, Injectable, Logger, Optional, ServiceUnavailableException } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  Optional,
+  ServiceUnavailableException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { isCanonicalCurrency } from '@buildingos/contracts';
 import {
   PaymentProvider,
   CreatePreferenceInput,
@@ -45,7 +53,20 @@ export class PaymentGatewayService {
   }
 
   /**
-   * Process a webhook event after signature validation
+   * Process a webhook event after signature validation.
+   *
+   * 3E1 financial rules:
+   * - A charge is NEVER marked PAID directly: every gateway-confirmed payment
+   *   must produce ledger evidence (Payment + PaymentAllocation) and the
+   *   charge status is recalculated from its allocations.
+   * - The event must carry verifiable amount + currency from the provider.
+   *   Missing/invalid evidence produces NO financial mutation and leaves the
+   *   event unprocessed (provider will retry; manual review required).
+   * - 3E1 is same-currency: event.currency must equal Charge.currency and the
+   *   local Payment currency. Cross-currency arrives with 3E3.
+   * - A local Payment is matched tenant-scoped by reference; if it does not
+   *   exist, no Payment is invented (no verifiable actor) and no mutation
+   *   happens — the charge stays PENDING for the resident/admin flow.
    */
   async processWebhookEvent(
     payload: unknown,
@@ -83,39 +104,271 @@ export class PaymentGatewayService {
       return { ...event, chargeUpdated: false };
     }
 
-    // Confirm charge status
-    let chargeUpdated = false;
-    if (event.chargeId) {
-      const charge = await this.prisma.charge.findUnique({
-        where: { id: event.chargeId },
-      });
+    const chargeUpdated = await this.applyPaidEvent(event);
 
-      if (charge && charge.status === 'PENDING') {
-        await this.prisma.charge.update({
-          where: { id: event.chargeId },
-          data: { status: ChargeStatus.PAID, paymentExternalId: event.externalId },
-        });
-        chargeUpdated = true;
-        this.logger.log(`Charge ${event.chargeId} updated to PAID`);
-      }
+    if (chargeUpdated) {
+      await this.idempotencyService.markProcessed(event.eventId, providerName);
+    } else {
+      // No durable side effects applied: do not mark processed so the
+      // provider retries and the event stays in manual-review visibility.
+      this.logger.error(
+        `Webhook event ${event.eventId} left unprocessed: manual review required`,
+      );
     }
-
-    // Record event on payment if available
-    if (event.externalId) {
-      const payment = await this.prisma.payment.findFirst({
-        where: { reference: event.externalId },
-      });
-      if (payment) {
-        await this.prisma.payment.update({
-          where: { id: payment.id },
-          data: { paymentEventId: event.eventId },
-        });
-      }
-    }
-
-    await this.idempotencyService.markProcessed(event.eventId, providerName);
 
     return { ...event, chargeUpdated };
+  }
+
+  private async applyPaidEvent(event: WebhookEvent): Promise<boolean> {
+    if (!event.chargeId) {
+      this.logger.warn(`Webhook event ${event.eventId} has no chargeId; no financial mutation`);
+      return false;
+    }
+
+    const charge = await this.prisma.charge.findFirst({
+      where: { id: event.chargeId },
+      include: {
+        paymentAllocations: {
+          where: {
+            payment: { status: { in: ['APPROVED', 'RECONCILED'] } },
+          },
+          select: { amount: true },
+        },
+      },
+    });
+
+    if (!charge) {
+      this.logger.error(`Webhook event ${event.eventId}: charge ${event.chargeId} not found`);
+      return false;
+    }
+
+    // Verifiable financial evidence is mandatory: never infer amount/currency.
+    if (
+      event.amount === undefined ||
+      event.amount === null ||
+      !Number.isSafeInteger(event.amount) ||
+      event.amount <= 0
+    ) {
+      this.logger.error(
+        `Webhook event ${event.eventId}: missing or invalid provider amount; no financial mutation`,
+      );
+      throw new ServiceUnavailableException(
+        'Webhook event missing verifiable amount; manual review required',
+      );
+    }
+    const verifiedAmount: number = event.amount;
+
+    if (!event.currency || !isCanonicalCurrency(event.currency)) {
+      this.logger.error(
+        `Webhook event ${event.eventId}: missing or invalid provider currency; no financial mutation`,
+      );
+      throw new ServiceUnavailableException(
+        'Webhook event missing verifiable currency; manual review required',
+      );
+    }
+
+    // 3E1 same-currency invariant.
+    if (event.currency !== charge.currency) {
+      this.logger.error(
+        `Webhook event ${event.eventId}: provider currency ${event.currency} does not match charge currency ${charge.currency}`,
+      );
+      throw new UnprocessableEntityException({
+        statusCode: 422,
+        error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED',
+        message: `La moneda del evento (${event.currency}) no coincide con la moneda del cargo (${charge.currency})`,
+      });
+    }
+
+    if (verifiedAmount > charge.amount) {
+      this.logger.error(
+        `Webhook event ${event.eventId}: provider amount ${verifiedAmount} exceeds charge amount ${charge.amount}`,
+      );
+      throw new UnprocessableEntityException({
+        statusCode: 422,
+        error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_CHARGE',
+        message: 'El monto del evento excede el monto del cargo',
+      });
+    }
+
+    const effectiveAllocated = charge.paymentAllocations.reduce(
+      (sum, allocation) => sum + allocation.amount,
+      0,
+    );
+    const outstanding = charge.amount - effectiveAllocated;
+
+    if (verifiedAmount > outstanding) {
+      this.logger.error(
+        `Webhook event ${event.eventId}: provider amount ${verifiedAmount} exceeds charge outstanding ${outstanding}`,
+      );
+      throw new UnprocessableEntityException({
+        statusCode: 422,
+        error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_OUTSTANDING',
+        message: 'El monto del evento supera el saldo pendiente del cargo',
+      });
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      const payment = await tx.payment.findFirst({
+        where: {
+          tenantId: charge.tenantId,
+          reference: event.externalId ?? undefined,
+        },
+        include: { paymentAllocations: true },
+      });
+
+      if (!payment) {
+        this.logger.error(
+          `Webhook event ${event.eventId}: no local payment with reference ${event.externalId} for tenant ${charge.tenantId}; manual review required`,
+        );
+        return false;
+      }
+
+      if (payment.currency !== event.currency || payment.currency !== charge.currency) {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED',
+          message: `La moneda del pago (${payment.currency}) no coincide con la del evento (${event.currency})`,
+        });
+      }
+
+      const alreadyAllocated = payment.paymentAllocations.reduce(
+        (sum, allocation) => sum + allocation.amount,
+        0,
+      );
+      if (alreadyAllocated + verifiedAmount > payment.amount) {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_PAYMENT',
+          message: 'El monto del evento supera el monto del pago local',
+        });
+      }
+
+      const existingAllocation = payment.paymentAllocations.find(
+        (allocation) => allocation.chargeId === charge.id,
+      );
+      if (existingAllocation) {
+        this.logger.log(
+          `Webhook event ${event.eventId}: allocation for payment ${payment.id} / charge ${charge.id} already exists`,
+        );
+        return true;
+      }
+
+      let effectivePaymentStatus = payment.status;
+      if (payment.status === 'SUBMITTED') {
+        await tx.payment.update({
+          where: { id: payment.id },
+          data: {
+            status: 'APPROVED',
+            paidAt: new Date(),
+            paymentEventId: event.eventId,
+            updatedAt: new Date(),
+          },
+        });
+        effectivePaymentStatus = 'APPROVED';
+      } else if (payment.status === 'APPROVED' || payment.status === 'RECONCILED') {
+        await tx.payment.update({
+          where: { id: payment.id },
+          data: { paymentEventId: event.eventId, updatedAt: new Date() },
+        });
+      } else {
+        this.logger.error(
+          `Webhook event ${event.eventId}: payment ${payment.id} in status ${payment.status}; no allocation created`,
+        );
+        return false;
+      }
+
+      await tx.paymentAllocation.create({
+        data: {
+          tenantId: charge.tenantId,
+          paymentId: payment.id,
+          chargeId: charge.id,
+          amount: verifiedAmount,
+        },
+      });
+
+      await this.recalculateChargeStatus(tx, charge.id);
+
+      if (effectivePaymentStatus === 'APPROVED') {
+        await this.reconcilePaymentIfAllPaid(tx, payment.id);
+      }
+
+      return true;
+    });
+  }
+
+  /**
+   * Mirrors the ledger status computation: charge status derives exclusively
+   * from its effective allocations. Never a direct PAID mutation.
+   */
+  private async recalculateChargeStatus(
+    tx: Parameters<Parameters<PrismaService['$transaction']>[0]>[0],
+    chargeId: string,
+  ): Promise<void> {
+    const charge = await tx.charge.findFirst({
+      where: { id: chargeId },
+      include: {
+        paymentAllocations: {
+          where: {
+            payment: { status: { in: ['APPROVED', 'RECONCILED'] } },
+          },
+          select: { amount: true },
+        },
+      },
+    });
+
+    if (!charge) {
+      return;
+    }
+
+    const totalAllocated = charge.paymentAllocations.reduce(
+      (sum, allocation) => sum + allocation.amount,
+      0,
+    );
+
+    let newStatus: ChargeStatus;
+    if (totalAllocated === 0) {
+      newStatus = ChargeStatus.PENDING;
+    } else if (totalAllocated < charge.amount) {
+      newStatus = ChargeStatus.PARTIAL;
+    } else {
+      newStatus = ChargeStatus.PAID;
+    }
+
+    if (newStatus !== charge.status) {
+      await tx.charge.update({
+        where: { id: chargeId },
+        data: { status: newStatus, updatedAt: new Date() },
+      });
+    }
+  }
+
+  private async reconcilePaymentIfAllPaid(
+    tx: Parameters<Parameters<PrismaService['$transaction']>[0]>[0],
+    paymentId: string,
+  ): Promise<void> {
+    const payment = await tx.payment.findFirst({
+      where: { id: paymentId },
+      include: {
+        paymentAllocations: { include: { charge: true } },
+      },
+    });
+
+    if (!payment || payment.status !== 'APPROVED') {
+      return;
+    }
+
+    const allPaid =
+      payment.paymentAllocations.length > 0 &&
+      payment.paymentAllocations.every(
+        (allocation) => allocation.charge.status === ChargeStatus.PAID,
+      );
+
+    if (allPaid) {
+      await tx.payment.update({
+        where: { id: paymentId },
+        data: { status: 'RECONCILED', updatedAt: new Date() },
+      });
+    }
   }
 
   /**

--- a/apps/api/src/finanzas/payment-status-semantics.ts
+++ b/apps/api/src/finanzas/payment-status-semantics.ts
@@ -1,0 +1,15 @@
+/**
+ * Single source of truth for which Payment statuses count as effective money.
+ *
+ * SUBMITTED is a reservation and NEVER counts as effective money.
+ * APPROVED and RECONCILED are effective.
+ * REJECTED/CANCELED are not effective.
+ *
+ * Used by Charge.status derivation, PaymentAllocation effective sums,
+ * the cancelCharge guard and the payment gateway ledger — one definition.
+ */
+export const EFFECTIVE_PAYMENT_STATUSES = ['APPROVED', 'RECONCILED'] as const;
+
+export function isEffectivePaymentStatus(status?: string | null): boolean {
+  return status === 'APPROVED' || status === 'RECONCILED';
+}


### PR DESCRIPTION
## PHASE 3E1

- Canonical USD/VES/ARS/COP en nuevos writes de Charge/Payment (`CreateChargeDto`/`UpdateChargeDto`/`SubmitPaymentDto`)
- Invariante same-currency explícita para `PaymentAllocation` (cross-currency sigue bloqueado hasta 3E3)
- `CHARGE_HAS_EFFECTIVE_ALLOCATIONS` (409): no se cancela un Charge con pagos efectivos
- `SUBMITTED` = reserva, no pago efectivo; `APPROVED`/`RECONCILED` = efectivos (definición única compartida)
- `approvePayment` recalcula `Charge.status` desde allocations efectivas (fix de inconsistencia real)
- El gateway deja de marcar Charge PAID directamente: requiere `Payment` local existente (actor verificable) y crea `PaymentAllocation` como evidencia ledger
- Monto y moneda del provider obligatorios y verificables (nunca inferidos del outstanding)
- El monto del provider debe coincidir EXACTAMENTE con `Payment.amount`
- Provider amount > outstanding bloqueado
- Partial same-currency del provider → `Charge PARTIAL` (allocation parcial legítima, replay idempotente)
- Webhook idempotente; lookup de Payment tenant-scoped
- Mercado Pago usa conversión Decimal exacta a minor units (sin binary-float money)
- Sin migration

Errores:
- `PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED` — 422
- `PAYMENT_PROVIDER_AMOUNT_MISMATCH` — 422
- `PAYMENT_EVENT_AMOUNT_EXCEEDS_OUTSTANDING` — 422
- `CHARGE_HAS_EFFECTIVE_ALLOCATIONS` — 409

Explicitamente NO incluido: Payment FX snapshot, cross-currency allocation, 3E2, 3E3, Reports/Dashboard, producción.