### PR TITLE
fix(dashboard): make finance KPIs currency-safe

### DIFF
--- a/apps/api/src/dashboard/dashboard.controller.spec.ts
+++ b/apps/api/src/dashboard/dashboard.controller.spec.ts
@@ -73,9 +73,9 @@ describe('DashboardController admin summary access', () => {
   it('allows administrative roles with admin context and preserves the no-header compatible path', async () => {
     const summary: DashboardSummaryDto = {
       kpis: {
-        outstandingAmount: 1000,
-        collectedAmount: 200,
-        collectionRate: 20,
+        outstandingByCurrency: [{ currency: 'ARS', amountMinor: 1000 }],
+        collectedByCurrency: [{ currency: 'ARS', amountMinor: 200 }],
+        collectionRateByCurrency: [{ currency: 'ARS', rate: 20 }],
         delinquentUnits: 1,
       },
       queues: {

--- a/apps/api/src/dashboard/dashboard.dto.ts
+++ b/apps/api/src/dashboard/dashboard.dto.ts
@@ -1,5 +1,6 @@
 import { IsOptional, IsString } from 'class-validator';
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import type { CurrencyAmountBucket } from '../finanzas/charge-aggregation';
 
 export enum DashboardPeriod {
   CURRENT_MONTH = 'CURRENT_MONTH',
@@ -56,10 +57,15 @@ export interface BuildingAlert {
   riskScore: 'HIGH' | 'MEDIUM' | 'LOW';
 }
 
+export interface CollectionRateBucket {
+  readonly currency: string;
+  readonly rate: number;
+}
+
 export interface DashboardKpis {
-  outstandingAmount: number | null;
-  collectedAmount: number | null;
-  collectionRate: number | null;
+  outstandingByCurrency: CurrencyAmountBucket[];
+  collectedByCurrency: CurrencyAmountBucket[];
+  collectionRateByCurrency: CollectionRateBucket[];
   delinquentUnits: number | null;
 }
 

--- a/apps/api/src/dashboard/dashboard.service.spec.ts
+++ b/apps/api/src/dashboard/dashboard.service.spec.ts
@@ -96,4 +96,147 @@ describe('DashboardService', () => {
       ),
     ).toBe(true);
   });
+
+  function chargeFixture(overrides: Partial<{ id: string; amount: number; currency: string; unitId: string; paymentAllocations: unknown[] }> = {}) {
+    return {
+      id: 'charge-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      amount: 10000,
+      currency: 'ARS',
+      period: '2026-05',
+      paymentAllocations: [],
+      ...overrides,
+    };
+  }
+
+  function allocationFixture(amount: number, status: string, overrides: Record<string, unknown> = {}) {
+    return { id: `alloc-${amount}`, amount, payment: { status, ...overrides }, ...overrides };
+  }
+
+  it('KPI single currency: ARS charge with APPROVED+SUBMITTED allocations', async () => {
+    (prisma.charge.findMany as unknown as jest.Mock).mockResolvedValue([
+      chargeFixture({ amount: 10000, paymentAllocations: [
+        allocationFixture(3000, 'APPROVED'),
+        allocationFixture(7000, 'SUBMITTED'),
+      ] }),
+    ]);
+
+    const result = await service.getSummary('tenant-1', { period: '2026-05' });
+
+    expect(result.kpis.outstandingByCurrency).toEqual([{ currency: 'ARS', amountMinor: 7000 }]);
+    expect(result.kpis.collectedByCurrency).toEqual([{ currency: 'ARS', amountMinor: 3000 }]);
+    expect(result.kpis.collectionRateByCurrency).toEqual([{ currency: 'ARS', rate: 0.3 }]);
+    expect(result.kpis.delinquentUnits).toBe(1);
+  });
+
+  it('KPI multi-currency: ARS + USD + COP buckets stay separate', async () => {
+    (prisma.charge.findMany as unknown as jest.Mock).mockResolvedValue([
+      chargeFixture({ id: 'c-ars', amount: 10000, currency: 'ARS', unitId: 'u1', paymentAllocations: [
+        allocationFixture(4000, 'APPROVED'),
+      ] }),
+      chargeFixture({ id: 'c-usd', amount: 5000, currency: 'USD', unitId: 'u2', paymentAllocations: [
+        allocationFixture(5000, 'RECONCILED'),
+      ] }),
+      chargeFixture({ id: 'c-cop', amount: 40000, currency: 'COP', unitId: 'u3', paymentAllocations: [] }),
+    ]);
+
+    const result = await service.getSummary('tenant-1', { period: '2026-05' });
+
+    expect(result.kpis.outstandingByCurrency).toEqual([
+      { currency: 'USD', amountMinor: 0 },
+      { currency: 'ARS', amountMinor: 6000 },
+      { currency: 'COP', amountMinor: 40000 },
+    ]);
+    expect(result.kpis.collectedByCurrency).toEqual([
+      { currency: 'USD', amountMinor: 5000 },
+      { currency: 'ARS', amountMinor: 4000 },
+      { currency: 'COP', amountMinor: 0 },
+    ]);
+    expect(result.kpis.collectionRateByCurrency).toEqual([
+      { currency: 'USD', rate: 1 },
+      { currency: 'ARS', rate: 0.4 },
+      { currency: 'COP', rate: 0 },
+    ]);
+    expect(result.kpis.delinquentUnits).toBe(2);
+  });
+
+  it('KPI CROSS: uses allocation.amount in Charge.currency, never the Payment original share', async () => {
+    // Payment USD 5000, Charge ARS 182500, allocation.amount = 182500 ARS,
+    // paymentOriginalAmountMinor = 5000 USD. Charge-side outstanding uses ARS only.
+    (prisma.charge.findMany as unknown as jest.Mock).mockResolvedValue([
+      chargeFixture({ id: 'c-cross', amount: 182500, currency: 'ARS', paymentAllocations: [
+        allocationFixture(182500, 'APPROVED', { paymentOriginalAmountMinor: 5000 }),
+      ] }),
+    ]);
+
+    const result = await service.getSummary('tenant-1', { period: '2026-05' });
+
+    expect(result.kpis.outstandingByCurrency).toEqual([{ currency: 'ARS', amountMinor: 0 }]);
+    expect(result.kpis.collectedByCurrency).toEqual([{ currency: 'ARS', amountMinor: 182500 }]);
+    expect(result.kpis.collectionRateByCurrency).toEqual([{ currency: 'ARS', rate: 1 }]);
+  });
+
+  it('KPI SUBMITTED-only: does not reduce accounting outstanding', async () => {
+    (prisma.charge.findMany as unknown as jest.Mock).mockResolvedValue([
+      chargeFixture({ amount: 10000, paymentAllocations: [
+        allocationFixture(10000, 'SUBMITTED'),
+      ] }),
+    ]);
+
+    const result = await service.getSummary('tenant-1', { period: '2026-05' });
+
+    expect(result.kpis.outstandingByCurrency).toEqual([{ currency: 'ARS', amountMinor: 10000 }]);
+    expect(result.kpis.collectedByCurrency).toEqual([{ currency: 'ARS', amountMinor: 0 }]);
+    expect(result.kpis.collectionRateByCurrency).toEqual([{ currency: 'ARS', rate: 0 }]);
+    expect(result.kpis.delinquentUnits).toBe(1);
+  });
+
+  it('KPI overallocation: collected is bounded by Charge.amount', async () => {
+    (prisma.charge.findMany as unknown as jest.Mock).mockResolvedValue([
+      chargeFixture({ amount: 10000, paymentAllocations: [
+        allocationFixture(12000, 'APPROVED'),
+      ] }),
+    ]);
+
+    const result = await service.getSummary('tenant-1', { period: '2026-05' });
+
+    expect(result.kpis.outstandingByCurrency).toEqual([{ currency: 'ARS', amountMinor: 0 }]);
+    expect(result.kpis.collectedByCurrency).toEqual([{ currency: 'ARS', amountMinor: 10000 }]);
+    expect(result.kpis.collectionRateByCurrency).toEqual([{ currency: 'ARS', rate: 1 }]);
+  });
+
+  it('KPI multi-currency rates are independent per currency', async () => {
+    (prisma.charge.findMany as unknown as jest.Mock).mockResolvedValue([
+      chargeFixture({ id: 'c-ars', amount: 10000, currency: 'ARS', unitId: 'u1', paymentAllocations: [
+        allocationFixture(5000, 'APPROVED'),
+      ] }),
+      chargeFixture({ id: 'c-usd', amount: 2000, currency: 'USD', unitId: 'u2', paymentAllocations: [
+        allocationFixture(2000, 'RECONCILED'),
+      ] }),
+      chargeFixture({ id: 'c-cop', amount: 40000, currency: 'COP', unitId: 'u3', paymentAllocations: [
+        allocationFixture(10000, 'APPROVED'),
+      ] }),
+    ]);
+
+    const result = await service.getSummary('tenant-1', { period: '2026-05' });
+
+    expect(result.kpis.collectionRateByCurrency).toEqual([
+      { currency: 'USD', rate: 1 },
+      { currency: 'ARS', rate: 0.5 },
+      { currency: 'COP', rate: 0.25 },
+    ]);
+    // Never a mixed-currency global ratio: (5000+2000+10000)/(10000+2000+40000).
+    expect(result.kpis.collectionRateByCurrency).toHaveLength(3);
+  });
+
+  it('KPI empty: no monetary data -> empty buckets, no invented ARS', async () => {
+    const result = await service.getSummary('tenant-1', { period: '2026-05' });
+
+    expect(result.kpis.outstandingByCurrency).toEqual([]);
+    expect(result.kpis.collectedByCurrency).toEqual([]);
+    expect(result.kpis.collectionRateByCurrency).toEqual([]);
+    expect(result.kpis.delinquentUnits).toBe(0);
+  });
 });

--- a/apps/api/src/dashboard/dashboard.service.ts
+++ b/apps/api/src/dashboard/dashboard.service.ts
@@ -12,7 +12,7 @@ import {
   BuildingAlert,
 } from './dashboard.dto';
 import { PaymentStatus, ChargeStatus, TicketStatus, Prisma } from '@prisma/client';
-import { calculateChargeOutstandingMinor } from '../finanzas/charge-aggregation';
+import { calculateChargeOutstandingMinor, sumByCurrency } from '../finanzas/charge-aggregation';
 
 interface UnitWithOccupants extends Prisma.UnitGetPayload<{
   include: { unitOccupants: true; building: { select: { name: true } } };
@@ -179,10 +179,37 @@ export class DashboardService {
       };
     });
 
-    const totalChargesEmitted = chargesWithOutstanding.reduce((sum, item) => sum + item.charge.amount, 0);
-    const collected = chargesWithOutstanding.reduce((sum, item) => sum + item.allocated, 0);
-    const outstandingAmount = chargesWithOutstanding.reduce((sum, item) => sum + item.outstanding, 0);
-    const collectionRate = totalChargesEmitted > 0 ? collected / totalChargesEmitted : 0;
+    // Currency-safe buckets: every charge keeps its own Charge.currency.
+    const outstandingByCurrency = sumByCurrency(
+      chargesWithOutstanding.map((item) => ({
+        currency: item.charge.currency,
+        amountMinor: item.outstanding,
+      })),
+    );
+    // Collected is bounded by Charge.amount: an over-allocated charge can
+    // never produce collected > emitted. Same clamp contract as outstanding.
+    const collectedByCurrency = sumByCurrency(
+      chargesWithOutstanding.map((item) => ({
+        currency: item.charge.currency,
+        amountMinor: Math.max(0, item.charge.amount - item.outstanding),
+      })),
+    );
+    // Collection rate per currency: collected / emitted, both expressed in
+    // the same Charge.currency. Never a mixed-currency ratio.
+    const emittedByCurrency = new Map<string, number>();
+    for (const item of chargesWithOutstanding) {
+      emittedByCurrency.set(
+        item.charge.currency,
+        (emittedByCurrency.get(item.charge.currency) ?? 0) + item.charge.amount,
+      );
+    }
+    const collectionRateByCurrency = collectedByCurrency.map((bucket) => {
+      const emitted = emittedByCurrency.get(bucket.currency) ?? 0;
+      return {
+        currency: bucket.currency,
+        rate: emitted > 0 ? Math.round((bucket.amountMinor / emitted) * 1000) / 1000 : 0,
+      };
+    });
 
     // Delinquent units (units with outstanding > 0)
     const delinquentUnitsMap = new Map<string, number>();
@@ -194,9 +221,9 @@ export class DashboardService {
     }
 
     return {
-      outstandingAmount,
-      collectedAmount: collected,
-      collectionRate: Math.round(collectionRate * 1000) / 1000,
+      outstandingByCurrency,
+      collectedByCurrency,
+      collectionRateByCurrency,
       delinquentUnits: delinquentUnitsMap.size,
     };
   }

--- a/apps/web/app/(tenant)/[tenantId]/dashboard/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/dashboard/page.tsx
@@ -13,12 +13,12 @@ import { useDashboardSummary, useBuildingList } from "@/features/dashboard/hooks
 import { Table, THead, TBody, TR, TH, TD } from "@/shared/components/ui/Table";
 import { formatAccountingPeriodLabel, getCurrentAccountingPeriod } from "@/features/dashboard/utils/period";
 import { getTotalAccumulatedDebt } from "@/features/dashboard/utils/building-alerts";
+import { formatCurrencyBuckets } from "@/features/dashboard/utils/currency-buckets";
 import { ticketDetailPath } from "@/shared/lib/routes";
 import {
   AlertCircle,
   CheckCircle,
   DollarSign,
-  Percent,
   Home,
   Users,
   Wrench,
@@ -270,7 +270,9 @@ const AdminDashboard = ({ tenantId }: AdminDashboardProps) => {
   const totalAccumulatedDebt = getTotalAccumulatedDebt(buildingAlerts);
   const quickActions = summary?.quickActions || [];
 
-  const cr = kpis?.collectionRate ?? 0;
+  const cr = kpis?.collectionRateByCurrency && kpis.collectionRateByCurrency.length > 0
+    ? kpis.collectionRateByCurrency.reduce((sum, entry) => sum + entry.rate, 0) / kpis.collectionRateByCurrency.length
+    : 0;
   const crColor = collectionRateColor(cr);
   const sev = delinquentSeverity(kpis?.delinquentUnits ?? 0);
 
@@ -355,11 +357,11 @@ const AdminDashboard = ({ tenantId }: AdminDashboardProps) => {
         <KPICard
           label="Saldo pendiente del período"
           subtitle="Lo que queda por cobrar del período seleccionado."
-          value={kpis?.outstandingAmount != null ? formatARS(kpis.outstandingAmount) : '$0'}
-          badge={kpis?.outstandingAmount != null && kpis.outstandingAmount > 0
+          value={formatCurrencyBuckets(kpis?.outstandingByCurrency)}
+          badge={kpis?.outstandingByCurrency && kpis.outstandingByCurrency.length > 0
             ? { label: `${(kpis.delinquentUnits ?? 0)} unidades`, color: sev.text }
             : undefined}
-          color={kpis?.outstandingAmount != null && kpis.outstandingAmount > 0 ? 'text-orange-400' : 'text-green-400'}
+          color={kpis?.outstandingByCurrency && kpis.outstandingByCurrency.length > 0 ? 'text-orange-400' : 'text-green-400'}
           icon={<DollarSign className="w-5 h-5 text-current" />}
           cta="Ver morosidad"
           onClick={() => router.push(`/${tenantId}/finanzas`)}
@@ -367,12 +369,7 @@ const AdminDashboard = ({ tenantId }: AdminDashboardProps) => {
         <KPICard
           label="Cobrado del período"
           subtitle="Monto cobrado o aplicado durante el período seleccionado."
-          value={kpis?.collectedAmount != null ? formatARS(kpis.collectedAmount) : '$0'}
-          subValue={
-            kpis?.collectedAmount != null && (kpis.outstandingAmount ?? 0) + kpis.collectedAmount > 0
-              ? `de ${formatARS((kpis.outstandingAmount || 0) + kpis.collectedAmount)}`
-              : undefined
-          }
+          value={formatCurrencyBuckets(kpis?.collectedByCurrency)}
           color="text-green-400"
           icon={<TrendingUp className="w-5 h-5 text-current" />}
           cta="Ver cobros"
@@ -381,7 +378,9 @@ const AdminDashboard = ({ tenantId }: AdminDashboardProps) => {
         <KPICard
           label="Tasa de cobranza del período"
           subtitle="Porcentaje cobrado sobre el total esperado del período."
-          value={kpis?.collectionRate != null ? formatPercentage(kpis.collectionRate) : '0%'}
+          value={kpis?.collectionRateByCurrency && kpis.collectionRateByCurrency.length > 0
+            ? kpis.collectionRateByCurrency.map((entry) => `${entry.currency} ${formatPercentage(entry.rate)}`).join(' · ')
+            : '—'}
           badge={{ label: collectionRateLabel(cr), color: collectionRateIcon(cr).props.className || '' }}
           color={cr >= 0.8 ? 'text-green-400' : cr >= 0.5 ? 'text-yellow-400' : 'text-red-400'}
           icon={collectionRateIcon(cr)}

--- a/apps/web/app/(tenant)/[tenantId]/dashboard/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/dashboard/page.tsx
@@ -270,11 +270,12 @@ const AdminDashboard = ({ tenantId }: AdminDashboardProps) => {
   const totalAccumulatedDebt = getTotalAccumulatedDebt(buildingAlerts);
   const quickActions = summary?.quickActions || [];
 
-  const cr = kpis?.collectionRateByCurrency && kpis.collectionRateByCurrency.length > 0
-    ? kpis.collectionRateByCurrency.reduce((sum, entry) => sum + entry.rate, 0) / kpis.collectionRateByCurrency.length
-    : 0;
-  const crColor = collectionRateColor(cr);
+  const cr = kpis?.collectionRateByCurrency && kpis.collectionRateByCurrency.length === 1
+    ? kpis.collectionRateByCurrency[0]!.rate
+    : null;
+  const crColor = cr != null ? collectionRateColor(cr) : 'bg-muted';
   const sev = delinquentSeverity(kpis?.delinquentUnits ?? 0);
+  const hasOutstanding = (kpis?.outstandingByCurrency ?? []).some((bucket) => bucket.amountMinor > 0);
 
   return (
     <div className="space-y-6">
@@ -358,10 +359,10 @@ const AdminDashboard = ({ tenantId }: AdminDashboardProps) => {
           label="Saldo pendiente del período"
           subtitle="Lo que queda por cobrar del período seleccionado."
           value={formatCurrencyBuckets(kpis?.outstandingByCurrency)}
-          badge={kpis?.outstandingByCurrency && kpis.outstandingByCurrency.length > 0
-            ? { label: `${(kpis.delinquentUnits ?? 0)} unidades`, color: sev.text }
+          badge={hasOutstanding
+            ? { label: `${(kpis?.delinquentUnits ?? 0)} unidades`, color: sev.text }
             : undefined}
-          color={kpis?.outstandingByCurrency && kpis.outstandingByCurrency.length > 0 ? 'text-orange-400' : 'text-green-400'}
+          color={hasOutstanding ? 'text-orange-400' : 'text-green-400'}
           icon={<DollarSign className="w-5 h-5 text-current" />}
           cta="Ver morosidad"
           onClick={() => router.push(`/${tenantId}/finanzas`)}
@@ -381,19 +382,21 @@ const AdminDashboard = ({ tenantId }: AdminDashboardProps) => {
           value={kpis?.collectionRateByCurrency && kpis.collectionRateByCurrency.length > 0
             ? kpis.collectionRateByCurrency.map((entry) => `${entry.currency} ${formatPercentage(entry.rate)}`).join(' · ')
             : '—'}
-          badge={{ label: collectionRateLabel(cr), color: collectionRateIcon(cr).props.className || '' }}
-          color={cr >= 0.8 ? 'text-green-400' : cr >= 0.5 ? 'text-yellow-400' : 'text-red-400'}
-          icon={collectionRateIcon(cr)}
+          badge={cr != null ? { label: collectionRateLabel(cr), color: collectionRateIcon(cr).props.className || '' } : undefined}
+          color={cr == null ? 'text-green-400' : cr >= 0.8 ? 'text-green-400' : cr >= 0.5 ? 'text-yellow-400' : 'text-red-400'}
+          icon={collectionRateIcon(cr ?? 0)}
           cta="Ver finanzas"
           onClick={() => router.push(`/${tenantId}/finanzas`)}
         >
-          {/* Collection rate bar */}
-          <div className="mt-3 w-full bg-muted rounded-full h-2 overflow-hidden">
-            <div
-              className={`h-full rounded-full transition-all duration-500 ${crColor}`}
-              style={{ width: `${Math.min(cr * 100, 100)}%` }}
-            />
-          </div>
+          {/* Collection rate bar: only meaningful for a single currency */}
+          {cr != null && (
+            <div className="mt-3 w-full bg-muted rounded-full h-2 overflow-hidden">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${crColor}`}
+                style={{ width: `${Math.min(cr * 100, 100)}%` }}
+              />
+            </div>
+          )}
         </KPICard>
         <KPICard
           label="Unidades morosas del período"

--- a/apps/web/features/dashboard/services/dashboard.api.ts
+++ b/apps/web/features/dashboard/services/dashboard.api.ts
@@ -30,6 +30,16 @@ export interface UnitWithoutResponsibleSummary {
   buildingName: string;
 }
 
+export interface CurrencyAmountBucket {
+  currency: string;
+  amountMinor: number;
+}
+
+export interface CollectionRateBucket {
+  currency: string;
+  rate: number;
+}
+
 export interface BuildingAlert {
   buildingId: string;
   buildingName: string;
@@ -40,9 +50,9 @@ export interface BuildingAlert {
 }
 
 export interface DashboardKpis {
-  outstandingAmount: number | null;
-  collectedAmount: number | null;
-  collectionRate: number | null;
+  outstandingByCurrency: CurrencyAmountBucket[];
+  collectedByCurrency: CurrencyAmountBucket[];
+  collectionRateByCurrency: CollectionRateBucket[];
   delinquentUnits: number | null;
 }
 

--- a/apps/web/features/dashboard/utils/currency-buckets.test.ts
+++ b/apps/web/features/dashboard/utils/currency-buckets.test.ts
@@ -1,0 +1,42 @@
+import { formatCurrencyBuckets } from './currency-buckets';
+
+describe('formatCurrencyBuckets', () => {
+  it('renders a single ARS bucket', () => {
+    const result = formatCurrencyBuckets([{ currency: 'ARS', amountMinor: 10000 }]);
+    expect(result).toContain('100');
+    expect(result).not.toContain('·');
+  });
+
+  it('renders ARS + USD as two separate values', () => {
+    const result = formatCurrencyBuckets([
+      { currency: 'ARS', amountMinor: 12500 },
+      { currency: 'USD', amountMinor: 6000 },
+    ]);
+    expect(result).toContain('125');
+    expect(result).toContain('60');
+    expect(result).toContain('·');
+    // No combined scalar total is ever produced (12500+6000=18500).
+    expect(result).not.toContain('185');
+  });
+
+  it('renders all four currencies separately and preserves backend order', () => {
+    const result = formatCurrencyBuckets([
+      { currency: 'USD', amountMinor: 100 },
+      { currency: 'VES', amountMinor: 200 },
+      { currency: 'ARS', amountMinor: 300 },
+      { currency: 'COP', amountMinor: 400 },
+    ]);
+    expect(result.split('·')).toHaveLength(4);
+    // Backend canonical order is USD first, COP last: their formatted
+    // amounts must appear in that relative order in the output.
+    expect(result.indexOf('1')).toBeLessThan(result.indexOf('4'));
+    // No mixed scalar total (100+200+300+400=1000).
+    expect(result).not.toContain('1000');
+  });
+
+  it('renders empty buckets with an empty representation', () => {
+    expect(formatCurrencyBuckets([])).toBe('—');
+    expect(formatCurrencyBuckets(null)).toBe('—');
+    expect(formatCurrencyBuckets(undefined)).toBe('—');
+  });
+});

--- a/apps/web/features/dashboard/utils/currency-buckets.ts
+++ b/apps/web/features/dashboard/utils/currency-buckets.ts
@@ -1,0 +1,22 @@
+import { formatCurrency } from '@/shared/lib/format/money';
+
+export interface DisplayCurrencyBucket {
+  readonly currency: string;
+  readonly amountMinor: number;
+}
+
+/**
+ * Render a currency bucket list (minor units) as compact lines, one per
+ * currency, in the order provided by the backend (canonical currency order).
+ * Never sums different currencies into a single nominal total.
+ */
+export const formatCurrencyBuckets = (
+  buckets: readonly DisplayCurrencyBucket[] | null | undefined,
+): string => {
+  if (!buckets || buckets.length === 0) {
+    return '—';
+  }
+  return buckets
+    .map((bucket) => formatCurrency(bucket.amountMinor, bucket.currency))
+    .join(' · ');
+};


### PR DESCRIPTION
## Summary

Closes #153

Phase 3F2 removes ambiguous mixed-currency scalar KPIs from the administrative dashboard and replaces them with explicit currency buckets.

## Contract

Old:

- outstandingAmount
- collectedAmount
- collectionRate

New:

- outstandingByCurrency[]
- collectedByCurrency[]
- collectionRateByCurrency[]

## Financial semantics

- values remain on Charge.currency
- outstanding uses the canonical 3F1 helper
- collected is bounded by Charge.amount
- APPROVED / RECONCILED count as accounting-effective
- SUBMITTED does not count as collected
- collection rate is calculated independently per currency
- no live FX
- no nominal cross-currency totals

## Validation

- backend dashboard tests PASS
- frontend dashboard tests PASS
- over-allocation PASS
- CROSS PASS
- SUBMITTED PASS
- multi-currency rate PASS
- empty state PASS
- API typecheck/lint/build PASS
- WEB typecheck/build PASS
- scoped changed-file WEB lint PASS
- full WEB lint remains baseline-red from unrelated pre-existing files;
  zero new lint findings introduced by 3F2
- local functional API/web acceptance PASS
- review P0/P1/P2 = 0/0/0

## Safety

- no schema/migrations
- no DB mutation
- no live FX
- no 3F3–3F7 changes
- no staging/production changes