### PR TITLE
fix(finance): make monthly summary email currency-safe

### DIFF
--- a/apps/api/src/finanzas/currency-buckets.ts
+++ b/apps/api/src/finanzas/currency-buckets.ts
@@ -1,0 +1,73 @@
+import { CANONICAL_CURRENCIES, isCanonicalCurrency } from '@buildingos/contracts';
+
+/**
+ * Shared backend report-side currency bucket helpers (Phase 3F).
+ *
+ * Reportable currency = the currency string as stored on the charge.
+ * Canonical write currencies (USD/VES/ARS/COP) come first in canonical
+ * order; historical legacy currencies (e.g. UYU) or malformed historical
+ * codes are preserved explicitly in their own bucket — never converted,
+ * never renamed, never summed across currencies.
+ */
+
+export interface ReportCurrencyAmountBucket {
+  readonly currency: string;
+  readonly amountMinor: number;
+}
+
+export interface ReportCurrencyInput {
+  readonly currency: string;
+  readonly amountMinor: number;
+}
+
+/**
+ * Deterministic report-side ordering: canonical currencies first in
+ * canonical order, then any other currency in lexicographic order.
+ * Never converts or compares values across currencies.
+ */
+export function compareReportCurrencies(a: string, b: string): number {
+  if (isCanonicalCurrency(a)) {
+    return isCanonicalCurrency(b)
+      ? CANONICAL_CURRENCIES.indexOf(a) - CANONICAL_CURRENCIES.indexOf(b)
+      : -1;
+  }
+  return isCanonicalCurrency(b) ? 1 : a.localeCompare(b);
+}
+
+/**
+ * Aggregate integer minor amounts grouped by currency into explicit
+ * buckets, ordered deterministically (canonical first, then legacy
+ * lexicographic). Never converts, never sums across currencies.
+ */
+export function aggregateReportBuckets(
+  entries: readonly ReportCurrencyInput[],
+): ReportCurrencyAmountBucket[] {
+  const totals = new Map<string, number>();
+  for (const entry of entries) {
+    totals.set(entry.currency, (totals.get(entry.currency) ?? 0) + entry.amountMinor);
+  }
+  return Array.from(totals.entries())
+    .map(([currency, amountMinor]) => ({ currency, amountMinor }))
+    .sort((a, b) => compareReportCurrencies(a.currency, b.currency));
+}
+
+/**
+ * Render a single bucket amount for report output (email, CSV-like text).
+ * Legacy report currencies such as UYU format normally; a malformed
+ * historical code (e.g. "US" or an empty string) must never throw — it is
+ * rendered as a plain number with its raw code (escaping is the caller's
+ * responsibility).
+ */
+export function formatCurrencySafe(amountMinor: number, currency: string): string {
+  try {
+    return new Intl.NumberFormat('es-AR', {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amountMinor / 100);
+  } catch {
+    const major = (amountMinor / 100).toFixed(2);
+    return currency ? `${major} ${currency}` : major;
+  }
+}

--- a/apps/api/src/finanzas/finance-summary.service.spec.ts
+++ b/apps/api/src/finanzas/finance-summary.service.spec.ts
@@ -1,0 +1,555 @@
+import { PaymentStatus } from '@prisma/client';
+import { FinanceSummaryService } from './finance-summary.service';
+import type { PrismaService } from '../prisma/prisma.service';
+import type { EmailService } from '../email/email.service';
+
+const APPROVED = PaymentStatus.APPROVED;
+const RECONCILED = PaymentStatus.RECONCILED;
+const SUBMITTED = PaymentStatus.SUBMITTED;
+
+// The service resolves "last month" from the current date; fixtures must
+// use that same period so the MONTHLY ACTIVITY filter matches them.
+function lastMonthPeriod(): string {
+  const d = new Date(new Date().getFullYear(), new Date().getMonth() - 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
+}
+const PERIOD = lastMonthPeriod();
+
+interface ChargeFixture {
+  id?: string;
+  unitId?: string;
+  amount: number;
+  currency?: string;
+  period?: string;
+  dueDate?: Date;
+  canceledAt?: Date | null;
+  liquidationId?: string | null;
+  allocations?: Array<{ amount: number; payment?: { status?: string | null } | null }>;
+  unitLabel?: string;
+  buildingName?: string;
+}
+
+function charge({
+  id = 'chg-1',
+  unitId = 'unit-1',
+  amount,
+  currency = 'ARS',
+  period = PERIOD,
+  dueDate = new Date('2024-01-15T00:00:00Z'),
+  canceledAt = null,
+  liquidationId = 'liq-1',
+  allocations = [],
+  unitLabel = 'Apt 1',
+  buildingName = 'Building 1',
+}: ChargeFixture) {
+  return {
+    id,
+    unitId,
+    amount,
+    currency,
+    period,
+    dueDate,
+    canceledAt,
+    liquidationId,
+    tenantId: 'tenant-1',
+    unit: { id: unitId, label: unitLabel, building: { name: buildingName } },
+    paymentAllocations: allocations,
+  };
+}
+
+describe('FinanceSummaryService', () => {
+  let service: FinanceSummaryService;
+  let membershipFindMany: jest.Mock;
+  let chargeFindMany: jest.Mock;
+  let sendEmail: jest.Mock;
+
+  function mockCharges(charges: unknown[]) {
+    chargeFindMany.mockResolvedValueOnce(charges).mockResolvedValue(charges);
+  }
+
+  function mockQueries(reportCharges: unknown[], delinquentCharges: unknown[]) {
+    chargeFindMany.mockResolvedValueOnce(reportCharges).mockResolvedValue(delinquentCharges);
+  }
+
+  function mockAdmins(entries: Array<{ tenantId: string; tenantName: string; email: string }>) {
+    membershipFindMany.mockResolvedValue(
+      entries.map((e) => ({
+        tenantId: e.tenantId,
+        tenant: { id: e.tenantId, name: e.tenantName },
+        user: { id: `u-${e.email}`, email: e.email },
+        roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+      })),
+    );
+  }
+
+  function mockAdminsWithRoles(
+    entries: Array<{
+      tenantId: string;
+      tenantName: string;
+      email: string;
+      roles: Array<{ role: string; scopeType: string }>;
+    }>,
+  ) {
+    // Simulate the database filter: Prisma returns only memberships whose
+    // MembershipRole matches the query (role + scopeType).
+    membershipFindMany.mockImplementation((args: { where: { roles: { some: { role: string; scopeType: string } } } }) => {
+      const { role, scopeType } = args.where.roles.some;
+      return Promise.resolve(
+        entries
+          .filter((e) => e.roles.some((r) => r.role === role && r.scopeType === scopeType))
+          .map((e) => ({
+            tenantId: e.tenantId,
+            tenant: { id: e.tenantId, name: e.tenantName },
+            user: { id: `u-${e.email}`, email: e.email },
+            roles: e.roles,
+          })),
+      );
+    });
+  }
+
+  beforeEach(() => {
+    membershipFindMany = jest.fn().mockResolvedValue([]);
+    chargeFindMany = jest.fn().mockResolvedValue([]);
+    sendEmail = jest.fn().mockResolvedValue({ ok: true });
+    const prisma = {
+      membership: { findMany: membershipFindMany },
+      charge: { findMany: chargeFindMany },
+    } as unknown as PrismaService;
+    const email = { sendEmail } as unknown as EmailService;
+    service = new FinanceSummaryService(prisma, email);
+  });
+
+  describe('charge-side currency-safe aggregation', () => {
+    it('A: single currency — exact buckets, no mixed totals', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      mockCharges([
+        charge({ amount: 10000, allocations: [{ amount: 4000, payment: { status: APPROVED } }] }),
+        charge({ id: 'chg-2', unitId: 'unit-2', amount: 20000 }),
+      ]);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      expect(sendEmail.mock.calls[0][0].subject).toBe(
+        'Tenant A - Resumen Financiero ' +
+          new Date(new Date().getFullYear(), new Date().getMonth() - 1).toLocaleDateString(
+            'es-AR',
+            { month: 'long', year: 'numeric' },
+          ),
+      );
+      // 30000 charges, 4000 paid, 26000 outstanding, rate 13
+      expect(html).toContain('300,00');
+      expect(html).toContain('40,00');
+      expect(html).toContain('260,00');
+      expect(html).toContain('13% ARS');
+      // Currency explicit, no bare $ mixed display
+      expect(html).not.toContain('$300');
+    });
+
+    it('B: multi-currency — canonical order USD, VES, ARS, COP, no global total', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      mockCharges([
+        charge({ amount: 10000, currency: 'USD' }),
+        charge({ id: 'c2', unitId: 'u2', amount: 5000, currency: 'VES' }),
+        charge({ id: 'c3', unitId: 'u3', amount: 2000, currency: 'ARS' }),
+        charge({ id: 'c4', unitId: 'u4', amount: 3000, currency: 'COP' }),
+      ]);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      // Intl emits non-breaking spaces; normalize before matching.
+      const flat = html.replace(/\u00A0/g, ' ');
+      // Each currency appears with its own explicit label/symbol, in
+      // canonical order USD -> VES -> ARS -> COP.
+      const usdIndex = flat.indexOf('US$ 100,00');
+      const vesIndex = flat.indexOf('VES 50,00');
+      const arsIndex = flat.indexOf('$ 20,00');
+      const copIndex = flat.indexOf('COP 30,00');
+      expect(usdIndex).toBeGreaterThan(-1);
+      expect(vesIndex).toBeGreaterThan(-1);
+      expect(arsIndex).toBeGreaterThan(-1);
+      expect(copIndex).toBeGreaterThan(-1);
+      expect(usdIndex).toBeLessThan(vesIndex);
+      expect(vesIndex).toBeLessThan(arsIndex);
+      expect(arsIndex).toBeLessThan(copIndex);
+      // No single nominal global total anywhere
+      expect(html).not.toContain('Global');
+    });
+
+    it('C: CROSS — allocation in Charge currency, no USD bucket from original payment', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      // Payment was USD 5000 original; allocation covers ARS 182500
+      mockCharges([
+        charge({ amount: 182500, allocations: [{ amount: 182500, payment: { status: APPROVED } }] }),
+      ]);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      expect(html).toContain('1.825,00');
+      expect(html).toContain('100% ARS');
+      expect(html).not.toContain('US$ 5.000,00');
+      expect(html).not.toContain('US$ 1825');
+    });
+
+    it('D: SUBMITTED excluded — not paid, not reducing outstanding', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      mockCharges([
+        charge({ amount: 10000, allocations: [{ amount: 7000, payment: { status: SUBMITTED } }] }),
+      ]);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      expect(html).toContain('100,00');
+      expect(html).toContain('0% ARS');
+    });
+
+    it('E: RECONCILED effective — counts as paid, reduces outstanding', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      mockCharges([
+        charge({ amount: 10000, allocations: [{ amount: 10000, payment: { status: RECONCILED } }] }),
+      ]);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      expect(html).toContain('100% ARS');
+    });
+
+    it('F: overallocation bounded — collected never exceeds charge amount', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      mockCharges([
+        charge({ amount: 10000, allocations: [{ amount: 12000, payment: { status: APPROVED } }] }),
+      ]);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      expect(html).toContain('100,00');
+      expect(html).toContain('100% ARS');
+      // No 120 collected anywhere
+      expect(html).not.toContain('120,00');
+    });
+  });
+
+  describe('legacy and malformed historical currencies', () => {
+    it('G: legacy UYU renders explicitly — no ARS fallback, no throw', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      mockCharges([
+        charge({ amount: 500000, currency: 'UYU' }),
+        charge({ id: 'c2', unitId: 'u2', amount: 10000 }),
+      ]);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      expect(html).toContain('UYU');
+      expect(html).toContain('5.000,00');
+      // ARS bucket present too, UYU after canonical
+      expect(html).toContain('100,00');
+    });
+
+    it('H: malformed codes US / empty / XX12 never throw', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      mockCharges([
+        charge({ amount: 12345, currency: 'US' }),
+        charge({ id: 'c2', unitId: 'u2', amount: 67890, currency: '' }),
+        charge({ id: 'c3', unitId: 'u3', amount: 11111, currency: 'XX12' }),
+      ]);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      // Malformed codes use the raw fallback format (major units, dot
+      // separator): amount + raw code when the code exists.
+      expect(html).toContain('123.45 US');
+      expect(html).toContain('678.90');
+      expect(html).toContain('111.11 XX12');
+    });
+
+    it('I: malicious currency code is HTML-escaped, never executable markup', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      mockCharges([
+        charge({ amount: 10000, currency: '<script>alert(1)</script>' }),
+      ]);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      expect(html).not.toContain('<script>alert(1)</script>');
+      expect(html).toContain('&lt;script&gt;');
+    });
+
+    it('J: tenant name and unit labels are HTML-escaped', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: '<b>Tenant</b>', email: 'admin@a.com' }]);
+      mockCharges([
+        charge({
+          amount: 10000,
+          dueDate: new Date('2024-01-01T00:00:00Z'),
+          unitLabel: '<img src=x onerror=alert(1)>',
+        }),
+      ]);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      expect(html).not.toContain('<b>Tenant</b>');
+      expect(html).toContain('&lt;b&gt;Tenant&lt;/b&gt;');
+      expect(html).toContain('&lt;img');
+    });
+  });
+
+  describe('empty contract and delivery boundary', () => {
+    it('K: empty tenant renders deterministic placeholder, no invented ARS zero', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      mockCharges([]);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      expect(html).toContain('—');
+      expect(html).toContain('Sin unidades morosas');
+      expect(html).not.toContain('NaN');
+      expect(html).not.toContain('undefined');
+      expect(html).not.toContain('[object Object]');
+    });
+
+    it('L: delivery boundary — recipients, subject and call count unchanged', async () => {
+      mockAdmins([
+        { tenantId: 't-1', tenantName: 'Tenant A', email: 'admin1@a.com' },
+        { tenantId: 't-1', tenantName: 'Tenant A', email: 'admin2@a.com' },
+        { tenantId: 't-2', tenantName: 'Tenant B', email: 'admin@b.com' },
+      ]);
+      mockCharges([charge({ amount: 10000 })]);
+
+      const result = await service.sendMonthlyFinanceSummaries();
+
+      expect(result.sentCount).toBe(3);
+      expect(sendEmail).toHaveBeenCalledTimes(3);
+      const emails = sendEmail.mock.calls.map((c) => c[0].to);
+      expect(emails).toContain('admin1@a.com');
+      expect(emails).toContain('admin2@a.com');
+      expect(emails).toContain('admin@b.com');
+      const subjects = sendEmail.mock.calls.map((c) => c[0].subject);
+      expect(subjects[0]).toContain('Tenant A - Resumen Financiero');
+      expect(subjects[2]).toContain('Tenant B - Resumen Financiero');
+    });
+
+    it('L2: recipient query filters TENANT_ADMIN via MembershipRole (schema-accurate)', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      mockCharges([charge({ amount: 10000 })]);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const callArgs = membershipFindMany.mock.calls[0][0];
+      const memberWhere = callArgs.where;
+      // roles.some(TENANT_ADMIN) matches the RBAC source of truth
+      // (MembershipRole[]); the parallel TenantMember table is not used.
+      expect(memberWhere.roles.some.role).toBe('TENANT_ADMIN');
+    });
+  });
+
+  describe('period semantics (remediation)', () => {
+    it('M1: MONTHLY ACTIVITY only includes charges of the requested period', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      // Charge B belongs to the previous period with a large amount and an
+      // APPROVED allocation: it must not leak into this month's KPIs.
+      mockQueries(
+        [
+          charge({ id: 'A', amount: 10000, period: PERIOD }),
+        ],
+        [
+          charge({ id: 'B', amount: 900000, period: '2026-06', dueDate: new Date('2026-06-01T00:00:00Z') }),
+        ],
+      );
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      // The Facturado KPI block must only contain this month's charge
+      // (10000 minor -> 100,00); the 900000 charge of another period must
+      // not appear in the monthly KPIs (it may appear in delinquency).
+      const facturadoBlock = html.split('Total Facturado')[1]!.split('Total Cobrado')[0]!;
+      expect(facturadoBlock).toContain('100,00');
+      expect(facturadoBlock).not.toContain('9.000,00');
+      expect(facturadoBlock).not.toContain('910');
+    });
+
+    it('M2: old overdue unpaid debt stays in the CURRENT DELINQUENCY SNAPSHOT', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      // No charges in the current period; one old (2026-06) overdue unpaid
+      // charge. Monthly KPIs must be empty; delinquency must show it.
+      mockQueries(
+        [],
+        [
+          charge({
+            id: 'old',
+            amount: 900000,
+            period: '2026-06',
+            dueDate: new Date('2026-06-01T00:00:00Z'),
+          }),
+        ],
+      );
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      // Empty monthly KPIs use the placeholder.
+      expect(html).toContain('—');
+      // Delinquency snapshot still lists the old debt.
+      expect(html).toContain('Unidades Morosas (1)');
+      expect(html).toContain('9.000,00');
+    });
+
+    it('M3: the financial query passes the period filter', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      mockQueries([], []);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const firstCall = chargeFindMany.mock.calls[0][0];
+      expect(firstCall.where.period).toBe(PERIOD);
+      // Delinquency query (second call) must NOT filter by period.
+      const secondCall = chargeFindMany.mock.calls[1][0];
+      expect(secondCall.where).not.toHaveProperty('period');
+    });
+  });
+
+  describe('delinquent count semantics (remediation)', () => {
+    it('M4: count reflects the real total; preview is capped at 10', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      const units = Array.from({ length: 17 }, (_, i) =>
+        charge({
+          id: `c-${i}`,
+          unitId: `unit-${i}`,
+          amount: 1000,
+          dueDate: new Date('2024-01-01T00:00:00Z'),
+        }),
+      );
+      mockQueries([charge({ amount: 10000 })], units);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      expect(html).toContain('Unidades Morosas (17)');
+      // Preview renders 10 rows: one header + 10 unit rows.
+      const previewCount = (html.match(/<tr>/g) ?? []).length - 1;
+      expect(previewCount).toBe(10);
+    });
+
+    it('M5: a unit with several overdue charges counts exactly once', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      mockQueries(
+        [charge({ amount: 10000 })],
+        [
+          charge({ id: 'c1', unitId: 'unit-x', amount: 1000, dueDate: new Date('2024-01-01T00:00:00Z') }),
+          charge({ id: 'c2', unitId: 'unit-x', amount: 2000, dueDate: new Date('2024-02-01T00:00:00Z') }),
+          charge({ id: 'c3', unitId: 'unit-y', amount: 3000, dueDate: new Date('2024-03-01T00:00:00Z') }),
+        ],
+      );
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      expect(html).toContain('Unidades Morosas (2)');
+    });
+
+    it('M6: no pre-limit can corrupt the count (fails with the old take:100)', async () => {
+      mockAdmins([{ tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com' }]);
+      // 110 overdue charges: 10 units with 10 old charges each (100) plus
+      // 5 units with 2 newer charges each (10). A take:100 pre-limit on
+      // dueDate ASC would only see the first 10 units.
+      const charges: unknown[] = [];
+      for (let i = 0; i < 10; i++) {
+        for (let j = 0; j < 10; j++) {
+          charges.push(
+            charge({
+              id: `old-${i}-${j}`,
+              unitId: `unit-old-${i}`,
+              amount: 1000,
+              dueDate: new Date(`2024-01-${String(j + 1).padStart(2, '0')}T00:00:00Z`),
+            }),
+          );
+        }
+      }
+      for (let i = 0; i < 5; i++) {
+        for (let j = 0; j < 2; j++) {
+          charges.push(
+            charge({
+              id: `new-${i}-${j}`,
+              unitId: `unit-new-${i}`,
+              amount: 1000,
+              dueDate: new Date(`2025-01-0${j + 1}T00:00:00Z`),
+            }),
+          );
+        }
+      }
+      mockQueries([charge({ amount: 10000 })], charges);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const html = sendEmail.mock.calls[0][0].htmlBody as string;
+      expect(html).toContain('Unidades Morosas (15)');
+    });
+  });
+
+  describe('recipient scope (remediation)', () => {
+    it('M7: only TENANT-scoped TENANT_ADMIN memberships receive the email', async () => {
+      mockAdminsWithRoles([
+        { tenantId: 't-1', tenantName: 'Tenant A', email: 'tenant-admin@a.com', roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }] },
+        { tenantId: 't-1', tenantName: 'Tenant A', email: 'building-admin@a.com', roles: [{ role: 'TENANT_ADMIN', scopeType: 'BUILDING' }] },
+        { tenantId: 't-1', tenantName: 'Tenant A', email: 'unit-admin@a.com', roles: [{ role: 'TENANT_ADMIN', scopeType: 'UNIT' }] },
+        { tenantId: 't-1', tenantName: 'Tenant A', email: 'owner@a.com', roles: [{ role: 'TENANT_OWNER', scopeType: 'TENANT' }] },
+        { tenantId: 't-1', tenantName: 'Tenant A', email: 'operator@a.com', roles: [{ role: 'OPERATOR', scopeType: 'TENANT' }] },
+        { tenantId: 't-1', tenantName: 'Tenant A', email: 'resident@a.com', roles: [{ role: 'RESIDENT', scopeType: 'TENANT' }] },
+        { tenantId: 't-1', tenantName: 'Tenant A', email: 'norole@a.com', roles: [] },
+      ]);
+      mockCharges([charge({ amount: 10000 })]);
+
+      const result = await service.sendMonthlyFinanceSummaries();
+
+      expect(sendEmail).toHaveBeenCalledTimes(1);
+      expect(sendEmail.mock.calls[0][0].to).toBe('tenant-admin@a.com');
+      expect(result.sentCount).toBe(1);
+    });
+
+    it('M8: multi-role membership sends exactly one email', async () => {
+      mockAdminsWithRoles([
+        {
+          tenantId: 't-1',
+          tenantName: 'Tenant A',
+          email: 'multi@a.com',
+          roles: [
+            { role: 'TENANT_ADMIN', scopeType: 'TENANT' },
+            { role: 'OPERATOR', scopeType: 'BUILDING' },
+            { role: 'RESIDENT', scopeType: 'UNIT' },
+          ],
+        },
+      ]);
+      mockCharges([charge({ amount: 10000 })]);
+
+      const result = await service.sendMonthlyFinanceSummaries();
+
+      expect(sendEmail).toHaveBeenCalledTimes(1);
+      expect(sendEmail.mock.calls[0][0].to).toBe('multi@a.com');
+      expect(result.sentCount).toBe(1);
+    });
+
+    it('M9: recipient query requires scopeType TENANT', async () => {
+      mockAdminsWithRoles([
+        { tenantId: 't-1', tenantName: 'Tenant A', email: 'admin@a.com', roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }] },
+      ]);
+      mockCharges([charge({ amount: 10000 })]);
+
+      await service.sendMonthlyFinanceSummaries();
+
+      const memberWhere = membershipFindMany.mock.calls[0][0].where;
+      expect(memberWhere.roles.some).toMatchObject({
+        role: 'TENANT_ADMIN',
+        scopeType: 'TENANT',
+      });
+    });
+  });
+});

