### PR TITLE
feat(finance): support cross-currency payment allocations

### DIFF
--- a/apps/api/prisma/migrations/20260812000000_add_payment_allocation_original_share/migration.sql
+++ b/apps/api/prisma/migrations/20260812000000_add_payment_allocation_original_share/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "PaymentAllocation" ADD COLUMN     "paymentOriginalAmountMinor" INTEGER;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1709,6 +1709,7 @@ model PaymentAllocation {
   paymentId String
   chargeId  String
   amount    Int      // Amount allocated (in cents, must be <= Payment.amount)
+  paymentOriginalAmountMinor Int? // 3E3: porción del Payment ORIGINAL consumida (en Payment.currency); NULL = legacy same-currency
   createdAt DateTime @default(now())
 
   // Relations

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -3930,6 +3930,61 @@ describe('FinanzasService', () => {
         expect(prismaService.paymentAllocation.create).toHaveBeenCalled();
       });
 
+      it.each(['foreign', 'nonexistent'])('%s payment returns the canonical 404 without mutations', async () => {
+        jest.spyOn(validators, 'canAllocate').mockReturnValue(true);
+        jest.spyOn(validators, 'validateBuildingBelongsToTenant').mockResolvedValue(undefined);
+        jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValue(null);
+
+        await expect(service.createAllocation(
+          'tenant-1',
+          'building-1',
+          ['TENANT_ADMIN'],
+          'member-1',
+          { paymentId: 'payment-1', chargeId: 'charge-1', amount: 10000 },
+        )).rejects.toMatchObject({
+          response: {
+            statusCode: 404,
+            message: 'Payment not found or does not belong to this building/tenant',
+          },
+        });
+        expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
+        expect(prismaService.charge.update).not.toHaveBeenCalled();
+        expect(prismaService.payment.update).not.toHaveBeenCalled();
+      });
+
+      it('keeps the existing 409 when the scoped payment has no unit', async () => {
+        await expect(allocate({ unitId: null }, {})).rejects.toMatchObject({
+          response: {
+            statusCode: 409,
+            message: 'Payment must belong to a unit',
+          },
+        });
+        expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
+      });
+
+      it('returns the canonical 404 when the scoped charge lookup cannot see a foreign charge', async () => {
+        jest.spyOn(validators, 'canAllocate').mockReturnValue(true);
+        jest.spyOn(validators, 'validateBuildingBelongsToTenant').mockResolvedValue(undefined);
+        jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValue(basePayment as never);
+        jest.spyOn(prismaService.charge, 'findFirst').mockResolvedValue(null);
+
+        await expect(service.createAllocation(
+          'tenant-1',
+          'building-1',
+          ['TENANT_ADMIN'],
+          'member-1',
+          { paymentId: 'payment-1', chargeId: 'charge-1', amount: 10000 },
+        )).rejects.toMatchObject({
+          response: {
+            statusCode: 404,
+            message: 'Charge not found or does not belong to this building/tenant',
+          },
+        });
+        expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
+        expect(prismaService.charge.update).not.toHaveBeenCalled();
+        expect(prismaService.payment.update).not.toHaveBeenCalled();
+      });
+
       it('blocks cross-currency allocation with a legacy-null payment (422 PAYMENT_LEGACY_SNAPSHOT_REQUIRED)', async () => {
         await expect(allocate({ currency: 'VES' }, {})).rejects.toMatchObject({
           response: {

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -646,7 +646,7 @@ describe('FinanzasService', () => {
     });
 
     it('should accept an overdue resident charge as long as it still has outstanding balance', async () => {
-      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValueOnce([
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([
         {
           id: 'charge-123',
           tenantId,
@@ -813,7 +813,7 @@ describe('FinanzasService', () => {
 
     it('should allow the same unit and amount when the selected charge is different', async () => {
       jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValue(null);
-      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValueOnce([
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([
         {
           id: 'charge-456',
           tenantId,
@@ -949,7 +949,7 @@ describe('FinanzasService', () => {
     });
 
     it('should accept a prefix of two consecutive resident obligations and allocate the exact total', async () => {
-      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValueOnce([
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([
         {
           id: 'charge-1',
           tenantId,
@@ -1714,10 +1714,18 @@ describe('FinanzasService', () => {
           amount: 10000,
           currency: 'ARS',
           status: PaymentStatus.APPROVED,
+          functionalAmountMinor: null,
+          functionalCurrencyCode: null,
+          exchangeRateId: null,
+          exchangeRateValue: null,
+          exchangeRateDirection: null,
+          exchangeRateEffectiveAt: null,
+          conversionDate: null,
           paymentAllocations: [
             {
               amount: 10000,
-              charge: { status: ChargeStatus.PAID },
+              paymentOriginalAmountMinor: null,
+              charge: { currency: 'ARS', status: ChargeStatus.PAID },
             },
           ],
         } as any)
@@ -4172,6 +4180,8 @@ describe('FinanzasService', () => {
     it('reconcile allows legacy APPROVED NULL without any rate lookup', async () => {
       jest.spyOn(prismaService.payment, 'findUnique').mockResolvedValue({
         id: paymentId,
+        amount: 10000,
+        currency: 'ARS',
         status: PaymentStatus.APPROVED,
         functionalAmountMinor: null,
         functionalCurrencyCode: null,
@@ -4181,7 +4191,7 @@ describe('FinanzasService', () => {
         exchangeRateEffectiveAt: null,
         conversionDate: null,
         paymentAllocations: [
-          { charge: { id: 'charge-123', status: ChargeStatus.PAID }, amount: 10000 },
+          { charge: { id: 'charge-123', currency: 'ARS', status: ChargeStatus.PAID }, amount: 10000, paymentOriginalAmountMinor: null },
         ],
       } as never);
       jest.spyOn(prismaService.payment, 'update').mockResolvedValue({} as never);
@@ -4199,6 +4209,8 @@ describe('FinanzasService', () => {
     it('reconcile blocks a PARTIAL snapshot (no RECONCILED)', async () => {
       jest.spyOn(prismaService.payment, 'findUnique').mockResolvedValue({
         id: paymentId,
+        amount: 10000,
+        currency: 'USD',
         status: PaymentStatus.APPROVED,
         functionalAmountMinor: 36500,
         functionalCurrencyCode: null,
@@ -4208,7 +4220,7 @@ describe('FinanzasService', () => {
         exchangeRateEffectiveAt: null,
         conversionDate: null,
         paymentAllocations: [
-          { charge: { id: 'charge-123', status: ChargeStatus.PAID }, amount: 10000 },
+          { charge: { id: 'charge-123', currency: 'VES', status: ChargeStatus.PAID }, amount: 10000, paymentOriginalAmountMinor: null },
         ],
       } as never);
       jest.spyOn(prismaService.payment, 'update').mockResolvedValue({} as never);

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -632,14 +632,16 @@ describe('FinanzasService', () => {
           notes: 'resident-charge-selection-requires-resubmission',
         }),
       });
-      expect(prismaService.paymentAllocation.create).toHaveBeenCalledWith({
-        data: {
-          tenantId,
-          paymentId: 'payment-123',
-          chargeId: 'charge-123',
-          amount: 10000,
-        },
-      });
+      expect(prismaService.paymentAllocation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            tenantId,
+            paymentId: 'payment-123',
+            chargeId: 'charge-123',
+            amount: 10000,
+          }),
+        }),
+      );
       expect(prismaService.$executeRaw).toHaveBeenCalledTimes(2);
     });
 
@@ -680,14 +682,16 @@ describe('FinanzasService', () => {
 
       expect(result.status).toBe(PaymentStatus.SUBMITTED);
       expect(prismaService.payment.create).toHaveBeenCalled();
-      expect(prismaService.paymentAllocation.create).toHaveBeenCalledWith({
-        data: {
-          tenantId,
-          paymentId: 'payment-123',
-          chargeId: 'charge-123',
-          amount: 10000,
-        },
-      });
+      expect(prismaService.paymentAllocation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            tenantId,
+            paymentId: 'payment-123',
+            chargeId: 'charge-123',
+            amount: 10000,
+          }),
+        }),
+      );
     });
 
     it('should reject transfer payment without proofFileId', async () => {
@@ -3918,11 +3922,11 @@ describe('FinanzasService', () => {
         expect(prismaService.paymentAllocation.create).toHaveBeenCalled();
       });
 
-      it('blocks cross-currency allocation with 422 PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED', async () => {
+      it('blocks cross-currency allocation with a legacy-null payment (422 PAYMENT_LEGACY_SNAPSHOT_REQUIRED)', async () => {
         await expect(allocate({ currency: 'VES' }, {})).rejects.toMatchObject({
           response: {
             statusCode: 422,
-            error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED',
+            error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED',
           },
         });
         expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
@@ -4248,6 +4252,204 @@ describe('FinanzasService', () => {
         }),
       );
       expect(prismaService.exchangeRate.findFirst).not.toHaveBeenCalled();
+    });
+  });
+
+  // ========== 3E3: CROSS-CURRENCY PAYMENT ALLOCATION ==========
+  describe('3E3 cross-currency payment allocation', () => {
+    const tenantId = 'tenant-123';
+    const buildingId = 'building-123';
+    const membershipId = 'membership-123';
+
+    const paymentFixture = (overrides: Record<string, unknown> = {}) => ({
+      id: 'payment-x',
+      tenantId,
+      buildingId,
+      unitId: 'unit-123',
+      amount: 10000,
+      currency: 'USD',
+      status: PaymentStatus.APPROVED,
+      functionalAmountMinor: 365000,
+      functionalCurrencyCode: 'VES',
+      exchangeRateId: 'rate-1',
+      exchangeRateValue: '36.5',
+      exchangeRateDirection: 'DIRECT',
+      exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+      conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+      paymentAllocations: [],
+      ...overrides,
+    });
+
+    const chargeFixture = (overrides: Record<string, unknown> = {}) => ({
+      id: 'charge-x',
+      tenantId,
+      buildingId,
+      unitId: 'unit-123',
+      amount: 182500,
+      currency: 'VES',
+      status: ChargeStatus.PENDING,
+      canceledAt: null,
+      dueDate: new Date('2026-08-20T00:00:00.000Z'),
+      createdAt: new Date('2026-08-01T00:00:00.000Z'),
+      ...overrides,
+    });
+
+    const setup = (
+      payment: Record<string, unknown>,
+      charge: Record<string, unknown>,
+      outstanding = 182500,
+    ) => {
+      jest.spyOn(validators, 'canAllocate').mockReturnValue(true);
+      jest.spyOn(validators, 'validateBuildingBelongsToTenant').mockResolvedValue(undefined);
+      jest.spyOn(prismaService.payment, 'findFirst').mockResolvedValue(payment as never);
+      jest.spyOn(prismaService.charge, 'findFirst').mockResolvedValue(charge as never);
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([
+        {
+          ...charge,
+          paymentAllocations: [],
+        },
+      ] as never);
+      jest.spyOn(prismaService.paymentAllocation, 'findFirst').mockResolvedValue(null);
+      jest.spyOn(prismaService.paymentAllocation, 'create').mockResolvedValue({} as never);
+      jest.spyOn(prismaService.charge, 'findUnique').mockResolvedValue({
+        ...charge,
+        paymentAllocations: [{ amount: 0, payment: { status: 'APPROVED' } }],
+      } as never);
+      jest.spyOn(prismaService.charge, 'update').mockResolvedValue({} as never);
+      jest.spyOn(prismaService.payment, 'findUnique').mockResolvedValue(null);
+      jest.spyOn(prismaService.payment, 'update').mockResolvedValue({} as never);
+      jest.spyOn(prismaService.paymentAuditLog, 'create').mockResolvedValue({} as never);
+      return service.createAllocation(
+        tenantId,
+        buildingId,
+        ['TENANT_ADMIN'],
+        membershipId,
+        { paymentId: 'payment-x', chargeId: 'charge-x', amount: outstanding },
+      );
+    };
+
+    it('cross-currency full allocation: amount in Charge.currency + exact original share', async () => {
+      await setup(paymentFixture(), chargeFixture());
+
+      expect(prismaService.paymentAllocation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            amount: 182500,
+            paymentOriginalAmountMinor: 5000,
+          }),
+        }),
+      );
+    });
+
+    it('cross-currency partial allocation consumes proportional original share', async () => {
+      await setup(paymentFixture(), chargeFixture({ amount: 10000 }), 1825);
+
+      expect(prismaService.paymentAllocation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            amount: 1825,
+            paymentOriginalAmountMinor: 50,
+          }),
+        }),
+      );
+    });
+
+    it('same-currency new allocation carries the explicit original share', async () => {
+      await setup(
+        paymentFixture({ currency: 'VES', functionalCurrencyCode: 'VES', amount: 10000, functionalAmountMinor: 10000 }),
+        chargeFixture({ currency: 'VES', amount: 10000 }),
+        10000,
+      );
+
+      expect(prismaService.paymentAllocation.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            amount: 10000,
+            paymentOriginalAmountMinor: 10000,
+          }),
+        }),
+      );
+    });
+
+    it('cross-currency over functional snapshot blocked', async () => {
+      await expect(
+        setup(paymentFixture(), chargeFixture({ amount: 1000000 }), 500000),
+      ).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'PAYMENT_FUNCTIONAL_AMOUNT_EXCEEDED' },
+      });
+      expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
+    });
+
+    it('cross-currency LEGACY_NULL blocked with PAYMENT_LEGACY_SNAPSHOT_REQUIRED', async () => {
+      await expect(
+        setup(
+          paymentFixture({
+            functionalAmountMinor: null,
+            functionalCurrencyCode: null,
+            exchangeRateId: null,
+            exchangeRateValue: null,
+            exchangeRateDirection: null,
+            exchangeRateEffectiveAt: null,
+            conversionDate: null,
+          }),
+          chargeFixture(),
+        ),
+      ).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED' },
+      });
+      expect(prismaService.paymentAllocation.create).not.toHaveBeenCalled();
+    });
+
+    it('cross-currency PARTIAL_INVALID blocked with PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID', async () => {
+      await expect(
+        setup(
+          paymentFixture({ functionalAmountMinor: 365000, functionalCurrencyCode: null }),
+          chargeFixture(),
+        ),
+      ).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID' },
+      });
+    });
+
+    it('cross-currency incompatible functional currency blocked', async () => {
+      await expect(
+        setup(
+          paymentFixture({ functionalCurrencyCode: 'ARS' }),
+          chargeFixture(),
+        ),
+      ).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED' },
+      });
+    });
+
+    it('cross-currency never queries ExchangeRate during allocation', async () => {
+      await setup(paymentFixture(), chargeFixture());
+
+      expect(prismaService.exchangeRate.findFirst).not.toHaveBeenCalled();
+    });
+
+    it('frozen snapshot survives tenant functionalCurrency change (no current lookup)', async () => {
+      await setup(paymentFixture(), chargeFixture());
+      jest
+        .spyOn(prismaService.tenant, 'findFirst')
+        .mockResolvedValue({ id: tenantId, functionalCurrency: 'ARS' });
+
+      expect(prismaService.paymentAllocation.create).toHaveBeenCalled();
+    });
+
+    it('odd split: partial shares are deterministic and never exceed originals', async () => {
+      const payment = paymentFixture({ amount: 10000, functionalAmountMinor: 33333 });
+      const charge = chargeFixture({ amount: 33333 });
+      await setup(payment, charge, 11111);
+
+      const share = (
+        (prismaService.paymentAllocation.create as jest.Mock).mock.calls[0][0] as {
+          data: { paymentOriginalAmountMinor: number };
+        }
+      ).data.paymentOriginalAmountMinor;
+      expect(Number.isSafeInteger(share)).toBe(true);
+      expect(share).toBeGreaterThanOrEqual(0);
+      expect(share).toBeLessThanOrEqual(10000);
     });
   });
 });

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -2642,7 +2642,7 @@ describe('FinanzasService', () => {
         }),
       }));
       expect(prismaService.paymentAllocation.deleteMany).toHaveBeenCalledWith({
-        where: { tenantId, paymentId },
+        where: { tenantId, paymentId, chargeId: { in: [chargeId] } },
       });
       expect(makeAllocation()).toHaveLength(0);
       expect(notificationSpy).toHaveBeenCalledWith(tenantId, expect.any(Object), 'OTHER', undefined);
@@ -2697,7 +2697,7 @@ describe('FinanzasService', () => {
         }),
       }));
       expect(prismaService.paymentAllocation.deleteMany).toHaveBeenCalledWith({
-        where: { tenantId, paymentId },
+        where: { tenantId, paymentId, chargeId: { in: [chargeId] } },
       });
       expect(makeAllocation()).toHaveLength(0);
       expect(notificationSpy).toHaveBeenCalledWith(tenantId, expect.any(Object), 'OTHER', undefined);
@@ -2717,7 +2717,7 @@ describe('FinanzasService', () => {
 
       expect(result.canceledAt).toBeTruthy();
       expect(prismaService.paymentAllocation.deleteMany).toHaveBeenCalledWith({
-        where: { tenantId, paymentId },
+        where: { tenantId, paymentId, chargeId: { in: [chargeId] } },
       });
       expect(makeAllocation()).toHaveLength(0);
     });
@@ -3009,7 +3009,7 @@ describe('FinanzasService', () => {
 
       expect(makeAllocation()).toHaveLength(1);
       expect(prismaService.paymentAllocation.deleteMany).toHaveBeenCalledWith({
-        where: { tenantId, paymentId },
+        where: { tenantId, paymentId, chargeId: { in: [chargeId] } },
       });
       expect(notificationSpy).not.toHaveBeenCalled();
     });

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -15,6 +15,7 @@ import {
   type FunctionalSnapshotFields,
 } from './functional-snapshot';
 import {
+  assertPaymentAllocationCurrencyMode,
   createLockedAllocation,
   lockChargesForAllocation,
   lockPaymentForAllocation,
@@ -844,6 +845,10 @@ export class FinanzasService {
             'El monto ya no coincide con la deuda actual. Actualiza la información e inténtalo nuevamente.',
           );
         }
+        assertPaymentAllocationCurrencyMode(
+          payment.currency,
+          lockedSelection.map((selection) => ({ charge: selection.charge })),
+        );
 
         for (const selection of lockedSelection) {
           await tx.paymentAllocation.create({
@@ -1015,11 +1020,15 @@ export class FinanzasService {
         );
       }
 
-      await this.validateResidentPaymentAllocationsForApproval(
+      const lockedSelection = await this.validateResidentPaymentAllocationsForApproval(
         tx,
         tenantId,
         buildingId,
         payment,
+      );
+      assertPaymentAllocationCurrencyMode(
+        payment.currency,
+        lockedSelection.map((selection) => ({ charge: selection.charge })),
       );
       const paidAt = dto.paidAt ? new Date(dto.paidAt) : new Date();
       const snapshot = await this.ensurePaymentFunctionalSnapshot(
@@ -3079,11 +3088,15 @@ export class FinanzasService {
         );
       }
 
-      await this.validateResidentPaymentAllocationsForApproval(
+      const lockedSelection = await this.validateResidentPaymentAllocationsForApproval(
         tx,
         tenantId,
         payment.buildingId,
         payment,
+      );
+      assertPaymentAllocationCurrencyMode(
+        payment.currency,
+        lockedSelection.map((selection) => ({ charge: selection.charge })),
       );
       const paidAt = dto.paidAt ? new Date(dto.paidAt) : new Date();
       const snapshot = await this.ensurePaymentFunctionalSnapshot(

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -14,6 +14,12 @@ import {
   classifyFunctionalSnapshot,
   type FunctionalSnapshotFields,
 } from './functional-snapshot';
+import {
+  createLockedAllocation,
+  lockChargesForAllocation,
+  lockPaymentForAllocation,
+  reconcilePaymentWhenConsumed,
+} from './payment-allocation-transaction';
 import { acquirePaymentLinkedDocumentLock } from '../common/payment-linked-document-lock';
 import { isEffectivePaymentStatus as isEffectivePaymentStatusShared } from './payment-status-semantics';
 import type { Role, ScopedRole } from '@buildingos/contracts';
@@ -814,8 +820,32 @@ export class FinanzasService {
             ...(submitSnapshot ?? {}),
           },
         });
+        await lockPaymentForAllocation(tx, {
+          tenantId,
+          buildingId,
+          paymentId: payment.id,
+        });
+        await lockChargesForAllocation(
+          tx,
+          tenantId,
+          buildingId,
+          canonicalSelection.map(({ charge }) => charge.id),
+        );
+        const lockedSelection = this.validateCanonicalResidentChargeSelection(
+          await this.loadResidentChargeSelection(tx, tenantId, buildingId, dto.unitId!),
+          requestedChargeIds,
+        );
+        const lockedAmount = lockedSelection.reduce(
+          (sum, item) => sum + item.approvedOutstanding,
+          0,
+        );
+        if (lockedAmount !== calculatedAmount) {
+          throw new ConflictException(
+            'El monto ya no coincide con la deuda actual. Actualiza la información e inténtalo nuevamente.',
+          );
+        }
 
-        for (const selection of canonicalSelection) {
+        for (const selection of lockedSelection) {
           await tx.paymentAllocation.create({
             data: {
               tenantId,
@@ -1166,244 +1196,28 @@ export class FinanzasService {
       buildingId,
     );
 
-    // 3. Validate payment and charge (outside transaction for initial validation)
-    const payment = await this.prisma.payment.findFirst({
-      where: {
-        id: dto.paymentId,
-        tenantId,
-        buildingId,
-      },
-      include: {
-        paymentAllocations: {
-          include: {
-            charge: { select: { currency: true } },
-          },
-        },
-      },
-    });
-
-    if (!payment) {
-      throw new NotFoundException(
-        `Payment not found or does not belong to this building/tenant`,
-      );
-    }
-
-    // 3.5. Validate payment is in valid status for allocation
-    if (
-      payment.status !== PaymentStatus.APPROVED &&
-      payment.status !== PaymentStatus.RECONCILED
-    ) {
-      throw new ConflictException(
-        `Cannot allocate payment in status ${payment.status}. Payment must be APPROVED or RECONCILED.`,
-      );
-    }
-
-    const charge = await this.prisma.charge.findFirst({
-      where: {
-        id: dto.chargeId,
-        tenantId,
-        buildingId,
-      },
-    });
-
-    if (!charge) {
-      throw new NotFoundException(
-        `Charge not found or does not belong to this building/tenant`,
-      );
-    }
-
-    // 3E3: allocation amount is ALWAYS expressed in Charge.currency.
-    // Same-currency: legacy behavior. Cross-currency is supported only when
-    // the Payment has a COMPLETE frozen snapshot whose functionalCurrencyCode
-    // equals Charge.currency — the frozen snapshot is the historical truth,
-    // never a new rate lookup.
-    const sameCurrency = payment.currency === charge.currency;
-    let originalShare: number | null;
-
-    if (!sameCurrency) {
-      const state = classifyFunctionalSnapshot(payment);
-
-      if (state === 'LEGACY_NULL') {
-        throw new UnprocessableEntityException({
-          statusCode: 422,
-          error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED',
-          message: 'El pago no posee snapshot funcional; no se puede asignar en otra moneda',
-        });
-      }
-
-      if (state === 'PARTIAL_INVALID') {
-        throw new UnprocessableEntityException({
-          statusCode: 422,
-          error: 'PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID',
-          message: 'El pago posee un snapshot funcional incompleto o incoherente',
-        });
-      }
-
-      if (payment.functionalCurrencyCode !== charge.currency) {
-        throw new UnprocessableEntityException({
-          statusCode: 422,
-          error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED',
-          message: `La moneda funcional del pago (${payment.functionalCurrencyCode}) no coincide con la moneda del cargo (${charge.currency})`,
-        });
-      }
-
-      if (payment.functionalAmountMinor === null) {
-        throw new UnprocessableEntityException({
-          statusCode: 422,
-          error: 'PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID',
-          message: 'El pago no posee monto funcional congelado',
-        });
-      }
-
-      // Functional consumption counts only allocations expressed in the
-      // payment's frozen functional currency (cross-currency shares).
-      const functionalConsumed = payment.paymentAllocations.reduce(
-        (sum, allocation) =>
-          allocation.charge?.currency === payment.functionalCurrencyCode
-            ? sum + allocation.amount
-            : sum,
-        0,
-      );
-      const functionalRemaining =
-        payment.functionalAmountMinor - functionalConsumed;
-
-      // Original consumption: same-currency allocations consume their amount;
-      // cross-currency allocations consume their frozen original share.
-      // Legacy NULL shares fall back to amount only for same-currency pairs.
-      const originalConsumed = payment.paymentAllocations.reduce(
-        (sum, allocation) => {
-          const isSameCurrencyAllocation =
-            allocation.charge?.currency === payment.currency;
-          return (
-            sum +
-            (allocation.paymentOriginalAmountMinor !== null
-              ? allocation.paymentOriginalAmountMinor
-              : isSameCurrencyAllocation
-                ? allocation.amount
-                : 0)
-          );
-        },
-        0,
-      );
-      const originalRemaining = payment.amount - originalConsumed;
-
-      // The cross-currency allocation consumes BOTH sides proportionally:
-      // never more functional than the frozen snapshot, and never more
-      // original than what is still backed by the remaining original.
-      // A full functional consumption (dto.amount == functionalRemaining)
-      // closes exactly with the full original remainder — no drift.
-      const originalBackedFunctional = new Prisma.Decimal(originalRemaining)
-        .mul(payment.functionalAmountMinor)
-        .div(payment.amount)
-        .toDecimalPlaces(0, Prisma.Decimal.ROUND_DOWN)
-        .toNumber();
-      const crossAvailable = Math.min(functionalRemaining, originalBackedFunctional);
-
-      if (dto.amount > functionalRemaining) {
-        throw new UnprocessableEntityException({
-          statusCode: 422,
-          error: 'PAYMENT_FUNCTIONAL_AMOUNT_EXCEEDED',
-          message: 'La asignación supera el monto funcional disponible del pago',
-        });
-      }
-
-      if (dto.amount !== functionalRemaining && dto.amount > crossAvailable) {
-        throw new UnprocessableEntityException({
-          statusCode: 422,
-          error: 'PAYMENT_FUNCTIONAL_AMOUNT_EXCEEDED',
-          message: 'La asignación supera el valor funcional respaldado disponible del pago',
-        });
-      }
-
-      // Deterministic proportional original share (exact decimal, HALF_EVEN);
-      // a full functional consumption consumes the exact original remainder.
-      if (dto.amount === functionalRemaining || functionalRemaining === 0) {
-        originalShare = originalRemaining;
-      } else {
-        originalShare = new Prisma.Decimal(originalRemaining)
-          .mul(dto.amount)
-          .div(functionalRemaining)
-          .toDecimalPlaces(0, Prisma.Decimal.ROUND_HALF_EVEN)
-          .toNumber();
-        if (originalShare > originalRemaining) {
-          originalShare = originalRemaining;
-        }
-      }
-    } else {
-      // New same-currency allocations carry the explicit original share.
-      originalShare = dto.amount;
-    }
-
-    if (!payment.unitId) {
-      throw new ConflictException(
-        'Payment must belong to a unit to create allocations in canonical order.',
-      );
-    }
-
-    // 5. Validate allocation amount doesn't exceed charge amount
-    if (dto.amount > charge.amount) {
-      throw new ConflictException(
-        `Allocation amount (${dto.amount}) cannot exceed charge amount (${charge.amount})`,
-      );
-    }
-
-    const selectableCharges = await this.loadResidentChargeSelection(
-      this.prisma as Prisma.TransactionClient,
-      tenantId,
-      buildingId,
-      payment.unitId,
-    );
-    const expectedCharge = selectableCharges[0];
-    if (!expectedCharge || expectedCharge.charge.id !== charge.id) {
-      throw new ConflictException(
-        'Solo puedes asignar pagos completos siguiendo la obligación más antigua pendiente.',
-      );
-    }
-
-    if (sameCurrency && dto.amount !== expectedCharge.approvedOutstanding) {
-      throw new ConflictException(
-        'Cada período debe pagarse completamente.',
-      );
-    }
-
-    if (!sameCurrency && dto.amount > expectedCharge.approvedOutstanding) {
-      throw new ConflictException(
-        'La asignación supera el saldo pendiente del cargo.',
-      );
-    }
-
-    // 6. Check for duplicate allocation
-    const existing = await this.prisma.paymentAllocation.findFirst({
-      where: {
-        tenantId,
-        paymentId: dto.paymentId,
-        chargeId: dto.chargeId,
-      },
-    });
-
-    if (existing) {
-      throw new ConflictException(
-        `Allocation already exists for this payment/charge pair`,
-      );
-    }
-
-    // 7. Create allocation + recalculate status within transaction
     return this.prisma.$transaction(async (tx) => {
-      const allocation = await tx.paymentAllocation.create({
-        data: {
-          tenantId,
-          paymentId: dto.paymentId,
-          chargeId: dto.chargeId,
-          amount: dto.amount,
-          paymentOriginalAmountMinor: originalShare,
-        },
+      const scope = { tenantId, buildingId, paymentId: dto.paymentId, chargeId: dto.chargeId };
+      await lockPaymentForAllocation(tx, scope);
+      const payment = await tx.payment.findFirst({
+        where: { id: dto.paymentId, tenantId, buildingId },
+        select: { unitId: true, currency: true },
       });
-
-      // Recalculate charge status within transaction
-      await this.recalculateChargeStatus(dto.chargeId, tx);
-
-      // Attempt to reconcile payment if all charges are PAID
-      await this.tryReconcilePayment(dto.paymentId, tx);
+      if (!payment?.unitId) throw new ConflictException('Payment must belong to a unit');
+      await lockChargesForAllocation(tx, tenantId, buildingId, [dto.chargeId]);
+      const selectableCharges = await this.loadResidentChargeSelection(
+        tx, tenantId, buildingId, payment.unitId,
+      );
+      const expectedCharge = selectableCharges[0];
+      if (!expectedCharge || expectedCharge.charge.id !== dto.chargeId) {
+        throw new ConflictException('Solo puedes asignar pagos siguiendo la obligación más antigua pendiente.');
+      }
+      if (payment.currency === expectedCharge.charge.currency
+        ? dto.amount !== expectedCharge.approvedOutstanding
+        : dto.amount > expectedCharge.approvedOutstanding) {
+        throw new ConflictException('La asignación supera o no completa el saldo pendiente del cargo.');
+      }
+      const allocation = await createLockedAllocation(tx, scope, dto.amount);
 
       // Audit: PAYMENT_ALLOCATE
       void this.auditService.createLog({
@@ -1899,8 +1713,8 @@ export class FinanzasService {
       selectedUnitId,
     );
 
-    for (const chargeId of selectedChargeIds) {
-      await this.lockChargeForApproval(tx, chargeId);
+    for (const chargeId of [...selectedChargeIds].sort()) {
+      await this.lockChargeForApproval(tx, tenantId, buildingId, chargeId);
     }
 
     const selectableCharges = await this.loadResidentChargeSelection(
@@ -1955,9 +1769,13 @@ export class FinanzasService {
 
   private async lockChargeForApproval(
     tx: Prisma.TransactionClient,
+    tenantId: string,
+    buildingId: string,
     chargeId: string,
   ): Promise<void> {
-    await tx.$queryRaw(Prisma.sql`SELECT 1 FROM "Charge" WHERE id = ${chargeId} FOR UPDATE`);
+    await tx.$queryRaw(
+      Prisma.sql`SELECT 1 FROM "Charge" WHERE id = ${chargeId} AND "tenantId" = ${tenantId} AND "buildingId" = ${buildingId} FOR UPDATE`,
+    );
   }
 
   private async lockSubmittedPaymentForApproval(
@@ -3099,48 +2917,10 @@ export class FinanzasService {
     paymentId: string,
     tx?: Prisma.TransactionClient,
   ): Promise<void> {
-    const client = tx ?? this.prisma;
-
-    const payment = await client.payment.findUnique({
-      where: { id: paymentId },
-      include: {
-        paymentAllocations: {
-          include: {
-            charge: true,
-          },
-        },
-      },
-    });
-
-    if (!payment || payment.status !== PaymentStatus.APPROVED) {
-      return;
-    }
-
-    // 3E2: an APPROVED payment may reach RECONCILED only with a COMPLETE
-    // snapshot or as historical legacy (ALL snapshot fields NULL). A partial
-    // snapshot is corruption and blocks reconciliation.
-    const snapshotState = classifyFunctionalSnapshot(payment);
-    if (snapshotState === 'PARTIAL_INVALID') {
-      this.logger.error(
-        `Payment ${paymentId} has a partial functional snapshot; RECONCILED blocked`,
-      );
-      return;
-    }
-
-    // Check if all allocated charges are fully paid
-    const allPaid = payment.paymentAllocations.every(
-      (alloc) => alloc.charge.status === ChargeStatus.PAID,
+    await reconcilePaymentWhenConsumed(
+      (tx ?? this.prisma) as Prisma.TransactionClient,
+      paymentId,
     );
-
-    if (allPaid && payment.paymentAllocations.length > 0) {
-      await client.payment.update({
-        where: { id: paymentId },
-        data: {
-          status: PaymentStatus.RECONCILED,
-          updatedAt: new Date(),
-        },
-      });
-    }
   }
 
   // ============================================================================

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -822,6 +822,7 @@ export class FinanzasService {
               paymentId: payment.id,
               chargeId: selection.charge.id,
               amount: selection.approvedOutstanding,
+              paymentOriginalAmountMinor: selection.approvedOutstanding,
             },
           });
         }
@@ -1173,7 +1174,11 @@ export class FinanzasService {
         buildingId,
       },
       include: {
-        paymentAllocations: true,
+        paymentAllocations: {
+          include: {
+            charge: { select: { currency: true } },
+          },
+        },
       },
     });
 
@@ -1207,31 +1212,131 @@ export class FinanzasService {
       );
     }
 
-    // 3.75. Same-currency invariant: allocation amount is always expressed in
-    // Charge.currency. A cross-currency allocation is not supported until 3E3.
-    if (payment.currency !== charge.currency) {
-      throw new UnprocessableEntityException({
-        statusCode: 422,
-        error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED',
-        message: `La moneda del pago (${payment.currency}) no coincide con la moneda del cargo (${charge.currency})`,
-      });
+    // 3E3: allocation amount is ALWAYS expressed in Charge.currency.
+    // Same-currency: legacy behavior. Cross-currency is supported only when
+    // the Payment has a COMPLETE frozen snapshot whose functionalCurrencyCode
+    // equals Charge.currency — the frozen snapshot is the historical truth,
+    // never a new rate lookup.
+    const sameCurrency = payment.currency === charge.currency;
+    let originalShare: number | null;
+
+    if (!sameCurrency) {
+      const state = classifyFunctionalSnapshot(payment);
+
+      if (state === 'LEGACY_NULL') {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED',
+          message: 'El pago no posee snapshot funcional; no se puede asignar en otra moneda',
+        });
+      }
+
+      if (state === 'PARTIAL_INVALID') {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID',
+          message: 'El pago posee un snapshot funcional incompleto o incoherente',
+        });
+      }
+
+      if (payment.functionalCurrencyCode !== charge.currency) {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED',
+          message: `La moneda funcional del pago (${payment.functionalCurrencyCode}) no coincide con la moneda del cargo (${charge.currency})`,
+        });
+      }
+
+      if (payment.functionalAmountMinor === null) {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID',
+          message: 'El pago no posee monto funcional congelado',
+        });
+      }
+
+      // Functional consumption counts only allocations expressed in the
+      // payment's frozen functional currency (cross-currency shares).
+      const functionalConsumed = payment.paymentAllocations.reduce(
+        (sum, allocation) =>
+          allocation.charge?.currency === payment.functionalCurrencyCode
+            ? sum + allocation.amount
+            : sum,
+        0,
+      );
+      const functionalRemaining =
+        payment.functionalAmountMinor - functionalConsumed;
+
+      // Original consumption: same-currency allocations consume their amount;
+      // cross-currency allocations consume their frozen original share.
+      // Legacy NULL shares fall back to amount only for same-currency pairs.
+      const originalConsumed = payment.paymentAllocations.reduce(
+        (sum, allocation) => {
+          const isSameCurrencyAllocation =
+            allocation.charge?.currency === payment.currency;
+          return (
+            sum +
+            (allocation.paymentOriginalAmountMinor !== null
+              ? allocation.paymentOriginalAmountMinor
+              : isSameCurrencyAllocation
+                ? allocation.amount
+                : 0)
+          );
+        },
+        0,
+      );
+      const originalRemaining = payment.amount - originalConsumed;
+
+      // The cross-currency allocation consumes BOTH sides proportionally:
+      // never more functional than the frozen snapshot, and never more
+      // original than what is still backed by the remaining original.
+      // A full functional consumption (dto.amount == functionalRemaining)
+      // closes exactly with the full original remainder — no drift.
+      const originalBackedFunctional = new Prisma.Decimal(originalRemaining)
+        .mul(payment.functionalAmountMinor)
+        .div(payment.amount)
+        .toDecimalPlaces(0, Prisma.Decimal.ROUND_DOWN)
+        .toNumber();
+      const crossAvailable = Math.min(functionalRemaining, originalBackedFunctional);
+
+      if (dto.amount > functionalRemaining) {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'PAYMENT_FUNCTIONAL_AMOUNT_EXCEEDED',
+          message: 'La asignación supera el monto funcional disponible del pago',
+        });
+      }
+
+      if (dto.amount !== functionalRemaining && dto.amount > crossAvailable) {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'PAYMENT_FUNCTIONAL_AMOUNT_EXCEEDED',
+          message: 'La asignación supera el valor funcional respaldado disponible del pago',
+        });
+      }
+
+      // Deterministic proportional original share (exact decimal, HALF_EVEN);
+      // a full functional consumption consumes the exact original remainder.
+      if (dto.amount === functionalRemaining || functionalRemaining === 0) {
+        originalShare = originalRemaining;
+      } else {
+        originalShare = new Prisma.Decimal(originalRemaining)
+          .mul(dto.amount)
+          .div(functionalRemaining)
+          .toDecimalPlaces(0, Prisma.Decimal.ROUND_HALF_EVEN)
+          .toNumber();
+        if (originalShare > originalRemaining) {
+          originalShare = originalRemaining;
+        }
+      }
+    } else {
+      // New same-currency allocations carry the explicit original share.
+      originalShare = dto.amount;
     }
 
     if (!payment.unitId) {
       throw new ConflictException(
         'Payment must belong to a unit to create allocations in canonical order.',
-      );
-    }
-
-    // 4. Validate total allocations don't exceed payment amount
-    const totalAllocated = payment.paymentAllocations.reduce(
-      (sum, a) => sum + a.amount,
-      0,
-    );
-
-    if (totalAllocated + dto.amount > payment.amount) {
-      throw new ConflictException(
-        `Total allocations (${totalAllocated + dto.amount}) exceed payment amount (${payment.amount})`,
       );
     }
 
@@ -1255,9 +1360,15 @@ export class FinanzasService {
       );
     }
 
-    if (dto.amount !== expectedCharge.approvedOutstanding) {
+    if (sameCurrency && dto.amount !== expectedCharge.approvedOutstanding) {
       throw new ConflictException(
         'Cada período debe pagarse completamente.',
+      );
+    }
+
+    if (!sameCurrency && dto.amount > expectedCharge.approvedOutstanding) {
+      throw new ConflictException(
+        'La asignación supera el saldo pendiente del cargo.',
       );
     }
 
@@ -1284,6 +1395,7 @@ export class FinanzasService {
           paymentId: dto.paymentId,
           chargeId: dto.chargeId,
           amount: dto.amount,
+          paymentOriginalAmountMinor: originalShare,
         },
       });
 

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -1203,8 +1203,22 @@ export class FinanzasService {
         where: { id: dto.paymentId, tenantId, buildingId },
         select: { unitId: true, currency: true },
       });
