### PR TITLE
chore(tooling): make Gentle review advisory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,14 @@ gentle-ai review mode disable --scope clone
 
 This disables receipt-driven review only for this BuildingOS clone; it must never be applied automatically to other repositories (CocinaCore, JurisManager, etc.), which keep their own default mode.
 
+The versioned pre-commit gate is installed per clone with:
+
+```bash
+./scripts/install-git-hooks.sh
+```
+
+This sets repo-local `core.hooksPath` to `scripts/git-hooks`, wiring the safety gate (blocking) and the Gentle advisory wrapper (non-blocking). It is repo-local and never affects other repositories.
+
 ## Regla obligatoria: desarrollo local antes de staging
 
 Todo desarrollo en BuildingOS se realiza localmente antes de cualquier interacción con staging.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,23 @@
 - Never say "listo" without validation, or clarify that validation was not performed.
 - GitHub Actions build, lint, test, and E2E jobs declared in `.github/workflows/` are preauthorized quality gates for CI alignment work. This does not authorize deploys, VPS access, staging, production, or remote migrations.
 
+## Gentle AI is advisory and non-blocking
+
+Gentle AI (including the repository AI-review gate) is **advisory and non-blocking**.
+
+- Its findings must be adjudicated independently; they are not auto-approvals.
+- An internal Gentle tool error (provider failure, history/context protection, receipt binding failure, reviewer execution failure, scope-changed, etc.) never blocks development, commit, push, PR, CI, or merge.
+- The normal quality gates remain **blocking and mandatory**: tests, typecheck, lint, build, E2E, and CI.
+- Gentle AI may return to `required` only after demonstrated stability; until then treat any Gentle failure as an advisory warning.
+
+The external `gentle-ai` CLI override is **clone-scoped, not global**: apply it per BuildingOS clone with
+
+```bash
+gentle-ai review mode disable --scope clone
+```
+
+This disables receipt-driven review only for this BuildingOS clone; it must never be applied automatically to other repositories (CocinaCore, JurisManager, etc.), which keep their own default mode.
+
 ## Regla obligatoria: desarrollo local antes de staging
 
 Todo desarrollo en BuildingOS se realiza localmente antes de cualquier interacción con staging.