--- a/apps/api/src/finanzas/finance-summary.service.ts
+++ b/apps/api/src/finanzas/finance-summary.service.ts
@@ -3,6 +3,13 @@ import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { EmailService } from '../email/email.service';
 import { EmailType } from '../email/email.types';
+import { calculateChargeOutstandingMinor } from './charge-aggregation';
+import {
+  aggregateReportBuckets,
+  compareReportCurrencies,
+  formatCurrencySafe,
+  type ReportCurrencyAmountBucket,
+} from './currency-buckets';
 
 type ChargeWithUnitAndAllocations = Prisma.ChargeGetPayload<{
   include: {
@@ -49,50 +56,66 @@ export class FinanceSummaryService {
     const lastMonth = this.getLastMonth();
     let sentCount = 0;
 
-    // Get all tenants with their TENANT_ADMIN members
-    const tenants = await this.prisma.tenant.findMany({
-      include: {
-        tenantMembers: {
-          where: {
-            role: 'TENANT_ADMIN',
-            status: 'ACTIVE',
-            userId: { not: null },
-          },
-          include: {
-            user: { select: { id: true, email: true } },
-          },
+    // Get all TENANT-scoped TENANT_ADMIN memberships grouped by tenant.
+    // Roles live on MembershipRole[] (the RBAC source of truth); the
+    // parallel TenantMember table is not used here because it is
+    // stale/partial for admin roles. The finance summary is tenant-wide, so
+    // BUILDING/UNIT-scoped admins must never receive it.
+    const memberships = await this.prisma.membership.findMany({
+      where: {
+        roles: {
+          some: { role: 'TENANT_ADMIN', scopeType: 'TENANT' },
         },
+      },
+      include: {
+        tenant: { select: { id: true, name: true } },
+        user: { select: { id: true, email: true } },
       },
     });
 
-    for (const tenant of tenants) {
-      const tenantMembers = tenant.tenantMembers;
-      if (tenantMembers.length === 0) continue;
+    const adminsByTenant = new Map<
+      string,
+      { name: string; admins: Array<{ id: string; email: string | null }> }
+    >();
+    for (const membership of memberships) {
+      const entry = adminsByTenant.get(membership.tenantId);
+      if (entry) {
+        entry.admins.push(membership.user);
+      } else {
+        adminsByTenant.set(membership.tenantId, {
+          name: membership.tenant.name,
+          admins: [membership.user],
+        });
+      }
+    }
+
+    for (const [tenantId, { name: tenantName, admins }] of adminsByTenant) {
+      if (admins.length === 0) continue;
 
       try {
         // Get finance report for last month
-        const report = await this.generateFinanceReport(tenant.id, lastMonth);
+        const report = await this.generateFinanceReport(tenantId, lastMonth);
 
         // Generate HTML
-        const html = this.generateSummaryHtml(tenant.name, lastMonth, report);
+        const html = this.generateSummaryHtml(tenantName, lastMonth, report);
 
         // Send to all TENANT_ADMINs
-        for (const membership of tenantMembers) {
-          if (membership.user?.email) {
+        for (const admin of admins) {
+          if (admin.email) {
             try {
               await this.emailService.sendEmail(
                 {
-                  to: membership.user.email,
-                  subject: `${tenant.name} - Resumen Financiero ${this.formatMonth(lastMonth)}`,
+                  to: admin.email,
+                  subject: `${tenantName} - Resumen Financiero ${this.formatMonth(lastMonth)}`,
                   htmlBody: html,
-                  tenantId: tenant.id,
+                  tenantId,
                 },
                 EmailType.FINANCE_SUMMARY,
               );
               sentCount++;
             } catch (emailError) {
               this.logger.error(
-                `Failed to send email to ${membership.user.email} for tenant ${tenant.id}`,
+                `Failed to send email to ${admin.email} for tenant ${tenantId}`,
                 emailError instanceof Error ? emailError.stack : String(emailError),
               );
             }
@@ -100,11 +123,11 @@ export class FinanceSummaryService {
         }
 
         this.logger.log(
-          `Finance summary sent to ${tenantMembers.length} admins for tenant ${tenant.id}`,
+          `Finance summary sent to ${admins.length} admins for tenant ${tenantId}`,
         );
       } catch (error) {
         this.logger.error(
-          `Failed to generate/send finance summary for tenant ${tenant.id}`,
+          `Failed to generate/send finance summary for tenant ${tenantId}`,
           error instanceof Error ? error.stack : String(error),
         );
       }
@@ -115,15 +138,23 @@ export class FinanceSummaryService {
 
   /**
    * Generate finance report for a tenant in a given period
+   *
+   * Charge-side, currency-safe: every monetary aggregate is expressed in
+   * Charge.currency (integer minor units), grouped into explicit buckets.
+   * Currencies are never mixed, converted or summed; canonical currencies
+   * come first (USD, VES, ARS, COP), legacy reportable currencies after.
    */
   private async generateFinanceReport(
     tenantId: string,
     period: string,
   ): Promise<FinanceReport> {
-    // Get all charges for period with allocations
+    // Get all charges for the requested period with allocations
+    // (MONTHLY ACTIVITY: Charge.period is the accrual period authority —
+    // YYYY-MM, inherited from Liquidation.period on publication).
     const charges = await this.prisma.charge.findMany({
       where: {
         tenantId,
+        period,
         liquidationId: { not: null }, // Only published charges
         canceledAt: null,
       },
@@ -134,23 +165,60 @@ export class FinanceSummaryService {
       },
     });
 
-    // Calculate totals using REAL outstanding from allocations
-    const totalCharges = charges.reduce((sum, c) => sum + c.amount, 0);
-    const totalPaid = charges.reduce((sum, c) => {
-      const allocated = c.paymentAllocations.reduce((aSum, pa) => {
-        const status = pa.payment?.status;
-        if (status === 'APPROVED' || status === 'RECONCILED') {
-          return aSum + pa.amount;
-        }
-        return aSum;
-      }, 0);
-      return sum + allocated;
-    }, 0);
-    const totalOutstanding = Math.max(0, totalCharges - totalPaid);
-    const collectionRate =
-      totalCharges > 0 ? Math.round((totalPaid / totalCharges) * 100) : 0;
+    // Per-charge accounting (charge-side):
+    // - outstanding = charge.amount - effective allocations (clamped >= 0)
+    //   (effective = APPROVED | RECONCILED; SUBMITTED never reduces outstanding)
+    // - collected = charge.amount - outstanding (bounded by charge.amount)
+    const totalsByCurrency = new Map<
+      string,
+      { charges: number; paid: number; outstanding: number }
+    >();
 
-    // Get delinquent units (calculate from real allocations, not Charge.status)
+    for (const charge of charges) {
+      const outstanding = calculateChargeOutstandingMinor(charge);
+      const paid = charge.amount - outstanding;
+
+      const acc = totalsByCurrency.get(charge.currency) ?? {
+        charges: 0,
+        paid: 0,
+        outstanding: 0,
+      };
+      acc.charges += charge.amount;
+      acc.paid += paid;
+      acc.outstanding += outstanding;
+      totalsByCurrency.set(charge.currency, acc);
+    }
+
+    const totalChargesByCurrency = aggregateReportBuckets(
+      Array.from(totalsByCurrency.entries(), ([currency, acc]) => ({
+        currency,
+        amountMinor: acc.charges,
+      })),
+    );
+    const totalPaidByCurrency = aggregateReportBuckets(
+      Array.from(totalsByCurrency.entries(), ([currency, acc]) => ({
+        currency,
+        amountMinor: acc.paid,
+      })),
+    );
+    const totalOutstandingByCurrency = aggregateReportBuckets(
+      Array.from(totalsByCurrency.entries(), ([currency, acc]) => ({
+        currency,
+        amountMinor: acc.outstanding,
+      })),
+    );
+
+    const collectionRateByCurrency = Array.from(totalsByCurrency.entries())
+      .map(([currency, acc]) => ({
+        currency,
+        rate: acc.charges > 0 ? Math.round((acc.paid / acc.charges) * 100) : 0,
+      }))
+      .sort((a, b) => compareReportCurrencies(a.currency, b.currency));
+
+    // CURRENT DELINQUENCY SNAPSHOT: overdue unpaid charges regardless of
+    // their accrual period (a June debt still unpaid must appear in the
+    // July email). No pre-limit: the full overdue set is needed so the
+    // delinquent unit count is exact.
     const allCharges = await this.prisma.charge.findMany({
       where: {
         tenantId,
@@ -169,74 +237,115 @@ export class FinanceSummaryService {
           include: { payment: true },
         },
       },
-      orderBy: { amount: 'desc' },
-      take: 100,
     });
 
-    // Calculate real outstanding from APPROVED/RECONCILED payments only
-    const unitDebtMap = new Map<
+    // Aggregate per unit with explicit per-currency buckets. Ordering is
+    // NON-monetary: earliest delinquency (dueDate ASC), then unitId ASC
+    // (3F3 rule) — amounts in different currencies are never compared or
+    // summed, and unitLabel is display-only (labels can repeat).
+    const unitEntries = new Map<
       string,
       {
         unit: ChargeWithUnitAndAllocations['unit'];
         buildingName: string;
-        outstanding: number;
+        earliestDue: Date;
+        entries: Array<{ currency: string; amountMinor: number }>;
       }
     >();
-    for (const charge of allCharges) {
-      const allocatedApproved = charge.paymentAllocations.reduce((sum, pa) => {
-        const status = pa.payment?.status;
-        if (status === 'APPROVED' || status === 'RECONCILED') {
-          return sum + pa.amount;
-        }
-        return sum;
-      }, 0);
-      const outstanding = charge.amount - allocatedApproved;
 
-      if (outstanding > 0) {
-        const existing = unitDebtMap.get(charge.unitId);
-        if (existing) {
-          existing.outstanding += outstanding;
-        } else {
-          unitDebtMap.set(charge.unitId, {
-            unit: charge.unit,
-            buildingName: charge.unit.building.name,
-            outstanding,
-          });
+    for (const charge of allCharges) {
+      const outstanding = calculateChargeOutstandingMinor(charge);
+      if (outstanding <= 0) continue;
+
+      const existing = unitEntries.get(charge.unitId);
+      if (existing) {
+        existing.entries.push({ currency: charge.currency, amountMinor: outstanding });
+        if (charge.dueDate < existing.earliestDue) {
+          existing.earliestDue = charge.dueDate;
         }
+      } else {
+        unitEntries.set(charge.unitId, {
+          unit: charge.unit,
+          buildingName: charge.unit.building.name,
+          earliestDue: charge.dueDate,
+          entries: [{ currency: charge.currency, amountMinor: outstanding }],
+        });
       }
     }
 
-    // Sort by outstanding and take top 10
-    const delinquentUnits = Array.from(unitDebtMap.values())
-      .sort((a, b) => b.outstanding - a.outstanding)
+    // Exact count over the complete unit map; preview capped at 10.
+    const delinquentUnitsCount = unitEntries.size;
+
+    const delinquentUnits = Array.from(unitEntries.values())
+      .sort((a, b) => {
+        const dueDiff = a.earliestDue.getTime() - b.earliestDue.getTime();
+        if (dueDiff !== 0) return dueDiff;
+        return a.unit.id.localeCompare(b.unit.id);
+      })
       .slice(0, 10)
       .map((item) => ({
         unitId: item.unit.id,
         unitLabel: item.unit.label || 'N/A',
         buildingName: item.buildingName,
-        outstanding: item.outstanding,
+        outstandingByCurrency: aggregateReportBuckets(item.entries),
       }));
 
     return {
-      totalCharges,
-      totalPaid,
-      totalOutstanding,
-      collectionRate,
-      delinquentUnitsCount: delinquentUnits.length,
+      totalChargesByCurrency,
+      totalPaidByCurrency,
+      totalOutstandingByCurrency,
+      collectionRateByCurrency,
+      delinquentUnitsCount,
       delinquentUnits,
     };
   }
 
   /**
    * Generate HTML email template
+   *
+   * Monetary values are rendered per currency bucket (canonical first,
+   * legacy after) using a safe formatter that never throws on malformed
+   * historical codes. All interpolated dynamic values (tenant, unit,
+   * building, currency) are HTML-escaped.
    */
   private generateSummaryHtml(
     tenantName: string,
     period: string,
     report: FinanceReport,
   ): string {
-    const formatCurrency = (cents: number): string =>
-      `$${(cents / 100).toFixed(2)}`;
+    const escapeHtml = (value: string): string =>
+      value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+
+    const formatBuckets = (buckets: ReportCurrencyAmountBucket[]): string =>
+      buckets.length === 0
+        ? '—'
+        : buckets
+            .map(
+              (bucket) =>
+                `<div>${escapeHtml(formatCurrencySafe(bucket.amountMinor, bucket.currency))}</div>`,
+            )
+            .join('');
+
+    const formatRates = (
+      rates: FinanceReport['collectionRateByCurrency'],
+    ): string =>
+      rates.length === 0
+        ? '—'
+        : rates
+            .map(
+              (rate) =>
+                `<div>${rate.rate}% ${escapeHtml(rate.currency)}</div>`,
+            )
+            .join('');
+
+    const hasMovements = report.totalChargesByCurrency.length > 0;
+    const kpiClass = (buckets: ReportCurrencyAmountBucket[]): string =>
+      buckets.some((b) => b.amountMinor > 0) ? 'negative' : 'positive';
 
     return `
 <!DOCTYPE html>
@@ -287,7 +396,7 @@ export class FinanceSummaryService {
       margin-bottom: 10px;
     }
     .kpi-value {
-      font-size: 24px;
+      font-size: 18px;
       font-weight: bold;
       color: #1f2937;
     }
@@ -341,7 +450,7 @@ export class FinanceSummaryService {
 </head>
 <body>
   <div class="header">
-    <h1>${tenantName}</h1>
+    <h1>${escapeHtml(tenantName)}</h1>
     <p>Resumen Financiero • ${this.formatMonth(period)}</p>
   </div>
 
@@ -349,19 +458,19 @@ export class FinanceSummaryService {
     <div class="kpi-container">
       <div class="kpi">
         <div class="kpi-label">Total Facturado</div>
-        <div class="kpi-value">${formatCurrency(report.totalCharges)}</div>
+        <div class="kpi-value">${formatBuckets(report.totalChargesByCurrency)}</div>
       </div>
       <div class="kpi positive">
         <div class="kpi-label">Total Cobrado</div>
-        <div class="kpi-value">${formatCurrency(report.totalPaid)}</div>
+        <div class="kpi-value">${formatBuckets(report.totalPaidByCurrency)}</div>
       </div>
-      <div class="kpi ${report.totalOutstanding > 0 ? 'negative' : 'positive'}">
+      <div class="kpi ${hasMovements ? kpiClass(report.totalOutstandingByCurrency) : 'positive'}">
         <div class="kpi-label">Pendiente</div>
-        <div class="kpi-value">${formatCurrency(report.totalOutstanding)}</div>
+        <div class="kpi-value">${formatBuckets(report.totalOutstandingByCurrency)}</div>
       </div>
       <div class="kpi">
         <div class="kpi-label">Cobranza</div>
-        <div class="kpi-value">${report.collectionRate}%</div>
+        <div class="kpi-value">${formatRates(report.collectionRateByCurrency)}</div>
       </div>
     </div>
 
@@ -382,9 +491,9 @@ export class FinanceSummaryService {
           .map(
             (u) => `
         <tr>
-          <td><strong>${u.unitLabel}</strong></td>
-          <td>${u.buildingName}</td>
-          <td style="text-align: right; font-weight: 600; color: #ef4444;">${formatCurrency(u.outstanding)}</td>
+          <td><strong>${escapeHtml(u.unitLabel)}</strong></td>
+          <td>${escapeHtml(u.buildingName)}</td>
+          <td style="text-align: right; font-weight: 600; color: #ef4444;">${formatBuckets(u.outstandingByCurrency)}</td>
         </tr>
         `,
           )
@@ -435,15 +544,15 @@ export class FinanceSummaryService {
 }
 
 interface FinanceReport {
-  totalCharges: number;
-  totalPaid: number;
-  totalOutstanding: number;
-  collectionRate: number;
+  totalChargesByCurrency: ReportCurrencyAmountBucket[];
+  totalPaidByCurrency: ReportCurrencyAmountBucket[];
+  totalOutstandingByCurrency: ReportCurrencyAmountBucket[];
+  collectionRateByCurrency: Array<{ currency: string; rate: number }>;
   delinquentUnitsCount: number;
   delinquentUnits: Array<{
     unitId: string;
     unitLabel: string;
     buildingName: string;
-    outstanding: number;
+    outstandingByCurrency: ReportCurrencyAmountBucket[];
   }>;
 }

--- a/apps/api/src/reports/reports.service.ts
+++ b/apps/api/src/reports/reports.service.ts
@@ -2,14 +2,13 @@ import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { ChargeStatus, PaymentStatus, Prisma } from '@prisma/client';
 import { CsvUtility, CsvExportResult } from './csv.utility';
+import { calculateChargeOutstandingMinor } from '../finanzas/charge-aggregation';
 import {
-  calculateChargeOutstandingMinor,
-  type CurrencyAmountInput,
-} from '../finanzas/charge-aggregation';
-import {
-  CANONICAL_CURRENCIES,
-  isCanonicalCurrency,
-} from '@buildingos/contracts';
+  aggregateReportBuckets,
+  compareReportCurrencies,
+  type ReportCurrencyAmountBucket,
+  type ReportCurrencyInput,
+} from '../finanzas/currency-buckets';
 
 export interface ReportFilters {
   buildingId?: string;
@@ -37,18 +36,6 @@ export interface TicketsReportData {
     unitId: string | null;
     unit: { id: string; label: string | null; code: string } | null;
   }>;
-}
-
-/**
- * Report-side currency bucket. `currency` is the reportable currency as
- * stored on the charge (canonical USD/VES/ARS/COP, or a historical legacy
- * currency such as UYU). Reportable currencies are never canonicalized —
- * no conversion, no fallback — they are only labelled and aggregated in
- * their own dimension.
- */
-export interface ReportCurrencyAmountBucket {
-  readonly currency: string;
-  readonly amountMinor: number;
 }
 
 export interface DelinquentUnit {
@@ -89,41 +76,6 @@ export interface ActivityReportData {
   paymentsSubmitted: number;
   documentsUploaded: number;
   communicationsSent: number;
-}
-
-/**
- * Deterministic report-side currency ordering: canonical currencies first
- * in canonical order, then any legacy currency in lexicographic order.
- * Never converts or compares values across currencies.
- */
-function compareCurrencies(a: string, b: string): number {
-  if (isCanonicalCurrency(a)) {
-    return isCanonicalCurrency(b)
-      ? CANONICAL_CURRENCIES.indexOf(a) - CANONICAL_CURRENCIES.indexOf(b)
-      : -1;
-  }
-  return isCanonicalCurrency(b) ? 1 : a.localeCompare(b);
-}
-
-function aggregateBuckets(
-  totals: Map<string, { charges: number; paid: number; outstanding: number }>,
-  pick: (acc: { charges: number; paid: number; outstanding: number }) => number,
-): ReportCurrencyAmountBucket[] {
-  return Array.from(totals.entries())
-    .map(([currency, acc]) => ({ currency, amountMinor: pick(acc) }))
-    .sort((a, b) => compareCurrencies(a.currency, b.currency));
-}
-
-function aggregateBucketsFromEntries(
-  entries: readonly CurrencyAmountInput[],
-): ReportCurrencyAmountBucket[] {
-  const totals = new Map<string, number>();
-  for (const entry of entries) {
-    totals.set(entry.currency, (totals.get(entry.currency) ?? 0) + entry.amountMinor);
-  }
-  return Array.from(totals.entries())
-    .map(([currency, amountMinor]) => ({ currency, amountMinor }))
-    .sort((a, b) => compareCurrencies(a.currency, b.currency));
 }
 
 /**
@@ -308,7 +260,7 @@ export class ReportsService {
     // own explicit bucket after canonical ones, in stable lexicographic
     // order — no fallback, no loss, no write-side change.
     const totalsByCurrency = new Map<string, { charges: number; paid: number; outstanding: number }>();
-    const delinquentByUnit = new Map<string, CurrencyAmountInput[]>();
+    const delinquentByUnit = new Map<string, ReportCurrencyInput[]>();
     const delinquentEarliestDue = new Map<string, Date>();
     const now = new Date();
 
@@ -338,16 +290,31 @@ export class ReportsService {
       }
     }
 
-    const totalChargesByCurrency = aggregateBuckets(totalsByCurrency, (acc) => acc.charges);
-    const totalPaidByCurrency = aggregateBuckets(totalsByCurrency, (acc) => acc.paid);
-    const totalOutstandingByCurrency = aggregateBuckets(totalsByCurrency, (acc) => acc.outstanding);
+    const totalChargesByCurrency = aggregateReportBuckets(
+      Array.from(totalsByCurrency.entries(), ([currency, acc]) => ({
+        currency,
+        amountMinor: acc.charges,
+      })),
+    );
+    const totalPaidByCurrency = aggregateReportBuckets(
+      Array.from(totalsByCurrency.entries(), ([currency, acc]) => ({
+        currency,
+        amountMinor: acc.paid,
+      })),
+    );
+    const totalOutstandingByCurrency = aggregateReportBuckets(
+      Array.from(totalsByCurrency.entries(), ([currency, acc]) => ({
+        currency,
+        amountMinor: acc.outstanding,
+      })),
+    );
 
     const collectionRateByCurrency = Array.from(totalsByCurrency.entries())
       .map(([currency, acc]) => ({
         currency,
         rate: acc.charges > 0 ? Math.round((acc.paid / acc.charges) * 100) : 0,
       }))
-      .sort((a, b) => compareCurrencies(a.currency, b.currency));
+      .sort((a, b) => compareReportCurrencies(a.currency, b.currency));
 
     // Delinquent units: dueDate < now with positive outstanding in at least
     // one currency. Ordered by earliest delinquency (dueDate ASC), then by
@@ -358,7 +325,7 @@ export class ReportsService {
     const delinquentUnits = Array.from(delinquentByUnit.entries())
       .map(([unitId, entries]) => ({
         unitId,
-        outstandingByCurrency: aggregateBucketsFromEntries(entries),
+        outstandingByCurrency: aggregateReportBuckets(entries),
       }))
       .sort((a, b) => {
         const dueDiff =


### PR DESCRIPTION
## Summary

Closes #157

Phase 3F4 makes the automated monthly finance summary email currency-safe and fixes correctness issues discovered during the finance audit.

## Financial contract

The email now represents monetary aggregates per currency:

- total charges
- collected
- outstanding
- collection rate
- delinquent outstanding

No nominal totals are calculated across currencies.

Charge-side semantics:

- APPROVED / RECONCILED are effective
- SUBMITTED is excluded
- collected is bounded by Charge.amount
- CROSS allocations remain in Charge.currency
- no live FX

## Monthly vs delinquency semantics

Monthly activity KPIs are scoped by Charge.period.

Delinquency is intentionally a current snapshot, so older still-unpaid charges can appear in the delinquency section without contaminating the monthly KPIs.

## Delinquency

- exact total delinquent-unit count
- preview limited to 10
- no pre-limit that corrupts count
- deterministic ordering:
  earliest dueDate -> unitId
- no cross-currency monetary ranking

## Recipients

Recipient authority now uses Membership + MembershipRole.

Tenant-wide summaries are sent only to:

TENANT_ADMIN
scopeType = TENANT

BUILDING/UNIT-scoped admins are excluded.

## Historical compatibility

- canonical writes remain USD/VES/ARS/COP
- historical currencies such as UYU remain reportable
- malformed legacy currency codes do not crash rendering
- no ARS fallback
- HTML output escapes dynamic values

## Delivery boundary

Unchanged:

- cron
- subject
- EmailType.FINANCE_SUMMARY
- EmailService/provider
- error handling

No real email was sent during testing.

## Validation

- finance-summary: 22/22 PASS
- reports + charge aggregation: 50/50 PASS
- API full: 2525 PASS / 0 failed
- typecheck PASS
- lint PASS
- build PASS
- functional local render PASS
- git diff --check PASS

## Safety

- no schema changes
- no migrations
- no DB mutation
- no ExchangeRate lookup
- no real email sending
- no staging/production changes
- no 3F5 work

## Known P3

- getLastMonth month-edge timezone ambiguity
- exact delinquency count requires reading all overdue tenant charges
