### PR TITLE
fix(finance): add currency-safe charge aggregation foundation

### DIFF
--- a/apps/api/src/assistant/assistant-debt-calculator.service.ts
+++ b/apps/api/src/assistant/assistant-debt-calculator.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PaymentStatus } from '@prisma/client';
+import { calculateChargeOutstandingMinor } from '../finanzas/charge-aggregation';
 
 export interface AssistantDebtAllocation {
   readonly amount: number;
@@ -15,14 +16,11 @@ export interface AssistantDebtCharge {
 @Injectable()
 export class AssistantDebtCalculatorService {
   /**
-   * Calculate outstanding debt for a single charge.
+   * Calculate outstanding debt for a single charge (Charge.currency, minor units).
+   * Delegates to the canonical Phase 3F charge-aggregation helper.
    */
   calculateChargeOutstanding(charge: AssistantDebtCharge): number {
-    const approvedAllocated = charge.paymentAllocations.reduce((sum, allocation) => {
-      return this.isApprovedAllocation(allocation) ? sum + allocation.amount : sum;
-    }, 0);
-
-    return Math.max(0, charge.amount - approvedAllocated);
+    return calculateChargeOutstandingMinor(charge);
   }
 
   /**
@@ -48,10 +46,5 @@ export class AssistantDebtCalculatorService {
     }
 
     return debtByUnit;
-  }
-
-  private isApprovedAllocation(allocation: AssistantDebtAllocation): boolean {
-    const status = allocation.payment?.status;
-    return status === PaymentStatus.APPROVED || status === PaymentStatus.RECONCILED;
   }
 }

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -12,6 +12,7 @@ import {
   BuildingAlert,
 } from './dashboard.dto';
 import { PaymentStatus, ChargeStatus, TicketStatus, Prisma } from '@prisma/client';
+import { calculateChargeOutstandingMinor } from '../finanzas/charge-aggregation';
 
 interface UnitWithOccupants extends Prisma.UnitGetPayload<{
   include: { unitOccupants: true; building: { select: { name: true } } };
@@ -174,7 +175,7 @@ export class DashboardService {
       return {
         charge,
         allocated: approvedAllocated,
-        outstanding: Math.max(0, charge.amount - approvedAllocated),
+        outstanding: calculateChargeOutstandingMinor(charge),
       };
     });
 

--- a/apps/api/src/finanzas/charge-aggregation.spec.ts
+++ b/apps/api/src/finanzas/charge-aggregation.spec.ts
@@ -1,0 +1,215 @@
+import {
+  calculateChargeOutstandingMinor,
+  sumByCurrency,
+} from './charge-aggregation';
+import { ChargeStatus, PaymentStatus } from '@prisma/client';
+
+describe('calculateChargeOutstandingMinor', () => {
+  const effectiveApproved = { payment: { status: PaymentStatus.APPROVED } };
+  const effectiveReconciled = { payment: { status: PaymentStatus.RECONCILED } };
+  const submitted = { payment: { status: PaymentStatus.SUBMITTED } };
+  const rejected = { payment: { status: PaymentStatus.REJECTED } };
+
+  function charge(amount: number, allocations: Array<{ amount: number; payment?: { status?: string | null } | null }> = []) {
+    return { amount, paymentAllocations: allocations };
+  }
+
+  it('A: no allocations -> full amount', () => {
+    expect(calculateChargeOutstandingMinor(charge(10000))).toBe(10000);
+  });
+
+  it('B: APPROVED allocation 4000 of 10000 -> 6000', () => {
+    expect(
+      calculateChargeOutstandingMinor(charge(10000, [{ amount: 4000, ...effectiveApproved }])),
+    ).toBe(6000);
+  });
+
+  it('C: RECONCILED allocation 10000 of 10000 -> 0', () => {
+    expect(
+      calculateChargeOutstandingMinor(charge(10000, [{ amount: 10000, ...effectiveReconciled }])),
+    ).toBe(0);
+  });
+
+  it('D: SUBMITTED allocation 7000 of 10000 -> accounting outstanding 10000', () => {
+    expect(
+      calculateChargeOutstandingMinor(charge(10000, [{ amount: 7000, ...submitted }])),
+    ).toBe(10000);
+  });
+
+  it('E: APPROVED 3000 + SUBMITTED 7000 of 10000 -> 7000', () => {
+    expect(
+      calculateChargeOutstandingMinor(
+        charge(10000, [
+          { amount: 3000, ...effectiveApproved },
+          { amount: 7000, ...submitted },
+        ]),
+      ),
+    ).toBe(7000);
+  });
+
+  it('F: CROSS charge-side (allocation in Charge.currency only) -> 0, never mixes Payment original', () => {
+    // Charge 182500 ARS, allocation.amount = 182500 ARS (Charge.currency),
+    // paymentOriginalAmountMinor = 5000 USD is NOT part of the input.
+    expect(
+      calculateChargeOutstandingMinor(
+        charge(182500, [{ amount: 182500, ...effectiveApproved }]),
+      ),
+    ).toBe(0);
+  });
+
+  it('G: REJECTED allocation does not reduce outstanding', () => {
+    expect(
+      calculateChargeOutstandingMinor(charge(10000, [{ amount: 10000, ...rejected }])),
+    ).toBe(10000);
+  });
+
+  it('allocation without payment relation is ignored', () => {
+    expect(calculateChargeOutstandingMinor(charge(10000, [{ amount: 5000 }]))).toBe(10000);
+  });
+
+  it('null payment status is ignored', () => {
+    expect(
+      calculateChargeOutstandingMinor(charge(10000, [{ amount: 5000, payment: { status: null } }])),
+    ).toBe(10000);
+  });
+
+  it('mixed effective and non-effective statuses', () => {
+    expect(
+      calculateChargeOutstandingMinor(
+        charge(10000, [
+          { amount: 3000, ...effectiveApproved },
+          { amount: 2000, ...effectiveReconciled },
+          { amount: 4000, ...submitted },
+          { amount: 1000, ...rejected },
+        ]),
+      ),
+    ).toBe(5000);
+  });
+
+  it('over-allocated charge clamps to 0 (never negative)', () => {
+    expect(
+      calculateChargeOutstandingMinor(charge(10000, [{ amount: 15000, ...effectiveApproved }])),
+    ).toBe(0);
+  });
+
+  it('zero-amount charge stays 0', () => {
+    expect(calculateChargeOutstandingMinor(charge(0))).toBe(0);
+    expect(
+      calculateChargeOutstandingMinor(charge(0, [{ amount: 0, ...effectiveApproved }])),
+    ).toBe(0);
+  });
+
+  it('empty/null paymentAllocations treated as no allocations', () => {
+    expect(calculateChargeOutstandingMinor({ amount: 5000, paymentAllocations: null })).toBe(5000);
+    expect(calculateChargeOutstandingMinor({ amount: 5000, paymentAllocations: undefined })).toBe(5000);
+  });
+
+  it('does not use paymentOriginalAmountMinor or Payment.amount (not part of input contract)', () => {
+    // The input contract has no original-side fields; this is a compile-time
+    // guarantee via the ChargeOutstandingInput interface. Behavior is proven
+    // by CROSS test F above.
+    expect(calculateChargeOutstandingMinor(charge(10000, []))).toBe(10000);
+  });
+
+  it('ChargeStatus of the charge itself does not alter outstanding (derived from allocations)', () => {
+    // Outstanding is computed from amount minus effective allocations
+    // regardless of the charge.status column.
+    expect(
+      calculateChargeOutstandingMinor(charge(10000, [{ amount: 4000, ...effectiveApproved }])),
+    ).toBe(6000);
+    void ChargeStatus; // imported enum documented as not used by the helper
+  });
+});
+
+describe('sumByCurrency', () => {
+  it('single currency ARS', () => {
+    expect(
+      sumByCurrency([
+        { currency: 'ARS', amountMinor: 100 },
+        { currency: 'ARS', amountMinor: 200 },
+      ]),
+    ).toEqual([{ currency: 'ARS', amountMinor: 300 }]);
+  });
+
+  it('single currency USD', () => {
+    expect(sumByCurrency([{ currency: 'USD', amountMinor: 500 }])).toEqual([
+      { currency: 'USD', amountMinor: 500 },
+    ]);
+  });
+
+  it('single currency VES', () => {
+    expect(sumByCurrency([{ currency: 'VES', amountMinor: 700 }])).toEqual([
+      { currency: 'VES', amountMinor: 700 },
+    ]);
+  });
+
+  it('single currency COP', () => {
+    expect(sumByCurrency([{ currency: 'COP', amountMinor: 900 }])).toEqual([
+      { currency: 'COP', amountMinor: 900 },
+    ]);
+  });
+
+  it('ARS + USD stays separate', () => {
+    expect(
+      sumByCurrency([
+        { currency: 'ARS', amountMinor: 1000 },
+        { currency: 'USD', amountMinor: 2000 },
+      ]),
+    ).toEqual([
+      { currency: 'USD', amountMinor: 2000 },
+      { currency: 'ARS', amountMinor: 1000 },
+    ]);
+  });
+
+  it('all four canonical currencies stay separate', () => {
+    expect(
+      sumByCurrency([
+        { currency: 'USD', amountMinor: 1 },
+        { currency: 'VES', amountMinor: 2 },
+        { currency: 'COP', amountMinor: 3 },
+        { currency: 'ARS', amountMinor: 4 },
+      ]),
+    ).toEqual([
+      { currency: 'USD', amountMinor: 1 },
+      { currency: 'VES', amountMinor: 2 },
+      { currency: 'ARS', amountMinor: 4 },
+      { currency: 'COP', amountMinor: 3 },
+    ]);
+  });
+
+  it('input order does not change the result', () => {
+    const a = [
+      { currency: 'USD', amountMinor: 10 },
+      { currency: 'ARS', amountMinor: 20 },
+      { currency: 'USD', amountMinor: 30 },
+    ];
+    const b = [
+      { currency: 'USD', amountMinor: 30 },
+      { currency: 'USD', amountMinor: 10 },
+      { currency: 'ARS', amountMinor: 20 },
+    ];
+    expect(sumByCurrency(a)).toEqual(sumByCurrency(b));
+  });
+
+  it('zero amounts are preserved per currency', () => {
+    expect(sumByCurrency([{ currency: 'ARS', amountMinor: 0 }])).toEqual([
+      { currency: 'ARS', amountMinor: 0 },
+    ]);
+  });
+
+  it('empty input -> empty buckets', () => {
+    expect(sumByCurrency([])).toEqual([]);
+  });
+
+  it('unsupported currency fails fast (no unlabeled total)', () => {
+    expect(() =>
+      sumByCurrency([{ currency: 'UYU', amountMinor: 100 }]),
+    ).toThrow('unsupported currency "UYU"');
+  });
+
+  it('missing currency fails fast', () => {
+    expect(() =>
+      sumByCurrency([{ currency: '', amountMinor: 100 }]),
+    ).toThrow('unsupported currency ""');
+  });
+});

--- a/apps/api/src/finanzas/charge-aggregation.ts
+++ b/apps/api/src/finanzas/charge-aggregation.ts
@@ -1,0 +1,91 @@
+import { isEffectivePaymentStatus } from './payment-status-semantics';
+import {
+  CANONICAL_CURRENCIES,
+  isCanonicalCurrency,
+  type CanonicalCurrency,
+} from '@buildingos/contracts';
+
+/**
+ * Phase 3F foundation — currency-safe charge-side aggregation.
+ *
+ * Contract:
+ * - Charge.amount is expressed in Charge.currency (integer minor units).
+ * - PaymentAllocation.amount is expressed in the SAME Charge.currency.
+ * - Charge outstanding (reportable/accounting) =
+ *     Charge.amount - SUM(PaymentAllocation.amount WHERE Payment.status is
+ *     accounting-effective).
+ * - Accounting-effective = APPROVED | RECONCILED (see payment-status-semantics).
+ * - SUBMITTED reservations, REJECTED, CANCELED never reduce outstanding.
+ * - paymentOriginalAmountMinor, Payment.amount, Payment.currency and
+ *   Payment.functionalAmountMinor NEVER participate in charge-side math.
+ * - No ExchangeRate lookup, no live FX, no floats.
+ */
+
+export interface ChargeOutstandingInputAllocation {
+  readonly amount: number;
+  readonly payment?: { readonly status?: string | null } | null;
+}
+
+export interface ChargeOutstandingInput {
+  readonly amount: number;
+  readonly paymentAllocations?: readonly ChargeOutstandingInputAllocation[] | null;
+}
+
+/**
+ * Calculate reportable/accounting outstanding for a single charge,
+ * expressed in Charge.currency (integer minor units).
+ *
+ * Clamping: returns Math.max(0, ...) — never negative — matching the
+ * dominant existing contract across BuildingOS callers.
+ */
+export function calculateChargeOutstandingMinor(charge: ChargeOutstandingInput): number {
+  const effectiveAllocated = (charge.paymentAllocations ?? []).reduce(
+    (sum, allocation) =>
+      isEffectivePaymentStatus(allocation.payment?.status)
+        ? sum + allocation.amount
+        : sum,
+    0,
+  );
+  return Math.max(0, charge.amount - effectiveAllocated);
+}
+
+/**
+ * A deterministic currency bucket: an amount expressed in one currency,
+ * integer minor units. Never mix currencies inside a single bucket.
+ */
+export interface CurrencyAmountBucket {
+  readonly currency: CanonicalCurrency;
+  readonly amountMinor: number;
+}
+
+export interface CurrencyAmountInput {
+  readonly currency: string;
+  readonly amountMinor: number;
+}
+
+/**
+ * Aggregate integer minor amounts grouped by currency, preserving each
+ * currency's own dimension. Never converts, never sums across currencies,
+ * never invents a fallback currency.
+ *
+ * A missing/unknown currency fails fast (throws) instead of producing an
+ * unlabeled total. Order of buckets follows CANONICAL_CURRENCIES so output
+ * is deterministic regardless of input order. Only amounts for canonical
+ * currencies are aggregated; any other value is rejected.
+ */
+export function sumByCurrency(items: readonly CurrencyAmountInput[]): CurrencyAmountBucket[] {
+  const totals = new Map<CanonicalCurrency, number>();
+
+  for (const item of items) {
+    if (!isCanonicalCurrency(item.currency)) {
+      throw new Error(`sumByCurrency: unsupported currency "${item.currency}"`);
+    }
+    const current = totals.get(item.currency) ?? 0;
+    totals.set(item.currency, current + item.amountMinor);
+  }
+
+  return CANONICAL_CURRENCIES.filter((currency) => totals.has(currency)).map((currency) => ({
+    currency,
+    amountMinor: totals.get(currency) as number,
+  }));
+}

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -24,6 +24,7 @@ import {
   recalculateLockedCharge,
   reconcilePaymentWhenConsumed,
 } from './payment-allocation-transaction';
+import { calculateChargeOutstandingMinor } from './charge-aggregation';
 import { acquirePaymentLinkedDocumentLock } from '../common/payment-linked-document-lock';
 import { isEffectivePaymentStatus as isEffectivePaymentStatusShared } from './payment-status-semantics';
 import type { Role, ScopedRole } from '@buildingos/contracts';
@@ -1484,15 +1485,7 @@ export class FinanzasService {
   }
 
   private calculateApprovedChargeOutstanding(charge: ChargeWithAllocations): number {
-    const approvedAllocated = charge.paymentAllocations.reduce((sum, allocation) => {
-      if (this.isEffectivePaymentStatus(allocation.payment?.status)) {
-        return sum + allocation.amount;
-      }
-
-      return sum;
-    }, 0);
-
-    return Math.max(0, charge.amount - approvedAllocated);
+    return calculateChargeOutstandingMinor(charge);
   }
 
   private calculatePendingReservationAmount(
@@ -1896,7 +1889,7 @@ export class FinanzasService {
       return {
         charge: c,
         allocated,
-        outstanding: Math.max(0, c.amount - allocated),
+        outstanding: calculateChargeOutstandingMinor(c),
       };
     });
 
@@ -2297,7 +2290,7 @@ export class FinanzasService {
       return {
         charge,
         approvedAllocated,
-        outstanding: Math.max(0, charge.amount - approvedAllocated),
+        outstanding: calculateChargeOutstandingMinor(charge),
       };
     });
 
@@ -2755,7 +2748,7 @@ export class FinanzasService {
       return {
         charge: c,
         allocated,
-        outstanding: Math.max(0, c.amount - allocated),
+        outstanding: calculateChargeOutstandingMinor(c),
       };
     });
 


### PR DESCRIPTION
## Summary

Closes #151

Phase 3F1 establishes the currency-safe aggregation foundation for financial reports and dashboards.

- adds canonical charge-side outstanding calculation
- counts only APPROVED / RECONCILED allocations as accounting-effective
- adds canonical currency bucket aggregation
- reuses the canonical USD/VES/ARS/COP contract
- replaces six semantically equivalent duplicated charge-outstanding formulas
- preserves all existing public API contracts

## Currency semantics

`Charge.amount`
→ Charge.currency

`PaymentAllocation.amount`
→ Charge.currency

Not used for charge outstanding:

- Payment.amount
- paymentOriginalAmountMinor
- functionalAmountMinor
- live ExchangeRate lookup

SUBMITTED allocations do not reduce accounting outstanding.

## Local acceptance

- helper tests 26/26 PASS
- caller regression tests PASS
- finanzas.service 118/118 PASS
- finance suite no failures
- API typecheck PASS
- API lint PASS
- API build PASS
- CROSS harness PASS: USD Payment / ARS Charge produces 0 ARS outstanding
- multi-currency bucket harness PASS
- public contracts unchanged
- review P0/P1/P2/P3 = 0/0/0/0

## Out of scope

3F2–3F7 remain untouched.

## Safety

- no frontend changes
- no schema/migrations
- no DB mutation
- no FX-at-read
- no staging/production changes