-      if (!payment?.unitId) throw new ConflictException('Payment must belong to a unit');
+      if (!payment) {
+        throw new NotFoundException(
+          'Payment not found or does not belong to this building/tenant',
+        );
+      }
+      if (!payment.unitId) throw new ConflictException('Payment must belong to a unit');
       await lockChargesForAllocation(tx, tenantId, buildingId, [dto.chargeId]);
+      const charge = await tx.charge.findFirst({
+        where: { id: dto.chargeId, tenantId, buildingId },
+        select: { id: true },
+      });
+      if (!charge) {
+        throw new NotFoundException(
+          'Charge not found or does not belong to this building/tenant',
+        );
+      }
       const selectableCharges = await this.loadResidentChargeSelection(
         tx, tenantId, buildingId, payment.unitId,
       );

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -17,8 +17,10 @@ import {
 import {
   assertPaymentAllocationCurrencyMode,
   createLockedAllocation,
+  deleteLockedAllocation,
   lockChargesForAllocation,
   lockPaymentForAllocation,
+  recalculateLockedCharge,
   reconcilePaymentWhenConsumed,
 } from './payment-allocation-transaction';
 import { acquirePaymentLinkedDocumentLock } from '../common/payment-linked-document-lock';
@@ -1124,13 +1126,12 @@ export class FinanzasService {
         throw new BadRequestException('Cannot reject a canceled payment');
       }
 
-      const releasedAllocations = await this.releaseSubmittedPaymentAllocations(
+      await this.releaseSubmittedPaymentAllocations(
         tx,
         paymentId,
         tenantId,
+        buildingId,
       );
-      const chargeIds = releasedAllocations.map((allocation) => allocation.chargeId);
-
       const rejectedPayment = await tx.payment.update({
         where: { id: paymentId },
         data: {
@@ -1143,10 +1144,6 @@ export class FinanzasService {
           updatedAt: new Date(),
         },
       });
-
-      for (const chargeId of chargeIds) {
-        await this.recalculateChargeStatus(chargeId, tx);
-      }
 
       await tx.paymentAuditLog.create({
         data: {
@@ -1280,34 +1277,9 @@ export class FinanzasService {
       this.validators.throwForbidden('allocations', 'delete');
     }
 
-    // 2. Validate allocation
-    const allocation = await this.prisma.paymentAllocation.findFirst({
-      where: { id: allocationId, tenantId },
-    });
-
-    if (!allocation) {
-      throw new NotFoundException(
-        `Allocation not found or does not belong to this tenant`,
-      );
-    }
-
-    // 3. Verify payment belongs to building
-    const payment = await this.prisma.payment.findFirst({
-      where: {
-        id: allocation.paymentId,
-        tenantId,
-        buildingId,
-      },
-    });
-
-    if (!payment) {
-      throw new NotFoundException(
-        `Associated payment does not belong to this building`,
-      );
-    }
-
-    // 4. Delete allocation + recalculate status within transaction
     return this.prisma.$transaction(async (tx) => {
+      const allocation = await deleteLockedAllocation(tx, tenantId, buildingId, allocationId);
+
       // Audit: ALLOCATION_DELETE (before deletion)
       void this.auditService.createLog({
         tenantId,
@@ -1322,16 +1294,6 @@ export class FinanzasService {
         },
       });
 
-      // Delete allocation
-      await tx.paymentAllocation.delete({
-        where: { id: allocationId },
-      });
-
-      // Recalculate charge status within transaction
-      await this.recalculateChargeStatus(allocation.chargeId, tx);
-
-      // Attempt to reconcile payment if all charges are PAID
-      await this.tryReconcilePayment(allocation.paymentId, tx);
     });
   }
 
@@ -1403,6 +1365,7 @@ export class FinanzasService {
     tx: Prisma.TransactionClient,
     paymentId: string,
     tenantId: string,
+    buildingId: string,
   ): Promise<Array<{ chargeId: string; amount: number }>> {
     const allocations = await tx.paymentAllocation.findMany({
       where: {
@@ -1419,14 +1382,32 @@ export class FinanzasService {
       return [];
     }
 
+    await lockChargesForAllocation(
+      tx,
+      tenantId,
+      buildingId,
+      allocations.map((allocation) => allocation.chargeId),
+    );
+    const lockedAllocations = await tx.paymentAllocation.findMany({
+      where: {
+        tenantId,
+        paymentId,
+        charge: { tenantId, buildingId },
+      },
+      select: { chargeId: true, amount: true },
+    });
+
     await tx.paymentAllocation.deleteMany({
       where: {
         tenantId,
         paymentId,
+        chargeId: { in: lockedAllocations.map((allocation) => allocation.chargeId) },
       },
     });
-
-    return allocations;
+    for (const chargeId of [...new Set(lockedAllocations.map((allocation) => allocation.chargeId))].sort()) {
+      await recalculateLockedCharge(tx, chargeId);
+    }
+    return lockedAllocations;
   }
 
   private async validatePaymentProofFileInTransaction(
@@ -2662,20 +2643,13 @@ export class FinanzasService {
         );
       }
 
-      const releasedAllocations =
-        payment.status === PaymentStatus.SUBMITTED
-          ? await this.releaseSubmittedPaymentAllocations(tx, paymentId, tenantId)
-          : [];
-      const chargeIds = releasedAllocations.map((allocation) => allocation.chargeId);
-
+      if (payment.status === PaymentStatus.SUBMITTED) {
+        await this.releaseSubmittedPaymentAllocations(tx, paymentId, tenantId, buildingId);
+      }
       const canceledPayment = await tx.payment.update({
         where: { id: paymentId },
         data: { canceledAt: new Date(), updatedAt: new Date() },
       });
-
-      for (const chargeId of chargeIds) {
-        await this.recalculateChargeStatus(chargeId, tx);
-      }
 
       await tx.paymentAuditLog.create({
         data: {
@@ -3201,13 +3175,12 @@ export class FinanzasService {
         throw new BadRequestException('Cannot reject a canceled payment');
       }
 
-      const releasedAllocations = await this.releaseSubmittedPaymentAllocations(
+      await this.releaseSubmittedPaymentAllocations(
         tx,
         paymentId,
         tenantId,
+        payment.buildingId,
       );
-      const chargeIds = releasedAllocations.map((allocation) => allocation.chargeId);
-
       const rejectedPayment = await tx.payment.update({
         where: { id: paymentId },
         data: {
@@ -3220,10 +3193,6 @@ export class FinanzasService {
           updatedAt: new Date(),
         },
       });
-
-      for (const chargeId of chargeIds) {
-        await this.recalculateChargeStatus(chargeId, tx);
-      }
 
       await tx.paymentAuditLog.create({
         data: {

--- a/apps/api/src/finanzas/payment-allocation-concurrency.postgres.spec.ts
+++ b/apps/api/src/finanzas/payment-allocation-concurrency.postgres.spec.ts
@@ -1,5 +1,5 @@
 import { ChargeStatus, PaymentMethod, PaymentStatus, PrismaClient, TenantType } from '@prisma/client';
-import { createLockedAllocation } from './payment-allocation-transaction';
+import { createLockedAllocation, deleteLockedAllocation } from './payment-allocation-transaction';
 
 const enabled =
   process.env.RUN_POSTGRES_INTEGRATION === '1' &&
@@ -233,5 +233,167 @@ describePostgres('Payment allocation PostgreSQL concurrency', () => {
     expect(allocation.paymentOriginalAmountMinor).toBe(10000);
     expect(persistedCharge.status).toBe(ChargeStatus.PAID);
     expect(persistedPayment.status).toBe(PaymentStatus.RECONCILED);
+  });
+
+  it('downgrades and restores a reconciled cross-currency payment when an allocation is deleted and recreated', async () => {
+    const ctx = await fixture('cross-currency-delete-recreate');
+    const effectiveAt = new Date('2026-08-08T00:00:00.000Z');
+    const rate = await observer.exchangeRate.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        baseCurrency: 'USD',
+        quoteCurrency: 'VES',
+        rate: '36.5',
+        effectiveAt,
+        source: '3E3 PostgreSQL regression',
+      },
+    });
+    const payment = await observer.payment.create({
+      data: {
+        ...ctx.paymentData,
+        currency: 'USD',
+        status: PaymentStatus.RECONCILED,
+        functionalAmountMinor: 365000,
+        functionalCurrencyCode: 'VES',
+        exchangeRateId: rate.id,
+        exchangeRateValue: '36.5',
+        exchangeRateDirection: 'DIRECT',
+        exchangeRateEffectiveAt: effectiveAt,
+        conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+      },
+    });
+    const charges = await Promise.all([
+      observer.charge.create({
+        data: { ...ctx.chargeData, amount: 100000, currency: 'VES', status: ChargeStatus.PAID },
+      }),
+      observer.charge.create({
+        data: {
+          ...ctx.chargeData,
+          period: '2026-09',
+          concept: 'cross-currency-delete-recreate-2',
+          amount: 100000,
+          currency: 'VES',
+          status: ChargeStatus.PAID,
+        },
+      }),
+      observer.charge.create({
+        data: {
+          ...ctx.chargeData,
+          period: '2026-10',
+          concept: 'cross-currency-delete-recreate-3',
+          amount: 165000,
+          currency: 'VES',
+          status: ChargeStatus.PAID,
+        },
+      }),
+    ]);
+    const allocations = await Promise.all([
+      observer.paymentAllocation.create({
+        data: {
+          tenantId: ctx.tenant.id,
+          paymentId: payment.id,
+          chargeId: charges[0].id,
+          amount: 100000,
+          paymentOriginalAmountMinor: 2740,
+        },
+      }),
+      observer.paymentAllocation.create({
+        data: {
+          tenantId: ctx.tenant.id,
+          paymentId: payment.id,
+          chargeId: charges[1].id,
+          amount: 100000,
+          paymentOriginalAmountMinor: 2740,
+        },
+      }),
+      observer.paymentAllocation.create({
+        data: {
+          tenantId: ctx.tenant.id,
+          paymentId: payment.id,
+          chargeId: charges[2].id,
+          amount: 165000,
+          paymentOriginalAmountMinor: 4520,
+        },
+      }),
+    ]);
+
+    await firstClient.$transaction((tx) => deleteLockedAllocation(
+      tx,
+      ctx.tenant.id,
+      ctx.building.id,
+      allocations[2].id,
+    ));
+
+    const [downgradedPayment, pendingCharge, remainingTotals] = await Promise.all([
+      observer.payment.findUniqueOrThrow({ where: { id: payment.id } }),
+      observer.charge.findUniqueOrThrow({ where: { id: charges[2].id } }),
+      observer.paymentAllocation.aggregate({
+        where: { paymentId: payment.id },
+        _sum: { paymentOriginalAmountMinor: true, amount: true },
+      }),
+    ]);
+    expect(downgradedPayment.status).toBe(PaymentStatus.APPROVED);
+    expect(pendingCharge.status).toBe(ChargeStatus.PENDING);
+    expect(remainingTotals._sum.paymentOriginalAmountMinor).toBe(5480);
+    expect(remainingTotals._sum.amount).toBe(200000);
+
+    await firstClient.$transaction((tx) => createLockedAllocation(tx, {
+      tenantId: ctx.tenant.id,
+      buildingId: ctx.building.id,
+      paymentId: payment.id,
+      chargeId: charges[2].id,
+    }, 165000));
+
+    const [restoredPayment, paidCharge, restoredTotals] = await Promise.all([
+      observer.payment.findUniqueOrThrow({ where: { id: payment.id } }),
+      observer.charge.findUniqueOrThrow({ where: { id: charges[2].id } }),
+      observer.paymentAllocation.aggregate({
+        where: { paymentId: payment.id },
+        _sum: { paymentOriginalAmountMinor: true, amount: true },
+      }),
+    ]);
+    expect(restoredPayment.status).toBe(PaymentStatus.RECONCILED);
+    expect(paidCharge.status).toBe(ChargeStatus.PAID);
+    expect(restoredTotals._sum.paymentOriginalAmountMinor).toBe(10000);
+    expect(restoredTotals._sum.amount).toBe(365000);
+  });
+
+  it('serializes delete with create and returns canonical 404 for a repeated delete', async () => {
+    const ctx = await fixture('delete-create-race');
+    const payment = await observer.payment.create({ data: ctx.paymentData });
+    const charge = await observer.charge.create({ data: ctx.chargeData });
+    const allocation = await firstClient.$transaction((tx) => createLockedAllocation(tx, {
+      tenantId: ctx.tenant.id, buildingId: ctx.building.id,
+      paymentId: payment.id, chargeId: charge.id,
+    }, 10000));
+    let releaseDelete!: () => void;
+    const holdDelete = new Promise<void>((resolve) => { releaseDelete = resolve; });
+    let deleted!: () => void;
+    const deleteReached = new Promise<void>((resolve) => { deleted = resolve; });
+    const first = firstClient.$transaction(async (tx) => {
+      await deleteLockedAllocation(tx, ctx.tenant.id, ctx.building.id, allocation.id);
+      deleted();
+      await holdDelete;
+    });
+    await deleteReached;
+    let secondPid = 0;
+    const second = secondClient.$transaction(async (tx) => {
+      const [row] = await tx.$queryRaw<Array<{ pid: number }>>`SELECT pg_backend_pid() AS pid`;
+      secondPid = row.pid;
+      return createLockedAllocation(tx, {
+        tenantId: ctx.tenant.id, buildingId: ctx.building.id,
+        paymentId: payment.id, chargeId: charge.id,
+      }, 10000);
+    });
+    while (secondPid === 0) await new Promise((resolve) => setTimeout(resolve, 0));
+    await waitUntilBlocked(secondPid);
+    releaseDelete();
+    await first;
+    await expect(second).resolves.toMatchObject({ amount: 10000 });
+    await expect(firstClient.$transaction((tx) => deleteLockedAllocation(
+      tx, ctx.tenant.id, ctx.building.id, allocation.id,
+    ))).rejects.toMatchObject({ status: 404 });
+    await expect(observer.payment.findUniqueOrThrow({ where: { id: payment.id } }))
+      .resolves.toMatchObject({ status: PaymentStatus.RECONCILED });
   });
 });

--- a/apps/api/src/finanzas/payment-allocation-concurrency.postgres.spec.ts
+++ b/apps/api/src/finanzas/payment-allocation-concurrency.postgres.spec.ts
@@ -1,4 +1,4 @@
-import { PaymentMethod, PaymentStatus, PrismaClient, TenantType } from '@prisma/client';
+import { ChargeStatus, PaymentMethod, PaymentStatus, PrismaClient, TenantType } from '@prisma/client';
 import { createLockedAllocation } from './payment-allocation-transaction';
 
 const enabled =
@@ -11,6 +11,7 @@ describePostgres('Payment allocation PostgreSQL concurrency', () => {
   let firstClient: PrismaClient;
   let secondClient: PrismaClient;
   const tenantIds: string[] = [];
+  const userIds: string[] = [];
 
   beforeAll(async () => {
     if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required');
@@ -27,6 +28,9 @@ describePostgres('Payment allocation PostgreSQL concurrency', () => {
   afterEach(async () => {
     for (const tenantId of tenantIds.splice(0)) {
       await observer.tenant.delete({ where: { id: tenantId } });
+    }
+    for (const userId of userIds.splice(0)) {
+      await observer.user.delete({ where: { id: userId } });
     }
   });
 
@@ -51,6 +55,7 @@ describePostgres('Payment allocation PostgreSQL concurrency', () => {
         passwordHash: 'test',
       },
     });
+    userIds.push(user.id);
     const building = await observer.building.create({
       data: { tenantId: tenant.id, name: `Building ${suffix}`, alias: `B-${suffix}`, address: 'Test' },
     });
@@ -178,5 +183,55 @@ describePostgres('Payment allocation PostgreSQL concurrency', () => {
       where: { chargeId: charge.id }, _sum: { amount: true },
     });
     expect(total._sum.amount).toBe(7000);
+  });
+
+  it('reconciles a same-currency allocation despite a complete cross-currency snapshot', async () => {
+    const ctx = await fixture('same-currency-complete-snapshot');
+    const effectiveAt = new Date('2026-08-08T00:00:00.000Z');
+    const rate = await observer.exchangeRate.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        baseCurrency: 'USD',
+        quoteCurrency: 'VES',
+        rate: '36.5',
+        effectiveAt,
+        source: '3E3 PostgreSQL regression',
+      },
+    });
+    const payment = await observer.payment.create({
+      data: {
+        ...ctx.paymentData,
+        currency: 'USD',
+        functionalAmountMinor: 365000,
+        functionalCurrencyCode: 'VES',
+        exchangeRateId: rate.id,
+        exchangeRateValue: '36.5',
+        exchangeRateDirection: 'DIRECT',
+        exchangeRateEffectiveAt: effectiveAt,
+        conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+      },
+    });
+    const charge = await observer.charge.create({
+      data: { ...ctx.chargeData, currency: 'USD' },
+    });
+
+    await firstClient.$transaction((tx) => createLockedAllocation(tx, {
+      tenantId: ctx.tenant.id,
+      buildingId: ctx.building.id,
+      paymentId: payment.id,
+      chargeId: charge.id,
+    }, 10000));
+
+    const [allocation, persistedCharge, persistedPayment] = await Promise.all([
+      observer.paymentAllocation.findUniqueOrThrow({
+        where: { paymentId_chargeId: { paymentId: payment.id, chargeId: charge.id } },
+      }),
+      observer.charge.findUniqueOrThrow({ where: { id: charge.id } }),
+      observer.payment.findUniqueOrThrow({ where: { id: payment.id } }),
+    ]);
+    expect(allocation.amount).toBe(10000);
+    expect(allocation.paymentOriginalAmountMinor).toBe(10000);
+    expect(persistedCharge.status).toBe(ChargeStatus.PAID);
+    expect(persistedPayment.status).toBe(PaymentStatus.RECONCILED);
   });
 });

--- a/apps/api/src/finanzas/payment-allocation-concurrency.postgres.spec.ts
+++ b/apps/api/src/finanzas/payment-allocation-concurrency.postgres.spec.ts
@@ -1,0 +1,182 @@
+import { PaymentMethod, PaymentStatus, PrismaClient, TenantType } from '@prisma/client';
+import { createLockedAllocation } from './payment-allocation-transaction';
+
+const enabled =
+  process.env.RUN_POSTGRES_INTEGRATION === '1' &&
+  process.env.POSTGRES_TEST_DB_NAME === 'buildingos_3e3_acceptance';
+const describePostgres = enabled ? describe : describe.skip;
+
+describePostgres('Payment allocation PostgreSQL concurrency', () => {
+  let observer: PrismaClient;
+  let firstClient: PrismaClient;
+  let secondClient: PrismaClient;
+  const tenantIds: string[] = [];
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required');
+    observer = new PrismaClient();
+    firstClient = new PrismaClient();
+    secondClient = new PrismaClient();
+    await Promise.all([observer.$connect(), firstClient.$connect(), secondClient.$connect()]);
+    const [database] = await observer.$queryRaw<Array<{ name: string }>>`SELECT current_database() AS name`;
+    if (database?.name !== 'buildingos_3e3_acceptance') {
+      throw new Error(`Refusing destructive test database ${database?.name ?? 'unknown'}`);
+    }
+  });
+
+  afterEach(async () => {
+    for (const tenantId of tenantIds.splice(0)) {
+      await observer.tenant.delete({ where: { id: tenantId } });
+    }
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      observer?.$disconnect(),
+      firstClient?.$disconnect(),
+      secondClient?.$disconnect(),
+    ]);
+  });
+
+  async function fixture(label: string) {
+    const suffix = `${Date.now()}-${Math.random()}`;
+    const tenant = await observer.tenant.create({
+      data: { name: `3E3 ${label} ${suffix}`, type: TenantType.ADMINISTRADORA },
+    });
+    tenantIds.push(tenant.id);
+    const user = await observer.user.create({
+      data: {
+        email: `3e3-${suffix}@buildingos.local`,
+        name: '3E3 concurrency',
+        passwordHash: 'test',
+      },
+    });
+    const building = await observer.building.create({
+      data: { tenantId: tenant.id, name: `Building ${suffix}`, alias: `B-${suffix}`, address: 'Test' },
+    });
+    const unit = await observer.unit.create({
+      data: {
+        tenantId: tenant.id,
+        buildingId: building.id,
+        code: '1',
+        label: '1',
+        unitType: 'APARTAMENTO',
+        occupancyStatus: 'OCCUPIED',
+        isBillable: true,
+      },
+    });
+    const paymentData = {
+      tenantId: tenant.id,
+      buildingId: building.id,
+      unitId: unit.id,
+      amount: 10000,
+      currency: 'ARS',
+      method: PaymentMethod.TRANSFER,
+      status: PaymentStatus.APPROVED,
+      createdByUserId: user.id,
+    } as const;
+    const chargeData = {
+      tenantId: tenant.id,
+      buildingId: building.id,
+      unitId: unit.id,
+      period: '2026-08',
+      concept: label,
+      amount: 10000,
+      currency: 'ARS',
+      dueDate: new Date('2026-08-31T00:00:00.000Z'),
+    } as const;
+    return { tenant, building, paymentData, chargeData };
+  }
+
+  async function waitUntilBlocked(pid: number): Promise<void> {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [activity] = await observer.$queryRaw<Array<{ wait_event_type: string | null }>>`
+        SELECT wait_event_type FROM pg_stat_activity WHERE pid = ${pid}
+      `;
+      if (activity?.wait_event_type === 'Lock') return;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error(`Backend ${pid} did not reach a database lock wait`);
+  }
+
+  it('serializes two 7000 allocations against one 10000 payment', async () => {
+    const ctx = await fixture('payment-race');
+    const payment = await observer.payment.create({ data: ctx.paymentData });
+    const firstCharge = await observer.charge.create({ data: ctx.chargeData });
+    const secondCharge = await observer.charge.create({
+      data: { ...ctx.chargeData, period: '2026-09', concept: 'payment-race-2' },
+    });
+    let releaseFirst!: () => void;
+    const holdFirst = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    let firstInserted!: () => void;
+    const inserted = new Promise<void>((resolve) => { firstInserted = resolve; });
+
+    const first = firstClient.$transaction(async (tx) => {
+      await createLockedAllocation(tx, {
+        tenantId: ctx.tenant.id, buildingId: ctx.building.id,
+        paymentId: payment.id, chargeId: firstCharge.id,
+      }, 7000);
+      firstInserted();
+      await holdFirst;
+    });
+    await inserted;
+    let secondPid = 0;
+    const second = secondClient.$transaction(async (tx) => {
+      const [row] = await tx.$queryRaw<Array<{ pid: number }>>`SELECT pg_backend_pid() AS pid`;
+      secondPid = row.pid;
+      await createLockedAllocation(tx, {
+        tenantId: ctx.tenant.id, buildingId: ctx.building.id,
+        paymentId: payment.id, chargeId: secondCharge.id,
+      }, 7000);
+    });
+    while (secondPid === 0) await new Promise((resolve) => setTimeout(resolve, 0));
+    await waitUntilBlocked(secondPid);
+    releaseFirst();
+    await first;
+    await expect(second).rejects.toMatchObject({ response: { error: 'PAYMENT_ORIGINAL_AMOUNT_EXCEEDED' } });
+    const total = await observer.paymentAllocation.aggregate({
+      where: { paymentId: payment.id }, _sum: { paymentOriginalAmountMinor: true },
+    });
+    expect(total._sum.paymentOriginalAmountMinor).toBe(7000);
+  });
+
+  it('serializes two 7000 payments against one 10000 charge', async () => {
+    const ctx = await fixture('charge-race');
+    const [firstPayment, secondPayment] = await Promise.all([
+      observer.payment.create({ data: ctx.paymentData }),
+      observer.payment.create({ data: { ...ctx.paymentData, reference: 'second' } }),
+    ]);
+    const charge = await observer.charge.create({ data: ctx.chargeData });
+    let releaseFirst!: () => void;
+    const holdFirst = new Promise<void>((resolve) => { releaseFirst = resolve; });
+    let firstInserted!: () => void;
+    const inserted = new Promise<void>((resolve) => { firstInserted = resolve; });
+    const first = firstClient.$transaction(async (tx) => {
+      await createLockedAllocation(tx, {
+        tenantId: ctx.tenant.id, buildingId: ctx.building.id,
+        paymentId: firstPayment.id, chargeId: charge.id,
+      }, 7000);
+      firstInserted();
+      await holdFirst;
+    });
+    await inserted;
+    let secondPid = 0;
+    const second = secondClient.$transaction(async (tx) => {
+      const [row] = await tx.$queryRaw<Array<{ pid: number }>>`SELECT pg_backend_pid() AS pid`;
+      secondPid = row.pid;
+      await createLockedAllocation(tx, {
+        tenantId: ctx.tenant.id, buildingId: ctx.building.id,
+        paymentId: secondPayment.id, chargeId: charge.id,
+      }, 7000);
+    });
+    while (secondPid === 0) await new Promise((resolve) => setTimeout(resolve, 0));
+    await waitUntilBlocked(secondPid);
+    releaseFirst();
+    await first;
+    await expect(second).rejects.toThrow('charge available outstanding');
+    const total = await observer.paymentAllocation.aggregate({
+      where: { chargeId: charge.id }, _sum: { amount: true },
+    });
+    expect(total._sum.amount).toBe(7000);
+  });
+});

--- a/apps/api/src/finanzas/payment-allocation-transaction.spec.ts
+++ b/apps/api/src/finanzas/payment-allocation-transaction.spec.ts
@@ -1,5 +1,9 @@
 import { ChargeStatus, PaymentStatus, Prisma } from '@prisma/client';
-import { createLockedAllocation, reconcilePaymentWhenConsumed } from './payment-allocation-transaction';
+import {
+  assertPaymentAllocationCurrencyMode,
+  createLockedAllocation,
+  reconcilePaymentWhenConsumed,
+} from './payment-allocation-transaction';
 
 describe('payment allocation transaction semantics', () => {
   const completeSnapshot = {
@@ -23,22 +27,60 @@ describe('payment allocation transaction semantics', () => {
     return { tx, update };
   }
 
-  it('A: keeps a same-currency payment APPROVED while an original remainder is usable', async () => {
+  it.each([
+    { existing: 'ARS', candidate: 'VES', label: 'SAME to CROSS' },
+    { existing: 'VES', candidate: 'ARS', label: 'CROSS to SAME' },
+  ])('rejects mixed allocation mode: $label', ({ existing, candidate }) => {
+    expect(() => assertPaymentAllocationCurrencyMode(
+      'ARS',
+      [{ charge: { currency: existing } }],
+      candidate,
+    )).toThrow(expect.objectContaining({ response: {
+      statusCode: 422,
+      error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED',
+    } }));
+  });
+
+  it.each([
+    { currency: 'ARS', label: 'SAME' },
+    { currency: 'VES', label: 'CROSS' },
+  ])('allows two pure $label allocations', ({ currency }) => {
+    expect(() => assertPaymentAllocationCurrencyMode(
+      'ARS',
+      [{ charge: { currency } }],
+      currency,
+    )).not.toThrow();
+  });
+
+  it('keeps a pure SAME payment with a COMPLETE cross-capable snapshot APPROVED while an original remainder remains', async () => {
     const { tx, update } = transaction({
-      id: 'payment', amount: 10000, currency: 'ARS', status: PaymentStatus.APPROVED,
-      functionalAmountMinor: null, functionalCurrencyCode: null, exchangeRateId: null,
-      exchangeRateValue: null, exchangeRateDirection: null, exchangeRateEffectiveAt: null,
-      conversionDate: null,
+      id: 'payment', amount: 10000, currency: 'USD', status: PaymentStatus.APPROVED,
+      ...completeSnapshot,
       paymentAllocations: [{
         amount: 7000, paymentOriginalAmountMinor: 7000,
-        charge: { currency: 'ARS', status: ChargeStatus.PAID },
+        charge: { currency: 'USD', status: ChargeStatus.PAID },
       }],
     });
     await reconcilePaymentWhenConsumed(tx, 'payment');
     expect(update).not.toHaveBeenCalled();
   });
 
-  it('B: reconciles 2740 + 2740 + 4520 only after exact functional consumption', async () => {
+  it('reconciles a fully consumed pure SAME payment with a COMPLETE cross-capable snapshot', async () => {
+    const { tx, update } = transaction({
+      id: 'payment', amount: 10000, currency: 'USD', status: PaymentStatus.APPROVED,
+      ...completeSnapshot,
+      paymentAllocations: [{
+        amount: 10000, paymentOriginalAmountMinor: 10000,
+        charge: { currency: 'USD', status: ChargeStatus.PAID },
+      }],
+    });
+    await reconcilePaymentWhenConsumed(tx, 'payment');
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ status: PaymentStatus.RECONCILED }),
+    }));
+  });
+
+  it('reconciles a pure CROSS payment only after exact original and functional consumption', async () => {
     const { tx, update } = transaction({
       id: 'payment', amount: 10000, currency: 'USD', status: PaymentStatus.APPROVED,
       ...completeSnapshot,
@@ -52,6 +94,19 @@ describe('payment allocation transaction semantics', () => {
     expect(update).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({ status: PaymentStatus.RECONCILED }),
     }));
+  });
+
+  it('keeps a pure CROSS payment APPROVED while a functional remainder remains', async () => {
+    const { tx, update } = transaction({
+      id: 'payment', amount: 10000, currency: 'USD', status: PaymentStatus.APPROVED,
+      ...completeSnapshot,
+      paymentAllocations: [{
+        amount: 300000, paymentOriginalAmountMinor: 10000,
+        charge: { currency: 'VES', status: ChargeStatus.PAID },
+      }],
+    });
+    await reconcilePaymentWhenConsumed(tx, 'payment');
+    expect(update).not.toHaveBeenCalled();
   });
 
   it('F: uses amount as the original share for legacy same-currency NULL allocations', async () => {
@@ -82,14 +137,30 @@ describe('payment allocation transaction semantics', () => {
     expect(update).not.toHaveBeenCalled();
   });
 
+  it('blocks reconciliation for a historical mixed-mode payment without mutation', async () => {
+    const { tx, update } = transaction({
+      id: 'payment', amount: 10000, currency: 'ARS', status: PaymentStatus.APPROVED,
+      ...completeSnapshot,
+      paymentAllocations: [
+        { amount: 5000, paymentOriginalAmountMinor: 5000, charge: { currency: 'ARS', status: ChargeStatus.PAID } },
+        { amount: 182500, paymentOriginalAmountMinor: 5000, charge: { currency: 'VES', status: ChargeStatus.PAID } },
+      ],
+    });
+
+    await expect(reconcilePaymentWhenConsumed(tx, 'payment')).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED' },
+    });
+    expect(update).not.toHaveBeenCalled();
+  });
+
   it('rejects a non-full cross allocation with no original-backed functional amount', async () => {
     const create = jest.fn();
     const tx = {
       $queryRaw: jest.fn().mockResolvedValue([]),
       payment: { findFirst: jest.fn().mockResolvedValue({
         id: 'payment', amount: 10000, currency: 'USD', status: PaymentStatus.APPROVED,
-        ...completeSnapshot, functionalAmountMinor: 100,
-        paymentAllocations: [{ amount: 9999, paymentOriginalAmountMinor: 9999, charge: { currency: 'USD' } }],
+        ...completeSnapshot, functionalAmountMinor: 102,
+        paymentAllocations: [{ amount: 100, paymentOriginalAmountMinor: 9999, charge: { currency: 'VES' } }],
       }) },
       charge: { findFirst: jest.fn().mockResolvedValue({
         id: 'charge', amount: 100, currency: 'VES', paymentAllocations: [],

--- a/apps/api/src/finanzas/payment-allocation-transaction.spec.ts
+++ b/apps/api/src/finanzas/payment-allocation-transaction.spec.ts
@@ -1,7 +1,9 @@
 import { ChargeStatus, PaymentStatus, Prisma } from '@prisma/client';
 import {
   assertPaymentAllocationCurrencyMode,
+  calculateChargeAvailableOutstanding,
   createLockedAllocation,
+  deleteLockedAllocation,
   reconcilePaymentWhenConsumed,
 } from './payment-allocation-transaction';
 
@@ -151,6 +153,112 @@ describe('payment allocation transaction semantics', () => {
       response: { statusCode: 422, error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED' },
     });
     expect(update).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      label: 'SAME',
+      payment: {
+        id: 'payment', amount: 10000, currency: 'USD', status: PaymentStatus.RECONCILED,
+        ...completeSnapshot,
+        paymentAllocations: [{
+          amount: 7000, paymentOriginalAmountMinor: 7000,
+          charge: { currency: 'USD', status: ChargeStatus.PAID },
+        }],
+      },
+    },
+    {
+      label: 'CROSS',
+      payment: {
+        id: 'payment', amount: 10000, currency: 'USD', status: PaymentStatus.RECONCILED,
+        ...completeSnapshot,
+        paymentAllocations: [{
+          amount: 300000, paymentOriginalAmountMinor: 8000,
+          charge: { currency: 'VES', status: ChargeStatus.PAID },
+        }],
+      },
+    },
+  ])('downgrades incomplete RECONCILED $label payments to APPROVED', async ({ payment }) => {
+    const { tx, update } = transaction(payment);
+    await reconcilePaymentWhenConsumed(tx, 'payment');
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ status: PaymentStatus.APPROVED }),
+    }));
+  });
+
+  it('keeps PARTIAL_INVALID reconciliation fail closed without mutation', async () => {
+    const { tx, update } = transaction({
+      id: 'payment', amount: 10000, currency: 'USD', status: PaymentStatus.RECONCILED,
+      ...completeSnapshot, exchangeRateId: null,
+      paymentAllocations: [],
+    });
+    await reconcilePaymentWhenConsumed(tx, 'payment');
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('counts effective and SUBMITTED reservations while excluding the current payment once', () => {
+    const allocations = [
+      { amount: 2000, payment: { id: 'effective', status: PaymentStatus.APPROVED } },
+      { amount: 3000, payment: { id: 'submitted', status: PaymentStatus.SUBMITTED } },
+      { amount: 7000, payment: { id: 'current', status: PaymentStatus.SUBMITTED } },
+    ];
+    expect(calculateChargeAvailableOutstanding(12000, allocations, 'current')).toBe(7000);
+    expect(calculateChargeAvailableOutstanding(12000, allocations)).toBe(0);
+  });
+
+  it('deletes under Payment then Charge locks, recalculates, and downgrades reconciliation', async () => {
+    const calls: string[] = [];
+    const tx = {
+      $queryRaw: jest.fn().mockImplementation(async () => { calls.push('lock'); return []; }),
+      paymentAllocation: {
+        findFirst: jest.fn()
+          .mockResolvedValueOnce({ paymentId: 'payment', chargeId: 'charge' })
+          .mockResolvedValueOnce({ id: 'allocation', paymentId: 'payment', chargeId: 'charge', amount: 10000 }),
+        deleteMany: jest.fn().mockImplementation(async () => { calls.push('delete'); return { count: 1 }; }),
+      },
+      charge: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'charge', amount: 10000, status: ChargeStatus.PAID, paymentAllocations: [],
+        }),
+        update: jest.fn().mockImplementation(async () => { calls.push('charge'); }),
+      },
+      payment: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'payment', amount: 10000, currency: 'ARS', status: PaymentStatus.RECONCILED,
+          functionalAmountMinor: null, functionalCurrencyCode: null, exchangeRateId: null,
+          exchangeRateValue: null, exchangeRateDirection: null, exchangeRateEffectiveAt: null,
+          conversionDate: null, paymentAllocations: [],
+        }),
+        update: jest.fn().mockImplementation(async () => { calls.push('payment'); }),
+      },
+    } as unknown as Prisma.TransactionClient;
+
+    await expect(deleteLockedAllocation(tx, 'tenant', 'building', 'allocation')).resolves.toEqual({
+      id: 'allocation', paymentId: 'payment', chargeId: 'charge', amount: 10000,
+    });
+    expect(calls).toEqual(['lock', 'lock', 'delete', 'charge', 'payment']);
+  });
+
+  it.each([
+    { label: 'stale discovery', authoritative: null, deleted: 1 },
+    { label: 'double delete', authoritative: { id: 'allocation', paymentId: 'payment', chargeId: 'charge', amount: 1 }, deleted: 0 },
+  ])('returns canonical 404 for $label', async ({ authoritative, deleted }) => {
+    const tx = {
+      $queryRaw: jest.fn().mockResolvedValue([]),
+      paymentAllocation: {
+        findFirst: jest.fn()
+          .mockResolvedValueOnce({ paymentId: 'payment', chargeId: 'charge' })
+          .mockResolvedValueOnce(authoritative),
+        deleteMany: jest.fn().mockResolvedValue({ count: deleted }),
+      },
+    } as unknown as Prisma.TransactionClient;
+    await expect(deleteLockedAllocation(tx, 'tenant', 'building', 'allocation')).rejects.toMatchObject({
+      status: 404,
+      response: expect.objectContaining({
+        statusCode: 404,
+        message: 'Allocation not found or does not belong to this tenant',
+      }),
+    });
   });
 
   it('rejects a non-full cross allocation with no original-backed functional amount', async () => {

--- a/apps/api/src/finanzas/payment-allocation-transaction.spec.ts
+++ b/apps/api/src/finanzas/payment-allocation-transaction.spec.ts
@@ -1,0 +1,107 @@
+import { ChargeStatus, PaymentStatus, Prisma } from '@prisma/client';
+import { createLockedAllocation, reconcilePaymentWhenConsumed } from './payment-allocation-transaction';
+
+describe('payment allocation transaction semantics', () => {
+  const completeSnapshot = {
+    functionalAmountMinor: 365000,
+    functionalCurrencyCode: 'VES',
+    exchangeRateId: 'rate-1',
+    exchangeRateValue: new Prisma.Decimal('36.5'),
+    exchangeRateDirection: 'DIRECT',
+    exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+    conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+  };
+
+  function transaction(payment: Record<string, unknown>) {
+    const update = jest.fn().mockResolvedValue(undefined);
+    const tx = {
+      payment: {
+        findUnique: jest.fn().mockResolvedValue(payment),
+        update,
+      },
+    } as unknown as Prisma.TransactionClient;
+    return { tx, update };
+  }
+
+  it('A: keeps a same-currency payment APPROVED while an original remainder is usable', async () => {
+    const { tx, update } = transaction({
+      id: 'payment', amount: 10000, currency: 'ARS', status: PaymentStatus.APPROVED,
+      functionalAmountMinor: null, functionalCurrencyCode: null, exchangeRateId: null,
+      exchangeRateValue: null, exchangeRateDirection: null, exchangeRateEffectiveAt: null,
+      conversionDate: null,
+      paymentAllocations: [{
+        amount: 7000, paymentOriginalAmountMinor: 7000,
+        charge: { currency: 'ARS', status: ChargeStatus.PAID },
+      }],
+    });
+    await reconcilePaymentWhenConsumed(tx, 'payment');
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('B: reconciles 2740 + 2740 + 4520 only after exact functional consumption', async () => {
+    const { tx, update } = transaction({
+      id: 'payment', amount: 10000, currency: 'USD', status: PaymentStatus.APPROVED,
+      ...completeSnapshot,
+      paymentAllocations: [2740, 2740, 4520].map((share, index) => ({
+        amount: [100000, 100000, 165000][index],
+        paymentOriginalAmountMinor: share,
+        charge: { currency: 'VES', status: ChargeStatus.PAID },
+      })),
+    });
+    await reconcilePaymentWhenConsumed(tx, 'payment');
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ status: PaymentStatus.RECONCILED }),
+    }));
+  });
+
+  it('F: uses amount as the original share for legacy same-currency NULL allocations', async () => {
+    const { tx, update } = transaction({
+      id: 'payment', amount: 10000, currency: 'ARS', status: PaymentStatus.APPROVED,
+      functionalAmountMinor: null, functionalCurrencyCode: null, exchangeRateId: null,
+      exchangeRateValue: null, exchangeRateDirection: null, exchangeRateEffectiveAt: null,
+      conversionDate: null,
+      paymentAllocations: [{
+        amount: 10000, paymentOriginalAmountMinor: null,
+        charge: { currency: 'ARS', status: ChargeStatus.PAID },
+      }],
+    });
+    await reconcilePaymentWhenConsumed(tx, 'payment');
+    expect(update).toHaveBeenCalled();
+  });
+
+  it('G: never nominally falls back for a historical cross-currency NULL original share', async () => {
+    const { tx, update } = transaction({
+      id: 'payment', amount: 10000, currency: 'USD', status: PaymentStatus.APPROVED,
+      ...completeSnapshot,
+      paymentAllocations: [{
+        amount: 365000, paymentOriginalAmountMinor: null,
+        charge: { currency: 'VES', status: ChargeStatus.PAID },
+      }],
+    });
+    await reconcilePaymentWhenConsumed(tx, 'payment');
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-full cross allocation with no original-backed functional amount', async () => {
+    const create = jest.fn();
+    const tx = {
+      $queryRaw: jest.fn().mockResolvedValue([]),
+      payment: { findFirst: jest.fn().mockResolvedValue({
+        id: 'payment', amount: 10000, currency: 'USD', status: PaymentStatus.APPROVED,
+        ...completeSnapshot, functionalAmountMinor: 100,
+        paymentAllocations: [{ amount: 9999, paymentOriginalAmountMinor: 9999, charge: { currency: 'USD' } }],
+      }) },
+      charge: { findFirst: jest.fn().mockResolvedValue({
+        id: 'charge', amount: 100, currency: 'VES', paymentAllocations: [],
+      }) },
+      paymentAllocation: { create },
+    } as unknown as Prisma.TransactionClient;
+
+    await expect(createLockedAllocation(tx, {
+      tenantId: 'tenant', buildingId: 'building', paymentId: 'payment', chargeId: 'charge',
+    }, 1)).rejects.toMatchObject({ response: {
+      statusCode: 422, error: 'PAYMENT_FUNCTIONAL_AMOUNT_EXCEEDED',
+    } });
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/finanzas/payment-allocation-transaction.ts
+++ b/apps/api/src/finanzas/payment-allocation-transaction.ts
@@ -23,6 +23,18 @@ interface AllocationChargeCurrency {
   readonly charge: { readonly currency: string };
 }
 
+interface ChargeAvailabilityAllocation {
+  readonly amount: number;
+  readonly payment: { readonly id?: string; readonly status: PaymentStatus };
+}
+
+export interface DeletedAllocationMetadata {
+  readonly id: string;
+  readonly paymentId: string;
+  readonly chargeId: string;
+  readonly amount: number;
+}
+
 type PaymentAllocationCurrencyMode = 'SAME' | 'CROSS' | null;
 
 export function assertPaymentAllocationCurrencyMode(
@@ -133,6 +145,21 @@ export async function recalculateLockedCharge(
   }
 }
 
+export function calculateChargeAvailableOutstanding(
+  chargeAmount: number,
+  allocations: readonly ChargeAvailabilityAllocation[],
+  currentPaymentId?: string,
+): number {
+  const consumed = allocations.reduce((sum, allocation) => {
+    if (currentPaymentId !== undefined && allocation.payment.id === currentPaymentId) return sum;
+    return isEffectivePaymentStatus(allocation.payment.status) ||
+      allocation.payment.status === PaymentStatus.SUBMITTED
+      ? sum + allocation.amount
+      : sum;
+  }, 0);
+  return chargeAmount - consumed;
+}
+
 export async function reconcilePaymentWhenConsumed(
   tx: Prisma.TransactionClient,
   paymentId: string,
@@ -143,13 +170,16 @@ export async function reconcilePaymentWhenConsumed(
       paymentAllocations: { include: { charge: { select: { currency: true, status: true } } } },
     },
   });
-  if (!payment || payment.status !== PaymentStatus.APPROVED) return;
+  if (
+    !payment ||
+    (payment.status !== PaymentStatus.APPROVED && payment.status !== PaymentStatus.RECONCILED)
+  ) return;
   const allocationMode = assertPaymentAllocationCurrencyMode(
     payment.currency,
     payment.paymentAllocations,
   );
   const snapshotState = classifyFunctionalSnapshot(payment);
-  if (snapshotState === 'PARTIAL_INVALID' || allocationMode === null) return;
+  if (snapshotState === 'PARTIAL_INVALID') return;
 
   let originalConsumed = 0;
   let functionalConsumed = 0;
@@ -172,13 +202,49 @@ export async function reconcilePaymentWhenConsumed(
     ? snapshotState === 'COMPLETE' &&
       originalConsumed === payment.amount &&
       functionalConsumed === payment.functionalAmountMinor
-    : originalConsumed === payment.amount;
-  if (allPaid && completelyConsumed) {
+    : allocationMode === 'SAME' && originalConsumed === payment.amount;
+  const nextStatus = allPaid && completelyConsumed
+    ? PaymentStatus.RECONCILED
+    : PaymentStatus.APPROVED;
+  if (nextStatus !== payment.status) {
     await tx.payment.update({
       where: { id: paymentId },
-      data: { status: PaymentStatus.RECONCILED, updatedAt: new Date() },
+      data: { status: nextStatus, updatedAt: new Date() },
     });
   }
+}
+
+export async function deleteLockedAllocation(
+  tx: Prisma.TransactionClient,
+  tenantId: string,
+  buildingId: string,
+  allocationId: string,
+): Promise<DeletedAllocationMetadata> {
+  const discovered = await tx.paymentAllocation.findFirst({
+    where: { id: allocationId, tenantId },
+    select: { paymentId: true, chargeId: true },
+  });
+  const notFound = () => new NotFoundException('Allocation not found or does not belong to this tenant');
+  if (!discovered) throw notFound();
+
+  await lockPaymentForAllocation(tx, { tenantId, buildingId, paymentId: discovered.paymentId });
+  await lockChargesForAllocation(tx, tenantId, buildingId, [discovered.chargeId]);
+  const allocation = await tx.paymentAllocation.findFirst({
+    where: {
+      id: allocationId,
+      tenantId,
+      payment: { tenantId, buildingId },
+      charge: { tenantId, buildingId },
+    },
+    select: { id: true, paymentId: true, chargeId: true, amount: true },
+  });
+  if (!allocation) throw notFound();
+
+  const deleted = await tx.paymentAllocation.deleteMany({ where: { id: allocationId, tenantId } });
+  if (deleted.count !== 1) throw notFound();
+  await recalculateLockedCharge(tx, allocation.chargeId);
+  await reconcilePaymentWhenConsumed(tx, allocation.paymentId);
+  return allocation;
 }
 
 export async function createLockedAllocation(
@@ -255,16 +321,7 @@ export async function createLockedAllocation(
     throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_ORIGINAL_AMOUNT_EXCEEDED' });
   }
 
-  const chargeAllocations = charge.paymentAllocations ?? [];
-  const effectiveConsumed = chargeAllocations.reduce(
-    (sum, allocation) => isEffectivePaymentStatus(allocation.payment.status) ? sum + allocation.amount : sum,
-    0,
-  );
-  const reservedConsumed = chargeAllocations.reduce(
-    (sum, allocation) => allocation.payment.status === PaymentStatus.SUBMITTED ? sum + allocation.amount : sum,
-    0,
-  );
-  if (amount > charge.amount - effectiveConsumed - reservedConsumed) {
+  if (amount > calculateChargeAvailableOutstanding(charge.amount, charge.paymentAllocations ?? [])) {
     throw new ConflictException('The allocation exceeds the charge available outstanding');
   }
 

--- a/apps/api/src/finanzas/payment-allocation-transaction.ts
+++ b/apps/api/src/finanzas/payment-allocation-transaction.ts
@@ -19,6 +19,33 @@ export interface AllocationScope {
   readonly chargeId: string;
 }
 
+interface AllocationChargeCurrency {
+  readonly charge: { readonly currency: string };
+}
+
+type PaymentAllocationCurrencyMode = 'SAME' | 'CROSS' | null;
+
+export function assertPaymentAllocationCurrencyMode(
+  paymentCurrency: string,
+  allocations: readonly AllocationChargeCurrency[],
+  candidateChargeCurrency?: string,
+): PaymentAllocationCurrencyMode {
+  const currencies = candidateChargeCurrency
+    ? [...allocations.map((allocation) => allocation.charge.currency), candidateChargeCurrency]
+    : allocations.map((allocation) => allocation.charge.currency);
+  const hasSame = currencies.some((currency) => currency === paymentCurrency);
+  const hasCross = currencies.some((currency) => currency !== paymentCurrency);
+  if (hasSame && hasCross) {
+    throw new UnprocessableEntityException({
+      statusCode: 422,
+      error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED',
+    });
+  }
+  if (hasSame) return 'SAME';
+  if (hasCross) return 'CROSS';
+  return null;
+}
+
 export async function lockPaymentForAllocation(
   tx: Prisma.TransactionClient,
   scope: Pick<AllocationScope, 'tenantId' | 'buildingId' | 'paymentId'>,
@@ -117,8 +144,12 @@ export async function reconcilePaymentWhenConsumed(
     },
   });
   if (!payment || payment.status !== PaymentStatus.APPROVED) return;
+  const allocationMode = assertPaymentAllocationCurrencyMode(
+    payment.currency,
+    payment.paymentAllocations,
+  );
   const snapshotState = classifyFunctionalSnapshot(payment);
-  if (snapshotState === 'PARTIAL_INVALID' || payment.paymentAllocations.length === 0) return;
+  if (snapshotState === 'PARTIAL_INVALID' || allocationMode === null) return;
 
   let originalConsumed = 0;
   let functionalConsumed = 0;
@@ -137,8 +168,10 @@ export async function reconcilePaymentWhenConsumed(
   const allPaid = payment.paymentAllocations.every(
     (allocation) => allocation.charge.status === ChargeStatus.PAID,
   );
-  const completelyConsumed = snapshotState === 'COMPLETE' && payment.currency !== payment.functionalCurrencyCode
-    ? originalConsumed === payment.amount && functionalConsumed === payment.functionalAmountMinor
+  const completelyConsumed = allocationMode === 'CROSS'
+    ? snapshotState === 'COMPLETE' &&
+      originalConsumed === payment.amount &&
+      functionalConsumed === payment.functionalAmountMinor
     : originalConsumed === payment.amount;
   if (allPaid && completelyConsumed) {
     await tx.payment.update({
@@ -157,6 +190,12 @@ export async function createLockedAllocation(
   const payment = await loadLockedPayment(tx, scope);
   await lockChargesForAllocation(tx, scope.tenantId, scope.buildingId, [scope.chargeId]);
   const charge = await loadLockedCharge(tx, scope);
+
+  assertPaymentAllocationCurrencyMode(
+    payment.currency,
+    payment.paymentAllocations,
+    charge.currency,
+  );
 
   if (payment.status !== PaymentStatus.APPROVED && payment.status !== PaymentStatus.RECONCILED) {
     throw new ConflictException(`Cannot allocate payment in status ${payment.status}`);

--- a/apps/api/src/finanzas/payment-allocation-transaction.ts
+++ b/apps/api/src/finanzas/payment-allocation-transaction.ts
@@ -1,0 +1,244 @@
+import {
+  ChargeStatus,
+  PaymentStatus,
+  Prisma,
+  type PaymentAllocation,
+} from '@prisma/client';
+import {
+  ConflictException,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import { classifyFunctionalSnapshot } from './functional-snapshot';
+import { isEffectivePaymentStatus } from './payment-status-semantics';
+
+export interface AllocationScope {
+  readonly tenantId: string;
+  readonly buildingId: string;
+  readonly paymentId: string;
+  readonly chargeId: string;
+}
+
+export async function lockPaymentForAllocation(
+  tx: Prisma.TransactionClient,
+  scope: Pick<AllocationScope, 'tenantId' | 'buildingId' | 'paymentId'>,
+): Promise<void> {
+  await tx.$queryRaw(
+    Prisma.sql`SELECT 1 FROM "Payment" WHERE id = ${scope.paymentId} AND "tenantId" = ${scope.tenantId} AND "buildingId" = ${scope.buildingId} FOR UPDATE`,
+  );
+}
+
+export async function lockChargesForAllocation(
+  tx: Prisma.TransactionClient,
+  tenantId: string,
+  buildingId: string,
+  chargeIds: readonly string[],
+): Promise<void> {
+  for (const chargeId of [...new Set(chargeIds)].sort()) {
+    await tx.$queryRaw(
+      Prisma.sql`SELECT 1 FROM "Charge" WHERE id = ${chargeId} AND "tenantId" = ${tenantId} AND "buildingId" = ${buildingId} FOR UPDATE`,
+    );
+  }
+}
+
+async function loadLockedPayment(tx: Prisma.TransactionClient, scope: AllocationScope) {
+  const payment = await tx.payment.findFirst({
+    where: {
+      id: scope.paymentId,
+      tenantId: scope.tenantId,
+      buildingId: scope.buildingId,
+    },
+    include: {
+      paymentAllocations: { include: { charge: { select: { currency: true } } } },
+    },
+  });
+  if (!payment) {
+    throw new NotFoundException('Payment not found or does not belong to this building/tenant');
+  }
+  return payment;
+}
+
+async function loadLockedCharge(tx: Prisma.TransactionClient, scope: AllocationScope) {
+  const charge = await tx.charge.findFirst({
+    where: {
+      id: scope.chargeId,
+      tenantId: scope.tenantId,
+      buildingId: scope.buildingId,
+      canceledAt: null,
+    },
+    include: {
+      paymentAllocations: {
+        include: { payment: { select: { status: true } } },
+      },
+    },
+  });
+  if (!charge) {
+    throw new NotFoundException('Charge not found or does not belong to this building/tenant');
+  }
+  return charge;
+}
+
+export async function recalculateLockedCharge(
+  tx: Prisma.TransactionClient,
+  chargeId: string,
+): Promise<void> {
+  const charge = await tx.charge.findUnique({
+    where: { id: chargeId },
+    include: {
+      paymentAllocations: {
+        include: { payment: { select: { status: true } } },
+      },
+    },
+  });
+  if (!charge) return;
+  const consumed = charge.paymentAllocations.reduce(
+    (sum, allocation) =>
+      isEffectivePaymentStatus(allocation.payment.status) ? sum + allocation.amount : sum,
+    0,
+  );
+  const status = consumed === 0
+    ? ChargeStatus.PENDING
+    : consumed < charge.amount
+      ? ChargeStatus.PARTIAL
+      : ChargeStatus.PAID;
+  if (status !== charge.status) {
+    await tx.charge.update({ where: { id: chargeId }, data: { status, updatedAt: new Date() } });
+  }
+}
+
+export async function reconcilePaymentWhenConsumed(
+  tx: Prisma.TransactionClient,
+  paymentId: string,
+): Promise<void> {
+  const payment = await tx.payment.findUnique({
+    where: { id: paymentId },
+    include: {
+      paymentAllocations: { include: { charge: { select: { currency: true, status: true } } } },
+    },
+  });
+  if (!payment || payment.status !== PaymentStatus.APPROVED) return;
+  const snapshotState = classifyFunctionalSnapshot(payment);
+  if (snapshotState === 'PARTIAL_INVALID' || payment.paymentAllocations.length === 0) return;
+
+  let originalConsumed = 0;
+  let functionalConsumed = 0;
+  for (const allocation of payment.paymentAllocations) {
+    const sameCurrency = allocation.charge.currency === payment.currency;
+    if (allocation.paymentOriginalAmountMinor !== null) {
+      originalConsumed += allocation.paymentOriginalAmountMinor;
+    } else if (sameCurrency) {
+      originalConsumed += allocation.amount;
+    }
+    if (!sameCurrency && allocation.charge.currency === payment.functionalCurrencyCode) {
+      functionalConsumed += allocation.amount;
+    }
+  }
+
+  const allPaid = payment.paymentAllocations.every(
+    (allocation) => allocation.charge.status === ChargeStatus.PAID,
+  );
+  const completelyConsumed = snapshotState === 'COMPLETE' && payment.currency !== payment.functionalCurrencyCode
+    ? originalConsumed === payment.amount && functionalConsumed === payment.functionalAmountMinor
+    : originalConsumed === payment.amount;
+  if (allPaid && completelyConsumed) {
+    await tx.payment.update({
+      where: { id: paymentId },
+      data: { status: PaymentStatus.RECONCILED, updatedAt: new Date() },
+    });
+  }
+}
+
+export async function createLockedAllocation(
+  tx: Prisma.TransactionClient,
+  scope: AllocationScope,
+  amount: number,
+): Promise<PaymentAllocation> {
+  await lockPaymentForAllocation(tx, scope);
+  const payment = await loadLockedPayment(tx, scope);
+  await lockChargesForAllocation(tx, scope.tenantId, scope.buildingId, [scope.chargeId]);
+  const charge = await loadLockedCharge(tx, scope);
+
+  if (payment.status !== PaymentStatus.APPROVED && payment.status !== PaymentStatus.RECONCILED) {
+    throw new ConflictException(`Cannot allocate payment in status ${payment.status}`);
+  }
+  if (payment.paymentAllocations.some((allocation) => allocation.chargeId === charge.id)) {
+    throw new ConflictException('Allocation already exists for this payment/charge pair');
+  }
+
+  const originalConsumed = payment.paymentAllocations.reduce((sum, allocation) => {
+    if (allocation.paymentOriginalAmountMinor !== null) return sum + allocation.paymentOriginalAmountMinor;
+    return allocation.charge.currency === payment.currency ? sum + allocation.amount : sum;
+  }, 0);
+  if (originalConsumed > payment.amount) {
+    throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_ORIGINAL_AMOUNT_EXCEEDED' });
+  }
+  const sameCurrency = payment.currency === charge.currency;
+  let originalShare = amount;
+  if (!sameCurrency) {
+    const snapshotState = classifyFunctionalSnapshot(payment);
+    if (snapshotState === 'LEGACY_NULL') {
+      throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED' });
+    }
+    if (snapshotState !== 'COMPLETE') {
+      throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID' });
+    }
+    if (payment.functionalCurrencyCode !== charge.currency || payment.functionalAmountMinor === null) {
+      throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED' });
+    }
+    const functionalConsumed = payment.paymentAllocations.reduce(
+      (sum, allocation) =>
+        allocation.charge.currency === payment.functionalCurrencyCode &&
+        allocation.charge.currency !== payment.currency
+          ? sum + allocation.amount
+          : sum,
+      0,
+    );
+    const functionalRemaining = payment.functionalAmountMinor - functionalConsumed;
+    const originalRemaining = payment.amount - originalConsumed;
+    const originalBackedFunctional = new Prisma.Decimal(originalRemaining)
+      .mul(payment.functionalAmountMinor)
+      .div(payment.amount)
+      .toDecimalPlaces(0, Prisma.Decimal.ROUND_DOWN)
+      .toNumber();
+    const crossAvailable = Math.min(functionalRemaining, originalBackedFunctional);
+    if (amount !== functionalRemaining && amount > crossAvailable) {
+      throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_FUNCTIONAL_AMOUNT_EXCEEDED' });
+    }
+    originalShare = amount === functionalRemaining
+      ? originalRemaining
+      : new Prisma.Decimal(originalRemaining)
+          .mul(amount)
+          .div(functionalRemaining)
+          .toDecimalPlaces(0, Prisma.Decimal.ROUND_HALF_EVEN)
+          .toNumber();
+  }
+  if (originalConsumed + originalShare > payment.amount) {
+    throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_ORIGINAL_AMOUNT_EXCEEDED' });
+  }
+
+  const chargeAllocations = charge.paymentAllocations ?? [];
+  const effectiveConsumed = chargeAllocations.reduce(
+    (sum, allocation) => isEffectivePaymentStatus(allocation.payment.status) ? sum + allocation.amount : sum,
+    0,
+  );
+  const reservedConsumed = chargeAllocations.reduce(
+    (sum, allocation) => allocation.payment.status === PaymentStatus.SUBMITTED ? sum + allocation.amount : sum,
+    0,
+  );
+  if (amount > charge.amount - effectiveConsumed - reservedConsumed) {
+    throw new ConflictException('The allocation exceeds the charge available outstanding');
+  }
+
+  const allocation = await tx.paymentAllocation.create({
+    data: {
+      tenantId: scope.tenantId,
+      paymentId: scope.paymentId,
+      chargeId: scope.chargeId,
+      amount,
+      paymentOriginalAmountMinor: originalShare,
+    },
+  });
+  await recalculateLockedCharge(tx, scope.chargeId);
+  await reconcilePaymentWhenConsumed(tx, scope.paymentId);
+  return allocation;
+}

--- a/apps/api/src/finanzas/payment-gateway/e2e/payment-e2e.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/e2e/payment-e2e.spec.ts
@@ -96,6 +96,7 @@ describe('E2E Payment Flow', () => {
         update: jest.fn(),
       },
       payment: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'payment-e2e-1' }]),
         findFirst: jest.fn().mockImplementation(() => Promise.resolve(paymentRecord)),
         findUnique: jest.fn().mockImplementation(() => Promise.resolve(paymentRecord)),
         update: jest.fn().mockImplementation(

--- a/apps/api/src/finanzas/payment-gateway/e2e/payment-e2e.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/e2e/payment-e2e.spec.ts
@@ -37,6 +37,18 @@ describe('E2E Payment Flow', () => {
   let mockIdempotencyService: any;
 
   beforeEach(() => {
+    const createdAllocations: Array<{ amount: number }> = [];
+    let paymentRecord = {
+      id: 'payment-e2e-1',
+      tenantId: 'tenant-e2e',
+      buildingId: 'building-e2e',
+      unitId: 'unit-e2e',
+      amount: 10000,
+      currency: 'ARS',
+      status: 'SUBMITTED',
+      reference: 'mock-ext-1',
+      paymentAllocations: [] as Array<Record<string, unknown>>,
+    };
     mockProvider = new MockPaymentProvider() as jest.Mocked<MockPaymentProvider>;
     mockProvider.createPreference = jest.fn().mockResolvedValue({
       preferenceId: 'mock-pref-1',
@@ -71,28 +83,52 @@ describe('E2E Payment Flow', () => {
           status: 'PENDING',
           paymentAllocations: [],
         }),
+        findUnique: jest.fn().mockImplementation(() => Promise.resolve({
+          id: 'charge-e2e-1',
+          amount: 10000,
+          currency: 'ARS',
+          status: createdAllocations.length === 0 ? 'PENDING' : 'PAID',
+          paymentAllocations: createdAllocations.map((allocation) => ({
+            ...allocation,
+            payment: { status: paymentRecord.status },
+          })),
+        })),
         update: jest.fn(),
       },
       payment: {
-        findFirst: jest.fn().mockResolvedValue({
-          id: 'payment-e2e-1',
-          tenantId: 'tenant-e2e',
-          buildingId: 'building-e2e',
-          unitId: 'unit-e2e',
-          amount: 10000,
-          currency: 'ARS',
-          status: 'SUBMITTED',
-          reference: 'mock-ext-1',
-          paymentAllocations: [],
-        }),
-        update: jest.fn(),
+        findFirst: jest.fn().mockImplementation(() => Promise.resolve(paymentRecord)),
+        findUnique: jest.fn().mockImplementation(() => Promise.resolve(paymentRecord)),
+        update: jest.fn().mockImplementation(
+          ({ data }: { data: Record<string, unknown> }) => {
+            paymentRecord = { ...paymentRecord, ...data };
+            return Promise.resolve(paymentRecord);
+          },
+        ),
       },
-      paymentAllocation: { create: jest.fn() },
+      paymentAllocation: {
+        create: jest.fn().mockImplementation(
+          ({ data }: { data: { amount: number; chargeId: string } }) => {
+            createdAllocations.push({ amount: data.amount });
+            paymentRecord.paymentAllocations.push({
+              ...data,
+              charge: { currency: 'ARS', status: 'PAID' },
+            });
+            return Promise.resolve({ id: 'allocation-e2e-1', ...data });
+          },
+        ),
+      },
+      processedWebhookEvent: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'processed-e2e-1' }),
+      },
+      $executeRaw: jest.fn().mockResolvedValue(1),
+      $queryRaw: jest.fn().mockResolvedValue([{ '?column?': 1 }]),
       $transaction: jest.fn((callback: (client: unknown) => unknown) => callback(mockPrisma)),
     };
     mockIdempotencyService = {
       isProcessed: jest.fn(),
       markProcessed: jest.fn(),
+      cacheProcessed: jest.fn(),
     };
 
     service = new PaymentGatewayService(
@@ -130,6 +166,7 @@ describe('E2E Payment Flow', () => {
     // Step 2: Process webhook (charge PENDING + local SUBMITTED payment)
     mockIdempotencyService.isProcessed.mockResolvedValue(false);
     mockIdempotencyService.markProcessed.mockResolvedValue(undefined);
+    mockIdempotencyService.cacheProcessed.mockResolvedValue(undefined);
 
     const result = await service.processWebhookEvent(
       { action: 'payment.approved', data: { id: 'mock-evt-1' } },
@@ -151,7 +188,7 @@ describe('E2E Payment Flow', () => {
       }),
     );
     expect(mockIdempotencyService.isProcessed).toHaveBeenCalledWith('mock-evt-1', 'mercadopago');
-    expect(mockIdempotencyService.markProcessed).toHaveBeenCalledWith('mock-evt-1', 'mercadopago');
+    expect(mockIdempotencyService.cacheProcessed).toHaveBeenCalledWith('mock-evt-1', 'mercadopago');
   });
 
   it('rejects duplicate webhook delivery (idempotency)', async () => {

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway-concurrency.postgres.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway-concurrency.postgres.spec.ts
@@ -1,0 +1,281 @@
+import {
+  ChargeStatus,
+  PaymentMethod,
+  PaymentStatus,
+  Prisma,
+  PrismaClient,
+  TenantType,
+} from '@prisma/client';
+import { CurrencyConversionService } from '../currency-conversion.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { PaymentGatewayService } from './payment-gateway.service';
+import {
+  PaymentPreference,
+  PaymentProvider,
+  PaymentStatus as ProviderPaymentStatus,
+  WebhookEvent,
+} from './interfaces/payment-provider.interface';
+import { IdempotencyService } from './webhooks/idempotency.service';
+
+const enabled =
+  process.env.RUN_POSTGRES_INTEGRATION === '1' &&
+  process.env.POSTGRES_TEST_DB_NAME === 'buildingos_3e3_acceptance';
+const describePostgres = enabled ? describe : describe.skip;
+
+class DeterministicProvider implements PaymentProvider {
+  readonly providerName = 'mercadopago' as const;
+
+  constructor(private readonly event: WebhookEvent) {}
+
+  async createPreference(): Promise<PaymentPreference> {
+    throw new Error('Not used by this test');
+  }
+
+  async handleWebhook(): Promise<WebhookEvent> {
+    return this.event;
+  }
+
+  async getChargeStatus(): Promise<ProviderPaymentStatus> {
+    return 'PAID';
+  }
+}
+
+const noOpIdempotency = {
+  isProcessed: async () => false,
+  cacheProcessed: async () => undefined,
+} as unknown as IdempotencyService;
+
+describePostgres('Payment gateway PostgreSQL webhook concurrency', () => {
+  let observer: PrismaClient;
+  let blocker: PrismaClient;
+  let firstPrisma: PrismaService;
+  let secondPrisma: PrismaService;
+  const tenantIds: string[] = [];
+  const userIds: string[] = [];
+  const eventIds: string[] = [];
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required');
+    const clientUrl = (applicationName: string) => {
+      const url = new URL(process.env.DATABASE_URL!);
+      url.searchParams.set('application_name', applicationName);
+      return url.toString();
+    };
+    observer = new PrismaClient();
+    blocker = new PrismaClient();
+    firstPrisma = new PrismaService({
+      datasources: { db: { url: clientUrl('gateway-concurrency-first') } },
+    });
+    secondPrisma = new PrismaService({
+      datasources: { db: { url: clientUrl('gateway-concurrency-second') } },
+    });
+    await Promise.all([
+      observer.$connect(),
+      blocker.$connect(),
+      firstPrisma.$connect(),
+      secondPrisma.$connect(),
+    ]);
+    const [database] = await observer.$queryRaw<Array<{ name: string }>>`
+      SELECT current_database() AS name
+    `;
+    if (database?.name !== 'buildingos_3e3_acceptance') {
+      throw new Error(`Refusing destructive test database ${database?.name ?? 'unknown'}`);
+    }
+  });
+
+  afterEach(async () => {
+    for (const eventId of eventIds.splice(0)) {
+      await observer.processedWebhookEvent.deleteMany({ where: { eventId } });
+    }
+    for (const tenantId of tenantIds.splice(0)) {
+      await observer.tenant.delete({ where: { id: tenantId } });
+    }
+    for (const userId of userIds.splice(0)) {
+      await observer.user.delete({ where: { id: userId } });
+    }
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      observer?.$disconnect(),
+      blocker?.$disconnect(),
+      firstPrisma?.$disconnect(),
+      secondPrisma?.$disconnect(),
+    ]);
+  });
+
+  async function waitForBothServiceTransactionsToBlock(): Promise<number[]> {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const activity = await observer.$queryRaw<Array<{ pid: number }>>(Prisma.sql`
+        SELECT pid
+        FROM pg_stat_activity
+        WHERE application_name IN ('gateway-concurrency-first', 'gateway-concurrency-second')
+          AND wait_event_type = 'Lock'
+      `);
+      const pids = [...new Set(activity.map(({ pid }) => pid))];
+      if (pids.length === 2) return pids;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error('Both gateway transactions did not reach a database lock wait');
+  }
+
+  async function fixture() {
+    const suffix = `${Date.now()}-${Math.random()}`;
+    const tenant = await observer.tenant.create({
+      data: {
+        name: `Gateway concurrency ${suffix}`,
+        type: TenantType.ADMINISTRADORA,
+        functionalCurrency: 'ARS',
+      },
+    });
+    tenantIds.push(tenant.id);
+    const user = await observer.user.create({
+      data: {
+        email: `gateway-concurrency-${suffix}@buildingos.local`,
+        name: 'Gateway concurrency resident',
+        passwordHash: 'test',
+      },
+    });
+    userIds.push(user.id);
+    const building = await observer.building.create({
+      data: {
+        tenantId: tenant.id,
+        name: `Building ${suffix}`,
+        alias: `GW-${suffix}`,
+        address: 'Test',
+      },
+    });
+    const unit = await observer.unit.create({
+      data: {
+        tenantId: tenant.id,
+        buildingId: building.id,
+        code: '1',
+        label: '1',
+        unitType: 'APARTAMENTO',
+        occupancyStatus: 'OCCUPIED',
+        isBillable: true,
+      },
+    });
+    const charge = await observer.charge.create({
+      data: {
+        tenantId: tenant.id,
+        buildingId: building.id,
+        unitId: unit.id,
+        period: '2026-08',
+        concept: 'Concurrent gateway reservation',
+        amount: 10000,
+        currency: 'ARS',
+        dueDate: new Date('2026-08-31T00:00:00.000Z'),
+      },
+    });
+    const externalId = `gateway-external-${suffix}`;
+    const payment = await observer.payment.create({
+      data: {
+        tenantId: tenant.id,
+        buildingId: building.id,
+        unitId: unit.id,
+        amount: 10000,
+        currency: 'ARS',
+        method: PaymentMethod.TRANSFER,
+        status: PaymentStatus.SUBMITTED,
+        reference: externalId,
+        createdByUserId: user.id,
+        functionalAmountMinor: 10000,
+        functionalCurrencyCode: 'ARS',
+        exchangeRateValue: new Prisma.Decimal(1),
+        exchangeRateDirection: 'IDENTITY',
+        conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+      },
+    });
+    const allocation = await observer.paymentAllocation.create({
+      data: {
+        tenantId: tenant.id,
+        paymentId: payment.id,
+        chargeId: charge.id,
+        amount: 10000,
+        paymentOriginalAmountMinor: 10000,
+      },
+    });
+    const event: WebhookEvent = {
+      eventId: `gateway-event-${suffix}`,
+      eventType: 'payment.updated',
+      chargeId: charge.id,
+      externalId,
+      status: 'PAID',
+      amount: 10000,
+      currency: 'ARS',
+      paidAt: '2026-08-10',
+      rawPayload: { source: 'deterministic-test-provider' },
+    };
+    eventIds.push(event.eventId);
+    return { allocation, charge, event, payment };
+  }
+
+  it('serializes duplicate paid webhooks and reuses the submitted reservation exactly once', async () => {
+    const ctx = await fixture();
+    const provider = new DeterministicProvider(ctx.event);
+    const firstService = new PaymentGatewayService(
+      provider,
+      firstPrisma,
+      noOpIdempotency,
+      new CurrencyConversionService(firstPrisma),
+    );
+    const secondService = new PaymentGatewayService(
+      provider,
+      secondPrisma,
+      noOpIdempotency,
+      new CurrencyConversionService(secondPrisma),
+    );
+    const eventLockKey = `webhook:${provider.providerName}:${ctx.event.eventId}`;
+    let releaseBlocker!: () => void;
+    const holdBlocker = new Promise<void>((resolve) => { releaseBlocker = resolve; });
+    let blockerReady!: () => void;
+    const blockerAcquired = new Promise<void>((resolve) => { blockerReady = resolve; });
+    const blockingTransaction = blocker.$transaction(async (tx) => {
+      await tx.$executeRaw(
+        Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${eventLockKey}, 0))`,
+      );
+      blockerReady();
+      await holdBlocker;
+    });
+    await blockerAcquired;
+
+    const first = firstService.processWebhookEvent(ctx.event.rawPayload, 'sig', 'mercadopago');
+    const second = secondService.processWebhookEvent(ctx.event.rawPayload, 'sig', 'mercadopago');
+    const blockedPids = await waitForBothServiceTransactionsToBlock();
+    expect(new Set(blockedPids).size).toBe(2);
+    releaseBlocker();
+    await blockingTransaction;
+
+    const results = await Promise.all([first, second]);
+    expect(results).toEqual([
+      expect.objectContaining({ chargeUpdated: true }),
+      expect.objectContaining({ chargeUpdated: true }),
+    ]);
+
+    const [payment, charge, allocations, processedEvents] = await Promise.all([
+      observer.payment.findUniqueOrThrow({ where: { id: ctx.payment.id } }),
+      observer.charge.findUniqueOrThrow({ where: { id: ctx.charge.id } }),
+      observer.paymentAllocation.findMany({ where: { paymentId: ctx.payment.id } }),
+      observer.processedWebhookEvent.findMany({ where: { eventId: ctx.event.eventId } }),
+    ]);
+    expect(allocations).toHaveLength(1);
+    expect(allocations[0]).toMatchObject({
+      id: ctx.allocation.id,
+      amount: 10000,
+      paymentOriginalAmountMinor: 10000,
+    });
+    expect(processedEvents).toHaveLength(1);
+    expect(payment.status).toBe(PaymentStatus.RECONCILED);
+    expect(payment.paymentEventId).toBe(ctx.event.eventId);
+    expect(charge.status).toBe(ChargeStatus.PAID);
+
+    await expect(
+      firstService.processWebhookEvent(ctx.event.rawPayload, 'sig', 'mercadopago'),
+    ).resolves.toEqual(expect.objectContaining({ chargeUpdated: true }));
+    await expect(observer.paymentAllocation.count({ where: { paymentId: ctx.payment.id } }))
+      .resolves.toBe(1);
+    await expect(observer.processedWebhookEvent.count({ where: { eventId: ctx.event.eventId } }))
+      .resolves.toBe(1);
+  });
+});

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
@@ -22,6 +22,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
   let mockIdempotencyService: any;
   let mockConversion: any;
   let createdAllocations: Array<{ amount: number }>;
+  let currentPayment: ReturnType<typeof payment>;
 
   const charge = (overrides: Record<string, unknown> = {}) => ({
     id: 'charge-1',
@@ -63,6 +64,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
 
   beforeEach(() => {
     createdAllocations = [];
+    currentPayment = payment();
     mockProvider = {
       providerName: 'mercadopago',
       createPreference: jest.fn(),
@@ -77,23 +79,49 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
         findFirst: jest.fn(() =>
           Promise.resolve(charge({ paymentAllocations: [...createdAllocations] })),
         ),
+        findUnique: jest.fn(() =>
+          Promise.resolve(charge({
+            paymentAllocations: createdAllocations.map((allocation) => ({
+              ...allocation,
+              payment: { status: currentPayment.status },
+            })),
+          })),
+        ),
         update: jest.fn(),
       },
       payment: {
-        findFirst: jest.fn(() => Promise.resolve(payment())),
-        update: jest.fn(),
+        findFirst: jest.fn(() => Promise.resolve(currentPayment)),
+        findUnique: jest.fn(() => Promise.resolve(currentPayment)),
+        update: jest.fn(({ data }: { data: Record<string, unknown> }) => {
+          currentPayment = { ...currentPayment, ...data };
+          return Promise.resolve(currentPayment);
+        }),
       },
       paymentAllocation: {
         create: jest.fn(({ data }: { data: { amount: number } }) => {
           createdAllocations.push({ amount: data.amount });
+          currentPayment = {
+            ...currentPayment,
+            paymentAllocations: [
+              ...currentPayment.paymentAllocations,
+              { ...data, charge: { currency: 'ARS', status: 'PAID' } },
+            ],
+          };
           return Promise.resolve({ id: 'alloc-1', ...data });
         }),
       },
+      processedWebhookEvent: {
+        findUnique: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockResolvedValue({ id: 'processed-1' }),
+      },
+      $executeRaw: jest.fn().mockResolvedValue(1),
+      $queryRaw: jest.fn().mockResolvedValue([{ '?column?': 1 }]),
       $transaction: jest.fn((callback: (client: unknown) => unknown) => callback(mockPrisma)),
     };
     mockIdempotencyService = {
       isProcessed: jest.fn().mockResolvedValue(false),
       markProcessed: jest.fn().mockResolvedValue(undefined),
+      cacheProcessed: jest.fn().mockResolvedValue(undefined),
     };
     mockConversion = {
       convert: jest.fn().mockResolvedValue({
@@ -156,7 +184,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
       expect(paidUpdate).toBeDefined();
       expect((mockPrisma.paymentAllocation.create as jest.Mock).mock.invocationCallOrder[0])
         .toBeLessThan((mockPrisma.charge.update as jest.Mock).mock.invocationCallOrder[0]);
-      expect(mockIdempotencyService.markProcessed).toHaveBeenCalledWith('evt-1', 'mercadopago');
+      expect(mockIdempotencyService.cacheProcessed).toHaveBeenCalledWith('evt-1', 'mercadopago');
     });
 
     it('uses the real provider amount, never an inferred outstanding', async () => {
@@ -202,7 +230,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
 
       expect(result.chargeUpdated).toBe(true);
       expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
-      expect(mockIdempotencyService.markProcessed).toHaveBeenCalled();
+      expect(mockIdempotencyService.cacheProcessed).toHaveBeenCalled();
     });
   });
 
@@ -294,7 +322,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
       mockPrisma.charge.findFirst.mockImplementation(() =>
         Promise.resolve(charge({ amount: 10000, paymentAllocations: [...createdAllocations] })),
       );
-      mockPrisma.payment.findFirst.mockResolvedValue(payment({ amount: 4000 }));
+      currentPayment = payment({ amount: 4000 });
 
       const result = await run(paidEvent({ amount: 4000 }));
 
@@ -315,7 +343,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
       mockPrisma.charge.findFirst.mockImplementation(() =>
         Promise.resolve(charge({ amount: 10000, paymentAllocations: [...createdAllocations] })),
       );
-      mockPrisma.payment.findFirst.mockResolvedValue(payment({ amount: 4000 }));
+      currentPayment = payment({ amount: 4000 });
 
       await run(paidEvent({ amount: 4000 }));
       mockIdempotencyService.isProcessed.mockResolvedValue(true);
@@ -404,12 +432,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
     });
 
     it('an existing COMPLETE snapshot is reused exactly (no reconversion)', async () => {
-      mockPrisma.payment.findFirst.mockResolvedValue(
-        payment({
-          status: 'SUBMITTED',
-          ...completePaymentSnapshot,
-        }),
-      );
+      currentPayment = payment({ status: 'SUBMITTED', ...completePaymentSnapshot });
 
       const result = await run(paidEvent());
 

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
@@ -140,6 +140,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
             paymentId: 'payment-1',
             chargeId: 'charge-1',
             amount: 10000,
+            paymentOriginalAmountMinor: 10000,
           }),
         }),
       );

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
@@ -452,6 +452,50 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
         response: { statusCode: 422, error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_CHARGE' },
       });
     });
+
+    it('accepts 7000 when another SUBMITTED payment reserves 3000 and reuses its own 7000 reservation', async () => {
+      currentPayment = payment({
+        amount: 7000,
+        paymentAllocations: [{ chargeId: 'charge-1', amount: 7000, charge: { currency: 'ARS' } }],
+      });
+      mockPrisma.charge.findFirst.mockResolvedValue(charge({
+        paymentAllocations: [
+          { amount: 7000, payment: { id: 'payment-1', status: 'SUBMITTED' } },
+          { amount: 3000, payment: { id: 'other', status: 'SUBMITTED' } },
+        ],
+      }));
+
+      await expect(run(paidEvent({ amount: 7000 }))).resolves.toEqual(
+        expect.objectContaining({ chargeUpdated: true }),
+      );
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+    });
+
+    it('blocks 7000 when another SUBMITTED payment reserves 7000', async () => {
+      currentPayment = payment({ amount: 7000 });
+      mockPrisma.charge.findFirst.mockResolvedValue(charge({
+        paymentAllocations: [{ amount: 7000, payment: { id: 'other', status: 'SUBMITTED' } }],
+      }));
+
+      await expect(run(paidEvent({ amount: 7000 }))).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_OUTSTANDING' },
+      });
+      expect(mockPrisma.payment.update).not.toHaveBeenCalled();
+    });
+
+    it('subtracts both effective allocations and SUBMITTED reservations from gateway capacity', async () => {
+      currentPayment = payment({ amount: 6000 });
+      mockPrisma.charge.findFirst.mockResolvedValue(charge({
+        paymentAllocations: [
+          { amount: 2000, payment: { id: 'approved', status: 'APPROVED' } },
+          { amount: 3000, payment: { id: 'submitted', status: 'SUBMITTED' } },
+        ],
+      }));
+
+      await expect(run(paidEvent({ amount: 6000 }))).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_OUTSTANDING' },
+      });
+    });
   });
 
   describe('3E2 gateway snapshot', () => {

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.spec.ts
@@ -77,19 +77,28 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
       },
       charge: {
         findFirst: jest.fn(() =>
-          Promise.resolve(charge({ paymentAllocations: [...createdAllocations] })),
+          Promise.resolve(charge({
+            paymentAllocations: createdAllocations.map((allocation) => ({
+              ...allocation,
+              payment: { id: 'other-payment', status: 'APPROVED' },
+            })).concat(currentPayment.paymentAllocations.map((allocation) => ({
+              ...allocation,
+              payment: { id: currentPayment.id, status: currentPayment.status },
+            }))),
+          })),
         ),
         findUnique: jest.fn(() =>
           Promise.resolve(charge({
             paymentAllocations: createdAllocations.map((allocation) => ({
               ...allocation,
-              payment: { status: currentPayment.status },
+              payment: { id: 'other-payment', status: 'APPROVED' },
             })),
           })),
         ),
         update: jest.fn(),
       },
       payment: {
+        findMany: jest.fn().mockResolvedValue([{ id: 'payment-1' }]),
         findFirst: jest.fn(() => Promise.resolve(currentPayment)),
         findUnique: jest.fn(() => Promise.resolve(currentPayment)),
         update: jest.fn(({ data }: { data: Record<string, unknown> }) => {
@@ -158,6 +167,41 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
   };
 
   describe('ledger evidence', () => {
+    it('approves and reuses an existing SUBMITTED reservation without duplication', async () => {
+      currentPayment = payment({
+        paymentAllocations: [{
+          chargeId: 'charge-1',
+          amount: 10000,
+          paymentOriginalAmountMinor: 10000,
+          charge: { currency: 'ARS', status: 'PENDING' },
+        }],
+      });
+
+      const result = await run(paidEvent());
+
+      expect(result.chargeUpdated).toBe(true);
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(mockPrisma.payment.update).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({ status: 'APPROVED', paymentEventId: 'evt-1' }),
+      }));
+      expect(mockPrisma.processedWebhookEvent.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('blocks an existing allocation amount mismatch without mutation or processed event', async () => {
+      currentPayment = payment({
+        paymentAllocations: [{
+          chargeId: 'charge-1', amount: 9000, charge: { currency: 'ARS' },
+        }],
+      });
+
+      await expect(run(paidEvent())).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'PAYMENT_PROVIDER_AMOUNT_MISMATCH' },
+      });
+      expect(mockPrisma.payment.update).not.toHaveBeenCalled();
+      expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+      expect(mockPrisma.processedWebhookEvent.create).not.toHaveBeenCalled();
+    });
+
     it('creates PaymentAllocation and recalculates charge status (never direct PAID)', async () => {
       const result = await run(paidEvent());
 
@@ -218,13 +262,11 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
     });
 
     it('skips allocation creation when the pair already exists (idempotent ledger)', async () => {
-      mockPrisma.payment.findFirst.mockResolvedValue(
-        payment({
+      currentPayment = payment({
           amount: 10000,
           status: 'APPROVED',
-          paymentAllocations: [{ chargeId: 'charge-1', amount: 10000 }],
-        }),
-      );
+          paymentAllocations: [{ chargeId: 'charge-1', amount: 10000, charge: { currency: 'ARS' } }],
+        });
 
       const result = await run(paidEvent());
 
@@ -235,6 +277,43 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
   });
 
   describe('missing financial evidence', () => {
+    it.each([undefined, '', '   '])(
+      'missing provider reference %p fails before any Payment query or mutation',
+      async (externalId) => {
+        await expect(run(paidEvent({ externalId }))).rejects.toMatchObject({
+          response: { statusCode: 503, error: 'PAYMENT_PROVIDER_REFERENCE_REQUIRED' },
+        });
+        expect(mockPrisma.payment.findMany).not.toHaveBeenCalled();
+        expect(mockPrisma.payment.findFirst).not.toHaveBeenCalled();
+        expect(mockPrisma.payment.update).not.toHaveBeenCalled();
+        expect(mockPrisma.paymentAllocation.create).not.toHaveBeenCalled();
+        expect(mockPrisma.processedWebhookEvent.create).not.toHaveBeenCalled();
+      },
+    );
+
+    it('uses the normalized provider reference for exact lookup', async () => {
+      await run(paidEvent({ externalId: '  ext-1  ' }));
+      expect(mockPrisma.payment.findMany).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({ tenantId: 'tenant-1', reference: 'ext-1' }),
+        take: 2,
+      }));
+    });
+
+    it('fails closed when a tenant has multiple payments with the same reference', async () => {
+      mockPrisma.payment.findMany.mockResolvedValue([{ id: 'payment-1' }, { id: 'payment-2' }]);
+      const result = await run(paidEvent());
+      expect(result.chargeUpdated).toBe(false);
+      expect(mockPrisma.payment.findFirst).not.toHaveBeenCalled();
+      expect(mockPrisma.payment.update).not.toHaveBeenCalled();
+      expect(mockPrisma.processedWebhookEvent.create).not.toHaveBeenCalled();
+    });
+
+    it('acknowledges a non-PAID event without requiring a provider reference', async () => {
+      const result = await run(paidEvent({ status: 'PENDING', externalId: undefined }));
+      expect(result.chargeUpdated).toBe(false);
+      expect(mockPrisma.payment.findMany).not.toHaveBeenCalled();
+    });
+
     it('missing provider amount => no financial mutation, event left unprocessed', async () => {
       await expect(run(paidEvent({ amount: undefined }))).rejects.toThrow(
         ServiceUnavailableException,
@@ -280,7 +359,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
     });
 
     it('currency mismatch payment vs event => 422, no allocation', async () => {
-      mockPrisma.payment.findFirst.mockResolvedValue(payment({ currency: 'VES' }));
+      currentPayment = payment({ currency: 'VES' });
 
       await expect(run(paidEvent())).rejects.toMatchObject({
         response: { statusCode: 422, error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED' },
@@ -295,7 +374,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
     it('matches the local payment tenant-scoped by reference', async () => {
       await run(paidEvent());
 
-      expect(mockPrisma.payment.findFirst).toHaveBeenCalledWith(
+      expect(mockPrisma.payment.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
             tenantId: 'tenant-1',
@@ -306,7 +385,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
     });
 
     it('no local payment => no mutation and event left unprocessed', async () => {
-      mockPrisma.payment.findFirst.mockResolvedValue(null);
+      mockPrisma.payment.findMany.mockResolvedValue([]);
 
       const result = await run(paidEvent());
 
@@ -357,6 +436,7 @@ describe('PaymentGatewayService (3E1 ledger)', () => {
   describe('amount guards', () => {
     it('event amount above charge outstanding => 422, no mutation', async () => {
       createdAllocations.push({ amount: 8000 });
+      currentPayment = payment({ amount: 3000 });
 
       await expect(run(paidEvent({ amount: 3000 }))).rejects.toMatchObject({
         response: { statusCode: 422, error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_OUTSTANDING' },

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
@@ -28,7 +28,6 @@ import { Prisma } from '@prisma/client';
 import { Inject } from '@nestjs/common';
 import {
   EFFECTIVE_PAYMENT_STATUSES,
-  isEffectivePaymentStatus,
 } from '../payment-status-semantics';
 import { CurrencyConversionService } from '../currency-conversion.service';
 import {
@@ -38,6 +37,7 @@ import {
 } from '../functional-snapshot';
 import {
   assertPaymentAllocationCurrencyMode,
+  calculateChargeAvailableOutstanding,
   createLockedAllocation,
   lockChargesForAllocation,
   lockPaymentForAllocation,
@@ -290,12 +290,10 @@ export class PaymentGatewayService {
         },
       });
       if (!lockedCharge) return false;
-      const lockedOutstanding = lockedCharge.amount - lockedCharge.paymentAllocations.reduce(
-        (sum, allocation) =>
-          allocation.payment.id !== payment.id && isEffectivePaymentStatus(allocation.payment.status)
-            ? sum + allocation.amount
-            : sum,
-        0,
+      const lockedOutstanding = calculateChargeAvailableOutstanding(
+        lockedCharge.amount,
+        lockedCharge.paymentAllocations,
+        payment.id,
       );
       if (verifiedAmount > lockedOutstanding) {
         throw new UnprocessableEntityException({

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
@@ -24,7 +24,7 @@ import {
 } from './interfaces/payment-provider.interface';
 import { PrismaService } from '../../prisma/prisma.service';
 import { IdempotencyService } from './webhooks/idempotency.service';
-import { ChargeStatus } from '@prisma/client';
+import { ChargeStatus, Prisma } from '@prisma/client';
 import { Inject } from '@nestjs/common';
 import {
   EFFECTIVE_PAYMENT_STATUSES,
@@ -36,6 +36,11 @@ import {
   classifyFunctionalSnapshot,
   type FunctionalSnapshotFields,
 } from '../functional-snapshot';
+import {
+  createLockedAllocation,
+  lockChargesForAllocation,
+  lockPaymentForAllocation,
+} from '../payment-allocation-transaction';
 
 /**
  * 3E2 fix: the gateway Payment.paidAt must derive from the SAME verified
@@ -135,7 +140,7 @@ export class PaymentGatewayService {
     const chargeUpdated = await this.applyPaidEvent(event);
 
     if (chargeUpdated) {
-      await this.idempotencyService.markProcessed(event.eventId, providerName);
+      await this.idempotencyService.cacheProcessed(event.eventId, providerName);
     } else {
       // No durable side effects applied: do not mark processed so the
       // provider retries and the event stays in manual-review visibility.
@@ -236,19 +241,65 @@ export class PaymentGatewayService {
     }
 
     return this.prisma.$transaction(async (tx) => {
-      const payment = await tx.payment.findFirst({
+      const eventLockKey = `webhook:${this.provider?.providerName}:${event.eventId}`;
+      await tx.$executeRaw(
+        Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${eventLockKey}, 0))`,
+      );
+      const processed = await tx.processedWebhookEvent.findUnique({
+        where: {
+          eventId_provider: {
+            eventId: event.eventId,
+            provider: this.provider!.providerName,
+          },
+        },
+      });
+      if (processed) return true;
+
+      const discoveredPayment = await tx.payment.findFirst({
         where: {
           tenantId: charge.tenantId,
           reference: event.externalId ?? undefined,
         },
-        include: { paymentAllocations: true },
+        select: { id: true },
       });
-
-      if (!payment) {
+      if (!discoveredPayment) {
         this.logger.error(
           `Webhook event ${event.eventId}: no local payment with reference ${event.externalId} for tenant ${charge.tenantId}; manual review required`,
         );
         return false;
+      }
+      const scope = {
+        tenantId: charge.tenantId,
+        buildingId: charge.buildingId,
+        paymentId: discoveredPayment.id,
+        chargeId: charge.id,
+      };
+      await lockPaymentForAllocation(tx, scope);
+      const payment = await tx.payment.findFirst({
+        where: { id: discoveredPayment.id, tenantId: charge.tenantId, buildingId: charge.buildingId },
+        include: { paymentAllocations: true },
+      });
+      if (!payment) return false;
+      await lockChargesForAllocation(tx, charge.tenantId, charge.buildingId, [charge.id]);
+      const lockedCharge = await tx.charge.findFirst({
+        where: { id: charge.id, tenantId: charge.tenantId, buildingId: charge.buildingId },
+        include: {
+          paymentAllocations: {
+            where: { payment: { status: { in: [...EFFECTIVE_PAYMENT_STATUSES] } } },
+            select: { amount: true },
+          },
+        },
+      });
+      if (!lockedCharge) return false;
+      const lockedOutstanding = lockedCharge.amount - lockedCharge.paymentAllocations.reduce(
+        (sum, allocation) => sum + allocation.amount,
+        0,
+      );
+      if (verifiedAmount > lockedOutstanding) {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_OUTSTANDING',
+        });
       }
 
       if (payment.currency !== event.currency || payment.currency !== charge.currency) {
@@ -280,6 +331,9 @@ export class PaymentGatewayService {
         this.logger.log(
           `Webhook event ${event.eventId}: allocation for payment ${payment.id} / charge ${charge.id} already exists`,
         );
+        await tx.processedWebhookEvent.create({
+          data: { eventId: event.eventId, provider: this.provider!.providerName },
+        });
         return true;
       }
 
@@ -295,7 +349,6 @@ export class PaymentGatewayService {
         });
       }
 
-      let effectivePaymentStatus = payment.status;
       if (payment.status === 'SUBMITTED') {
         const snapshotData = await this.gatewayPaymentSnapshot(
           tx,
@@ -313,7 +366,6 @@ export class PaymentGatewayService {
             ...snapshotData,
           },
         });
-        effectivePaymentStatus = 'APPROVED';
       } else if (payment.status === 'APPROVED' || payment.status === 'RECONCILED') {
         await tx.payment.update({
           where: { id: payment.id },
@@ -326,21 +378,10 @@ export class PaymentGatewayService {
         return false;
       }
 
-      await tx.paymentAllocation.create({
-        data: {
-          tenantId: charge.tenantId,
-          paymentId: payment.id,
-          chargeId: charge.id,
-          amount: verifiedAmount,
-          paymentOriginalAmountMinor: verifiedAmount,
-        },
+      await createLockedAllocation(tx, scope, verifiedAmount);
+      await tx.processedWebhookEvent.create({
+        data: { eventId: event.eventId, provider: this.provider!.providerName },
       });
-
-      await this.recalculateChargeStatus(tx, charge.id);
-
-      if (effectivePaymentStatus === 'APPROVED') {
-        await this.reconcilePaymentIfAllPaid(tx, payment.id);
-      }
 
       return true;
     });

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
@@ -332,6 +332,7 @@ export class PaymentGatewayService {
           paymentId: payment.id,
           chargeId: charge.id,
           amount: verifiedAmount,
+          paymentOriginalAmountMinor: verifiedAmount,
         },
       });
 

--- a/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
+++ b/apps/api/src/finanzas/payment-gateway/payment-gateway.service.ts
@@ -24,7 +24,7 @@ import {
 } from './interfaces/payment-provider.interface';
 import { PrismaService } from '../../prisma/prisma.service';
 import { IdempotencyService } from './webhooks/idempotency.service';
-import { ChargeStatus, Prisma } from '@prisma/client';
+import { Prisma } from '@prisma/client';
 import { Inject } from '@nestjs/common';
 import {
   EFFECTIVE_PAYMENT_STATUSES,
@@ -37,9 +37,12 @@ import {
   type FunctionalSnapshotFields,
 } from '../functional-snapshot';
 import {
+  assertPaymentAllocationCurrencyMode,
   createLockedAllocation,
   lockChargesForAllocation,
   lockPaymentForAllocation,
+  recalculateLockedCharge,
+  reconcilePaymentWhenConsumed,
 } from '../payment-allocation-transaction';
 
 /**
@@ -130,6 +133,15 @@ export class PaymentGatewayService {
       return { ...event, chargeUpdated: false };
     }
 
+    const providerReference = event.externalId?.trim();
+    if (!providerReference) {
+      throw new ServiceUnavailableException({
+        statusCode: 503,
+        error: 'PAYMENT_PROVIDER_REFERENCE_REQUIRED',
+        message: 'Paid webhook event missing provider reference',
+      });
+    }
+
     // Idempotency: check only after the event is known to require durable side effects.
     const isDuplicate = await this.idempotencyService.isProcessed(event.eventId, providerName);
     if (isDuplicate) {
@@ -137,7 +149,7 @@ export class PaymentGatewayService {
       return { ...event, chargeUpdated: false };
     }
 
-    const chargeUpdated = await this.applyPaidEvent(event);
+    const chargeUpdated = await this.applyPaidEvent(event, providerReference);
 
     if (chargeUpdated) {
       await this.idempotencyService.cacheProcessed(event.eventId, providerName);
@@ -152,7 +164,7 @@ export class PaymentGatewayService {
     return { ...event, chargeUpdated };
   }
 
-  private async applyPaidEvent(event: WebhookEvent): Promise<boolean> {
+  private async applyPaidEvent(event: WebhookEvent, providerReference: string): Promise<boolean> {
     if (!event.chargeId) {
       this.logger.warn(`Webhook event ${event.eventId} has no chargeId; no financial mutation`);
       return false;
@@ -223,23 +235,6 @@ export class PaymentGatewayService {
       });
     }
 
-    const effectiveAllocated = charge.paymentAllocations.reduce(
-      (sum, allocation) => sum + allocation.amount,
-      0,
-    );
-    const outstanding = charge.amount - effectiveAllocated;
-
-    if (verifiedAmount > outstanding) {
-      this.logger.error(
-        `Webhook event ${event.eventId}: provider amount ${verifiedAmount} exceeds charge outstanding ${outstanding}`,
-      );
-      throw new UnprocessableEntityException({
-        statusCode: 422,
-        error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_OUTSTANDING',
-        message: 'El monto del evento supera el saldo pendiente del cargo',
-      });
-    }
-
     return this.prisma.$transaction(async (tx) => {
       const eventLockKey = `webhook:${this.provider?.providerName}:${event.eventId}`;
       await tx.$executeRaw(
@@ -255,19 +250,22 @@ export class PaymentGatewayService {
       });
       if (processed) return true;
 
-      const discoveredPayment = await tx.payment.findFirst({
+      const discoveredPayments = await tx.payment.findMany({
         where: {
           tenantId: charge.tenantId,
-          reference: event.externalId ?? undefined,
+          reference: providerReference,
         },
         select: { id: true },
+        take: 2,
       });
-      if (!discoveredPayment) {
+      if (discoveredPayments.length !== 1) {
         this.logger.error(
-          `Webhook event ${event.eventId}: no local payment with reference ${event.externalId} for tenant ${charge.tenantId}; manual review required`,
+          `Webhook event ${event.eventId}: expected one local payment with reference ${providerReference} for tenant ${charge.tenantId}, found ${discoveredPayments.length}; manual review required`,
         );
         return false;
       }
+      const discoveredPayment = discoveredPayments[0];
+      if (discoveredPayment === undefined) return false;
       const scope = {
         tenantId: charge.tenantId,
         buildingId: charge.buildingId,
@@ -277,7 +275,9 @@ export class PaymentGatewayService {
       await lockPaymentForAllocation(tx, scope);
       const payment = await tx.payment.findFirst({
         where: { id: discoveredPayment.id, tenantId: charge.tenantId, buildingId: charge.buildingId },
-        include: { paymentAllocations: true },
+        include: {
+          paymentAllocations: { include: { charge: { select: { currency: true } } } },
+        },
       });
       if (!payment) return false;
       await lockChargesForAllocation(tx, charge.tenantId, charge.buildingId, [charge.id]);
@@ -285,14 +285,16 @@ export class PaymentGatewayService {
         where: { id: charge.id, tenantId: charge.tenantId, buildingId: charge.buildingId },
         include: {
           paymentAllocations: {
-            where: { payment: { status: { in: [...EFFECTIVE_PAYMENT_STATUSES] } } },
-            select: { amount: true },
+            include: { payment: { select: { id: true, status: true } } },
           },
         },
       });
       if (!lockedCharge) return false;
       const lockedOutstanding = lockedCharge.amount - lockedCharge.paymentAllocations.reduce(
-        (sum, allocation) => sum + allocation.amount,
+        (sum, allocation) =>
+          allocation.payment.id !== payment.id && isEffectivePaymentStatus(allocation.payment.status)
+            ? sum + allocation.amount
+            : sum,
         0,
       );
       if (verifiedAmount > lockedOutstanding) {
@@ -328,20 +330,21 @@ export class PaymentGatewayService {
         (allocation) => allocation.chargeId === charge.id,
       );
       if (existingAllocation) {
-        this.logger.log(
-          `Webhook event ${event.eventId}: allocation for payment ${payment.id} / charge ${charge.id} already exists`,
-        );
-        await tx.processedWebhookEvent.create({
-          data: { eventId: event.eventId, provider: this.provider!.providerName },
-        });
-        return true;
+        if (existingAllocation.amount !== verifiedAmount) {
+          throw new UnprocessableEntityException({
+            statusCode: 422,
+            error: 'PAYMENT_PROVIDER_AMOUNT_MISMATCH',
+          });
+        }
       }
+
+      assertPaymentAllocationCurrencyMode(payment.currency, payment.paymentAllocations);
 
       const alreadyAllocated = payment.paymentAllocations.reduce(
         (sum, allocation) => sum + allocation.amount,
         0,
       );
-      if (alreadyAllocated + verifiedAmount > payment.amount) {
+      if (!existingAllocation && alreadyAllocated + verifiedAmount > payment.amount) {
         throw new UnprocessableEntityException({
           statusCode: 422,
           error: 'PAYMENT_EVENT_AMOUNT_EXCEEDS_PAYMENT',
@@ -378,7 +381,12 @@ export class PaymentGatewayService {
         return false;
       }
 
-      await createLockedAllocation(tx, scope, verifiedAmount);
+      if (!existingAllocation) {
+        await createLockedAllocation(tx, scope, verifiedAmount);
+      } else {
+        await recalculateLockedCharge(tx, charge.id);
+        await reconcilePaymentWhenConsumed(tx, payment.id);
+      }
       await tx.processedWebhookEvent.create({
         data: { eventId: event.eventId, provider: this.provider!.providerName },
       });
@@ -386,9 +394,6 @@ export class PaymentGatewayService {
       return true;
     });
   }
-
-
-
   /**
    * 3E2: freeze a COMPLETE functional snapshot before the gateway effective
    * transition. COMPLETE → reuse; LEGACY_NULL → requires the provider
@@ -463,81 +468,6 @@ export class PaymentGatewayService {
         conversionDate: event.paidAt,
       },
     );
-  }
-
-  /**
-   * Mirrors the ledger status computation: charge status derives exclusively
-   * from its effective allocations. Never a direct PAID mutation.
-   */
-  private async recalculateChargeStatus(
-    tx: Parameters<Parameters<PrismaService['$transaction']>[0]>[0],
-    chargeId: string,
-  ): Promise<void> {
-    const charge = await tx.charge.findFirst({
-      where: { id: chargeId },
-      include: {
-        paymentAllocations: {
-          where: {
-            payment: { status: { in: [...EFFECTIVE_PAYMENT_STATUSES] } },
-          },
-          select: { amount: true },
-        },
-      },
-    });
-
-    if (!charge) {
-      return;
-    }
-
-    const totalAllocated = charge.paymentAllocations.reduce(
-      (sum, allocation) => sum + allocation.amount,
-      0,
-    );
-
-    let newStatus: ChargeStatus;
-    if (totalAllocated === 0) {
-      newStatus = ChargeStatus.PENDING;
-    } else if (totalAllocated < charge.amount) {
-      newStatus = ChargeStatus.PARTIAL;
-    } else {
-      newStatus = ChargeStatus.PAID;
-    }
-
-    if (newStatus !== charge.status) {
-      await tx.charge.update({
-        where: { id: chargeId },
-        data: { status: newStatus, updatedAt: new Date() },
-      });
-    }
-  }
-
-  private async reconcilePaymentIfAllPaid(
-    tx: Parameters<Parameters<PrismaService['$transaction']>[0]>[0],
-    paymentId: string,
-  ): Promise<void> {
-    const payment = await tx.payment.findFirst({
-      where: { id: paymentId },
-      include: {
-        paymentAllocations: { include: { charge: true } },
-      },
-    });
-
-    if (!payment || !isEffectivePaymentStatus(payment.status)) {
-      return;
-    }
-
-    const allPaid =
-      payment.paymentAllocations.length > 0 &&
-      payment.paymentAllocations.every(
-        (allocation) => allocation.charge.status === ChargeStatus.PAID,
-      );
-
-    if (allPaid) {
-      await tx.payment.update({
-        where: { id: paymentId },
-        data: { status: 'RECONCILED', updatedAt: new Date() },
-      });
-    }
   }
 
   /**

--- a/apps/api/src/finanzas/payment-gateway/webhooks/idempotency.service.ts
+++ b/apps/api/src/finanzas/payment-gateway/webhooks/idempotency.service.ts
@@ -63,4 +63,8 @@ export class IdempotencyService {
 
     this.logger.debug(`Webhook ${eventId} marked as processed for provider ${provider}`);
   }
+
+  async cacheProcessed(eventId: string, provider: string): Promise<void> {
+    await this.redis.set(`webhook:${provider}:${eventId}`, '1', this.REDIS_TTL);
+  }
 }


### PR DESCRIPTION
Closes #146

## Phase 3E3

- PaymentAllocation.paymentOriginalAmountMinor
- same-currency explicit original share
- cross-currency allocation backed only by frozen Payment snapshot
- exact original/functional conservation
- SAME/CROSS mode exclusivity
- Payment/Charge row locking
- concurrency-safe create/delete
- bidirectional reconciliation / downgrade
- gateway reservation capacity
- webhook reservation reuse
- required provider external reference
- tenant-safe lookups
- legacy fail-closed behavior
- no ExchangeRate lookup during allocation

## Migration

20260812000000_add_payment_allocation_original_share

SHA256:
857e76ba79b6ce52adba7e07bbda723a33ab0db76cfb55f3de177a1892f65832

## Validation

- local functional acceptance PASS
- PostgreSQL concurrency tests PASS
- Finance suite PASS
- typecheck PASS
- lint PASS
- Prisma validate PASS
- builds PASS
- independent final review: 0 P0/P1/P2