### PR TITLE
fix(finance): make payment allocation aggregation currency-safe

### DIFF
--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -2014,7 +2014,11 @@ describe('FinanzasService', () => {
           ...toPaymentRecord(where.id),
           paymentAllocations: paymentState.paymentAllocations.map((allocation) => ({
             amount: allocation.amount,
-            charge: { status: chargeStates[allocation.chargeId]?.status ?? ChargeStatus.PENDING },
+            paymentOriginalAmountMinor: null,
+            charge: {
+              currency: chargeStates[allocation.chargeId]?.currency ?? paymentState.currency,
+              status: chargeStates[allocation.chargeId]?.status ?? ChargeStatus.PENDING,
+            },
           })),
         } as never;
       });
@@ -2427,6 +2431,9 @@ describe('FinanzasService', () => {
         membershipId,
         'Manual cancellation',
       );
+      const cancellationExpectation = expect(cancellation).rejects.toThrow(
+        'Cannot cancel payment with existing allocations. Remove allocations first.',
+      );
 
       await secondLockAttempted;
       expect(paymentLockAttempts).toBe(2);
@@ -2435,9 +2442,7 @@ describe('FinanzasService', () => {
       await expect(approval).resolves.toEqual(
         expect.objectContaining({ status: PaymentStatus.APPROVED }),
       );
-      await expect(cancellation).rejects.toThrow(
-        'Cannot cancel payment with existing allocations. Remove allocations first.',
-      );
+      await cancellationExpectation;
 
       expect(paymentStates[paymentId]).toEqual(
         expect.objectContaining({
@@ -3442,6 +3447,92 @@ describe('FinanzasService', () => {
       jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([] as never);
       jest.spyOn(prismaService.payment, 'findMany').mockResolvedValue([] as never);
     };
+
+    const ledgerPayment = (overrides: Record<string, unknown> = {}) => ({
+      id: 'payment-1', amount: 10000, currency: 'USD', method: PaymentMethod.TRANSFER,
+      status: PaymentStatus.APPROVED, createdAt: new Date('2026-08-11T00:00:00.000Z'),
+      functionalAmountMinor: null, functionalCurrencyCode: null, exchangeRateId: null,
+      exchangeRateValue: null, exchangeRateDirection: null, exchangeRateEffectiveAt: null,
+      conversionDate: null, paymentAllocations: [], ...overrides,
+    });
+
+    it.each([
+      {
+        label: 'explicit SAME',
+        payment: ledgerPayment({ paymentAllocations: [{
+          amount: 4000, paymentOriginalAmountMinor: 4000, charge: { currency: 'USD' },
+        }] }),
+        allocated: 4000,
+      },
+      {
+        label: 'legacy SAME NULL',
+        payment: ledgerPayment({ paymentAllocations: [{
+          amount: 4000, paymentOriginalAmountMinor: null, charge: { currency: 'USD' },
+        }] }),
+        allocated: 4000,
+      },
+      {
+        label: 'CROSS original share',
+        payment: ledgerPayment({
+          ...completePaymentSnapshot,
+          functionalAmountMinor: 365000,
+          paymentAllocations: [2740, 2740].map((share) => ({
+            amount: 100000, paymentOriginalAmountMinor: share, charge: { currency: 'VES' },
+          })),
+        }),
+        allocated: 5480,
+      },
+    ])('reports $label allocation in Payment currency', async ({ payment, allocated }) => {
+      mockLedgerBase();
+      jest.spyOn(prismaService.payment, 'findMany').mockResolvedValue([payment] as never);
+
+      const ledger = await service.getUnitLedger(
+        tenantId, unitId, undefined, undefined, ['TENANT_ADMIN'], 'user-1',
+        { id: 'membership-1', tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] } as never,
+      );
+
+      expect(ledger.payments).toEqual([expect.objectContaining({ allocated })]);
+      expect(prismaService.payment.findMany).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          tenantId,
+          unitId,
+          status: { in: [PaymentStatus.APPROVED, PaymentStatus.RECONCILED] },
+        }),
+      }));
+    });
+
+    it('fails closed when the ledger encounters a legacy CROSS NULL share', async () => {
+      mockLedgerBase();
+      jest.spyOn(prismaService.payment, 'findMany').mockResolvedValue([ledgerPayment({
+        ...completePaymentSnapshot,
+        functionalAmountMinor: 365000,
+        paymentAllocations: [{
+          amount: 365000, paymentOriginalAmountMinor: null, charge: { currency: 'VES' },
+        }],
+      })] as never);
+
+      await expect(service.getUnitLedger(
+        tenantId, unitId, undefined, undefined, ['TENANT_ADMIN'], 'user-1',
+        { id: 'membership-1', tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] } as never,
+      )).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED' },
+      });
+    });
+
+    it('excludes SUBMITTED payments from accounting consumption', async () => {
+      mockLedgerBase();
+
+      await service.getUnitLedger(
+        tenantId, unitId, undefined, undefined, ['TENANT_ADMIN'], 'user-1',
+        { id: 'membership-1', tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] } as never,
+      );
+
+      expect(prismaService.payment.findMany).toHaveBeenCalledWith(expect.objectContaining({
+        where: expect.objectContaining({
+          status: { in: [PaymentStatus.APPROVED, PaymentStatus.RECONCILED] },
+        }),
+      }));
+    });
 
     it('allows a tenant-scoped admin membership for the requested tenant', async () => {
       mockLedgerBase();

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -15,6 +15,7 @@ import {
   type FunctionalSnapshotFields,
 } from './functional-snapshot';
 import {
+  aggregatePaymentSideAllocations,
   assertPaymentAllocationCurrencyMode,
   createLockedAllocation,
   deleteLockedAllocation,
@@ -2258,8 +2259,27 @@ export class FinanzasService {
         status: { in: [PaymentStatus.APPROVED, PaymentStatus.RECONCILED] },
         canceledAt: null,
       },
-      include: {
-        paymentAllocations: true,
+      select: {
+        id: true,
+        amount: true,
+        currency: true,
+        method: true,
+        status: true,
+        createdAt: true,
+        functionalAmountMinor: true,
+        functionalCurrencyCode: true,
+        exchangeRateId: true,
+        exchangeRateValue: true,
+        exchangeRateDirection: true,
+        exchangeRateEffectiveAt: true,
+        conversionDate: true,
+        paymentAllocations: {
+          select: {
+            amount: true,
+            paymentOriginalAmountMinor: true,
+            charge: { select: { currency: true } },
+          },
+        },
       },
       orderBy: { createdAt: 'desc' },
     });
@@ -2320,7 +2340,7 @@ export class FinanzasService {
         method: p.method,
         status: p.status,
         createdAt: p.createdAt,
-        allocated: p.paymentAllocations.reduce((sum, a) => sum + a.amount, 0),
+        allocated: aggregatePaymentSideAllocations(p).originalConsumedMinor,
       })),
       totals: {
         totalCharges,

--- a/apps/api/src/finanzas/payment-allocation-concurrency.postgres.spec.ts
+++ b/apps/api/src/finanzas/payment-allocation-concurrency.postgres.spec.ts
@@ -566,4 +566,65 @@ describePostgres('Payment allocation PostgreSQL concurrency', () => {
     await expect(observer.payment.findUniqueOrThrow({ where: { id: payment.id } }))
       .resolves.toMatchObject({ status: PaymentStatus.RECONCILED });
   });
+
+  it.each([
+    { label: 'LEGACY_NULL', snapshotData: {
+      functionalAmountMinor: null, functionalCurrencyCode: null, exchangeRateId: null,
+      exchangeRateValue: null, exchangeRateDirection: null, exchangeRateEffectiveAt: null,
+      conversionDate: null,
+    } },
+    { label: 'PARTIAL_INVALID', snapshotData: {
+      functionalAmountMinor: 365000, functionalCurrencyCode: 'VES', exchangeRateId: null,
+      exchangeRateValue: '36.5', exchangeRateDirection: 'DIRECT',
+      exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+      conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+    } },
+  ])('commits a CROSS delete when the remaining snapshot is $label (no invented capacity)', async ({ snapshotData }) => {
+    const ctx = await fixture(`delete-${fixturePhase}-cross-snapshot`);
+    const rate = await observer.exchangeRate.create({ data: {
+      tenantId: ctx.tenant.id, baseCurrency: 'USD', quoteCurrency: 'VES', rate: '36.5',
+      effectiveAt: new Date('2026-08-08T00:00:00.000Z'), source: `${fixturePhase} PostgreSQL snapshot delete`,
+    } });
+    const payment = await observer.payment.create({ data: {
+      ...ctx.paymentData, currency: 'USD', status: PaymentStatus.RECONCILED,
+      functionalAmountMinor: 365000, functionalCurrencyCode: 'VES', exchangeRateId: rate.id,
+      exchangeRateValue: '36.5', exchangeRateDirection: 'DIRECT',
+      exchangeRateEffectiveAt: new Date('2026-08-08T00:00:00.000Z'),
+      conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+    } });
+    const charges = await Promise.all([
+      observer.charge.create({ data: { ...ctx.chargeData, amount: 100000, currency: 'VES', status: ChargeStatus.PAID } }),
+      observer.charge.create({ data: {
+        ...ctx.chargeData, period: '2026-09', concept: 'snapshot-delete-2',
+        amount: 265000, currency: 'VES', status: ChargeStatus.PAID,
+      } }),
+    ]);
+    const allocations = await Promise.all(charges.map((charge, index) => observer.paymentAllocation.create({ data: {
+      tenantId: ctx.tenant.id, paymentId: payment.id, chargeId: charge.id,
+      amount: charge.amount, paymentOriginalAmountMinor: index === 0 ? 2740 : 7260,
+    } })));
+
+    await observer.payment.update({ where: { id: payment.id }, data: snapshotData });
+
+    await firstClient.$transaction((tx) => deleteLockedAllocation(
+      tx, ctx.tenant.id, ctx.building.id, allocations[0].id,
+    ));
+
+    const [remaining, persistedPayment, deletedCharge] = await Promise.all([
+      observer.paymentAllocation.findMany({ where: { paymentId: payment.id } }),
+      observer.payment.findUniqueOrThrow({ where: { id: payment.id } }),
+      observer.charge.findUniqueOrThrow({ where: { id: charges[0].id } }),
+    ]);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]).toMatchObject({ id: allocations[1].id, paymentOriginalAmountMinor: 7260 });
+    expect(persistedPayment.status).toBe(PaymentStatus.APPROVED);
+    expect(deletedCharge.status).toBe(ChargeStatus.PENDING);
+
+    await firstClient.$transaction((tx) => deleteLockedAllocation(
+      tx, ctx.tenant.id, ctx.building.id, allocations[1].id,
+    ));
+    await expect(observer.paymentAllocation.count({ where: { paymentId: payment.id } })).resolves.toBe(0);
+    await expect(observer.payment.findUniqueOrThrow({ where: { id: payment.id } }))
+      .resolves.toMatchObject({ status: PaymentStatus.APPROVED });
+  });
 });