--- a/scripts/gentle-advisory.sh
+++ b/scripts/gentle-advisory.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Gentle AI advisory wrapper (non-blocking review gate).
+#
+# Gentle AI is ADVISORY and NON-BLOCKING. This wrapper runs the AI review
+# command (e.g. `gga run` for the repository pre-commit review) and converts
+# every outcome into an advisory warning instead of a hard failure.
+#
+# Outcomes:
+#   - GENTLE PASS        -> log PASS, continue (exit 0)
+#   - GENTLE FINDING     -> keep findings on stdout, log advisory, continue (exit 0)
+#   - GENTLE TOOL ERROR  -> log tool error, continue (exit 0)
+#
+# The normal quality gates (tests, typecheck, lint, build, E2E, CI) remain
+# BLOCKING and are NOT routed through this wrapper.
+#
+# Configuration (environment):
+#   GENTLE_COMMAND   AI review command to run (default: gga run)
+#   GENTLE_PROVIDER  provider hint passed to the review tool, if supported
+#   GENTLE_TIMEOUT   timeout hint passed to the review tool, if supported
+#   GENTLE_DISABLED  set to "1" to skip the review entirely (still non-blocking)
+#
+# The wrapper always exits 0. Callers that need the real exit code for
+# reporting must capture stdout/stderr themselves.
+
+set -uo pipefail
+
+GENTLE_COMMAND="${GENTLE_COMMAND:-gga run}"
+GENTLE_PROVIDER="${GENTLE_PROVIDER:-codex}"
+GENTLE_TIMEOUT="${GENTLE_TIMEOUT:-240}"
+
+log() {
+  echo "[gentle-advisory] $*"
+}
+
+if [ "${GENTLE_DISABLED:-0}" = "1" ]; then
+  log "GENTLE NOT RUN (disabled by GENTLE_DISABLED=1) - advisory, continuing"
+  exit 0
+fi
+
+log "Running advisory AI review: ${GENTLE_COMMAND} (provider=${GENTLE_PROVIDER}, timeout=${GENTLE_TIMEOUT}s)"
+
+set +e
+GGA_PROVIDER="$GENTLE_PROVIDER" GGA_TIMEOUT="$GENTLE_TIMEOUT" $GENTLE_COMMAND
+REVIEW_EXIT=$?
+set -e
+
+if [ "$REVIEW_EXIT" -eq 0 ]; then
+  log "GENTLE PASS - advisory, continuing"
+  exit 0
+fi
+
+# GENTLE FINDING or GENTLE TOOL ERROR: both are advisory. Findings were already
+# printed to stdout by the review tool and remain available for independent
+# adjudication. A tool error (provider failure, context/history protection,
+# receipt binding failure, reviewer execution failure, ...) must not block.
+log "GENTLE review finished with exit ${REVIEW_EXIT} - ADVISORY WARNING, continuing"
+log "Findings (if any) are available above; they require independent adjudication."
+log "An internal Gentle tool error never blocks delivery."
+
+exit 0

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Versioned pre-commit hook installed via `scripts/install-git-hooks.sh`
+# (which sets repo-local core.hooksPath to this directory).
+#
+# Order of gates:
+#   1. SAFETY  (scripts/pre-commit-deny-dangerous.sh)  -> BLOCKING
+#   2. GENTLE  (scripts/gentle-advisory.sh)            -> ADVISORY / NON-BLOCKING
+
+# ======== DANGEROUS COMMANDS CHECK (BLOCKING - safety gate) ========
+./scripts/pre-commit-deny-dangerous.sh || exit 1
+
+# ======== GENTLE AI REVIEW (ADVISORY - non-blocking) ========
+# Gentle AI is advisory and non-blocking. Its findings require independent
+# adjudication, and an internal Gentle tool error never blocks commit/push.
+# The wrapper always exits 0; the normal quality gates (tests, typecheck,
+# lint, build, E2E, CI) remain blocking and are not part of this hook.
+if [ -x ./scripts/gentle-advisory.sh ]; then
+  ./scripts/gentle-advisory.sh
+else
+  echo "[pre-commit] gentle-advisory.sh not found; skipping advisory review"
+fi
+
+exit 0

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# Install the versioned BuildingOS git hooks into the CURRENT clone only.
+#
+# Sets repo-local core.hooksPath to scripts/git-hooks so every developer and
+# every fresh clone gets the same pre-commit gate:
+#   1. SAFETY  (pre-commit-deny-dangerous.sh)  -> BLOCKING
+#   2. GENTLE  (gentle-advisory.sh)            -> ADVISORY / NON-BLOCKING
+#
+# Repo-local only: never touches global git config, never affects other
+# repositories (CocinaCore, JurisManager, etc.).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ ! -f "$REPO_ROOT/scripts/git-hooks/pre-commit" ]; then
+  echo "ERROR: $REPO_ROOT/scripts/git-hooks/pre-commit not found" >&2
+  exit 1
+fi
+
+git config core.hooksPath scripts/git-hooks
+
+echo "Installed BuildingOS git hooks (repo-local core.hooksPath=scripts/git-hooks)"
+echo "Safety gate (pre-commit-deny-dangerous.sh) is BLOCKING."
+echo "Gentle review (gentle-advisory.sh) is ADVISORY / NON-BLOCKING."


### PR DESCRIPTION
## Summary
- makes the repo-local Gentle/GGA pre-commit review advisory
- preserves findings/output for independent adjudication
- documents BuildingOS clone-local `gentle-ai review mode disable --scope clone`
- leaves normal quality/security gates blocking

## Safety
- no application/finance/schema/migration changes
- no Gentle lineage/receipt/correction changes
- no staging or production changes
- clone-local Gentle override does not affect other projects

## Validation
- local review P0/P1/P2 = 0/0/0
- `git diff --check` PASS
- shell syntax PASS
- Gentle pass/failure simulations continue
- safety hook failure remains blocking

## Non-blocking review notes (P3)
1. empty `GENTLE_COMMAND` edge case can false-PASS
2. intentional unquoted command expansion lacks inline annotation