### PR TITLE
feat(finance): snapshot payment functional amounts

### DIFF
--- a/apps/api/prisma/migrations/20260811000000_add_payment_multicurrency_snapshot/migration.sql
+++ b/apps/api/prisma/migrations/20260811000000_add_payment_multicurrency_snapshot/migration.sql
@@ -1,0 +1,14 @@
+-- AlterTable
+ALTER TABLE "Payment" ADD COLUMN     "conversionDate" TIMESTAMP(3),
+ADD COLUMN     "exchangeRateDirection" TEXT,
+ADD COLUMN     "exchangeRateEffectiveAt" TIMESTAMP(3),
+ADD COLUMN     "exchangeRateId" TEXT,
+ADD COLUMN     "exchangeRateValue" DECIMAL(28,12),
+ADD COLUMN     "functionalAmountMinor" INTEGER,
+ADD COLUMN     "functionalCurrencyCode" TEXT;
+
+-- CreateIndex
+CREATE INDEX "Payment_tenantId_exchangeRateId_idx" ON "Payment"("tenantId", "exchangeRateId");
+
+-- AddForeignKey
+ALTER TABLE "Payment" ADD CONSTRAINT "Payment_exchangeRateId_fkey" FOREIGN KEY ("exchangeRateId") REFERENCES "ExchangeRate"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -362,6 +362,7 @@ model ExchangeRate {
   expenses            Expense[]
   incomes             Income[]
   adjustments         Adjustment[]
+  payments            Payment[]
 
   @@unique([tenantId, baseCurrency, quoteCurrency, effectiveAt], map: "ExchangeRate_tenant_pair_effective_key")
   @@index([tenantId, baseCurrency, quoteCurrency, effectiveAt(sort: Desc)], map: "ExchangeRate_tenant_pair_effective_idx")
@@ -1656,6 +1657,13 @@ model Payment {
 
   createdAt                DateTime        @default(now())
   updatedAt                DateTime        @updatedAt
+  functionalAmountMinor    Int?            // Snapshot: monto en moneda funcional (minor units) al congelarse
+  functionalCurrencyCode   String?         // Snapshot: moneda funcional del tenant al congelarse
+  exchangeRateId           String?         // Snapshot: FK a la tasa usada (null si IDENTITY)
+  exchangeRateValue        Decimal?        @db.Decimal(28, 12) // Snapshot numérico de la tasa aplicada
+  exchangeRateDirection    String?         // Snapshot: IDENTITY | DIRECT | INVERSE
+  exchangeRateEffectiveAt  DateTime?       // Snapshot: efectividad de la tasa fuente
+  conversionDate           DateTime?       // Snapshot: fecha económica del pago (UTC date-only)
 
   // Relations
   tenant                  Tenant              @relation(fields: [tenantId], references: [id], onDelete: Cascade)
@@ -1664,6 +1672,7 @@ model Payment {
   createdByUser           User                @relation("PaymentCreatedBy", fields: [createdByUserId], references: [id], onDelete: Restrict)
   reviewedByMembership    Membership?         @relation(fields: [reviewedByMembershipId], references: [id], onDelete: SetNull)
   proofFile               File?               @relation(fields: [proofFileId], references: [id], onDelete: SetNull)
+  exchangeRate            ExchangeRate?       @relation(fields: [exchangeRateId], references: [id], onDelete: SetNull)
   paymentAllocations      PaymentAllocation[]
   auditLogs               PaymentAuditLog[]
 
@@ -1672,6 +1681,7 @@ model Payment {
   @@index([tenantId, createdByUserId])
   @@index([status])
   @@index([tenantId, receiptStatus])
+  @@index([tenantId, exchangeRateId])
   @@unique([tenantId, receiptNumber])
 }
 

--- a/apps/api/src/finanzas/currency-conversion.service.spec.ts
+++ b/apps/api/src/finanzas/currency-conversion.service.spec.ts
@@ -342,4 +342,113 @@ describe("CurrencyConversionService", () => {
       ...overrides,
     } as Parameters<CurrencyConversionService["convert"]>[0];
   }
+
+describe("CurrencyConversionService transaction propagation", () => {
+  const rootExchangeRate = { findFirst: jest.fn() };
+  const rootPrisma = { exchangeRate: rootExchangeRate } as unknown as PrismaService;
+  const rootService = new CurrencyConversionService(rootPrisma);
+
+  const txExchangeRate = { findFirst: jest.fn() };
+  const tx = { exchangeRate: txExchangeRate } as unknown as Parameters<
+    CurrencyConversionService["convert"]
+  >[1];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    rootExchangeRate.findFirst.mockResolvedValue(null);
+    txExchangeRate.findFirst.mockResolvedValue(null);
+  });
+
+  const input = {
+    tenantId: "tenant-1",
+    amount: 1000,
+    originalCurrency: "USD" as CanonicalCurrency,
+    functionalCurrency: "VES" as CanonicalCurrency,
+    conversionDate: "2026-08-09",
+  };
+
+  it("uses the root PrismaService when no client is provided", async () => {
+    rootExchangeRate.findFirst.mockResolvedValue(
+      new Prisma.Decimal("36.5").toNumber() ? {
+        id: "rate-1",
+        rate: new Prisma.Decimal("36.5"),
+        effectiveAt: new Date("2026-08-08T00:00:00.000Z"),
+      } : null,
+    );
+
+    await rootService.convert(input);
+
+    expect(rootExchangeRate.findFirst).toHaveBeenCalledTimes(1);
+    expect(txExchangeRate.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("uses the provided tx client and NEVER the root client", async () => {
+    txExchangeRate.findFirst.mockResolvedValue({
+      id: "rate-1",
+      rate: new Prisma.Decimal("36.5"),
+      effectiveAt: new Date("2026-08-08T00:00:00.000Z"),
+    });
+
+    const result = await rootService.convert(input, tx);
+
+    expect(txExchangeRate.findFirst).toHaveBeenCalledTimes(1);
+    expect(rootExchangeRate.findFirst).not.toHaveBeenCalled();
+    expect(result.direction).toBe("DIRECT");
+    expect(result.functionalAmount).toBe(36500);
+  });
+
+  it("DIRECT with tx resolves through the tx client", async () => {
+    txExchangeRate.findFirst.mockResolvedValue({
+      id: "rate-direct",
+      rate: new Prisma.Decimal("36.5"),
+      effectiveAt: new Date("2026-08-08T00:00:00.000Z"),
+    });
+
+    const result = await rootService.convert(input, tx);
+
+    expect(result.direction).toBe("DIRECT");
+    expect(txExchangeRate.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: expect.objectContaining({ tenantId: "tenant-1" }) }),
+    );
+  });
+
+  it("INVERSE with tx resolves through the tx client", async () => {
+    txExchangeRate.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "rate-inv",
+        rate: new Prisma.Decimal("0.04"),
+        effectiveAt: new Date("2026-08-08T00:00:00.000Z"),
+      });
+
+    const result = await rootService.convert(
+      { ...input, originalCurrency: "ARS", functionalCurrency: "VES" },
+      tx,
+    );
+
+    expect(result.direction).toBe("INVERSE");
+    expect(txExchangeRate.findFirst).toHaveBeenCalledTimes(2);
+    expect(rootExchangeRate.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("IDENTITY with tx performs zero queries on root AND tx", async () => {
+    const result = await rootService.convert(
+      { ...input, originalCurrency: "VES", functionalCurrency: "VES" },
+      tx,
+    );
+
+    expect(result.direction).toBe("IDENTITY");
+    expect(txExchangeRate.findFirst).not.toHaveBeenCalled();
+    expect(rootExchangeRate.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("missing rate with tx rejects with EXCHANGE_RATE_NOT_FOUND", async () => {
+    txExchangeRate.findFirst.mockResolvedValue(null);
+
+    await expect(rootService.convert(input, tx)).rejects.toMatchObject({
+      response: expect.objectContaining({ code: "EXCHANGE_RATE_NOT_FOUND" }),
+    });
+    expect(rootExchangeRate.findFirst).not.toHaveBeenCalled();
+  });
+});
 });

--- a/apps/api/src/finanzas/currency-conversion.service.ts
+++ b/apps/api/src/finanzas/currency-conversion.service.ts
@@ -41,12 +41,32 @@ interface RateSnapshot {
   readonly effectiveAt: Date;
 }
 
+export interface CurrencyConversionDb {
+  readonly exchangeRate: {
+    findFirst: (args: {
+      where: {
+        tenantId: string;
+        baseCurrency: CanonicalCurrency;
+        quoteCurrency: CanonicalCurrency;
+        effectiveAt: { lte: Date };
+      };
+      orderBy: { effectiveAt: 'desc' };
+      select: { id: true; rate: true; effectiveAt: true };
+    }) => Promise<{
+      id: string;
+      rate: Prisma.Decimal;
+      effectiveAt: Date;
+    } | null>;
+  };
+}
+
 @Injectable()
 export class CurrencyConversionService {
   constructor(private readonly prisma: PrismaService) {}
 
   async convert(
     input: CurrencyConversionInput,
+    db: CurrencyConversionDb = this.prisma,
   ): Promise<CurrencyConversionResult> {
     this.assertInput(input);
     const conversionDate = this.normalizeDate(input.conversionDate);
@@ -63,6 +83,7 @@ export class CurrencyConversionService {
     }
 
     const direct = await this.findRate(
+      db,
       input.tenantId,
       input.originalCurrency,
       input.functionalCurrency,
@@ -84,6 +105,7 @@ export class CurrencyConversionService {
     }
 
     const inverse = await this.findRate(
+      db,
       input.tenantId,
       input.functionalCurrency,
       input.originalCurrency,
@@ -113,12 +135,13 @@ export class CurrencyConversionService {
   }
 
   private async findRate(
+    db: CurrencyConversionDb,
     tenantId: string,
     baseCurrency: CanonicalCurrency,
     quoteCurrency: CanonicalCurrency,
     conversionDate: Date,
   ): Promise<RateSnapshot | null> {
-    return this.prisma.exchangeRate.findFirst({
+    return db.exchangeRate.findFirst({
       where: {
         tenantId,
         baseCurrency,

--- a/apps/api/src/finanzas/finanzas.dto.ts
+++ b/apps/api/src/finanzas/finanzas.dto.ts
@@ -17,6 +17,7 @@ import {
 } from 'class-validator';
 import { ChargeType, ChargeStatus, PaymentStatus, PaymentMethod, RejectionReason } from '@prisma/client';
 import { CANONICAL_CURRENCIES } from '@buildingos/contracts';
+import { IsStrictDateString } from './strict-date.decorator';
 import {
   BuildingChargeParamDto,
   BuildingPaymentParamDto,
@@ -126,6 +127,14 @@ export class SubmitPaymentDto {
   @IsOptional()
   @IsString()
   proofFileId?: string;
+
+  /**
+   * Economic bank day of the transfer, declared by the user.
+   * Strict date-only YYYY-MM-DD (never a datetime).
+   */
+  @IsOptional()
+  @IsStrictDateString({ message: 'transferDate must be a valid YYYY-MM-DD date' })
+  transferDate?: string;
 }
 
 export class ApprovePaymentDto {
@@ -392,6 +401,14 @@ export interface PaymentDetailDto {
   rejectionReason?: string | null;
   rejectionComment?: string | null;
   reviewedAt?: Date | null;
+  transferDate?: Date | null;
+  functionalAmountMinor?: number | null;
+  functionalCurrencyCode?: string | null;
+  exchangeRateId?: string | null;
+  exchangeRateValue?: string | null;
+  exchangeRateDirection?: string | null;
+  exchangeRateEffectiveAt?: Date | null;
+  conversionDate?: Date | null;
   // Receipt fields
   receiptDocumentId?: string | null;
   receiptNumber?: string | null;

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -4094,8 +4094,15 @@ describe('FinanzasService', () => {
 
     it('approve on SUBMITTED legacy-null freezes a DIRECT snapshot with the definitive paidAt', async () => {
       approveSetup();
+      const convertSpy = jest.spyOn(CurrencyConversionService.prototype, 'convert');
 
       await approve('2026-08-10');
+
+      expect(convertSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ conversionDate: '2026-08-10' }),
+        prismaService,
+      );
+      convertSpy.mockRestore();
 
       expect(prismaService.payment.update).toHaveBeenCalledWith(
         expect.objectContaining({

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -8,11 +8,24 @@ import { FinanzasService } from './finanzas.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { FinanzasValidators } from './finanzas.validators';
+import { Prisma } from '@prisma/client';
+import { CurrencyConversionService } from './currency-conversion.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { PaymentReceiptService } from '../receipts/payment-receipt.service';
 import { CreateChargeDto, UpdateChargeDto } from './finanzas.dto';
 import { ExpensesService } from './expenses.service';
 import { ChargeStatus, PaymentStatus, PaymentMethod, AuditAction, ScopeType } from '@prisma/client';
+
+
+const completePaymentSnapshot = {
+  functionalAmountMinor: 36500,
+  functionalCurrencyCode: 'VES',
+  exchangeRateId: 'rate-1',
+  exchangeRateValue: '36.5',
+  exchangeRateDirection: 'DIRECT',
+  exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+  conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+};
 
 describe('FinanzasService', () => {
   let service: FinanzasService;
@@ -31,8 +44,12 @@ describe('FinanzasService', () => {
         {
           provide: PrismaService,
           useValue: {
+            $executeRaw: jest.fn().mockResolvedValue(1),
             tenant: {
               findUniqueOrThrow: jest.fn(),
+              findFirst: jest
+                .fn()
+                .mockResolvedValue({ id: 'tenant-1', functionalCurrency: 'VES' }),
             },
             charge: {
               create: jest.fn(),
@@ -66,6 +83,13 @@ describe('FinanzasService', () => {
             },
             paymentAuditLog: {
               create: jest.fn(),
+            },
+            exchangeRate: {
+              findFirst: jest.fn().mockResolvedValue({
+                id: 'rate-1',
+                rate: new Prisma.Decimal('36.5'),
+                effectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+              }),
             },
             membership: {
               findMany: jest.fn(),
@@ -112,6 +136,12 @@ describe('FinanzasService', () => {
           useValue: {
             validateExpenseFromBulk: jest.fn(),
           },
+        },
+        {
+          provide: CurrencyConversionService,
+          useFactory: (prismaService: PrismaService) =>
+            new CurrencyConversionService(prismaService),
+          inject: [PrismaService],
         },
         {
           provide: FinanzasValidators,
@@ -1176,6 +1206,7 @@ describe('FinanzasService', () => {
         currency: 'ARS',
         status: PaymentStatus.SUBMITTED,
         canceledAt: null,
+        ...completePaymentSnapshot,
         paymentAllocations: [
           {
             chargeId: 'charge-123',
@@ -3903,6 +3934,313 @@ describe('FinanzasService', () => {
         expect(prismaService.charge.update).not.toHaveBeenCalled();
         expect(prismaService.payment.update).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  // ========== 3E2: SUBMIT WITH TRANSFERDATE ==========
+  describe('3E2 submit with transferDate', () => {
+    const tenantId = 'tenant-123';
+    const buildingId = 'building-123';
+
+    const submitSetup = (currency = 'USD', transferDate?: string) => {
+      jest.spyOn(validators, 'isResidentOrOwner').mockReturnValue(true);
+      jest.spyOn(validators, 'validateResidentUnitAccess').mockResolvedValue(undefined);
+      jest
+        .spyOn(validators, 'validateUnitBelongsToBuildingAndTenant')
+        .mockResolvedValue(undefined);
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([
+        {
+          id: 'charge-123',
+          tenantId,
+          buildingId,
+          unitId: 'unit-123',
+          amount: 10000,
+          currency,
+          status: ChargeStatus.PENDING,
+          canceledAt: null,
+          paymentAllocations: [],
+        },
+      ] as never);
+      jest.spyOn(prismaService.payment, 'create').mockResolvedValue({} as never);
+      jest.spyOn(prismaService.paymentAllocation, 'create').mockResolvedValue({} as never);
+      jest
+        .spyOn(prismaService.tenant, 'findFirst')
+        .mockResolvedValue({ id: tenantId, functionalCurrency: 'USD' });
+      return service.submitPayment(
+        tenantId,
+        buildingId,
+        'user-1',
+        ['RESIDENT'],
+        {
+          unitId: 'unit-123',
+          chargeIds: ['charge-123'],
+          amount: 10000,
+          currency,
+          method: 'TRANSFER',
+          reference: 'ref-1',
+          proofFileId: 'file-1',
+          transferDate,
+        } as never,
+        'resident',
+      );
+    };
+
+    it('submit with transferDate freezes an IDENTITY snapshot (no ExchangeRate query)', async () => {
+      await submitSetup('USD', '2026-08-10');
+
+      expect(prismaService.payment.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            transferDate: new Date('2026-08-10T00:00:00.000Z'),
+            functionalAmountMinor: 10000,
+            functionalCurrencyCode: 'USD',
+            exchangeRateDirection: 'IDENTITY',
+            exchangeRateValue: '1',
+            exchangeRateId: null,
+          }),
+        }),
+      );
+      expect(prismaService.exchangeRate.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('submit with missing rate creates no Payment and no reservation allocations', async () => {
+      jest.spyOn(prismaService.exchangeRate, 'findFirst').mockResolvedValue(null);
+
+      await expect(submitSetup('VES', '2026-08-10')).rejects.toMatchObject({
+        response: expect.objectContaining({ code: 'EXCHANGE_RATE_NOT_FOUND' }),
+      });
+
+      expect(prismaService.payment.create).not.toHaveBeenCalled();
+      expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
+    });
+  });
+
+  // ========== 3E2: PAYMENT FUNCTIONAL SNAPSHOT ==========
+  describe('3E2 payment functional snapshot', () => {
+    const tenantId = 'tenant-123';
+    const buildingId = 'building-123';
+    const paymentId = 'payment-123';
+    const membershipId = 'membership-123';
+
+    const legacyNullPayment = (overrides: Record<string, unknown> = {}) => ({
+      id: paymentId,
+      tenantId,
+      buildingId,
+      unitId: 'unit-123',
+      amount: 10000,
+      currency: 'USD',
+      status: PaymentStatus.SUBMITTED,
+      canceledAt: null,
+      transferDate: null,
+      functionalAmountMinor: null,
+      functionalCurrencyCode: null,
+      exchangeRateId: null,
+      exchangeRateValue: null,
+      exchangeRateDirection: null,
+      exchangeRateEffectiveAt: null,
+      conversionDate: null,
+      paymentAllocations: [{ chargeId: 'charge-123', amount: 10000, charge: {} }],
+      ...overrides,
+    });
+
+    const approveSetup = () => {
+      jest.spyOn(validators, 'canReviewPayments').mockReturnValue(true);
+      jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValue(
+        legacyNullPayment() as never,
+      );
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([
+        {
+          id: 'charge-123',
+          tenantId,
+          buildingId,
+          unitId: 'unit-123',
+          amount: 10000,
+          currency: 'USD',
+          status: ChargeStatus.PENDING,
+          paymentAllocations: [],
+        },
+      ] as never);
+      jest.spyOn(prismaService.payment, 'update').mockResolvedValue({} as never);
+      jest.spyOn(prismaService.payment, 'findUnique').mockResolvedValue(null);
+      jest.spyOn(prismaService.charge, 'findUnique').mockResolvedValue({
+        id: 'charge-123',
+        amount: 10000,
+        status: ChargeStatus.PENDING,
+        paymentAllocations: [
+          { amount: 10000, payment: { status: PaymentStatus.APPROVED } },
+        ],
+      } as never);
+      jest.spyOn(prismaService.charge, 'update').mockResolvedValue({} as never);
+      jest.spyOn(prismaService.paymentAuditLog, 'create').mockResolvedValue({} as never);
+      jest
+        .spyOn(prismaService.tenant, 'findFirst')
+        .mockResolvedValue({ id: tenantId, functionalCurrency: 'VES' });
+      jest.spyOn(prismaService.exchangeRate, 'findFirst').mockResolvedValue({
+        id: 'rate-1',
+        rate: new Prisma.Decimal('36.5'),
+        effectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+      });
+    };
+
+    const approve = (paidAt?: string) =>
+      service.approvePayment(
+        tenantId,
+        buildingId,
+        paymentId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        { paidAt },
+      );
+
+    it('approve on SUBMITTED legacy-null freezes a DIRECT snapshot with the definitive paidAt', async () => {
+      approveSetup();
+
+      await approve('2026-08-10');
+
+      expect(prismaService.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: PaymentStatus.APPROVED,
+            functionalAmountMinor: 365000,
+            functionalCurrencyCode: 'VES',
+            exchangeRateDirection: 'DIRECT',
+            exchangeRateId: 'rate-1',
+            conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+          }),
+        }),
+      );
+    });
+
+    it('approve reuses an existing COMPLETE snapshot without reconverting', async () => {
+      approveSetup();
+      jest
+        .spyOn(prismaService.payment, 'findFirst')
+        .mockResolvedValue(
+          legacyNullPayment({ ...completePaymentSnapshot, status: PaymentStatus.SUBMITTED }) as never,
+        );
+
+      await approve('2026-08-11');
+
+      expect(prismaService.exchangeRate.findFirst).not.toHaveBeenCalled();
+      expect(prismaService.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: PaymentStatus.APPROVED }),
+        }),
+      );
+      expect(prismaService.payment.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ functionalAmountMinor: expect.anything() }),
+        }),
+      );
+    });
+
+    it('approve on a PARTIAL snapshot blocks with PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID', async () => {
+      approveSetup();
+      jest
+        .spyOn(prismaService.payment, 'findFirst')
+        .mockResolvedValue(
+          legacyNullPayment({ functionalAmountMinor: 36500 }) as never,
+        );
+
+      await expect(approve()).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID' },
+      });
+      expect(prismaService.payment.update).not.toHaveBeenCalled();
+    });
+
+    it('approve on missing rate leaves the payment SUBMITTED (no status mutation)', async () => {
+      approveSetup();
+      jest.spyOn(prismaService.exchangeRate, 'findFirst').mockResolvedValue(null);
+
+      await expect(approve()).rejects.toMatchObject({
+        response: expect.objectContaining({ code: 'EXCHANGE_RATE_NOT_FOUND' }),
+      });
+      expect(prismaService.payment.update).not.toHaveBeenCalled();
+    });
+
+    it('reconcile allows legacy APPROVED NULL without any rate lookup', async () => {
+      jest.spyOn(prismaService.payment, 'findUnique').mockResolvedValue({
+        id: paymentId,
+        status: PaymentStatus.APPROVED,
+        functionalAmountMinor: null,
+        functionalCurrencyCode: null,
+        exchangeRateId: null,
+        exchangeRateValue: null,
+        exchangeRateDirection: null,
+        exchangeRateEffectiveAt: null,
+        conversionDate: null,
+        paymentAllocations: [
+          { charge: { id: 'charge-123', status: ChargeStatus.PAID }, amount: 10000 },
+        ],
+      } as never);
+      jest.spyOn(prismaService.payment, 'update').mockResolvedValue({} as never);
+
+      await service.tryReconcilePayment(paymentId);
+
+      expect(prismaService.exchangeRate.findFirst).not.toHaveBeenCalled();
+      expect(prismaService.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ status: PaymentStatus.RECONCILED }),
+        }),
+      );
+    });
+
+    it('reconcile blocks a PARTIAL snapshot (no RECONCILED)', async () => {
+      jest.spyOn(prismaService.payment, 'findUnique').mockResolvedValue({
+        id: paymentId,
+        status: PaymentStatus.APPROVED,
+        functionalAmountMinor: 36500,
+        functionalCurrencyCode: null,
+        exchangeRateId: null,
+        exchangeRateValue: null,
+        exchangeRateDirection: null,
+        exchangeRateEffectiveAt: null,
+        conversionDate: null,
+        paymentAllocations: [
+          { charge: { id: 'charge-123', status: ChargeStatus.PAID }, amount: 10000 },
+        ],
+      } as never);
+      jest.spyOn(prismaService.payment, 'update').mockResolvedValue({} as never);
+
+      await service.tryReconcilePayment(paymentId);
+
+      expect(prismaService.payment.update).not.toHaveBeenCalled();
+    });
+
+    it('functionalCurrency is frozen at approval time: tenant changed to USD before approve uses USD', async () => {
+      approveSetup();
+      jest
+        .spyOn(prismaService.tenant, 'findFirst')
+        .mockResolvedValue({ id: tenantId, functionalCurrency: 'USD' });
+
+      await approve('2026-08-10');
+
+      expect(prismaService.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ functionalCurrencyCode: 'USD' }),
+        }),
+      );
+    });
+
+    it('a frozen COMPLETE snapshot is untouched by a later tenant currency change', async () => {
+      approveSetup();
+      jest
+        .spyOn(prismaService.payment, 'findFirst')
+        .mockResolvedValue(
+          legacyNullPayment({ ...completePaymentSnapshot, status: PaymentStatus.SUBMITTED }) as never,
+        );
+      jest
+        .spyOn(prismaService.tenant, 'findFirst')
+        .mockResolvedValue({ id: tenantId, functionalCurrency: 'USD' });
+
+      await approve('2026-08-11');
+
+      expect(prismaService.payment.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ functionalCurrencyCode: expect.anything() }),
+        }),
+      );
+      expect(prismaService.exchangeRate.findFirst).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -8,6 +8,12 @@ import { PaymentReceiptService } from '../receipts/payment-receipt.service';
 import type { AuthenticatedMembership, PortalContext } from '../common/types/request.types';
 import { resolveNotificationPortalContext } from '../common/portal-context';
 import { ExpensesService } from './expenses.service';
+import { CurrencyConversionService } from './currency-conversion.service';
+import {
+  buildPaymentFunctionalSnapshot,
+  classifyFunctionalSnapshot,
+  type FunctionalSnapshotFields,
+} from './functional-snapshot';
 import { acquirePaymentLinkedDocumentLock } from '../common/payment-linked-document-lock';
 import { isEffectivePaymentStatus as isEffectivePaymentStatusShared } from './payment-status-semantics';
 import type { Role, ScopedRole } from '@buildingos/contracts';
@@ -36,9 +42,11 @@ import {
   PaymentDuplicateCheckResultDto,
   UnitLedgerDto,
   MonthlyTrendDto,
+  PaymentDetailDto,
 } from './finanzas.dto';
 
-export interface PendingPaymentListItem extends Payment {
+export interface PendingPaymentListItem extends Omit<Payment, 'exchangeRateValue'> {
+  exchangeRateValue: string | null;
   building?: { id: string; name: string } | null;
   unit?: { id: string; label: string | null } | null;
   createdByUser?: { id: string; name: string; email: string } | null;
@@ -155,7 +163,105 @@ export class FinanzasService {
     private readonly notificationsService: NotificationsService,
     private readonly receiptService: PaymentReceiptService,
     private readonly expensesService: ExpensesService,
+    private readonly currencyConversionService: CurrencyConversionService,
   ) {}
+
+  private toConversionDate(date: Date): string {
+    const year = date.getUTCFullYear();
+    const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+    const day = String(date.getUTCDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  /**
+   * 3E2: guarantee a COMPLETE functional snapshot before an effective
+   * transition (SUBMITTED → APPROVED).
+   *
+   * - COMPLETE: reuse exactly, never reconvert.
+   * - LEGACY_NULL: freeze with transferDate if present, else the definitive
+   *   paidAt. Covers pre-3E2 SUBMITTED payments approved after rollout.
+   * - PARTIAL_INVALID: block with a stable structured error.
+   */
+  private async paymentFunctionalSnapshot(
+    client: Prisma.TransactionClient | PrismaService,
+    tenantId: string,
+    amountMinor: number,
+    currencyCode: string,
+    conversionDate: Date,
+  ): Promise<{
+    functionalAmountMinor: number;
+    functionalCurrencyCode: string;
+    exchangeRateId: string | null;
+    exchangeRateValue: string;
+    exchangeRateDirection: 'IDENTITY' | 'DIRECT' | 'INVERSE';
+    exchangeRateEffectiveAt: Date | null;
+    conversionDate: Date;
+  }> {
+    const tenant = await client.tenant.findFirst({
+      where: { id: tenantId },
+      select: { functionalCurrency: true },
+    });
+
+    if (!tenant) {
+      throw new NotFoundException(`Tenant no encontrado: ${tenantId}`);
+    }
+
+    return buildPaymentFunctionalSnapshot(
+      (input) =>
+        this.currencyConversionService.convert({
+          tenantId: input.tenantId,
+          amount: input.amount,
+          originalCurrency: input.originalCurrency as Parameters<
+            typeof this.currencyConversionService.convert
+          >[0]['originalCurrency'],
+          functionalCurrency: input.functionalCurrency as Parameters<
+            typeof this.currencyConversionService.convert
+          >[0]['functionalCurrency'],
+          conversionDate: input.conversionDate,
+        }),
+      tenantId,
+      {
+        amountMinor,
+        currencyCode,
+        functionalCurrency: tenant.functionalCurrency,
+        conversionDate: this.toConversionDate(conversionDate),
+      },
+    );
+  }
+
+  private async ensurePaymentFunctionalSnapshot(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    payment: FunctionalSnapshotFields & {
+      amount: number;
+      currency: string;
+      transferDate: Date | null;
+    },
+    paidAt: Date,
+  ): Promise<Record<string, unknown>> {
+    const state = classifyFunctionalSnapshot(payment);
+
+    if (state === 'COMPLETE') {
+      return {};
+    }
+
+    if (state === 'PARTIAL_INVALID') {
+      throw new UnprocessableEntityException({
+        statusCode: 422,
+        error: 'PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID',
+        message: 'El pago posee un snapshot funcional incompleto o incoherente',
+      });
+    }
+
+    const conversionDate = payment.transferDate ?? paidAt;
+    return this.paymentFunctionalSnapshot(
+      tx,
+      tenantId,
+      payment.amount,
+      payment.currency,
+      conversionDate,
+    );
+  }
 
   // ============================================================================
   // CHARGE OPERATIONS
@@ -525,7 +631,7 @@ export class FinanzasService {
     userRoles: string[],
     dto: SubmitPaymentDto,
     portalContext?: PortalContext,
-  ): Promise<Payment> {
+  ): Promise<PaymentDetailDto> {
     // 1. Permission check
     if (!this.validators.canSubmitPayments(userRoles)) {
       this.validators.throwForbidden('payments', 'submit');
@@ -673,6 +779,21 @@ export class FinanzasService {
           );
         }
 
+        // 3E2: when the resident declares a transferDate (economic bank day,
+        // strict YYYY-MM-DD), the functional snapshot is frozen AT SUBMIT.
+        // If the conversion fails the whole submit fails: no Payment and no
+        // reservation allocations are created.
+        const transferDate = dto.transferDate ? new Date(`${dto.transferDate}T00:00:00.000Z`) : null;
+        const submitSnapshot = transferDate
+          ? await this.paymentFunctionalSnapshot(
+              tx,
+              tenantId,
+              calculatedAmount,
+              paymentCurrency,
+              transferDate,
+            )
+          : null;
+
         const payment = await tx.payment.create({
           data: {
             tenantId,
@@ -686,6 +807,8 @@ export class FinanzasService {
             proofFileId: dto.proofFileId || null,
             createdByUserId: userId,
             notes: this.createResidentDirectedPaymentMarker(),
+            transferDate,
+            ...(submitSnapshot ?? {}),
           },
         });
 
@@ -827,7 +950,7 @@ export class FinanzasService {
     userRoles: string[],
     membershipId: string,
     dto: ApprovePaymentDto,
-  ): Promise<Payment> {
+  ): Promise<PaymentDetailDto> {
     // 1. Permission check
     if (!this.validators.canReviewPayments(userRoles)) {
       this.validators.throwForbidden('payments', 'approve');
@@ -864,13 +987,21 @@ export class FinanzasService {
         buildingId,
         payment,
       );
+      const paidAt = dto.paidAt ? new Date(dto.paidAt) : new Date();
+      const snapshot = await this.ensurePaymentFunctionalSnapshot(
+        tx,
+        tenantId,
+        payment,
+        paidAt,
+      );
       const approvedPayment = await tx.payment.update({
         where: { id: payment.id },
         data: {
           status: PaymentStatus.APPROVED,
-          paidAt: dto.paidAt ? new Date(dto.paidAt) : new Date(),
+          paidAt,
           reviewedByMembershipId: membershipId,
           updatedAt: new Date(),
+          ...snapshot,
         },
       });
 
@@ -927,7 +1058,7 @@ export class FinanzasService {
     userRoles: string[],
     membershipId: string,
     dto: RejectPaymentDto,
-  ): Promise<Payment> {
+  ): Promise<PaymentDetailDto> {
     if (!this.validators.canReviewPayments(userRoles)) {
       this.validators.throwForbidden('payments', 'reject');
     }
@@ -1403,13 +1534,19 @@ export class FinanzasService {
     return publicNotes || null;
   }
 
-  private sanitizePaymentForResponse<T extends { notes?: string | null }>(
-    payment: T,
-  ): SanitizedPayment<T> {
+  private sanitizePaymentForResponse<
+    T extends { notes?: string | null; exchangeRateValue?: unknown },
+  >(payment: T): SanitizedPayment<T> & { exchangeRateValue?: string | null } {
     const publicNotes = this.stripInternalPaymentMarkers(payment.notes);
-    const { notes: _internalNotes, ...publicPayment } = payment;
+    const { notes: _internalNotes, exchangeRateValue, ...publicPayment } = payment;
 
-    return { ...publicPayment, notes: publicNotes };
+    return {
+      ...publicPayment,
+      notes: publicNotes,
+      ...(exchangeRateValue === null || exchangeRateValue === undefined
+        ? { exchangeRateValue: null }
+        : { exchangeRateValue: (exchangeRateValue as { toString(): string }).toString() }),
+    } as SanitizedPayment<T> & { exchangeRateValue?: string | null };
   }
 
   private calculateApprovedChargeOutstanding(charge: ChargeWithAllocations): number {
@@ -2414,7 +2551,7 @@ export class FinanzasService {
     paymentId: string,
     userRoles: string[],
     membershipId: string,
-  ): Promise<Payment> {
+  ): Promise<PaymentDetailDto> {
     // 1. Permission check
     if (!this.validators.canReviewPayments(userRoles)) {
       this.validators.throwForbidden('payments', 'revive');
@@ -2478,7 +2615,7 @@ export class FinanzasService {
     paymentId: string,
     userRoles: string[],
     userId: string,
-  ): Promise<PaymentWithAllocationSummary> {
+  ): Promise<PaymentDetailDto> {
     // 1. Find payment
     const payment = await this.prisma.payment.findFirst({
       where: { id: paymentId, tenantId, buildingId },
@@ -2539,7 +2676,7 @@ export class FinanzasService {
     userRoles: string[],
     membershipId: string,
     reason?: string,
-  ): Promise<Payment> {
+  ): Promise<PaymentDetailDto> {
     // 1. Permission check
     if (!this.validators.canReviewPayments(userRoles)) {
       this.validators.throwForbidden('payments', 'cancel');
@@ -2864,6 +3001,17 @@ export class FinanzasService {
       return;
     }
 
+    // 3E2: an APPROVED payment may reach RECONCILED only with a COMPLETE
+    // snapshot or as historical legacy (ALL snapshot fields NULL). A partial
+    // snapshot is corruption and blocks reconciliation.
+    const snapshotState = classifyFunctionalSnapshot(payment);
+    if (snapshotState === 'PARTIAL_INVALID') {
+      this.logger.error(
+        `Payment ${paymentId} has a partial functional snapshot; RECONCILED blocked`,
+      );
+      return;
+    }
+
     // Check if all allocated charges are fully paid
     const allPaid = payment.paymentAllocations.every(
       (alloc) => alloc.charge.status === ChargeStatus.PAID,
@@ -2994,7 +3142,7 @@ export class FinanzasService {
     userRoles: string[],
     membershipId: string,
     dto: ApprovePaymentDto,
-  ): Promise<Payment> {
+  ): Promise<PaymentDetailDto> {
     // Permission check
     if (!this.validators.canReviewPayments(userRoles)) {
       this.validators.throwForbidden('payments', 'approve');
@@ -3028,14 +3176,22 @@ export class FinanzasService {
         payment.buildingId,
         payment,
       );
+      const paidAt = dto.paidAt ? new Date(dto.paidAt) : new Date();
+      const snapshot = await this.ensurePaymentFunctionalSnapshot(
+        tx,
+        tenantId,
+        payment,
+        paidAt,
+      );
       const approvedPayment = await tx.payment.update({
         where: { id: payment.id },
         data: {
           status: PaymentStatus.APPROVED,
           reviewedByMembershipId: membershipId,
           reviewedAt: new Date(),
-          paidAt: dto.paidAt ? new Date(dto.paidAt) : new Date(),
+          paidAt,
           updatedAt: new Date(),
+          ...snapshot,
         },
       });
 
@@ -3097,7 +3253,7 @@ export class FinanzasService {
     userRoles: string[],
     membershipId: string,
     dto: RejectPaymentDto,
-  ): Promise<Payment> {
+  ): Promise<PaymentDetailDto> {
     if (!this.validators.canReviewPayments(userRoles)) {
       this.validators.throwForbidden('payments', 'reject');
     }

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -208,17 +208,20 @@ export class FinanzasService {
 
     return buildPaymentFunctionalSnapshot(
       (input) =>
-        this.currencyConversionService.convert({
-          tenantId: input.tenantId,
-          amount: input.amount,
-          originalCurrency: input.originalCurrency as Parameters<
-            typeof this.currencyConversionService.convert
-          >[0]['originalCurrency'],
-          functionalCurrency: input.functionalCurrency as Parameters<
-            typeof this.currencyConversionService.convert
-          >[0]['functionalCurrency'],
-          conversionDate: input.conversionDate,
-        }),
+        this.currencyConversionService.convert(
+          {
+            tenantId: input.tenantId,
+            amount: input.amount,
+            originalCurrency: input.originalCurrency as Parameters<
+              typeof this.currencyConversionService.convert
+            >[0]['originalCurrency'],
+            functionalCurrency: input.functionalCurrency as Parameters<
+              typeof this.currencyConversionService.convert
+            >[0]['functionalCurrency'],
+            conversionDate: input.conversionDate,
+          },
+          client,
+        ),
       tenantId,
       {
         amountMinor,

--- a/apps/api/src/finanzas/functional-snapshot.spec.ts
+++ b/apps/api/src/finanzas/functional-snapshot.spec.ts
@@ -1,0 +1,165 @@
+import {
+  classifyFunctionalSnapshot,
+  isFunctionalSnapshotPresent,
+} from './functional-snapshot';
+
+const fields = (overrides: Record<string, unknown> = {}) => ({
+  functionalAmountMinor: null,
+  functionalCurrencyCode: null,
+  exchangeRateId: null,
+  exchangeRateValue: null,
+  exchangeRateDirection: null,
+  exchangeRateEffectiveAt: null,
+  conversionDate: null,
+  ...overrides,
+});
+
+describe('classifyFunctionalSnapshot', () => {
+  it('all null fields => LEGACY_NULL', () => {
+    expect(classifyFunctionalSnapshot(fields())).toBe('LEGACY_NULL');
+  });
+
+  it('valid IDENTITY => COMPLETE', () => {
+    expect(
+      classifyFunctionalSnapshot(
+        fields({
+          functionalAmountMinor: 1000,
+          functionalCurrencyCode: 'VES',
+          exchangeRateValue: '1',
+          exchangeRateDirection: 'IDENTITY',
+          conversionDate: '2026-08-10',
+        }),
+      ),
+    ).toBe('COMPLETE');
+  });
+
+  it('valid DIRECT => COMPLETE', () => {
+    expect(
+      classifyFunctionalSnapshot(
+        fields({
+          functionalAmountMinor: 36500,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'rate-1',
+          exchangeRateValue: '36.5',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: '2026-08-08',
+          conversionDate: '2026-08-10',
+        }),
+      ),
+    ).toBe('COMPLETE');
+  });
+
+  it('valid INVERSE => COMPLETE', () => {
+    expect(
+      classifyFunctionalSnapshot(
+        fields({
+          functionalAmountMinor: 50000,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'rate-2',
+          exchangeRateValue: '50',
+          exchangeRateDirection: 'INVERSE',
+          exchangeRateEffectiveAt: '2026-08-08',
+          conversionDate: '2026-08-10',
+        }),
+      ),
+    ).toBe('COMPLETE');
+  });
+
+  it('IDENTITY with exchangeRateId => PARTIAL_INVALID', () => {
+    expect(
+      classifyFunctionalSnapshot(
+        fields({
+          functionalAmountMinor: 1000,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'rate-1',
+          exchangeRateValue: '1',
+          exchangeRateDirection: 'IDENTITY',
+          conversionDate: '2026-08-10',
+        }),
+      ),
+    ).toBe('PARTIAL_INVALID');
+  });
+
+  it('DIRECT without exchangeRateId => PARTIAL_INVALID', () => {
+    expect(
+      classifyFunctionalSnapshot(
+        fields({
+          functionalAmountMinor: 36500,
+          functionalCurrencyCode: 'VES',
+          exchangeRateValue: '36.5',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: '2026-08-08',
+          conversionDate: '2026-08-10',
+        }),
+      ),
+    ).toBe('PARTIAL_INVALID');
+  });
+
+  it('INVERSE without exchangeRateEffectiveAt => PARTIAL_INVALID', () => {
+    expect(
+      classifyFunctionalSnapshot(
+        fields({
+          functionalAmountMinor: 50000,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'rate-2',
+          exchangeRateValue: '50',
+          exchangeRateDirection: 'INVERSE',
+          conversionDate: '2026-08-10',
+        }),
+      ),
+    ).toBe('PARTIAL_INVALID');
+  });
+
+  it('rate <= 0 => PARTIAL_INVALID', () => {
+    expect(
+      classifyFunctionalSnapshot(
+        fields({
+          functionalAmountMinor: 1000,
+          functionalCurrencyCode: 'VES',
+          exchangeRateId: 'rate-1',
+          exchangeRateValue: '0',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: '2026-08-08',
+          conversionDate: '2026-08-10',
+        }),
+      ),
+    ).toBe('PARTIAL_INVALID');
+  });
+
+  it('isolated functional field => PARTIAL_INVALID', () => {
+    expect(
+      classifyFunctionalSnapshot(fields({ functionalAmountMinor: 1000 })),
+    ).toBe('PARTIAL_INVALID');
+    expect(
+      classifyFunctionalSnapshot(fields({ conversionDate: '2026-08-10' })),
+    ).toBe('PARTIAL_INVALID');
+    expect(
+      classifyFunctionalSnapshot(fields({ exchangeRateValue: '36.5' })),
+    ).toBe('PARTIAL_INVALID');
+  });
+
+  it('functional currency without functional amount => PARTIAL_INVALID', () => {
+    expect(
+      classifyFunctionalSnapshot(fields({ functionalCurrencyCode: 'VES' })),
+    ).toBe('PARTIAL_INVALID');
+  });
+
+  it('invalid direction => PARTIAL_INVALID', () => {
+    expect(
+      classifyFunctionalSnapshot(
+        fields({
+          functionalAmountMinor: 1000,
+          functionalCurrencyCode: 'VES',
+          exchangeRateValue: '1',
+          exchangeRateDirection: 'HALF',
+          conversionDate: '2026-08-10',
+        }),
+      ),
+    ).toBe('PARTIAL_INVALID');
+  });
+
+  it('isFunctionalSnapshotPresent reflects any non-null field', () => {
+    expect(isFunctionalSnapshotPresent(fields())).toBe(false);
+    expect(isFunctionalSnapshotPresent(fields({ conversionDate: '2026-08-10' }))).toBe(true);
+  });
+});

--- a/apps/api/src/finanzas/functional-snapshot.ts
+++ b/apps/api/src/finanzas/functional-snapshot.ts
@@ -1,0 +1,189 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
+
+/**
+ * Generic functional FX snapshot classification shared by Liquidation (3D)
+ * and Payment (3E2). One semantic definition for COMPLETE / LEGACY_NULL /
+ * PARTIAL_INVALID — never treat a partially populated set as legacy.
+ */
+
+export type FunctionalSnapshotState = 'COMPLETE' | 'LEGACY_NULL' | 'PARTIAL_INVALID';
+
+export interface FunctionalSnapshotFields {
+  functionalAmountMinor: number | null;
+  functionalCurrencyCode: string | null;
+  exchangeRateId: string | null;
+  exchangeRateValue: string | number | { toString(): string } | null;
+  exchangeRateDirection: string | null;
+  exchangeRateEffectiveAt: Date | string | null;
+  conversionDate: Date | string | null;
+}
+
+const VALID_DIRECTIONS = new Set(['IDENTITY', 'DIRECT', 'INVERSE']);
+
+export function snapshotRateToString(
+  value: string | number | { toString(): string } | null,
+): string | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  return value.toString();
+}
+
+export function isFunctionalSnapshotPresent(
+  fields: FunctionalSnapshotFields,
+): boolean {
+  return (
+    fields.functionalAmountMinor != null ||
+    fields.functionalCurrencyCode != null ||
+    fields.exchangeRateId != null ||
+    snapshotRateToString(fields.exchangeRateValue) != null ||
+    fields.exchangeRateDirection != null ||
+    fields.exchangeRateEffectiveAt != null ||
+    fields.conversionDate != null
+  );
+}
+
+/**
+ * Classifies a snapshot:
+ * - LEGACY_NULL: every field is null.
+ * - COMPLETE: semantically coherent snapshot (see rules below).
+ * - PARTIAL_INVALID: any mixed/incoherent combination.
+ *
+ * Common required fields for a present snapshot:
+ * functionalAmountMinor, functionalCurrencyCode, exchangeRateValue,
+ * exchangeRateDirection, conversionDate.
+ *
+ * IDENTITY: direction == IDENTITY, rate == 1, rateId null, effectiveAt null.
+ * DIRECT/INVERSE: rate > 0, rateId != null, effectiveAt != null.
+ */
+export function classifyFunctionalSnapshot(
+  fields: FunctionalSnapshotFields,
+): FunctionalSnapshotState {
+  if (!isFunctionalSnapshotPresent(fields)) {
+    return 'LEGACY_NULL';
+  }
+
+  const rate = snapshotRateToString(fields.exchangeRateValue);
+
+  if (fields.functionalAmountMinor === null) {
+    return 'PARTIAL_INVALID';
+  }
+  if (fields.functionalCurrencyCode === null) {
+    return 'PARTIAL_INVALID';
+  }
+  if (rate === null) {
+    return 'PARTIAL_INVALID';
+  }
+  if (
+    fields.exchangeRateDirection === null ||
+    !VALID_DIRECTIONS.has(fields.exchangeRateDirection)
+  ) {
+    return 'PARTIAL_INVALID';
+  }
+  if (fields.conversionDate === null) {
+    return 'PARTIAL_INVALID';
+  }
+
+  const rateDecimal = new Prisma.Decimal(rate);
+
+  if (fields.exchangeRateDirection === 'IDENTITY') {
+    if (!rateDecimal.equals(1)) {
+      return 'PARTIAL_INVALID';
+    }
+    if (fields.exchangeRateId !== null || fields.exchangeRateEffectiveAt !== null) {
+      return 'PARTIAL_INVALID';
+    }
+    return 'COMPLETE';
+  }
+
+  // DIRECT or INVERSE
+  if (!rateDecimal.greaterThan(0)) {
+    return 'PARTIAL_INVALID';
+  }
+  if (fields.exchangeRateId === null) {
+    return 'PARTIAL_INVALID';
+  }
+  if (fields.exchangeRateEffectiveAt === null) {
+    return 'PARTIAL_INVALID';
+  }
+  return 'COMPLETE';
+}
+
+export function assertFunctionalSnapshotComplete(
+  fields: FunctionalSnapshotFields,
+  baseCurrency: string,
+): void {
+  if (classifyFunctionalSnapshot(fields) !== 'COMPLETE') {
+    throw new UnprocessableEntityException({
+      statusCode: 422,
+      error: 'FUNCTIONAL_SNAPSHOT_INVALID',
+      message: 'El snapshot funcional es incompleto o incoherente',
+    });
+  }
+  if (fields.functionalCurrencyCode !== baseCurrency) {
+    throw new UnprocessableEntityException({
+      statusCode: 422,
+      error: 'FUNCTIONAL_SNAPSHOT_INVALID',
+      message: `El snapshot funcional no converge a la moneda base (${baseCurrency})`,
+    });
+  }
+}
+
+export interface PaymentSnapshotBuildInput {
+  readonly amountMinor: number;
+  readonly currencyCode: string;
+  readonly functionalCurrency: string;
+  readonly conversionDate: string; // YYYY-MM-DD
+}
+
+/**
+ * Builds a complete functional snapshot for a Payment using the shared
+ * conversion engine (never duplicated lookup/rounding). The conversion date
+ * must already be normalized to YYYY-MM-DD.
+ */
+export async function buildPaymentFunctionalSnapshot(
+  convert: (input: {
+    tenantId: string;
+    amount: number;
+    originalCurrency: string;
+    functionalCurrency: string;
+    conversionDate: string;
+  }) => Promise<{
+    functionalAmount: number;
+    functionalCurrency: string;
+    sourceExchangeRateId: string | null;
+    appliedRate: string;
+    direction: 'IDENTITY' | 'DIRECT' | 'INVERSE';
+    sourceEffectiveAt: Date | null;
+    conversionDate: Date;
+  }>,
+  tenantId: string,
+  input: PaymentSnapshotBuildInput,
+): Promise<{
+  functionalAmountMinor: number;
+  functionalCurrencyCode: string;
+  exchangeRateId: string | null;
+  exchangeRateValue: string;
+  exchangeRateDirection: 'IDENTITY' | 'DIRECT' | 'INVERSE';
+  exchangeRateEffectiveAt: Date | null;
+  conversionDate: Date;
+}> {
+  const result = await convert({
+    tenantId,
+    amount: input.amountMinor,
+    originalCurrency: input.currencyCode,
+    functionalCurrency: input.functionalCurrency,
+    conversionDate: input.conversionDate,
+  });
+
+  return {
+    functionalAmountMinor: result.functionalAmount,
+    functionalCurrencyCode: result.functionalCurrency,
+    exchangeRateId: result.sourceExchangeRateId,
+    exchangeRateValue: result.appliedRate,
+    exchangeRateDirection: result.direction,
+    exchangeRateEffectiveAt: result.sourceEffectiveAt,
+    conversionDate: result.conversionDate,
+  };
+}

--- a/apps/api/src/finanzas/liquidation-valuation.ts
+++ b/apps/api/src/finanzas/liquidation-valuation.ts
@@ -1,5 +1,5 @@
 import { UnprocessableEntityException } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { classifyFunctionalSnapshot, isFunctionalSnapshotPresent } from './functional-snapshot';
 
 export type LiquidationValuationMode = 'FUNCTIONAL' | 'LEGACY_NOMINAL';
 
@@ -17,8 +17,6 @@ export interface LiquidationValuationSource {
   conversionDate: Date | string | null;
 }
 
-const VALID_DIRECTIONS = new Set(['IDENTITY', 'DIRECT', 'INVERSE']);
-
 function functionalSnapshotRequired(message: string): never {
   throw new UnprocessableEntityException({
     statusCode: 422,
@@ -27,43 +25,16 @@ function functionalSnapshotRequired(message: string): never {
   });
 }
 
-function rateToString(
-  value: string | number | { toString(): string } | null,
-): string | null {
-  if (value === null || value === undefined) {
-    return null;
-  }
-  return value.toString();
-}
-
-export function isFunctionalSnapshotPresent(
-  source: LiquidationValuationSource,
-): boolean {
-  return (
-    source.functionalAmountMinor != null ||
-    source.functionalCurrencyCode != null ||
-    source.exchangeRateId != null ||
-    rateToString(source.exchangeRateValue) != null ||
-    source.exchangeRateDirection != null ||
-    source.exchangeRateEffectiveAt != null ||
-    source.conversionDate != null
-  );
-}
+export { isFunctionalSnapshotPresent };
 
 export function assertFunctionalSnapshotComplete(
   source: LiquidationValuationSource,
   baseCurrency: string,
 ): void {
-  const rate = rateToString(source.exchangeRateValue);
-
-  if (source.functionalAmountMinor === null) {
+  const state = classifyFunctionalSnapshot(source);
+  if (state !== 'COMPLETE') {
     functionalSnapshotRequired(
-      `La fuente ${source.type}:${source.id} no posee functionalAmountMinor`,
-    );
-  }
-  if (source.functionalCurrencyCode === null) {
-    functionalSnapshotRequired(
-      `La fuente ${source.type}:${source.id} no posee functionalCurrencyCode`,
+      `La fuente ${source.type}:${source.id} posee un snapshot funcional incompleto o incoherente`,
     );
   }
   if (source.functionalCurrencyCode !== baseCurrency) {
@@ -71,59 +42,6 @@ export function assertFunctionalSnapshotComplete(
       `La fuente ${source.type}:${source.id} está en ${source.functionalCurrencyCode}, ` +
         `se esperaba la moneda base de la liquidación (${baseCurrency})`,
     );
-  }
-  if (rate === null) {
-    functionalSnapshotRequired(
-      `La fuente ${source.type}:${source.id} no posee exchangeRateValue`,
-    );
-  }
-  if (
-    source.exchangeRateDirection === null ||
-    !VALID_DIRECTIONS.has(source.exchangeRateDirection)
-  ) {
-    functionalSnapshotRequired(
-      `La fuente ${source.type}:${source.id} no posee una dirección de conversión válida`,
-    );
-  }
-  if (source.conversionDate === null) {
-    functionalSnapshotRequired(
-      `La fuente ${source.type}:${source.id} no posee conversionDate`,
-    );
-  }
-
-  const rateDecimal = new Prisma.Decimal(rate);
-
-  if (source.exchangeRateDirection === 'IDENTITY') {
-    if (!rateDecimal.equals(1)) {
-      functionalSnapshotRequired(
-        `La fuente ${source.type}:${source.id} es IDENTITY pero su tasa no es 1`,
-      );
-    }
-    if (source.exchangeRateId !== null || source.exchangeRateEffectiveAt !== null) {
-      functionalSnapshotRequired(
-        `La fuente ${source.type}:${source.id} es IDENTITY pero referencia una tasa`,
-      );
-    }
-    return;
-  }
-
-  if (source.exchangeRateDirection === 'DIRECT' || source.exchangeRateDirection === 'INVERSE') {
-    if (!rateDecimal.greaterThan(0)) {
-      functionalSnapshotRequired(
-        `La fuente ${source.type}:${source.id} posee una tasa no positiva`,
-      );
-    }
-    if (source.exchangeRateId === null) {
-      functionalSnapshotRequired(
-        `La fuente ${source.type}:${source.id} no referencia la tasa fuente`,
-      );
-    }
-    if (source.exchangeRateEffectiveAt === null) {
-      functionalSnapshotRequired(
-        `La fuente ${source.type}:${source.id} no posee la efectividad de la tasa`,
-      );
-    }
-    return;
   }
 }
 

--- a/apps/api/src/finanzas/payment-gateway/adapters/mercadopago.adapter.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/adapters/mercadopago.adapter.spec.ts
@@ -3,7 +3,7 @@
  * Task 2.1: Verify createPreference, handleWebhook, getChargeStatus
  */
 
-import { MercadoPagoAdapter, toMinorUnits } from './mercadopago.adapter';
+import { MercadoPagoAdapter, toMinorUnits, providerDeclaredDay } from './mercadopago.adapter';
 import { PaymentStatus } from '../interfaces/payment-provider.interface';
 import { createHmac } from 'crypto';
 import { HttpException } from '@nestjs/common';
@@ -299,4 +299,23 @@ describe('MercadoPagoAdapter', () => {
       expect(status).toBe('CANCELLED');
     });
   });
+
+describe('providerDeclaredDay (provider economic date)', () => {
+  it('preserves the provider-declared calendar day without UTC shift', () => {
+    expect(providerDeclaredDay('2026-08-10T23:30:00-04:00')).toBe('2026-08-10');
+    expect(providerDeclaredDay('2026-08-10T00:30:00+05:00')).toBe('2026-08-10');
+    expect(providerDeclaredDay('2026-08-10T12:00:00.000Z')).toBe('2026-08-10');
+  });
+
+  it.each(['2026-08-10', 'not-a-date', '', '2026-13-45T10:00:00Z', null, undefined, 123])(
+    'rejects invalid values %s',
+    (input) => {
+      expect(providerDeclaredDay(input as never)).toBeUndefined();
+    },
+  );
+
+  it('does NOT convert to UTC first (midnight boundary stays on declared day)', () => {
+    expect(providerDeclaredDay('2026-08-10T23:30:00-04:00')).toBe('2026-08-10');
+  });
+});
 });

--- a/apps/api/src/finanzas/payment-gateway/adapters/mercadopago.adapter.ts
+++ b/apps/api/src/finanzas/payment-gateway/adapters/mercadopago.adapter.ts
@@ -17,6 +17,28 @@ import {
 } from '../interfaces/payment-provider.interface';
 
 /**
+ * Extracts the provider-declared calendar day from a full ISO 8601 datetime
+ * WITHOUT converting to UTC first (2026-08-10T23:30:00-04:00 → 2026-08-10).
+ * Returns undefined when the value is not a valid ISO datetime.
+ */
+export function providerDeclaredDay(value: unknown): string | undefined {
+  if (typeof value !== 'string' || value.trim() !== value) {
+    return undefined;
+  }
+  const iso = value.trim();
+  const match = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.exec(iso);
+  if (!match) {
+    return undefined;
+  }
+  const day = match[0].slice(0, 10);
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) {
+    return undefined;
+  }
+  return day;
+}
+
+/**
  * Converts a provider monetary amount (currency units, e.g. 10.10) to minor
  * units (1010) using exact decimal arithmetic. Binary float paths are never
  * used for money.
@@ -117,6 +139,12 @@ export class MercadoPagoAdapter implements PaymentProvider {
     const transactionAmount = payment.transaction_amount;
     const currencyId = payment.currency_id;
 
+    // Economic date: the provider-declared day of approval, falling back to
+    // the transaction date. Never UTC-shifted; absent if not verifiable.
+    const declaredDay =
+      providerDeclaredDay(payment.date_approved) ??
+      providerDeclaredDay(payment.transaction_details?.transaction_date);
+
     return {
       eventId: String(payment.id),
       eventType: webhookData.action || 'payment.updated',
@@ -125,6 +153,7 @@ export class MercadoPagoAdapter implements PaymentProvider {
       status,
       amount: toMinorUnits(transactionAmount),
       currency: typeof currencyId === 'string' ? currencyId : undefined,
+      paidAt: declaredDay,
       rawPayload: payload,
     };
   }

--- a/apps/api/src/finanzas/payment-gateway/adapters/stripe.adapter.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/adapters/stripe.adapter.spec.ts
@@ -3,7 +3,7 @@
  * Task 2.2: Verify createPreference, handleWebhook, getChargeStatus
  */
 
-import { StripeAdapter } from './stripe.adapter';
+import { StripeAdapter, epochToUtcDay } from './stripe.adapter';
 import { BadRequestException } from '@nestjs/common';
 
 describe('StripeAdapter', () => {
@@ -157,4 +157,17 @@ describe('StripeAdapter', () => {
       expect(status).toBe('CANCELLED');
     });
   });
+
+describe('epochToUtcDay (Stripe economic date)', () => {
+  it('converts a Unix epoch to a deterministic UTC calendar date', () => {
+    // 2026-08-10T00:00:00Z
+    expect(epochToUtcDay(1786320000)).toBe('2026-08-10');
+    // 2026-08-10T23:59:59Z stays on the same UTC day
+    expect(epochToUtcDay(1786406399)).toBe('2026-08-10');
+  });
+
+  it.each([0, -1, NaN, Infinity, 1.5])('rejects invalid epochs %s', (epoch) => {
+    expect(epochToUtcDay(epoch)).toBeUndefined();
+  });
+});
 });

--- a/apps/api/src/finanzas/payment-gateway/adapters/stripe.adapter.ts
+++ b/apps/api/src/finanzas/payment-gateway/adapters/stripe.adapter.ts
@@ -13,6 +13,25 @@ import {
   PaymentProviderName,
 } from '../interfaces/payment-provider.interface';
 
+/**
+ * Stripe epoch (seconds since Unix epoch, UTC instant) → UTC calendar date
+ * YYYY-MM-DD. Explicit and deterministic: the project has no tenant timezone.
+ */
+export function epochToUtcDay(epochSeconds: number): string | undefined {
+  if (!Number.isInteger(epochSeconds) || epochSeconds <= 0) {
+    return undefined;
+  }
+  const date = new Date(epochSeconds * 1000);
+  if (Number.isNaN(date.getTime())) {
+    return undefined;
+  }
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(date.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+
 @Injectable()
 export class StripeAdapter implements PaymentProvider {
   readonly providerName: PaymentProviderName = 'stripe';
@@ -81,6 +100,16 @@ export class StripeAdapter implements PaymentProvider {
         status = 'PENDING';
     }
 
+    // Economic date: the provider EVENT timestamp (success event), NOT the
+    // Checkout Session creation timestamp. session.created is the start of
+    // the checkout, not evidence of the payment instant. Normalized as UTC
+    // calendar date (no tenant timezone exists).
+    const eventCreated = (payload as { created?: unknown }).created;
+    const paidAt =
+      status === 'PAID' && typeof eventCreated === 'number' && Number.isFinite(eventCreated)
+        ? epochToUtcDay(eventCreated)
+        : undefined;
+
     return {
       eventId: sessionId,
       eventType,
@@ -92,6 +121,7 @@ export class StripeAdapter implements PaymentProvider {
           ? session.amount_total
           : undefined,
       currency: typeof session.currency === 'string' ? session.currency.toUpperCase() : undefined,
+      paidAt,
       rawPayload: payload,
     };
   }

--- a/apps/api/src/finanzas/payment-gateway/e2e/payment-e2e.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/e2e/payment-e2e.spec.ts
@@ -51,11 +51,15 @@ describe('E2E Payment Flow', () => {
       status: 'PAID',
       amount: 10000,
       currency: 'ARS',
+      paidAt: '2026-08-10',
       rawPayload: {},
     });
     mockProvider.getChargeStatus = jest.fn().mockResolvedValue('PAID');
 
     mockPrisma = {
+      tenant: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'tenant-e2e', functionalCurrency: 'ARS' }),
+      },
       charge: {
         findFirst: jest.fn().mockResolvedValue({
           id: 'charge-e2e-1',
@@ -91,7 +95,22 @@ describe('E2E Payment Flow', () => {
       markProcessed: jest.fn(),
     };
 
-    service = new PaymentGatewayService(mockProvider as any, mockPrisma, mockIdempotencyService);
+    service = new PaymentGatewayService(
+      mockProvider as any,
+      mockPrisma,
+      mockIdempotencyService,
+      {
+        convert: jest.fn().mockResolvedValue({
+          functionalAmount: 10000,
+          functionalCurrency: 'ARS',
+          sourceExchangeRateId: null,
+          appliedRate: '1',
+          direction: 'IDENTITY',
+          sourceEffectiveAt: null,
+          conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+        }),
+      },
+    );
   });
 
   it('creates a payment preference and processes webhook to ledger evidence', async () => {

--- a/apps/api/src/finanzas/payment-gateway/interfaces/payment-provider.interface.ts
+++ b/apps/api/src/finanzas/payment-gateway/interfaces/payment-provider.interface.ts
@@ -37,6 +37,14 @@ export interface WebhookEvent {
    * Absent when the provider event does not carry verifiable currency evidence.
    */
   currency?: string;
+  /**
+   * Economic payment date (YYYY-MM-DD) as declared/verified by the provider.
+   * MP: date_approved (fallback transaction_details.transaction_date), using
+   * the provider-declared calendar day (never UTC-shifted). Stripe: the
+   * success event timestamp as UTC calendar date. Absent when the provider
+   * event does not carry a defensible economic date.
+   */
+  paidAt?: string;
   rawPayload: unknown;
 }
 

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.module.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.module.ts
@@ -9,8 +9,10 @@ import { PAYMENT_PROVIDER_TOKEN } from './interfaces/payment-provider.interface'
 import { MercadoPagoAdapter } from './adapters/mercadopago.adapter';
 import { StripeAdapter } from './adapters/stripe.adapter';
 import { PrismaModule } from '../../prisma/prisma.module';
+import { PrismaService } from '../../prisma/prisma.service';
 import { RedisModule } from '../../redis/redis.module';
 import { IdempotencyService } from './webhooks/idempotency.service';
+import { CurrencyConversionService } from '../currency-conversion.service';
 import { ConfiguredPaymentProviderName, PaymentProvider } from './interfaces/payment-provider.interface';
 
 export interface PaymentGatewayOptions {
@@ -37,7 +39,16 @@ export class PaymentGatewayModule {
       return {
         module: PaymentGatewayModule,
         imports: [PrismaModule, RedisModule],
-        providers: [noopPaymentProvider, IdempotencyService, PaymentGatewayService],
+        providers: [
+          noopPaymentProvider,
+          IdempotencyService,
+          PaymentGatewayService,
+          {
+            provide: CurrencyConversionService,
+            useFactory: (prisma: PrismaService) => new CurrencyConversionService(prisma),
+            inject: [PrismaService],
+          },
+        ],
         exports: [PAYMENT_PROVIDER_TOKEN, PaymentGatewayService],
       };
     }
@@ -59,7 +70,16 @@ export class PaymentGatewayModule {
     return {
       module: PaymentGatewayModule,
       imports: [PrismaModule, RedisModule],
-      providers: [providerFactory, IdempotencyService, PaymentGatewayService],
+      providers: [
+        providerFactory,
+        IdempotencyService,
+        PaymentGatewayService,
+        {
+          provide: CurrencyConversionService,
+          useFactory: (prisma: PrismaService) => new CurrencyConversionService(prisma),
+          inject: [PrismaService],
+        },
+      ],
       exports: [PAYMENT_PROVIDER_TOKEN, PaymentGatewayService],
     };
   }

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
@@ -421,6 +421,38 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
     });
   });
 
+  describe('3E2 gateway paidAt economic date', () => {
+    it('Payment.paidAt derives from the provider economic date (same day as conversionDate)', async () => {
+      const result = await run(paidEvent());
+
+      expect(result.chargeUpdated).toBe(true);
+      expect(mockPrisma.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            paidAt: new Date('2026-08-10T00:00:00.000Z'),
+          }),
+        }),
+      );
+      // conversionDate proviene del mismo event.paidAt (el convert mock recibe '2026-08-10')
+      expect(mockConversion.convert).toHaveBeenCalledWith(
+        expect.objectContaining({ conversionDate: '2026-08-10' }),
+      );
+    });
+
+    it('midnight boundary: a late-day provider date never shifts to the processing day', async () => {
+      const result = await run(paidEvent({ paidAt: '2026-08-10' }));
+
+      expect(result.chargeUpdated).toBe(true);
+      expect(mockPrisma.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            paidAt: new Date('2026-08-10T00:00:00.000Z'),
+          }),
+        }),
+      );
+    });
+  });
+
   describe('idempotency / replay', () => {
     it('skips processing when the event was already processed', async () => {
       mockIdempotencyService.isProcessed.mockResolvedValue(true);

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
@@ -362,6 +362,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
       );
       expect(mockConversion.convert).toHaveBeenCalledWith(
         expect.objectContaining({ conversionDate: '2026-08-10' }),
+        mockPrisma,
       );
     });
 
@@ -436,6 +437,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
       // conversionDate proviene del mismo event.paidAt (el convert mock recibe '2026-08-10')
       expect(mockConversion.convert).toHaveBeenCalledWith(
         expect.objectContaining({ conversionDate: '2026-08-10' }),
+        mockPrisma,
       );
     });
 

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
@@ -20,6 +20,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
   let mockProvider: jest.Mocked<PaymentProvider>;
   let mockPrisma: any;
   let mockIdempotencyService: any;
+  let mockConversion: any;
   let createdAllocations: Array<{ amount: number }>;
 
   const charge = (overrides: Record<string, unknown> = {}) => ({
@@ -55,6 +56,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
     status: 'PAID',
     amount: 10000,
     currency: 'ARS',
+    paidAt: '2026-08-10',
     rawPayload: {},
     ...overrides,
   });
@@ -68,6 +70,9 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
       getChargeStatus: jest.fn(),
     };
     mockPrisma = {
+      tenant: {
+        findFirst: jest.fn().mockResolvedValue({ id: 'tenant-1', functionalCurrency: 'VES' }),
+      },
       charge: {
         findFirst: jest.fn(() =>
           Promise.resolve(charge({ paymentAllocations: [...createdAllocations] })),
@@ -90,8 +95,34 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
       isProcessed: jest.fn().mockResolvedValue(false),
       markProcessed: jest.fn().mockResolvedValue(undefined),
     };
-    service = new PaymentGatewayService(mockProvider, mockPrisma, mockIdempotencyService);
+    mockConversion = {
+      convert: jest.fn().mockResolvedValue({
+        functionalAmount: 365000,
+        functionalCurrency: 'VES',
+        sourceExchangeRateId: 'rate-1',
+        appliedRate: '36.5',
+        direction: 'DIRECT',
+        sourceEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+        conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+      }),
+    };
+    service = new PaymentGatewayService(
+      mockProvider,
+      mockPrisma,
+      mockIdempotencyService,
+      mockConversion,
+    );
   });
+
+  const completePaymentSnapshot = {
+    functionalAmountMinor: 36500,
+    functionalCurrencyCode: 'VES',
+    exchangeRateId: 'rate-1',
+    exchangeRateValue: '36.5',
+    exchangeRateDirection: 'DIRECT',
+    exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+    conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+  };
 
   const run = (event: WebhookEvent) => {
     mockProvider.handleWebhook.mockResolvedValue(event);
@@ -311,6 +342,82 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
       await expect(run(paidEvent({ amount: 7500 }))).rejects.toMatchObject({
         response: { statusCode: 422, error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_CHARGE' },
       });
+    });
+  });
+
+  describe('3E2 gateway snapshot', () => {
+    it('freezes a COMPLETE snapshot before the effective transition when the payment is SUBMITTED', async () => {
+      const result = await run(paidEvent());
+
+      expect(result.chargeUpdated).toBe(true);
+      expect(mockPrisma.payment.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            status: 'APPROVED',
+            functionalAmountMinor: 365000,
+            functionalCurrencyCode: 'VES',
+            exchangeRateDirection: 'DIRECT',
+          }),
+        }),
+      );
+      expect(mockConversion.convert).toHaveBeenCalledWith(
+        expect.objectContaining({ conversionDate: '2026-08-10' }),
+      );
+    });
+
+    it('missing provider economic date => no effective transition (ServiceUnavailable)', async () => {
+      await expect(run(paidEvent({ paidAt: undefined }))).rejects.toThrow(
+        ServiceUnavailableException,
+      );
+
+      expect(mockPrisma.payment.update).not.toHaveBeenCalled();
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(mockIdempotencyService.markProcessed).not.toHaveBeenCalled();
+    });
+
+    it('missing rate => no effective transition and no markProcessed', async () => {
+      mockConversion.convert.mockRejectedValue(
+        new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'EXCHANGE_RATE_NOT_FOUND',
+          message: 'no rate',
+        }),
+      );
+
+      await expect(run(paidEvent())).rejects.toThrow(UnprocessableEntityException);
+
+      expect(mockPrisma.payment.update).not.toHaveBeenCalled();
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(mockIdempotencyService.markProcessed).not.toHaveBeenCalled();
+    });
+
+    it('replay after a frozen snapshot never reconverts', async () => {
+      await run(paidEvent());
+      const convertCallsAfterFirst = mockConversion.convert.mock.calls.length;
+      mockIdempotencyService.isProcessed.mockResolvedValue(true);
+      await run(paidEvent());
+
+      expect(mockConversion.convert.mock.calls.length).toBe(convertCallsAfterFirst);
+      expect(mockPrisma.paymentAllocation.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('an existing COMPLETE snapshot is reused exactly (no reconversion)', async () => {
+      mockPrisma.payment.findFirst.mockResolvedValue(
+        payment({
+          status: 'SUBMITTED',
+          ...completePaymentSnapshot,
+        }),
+      );
+
+      const result = await run(paidEvent());
+
+      expect(result.chargeUpdated).toBe(true);
+      expect(mockConversion.convert).not.toHaveBeenCalled();
+      expect(mockPrisma.payment.update).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ functionalAmountMinor: expect.anything() }),
+        }),
+      );
     });
   });
 

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
@@ -399,17 +399,20 @@ export class PaymentGatewayService {
 
     return buildPaymentFunctionalSnapshot(
       (input) =>
-        this.currencyConversionService.convert({
-          tenantId: input.tenantId,
-          amount: input.amount,
-          originalCurrency: input.originalCurrency as Parameters<
-            typeof this.currencyConversionService.convert
-          >[0]['originalCurrency'],
-          functionalCurrency: input.functionalCurrency as Parameters<
-            typeof this.currencyConversionService.convert
-          >[0]['functionalCurrency'],
-          conversionDate: input.conversionDate,
-        }),
+        this.currencyConversionService.convert(
+          {
+            tenantId: input.tenantId,
+            amount: input.amount,
+            originalCurrency: input.originalCurrency as Parameters<
+              typeof this.currencyConversionService.convert
+            >[0]['originalCurrency'],
+            functionalCurrency: input.functionalCurrency as Parameters<
+              typeof this.currencyConversionService.convert
+            >[0]['functionalCurrency'],
+            conversionDate: input.conversionDate,
+          },
+          tx,
+        ),
       tenantId,
       {
         amountMinor: payment.amount,

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
@@ -37,6 +37,23 @@ import {
   type FunctionalSnapshotFields,
 } from '../functional-snapshot';
 
+/**
+ * 3E2 fix: the gateway Payment.paidAt must derive from the SAME verified
+ * provider economic date used for the FX snapshot (YYYY-MM-DD), never from
+ * server processing time. Returns undefined for malformed days (defense).
+ */
+export function gatewayPaymentDate(day: string | undefined): Date | undefined {
+  if (typeof day !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(day)) {
+    return undefined;
+  }
+  const date = new Date(`${day}T00:00:00.000Z`);
+  if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== day) {
+    return undefined;
+  }
+  return date;
+}
+
+
 @Injectable()
 export class PaymentGatewayService {
   private readonly logger = new Logger(PaymentGatewayService.name);
@@ -290,7 +307,7 @@ export class PaymentGatewayService {
           where: { id: payment.id },
           data: {
             status: 'APPROVED',
-            paidAt: new Date(),
+            paidAt: gatewayPaymentDate(event.paidAt),
             paymentEventId: event.eventId,
             updatedAt: new Date(),
             ...snapshotData,
@@ -327,6 +344,7 @@ export class PaymentGatewayService {
       return true;
     });
   }
+
 
 
   /**

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
@@ -30,6 +30,12 @@ import {
   EFFECTIVE_PAYMENT_STATUSES,
   isEffectivePaymentStatus,
 } from '../payment-status-semantics';
+import { CurrencyConversionService } from '../currency-conversion.service';
+import {
+  buildPaymentFunctionalSnapshot,
+  classifyFunctionalSnapshot,
+  type FunctionalSnapshotFields,
+} from '../functional-snapshot';
 
 @Injectable()
 export class PaymentGatewayService {
@@ -39,6 +45,7 @@ export class PaymentGatewayService {
     @Optional() @Inject(PAYMENT_PROVIDER_TOKEN) private readonly provider: PaymentProvider | null,
     private readonly prisma: PrismaService,
     private readonly idempotencyService: IdempotencyService,
+    private readonly currencyConversionService: CurrencyConversionService,
   ) {}
 
   /**
@@ -273,6 +280,12 @@ export class PaymentGatewayService {
 
       let effectivePaymentStatus = payment.status;
       if (payment.status === 'SUBMITTED') {
+        const snapshotData = await this.gatewayPaymentSnapshot(
+          tx,
+          charge.tenantId,
+          payment,
+          event,
+        );
         await tx.payment.update({
           where: { id: payment.id },
           data: {
@@ -280,6 +293,7 @@ export class PaymentGatewayService {
             paidAt: new Date(),
             paymentEventId: event.eventId,
             updatedAt: new Date(),
+            ...snapshotData,
           },
         });
         effectivePaymentStatus = 'APPROVED';
@@ -312,6 +326,80 @@ export class PaymentGatewayService {
 
       return true;
     });
+  }
+
+
+  /**
+   * 3E2: freeze a COMPLETE functional snapshot before the gateway effective
+   * transition. COMPLETE → reuse; LEGACY_NULL → requires the provider
+   * economic date (event.paidAt, YYYY-MM-DD) — missing date blocks the whole
+   * reconciliation; PARTIAL_INVALID → block.
+   */
+  private async gatewayPaymentSnapshot(
+    tx: Parameters<Parameters<PrismaService['$transaction']>[0]>[0],
+    tenantId: string,
+    payment: FunctionalSnapshotFields & {
+      amount: number;
+      currency: string;
+    },
+    event: WebhookEvent,
+  ): Promise<Record<string, unknown>> {
+    const state = classifyFunctionalSnapshot(payment);
+
+    if (state === 'COMPLETE') {
+      return {};
+    }
+
+    if (state === 'PARTIAL_INVALID') {
+      throw new UnprocessableEntityException({
+        statusCode: 422,
+        error: 'PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID',
+        message: 'El pago posee un snapshot funcional incompleto o incoherente',
+      });
+    }
+
+    if (!event.paidAt) {
+      this.logger.error(
+        `Webhook event ${event.eventId}: no provider economic date; no effective transition`,
+      );
+      throw new ServiceUnavailableException(
+        'Webhook event missing provider economic date; manual review required',
+      );
+    }
+
+    const tenant = await tx.tenant.findFirst({
+      where: { id: tenantId },
+      select: { functionalCurrency: true },
+    });
+    if (!tenant) {
+      throw new UnprocessableEntityException({
+        statusCode: 422,
+        error: 'PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID',
+        message: 'Tenant no encontrado para el snapshot del pago',
+      });
+    }
+
+    return buildPaymentFunctionalSnapshot(
+      (input) =>
+        this.currencyConversionService.convert({
+          tenantId: input.tenantId,
+          amount: input.amount,
+          originalCurrency: input.originalCurrency as Parameters<
+            typeof this.currencyConversionService.convert
+          >[0]['originalCurrency'],
+          functionalCurrency: input.functionalCurrency as Parameters<
+            typeof this.currencyConversionService.convert
+          >[0]['functionalCurrency'],
+          conversionDate: input.conversionDate,
+        }),
+      tenantId,
+      {
+        amountMinor: payment.amount,
+        currencyCode: payment.currency,
+        functionalCurrency: tenant.functionalCurrency,
+        conversionDate: event.paidAt,
+      },
+    );
   }
 
   /**

--- a/apps/api/src/finanzas/tenant-finance.controller.ts
+++ b/apps/api/src/finanzas/tenant-finance.controller.ts
@@ -36,6 +36,7 @@ import {
   PaymentAuditLogDto,
   PaymentDuplicateCheckResultDto,
   ListTenantChargesQueryDto,
+  PaymentDetailDto,
 } from './finanzas.dto';
 import { Payment } from '@prisma/client';
 
@@ -134,7 +135,7 @@ export class TenantFinanceController {
     @Query() query: ListPendingPaymentsQueryDto,
     @Request() req: AuthenticatedRequest,
     @Headers('x-portal-context') portalContext?: string,
-  ): Promise<Payment[]> {
+  ): Promise<PaymentDetailDto[]> {
     const tenantId = req.tenantId!;
     const userId = req.user.id;
     const userRoles = req.user.roles || [];
@@ -157,7 +158,7 @@ export class TenantFinanceController {
     @Body() dto: ApprovePaymentDto,
     @Request() req: AuthenticatedRequest,
     @Headers('x-portal-context') portalContext?: string,
-  ): Promise<Payment> {
+  ): Promise<PaymentDetailDto> {
     const tenantId = req.tenantId!;
     const userRoles = req.user.roles || [];
     const membershipId = req.user.membershipId || '';
@@ -181,7 +182,7 @@ export class TenantFinanceController {
     @Body() dto: RejectPaymentDto,
     @Request() req: AuthenticatedRequest,
     @Headers('x-portal-context') portalContext?: string,
-  ): Promise<Payment> {
+  ): Promise<PaymentDetailDto> {
     const tenantId = req.tenantId!;
     const userRoles = req.user.roles || [];
     const membershipId = req.user.membershipId || '';


### PR DESCRIPTION
## PHASE 3E2 — Payment FX Snapshot

- Payment conserva `amount`/`currency` originales; +7 snapshot fields funcionales
- Snapshot IDENTITY / DIRECT / INVERSE (classifier semántico por direction, nunca la regla ingenua "7 non-null")
- `CurrencyConversionService` reutilizado (sin duplicar lookup/rounding)
- `Tenant.functionalCurrency` congelada al crear el snapshot
- `transferDate` estrictamente `YYYY-MM-DD` (datetimes rechazados); submit con transferDate congela el snapshot; sin transferDate el snapshot se congela al hacerse efectivo
- `approvePayment`/`approvePaymentTenant`: nunca producen APPROVED + snapshot NULL (COMPLETE reuse / LEGACY_NULL freeze / PARTIAL_INVALID 422)
- Gateway congela el snapshot antes de la transición efectiva
- Mercado Pago preserva la fecha económica declarada por el provider (`date_approved` → fallback `transaction_details.transaction_date`), sin shift UTC
- Stripe usa la fecha del EVENTO de éxito verificado; `Session.created` NO se usa como fecha del pago
- Missing provider date / missing rate → bloquean la transición efectiva (sin snapshot/APPROVED/RECONCILED/allocation/markProcessed)
- COMPLETE nunca se reconvierte (nuevo rate, cambio de tenant, approve, replay, reject/cancel/revive)
- LEGACY APPROVED NULL sigue reconciliable (rollout) sin rate lookup ni snapshot tardío; PARTIAL_INVALID bloquea
- Migration `20260811000000_add_payment_multicurrency_snapshot` aditiva sin backfill
- Compatibilidad 3D preservada (helper genérico re-exportado)

Errores: `PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID` — 422 (+ códigos del engine 3C reutilizados).

Explicitamente NO incluido: cross-currency PaymentAllocation, `paymentOriginalAmountMinor`, 3E3, Reports, Dashboard, producción.