--- a/apps/api/src/finanzas/payment-allocation-concurrency.postgres.spec.ts
+++ b/apps/api/src/finanzas/payment-allocation-concurrency.postgres.spec.ts
@@ -1,9 +1,19 @@
 import { ChargeStatus, PaymentMethod, PaymentStatus, PrismaClient, TenantType } from '@prisma/client';
-import { createLockedAllocation, deleteLockedAllocation } from './payment-allocation-transaction';
+import {
+  createLockedAllocation,
+  deleteLockedAllocation,
+} from './payment-allocation-transaction';
 
+const ACCEPTANCE_DATABASES = new Set([
+  'buildingos_3e3_acceptance',
+  'buildingos_3e4_acceptance',
+]);
+const expectedDatabaseName = process.env.POSTGRES_TEST_DB_NAME;
+const fixturePhase = expectedDatabaseName === 'buildingos_3e4_acceptance' ? 'qa3e4' : 'qa3e3';
 const enabled =
   process.env.RUN_POSTGRES_INTEGRATION === '1' &&
-  process.env.POSTGRES_TEST_DB_NAME === 'buildingos_3e3_acceptance';
+  expectedDatabaseName !== undefined &&
+  ACCEPTANCE_DATABASES.has(expectedDatabaseName);
 const describePostgres = enabled ? describe : describe.skip;
 
 describePostgres('Payment allocation PostgreSQL concurrency', () => {
@@ -20,7 +30,7 @@ describePostgres('Payment allocation PostgreSQL concurrency', () => {
     secondClient = new PrismaClient();
     await Promise.all([observer.$connect(), firstClient.$connect(), secondClient.$connect()]);
     const [database] = await observer.$queryRaw<Array<{ name: string }>>`SELECT current_database() AS name`;
-    if (database?.name !== 'buildingos_3e3_acceptance') {
+    if (database?.name !== expectedDatabaseName || !ACCEPTANCE_DATABASES.has(database.name)) {
       throw new Error(`Refusing destructive test database ${database?.name ?? 'unknown'}`);
     }
   });
@@ -45,13 +55,13 @@ describePostgres('Payment allocation PostgreSQL concurrency', () => {
   async function fixture(label: string) {
     const suffix = `${Date.now()}-${Math.random()}`;
     const tenant = await observer.tenant.create({
-      data: { name: `3E3 ${label} ${suffix}`, type: TenantType.ADMINISTRADORA },
+      data: { name: `${fixturePhase}-${label}-${suffix}`, type: TenantType.ADMINISTRADORA },
     });
     tenantIds.push(tenant.id);
     const user = await observer.user.create({
       data: {
-        email: `3e3-${suffix}@buildingos.local`,
-        name: '3E3 concurrency',
+        email: `${fixturePhase}-${suffix}@buildingos.local`,
+        name: `${fixturePhase} concurrency`,
         passwordHash: 'test',
       },
     });
@@ -356,6 +366,166 @@ describePostgres('Payment allocation PostgreSQL concurrency', () => {
     expect(paidCharge.status).toBe(ChargeStatus.PAID);
     expect(restoredTotals._sum.paymentOriginalAmountMinor).toBe(10000);
     expect(restoredTotals._sum.amount).toBe(365000);
+  });
+
+  it('rolls back creation when legacy CROSS consumption has no original share', async () => {
+    const ctx = await fixture('legacy-cross-null');
+    const effectiveAt = new Date('2026-08-08T00:00:00.000Z');
+    const rate = await observer.exchangeRate.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        baseCurrency: 'USD',
+        quoteCurrency: 'VES',
+        rate: '36.5',
+        effectiveAt,
+        source: `${fixturePhase} PostgreSQL regression`,
+      },
+    });
+    const payment = await observer.payment.create({
+      data: {
+        ...ctx.paymentData,
+        currency: 'USD',
+        functionalAmountMinor: 365000,
+        functionalCurrencyCode: 'VES',
+        exchangeRateId: rate.id,
+        exchangeRateValue: '36.5',
+        exchangeRateDirection: 'DIRECT',
+        exchangeRateEffectiveAt: effectiveAt,
+        conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+      },
+    });
+    const [legacyCharge, candidateCharge] = await Promise.all([
+      observer.charge.create({
+        data: { ...ctx.chargeData, amount: 100000, currency: 'VES', status: ChargeStatus.PAID },
+      }),
+      observer.charge.create({
+        data: {
+          ...ctx.chargeData,
+          period: '2026-09',
+          concept: 'legacy-cross-null-candidate',
+          amount: 265000,
+          currency: 'VES',
+        },
+      }),
+    ]);
+    await observer.paymentAllocation.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        paymentId: payment.id,
+        chargeId: legacyCharge.id,
+        amount: 100000,
+        paymentOriginalAmountMinor: null,
+      },
+    });
+
+    await expect(firstClient.$transaction((tx) => createLockedAllocation(tx, {
+      tenantId: ctx.tenant.id,
+      buildingId: ctx.building.id,
+      paymentId: payment.id,
+      chargeId: candidateCharge.id,
+    }, 265000))).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED' },
+    });
+
+    const [allocations, persistedPayment, persistedCandidateCharge] = await Promise.all([
+      observer.paymentAllocation.findMany({ where: { paymentId: payment.id } }),
+      observer.payment.findUniqueOrThrow({ where: { id: payment.id } }),
+      observer.charge.findUniqueOrThrow({ where: { id: candidateCharge.id } }),
+    ]);
+    expect(allocations).toHaveLength(1);
+    expect(allocations[0]).toMatchObject({
+      chargeId: legacyCharge.id,
+      amount: 100000,
+      paymentOriginalAmountMinor: null,
+    });
+    expect(persistedPayment.status).toBe(PaymentStatus.APPROVED);
+    expect(persistedCandidateCharge.status).toBe(ChargeStatus.PENDING);
+  });
+
+  it('commits sequential cleanup of two legacy CROSS NULL allocations', async () => {
+    const ctx = await fixture('legacy-cross-null-cleanup');
+    const effectiveAt = new Date('2026-08-08T00:00:00.000Z');
+    const rate = await observer.exchangeRate.create({ data: {
+      tenantId: ctx.tenant.id, baseCurrency: 'USD', quoteCurrency: 'VES', rate: '36.5',
+      effectiveAt, source: `${fixturePhase} PostgreSQL cleanup`,
+    } });
+    const payment = await observer.payment.create({ data: {
+      ...ctx.paymentData, currency: 'USD', status: PaymentStatus.RECONCILED,
+      functionalAmountMinor: 365000, functionalCurrencyCode: 'VES', exchangeRateId: rate.id,
+      exchangeRateValue: '36.5', exchangeRateDirection: 'DIRECT', exchangeRateEffectiveAt: effectiveAt,
+      conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+    } });
+    const charges = await Promise.all([100000, 265000].map((amount, index) => observer.charge.create({ data: {
+      ...ctx.chargeData, period: `2026-${index + 8}`, concept: `legacy-cleanup-${index}`,
+      amount, currency: 'VES', status: ChargeStatus.PAID,
+    } })));
+    const allocations = await Promise.all(charges.map((charge) => observer.paymentAllocation.create({ data: {
+      tenantId: ctx.tenant.id, paymentId: payment.id, chargeId: charge.id,
+      amount: charge.amount, paymentOriginalAmountMinor: null,
+    } })));
+
+    await firstClient.$transaction((tx) => deleteLockedAllocation(
+      tx, ctx.tenant.id, ctx.building.id, allocations[0].id,
+    ));
+    await expect(observer.paymentAllocation.findMany({ where: { paymentId: payment.id } }))
+      .resolves.toEqual([expect.objectContaining({ id: allocations[1].id, paymentOriginalAmountMinor: null })]);
+    await expect(observer.payment.findUniqueOrThrow({ where: { id: payment.id } }))
+      .resolves.toMatchObject({ status: PaymentStatus.APPROVED });
+    await expect(observer.charge.findUniqueOrThrow({ where: { id: charges[0].id } }))
+      .resolves.toMatchObject({ status: ChargeStatus.PENDING });
+
+    await firstClient.$transaction((tx) => deleteLockedAllocation(
+      tx, ctx.tenant.id, ctx.building.id, allocations[1].id,
+    ));
+    await expect(observer.paymentAllocation.count({ where: { paymentId: payment.id } })).resolves.toBe(0);
+    await expect(observer.payment.findUniqueOrThrow({ where: { id: payment.id } }))
+      .resolves.toMatchObject({ status: PaymentStatus.APPROVED });
+    await expect(observer.charge.findUniqueOrThrow({ where: { id: charges[1].id } }))
+      .resolves.toMatchObject({ status: ChargeStatus.PENDING });
+  });
+
+  it('commits progressive mixed cleanup and resumes canonical reconciliation', async () => {
+    const ctx = await fixture('mixed-progressive-cleanup');
+    const effectiveAt = new Date('2026-08-08T00:00:00.000Z');
+    const rate = await observer.exchangeRate.create({ data: {
+      tenantId: ctx.tenant.id, baseCurrency: 'USD', quoteCurrency: 'VES', rate: '36.5',
+      effectiveAt, source: `${fixturePhase} PostgreSQL mixed cleanup`,
+    } });
+    const payment = await observer.payment.create({ data: {
+      ...ctx.paymentData, currency: 'USD', status: PaymentStatus.RECONCILED,
+      functionalAmountMinor: 365000, functionalCurrencyCode: 'VES', exchangeRateId: rate.id,
+      exchangeRateValue: '36.5', exchangeRateDirection: 'DIRECT', exchangeRateEffectiveAt: effectiveAt,
+      conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+    } });
+    const definitions = [
+      { amount: 4000, currency: 'USD', original: 4000 },
+      { amount: 10000, currency: 'USD', original: 10000 },
+      { amount: 100000, currency: 'VES', original: null },
+      { amount: 265000, currency: 'VES', original: null },
+    ];
+    const charges = await Promise.all(definitions.map((definition, index) => observer.charge.create({ data: {
+      ...ctx.chargeData, period: `2027-0${index + 1}`, concept: `mixed-cleanup-${index}`,
+      amount: definition.amount, currency: definition.currency, status: ChargeStatus.PAID,
+    } })));
+    const allocations = await Promise.all(charges.map((charge, index) => observer.paymentAllocation.create({ data: {
+      tenantId: ctx.tenant.id, paymentId: payment.id, chargeId: charge.id,
+      amount: charge.amount, paymentOriginalAmountMinor: definitions[index].original,
+    } })));
+
+    for (const index of [0, 2]) {
+      await firstClient.$transaction((tx) => deleteLockedAllocation(
+        tx, ctx.tenant.id, ctx.building.id, allocations[index].id,
+      ));
+      await expect(observer.payment.findUniqueOrThrow({ where: { id: payment.id } }))
+        .resolves.toMatchObject({ status: PaymentStatus.APPROVED });
+    }
+    await firstClient.$transaction((tx) => deleteLockedAllocation(
+      tx, ctx.tenant.id, ctx.building.id, allocations[3].id,
+    ));
+    await expect(observer.paymentAllocation.findMany({ where: { paymentId: payment.id } }))
+      .resolves.toEqual([expect.objectContaining({ id: allocations[1].id, paymentOriginalAmountMinor: 10000 })]);
+    await expect(observer.payment.findUniqueOrThrow({ where: { id: payment.id } }))
+      .resolves.toMatchObject({ status: PaymentStatus.RECONCILED });
   });
 
   it('serializes delete with create and returns canonical 404 for a repeated delete', async () => {

--- a/apps/api/src/finanzas/payment-allocation-transaction.spec.ts
+++ b/apps/api/src/finanzas/payment-allocation-transaction.spec.ts
@@ -481,4 +481,128 @@ describe('payment allocation transaction semantics', () => {
     });
     expect(create).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { label: 'LEGACY_NULL', snapshot: {
+      functionalAmountMinor: null, functionalCurrencyCode: null, exchangeRateId: null,
+      exchangeRateValue: null, exchangeRateDirection: null, exchangeRateEffectiveAt: null,
+      conversionDate: null,
+    } },
+    { label: 'PARTIAL_INVALID', snapshot: { ...completeSnapshot, exchangeRateId: null } },
+  ])('commits a CROSS delete when the remaining snapshot is $label and downgrades conservatively', async ({ snapshot }) => {
+    const allocations = [
+      { id: 'a', paymentId: 'payment', chargeId: 'charge-a', amount: 100000,
+        paymentOriginalAmountMinor: 2740, charge: { currency: 'VES', status: ChargeStatus.PAID } },
+      { id: 'b', paymentId: 'payment', chargeId: 'charge-b', amount: 100000,
+        paymentOriginalAmountMinor: 2740, charge: { currency: 'VES', status: ChargeStatus.PAID } },
+    ];
+    let paymentStatus = PaymentStatus.RECONCILED;
+    const update = jest.fn().mockImplementation(async ({ data }: { data: { status: PaymentStatus } }) => {
+      paymentStatus = data.status;
+    });
+    const tx = {
+      $queryRaw: jest.fn().mockResolvedValue([]),
+      paymentAllocation: {
+        findFirst: jest.fn().mockImplementation(async ({ where }: { where: { id: string } }) => {
+          const allocation = allocations.find((item) => item.id === where.id);
+          return allocation && (where.payment === undefined
+            ? { paymentId: allocation.paymentId, chargeId: allocation.chargeId }
+            : { id: allocation.id, paymentId: allocation.paymentId, chargeId: allocation.chargeId,
+                amount: allocation.amount });
+        }),
+        deleteMany: jest.fn().mockImplementation(async ({ where }: { where: { id: string } }) => {
+          const index = allocations.findIndex((item) => item.id === where.id);
+          if (index < 0) return { count: 0 };
+          allocations.splice(index, 1);
+          return { count: 1 };
+        }),
+      },
+      charge: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'charge-a', amount: 100000, status: ChargeStatus.PAID, paymentAllocations: [],
+        }),
+        update: jest.fn(),
+      },
+      payment: {
+        findUnique: jest.fn().mockImplementation(async () => ({
+          id: 'payment', amount: 10000, currency: 'USD', status: paymentStatus, ...snapshot,
+          paymentAllocations: allocations,
+        })),
+        update,
+      },
+    } as unknown as Prisma.TransactionClient;
+
+    await expect(deleteLockedAllocation(tx, 'tenant', 'building', 'a')).resolves.toEqual({
+      id: 'a', paymentId: 'payment', chargeId: 'charge-a', amount: 100000,
+    });
+    expect(allocations).toHaveLength(1);
+    expect(allocations[0]).toMatchObject({ id: 'b' });
+    expect(paymentStatus).toBe(PaymentStatus.APPROVED);
+  });
+
+  it('resumes canonical reconciliation once the last unresolved-snapshot CROSS row is deleted', async () => {
+    const known = { id: 'known', paymentId: 'payment', chargeId: 'known-charge', amount: 365000,
+      paymentOriginalAmountMinor: 10000, charge: { currency: 'VES', status: ChargeStatus.PAID } };
+    const stale = { id: 'stale', paymentId: 'payment', chargeId: 'stale-charge', amount: 100000,
+      paymentOriginalAmountMinor: 2740, charge: { currency: 'VES', status: ChargeStatus.PAID } };
+    const allocations = [known, stale];
+    let paymentStatus = PaymentStatus.RECONCILED;
+    const update = jest.fn().mockImplementation(async ({ data }: { data: { status: PaymentStatus } }) => {
+      paymentStatus = data.status;
+    });
+    const tx = {
+      $queryRaw: jest.fn().mockResolvedValue([]),
+      paymentAllocation: {
+        findFirst: jest.fn().mockImplementation(async ({ where }: { where: { id: string } }) => {
+          const allocation = allocations.find((item) => item.id === where.id);
+          return allocation && (where.payment === undefined
+            ? { paymentId: allocation.paymentId, chargeId: allocation.chargeId }
+            : { id: allocation.id, paymentId: allocation.paymentId, chargeId: allocation.chargeId,
+                amount: allocation.amount });
+        }),
+        deleteMany: jest.fn().mockImplementation(async ({ where }: { where: { id: string } }) => {
+          const index = allocations.findIndex((item) => item.id === where.id);
+          if (index < 0) return { count: 0 };
+          allocations.splice(index, 1);
+          return { count: 1 };
+        }),
+      },
+      charge: {
+        findUnique: jest.fn().mockResolvedValue({
+          id: 'stale-charge', amount: 100000, status: ChargeStatus.PAID, paymentAllocations: [],
+        }),
+        update: jest.fn(),
+      },
+      payment: {
+        findUnique: jest.fn().mockImplementation(async () => ({
+          id: 'payment', amount: 10000, currency: 'USD', status: paymentStatus, ...completeSnapshot,
+          paymentAllocations: allocations,
+        })),
+        update,
+      },
+    } as unknown as Prisma.TransactionClient;
+
+    await deleteLockedAllocation(tx, 'tenant', 'building', 'stale');
+    expect(allocations).toHaveLength(1);
+    expect(paymentStatus).toBe(PaymentStatus.RECONCILED);
+    expect(aggregatePaymentSideAllocations({
+      id: 'payment', amount: 10000, currency: 'USD', ...completeSnapshot,
+      paymentAllocations: allocations,
+    })).toMatchObject({ mode: 'CROSS', originalRemainingMinor: 0, functionalRemainingMinor: 0 });
+  });
+
+  it.each([
+    { label: 'LEGACY_NULL', snapshot: {
+      functionalAmountMinor: null, functionalCurrencyCode: null, exchangeRateId: null,
+      exchangeRateValue: null, exchangeRateDirection: null, exchangeRateEffectiveAt: null,
+      conversionDate: null,
+    }, error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED' },
+    { label: 'PARTIAL_INVALID', snapshot: { ...completeSnapshot, exchangeRateId: null },
+      error: 'PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID' },
+  ])('strict aggregation still fails closed for CROSS with $label snapshot', async ({ snapshot, error }) => {
+    expect(() => aggregatePaymentSideAllocations({
+      id: 'payment', amount: 10000, currency: 'USD', ...snapshot,
+      paymentAllocations: [{ amount: 100000, paymentOriginalAmountMinor: 2740, charge: { currency: 'VES' } }],
+    })).toThrow(expect.objectContaining({ response: { statusCode: 422, error } }));
+  });
 });

--- a/apps/api/src/finanzas/payment-allocation-transaction.spec.ts
+++ b/apps/api/src/finanzas/payment-allocation-transaction.spec.ts
@@ -1,7 +1,9 @@
 import { ChargeStatus, PaymentStatus, Prisma } from '@prisma/client';
 import {
+  aggregatePaymentSideAllocations,
   assertPaymentAllocationCurrencyMode,
   calculateChargeAvailableOutstanding,
+  classifyPaymentSideAllocations,
   createLockedAllocation,
   deleteLockedAllocation,
   reconcilePaymentWhenConsumed,
@@ -52,6 +54,64 @@ describe('payment allocation transaction semantics', () => {
       [{ charge: { currency } }],
       currency,
     )).not.toThrow();
+  });
+
+  it('aggregates SAME explicit and legacy shares in original minor units', () => {
+    expect(aggregatePaymentSideAllocations({
+      id: 'payment', amount: 10000, currency: 'USD',
+      functionalAmountMinor: null, functionalCurrencyCode: null, exchangeRateId: null,
+      exchangeRateValue: null, exchangeRateDirection: null, exchangeRateEffectiveAt: null,
+      conversionDate: null,
+      paymentAllocations: [
+        { amount: 2500, paymentOriginalAmountMinor: 2500, charge: { currency: 'USD' } },
+        { amount: 1500, paymentOriginalAmountMinor: null, charge: { currency: 'USD' } },
+      ],
+    })).toEqual({
+      mode: 'SAME',
+      originalConsumedMinor: 4000,
+      originalRemainingMinor: 6000,
+      functionalConsumedMinor: null,
+      functionalRemainingMinor: null,
+    });
+  });
+
+  it('aggregates partial and full CROSS consumption in both currencies', () => {
+    const payment = {
+      id: 'payment', amount: 10000, currency: 'USD', ...completeSnapshot,
+      paymentAllocations: [2740, 2740].map((share) => ({
+        amount: 100000, paymentOriginalAmountMinor: share, charge: { currency: 'VES' },
+      })),
+    };
+    expect(aggregatePaymentSideAllocations(payment)).toEqual({
+      mode: 'CROSS', originalConsumedMinor: 5480, originalRemainingMinor: 4520,
+      functionalConsumedMinor: 200000, functionalRemainingMinor: 165000,
+    });
+    expect(aggregatePaymentSideAllocations({
+      ...payment,
+      paymentAllocations: [
+        ...payment.paymentAllocations,
+        { amount: 165000, paymentOriginalAmountMinor: 4520, charge: { currency: 'VES' } },
+      ],
+    })).toEqual({
+      mode: 'CROSS', originalConsumedMinor: 10000, originalRemainingMinor: 0,
+      functionalConsumedMinor: 365000, functionalRemainingMinor: 0,
+    });
+  });
+
+  it('fails closed for a legacy CROSS NULL original share', () => {
+    const payment = {
+      id: 'payment', amount: 10000, currency: 'USD', ...completeSnapshot,
+      paymentAllocations: [{
+        amount: 365000, paymentOriginalAmountMinor: null, charge: { currency: 'VES' },
+      }],
+    };
+    expect(classifyPaymentSideAllocations(payment)).toEqual({
+      kind: 'UNRESOLVED_LEGACY_CROSS',
+      aggregate: null,
+    });
+    expect(() => aggregatePaymentSideAllocations(payment)).toThrow(expect.objectContaining({ response: {
+      statusCode: 422, error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED',
+    } }));
   });
 
   it('keeps a pure SAME payment with a COMPLETE cross-capable snapshot APPROVED while an original remainder remains', async () => {
@@ -126,7 +186,7 @@ describe('payment allocation transaction semantics', () => {
     expect(update).toHaveBeenCalled();
   });
 
-  it('G: never nominally falls back for a historical cross-currency NULL original share', async () => {
+  it('G: fails closed for a historical cross-currency NULL original share', async () => {
     const { tx, update } = transaction({
       id: 'payment', amount: 10000, currency: 'USD', status: PaymentStatus.APPROVED,
       ...completeSnapshot,
@@ -135,7 +195,9 @@ describe('payment allocation transaction semantics', () => {
         charge: { currency: 'VES', status: ChargeStatus.PAID },
       }],
     });
-    await reconcilePaymentWhenConsumed(tx, 'payment');
+    await expect(reconcilePaymentWhenConsumed(tx, 'payment')).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED' },
+    });
     expect(update).not.toHaveBeenCalled();
   });
 
@@ -239,6 +301,116 @@ describe('payment allocation transaction semantics', () => {
     expect(calls).toEqual(['lock', 'lock', 'delete', 'charge', 'payment']);
   });
 
+  it('progressively cleans a mixed ledger without deriving malformed capacity, then resumes canonical reconciliation', async () => {
+    const calls: string[] = [];
+    const allocations = [
+      { id: 'same-a', paymentId: 'payment', chargeId: 'same-charge-a', amount: 4000,
+        paymentOriginalAmountMinor: 4000, charge: { currency: 'USD', status: ChargeStatus.PAID } },
+      { id: 'same-b', paymentId: 'payment', chargeId: 'same-charge-b', amount: 10000,
+        paymentOriginalAmountMinor: 10000, charge: { currency: 'USD', status: ChargeStatus.PAID } },
+      { id: 'cross-a', paymentId: 'payment', chargeId: 'cross-charge-a', amount: 100000,
+        paymentOriginalAmountMinor: null, charge: { currency: 'VES', status: ChargeStatus.PAID } },
+      { id: 'cross-b', paymentId: 'payment', chargeId: 'cross-charge-b', amount: 265000,
+        paymentOriginalAmountMinor: null, charge: { currency: 'VES', status: ChargeStatus.PAID } },
+    ];
+    let paymentStatus = PaymentStatus.RECONCILED;
+    const tx = {
+      $queryRaw: jest.fn().mockImplementation(async () => { calls.push('lock'); return []; }),
+      paymentAllocation: {
+        findFirst: jest.fn().mockImplementation(async ({ where }: { where: { id: string } }) => {
+          const allocation = allocations.find((item) => item.id === where.id);
+          return allocation && (where.payment === undefined
+            ? { paymentId: allocation.paymentId, chargeId: allocation.chargeId }
+            : { id: allocation.id, paymentId: allocation.paymentId, chargeId: allocation.chargeId,
+                amount: allocation.amount });
+        }),
+        deleteMany: jest.fn().mockImplementation(async ({ where }: { where: { id: string } }) => {
+          calls.push(`delete:${where.id}`);
+          const index = allocations.findIndex((item) => item.id === where.id);
+          if (index < 0) return { count: 0 };
+          allocations.splice(index, 1);
+          return { count: 1 };
+        }),
+      },
+      charge: {
+        findUnique: jest.fn().mockImplementation(async ({ where }: { where: { id: string } }) => ({
+          id: where.id, amount: 10000,
+          status: ChargeStatus.PAID, paymentAllocations: [],
+        })),
+        update: jest.fn().mockImplementation(async ({ where }: { where: { id: string } }) => {
+          calls.push(`charge:${where.id}`);
+        }),
+      },
+      payment: {
+        findUnique: jest.fn().mockImplementation(async () => ({
+          id: 'payment', amount: 10000, currency: 'USD', status: paymentStatus, ...completeSnapshot,
+          paymentAllocations: allocations,
+        })),
+        update: jest.fn().mockImplementation(async ({ data }: { data: { status: PaymentStatus } }) => {
+          paymentStatus = data.status;
+          calls.push(`payment:${data.status}`);
+        }),
+      },
+    } as unknown as Prisma.TransactionClient;
+
+    await deleteLockedAllocation(tx, 'tenant', 'building', 'same-a');
+    expect(allocations).toHaveLength(3);
+    expect(classifyPaymentSideAllocations({
+      id: 'payment', amount: 10000, currency: 'USD', ...completeSnapshot,
+      paymentAllocations: allocations,
+    })).toMatchObject({ kind: 'MIXED' });
+    expect(paymentStatus).toBe(PaymentStatus.APPROVED);
+
+    await deleteLockedAllocation(tx, 'tenant', 'building', 'cross-a');
+    expect(allocations).toHaveLength(2);
+    expect(paymentStatus).toBe(PaymentStatus.APPROVED);
+
+    await deleteLockedAllocation(tx, 'tenant', 'building', 'cross-b');
+    expect(allocations).toHaveLength(1);
+    expect(aggregatePaymentSideAllocations({
+      id: 'payment', amount: 10000, currency: 'USD', ...completeSnapshot,
+      paymentAllocations: allocations,
+    })).toMatchObject({ mode: 'SAME', originalRemainingMinor: 0 });
+    expect(paymentStatus).toBe(PaymentStatus.RECONCILED);
+
+    await deleteLockedAllocation(tx, 'tenant', 'building', 'same-b');
+    expect(allocations).toHaveLength(0);
+    expect(paymentStatus).toBe(PaymentStatus.APPROVED);
+    expect(calls).toContain('payment:APPROVED');
+  });
+
+  it('derives canonical status after deleting the unresolved row from a mixed known CROSS ledger', async () => {
+    const known = { id: 'known', paymentId: 'payment', chargeId: 'known-charge', amount: 365000,
+      paymentOriginalAmountMinor: 10000, charge: { currency: 'VES', status: ChargeStatus.PAID } };
+    const unresolved = { id: 'unresolved', paymentId: 'payment', chargeId: 'legacy-charge', amount: 1,
+      paymentOriginalAmountMinor: null, charge: { currency: 'VES', status: ChargeStatus.PAID } };
+    const allocations = [known, unresolved];
+    const update = jest.fn();
+    const tx = {
+      $queryRaw: jest.fn().mockResolvedValue([]),
+      paymentAllocation: {
+        findFirst: jest.fn().mockResolvedValueOnce({ paymentId: 'payment', chargeId: 'legacy-charge' })
+          .mockResolvedValueOnce({ id: 'unresolved', paymentId: 'payment', chargeId: 'legacy-charge', amount: 1 }),
+        deleteMany: jest.fn().mockImplementation(async () => { allocations.pop(); return { count: 1 }; }),
+      },
+      charge: { findUnique: jest.fn().mockResolvedValue({
+        id: 'legacy-charge', amount: 1, status: ChargeStatus.PAID, paymentAllocations: [],
+      }), update: jest.fn() },
+      payment: {
+        findUnique: jest.fn().mockImplementation(async () => ({
+          id: 'payment', amount: 10000, currency: 'USD', status: PaymentStatus.APPROVED,
+          ...completeSnapshot, paymentAllocations: allocations,
+        })),
+        update,
+      },
+    } as unknown as Prisma.TransactionClient;
+
+    await deleteLockedAllocation(tx, 'tenant', 'building', 'unresolved');
+    expect(update).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ status: PaymentStatus.RECONCILED }),
+    }));
+  });
+
   it.each([
     { label: 'stale discovery', authoritative: null, deleted: 1 },
     { label: 'double delete', authoritative: { id: 'allocation', paymentId: 'payment', chargeId: 'charge', amount: 1 }, deleted: 0 },
@@ -281,6 +453,32 @@ describe('payment allocation transaction semantics', () => {
     }, 1)).rejects.toMatchObject({ response: {
       statusCode: 422, error: 'PAYMENT_FUNCTIONAL_AMOUNT_EXCEEDED',
     } });
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('rejects create when an existing legacy CROSS share is NULL without mutation', async () => {
+    const create = jest.fn();
+    const tx = {
+      $queryRaw: jest.fn().mockResolvedValue([]),
+      payment: { findFirst: jest.fn().mockResolvedValue({
+        id: 'payment', amount: 10000, currency: 'USD', status: PaymentStatus.APPROVED,
+        ...completeSnapshot,
+        paymentAllocations: [{
+          chargeId: 'legacy-charge', amount: 100000, paymentOriginalAmountMinor: null,
+          charge: { currency: 'VES' },
+        }],
+      }) },
+      charge: { findFirst: jest.fn().mockResolvedValue({
+        id: 'new-charge', amount: 100000, currency: 'VES', paymentAllocations: [],
+      }) },
+      paymentAllocation: { create },
+    } as unknown as Prisma.TransactionClient;
+
+    await expect(createLockedAllocation(tx, {
+      tenantId: 'tenant', buildingId: 'building', paymentId: 'payment', chargeId: 'new-charge',
+    }, 100000)).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED' },
+    });
     expect(create).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/finanzas/payment-allocation-transaction.ts
+++ b/apps/api/src/finanzas/payment-allocation-transaction.ts
@@ -52,6 +52,11 @@ export interface PaymentSideAllocationAggregate {
 export type PaymentSideAllocationClassification =
   | { readonly kind: 'MIXED'; readonly aggregate: null }
   | { readonly kind: 'UNRESOLVED_LEGACY_CROSS'; readonly aggregate: null }
+  | {
+      readonly kind: 'UNRESOLVED_CROSS_SNAPSHOT';
+      readonly reason: 'LEGACY_NULL' | 'PARTIAL_INVALID' | 'CURRENCY_NOT_SUPPORTED';
+      readonly aggregate: null;
+    }
   | { readonly kind: 'CANONICAL'; readonly aggregate: PaymentSideAllocationAggregate };
 
 interface ChargeAvailabilityAllocation {
@@ -110,10 +115,10 @@ export function classifyPaymentSideAllocations(
   if (mode === 'CROSS') {
     const snapshotState = classifyFunctionalSnapshot(payment);
     if (snapshotState === 'LEGACY_NULL') {
-      throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED' });
+      return { kind: 'UNRESOLVED_CROSS_SNAPSHOT', reason: 'LEGACY_NULL', aggregate: null };
     }
     if (snapshotState !== 'COMPLETE') {
-      throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID' });
+      return { kind: 'UNRESOLVED_CROSS_SNAPSHOT', reason: 'PARTIAL_INVALID', aggregate: null };
     }
     const functionalCurrencyCode = payment.functionalCurrencyCode;
     const functionalAmountMinor = payment.functionalAmountMinor;
@@ -126,7 +131,7 @@ export function classifyPaymentSideAllocations(
         (allocation) => allocation.charge.currency !== functionalCurrencyCode,
       )
     ) {
-      throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED' });
+      return { kind: 'UNRESOLVED_CROSS_SNAPSHOT', reason: 'CURRENCY_NOT_SUPPORTED', aggregate: null };
     }
     functionalConsumedMinor = payment.paymentAllocations.reduce(
       (sum, allocation) => sum + allocation.amount,
@@ -169,6 +174,14 @@ export function aggregatePaymentSideAllocations(
   }
   if (classification.kind === 'UNRESOLVED_LEGACY_CROSS') {
     throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED' });
+  }
+  if (classification.kind === 'UNRESOLVED_CROSS_SNAPSHOT') {
+    const error = classification.reason === 'LEGACY_NULL'
+      ? 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED'
+      : classification.reason === 'PARTIAL_INVALID'
+        ? 'PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID'
+        : 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED';
+    throw new UnprocessableEntityException({ statusCode: 422, error });
   }
   return classification.aggregate;
 }

--- a/apps/api/src/finanzas/payment-allocation-transaction.ts
+++ b/apps/api/src/finanzas/payment-allocation-transaction.ts
@@ -23,6 +23,37 @@ interface AllocationChargeCurrency {
   readonly charge: { readonly currency: string };
 }
 
+interface PaymentSideAllocation extends AllocationChargeCurrency {
+  readonly amount: number;
+  readonly paymentOriginalAmountMinor: number | null;
+}
+
+interface PaymentSideAggregateInput {
+  readonly amount: number;
+  readonly currency: string;
+  readonly functionalAmountMinor: number | null;
+  readonly functionalCurrencyCode: string | null;
+  readonly exchangeRateId: string | null;
+  readonly exchangeRateValue: Prisma.Decimal | null;
+  readonly exchangeRateDirection: string | null;
+  readonly exchangeRateEffectiveAt: Date | null;
+  readonly conversionDate: Date | null;
+  readonly paymentAllocations: readonly PaymentSideAllocation[];
+}
+
+export interface PaymentSideAllocationAggregate {
+  readonly mode: PaymentAllocationCurrencyMode;
+  readonly originalConsumedMinor: number;
+  readonly originalRemainingMinor: number;
+  readonly functionalConsumedMinor: number | null;
+  readonly functionalRemainingMinor: number | null;
+}
+
+export type PaymentSideAllocationClassification =
+  | { readonly kind: 'MIXED'; readonly aggregate: null }
+  | { readonly kind: 'UNRESOLVED_LEGACY_CROSS'; readonly aggregate: null }
+  | { readonly kind: 'CANONICAL'; readonly aggregate: PaymentSideAllocationAggregate };
+
 interface ChargeAvailabilityAllocation {
   readonly amount: number;
   readonly payment: { readonly id?: string; readonly status: PaymentStatus };
@@ -56,6 +87,90 @@ export function assertPaymentAllocationCurrencyMode(
   if (hasSame) return 'SAME';
   if (hasCross) return 'CROSS';
   return null;
+}
+
+export function classifyPaymentSideAllocations(
+  payment: PaymentSideAggregateInput,
+  candidateChargeCurrency?: string,
+): PaymentSideAllocationClassification {
+  const currencies = candidateChargeCurrency === undefined
+    ? payment.paymentAllocations.map((allocation) => allocation.charge.currency)
+    : [...payment.paymentAllocations.map((allocation) => allocation.charge.currency), candidateChargeCurrency];
+  const hasSame = currencies.some((currency) => currency === payment.currency);
+  const hasCross = currencies.some((currency) => currency !== payment.currency);
+  if (hasSame && hasCross) return { kind: 'MIXED', aggregate: null };
+  const mode: PaymentAllocationCurrencyMode = hasSame ? 'SAME' : hasCross ? 'CROSS' : null;
+  const hasUnresolvedLegacyCross = payment.paymentAllocations.some(
+    (allocation) => allocation.paymentOriginalAmountMinor === null &&
+      allocation.charge.currency !== payment.currency,
+  );
+  if (hasUnresolvedLegacyCross) return { kind: 'UNRESOLVED_LEGACY_CROSS', aggregate: null };
+  let functionalConsumedMinor: number | null = null;
+
+  if (mode === 'CROSS') {
+    const snapshotState = classifyFunctionalSnapshot(payment);
+    if (snapshotState === 'LEGACY_NULL') {
+      throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED' });
+    }
+    if (snapshotState !== 'COMPLETE') {
+      throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID' });
+    }
+    const functionalCurrencyCode = payment.functionalCurrencyCode;
+    const functionalAmountMinor = payment.functionalAmountMinor;
+    if (
+      functionalCurrencyCode === null ||
+      functionalAmountMinor === null ||
+      functionalCurrencyCode === payment.currency ||
+      (candidateChargeCurrency !== undefined && candidateChargeCurrency !== functionalCurrencyCode) ||
+      payment.paymentAllocations.some(
+        (allocation) => allocation.charge.currency !== functionalCurrencyCode,
+      )
+    ) {
+      throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED' });
+    }
+    functionalConsumedMinor = payment.paymentAllocations.reduce(
+      (sum, allocation) => sum + allocation.amount,
+      0,
+    );
+  }
+
+  const originalConsumedMinor = payment.paymentAllocations.reduce((sum, allocation) => {
+    if (allocation.paymentOriginalAmountMinor !== null) {
+      return sum + allocation.paymentOriginalAmountMinor;
+    }
+    if (allocation.charge.currency === payment.currency) return sum + allocation.amount;
+    return sum;
+  }, 0);
+
+  return {
+    kind: 'CANONICAL',
+    aggregate: {
+      mode,
+      originalConsumedMinor,
+      originalRemainingMinor: payment.amount - originalConsumedMinor,
+      functionalConsumedMinor,
+      functionalRemainingMinor: functionalConsumedMinor === null || payment.functionalAmountMinor === null
+        ? null
+        : payment.functionalAmountMinor - functionalConsumedMinor,
+    },
+  };
+}
+
+export function aggregatePaymentSideAllocations(
+  payment: PaymentSideAggregateInput,
+  candidateChargeCurrency?: string,
+): PaymentSideAllocationAggregate {
+  const classification = classifyPaymentSideAllocations(payment, candidateChargeCurrency);
+  if (classification.kind === 'MIXED') {
+    throw new UnprocessableEntityException({
+      statusCode: 422,
+      error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED',
+    });
+  }
+  if (classification.kind === 'UNRESOLVED_LEGACY_CROSS') {
+    throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED' });
+  }
+  return classification.aggregate;
 }
 
 export async function lockPaymentForAllocation(
@@ -174,35 +289,15 @@ export async function reconcilePaymentWhenConsumed(
     !payment ||
     (payment.status !== PaymentStatus.APPROVED && payment.status !== PaymentStatus.RECONCILED)
   ) return;
-  const allocationMode = assertPaymentAllocationCurrencyMode(
-    payment.currency,
-    payment.paymentAllocations,
-  );
-  const snapshotState = classifyFunctionalSnapshot(payment);
-  if (snapshotState === 'PARTIAL_INVALID') return;
-
-  let originalConsumed = 0;
-  let functionalConsumed = 0;
-  for (const allocation of payment.paymentAllocations) {
-    const sameCurrency = allocation.charge.currency === payment.currency;
-    if (allocation.paymentOriginalAmountMinor !== null) {
-      originalConsumed += allocation.paymentOriginalAmountMinor;
-    } else if (sameCurrency) {
-      originalConsumed += allocation.amount;
-    }
-    if (!sameCurrency && allocation.charge.currency === payment.functionalCurrencyCode) {
-      functionalConsumed += allocation.amount;
-    }
-  }
+  if (classifyFunctionalSnapshot(payment) === 'PARTIAL_INVALID') return;
+  const aggregate = aggregatePaymentSideAllocations(payment);
 
   const allPaid = payment.paymentAllocations.every(
     (allocation) => allocation.charge.status === ChargeStatus.PAID,
   );
-  const completelyConsumed = allocationMode === 'CROSS'
-    ? snapshotState === 'COMPLETE' &&
-      originalConsumed === payment.amount &&
-      functionalConsumed === payment.functionalAmountMinor
-    : allocationMode === 'SAME' && originalConsumed === payment.amount;
+  const completelyConsumed = aggregate.mode === 'CROSS'
+    ? aggregate.originalRemainingMinor === 0 && aggregate.functionalRemainingMinor === 0
+    : aggregate.mode === 'SAME' && aggregate.originalRemainingMinor === 0;
   const nextStatus = allPaid && completelyConsumed
     ? PaymentStatus.RECONCILED
     : PaymentStatus.APPROVED;
@@ -210,6 +305,34 @@ export async function reconcilePaymentWhenConsumed(
     await tx.payment.update({
       where: { id: paymentId },
       data: { status: nextStatus, updatedAt: new Date() },
+    });
+  }
+}
+
+async function reconcilePaymentAfterAllocationDelete(
+  tx: Prisma.TransactionClient,
+  paymentId: string,
+): Promise<void> {
+  const payment = await tx.payment.findUnique({
+    where: { id: paymentId },
+    include: {
+      paymentAllocations: { include: { charge: { select: { currency: true, status: true } } } },
+    },
+  });
+  if (
+    !payment ||
+    (payment.status !== PaymentStatus.APPROVED && payment.status !== PaymentStatus.RECONCILED)
+  ) return;
+
+  const classification = classifyPaymentSideAllocations(payment);
+  if (classification.kind === 'CANONICAL') {
+    await reconcilePaymentWhenConsumed(tx, paymentId);
+    return;
+  }
+  if (payment.status === PaymentStatus.RECONCILED) {
+    await tx.payment.update({
+      where: { id: paymentId },
+      data: { status: PaymentStatus.APPROVED, updatedAt: new Date() },
     });
   }
 }
@@ -243,7 +366,7 @@ export async function deleteLockedAllocation(
   const deleted = await tx.paymentAllocation.deleteMany({ where: { id: allocationId, tenantId } });
   if (deleted.count !== 1) throw notFound();
   await recalculateLockedCharge(tx, allocation.chargeId);
-  await reconcilePaymentWhenConsumed(tx, allocation.paymentId);
+  await reconcilePaymentAfterAllocationDelete(tx, allocation.paymentId);
   return allocation;
 }
 
@@ -257,12 +380,6 @@ export async function createLockedAllocation(
   await lockChargesForAllocation(tx, scope.tenantId, scope.buildingId, [scope.chargeId]);
   const charge = await loadLockedCharge(tx, scope);
 
-  assertPaymentAllocationCurrencyMode(
-    payment.currency,
-    payment.paymentAllocations,
-    charge.currency,
-  );
-
   if (payment.status !== PaymentStatus.APPROVED && payment.status !== PaymentStatus.RECONCILED) {
     throw new ConflictException(`Cannot allocate payment in status ${payment.status}`);
   }
@@ -270,38 +387,22 @@ export async function createLockedAllocation(
     throw new ConflictException('Allocation already exists for this payment/charge pair');
   }
 
-  const originalConsumed = payment.paymentAllocations.reduce((sum, allocation) => {
-    if (allocation.paymentOriginalAmountMinor !== null) return sum + allocation.paymentOriginalAmountMinor;
-    return allocation.charge.currency === payment.currency ? sum + allocation.amount : sum;
-  }, 0);
+  const aggregate = aggregatePaymentSideAllocations(payment, charge.currency);
+  const originalConsumed = aggregate.originalConsumedMinor;
   if (originalConsumed > payment.amount) {
     throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_ORIGINAL_AMOUNT_EXCEEDED' });
   }
   const sameCurrency = payment.currency === charge.currency;
   let originalShare = amount;
   if (!sameCurrency) {
-    const snapshotState = classifyFunctionalSnapshot(payment);
-    if (snapshotState === 'LEGACY_NULL') {
-      throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED' });
-    }
-    if (snapshotState !== 'COMPLETE') {
+    const functionalRemaining = aggregate.functionalRemainingMinor;
+    const functionalAmountMinor = payment.functionalAmountMinor;
+    if (functionalRemaining === null || functionalAmountMinor === null) {
       throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_FUNCTIONAL_SNAPSHOT_INVALID' });
     }
-    if (payment.functionalCurrencyCode !== charge.currency || payment.functionalAmountMinor === null) {
-      throw new UnprocessableEntityException({ statusCode: 422, error: 'PAYMENT_ALLOCATION_CURRENCY_NOT_SUPPORTED' });
-    }
-    const functionalConsumed = payment.paymentAllocations.reduce(
-      (sum, allocation) =>
-        allocation.charge.currency === payment.functionalCurrencyCode &&
-        allocation.charge.currency !== payment.currency
-          ? sum + allocation.amount
-          : sum,
-      0,
-    );
-    const functionalRemaining = payment.functionalAmountMinor - functionalConsumed;
     const originalRemaining = payment.amount - originalConsumed;
     const originalBackedFunctional = new Prisma.Decimal(originalRemaining)
-      .mul(payment.functionalAmountMinor)
+      .mul(functionalAmountMinor)
       .div(payment.amount)
       .toDecimalPlaces(0, Prisma.Decimal.ROUND_DOWN)
       .toNumber();


### PR DESCRIPTION
## Summary

Implements Phase 3E4 currency-safe aggregation semantics for Payments,
Charges and PaymentAllocations.

This change centralizes Payment-side aggregation so original and functional
currency dimensions are never mixed.

## What changed

- adds canonical Payment-side allocation aggregation;
- preserves `PaymentAllocation.amount` as Charge-side currency;
- uses `paymentOriginalAmountMinor` for Payment original consumption;
- allows legacy SAME fallback only when Payment and Charge currencies match;
- keeps legacy CROSS NULL fail-closed;
- keeps read/create/reconcile paths fail-closed for unresolved legacy CROSS;
- allows progressive DELETE cleanup of unresolved legacy allocations without
  inventing FX or original consumption;
- keeps unresolved Payments conservatively non-RECONCILED during cleanup;
- returns to canonical reconciliation once the ledger becomes demonstrable;
- fixes `getUnitLedger().payments[].allocated` so it is expressed in
  `Payment.currency`;
- preserves Charge-side accounting semantics and SUBMITTED reservation
  capacity behavior.

## Local validation

- Payment allocation transaction tests: 25 PASS
- FinanzasService tests: 118 PASS
- Finance suite: 976 PASS, 20 SKIP
- PostgreSQL 3E4: 8 PASS
- PostgreSQL 3E3 compatibility: 8 PASS
- mixed cleanup: PASS
- multi-legacy cleanup: PASS
- API typecheck: PASS
- Web typecheck: PASS
- Lint: PASS
- Prisma validate: PASS
- Contracts build: PASS
- Permissions build: PASS
- API build: PASS
- Web build: PASS
- git diff --check: PASS

## Review

Independent senior review:

- P0: 0
- P1: 0
- P2: 0
- P3: 2 pre-existing/non-blocking notes

`R3-001` was independently adjudicated as invalid because allowing a legacy
CROSS allocation with `paymentOriginalAmountMinor = NULL` to produce an
original-currency `allocated` value would require inventing or assuming
financial data.

Gentle AI did NOT approve this candidate.
Its correction/recovery flow was blocked by its context/history protection
mechanism, so no Gentle approval or bypass is claimed.

## Out of scope

- dashboards
- reports
- KPIs
- delinquency
- aging
- global balances
- cross-building aggregates
- Phase 3F
- frontend redesign
- schema changes
- migrations
- backfills

Closes #148