### PR TITLE
fix(finance): make delinquency, inbox and assistant debt currency-safe

### DIFF
--- a/apps/api/src/assistant/assistant-debt-calculator.service.spec.ts
+++ b/apps/api/src/assistant/assistant-debt-calculator.service.spec.ts
@@ -9,48 +9,99 @@ describe('AssistantDebtCalculatorService', () => {
   });
 
   it('returns full charge amount when there are no allocations', () => {
-    expect(service.calculateOutstanding([{ amount: 10000, paymentAllocations: [] }])).toBe(10000);
+    expect(
+      service.calculateChargeOutstanding({
+        amount: 10000,
+        currency: 'ARS',
+        paymentAllocations: [],
+      }),
+    ).toBe(10000);
   });
 
   it('subtracts APPROVED allocations', () => {
-    expect(service.calculateOutstanding([
-      { amount: 10000, paymentAllocations: [{ amount: 2500, payment: { status: PaymentStatus.APPROVED } }] },
-    ])).toBe(7500);
+    expect(
+      service.calculateChargeOutstanding({
+        amount: 10000,
+        currency: 'ARS',
+        paymentAllocations: [{ amount: 2500, payment: { status: PaymentStatus.APPROVED } }],
+      }),
+    ).toBe(7500);
   });
 
   it('subtracts RECONCILED allocations', () => {
-    expect(service.calculateOutstanding([
-      { amount: 10000, paymentAllocations: [{ amount: 4000, payment: { status: PaymentStatus.RECONCILED } }] },
-    ])).toBe(6000);
+    expect(
+      service.calculateChargeOutstanding({
+        amount: 10000,
+        currency: 'ARS',
+        paymentAllocations: [{ amount: 4000, payment: { status: PaymentStatus.RECONCILED } }],
+      }),
+    ).toBe(6000);
   });
 
   it('ignores submitted, pending and rejected allocations', () => {
-    expect(service.calculateOutstanding([
-      {
+    expect(
+      service.calculateChargeOutstanding({
         amount: 10000,
+        currency: 'ARS',
         paymentAllocations: [
           { amount: 1000, payment: { status: PaymentStatus.SUBMITTED } },
           { amount: 2000, payment: { status: PaymentStatus.PENDING } },
           { amount: 3000, payment: { status: PaymentStatus.REJECTED } },
         ],
-      },
-    ])).toBe(10000);
+      }),
+    ).toBe(10000);
   });
 
   it('never returns negative debt on over-allocation', () => {
-    expect(service.calculateOutstanding([
-      { amount: 10000, paymentAllocations: [{ amount: 15000, payment: { status: PaymentStatus.APPROVED } }] },
-    ])).toBe(0);
+    expect(
+      service.calculateChargeOutstanding({
+        amount: 10000,
+        currency: 'ARS',
+        paymentAllocations: [{ amount: 15000, payment: { status: PaymentStatus.APPROVED } }],
+      }),
+    ).toBe(0);
   });
 
-  it('aggregates outstanding debt by unit', () => {
-    const result = service.calculateOutstandingByUnit([
-      { unitId: 'unit-1', amount: 10000, paymentAllocations: [{ amount: 2500, payment: { status: PaymentStatus.APPROVED } }] },
-      { unitId: 'unit-1', amount: 5000, paymentAllocations: [] },
-      { unitId: 'unit-2', amount: 7000, paymentAllocations: [{ amount: 2000, payment: { status: PaymentStatus.RECONCILED } }] },
+  it('aggregates outstanding by currency buckets — never a mixed scalar', () => {
+    const result = service.calculateOutstandingByCurrency([
+      { amount: 10000, currency: 'ARS', paymentAllocations: [] },
+      { amount: 5000, currency: 'USD', paymentAllocations: [] },
+      { amount: 2000, currency: 'ARS', paymentAllocations: [{ amount: 2000, payment: { status: PaymentStatus.APPROVED } }] },
     ]);
 
-    expect(result.get('unit-1')).toBe(12500);
-    expect(result.get('unit-2')).toBe(5000);
+    expect(result).toEqual([
+      { currency: 'USD', amountMinor: 5000 },
+      { currency: 'ARS', amountMinor: 10000 },
+    ]);
+  });
+
+  it('aggregates outstanding per unit with per-currency buckets', () => {
+    const result = service.calculateOutstandingByUnit([
+      {
+        unitId: 'unit-1',
+        amount: 10000,
+        currency: 'ARS',
+        paymentAllocations: [{ amount: 2500, payment: { status: PaymentStatus.APPROVED } }],
+      },
+      { unitId: 'unit-1', amount: 5000, currency: 'USD', paymentAllocations: [] },
+      { unitId: 'unit-2', amount: 7000, currency: 'ARS', paymentAllocations: [] },
+      { unitId: 'unit-3', amount: 9000, currency: 'VES', paymentAllocations: [{ amount: 9000, payment: { status: PaymentStatus.APPROVED } }] },
+    ]);
+
+    expect(result.get('unit-1')).toEqual([
+      { currency: 'USD', amountMinor: 5000 },
+      { currency: 'ARS', amountMinor: 7500 },
+    ]);
+    expect(result.get('unit-2')).toEqual([{ currency: 'ARS', amountMinor: 7000 }]);
+    // Fully paid unit has no entry.
+    expect(result.has('unit-3')).toBe(false);
+  });
+
+  it('drops charges without a currency instead of inventing one', () => {
+    const result = service.calculateOutstandingByCurrency([
+      { amount: 10000, paymentAllocations: [] },
+    ]);
+
+    expect(result).toEqual([]);
   });
 });

--- a/apps/api/src/assistant/assistant-debt-calculator.service.ts
+++ b/apps/api/src/assistant/assistant-debt-calculator.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { PaymentStatus } from '@prisma/client';
 import { calculateChargeOutstandingMinor } from '../finanzas/charge-aggregation';
+import {
+  aggregateReportBuckets,
+  type ReportCurrencyAmountBucket,
+} from '../finanzas/currency-buckets';
 
 export interface AssistantDebtAllocation {
   readonly amount: number;
@@ -9,6 +13,7 @@ export interface AssistantDebtAllocation {
 
 export interface AssistantDebtCharge {
   readonly amount: number;
+  readonly currency?: string | null;
   readonly unitId?: string | null;
   readonly paymentAllocations: readonly AssistantDebtAllocation[];
 }
@@ -24,27 +29,50 @@ export class AssistantDebtCalculatorService {
   }
 
   /**
-   * Calculate total outstanding debt for many charges.
+   * Aggregate outstanding debt for many charges into explicit currency
+   * buckets (canonical first, legacy after). Never sums across currencies.
    */
-  calculateOutstanding(charges: AssistantDebtCharge[]): number {
-    return charges.reduce((sum, charge) => sum + this.calculateChargeOutstanding(charge), 0);
+  calculateOutstandingByCurrency(
+    charges: AssistantDebtCharge[],
+  ): ReportCurrencyAmountBucket[] {
+    return aggregateReportBuckets(
+      charges
+        .filter((charge) => charge.currency)
+        .map((charge) => ({
+          currency: charge.currency as string,
+          amountMinor: this.calculateChargeOutstanding(charge),
+        })),
+    );
   }
 
   /**
-   * Calculate outstanding debt grouped by unitId.
+   * Aggregate outstanding debt per unit into explicit currency buckets.
+   * Each unit exposes one bucket per currency — no mixed scalar.
    */
-  calculateOutstandingByUnit(charges: AssistantDebtCharge[]): Map<string, number> {
-    const debtByUnit = new Map<string, number>();
+  calculateOutstandingByUnit(
+    charges: AssistantDebtCharge[],
+  ): Map<string, ReportCurrencyAmountBucket[]> {
+    const entriesByUnit = new Map<string, Array<{ currency: string; amountMinor: number }>>();
 
     for (const charge of charges) {
-      if (!charge.unitId) {
+      if (!charge.unitId || !charge.currency) {
         continue;
       }
 
       const debt = this.calculateChargeOutstanding(charge);
-      debtByUnit.set(charge.unitId, (debtByUnit.get(charge.unitId) ?? 0) + debt);
+      if (debt <= 0) {
+        continue;
+      }
+
+      const entries = entriesByUnit.get(charge.unitId) ?? [];
+      entries.push({ currency: charge.currency, amountMinor: debt });
+      entriesByUnit.set(charge.unitId, entries);
     }
 
-    return debtByUnit;
+    const result = new Map<string, ReportCurrencyAmountBucket[]>();
+    for (const [unitId, entries] of entriesByUnit) {
+      result.set(unitId, aggregateReportBuckets(entries));
+    }
+    return result;
   }
 }

--- a/apps/api/src/assistant/assistant.service.spec.ts
+++ b/apps/api/src/assistant/assistant.service.spec.ts
@@ -2258,6 +2258,7 @@ describe('AssistantService - Strict Operational Questions', () => {
       mockPrisma.charge.findMany.mockResolvedValue([
         {
           amount: 50000,
+      currency: 'ARS',
           paymentAllocations: [],
         },
       ]);
@@ -2277,6 +2278,7 @@ describe('AssistantService - Strict Operational Questions', () => {
       mockPrisma.charge.findMany.mockResolvedValue([
         {
           amount: 100000,
+      currency: 'ARS',
           paymentAllocations: [
             { amount: 30000, payment: { status: PaymentStatus.APPROVED } },
           ],
@@ -2310,6 +2312,7 @@ describe('AssistantService - Strict Operational Questions', () => {
       mockPrisma.charge.findMany.mockResolvedValue([
         {
           amount: 150000,
+      currency: 'ARS',
           paymentAllocations: [],
         },
       ]);
@@ -2328,6 +2331,7 @@ describe('AssistantService - Strict Operational Questions', () => {
       mockPrisma.charge.findMany.mockResolvedValue([
         {
           amount: 0,
+      currency: 'ARS',
           paymentAllocations: [],
         },
       ]);
@@ -2678,8 +2682,8 @@ describe('AssistantService - Strict Operational Questions', () => {
 
     it('P26: responde "cuanto debe el edificio"', async () => {
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 100000, unitId: 'u1', paymentAllocations: [] },
-        { amount: 50000, unitId: 'u2', paymentAllocations: [] },
+        { amount: 100000, currency: 'ARS', unitId: 'u1', paymentAllocations: [] },
+        { amount: 50000, currency: 'ARS', unitId: 'u2', paymentAllocations: [] },
       ]);
 
       const result = await (service as any).tryResolveStrictBuildingDebtQuestion(
@@ -2695,7 +2699,7 @@ describe('AssistantService - Strict Operational Questions', () => {
 
     it('P27: responde "deuda de la torre"', async () => {
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 200000, unitId: 'u1', paymentAllocations: [] },
+        { amount: 200000, currency: 'ARS', unitId: 'u1', paymentAllocations: [] },
       ]);
 
       const result = await (service as any).tryResolveStrictBuildingDebtQuestion(
@@ -2723,7 +2727,7 @@ describe('AssistantService - Strict Operational Questions', () => {
 
     it('P29: responde "cuanto adeuda el sector"', async () => {
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 75000, unitId: 'u1', paymentAllocations: [{ amount: 25000, payment: { status: PaymentStatus.APPROVED } }] },
+        { amount: 75000, currency: 'ARS', unitId: 'u1', paymentAllocations: [{ amount: 25000, payment: { status: PaymentStatus.APPROVED } }] },
       ]);
 
       const result = await (service as any).tryResolveStrictBuildingDebtQuestion(
@@ -2738,7 +2742,7 @@ describe('AssistantService - Strict Operational Questions', () => {
 
     it('P30: responde "deuda del complejo"', async () => {
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 0, unitId: 'u1', paymentAllocations: [] },
+        { amount: 0, currency: 'ARS', unitId: 'u1', paymentAllocations: [] },
       ]);
 
       const result = await (service as any).tryResolveStrictBuildingDebtQuestion(
@@ -2891,8 +2895,8 @@ describe('AssistantService - Strict Operational Questions', () => {
 
     it('P36: responde "quienes son los morosos"', async () => {
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 100000, unitId: 'u1', paymentAllocations: [] },
-        { amount: 50000, unitId: 'u2', paymentAllocations: [] },
+        { amount: 100000, currency: 'ARS', unitId: 'u1', paymentAllocations: [] },
+        { amount: 50000, currency: 'ARS', unitId: 'u2', paymentAllocations: [] },
       ]);
 
       const result = await (service as any).tryResolveStrictBuildingDelinquentsQuestion(
@@ -2902,7 +2906,7 @@ describe('AssistantService - Strict Operational Questions', () => {
       );
 
       expect(result).not.toBeNull();
-      expect(result.answer).toContain('Top deudores');
+      expect(result.answer).toContain('Unidades con deuda pendiente');
       expect(result.answer).toContain('Dpto 101');
       expect(result.answer).toContain('1.000');
       expect(result.answer).toContain('Dpto 102');
@@ -2911,7 +2915,7 @@ describe('AssistantService - Strict Operational Questions', () => {
 
     it('P37: responde "top deudores de la torre"', async () => {
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 200000, unitId: 'u1', paymentAllocations: [] },
+        { amount: 200000, currency: 'ARS', unitId: 'u1', paymentAllocations: [] },
       ]);
 
       const result = await (service as any).tryResolveStrictBuildingDelinquentsQuestion(
@@ -2921,13 +2925,13 @@ describe('AssistantService - Strict Operational Questions', () => {
       );
 
       expect(result).not.toBeNull();
-      expect(result.answer).toContain('Top deudores');
+      expect(result.answer).toContain('Unidades con deuda pendiente');
     });
 
     it('P38: responde "ranking de deuda del bloque"', async () => {
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 150000, unitId: 'u1', paymentAllocations: [{ amount: 50000, payment: { status: PaymentStatus.APPROVED } }] },
-        { amount: 80000, unitId: 'u2', paymentAllocations: [] },
+        { amount: 150000, currency: 'ARS', unitId: 'u1', paymentAllocations: [{ amount: 50000, payment: { status: PaymentStatus.APPROVED } }] },
+        { amount: 80000, currency: 'ARS', unitId: 'u2', paymentAllocations: [] },
       ]);
 
       const result = await (service as any).tryResolveStrictBuildingDelinquentsQuestion(
@@ -2955,9 +2959,9 @@ describe('AssistantService - Strict Operational Questions', () => {
 
     it('P40: responde "morosos del complejo"', async () => {
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 300000, unitId: 'u1', paymentAllocations: [] },
-        { amount: 200000, unitId: 'u2', paymentAllocations: [] },
-        { amount: 100000, unitId: 'u3', paymentAllocations: [] },
+        { amount: 300000, currency: 'ARS', unitId: 'u1', paymentAllocations: [] },
+        { amount: 200000, currency: 'ARS', unitId: 'u2', paymentAllocations: [] },
+        { amount: 100000, currency: 'ARS', unitId: 'u3', paymentAllocations: [] },
       ]);
 
       const result = await (service as any).tryResolveStrictBuildingDelinquentsQuestion(
@@ -2974,7 +2978,7 @@ describe('AssistantService - Strict Operational Questions', () => {
 
     it('P41: responde "deudores del edificio"', async () => {
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 50000, unitId: 'u1', paymentAllocations: [] },
+        { amount: 50000, currency: 'ARS', unitId: 'u1', paymentAllocations: [] },
       ]);
 
       const result = await (service as any).tryResolveStrictBuildingDelinquentsQuestion(
@@ -2984,12 +2988,12 @@ describe('AssistantService - Strict Operational Questions', () => {
       );
 
       expect(result).not.toBeNull();
-      expect(result.answer).toContain('Top deudores');
+      expect(result.answer).toContain('Unidades con deuda pendiente');
     });
 
     it('P41-V1: matchea "atrasados"', async () => {
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 80000, unitId: 'u1', paymentAllocations: [] },
+        { amount: 80000, currency: 'ARS', unitId: 'u1', paymentAllocations: [] },
       ]);
 
       const result = await (service as any).tryResolveStrictBuildingDelinquentsQuestion(
@@ -2999,7 +3003,7 @@ describe('AssistantService - Strict Operational Questions', () => {
       );
 
       expect(result).not.toBeNull();
-      expect(result.answer).toContain('Top deudores');
+      expect(result.answer).toContain('Unidades con deuda pendiente');
     });
 
     it('P41-V2: matchea "impagos"', async () => {
@@ -3033,8 +3037,8 @@ describe('AssistantService - Strict Operational Questions', () => {
     it('P42: responde "estadisticas del edificio"', async () => {
       mockPrisma.ticket.count.mockResolvedValueOnce(2).mockResolvedValueOnce(5);
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 100000, unitId: 'u1', paymentAllocations: [] },
-        { amount: 50000, unitId: 'u2', paymentAllocations: [] },
+        { amount: 100000, currency: 'ARS', unitId: 'u1', paymentAllocations: [] },
+        { amount: 50000, currency: 'ARS', unitId: 'u2', paymentAllocations: [] },
       ]);
 
       const result = await (service as any).tryResolveStrictBuildingStatsQuestion(
@@ -3046,7 +3050,7 @@ describe('AssistantService - Strict Operational Questions', () => {
       expect(result).not.toBeNull();
       expect(result.answer).toContain('Unidades: 2');
       expect(result.answer).toContain('Tickets abiertos: 2 de 5 totales');
-      expect(result.answer).toContain('Deuda total');
+      expect(result.answer).toContain('Deuda:');
       expect(result.answer).toContain('Deuda promedio por unidad');
     });
 
@@ -3067,7 +3071,7 @@ describe('AssistantService - Strict Operational Questions', () => {
     it('P44: responde "resumen del bloque"', async () => {
       mockPrisma.ticket.count.mockResolvedValueOnce(1).mockResolvedValueOnce(3);
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 200000, unitId: 'u1', paymentAllocations: [{ amount: 100000, payment: { status: PaymentStatus.APPROVED } }] },
+        { amount: 200000, currency: 'ARS', unitId: 'u1', paymentAllocations: [{ amount: 100000, payment: { status: PaymentStatus.APPROVED } }] },
       ]);
 
       const result = await (service as any).tryResolveStrictBuildingStatsQuestion(
@@ -3077,7 +3081,7 @@ describe('AssistantService - Strict Operational Questions', () => {
       );
 
       expect(result).not.toBeNull();
-      expect(result.answer).toContain('Deuda total');
+      expect(result.answer).toContain('Deuda:');
     });
 
     it('P45: responde "informacion del edificio"', async () => {
@@ -3097,8 +3101,8 @@ describe('AssistantService - Strict Operational Questions', () => {
     it('P46: responde "datos del edificio"', async () => {
       mockPrisma.ticket.count.mockResolvedValueOnce(5).mockResolvedValueOnce(10);
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 300000, unitId: 'u1', paymentAllocations: [] },
-        { amount: 100000, unitId: 'u2', paymentAllocations: [] },
+        { amount: 300000, currency: 'ARS', unitId: 'u1', paymentAllocations: [] },
+        { amount: 100000, currency: 'ARS', unitId: 'u2', paymentAllocations: [] },
       ]);
 
       const result = await (service as any).tryResolveStrictBuildingStatsQuestion(
@@ -3108,7 +3112,7 @@ describe('AssistantService - Strict Operational Questions', () => {
       );
 
       expect(result).not.toBeNull();
-      expect(result.answer).toContain('Deuda total');
+      expect(result.answer).toContain('Deuda:');
       expect(result.answer).toContain('Deuda promedio por unidad');
     });
 
@@ -3129,7 +3133,7 @@ describe('AssistantService - Strict Operational Questions', () => {
     it('P47-V1: matchea "como viene el edificio"', async () => {
       mockPrisma.ticket.count.mockResolvedValueOnce(2).mockResolvedValueOnce(8);
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 100000, unitId: 'u1', paymentAllocations: [] },
+        { amount: 100000, currency: 'ARS', unitId: 'u1', paymentAllocations: [] },
       ]);
 
       const result = await (service as any).tryResolveStrictBuildingStatsQuestion(
@@ -3140,7 +3144,7 @@ describe('AssistantService - Strict Operational Questions', () => {
 
       expect(result).not.toBeNull();
       expect(result.answer).toContain('Estadísticas del edificio');
-      expect(result.answer).toContain('Deuda total');
+      expect(result.answer).toContain('Deuda:');
     });
 
     it('P47-V2: matchea "cuentas del edificio"', async () => {
@@ -3479,7 +3483,7 @@ describe('AssistantService - Strict Operational Questions', () => {
 
     it('building-level se evalua antes que unit-level para "deuda edificio A"', async () => {
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 100000, unitId: 'u1', paymentAllocations: [] },
+        { amount: 100000, currency: 'ARS', unitId: 'u1', paymentAllocations: [] },
       ]);
 
       const result = await (service as any).tryResolveStrictOperationalQuestion(
@@ -3490,12 +3494,12 @@ describe('AssistantService - Strict Operational Questions', () => {
 
       expect(result).not.toBeNull();
       expect(result.answer).toContain('Edificio A');
-      expect(result.answer).toContain('deuda total');
+      expect(result.answer).toContain('deuda pendiente');
     });
 
     it('unit-level se usa para "deuda del depto 101 del Edificio A"', async () => {
       mockPrisma.charge.findMany.mockResolvedValue([
-        { amount: 50000, paymentAllocations: [] },
+        { amount: 50000, currency: 'ARS', paymentAllocations: [] },
       ]);
 
       const result = await (service as any).tryResolveStrictOperationalQuestion(

--- a/apps/api/src/assistant/assistant.service.ts
+++ b/apps/api/src/assistant/assistant.service.ts
@@ -1,5 +1,9 @@
 import { Injectable, BadRequestException, ConflictException, ForbiddenException, Logger, NotFoundException, OnModuleInit } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
+import {
+  formatCurrencySafe,
+  type ReportCurrencyAmountBucket,
+} from '../finanzas/currency-buckets';
 import { AuditService } from '../audit/audit.service';
 import { AuditAction, Prisma, UnitOccupantRole } from '@prisma/client';
 import { AiBudgetService } from './budget.service';
@@ -2535,12 +2539,12 @@ export class AssistantService implements OnModuleInit {
       }),
     ]);
 
-    const outstanding = this.debtCalculator.calculateOutstanding(charges);
-
-    const amountText = this.formatMoney(outstanding, tenant.currency);
-    const answer = outstanding > 0
+    const outstandingByCurrency = this.debtCalculator.calculateOutstandingByCurrency(charges);
+    const hasDebt = outstandingByCurrency.some((b) => b.amountMinor > 0);
+    const amountText = this.formatBuckets(outstandingByCurrency);
+    const answer = hasDebt
       ? `La unidad ${displayCode} (${building.name}) tiene una deuda pendiente de ${amountText}.`
-      : `La unidad ${displayCode} (${building.name}) no tiene deuda pendiente. Saldo actual: ${amountText}.`;
+      : `La unidad ${displayCode} (${building.name}) no tiene deuda pendiente.`;
 
     return {
       answer,
@@ -2881,13 +2885,13 @@ export class AssistantService implements OnModuleInit {
       },
     });
 
-    const outstanding = this.debtCalculator.calculateOutstanding(charges);
+    const outstandingByCurrency = this.debtCalculator.calculateOutstandingByCurrency(charges);
+    const hasDebt = outstandingByCurrency.some((b) => b.amountMinor > 0);
+    const amountText = this.formatBuckets(outstandingByCurrency);
 
-    const amountText = this.formatMoney(outstanding, tenant.currency);
-
-    if (outstanding > 0) {
+    if (hasDebt) {
       return {
-        answer: `El edificio ${building.name} tiene una deuda total pendiente de ${amountText} distribuida entre ${units.length} unidades.`,
+        answer: `El edificio ${building.name} tiene deuda pendiente de ${amountText} distribuida entre ${units.length} unidades.`,
         suggestedActions: [{ type: 'VIEW_PAYMENTS', payload: { buildingId: building.id } }],
       };
     }
@@ -3115,13 +3119,25 @@ export class AssistantService implements OnModuleInit {
       },
     });
 
-    // Calcular deuda por unidad
+    // Deuda por unidad en buckets; orden NO monetario
+    // (earliest overdue dueDate ASC, luego unitId ASC).
     const unitDebts = this.debtCalculator.calculateOutstandingByUnit(charges);
+    const earliestByUnit = new Map<string, Date>();
+    for (const charge of charges) {
+      if (!charge.unitId) continue;
+      const current = earliestByUnit.get(charge.unitId);
+      if (!current || charge.dueDate < current) {
+        earliestByUnit.set(charge.unitId, charge.dueDate);
+      }
+    }
 
-    // Ordenar por deuda descendente y tomar top 10
     const sortedDebts = Array.from(unitDebts.entries())
-      .filter(([, debt]) => debt > 0)
-      .sort(([, a], [, b]) => b - a)
+      .filter(([, buckets]) => buckets.some((b) => b.amountMinor > 0))
+      .sort(([aId], [bId]) => {
+        const dueDiff = (earliestByUnit.get(aId)?.getTime() ?? 0) - (earliestByUnit.get(bId)?.getTime() ?? 0);
+        if (dueDiff !== 0) return dueDiff;
+        return aId.localeCompare(bId);
+      })
       .slice(0, 10);
 
     if (sortedDebts.length === 0) {
@@ -3131,16 +3147,14 @@ export class AssistantService implements OnModuleInit {
       };
     }
 
-    const debtorList = sortedDebts.map(([unitId, debt], i) => {
+    const debtorList = sortedDebts.map(([unitId, buckets], i) => {
       const unit = units.find((u) => u.id === unitId);
       const unitLabel = unit ? (unit.label || unit.code) : 'Desconocida';
-      return `${i + 1}. ${unitLabel}: ${this.formatMoney(debt, tenant.currency)}`;
+      return `${i + 1}. ${unitLabel}: ${this.formatBuckets(buckets)}`;
     }).join('\n');
 
-    const totalDebt = sortedDebts.reduce((sum, [, debt]) => sum + debt, 0);
-
     return {
-      answer: `Top deudores del edificio ${building.name} (deuda total: ${this.formatMoney(totalDebt, tenant.currency)}):\n${debtorList}`,
+      answer: `Unidades con deuda pendiente del edificio ${building.name} (${sortedDebts.length}):\n${debtorList}`,
       suggestedActions: [{ type: 'VIEW_PAYMENTS', payload: { buildingId: building.id } }],
     };
   }
@@ -3236,16 +3250,22 @@ export class AssistantService implements OnModuleInit {
 
     const unitIds = units.map((u) => u.id);
 
-    const outstanding = this.debtCalculator.calculateOutstanding(charges);
-
-    const avgDebt = units.length > 0 ? outstanding / units.length : 0;
+    const outstandingByCurrency = this.debtCalculator.calculateOutstandingByCurrency(charges);
+    const hasDebt = outstandingByCurrency.some((b) => b.amountMinor > 0);
+    // Promedio por moneda únicamente — nunca entre monedas.
+    const averageOutstandingByCurrency = hasDebt && units.length > 0
+      ? outstandingByCurrency.map((b) => ({
+          currency: b.currency,
+          amountMinor: Math.round(b.amountMinor / units.length),
+        }))
+      : [];
 
     return {
       answer: `Estadísticas del edificio ${building.name}:\n` +
         `- Unidades: ${units.length}\n` +
         `- Tickets abiertos: ${openTickets} de ${totalTickets} totales\n` +
-        `- Deuda total: ${this.formatMoney(outstanding, tenant.currency)}\n` +
-        `- Deuda promedio por unidad: ${this.formatMoney(Math.round(avgDebt), tenant.currency)}`,
+        `- Deuda: ${this.formatBuckets(outstandingByCurrency)}\n` +
+        `- Deuda promedio por unidad: ${this.formatBuckets(averageOutstandingByCurrency)}`,
       suggestedActions: [
         { type: 'VIEW_REPORTS', payload: { buildingId: building.id } },
         { type: 'VIEW_TICKETS', payload: { buildingId: building.id } },
@@ -3506,6 +3526,21 @@ export class AssistantService implements OnModuleInit {
     } catch {
       return `${amount.toFixed(2)} ${currency}`;
     }
+  }
+
+  /**
+   * Render currency buckets as an explicit enumeration (canonical first,
+   * legacy after). Never produces a mixed nominal total.
+   */
+  private formatBuckets(
+    buckets: readonly ReportCurrencyAmountBucket[],
+  ): string {
+    if (!buckets || buckets.length === 0) {
+      return '—';
+    }
+    return buckets
+      .map((bucket) => formatCurrencySafe(bucket.amountMinor, bucket.currency))
+      .join(', ');
   }
 
   /**

--- a/apps/api/src/assistant/formatter/response-formatter.service.spec.ts
+++ b/apps/api/src/assistant/formatter/response-formatter.service.spec.ts
@@ -29,12 +29,13 @@ describe('ResponseFormatterService', () => {
       expect(result.answer).toContain('name');
     });
 
-    it('formats money with es-VE locale', () => {
+    it('does not guess a currency for money-like numbers without one', () => {
       const data = [{ id: '1', description: 'Test', amount: 10500 }];
       const result = service.formatV1(data, 'list_payments');
 
-      // es-VE format should show decimal places
-      expect(result.answer).toMatch(/\d+,\d{2}/);
+      // No VES/ARS fallback: the number is rendered plainly.
+      expect(result.answer).toContain('10500');
+      expect(result.answer).not.toMatch(/\d+,\d{2}/);
     });
 
     it('formats dates correctly', () => {
@@ -75,10 +76,10 @@ describe('ResponseFormatterService', () => {
     });
 
     it('includes overdue months for unit debt summaries', () => {
-      const data = { totalDebt: 2388869, overduePeriodCount: 3, currency: 'VES' };
+      const data = { outstandingByCurrency: [{ currency: 'VES', amountMinor: 2388869 }], overduePeriodCount: 3 };
       const result = service.formatV2(data, 'unit_debt', 0.9);
 
-      expect(result.summary).toContain('Deuda total');
+      expect(result.summary).toContain('Deuda pendiente');
       expect(result.summary).toContain('3 meses adeudados');
     });
 
@@ -115,11 +116,11 @@ describe('ResponseFormatterService', () => {
     });
 
     it('renders tenant_debt summaries as administration debt', () => {
-      const data = { totalDebt: 474568, currency: 'ARS' };
+      const data = { outstandingByCurrency: [{ currency: 'ARS', amountMinor: 474568 }] };
       const result = service.formatV2(data, 'tenant_debt', 0.9);
 
       expect(result.title).toBe('Tenant Debt');
-      expect(result.summary).toContain('Deuda total de la administración');
+      expect(result.summary).toContain('Deuda pendiente de la administración');
     });
   });
 

--- a/apps/api/src/assistant/formatter/response-formatter.service.ts
+++ b/apps/api/src/assistant/formatter/response-formatter.service.ts
@@ -1,6 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { StructuredResponse, ResponseType, SuggestedAction, IntentFilters } from '../intent-engine/intent.types';
 import { ChatResponse, SuggestedActionType } from '../ai.types';
+import {
+  formatCurrencySafe,
+  type ReportCurrencyAmountBucket,
+} from '../../finanzas/currency-buckets';
 
 /**
  * Supported formatter types
@@ -235,10 +239,9 @@ export class ResponseFormatterService {
     }
 
     if (typeof value === 'number') {
-      // Check if it looks like a money amount (whole numbers >= 100)
-      if (Number.isInteger(value) && value >= 100) {
-        return this.formatMoney(value);
-      }
+      // Money amounts must carry their currency from their source; a
+      // number without a known currency is never formatted with a
+      // guessed/default currency (no VES/ARS fallback).
       return String(value);
     }
 
@@ -254,9 +257,25 @@ export class ResponseFormatterService {
   }
 
   /**
-   * Format money amount with es-VE locale
+   * Render currency buckets as an explicit enumeration (canonical first,
+   * legacy after). Never produces a mixed nominal total.
    */
-  private formatMoney(amountCents: number, currency = 'VES'): string {
+  private formatBuckets(
+    buckets: readonly ReportCurrencyAmountBucket[],
+  ): string {
+    if (!buckets || buckets.length === 0) {
+      return '—';
+    }
+    return buckets
+      .map((bucket) => formatCurrencySafe(bucket.amountMinor, bucket.currency))
+      .join(', ');
+  }
+
+  /**
+   * Format money amount with the explicitly provided currency.
+   * Never guesses a currency.
+   */
+  private formatMoney(amountCents: number, currency: string): string {
     const amount = amountCents / 100;
     try {
       return new Intl.NumberFormat('es-VE', { style: 'currency', currency }).format(amount);
@@ -290,8 +309,9 @@ export class ResponseFormatterService {
 
     for (const [key, value] of Object.entries(record)) {
       const label = this.formatLabel(key);
-      if (typeof value === 'number' && this.isMoneyField(key)) {
-        lines.push(`${label}: ${this.formatMoney(value)}`);
+      const currency = typeof record.currency === 'string' ? record.currency : undefined;
+      if (typeof value === 'number' && this.isMoneyField(key) && currency) {
+        lines.push(`${label}: ${this.formatMoney(value, currency)}`);
       } else if (typeof value === 'number') {
         lines.push(`${label}: ${value}`);
       } else {
@@ -373,11 +393,12 @@ export class ResponseFormatterService {
 
       switch (intent) {
         case 'unit_debt': {
-          const totalDebt = record.totalDebt as number;
-          const currency = (record.currency as string) || 'VES';
+          const buckets = record.outstandingByCurrency as ReportCurrencyAmountBucket[] | undefined;
           const overduePeriodCount = record.overduePeriodCount as number | undefined;
-          if (totalDebt !== undefined) {
-            const debtSummary = `Deuda total: ${this.formatMoney(totalDebt, currency)}`;
+          if (buckets !== undefined) {
+            const debtSummary = buckets.length > 0
+              ? `Deuda pendiente: ${this.formatBuckets(buckets)}`
+              : 'Sin deuda pendiente';
             if (overduePeriodCount !== undefined) {
               const periodLabel = overduePeriodCount === 1 ? 'mes adeudado' : 'meses adeudados';
               return `${debtSummary} (${overduePeriodCount} ${periodLabel})`;
@@ -388,19 +409,21 @@ export class ResponseFormatterService {
         }
 
         case 'building_debt': {
-          const totalDebt = record.totalDebt as number;
-          const currency = (record.currency as string) || 'VES';
-          if (totalDebt !== undefined) {
-            return `Deuda total: ${this.formatMoney(totalDebt, currency)}`;
+          const buckets = record.outstandingByCurrency as ReportCurrencyAmountBucket[] | undefined;
+          if (buckets !== undefined) {
+            return buckets.length > 0
+              ? `Deuda pendiente: ${this.formatBuckets(buckets)}`
+              : 'Sin deuda pendiente';
           }
           break;
         }
 
         case 'tenant_debt': {
-          const totalDebt = record.totalDebt as number;
-          const currency = (record.currency as string) || 'VES';
-          if (totalDebt !== undefined) {
-            return `Deuda total de la administración: ${this.formatMoney(totalDebt, currency)}`;
+          const buckets = record.outstandingByCurrency as ReportCurrencyAmountBucket[] | undefined;
+          if (buckets !== undefined) {
+            return buckets.length > 0
+              ? `Deuda pendiente de la administración: ${this.formatBuckets(buckets)}`
+              : 'La administración no tiene deuda pendiente';
           }
           break;
         }
@@ -477,7 +500,8 @@ export class ResponseFormatterService {
         case 'expenses_summary': {
           const totalExpenses = record.totalExpenses as number;
           if (totalExpenses !== undefined) {
-            return `Gastos totales: ${this.formatMoney(totalExpenses)}`;
+            const currency = typeof record.currency === 'string' ? record.currency : undefined;
+            return `Gastos totales: ${currency ? this.formatMoney(totalExpenses, currency) : String(totalExpenses)}`;
           }
           break;
         }
@@ -487,7 +511,9 @@ export class ResponseFormatterService {
           const expenses = record.expenses as number;
           if (income !== undefined && expenses !== undefined) {
             const diff = income - expenses;
-            return `Ingresos: ${this.formatMoney(income)} | Gastos: ${this.formatMoney(expenses)} | Diferencia: ${this.formatMoney(Math.abs(diff))} ${diff >= 0 ? '(superávit)' : '(déficit)'}`;
+            const currency = typeof record.currency === 'string' ? record.currency : undefined;
+            const fmt = (v: number) => (currency ? this.formatMoney(v, currency) : String(v));
+            return `Ingresos: ${fmt(income)} | Gastos: ${fmt(expenses)} | Diferencia: ${fmt(Math.abs(diff))} ${diff >= 0 ? '(superávit)' : '(déficit)'}`;
           }
           break;
         }

--- a/apps/api/src/assistant/intent-engine/allowed-intents/building-debt.intent.ts
+++ b/apps/api/src/assistant/intent-engine/allowed-intents/building-debt.intent.ts
@@ -2,6 +2,7 @@ import { BadRequestException } from '@nestjs/common';
 import { ChargeStatus, Prisma } from '@prisma/client';
 import { Permission } from '../../../rbac/permissions';
 import { AssistantDebtCalculatorService } from '../../assistant-debt-calculator.service';
+import { aggregateReportBuckets } from '../../../finanzas/currency-buckets';
 import { PeriodResolverService } from '../../period-resolver.service';
 import type { CanonicalFinancePeriod } from '../../finance-period.types';
 import { IntentDefinition, IntentExecutionResult } from '../intent.types';
@@ -86,37 +87,57 @@ export const buildingDebtIntent: IntentDefinition = {
       }),
     ]);
 
-    // Group by unit and sum amounts
-    const unitDebts: Record<string, { unitCode: string; label: string; totalAmount: number; paidAmount: number; remainingDebt: number }> = {};
+    // Group by unit with per-currency buckets. Ordering is NON-monetary:
+    // earliest overdue dueDate ASC, then unitId ASC (3F rule) — amounts in
+    // different currencies are never compared or summed.
+    const unitDebts: Record<
+      string,
+      {
+        unitCode: string;
+        label: string;
+        earliestDue: Date;
+        entries: Array<{ currency: string; amountMinor: number }>;
+      }
+    > = {};
 
     for (const charge of charges) {
       const unitKey = charge.unitId;
       const remainingDebt = debtCalculator.calculateChargeOutstanding(charge);
-      const paidAmount = Math.max(0, charge.amount - remainingDebt);
+      if (remainingDebt <= 0) continue;
 
       if (!unitDebts[unitKey]) {
         unitDebts[unitKey] = {
           unitCode: charge.unit.code,
           label: charge.unit.label || charge.unit.code,
-          totalAmount: 0,
-          paidAmount: 0,
-          remainingDebt: 0,
+          earliestDue: charge.dueDate,
+          entries: [],
         };
       }
 
-      unitDebts[unitKey].totalAmount += charge.amount;
-      unitDebts[unitKey].paidAmount += paidAmount;
-      unitDebts[unitKey].remainingDebt += remainingDebt;
+      unitDebts[unitKey].entries.push({ currency: charge.currency, amountMinor: remainingDebt });
+      if (charge.dueDate < unitDebts[unitKey].earliestDue) {
+        unitDebts[unitKey].earliestDue = charge.dueDate;
+      }
     }
 
-    const totalDebt = debtCalculator.calculateOutstanding(charges);
+    const outstandingByCurrency = debtCalculator.calculateOutstandingByCurrency(charges);
 
     return {
       data: {
-        totalDebt,
-        currency: tenant.currency,
+        outstandingByCurrency,
         totalUnits: Object.keys(unitDebts).length,
-        byUnit: Object.values(unitDebts).sort((a, b) => b.remainingDebt - a.remainingDebt).slice(0, pagination?.limit || 20),
+        byUnit: Object.values(unitDebts)
+          .sort((a, b) => {
+            const dueDiff = a.earliestDue.getTime() - b.earliestDue.getTime();
+            if (dueDiff !== 0) return dueDiff;
+            return a.label.localeCompare(b.label);
+          })
+          .slice(0, pagination?.limit || 20)
+          .map((u) => ({
+            unitCode: u.unitCode,
+            label: u.label,
+            remainingDebtByCurrency: aggregateReportBuckets(u.entries),
+          })),
       },
     };
   },

--- a/apps/api/src/assistant/intent-engine/allowed-intents/building-delinquents.intent.spec.ts
+++ b/apps/api/src/assistant/intent-engine/allowed-intents/building-delinquents.intent.spec.ts
@@ -1,0 +1,134 @@
+import { BadRequestException } from '@nestjs/common';
+import { buildingDelinquentsIntent } from './building-delinquents.intent';
+import { IntentExecutionResult } from '../intent.types';
+
+function chg(o: {
+  id?: string;
+  unitId: string;
+  amount: number;
+  currency?: string;
+  dueDate: string;
+  status?: string;
+  overdueSince?: string | null;
+  allocations?: Array<{ amount: number; payment?: { status?: string } | null }>;
+}) {
+  return {
+    id: o.id || `c-${o.unitId}`,
+    unitId: o.unitId,
+    amount: o.amount,
+    currency: o.currency || 'ARS',
+    dueDate: new Date(o.dueDate),
+    canceledAt: null,
+    status: o.status || 'PENDING',
+    overdueSince: o.overdueSince === undefined ? new Date('2026-01-01T00:00:00Z') : o.overdueSince,
+    unit: { id: o.unitId, code: `code-${o.unitId}`, label: `Label ${o.unitId}` },
+    paymentAllocations: o.allocations || [],
+  };
+}
+
+function makePrisma(charges: unknown[]) {
+  return {
+    charge: { findMany: async () => charges },
+    tenant: { findUniqueOrThrow: async () => ({ currency: 'ARS' }) },
+  };
+}
+
+async function run(
+  filters: Record<string, unknown> | undefined,
+  charges: unknown[],
+): Promise<IntentExecutionResult> {
+  return buildingDelinquentsIntent.executor({
+    tenantId: 'tenant-1',
+    entityIds: { buildingId: 'building-1' },
+    filters,
+    pagination: { limit: 20 },
+    prisma: makePrisma(charges) as never,
+    userRoles: ['TENANT_ADMIN'],
+  } as never);
+}
+
+describe('building_delinquents intent (3F5 decision B)', () => {
+  it('default list: NON-monetary ordering (earliest dueDate ASC, then label)', async () => {
+    const result = await run(undefined, [
+      chg({ unitId: 'unit-a', amount: 1, currency: 'USD', dueDate: '2026-03-01T00:00:00Z' }),
+      chg({ unitId: 'unit-b', amount: 1000000000, dueDate: '2026-01-01T00:00:00Z' }),
+    ]);
+
+    const data = result.data as { delinquents: Array<{ label: string; outstandingByCurrency: unknown[] }> };
+    // ARS 10M (earlier dueDate) first even though its nominal value dwarfs USD 1.
+    expect(data.delinquents[0]!.label).toBe('Label unit-b');
+    expect(data.delinquents[1]!.label).toBe('Label unit-a');
+    expect(data.delinquents[0]!.outstandingByCurrency).toEqual([
+      { currency: 'ARS', amountMinor: 1000000000 },
+    ]);
+  });
+
+  it('USD filter: compares ONLY the USD bucket (same-currency)', async () => {
+    const result = await run(
+      { currency: 'USD', minAmount: 500 },
+      [
+        chg({ unitId: 'unit-a', amount: 1000000000, currency: 'ARS', dueDate: '2026-01-01T00:00:00Z' }),
+        chg({ unitId: 'unit-b', amount: 100, currency: 'USD', dueDate: '2026-01-02T00:00:00Z' }),
+        chg({ unitId: 'unit-c', amount: 60000, currency: 'USD', dueDate: '2026-01-03T00:00:00Z' }),
+      ],
+    );
+
+    const data = result.data as { delinquents: Array<{ label: string }> };
+    // unit-a (ARS 10M, USD 0) and unit-b (USD 1) do NOT match; only unit-c (USD 600).
+    expect(data.delinquents.map((d) => d.label)).toEqual(['Label unit-c']);
+  });
+
+  it('missing currency with monetary operation => clarification (BadRequest, query not executed)', async () => {
+    const prisma = makePrisma([]);
+    prisma.charge.findMany = jest.fn().mockResolvedValue([]);
+
+    await expect(
+      buildingDelinquentsIntent.executor({
+        tenantId: 'tenant-1',
+        entityIds: { buildingId: 'building-1' },
+        filters: { minAmount: 500 },
+        pagination: { limit: 20 },
+        prisma: prisma as never,
+        userRoles: ['TENANT_ADMIN'],
+      } as never),
+    ).rejects.toThrow(BadRequestException);
+
+    // The monetary filter must never execute without a currency.
+    expect(prisma.charge.findMany).not.toHaveBeenCalled();
+  });
+
+  it('same-currency monetary ranking: USD amounts only', async () => {
+    const result = await run(
+      { currency: 'USD', sortField: 'amount', sortOrder: 'desc' },
+      [
+        chg({ unitId: 'unit-a', amount: 10000, currency: 'USD', dueDate: '2026-01-01T00:00:00Z' }),
+        chg({ unitId: 'unit-b', amount: 50000, currency: 'USD', dueDate: '2026-01-02T00:00:00Z' }),
+        chg({ unitId: 'unit-c', amount: 20000, currency: 'USD', dueDate: '2026-01-03T00:00:00Z' }),
+      ],
+    );
+
+    const data = result.data as { delinquents: Array<{ label: string }> };
+    expect(data.delinquents.map((d) => d.label)).toEqual([
+      'Label unit-b',
+      'Label unit-c',
+      'Label unit-a',
+    ]);
+  });
+
+  it('cross-currency "biggest debtors" without currency => clarification, no nominal ranking', async () => {
+    const prisma = makePrisma([]);
+    prisma.charge.findMany = jest.fn().mockResolvedValue([]);
+
+    await expect(
+      buildingDelinquentsIntent.executor({
+        tenantId: 'tenant-1',
+        entityIds: { buildingId: 'building-1' },
+        filters: { sortField: 'amount' },
+        pagination: { limit: 20 },
+        prisma: prisma as never,
+        userRoles: ['TENANT_ADMIN'],
+      } as never),
+    ).rejects.toThrow(BadRequestException);
+    expect(prisma.charge.findMany).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/assistant/intent-engine/allowed-intents/building-delinquents.intent.ts
+++ b/apps/api/src/assistant/intent-engine/allowed-intents/building-delinquents.intent.ts
@@ -2,14 +2,29 @@ import { BadRequestException } from '@nestjs/common';
 import { ChargeStatus } from '@prisma/client';
 import { Permission } from '../../../rbac/permissions';
 import { AssistantDebtCalculatorService } from '../../assistant-debt-calculator.service';
-import { IntentDefinition, IntentExecutionResult } from '../intent.types';
+import { aggregateReportBuckets } from '../../../finanzas/currency-buckets';
+import { IntentDefinition, IntentExecutionResult, IntentFilters } from '../intent.types';
 
 const debtCalculator = new AssistantDebtCalculatorService();
+
+interface MonetaryOperation {
+  readonly minAmount?: number;
+  readonly maxAmount?: number;
+  readonly sortByAmount?: boolean;
+}
+
+function hasMonetaryOperation(filters: IntentFilters | undefined): MonetaryOperation {
+  const minAmount = typeof filters?.minAmount === 'number' ? filters.minAmount : undefined;
+  const maxAmount = typeof filters?.maxAmount === 'number' ? filters.maxAmount : undefined;
+  const sortByAmount =
+    filters?.sortField === 'amount' || filters?.sortField === 'debt' || filters?.sortField === 'totalDebt';
+  return { minAmount, maxAmount, sortByAmount };
+}
 
 export const buildingDelinquentsIntent: IntentDefinition = {
   name: 'building_delinquents',
   requiredPermission: 'payments.review' as Permission,
-  supportedFilters: ['minAmount', 'maxAmount', 'limit', 'sortField', 'sortOrder'],
+  supportedFilters: ['minAmount', 'maxAmount', 'limit', 'sortField', 'sortOrder', 'currency'],
   supportedResponseTypes: ['table', 'text'],
   executor: async (params): Promise<IntentExecutionResult> => {
     const { tenantId, entityIds, filters, pagination, prisma } = params;
@@ -19,13 +34,26 @@ export const buildingDelinquentsIntent: IntentDefinition = {
       throw new BadRequestException('buildingId required for building_delinquents intent');
     }
 
-    const [tenant, overdueCharges] = await Promise.all([
-      prisma.tenant.findUniqueOrThrow({
-        where: { id: tenantId },
-        select: { currency: true },
-      }),
-      // Find charges with OVERDUE status grouped by unit
-      prisma.charge.findMany({
+    // Monetary comparisons (minAmount/maxAmount/monetary sort) require an
+    // explicit currency: comparing amounts across different currencies has
+    // no meaning without a conversion. The assistant must ask the user
+    // which currency to use instead of guessing (no tenant/default/live FX).
+    const monetary = hasMonetaryOperation(filters);
+    const currency =
+      typeof filters?.currency === 'string' && filters.currency.length > 0
+        ? filters.currency
+        : undefined;
+    const wantsMonetaryComparison =
+      monetary.minAmount !== undefined ||
+      monetary.maxAmount !== undefined ||
+      monetary.sortByAmount;
+    if (wantsMonetaryComparison && !currency) {
+      throw new BadRequestException(
+        'currency required for monetary comparison in building_delinquents intent: ¿En qué moneda querés comparar la deuda?',
+      );
+    }
+
+    const overdueCharges = await prisma.charge.findMany({
       where: {
         buildingId,
         tenantId,
@@ -34,7 +62,7 @@ export const buildingDelinquentsIntent: IntentDefinition = {
         canceledAt: null,
       },
       include: {
-        unit: { select: { code: true, label: true } },
+        unit: { select: { id: true, code: true, label: true } },
         paymentAllocations: {
           include: {
             payment: {
@@ -45,11 +73,18 @@ export const buildingDelinquentsIntent: IntentDefinition = {
           },
         },
       },
-    }),
-    ]);
+    });
 
-    // Group by unit and calculate debt
-    const unitDebts: Record<string, { unitCode: string; label: string; totalDebt: number }> = {};
+    // Group by unit with per-currency buckets + earliest delinquency.
+    const unitDebts = new Map<
+      string,
+      {
+        unitCode: string;
+        label: string;
+        earliestDue: Date;
+        entries: Array<{ currency: string; amountMinor: number }>;
+      }
+    >();
 
     for (const charge of overdueCharges) {
       const unitKey = charge.unitId;
@@ -57,34 +92,71 @@ export const buildingDelinquentsIntent: IntentDefinition = {
 
       if (remainingDebt <= 0) continue; // Skip fully paid
 
-      if (!unitDebts[unitKey]) {
-        unitDebts[unitKey] = {
-          unitCode: charge.unit.code,
-          label: charge.unit.label || charge.unit.code,
-          totalDebt: 0,
-        };
+      const current = unitDebts.get(unitKey) ?? {
+        unitCode: charge.unit.code,
+        label: charge.unit.label || charge.unit.code,
+        earliestDue: charge.dueDate,
+        entries: [],
+      };
+      current.entries.push({ currency: charge.currency, amountMinor: remainingDebt });
+      if (charge.dueDate < current.earliestDue) {
+        current.earliestDue = charge.dueDate;
       }
-
-      unitDebts[unitKey].totalDebt += remainingDebt;
+      unitDebts.set(unitKey, current);
     }
 
-    const delinquents = Object.values(unitDebts)
-      .filter((u) => u.totalDebt > 0)
-      .sort((a, b) => b.totalDebt - a.totalDebt)
-      .filter((u) => {
-        const minDebt = typeof filters?.minDebt === 'number' ? filters.minDebt : filters?.minAmount;
-        const maxDebt = filters?.maxAmount;
-        if (typeof minDebt === 'number' && u.totalDebt < minDebt) return false;
-        if (typeof maxDebt === 'number' && u.totalDebt > maxDebt) return false;
+    let delinquents = Array.from(unitDebts.values()).map((u) => ({
+      unitCode: u.unitCode,
+      label: u.label,
+      outstandingByCurrency: aggregateReportBuckets(u.entries),
+      earliestDue: u.earliestDue,
+    }));
+
+    if (wantsMonetaryComparison && currency) {
+      // Same-currency comparison ONLY: filter/rank by the explicit
+      // currency bucket; other buckets never participate.
+      const minAmountMinor = monetary.minAmount !== undefined ? Math.round(monetary.minAmount * 100) : undefined;
+      const maxAmountMinor = monetary.maxAmount !== undefined ? Math.round(monetary.maxAmount * 100) : undefined;
+
+      delinquents = delinquents.filter((u) => {
+        const bucket = u.outstandingByCurrency.find((b) => b.currency === currency);
+        const amount = bucket?.amountMinor ?? 0;
+        if (minAmountMinor !== undefined && amount < minAmountMinor) return false;
+        if (maxAmountMinor !== undefined && amount > maxAmountMinor) return false;
         return true;
-      })
-      .slice(0, pagination?.limit || 20);
+      });
+
+      if (monetary.sortByAmount) {
+        const order = filters?.sortOrder === 'asc' ? 1 : -1;
+        delinquents.sort((a, b) => {
+          const aAmount = a.outstandingByCurrency.find((b2) => b2.currency === currency)?.amountMinor ?? 0;
+          const bAmount = b.outstandingByCurrency.find((b2) => b2.currency === currency)?.amountMinor ?? 0;
+          return (aAmount - bAmount) * order;
+        });
+      } else {
+        delinquents.sort((a, b) => {
+          const dueDiff = a.earliestDue.getTime() - b.earliestDue.getTime();
+          if (dueDiff !== 0) return dueDiff;
+          return a.label.localeCompare(b.label);
+        });
+      }
+    } else {
+      // Default delinquency list: NON-monetary ordering
+      // (earliest overdue dueDate ASC, then label ASC).
+      delinquents.sort((a, b) => {
+        const dueDiff = a.earliestDue.getTime() - b.earliestDue.getTime();
+        if (dueDiff !== 0) return dueDiff;
+        return a.label.localeCompare(b.label);
+      });
+    }
+
+    delinquents = delinquents.slice(0, pagination?.limit || 20);
 
     return {
       data: {
         delinquents,
         totalUnitsWithDebt: delinquents.length,
-        currency: tenant.currency,
+        ...(wantsMonetaryComparison && currency ? { currency } : {}),
       },
     };
   },

--- a/apps/api/src/assistant/intent-engine/allowed-intents/unit-debt.intent.ts
+++ b/apps/api/src/assistant/intent-engine/allowed-intents/unit-debt.intent.ts
@@ -57,7 +57,7 @@ export const unitDebtIntent: IntentDefinition = {
       return { ...charge, remainingDebt };
     });
 
-    const totalDebt = debtCalculator.calculateOutstanding(charges);
+    const outstandingByCurrency = debtCalculator.calculateOutstandingByCurrency(charges);
     const overduePeriods = Array.from(
       new Set(
         chargesWithDebt
@@ -68,7 +68,7 @@ export const unitDebtIntent: IntentDefinition = {
 
     return {
       data: {
-        totalDebt,
+        outstandingByCurrency,
         overduePeriodCount: overduePeriods.length,
         overduePeriods,
         currency: tenant.currency,

--- a/apps/api/src/assistant/intent-engine/intent.types.ts
+++ b/apps/api/src/assistant/intent-engine/intent.types.ts
@@ -21,6 +21,7 @@ export type SupportedFilter =
   | 'category'
   | 'sortField'
   | 'sortOrder'
+  | 'currency'
   | 'limit';
 
 /**
@@ -38,6 +39,7 @@ export interface IntentFilters {
   category?: string;
   sortField?: string;
   sortOrder?: 'asc' | 'desc';
+  currency?: string;
   limit?: number;
 }
 

--- a/apps/api/src/assistant/query-executors.service.spec.ts
+++ b/apps/api/src/assistant/query-executors.service.spec.ts
@@ -166,9 +166,9 @@ describe('AssistantQueryExecutorsService', () => {
     prisma.building.findMany.mockResolvedValue([{ id: 'building-1', name: 'Edificio A' }]);
     prisma.tenant.findUniqueOrThrow.mockResolvedValue({ currency: 'ARS' });
     finanzasService.getBuildingFinancialSummary.mockResolvedValue({
-      totalCharges: 150000,
-      totalPaid: 50000,
-      totalOutstanding: 100000,
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 150000 }],
+      totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 50000 }],
+      totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 100000 }],
       delinquentUnitsCount: 1,
       topDelinquentUnits: [],
       currency: 'ARS',
@@ -178,7 +178,7 @@ describe('AssistantQueryExecutorsService', () => {
 
     expect(policy.assertCanExecute).toHaveBeenCalledWith(expect.objectContaining({ buildingId: 'building-1' }));
     expect(finanzasService.getBuildingFinancialSummary).toHaveBeenCalledWith('tenant-1', 'building-1', undefined);
-    expect(result?.answer).toContain('deuda pendiente total');
+    expect(result?.answer).toContain('tiene deuda pendiente:');
   });
 
   it('executes building_debt with relative-range periods and a labeled range response', async () => {
@@ -210,9 +210,9 @@ describe('AssistantQueryExecutorsService', () => {
     prisma.building.findMany.mockResolvedValue([{ id: 'building-1', name: 'Torre El Parque' }]);
     prisma.tenant.findUniqueOrThrow.mockResolvedValue({ currency: 'ARS' });
     finanzasService.getBuildingFinancialSummary.mockResolvedValue({
-      totalCharges: 150000,
-      totalPaid: 50000,
-      totalOutstanding: 100000,
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 150000 }],
+      totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 50000 }],
+      totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 100000 }],
       delinquentUnitsCount: 1,
       topDelinquentUnits: [],
       currency: 'ARS',
@@ -248,9 +248,9 @@ describe('AssistantQueryExecutorsService', () => {
     prisma.building.findMany.mockResolvedValue([{ id: 'building-1', name: 'Edificio A' }]);
     prisma.tenant.findUniqueOrThrow.mockResolvedValue({ currency: 'ARS' });
     finanzasService.getBuildingFinancialSummary.mockResolvedValue({
-      totalCharges: 150000,
-      totalPaid: 50000,
-      totalOutstanding: 100000,
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 150000 }],
+      totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 50000 }],
+      totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 100000 }],
       delinquentUnitsCount: 1,
       topDelinquentUnits: [],
       currency: 'ARS',
@@ -275,9 +275,9 @@ describe('AssistantQueryExecutorsService', () => {
     prisma.building.findMany.mockResolvedValue([{ id: 'building-1', name: 'Edificio A' }]);
     prisma.tenant.findUniqueOrThrow.mockResolvedValue({ currency: 'ARS' });
     finanzasService.getBuildingFinancialSummary.mockResolvedValue({
-      totalCharges: 150000,
-      totalPaid: 50000,
-      totalOutstanding: 100000,
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 150000 }],
+      totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 50000 }],
+      totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 100000 }],
       delinquentUnitsCount: 1,
       topDelinquentUnits: [],
       currency: 'ARS',
@@ -321,9 +321,9 @@ describe('AssistantQueryExecutorsService', () => {
     prisma.building.findMany.mockResolvedValue([{ id: 'building-1', name: 'Torre El Parque' }]);
     prisma.tenant.findUniqueOrThrow.mockResolvedValue({ currency: 'ARS' });
     finanzasService.getBuildingFinancialSummary.mockResolvedValue({
-      totalCharges: 150000,
-      totalPaid: 50000,
-      totalOutstanding: 100000,
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 150000 }],
+      totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 50000 }],
+      totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 100000 }],
       delinquentUnitsCount: 1,
       topDelinquentUnits: [],
       currency: 'ARS',
@@ -350,9 +350,9 @@ describe('AssistantQueryExecutorsService', () => {
       source: 'deterministic_rules',
     };
     finanzasService.getTenantFinancialSummary.mockResolvedValue({
-      totalCharges: 30000,
-      totalPaid: 14199,
-      totalOutstanding: 15801,
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 30000 }],
+      totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 14199 }],
+      totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 15801 }],
       delinquentUnitsCount: 2,
       topDelinquentUnits: [],
       currency: 'ARS',
@@ -392,9 +392,9 @@ describe('AssistantQueryExecutorsService', () => {
       source: 'deterministic_rules',
     };
     finanzasService.getTenantFinancialSummary.mockResolvedValue({
-      totalCharges: 200000,
-      totalPaid: 50000,
-      totalOutstanding: 150000,
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 200000 }],
+      totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 50000 }],
+      totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 150000 }],
       delinquentUnitsCount: 2,
       topDelinquentUnits: [],
       currency: 'ARS',
@@ -455,13 +455,13 @@ describe('AssistantQueryExecutorsService', () => {
     };
     prisma.building.findMany.mockResolvedValue([{ id: 'building-1', name: 'Edificio A' }]);
     finanzasService.getBuildingFinancialSummary.mockResolvedValue({
-      totalCharges: 200000,
-      totalPaid: 50000,
-      totalOutstanding: 150000,
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 200000 }],
+      totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 50000 }],
+      totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 150000 }],
       delinquentUnitsCount: 2,
       topDelinquentUnits: [
-        { unitId: 'unit-1', unitLabel: 'Unidad 0101', buildingId: 'building-1', buildingName: 'Edificio A', outstanding: 90000 },
-        { unitId: 'unit-2', unitLabel: 'Unidad 0202', buildingId: 'building-1', buildingName: 'Edificio A', outstanding: 60000 },
+        { unitId: 'unit-1', unitLabel: 'Unidad 0101', buildingId: 'building-1', buildingName: 'Edificio A', outstandingByCurrency: [{ currency: 'ARS', amountMinor: 90000 }] },
+        { unitId: 'unit-2', unitLabel: 'Unidad 0202', buildingId: 'building-1', buildingName: 'Edificio A', outstandingByCurrency: [{ currency: 'ARS', amountMinor: 60000 }] },
       ],
       currency: 'ARS',
     });
@@ -469,7 +469,7 @@ describe('AssistantQueryExecutorsService', () => {
     const result = await service.execute({ tenantId: 'tenant-1', userId: 'operator-1', userRoles: ['OPERATOR'], plan });
 
     expect(finanzasService.getBuildingFinancialSummary).toHaveBeenCalledWith('tenant-1', 'building-1', undefined);
-    expect(result?.answer).toContain('Top deudores');
+    expect(result?.answer).toContain('Unidades con deuda pendiente');
     expect(result?.answer).toContain('Unidad 0101');
     expect(prisma.charge.findMany).not.toHaveBeenCalled();
   });
@@ -491,9 +491,9 @@ describe('AssistantQueryExecutorsService', () => {
     ]);
     prisma.unit.findMany.mockResolvedValue([{ id: 'unit-1', code: '0101', label: 'Unidad 0101' }]);
     finanzasService.getBuildingFinancialSummary.mockResolvedValue({
-      totalCharges: 150000,
-      totalPaid: 100000,
-      totalOutstanding: 50000,
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 150000 }],
+      totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 100000 }],
+      totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 50000 }],
       delinquentUnitsCount: 1,
       topDelinquentUnits: [],
       currency: 'ARS',
@@ -525,9 +525,9 @@ describe('AssistantQueryExecutorsService', () => {
     prisma.ticket.count.mockResolvedValue(1);
     prisma.ticket.findMany.mockResolvedValue([{ id: 'ticket-1', title: 'Ascensor', status: 'OPEN', priority: 'HIGH', unitId: null, createdAt: new Date() }]);
     finanzasService.getBuildingFinancialSummary.mockResolvedValue({
-      totalCharges: 160000,
-      totalPaid: 90000,
-      totalOutstanding: 70000,
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 160000 }],
+      totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 90000 }],
+      totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 70000 }],
       delinquentUnitsCount: 2,
       topDelinquentUnits: [],
       currency: 'ARS',

--- a/apps/api/src/assistant/query-executors.service.ts
+++ b/apps/api/src/assistant/query-executors.service.ts
@@ -10,6 +10,10 @@ import type { CanonicalFinancePeriod, ResolvedFinancePeriod } from './finance-pe
 import { PeriodResolverService } from './period-resolver.service';
 import type { AssistantQueryExecutionContext } from './query-plan.types';
 import type { BuildingFinancialSummaryPeriodFilter } from '../finanzas/finanzas.service';
+import {
+  formatCurrencySafe,
+  type ReportCurrencyAmountBucket,
+} from '../finanzas/currency-buckets';
 
 @Injectable()
 export class AssistantQueryExecutorsService {
@@ -390,16 +394,18 @@ export class AssistantQueryExecutorsService {
       building.id,
       periodResolution.filter,
     );
-    const outstanding = summary.totalOutstanding;
+    const outstandingByCurrency = summary.totalOutstandingByCurrency;
+    const hasDebt = outstandingByCurrency.some((b) => b.amountMinor > 0);
     const rangeLabel = periodResolution.resolved?.label;
+    const debtText = this.formatBuckets(outstandingByCurrency);
     return {
-      answer: outstanding > 0
+      answer: hasDebt
         ? rangeLabel
-          ? `Deuda de ${building.name}, ${rangeLabel}: ${this.formatMoney(outstanding, summary.currency)}.`
-          : `El edificio ${building.name} tiene una deuda pendiente total de ${this.formatMoney(outstanding, summary.currency)}.`
+          ? `Deuda de ${building.name}, ${rangeLabel}: ${debtText}.`
+          : `El edificio ${building.name} tiene deuda pendiente: ${debtText}.`
         : rangeLabel
-          ? `Deuda de ${building.name}, ${rangeLabel}: ${this.formatMoney(outstanding, summary.currency)}.`
-          : `El edificio ${building.name} no tiene deuda pendiente. Saldo actual: ${this.formatMoney(outstanding, summary.currency)}.`,
+          ? `Deuda de ${building.name}, ${rangeLabel}: sin deuda pendiente.`
+          : `El edificio ${building.name} no tiene deuda pendiente.`,
       suggestedActions: [{ type: 'VIEW_PAYMENTS', payload: { buildingId: building.id } }],
     };
   }
@@ -422,15 +428,17 @@ export class AssistantQueryExecutorsService {
       context.tenantId,
       periodResolution.filter,
     );
-    const totalDebt = tenantDebt.totalOutstanding;
+    const outstandingByCurrency = tenantDebt.totalOutstandingByCurrency;
+    const hasDebt = outstandingByCurrency.some((b) => b.amountMinor > 0);
+    const debtText = this.formatBuckets(outstandingByCurrency);
     return {
-      answer: totalDebt > 0
+      answer: hasDebt
         ? periodResolution.resolved?.label
-          ? `Deuda global de la administración, ${periodResolution.resolved.label}: ${this.formatMoney(totalDebt, tenantDebt.currency)}.`
-          : `La administración tiene una deuda pendiente total de ${this.formatMoney(totalDebt, tenantDebt.currency)}.`
+          ? `Deuda global de la administración, ${periodResolution.resolved.label}: ${debtText}.`
+          : `La administración tiene deuda pendiente: ${debtText}.`
         : periodResolution.resolved?.label
-          ? `Deuda global de la administración, ${periodResolution.resolved.label}: ${this.formatMoney(totalDebt, tenantDebt.currency)}.`
-          : `La administración no tiene deuda pendiente. Saldo actual: ${this.formatMoney(totalDebt, tenantDebt.currency)}.`,
+          ? `Deuda global de la administración, ${periodResolution.resolved.label}: sin deuda pendiente.`
+          : `La administración no tiene deuda pendiente.`,
       suggestedActions: [{ type: 'VIEW_PAYMENTS', payload: {} }],
     };
   }
@@ -465,11 +473,11 @@ export class AssistantQueryExecutorsService {
     }
 
     const debtorList = summary.topDelinquentUnits.map((unit, index) => {
-      return `${index + 1}. ${unit.unitLabel}: ${this.formatMoney(unit.outstanding, summary.currency)}`;
+      return `${index + 1}. ${unit.unitLabel}: ${this.formatBuckets(unit.outstandingByCurrency)}`;
     }).join('\n');
 
     return {
-      answer: `Top deudores del edificio ${building.name} (deuda total: ${this.formatMoney(summary.totalOutstanding, summary.currency)}):\n${debtorList}`,
+      answer: `Unidades con deuda pendiente del edificio ${building.name} (${summary.delinquentUnitsCount}):\n${debtorList}`,
       suggestedActions: [{ type: 'VIEW_PAYMENTS', payload: { buildingId: building.id } }],
     };
   }
@@ -617,10 +625,17 @@ export class AssistantQueryExecutorsService {
       ),
     ]);
 
-    const outstanding = summary.totalOutstanding;
-    const averageDebt = units.length > 0 ? Math.round(outstanding / units.length) : 0;
+    const outstandingByCurrency = summary.totalOutstandingByCurrency;
+    const hasDebt = outstandingByCurrency.some((b) => b.amountMinor > 0);
+    // Average is computed per currency only — never across currencies.
+    const averageOutstandingByCurrency = hasDebt && units.length > 0
+      ? outstandingByCurrency.map((bucket) => ({
+          currency: bucket.currency,
+          amountMinor: Math.round(bucket.amountMinor / units.length),
+        }))
+      : [];
     return {
-      answer: `Estadísticas del edificio ${building.name}:\n- Unidades: ${units.length}\n- Tickets abiertos: ${openTickets} de ${totalTickets} totales\n- Deuda total: ${this.formatMoney(outstanding, tenant.currency)}\n- Deuda promedio por unidad: ${this.formatMoney(averageDebt, tenant.currency)}`,
+      answer: `Estadísticas del edificio ${building.name}:\n- Unidades: ${units.length}\n- Tickets abiertos: ${openTickets} de ${totalTickets} totales\n- Deuda: ${this.formatBuckets(outstandingByCurrency)}\n- Deuda promedio por unidad: ${this.formatBuckets(averageOutstandingByCurrency)}`,
       suggestedActions: [
         { type: 'VIEW_REPORTS', payload: { buildingId: building.id } },
         { type: 'VIEW_TICKETS', payload: { buildingId: building.id } },
@@ -673,5 +688,20 @@ export class AssistantQueryExecutorsService {
     } catch {
       return `${amount.toFixed(2)} ${currency}`;
     }
+  }
+
+  /**
+   * Render currency buckets as an explicit enumeration (canonical first,
+   * legacy after). Never produces a mixed nominal total.
+   */
+  private formatBuckets(
+    buckets: readonly ReportCurrencyAmountBucket[],
+  ): string {
+    if (!buckets || buckets.length === 0) {
+      return '—';
+    }
+    return buckets
+      .map((bucket) => formatCurrencySafe(bucket.amountMinor, bucket.currency))
+      .join(', ');
   }
 }

--- a/apps/api/src/assistant/read-only-query.service.spec.ts
+++ b/apps/api/src/assistant/read-only-query.service.spec.ts
@@ -55,9 +55,9 @@ describe('AssistantReadOnlyQueryService', () => {
       roles: [{ role: 'TENANT_ADMIN' }],
     });
     finanzasService.getTenantFinancialSummary.mockResolvedValue({
-      totalCharges: 10000,
-      totalPaid: 2500,
-      totalOutstanding: 7500,
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 10000 }],
+      totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 2500 }],
+      totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 7500 }],
       delinquentUnitsCount: 1,
       topDelinquentUnits: [
         {
@@ -65,7 +65,7 @@ describe('AssistantReadOnlyQueryService', () => {
           unitLabel: 'A-101',
           buildingId: 'b-1',
           buildingName: 'Torre Norte',
-          outstanding: 7500,
+          outstandingByCurrency: [{ currency: 'ARS', amountMinor: 7500 }],
         },
       ],
       currency: 'ARS',
@@ -193,9 +193,9 @@ describe('AssistantReadOnlyQueryService', () => {
       roles: [{ role: 'TENANT_ADMIN' }],
     });
     finanzasService.getTenantFinancialSummary.mockResolvedValue({
-      totalCharges: 600000,
-      totalPaid: 125432,
-      totalOutstanding: 474568,
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 600000 }],
+      totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 125432 }],
+      totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 474568 }],
       delinquentUnitsCount: 18,
       topDelinquentUnits: [],
       currency: 'ARS',
@@ -222,7 +222,7 @@ describe('AssistantReadOnlyQueryService', () => {
     expect(finanzasService.getTenantFinancialSummary).toHaveBeenCalledWith('tenant-1');
     expect(result.metadata.intentCode).toBe('GET_TENANT_DEBT');
     expect(result.responseType).toBe('summary');
-    expect(result.answer).toContain('Deuda total de la administración');
+    expect(result.answer).toContain('Deuda pendiente de la administración:');
   });
 
   it('uses finance source of truth for collections summary without touching write paths', async () => {
@@ -232,9 +232,9 @@ describe('AssistantReadOnlyQueryService', () => {
       roles: [{ role: 'TENANT_ADMIN' }],
     });
     finanzasService.getTenantFinancialSummary.mockResolvedValue({
-      totalCharges: 150000,
-      totalPaid: 90000,
-      totalOutstanding: 60000,
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 150000 }],
+      totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 90000 }],
+      totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 60000 }],
       delinquentUnitsCount: 2,
       topDelinquentUnits: [],
       currency: 'ARS',

--- a/apps/api/src/assistant/read-only-query.service.ts
+++ b/apps/api/src/assistant/read-only-query.service.ts
@@ -8,6 +8,10 @@ import { PaymentStatus, TicketStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { FinanzasService } from '../finanzas/finanzas.service';
 import {
+  formatCurrencySafe,
+  type ReportCurrencyAmountBucket,
+} from '../finanzas/currency-buckets';
+import {
   ASSISTANT_READ_ONLY_INTENTS,
   AssistantReadOnlyAction,
   AssistantReadOnlyIntentCode,
@@ -126,14 +130,12 @@ export class AssistantReadOnlyQueryService {
     context: AssistantReadOnlyQueryContext,
   ): Promise<ResolverResult> {
     const summary = await this.finanzasService.getTenantFinancialSummary(context.tenantId);
-    const rows = summary.topDelinquentUnits
-      .map((item) => ({
-        unitId: item.unitId,
-        unitLabel: item.unitLabel,
-        buildingName: item.buildingName,
-        outstanding: item.outstanding,
-      }))
-      .sort((a, b) => b.outstanding - a.outstanding);
+    const rows = summary.topDelinquentUnits.map((item) => ({
+      unitId: item.unitId,
+      unitLabel: item.unitLabel,
+      buildingName: item.buildingName,
+      outstandingByCurrency: item.outstandingByCurrency,
+    }));
 
     if (rows.length === 0) {
       return {
@@ -154,12 +156,12 @@ export class AssistantReadOnlyQueryService {
       .slice(0, 5)
       .map(
         (row) =>
-          `${row.unitLabel} (${row.buildingName}): ${this.formatCurrency(row.outstanding)}`,
+          `${row.unitLabel} (${row.buildingName}): ${this.formatBuckets(row.outstandingByCurrency)}`,
       )
       .join(' | ');
 
     return {
-      answer: `Hay ${rows.length} unidades con deuda vencida. Top morosos: ${preview}.`,
+      answer: `Hay ${summary.delinquentUnitsCount} unidades con deuda vencida. Unidades con deuda pendiente: ${preview}.`,
       responseType: 'list',
       actions: [
         { key: 'open-charges', label: 'Open Charges' },
@@ -352,13 +354,10 @@ export class AssistantReadOnlyQueryService {
       this.finanzasService.getPaymentMetrics(context.tenantId, {}),
     ]);
 
-    const emitted = summary.totalCharges;
-    const outstanding = summary.totalOutstanding;
-    const collectedApplied = Math.max(0, emitted - outstanding);
     const pendingApprovals = metrics.backlogCount;
-    const collectionRate = emitted > 0 ? collectedApplied / emitted : 0;
+    const hasMovements = summary.totalChargesByCurrency.length > 0;
 
-    if (emitted === 0 && summary.totalPaid === 0) {
+    if (!hasMovements) {
       return {
         answer: `No hay movimientos de cobranzas para el período ${period}.`,
         responseType: 'no_data',
@@ -366,16 +365,27 @@ export class AssistantReadOnlyQueryService {
         metadata: {
           noData: true,
           period,
-          emitted,
-          collectedApplied,
-          outstanding,
+          emittedByCurrency: [],
+          collectedByCurrency: [],
+          outstandingByCurrency: [],
           pendingApprovals,
         },
       };
     }
 
+    const emittedByCurrency = summary.totalChargesByCurrency;
+    const collectedByCurrency = summary.totalPaidByCurrency;
+    const outstandingByCurrency = summary.totalOutstandingByCurrency;
+    const collectionRateByCurrency = emittedByCurrency.map((bucket) => {
+      const collected = collectedByCurrency.find((b) => b.currency === bucket.currency);
+      return {
+        currency: bucket.currency,
+        rate: bucket.amountMinor > 0 ? (collected?.amountMinor ?? 0) / bucket.amountMinor : 0,
+      };
+    });
+
     return {
-      answer: `Resumen ${period}: emitido ${this.formatCurrency(emitted)}, cobrado aplicado ${this.formatCurrency(collectedApplied)}, pendiente ${this.formatCurrency(outstanding)}, tasa de cobranza ${(collectionRate * 100).toFixed(1)}%, pagos pendientes de aprobación ${pendingApprovals}.`,
+      answer: `Resumen ${period}: emitido ${this.formatBuckets(emittedByCurrency)}, cobrado aplicado ${this.formatBuckets(collectedByCurrency)}, pendiente ${this.formatBuckets(outstandingByCurrency)}, tasa de cobranza ${collectionRateByCurrency.map((r) => `${(r.rate * 100).toFixed(1)}% ${r.currency}`).join(', ')}, pagos pendientes de aprobación ${pendingApprovals}.`,
       responseType: 'summary',
       actions: [
         { key: 'open-charges', label: 'Open Charges' },
@@ -383,12 +393,11 @@ export class AssistantReadOnlyQueryService {
       ],
       metadata: {
         period,
-        metricValue: Number((collectionRate * 100).toFixed(2)),
-        emitted,
-        collectedApplied,
-        outstanding,
+        emittedByCurrency,
+        collectedByCurrency,
+        outstandingByCurrency,
+        collectionRateByCurrency,
         pendingApprovals,
-        approvedTotal: summary.totalPaid,
       },
     };
   }
@@ -397,29 +406,28 @@ export class AssistantReadOnlyQueryService {
     context: AssistantReadOnlyQueryContext,
   ): Promise<ResolverResult> {
     const summary = await this.finanzasService.getTenantFinancialSummary(context.tenantId);
-    const totalDebt = summary.totalOutstanding;
+    const outstandingByCurrency = summary.totalOutstandingByCurrency;
+    const hasDebt = outstandingByCurrency.some((b) => b.amountMinor > 0);
 
-    if (totalDebt === 0) {
+    if (!hasDebt) {
       return {
         answer: 'La administración no tiene deuda pendiente.',
         responseType: 'no_data',
         actions: [{ key: 'open-charges', label: 'Open Charges' }],
         metadata: {
           noData: true,
-          totalDebt,
-          currency: summary.currency,
+          outstandingByCurrency: [],
           chargeCount: summary.delinquentUnitsCount,
         },
       };
     }
 
     return {
-      answer: `Deuda total de la administración: ${this.formatCurrency(totalDebt, summary.currency)}.`,
+      answer: `Deuda pendiente de la administración: ${this.formatBuckets(outstandingByCurrency)}.`,
       responseType: 'summary',
       actions: [{ key: 'open-charges', label: 'Open Charges' }],
       metadata: {
-        totalDebt,
-        currency: summary.currency,
+        outstandingByCurrency,
         chargeCount: summary.delinquentUnitsCount,
       },
     };
@@ -551,6 +559,21 @@ export class AssistantReadOnlyQueryService {
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,
     }).format(cents / 100);
+  }
+
+  /**
+   * Render currency buckets as an explicit enumeration (canonical first,
+   * legacy after). Never produces a mixed nominal total.
+   */
+  private formatBuckets(
+    buckets: readonly ReportCurrencyAmountBucket[],
+  ): string {
+    if (!buckets || buckets.length === 0) {
+      return '—';
+    }
+    return buckets
+      .map((bucket) => formatCurrencySafe(bucket.amountMinor, bucket.currency))
+      .join(', ');
   }
 
   private toPeriod(date: Date): string {

--- a/apps/api/src/assistant/tenant-debt.service.ts
+++ b/apps/api/src/assistant/tenant-debt.service.ts
@@ -2,10 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { ChargeStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AssistantDebtCalculatorService } from './assistant-debt-calculator.service';
+import type { ReportCurrencyAmountBucket } from '../finanzas/currency-buckets';
 
 export interface TenantDebtSummary {
-  totalDebt: number;
-  currency: string;
+  outstandingByCurrency: ReportCurrencyAmountBucket[];
   chargeCount: number;
 }
 
@@ -14,34 +14,27 @@ export async function resolveTenantDebtSummary(
   debtCalculator: AssistantDebtCalculatorService,
   tenantId: string,
 ): Promise<TenantDebtSummary> {
-  const [tenant, charges] = await Promise.all([
-    prisma.tenant.findUniqueOrThrow({
-      where: { id: tenantId },
-      select: { currency: true },
-    }),
-    prisma.charge.findMany({
-      where: {
-        tenantId,
-        status: { in: [ChargeStatus.PENDING, ChargeStatus.PARTIAL] },
-        canceledAt: null,
-      },
-      include: {
-        paymentAllocations: {
-          include: {
-            payment: {
-              select: {
-                status: true,
-              },
+  const charges = await prisma.charge.findMany({
+    where: {
+      tenantId,
+      status: { in: [ChargeStatus.PENDING, ChargeStatus.PARTIAL] },
+      canceledAt: null,
+    },
+    include: {
+      paymentAllocations: {
+        include: {
+          payment: {
+            select: {
+              status: true,
             },
           },
         },
       },
-    }),
-  ]);
+    },
+  });
 
   return {
-    totalDebt: debtCalculator.calculateOutstanding(charges),
-    currency: tenant.currency,
+    outstandingByCurrency: debtCalculator.calculateOutstandingByCurrency(charges),
     chargeCount: charges.length,
   };
 }

--- a/apps/api/src/assistant/tools.service.spec.ts
+++ b/apps/api/src/assistant/tools.service.spec.ts
@@ -100,7 +100,7 @@ describe('AssistantToolsService', () => {
       building: { name: 'Torre A' },
     });
     prisma.charge.findMany.mockResolvedValue([
-      { id: 'c1', amount: 50000, paymentAllocations: [] },
+      { id: 'c1', amount: 50000, currency: 'ARS', paymentAllocations: [] },
     ]);
 
     const result = await service.executeTool(
@@ -115,8 +115,8 @@ describe('AssistantToolsService', () => {
 
     expect(result.responseType).toBe('summary');
     expect(result.metadata.unitId).toBe('u1');
-    expect(result.metadata.outstanding).toBe(50000);
-    expect(result.metadata.amount).toBe(50000);
+    expect(result.metadata.outstandingByCurrency).toEqual([{ currency: 'ARS', amountMinor: 50000 }]);
+    
     expect(result.metadata.asOf).toEqual(expect.any(String));
     expect(result.metadata.status).toBe('operativo');
   });

--- a/apps/api/src/assistant/tools.service.ts
+++ b/apps/api/src/assistant/tools.service.ts
@@ -15,6 +15,11 @@ import {
 } from './tools.types';
 import { AssistantQueryParser } from './query-parser/assistant-query-parser';
 import { AssistantDebtCalculatorService } from './assistant-debt-calculator.service';
+import {
+  aggregateReportBuckets,
+  formatCurrencySafe,
+  type ReportCurrencyAmountBucket,
+} from '../finanzas/currency-buckets';
 
 const TOOL_PERMISSION = {
   resolve_unit_ref: 'tools.resolve_unit_ref',
@@ -259,19 +264,17 @@ export class AssistantToolsService {
       },
     });
 
-    const outstanding = this.debtCalculator.calculateOutstanding(charges);
+    const outstandingByCurrency = this.debtCalculator.calculateOutstandingByCurrency(charges);
+    const hasDebt = outstandingByCurrency.some((b) => b.amountMinor > 0);
 
-    const answer = outstanding > 0
-      ? `La unidad ${unit.label ?? unit.code} (${unit.building.name}) tiene deuda pendiente de ${this.formatMoney(outstanding)}.`
+    const answer = hasDebt
+      ? `La unidad ${unit.label ?? unit.code} (${unit.building.name}) tiene deuda pendiente de ${this.formatBuckets(outstandingByCurrency)}.`
       : `La unidad ${unit.label ?? unit.code} (${unit.building.name}) no tiene deuda pendiente.`;
 
     return this.buildResponse(answer, 'summary', {
       unitId,
       debtStatus,
-      outstanding,
-      amount: outstanding,
-      overdueAmount: outstanding,
-      currency: 'ARS',
+      outstandingByCurrency,
       asOf: now.toISOString().slice(0, 10),
       status: 'operativo',
     });
@@ -368,7 +371,7 @@ export class AssistantToolsService {
       const towerName = lastPayment.building?.name ?? lastPayment.unit?.building?.name ?? 'N/A';
 
       return this.buildResponse(
-        `Último pago recibido: ${this.formatMoney(lastPayment.amount)} el ${paymentDateIso} (${towerName}, estado ${String(lastPayment.status).toLowerCase()}).`,
+        `Último pago recibido: ${this.formatMoney(lastPayment.amount, lastPayment.currency)} el ${paymentDateIso} (${towerName}, estado ${String(lastPayment.status).toLowerCase()}).`,
         'summary',
         {
           mode,
@@ -397,32 +400,54 @@ export class AssistantToolsService {
           unit: { select: { id: true, label: true, code: true, building: { select: { name: true } } } },
           paymentAllocations: { include: { payment: { select: { status: true } } } },
         },
-        take: 5000,
       });
 
-      const debtByUnit = new Map<string, { label: string; building: string; amount: number }>();
+      // Per-unit per-currency buckets; ordering is NON-monetary
+      // (earliest dueDate ASC, then unitId ASC).
+      const debtByUnit = new Map<
+        string,
+        {
+          label: string;
+          building: string;
+          earliestDue: Date;
+          entries: Array<{ currency: string; amountMinor: number }>;
+        }
+      >();
       for (const charge of charges) {
         const outstanding = this.debtCalculator.calculateChargeOutstanding(charge);
         if (outstanding <= 0) continue;
         const current = debtByUnit.get(charge.unitId) ?? {
           label: charge.unit?.label ?? charge.unit?.code ?? charge.unitId,
           building: charge.unit?.building?.name ?? 'N/A',
-          amount: 0,
+          earliestDue: charge.dueDate,
+          entries: [],
         };
-        current.amount += outstanding;
+        current.entries.push({ currency: charge.currency, amountMinor: outstanding });
+        if (charge.dueDate < current.earliestDue) {
+          current.earliestDue = charge.dueDate;
+        }
         debtByUnit.set(charge.unitId, current);
       }
 
       const top = [...debtByUnit.entries()]
-        .map(([unitId, info]) => ({ unitId, ...info }))
-        .sort((a, b) => b.amount - a.amount)
+        .map(([unitId, info]) => ({
+          unitId,
+          label: info.label,
+          building: info.building,
+          outstandingByCurrency: aggregateReportBuckets(info.entries),
+        }))
+        .sort((a, b) => {
+          const dueDiff = debtByUnit.get(a.unitId)!.earliestDue.getTime() - debtByUnit.get(b.unitId)!.earliestDue.getTime();
+          if (dueDiff !== 0) return dueDiff;
+          return a.unitId.localeCompare(b.unitId);
+        })
         .slice(0, ranking);
 
       return this.buildResponse(
         top.length === 0
           ? 'No hay unidades con deuda vencida.'
-          : `Top ${top.length} unidades con deuda vencida: ${top
-              .map((item) => `${item.label} (${item.building}) ${this.formatMoney(item.amount)}`)
+          : `Unidades con deuda vencida: ${top
+              .map((item) => `${item.label} (${item.building}) ${this.formatBuckets(item.outstandingByCurrency)}`)
               .join(' | ')}.`,
         top.length === 0 ? 'no_data' : 'list',
         { ranking, debtStatus: 'OVERDUE', top },
@@ -446,7 +471,7 @@ export class AssistantToolsService {
     const answer = rows.length === 0
       ? 'No hay pagos para ese filtro.'
       : `Pagos encontrados: ${rows
-          .map((row) => `${row.unit?.label ?? row.unit?.code ?? 'N/A'} (${row.unit?.building?.name ?? 'N/A'}) ${this.formatMoney(row.amount)}`)
+          .map((row) => `${row.unit?.label ?? row.unit?.code ?? 'N/A'} (${row.unit?.building?.name ?? 'N/A'}) ${this.formatMoney(row.amount, row.currency)}`)
           .join(' | ')}.`;
     return this.buildResponse(answer, rows.length === 0 ? 'no_data' : 'list', {
       ranking,
@@ -664,12 +689,27 @@ export class AssistantToolsService {
       .trim();
   }
 
-  private formatMoney(cents: number): string {
+  private formatMoney(cents: number, currency: string): string {
     return new Intl.NumberFormat('es-AR', {
       style: 'currency',
-      currency: 'ARS',
+      currency,
       minimumFractionDigits: 2,
       maximumFractionDigits: 2,
     }).format(cents / 100);
+  }
+
+  /**
+   * Render currency buckets as an explicit enumeration (canonical first,
+   * legacy after). Never produces a mixed nominal total.
+   */
+  private formatBuckets(
+    buckets: readonly ReportCurrencyAmountBucket[],
+  ): string {
+    if (!buckets || buckets.length === 0) {
+      return '—';
+    }
+    return buckets
+      .map((bucket) => formatCurrencySafe(bucket.amountMinor, bucket.currency))
+      .join(', ');
   }
 }

--- a/apps/api/src/finanzas/finanzas.dto.ts
+++ b/apps/api/src/finanzas/finanzas.dto.ts
@@ -17,6 +17,7 @@ import {
 } from 'class-validator';
 import { ChargeType, ChargeStatus, PaymentStatus, PaymentMethod, RejectionReason } from '@prisma/client';
 import { CANONICAL_CURRENCIES } from '@buildingos/contracts';
+import type { ReportCurrencyAmountBucket } from './currency-buckets';
 import { IsStrictDateString } from './strict-date.decorator';
 import {
   BuildingChargeParamDto,
@@ -422,18 +423,17 @@ export interface PaymentDetailDto {
 }
 
 export interface FinancialSummaryDto {
-  totalCharges: number;
-  totalPaid: number;
-  totalOutstanding: number;
+  totalChargesByCurrency: ReportCurrencyAmountBucket[];
+  totalPaidByCurrency: ReportCurrencyAmountBucket[];
+  totalOutstandingByCurrency: ReportCurrencyAmountBucket[];
   delinquentUnitsCount: number;
   topDelinquentUnits: Array<{
     unitId: string;
     unitLabel: string;
     buildingId: string;
     buildingName: string;
-    outstanding: number;
+    outstandingByCurrency: ReportCurrencyAmountBucket[];
   }>;
-  currency: string;
 }
 
 export interface UnitLedgerDto {
@@ -587,10 +587,10 @@ export interface BuildingDelinquencyResponseDto {
 
 export interface MonthlyTrendDto {
   period: string;           // "YYYY-MM"
-  totalCharges: number;
-  totalPaid: number;
-  totalOutstanding: number;
-  collectionRate: number;   // 0-100
+  totalChargesByCurrency: ReportCurrencyAmountBucket[];
+  totalPaidByCurrency: ReportCurrencyAmountBucket[];
+  totalOutstandingByCurrency: ReportCurrencyAmountBucket[];
+  collectionRateByCurrency: Array<{ currency: string; rate: number }>; // 0-100
 }
 
 export class FinanceTrendQueryDto {

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -3223,9 +3223,7 @@ describe('FinanzasService', () => {
       jest.spyOn(validators, 'isResidentOrOwner').mockReturnValue(true);
       jest.spyOn(validators, 'getUserUnitIds').mockResolvedValue(['unit-1']);
       jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([] as never);
-      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue([] as never);
-
-      await service.getTenantFinancialSummary('tenant-1', undefined, ['RESIDENT'], 'resident-1');
+            await service.getTenantFinancialSummary('tenant-1', undefined, ['RESIDENT'], 'resident-1');
 
       expect(prismaService.charge.findMany).toHaveBeenCalledWith(expect.objectContaining({
         where: expect.objectContaining({
@@ -3244,19 +3242,11 @@ describe('FinanzasService', () => {
           buildingId: 'building-1',
           unitId: 'unit-1',
           amount: 1000,
+          dueDate: new Date('2020-01-01T00:00:00Z'),
           paymentAllocations: [],
         },
       ] as never);
-      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue([
-        {
-          id: 'unit-1',
-          label: '0101',
-          buildingId: 'building-1',
-          building: { name: 'Edificio A' },
-        },
-      ] as never);
-
-      await service.getTenantFinancialSummary('tenant-1', {
+            await service.getTenantFinancialSummary('tenant-1', {
         periods: ['2026-02', '2026-03', '2026-04', '2026-05', '2026-06'],
       });
 
@@ -3280,19 +3270,11 @@ describe('FinanzasService', () => {
           buildingId: 'building-1',
           unitId: 'unit-1',
           amount: 1000,
+          dueDate: new Date('2020-01-01T00:00:00Z'),
           paymentAllocations: [],
         },
       ] as never);
-      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue([
-        {
-          id: 'unit-1',
-          label: '0101',
-          buildingId: 'building-1',
-          building: { name: 'Edificio A' },
-        },
-      ] as never);
-
-      await service.getTenantFinancialSummary('tenant-1', '2026-06');
+            await service.getTenantFinancialSummary('tenant-1', '2026-06');
 
       expect(prismaService.charge.findMany).toHaveBeenCalledWith(expect.objectContaining({
         where: expect.objectContaining({
@@ -3310,6 +3292,8 @@ describe('FinanzasService', () => {
           buildingId: 'building-1',
           unitId: 'unit-paid',
           amount: 4_950_000,
+          currency: 'ARS',
+          dueDate: new Date('2020-01-01T00:00:00Z'),
           paymentAllocations: [
             {
               amount: 4_950_000,
@@ -3323,24 +3307,18 @@ describe('FinanzasService', () => {
           buildingId: 'building-1',
           unitId: 'unit-open',
           amount: 1_102_050_000,
+          currency: 'ARS',
+          dueDate: new Date('2020-01-01T00:00:00Z'),
+          unit: { id: 'unit-open', label: '0202', building: { id: 'building-1', name: 'Edificio A' } },
           paymentAllocations: [],
         },
       ] as never);
-      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue([
-        {
-          id: 'unit-open',
-          label: '0202',
-          buildingId: 'building-1',
-          building: { name: 'Edificio A' },
-        },
-      ] as never);
-
-      const result = await service.getTenantFinancialSummary('tenant-1', '2026-07');
+            const result = await service.getTenantFinancialSummary('tenant-1', '2026-07');
 
       expect(result).toEqual({
-        totalCharges: 1_107_000_000,
-        totalPaid: 4_950_000,
-        totalOutstanding: 1_102_050_000,
+        totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 1_107_000_000 }],
+        totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 4_950_000 }],
+        totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 1_102_050_000 }],
         delinquentUnitsCount: 1,
         topDelinquentUnits: [
           {
@@ -3348,10 +3326,10 @@ describe('FinanzasService', () => {
             unitLabel: '0202',
             buildingId: 'building-1',
             buildingName: 'Edificio A',
-            outstanding: 1_102_050_000,
+            outstandingByCurrency: [{ currency: 'ARS', amountMinor: 1_102_050_000 }],
           },
         ],
-        currency: 'ARS',
+        
       });
     });
 
@@ -3364,6 +3342,8 @@ describe('FinanzasService', () => {
           buildingId: 'building-1',
           unitId: 'unit-mixed',
           amount: 10000,
+          currency: 'ARS',
+          dueDate: new Date('2020-01-01T00:00:00Z'),
           paymentAllocations: [
             {
               amount: 3000,
@@ -3384,20 +3364,11 @@ describe('FinanzasService', () => {
           ],
         },
       ] as never);
-      jest.spyOn(prismaService.unit, 'findMany').mockResolvedValue([
-        {
-          id: 'unit-mixed',
-          label: '0303',
-          buildingId: 'building-1',
-          building: { name: 'Edificio A' },
-        },
-      ] as never);
+            const result = await service.getTenantFinancialSummary('tenant-1', '2026-07');
 
-      const result = await service.getTenantFinancialSummary('tenant-1', '2026-07');
-
-      expect(result.totalCharges).toBe(10000);
-      expect(result.totalPaid).toBe(5000);
-      expect(result.totalOutstanding).toBe(5000);
+      expect(result.totalChargesByCurrency).toEqual([{ currency: 'ARS', amountMinor: 10000 }]);
+      expect(result.totalPaidByCurrency).toEqual([{ currency: 'ARS', amountMinor: 5000 }]);
+      expect(result.totalOutstandingByCurrency).toEqual([{ currency: 'ARS', amountMinor: 5000 }]);
       expect(result.delinquentUnitsCount).toBe(1);
     });
   });

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -25,6 +25,10 @@ import {
   reconcilePaymentWhenConsumed,
 } from './payment-allocation-transaction';
 import { calculateChargeOutstandingMinor } from './charge-aggregation';
+import {
+  aggregateReportBuckets,
+  type ReportCurrencyAmountBucket,
+} from './currency-buckets';
 import { acquirePaymentLinkedDocumentLock } from '../common/payment-linked-document-lock';
 import { isEffectivePaymentStatus as isEffectivePaymentStatusShared } from './payment-status-semantics';
 import type { Role, ScopedRole } from '@buildingos/contracts';
@@ -1826,143 +1830,6 @@ export class FinanzasService {
   // SUMMARY & DELINQUENCY OPERATIONS
   // ============================================================================
 
-  /**
-   * Get financial summary for a building
-   *
-   * Returns:
-   * - totalCharges: Sum of all active charges (not canceled)
-   * - totalPaid: Sum of approved payments allocated
-   * - totalOutstanding: totalCharges - totalPaid
-   * - delinquentUnitsCount: Units with PENDING/PARTIAL charges past due date
-   * - topDelinquentUnits: List of most delinquent units
-   */
-  async getBuildingFinancialSummary(
-    tenantId: string,
-    buildingId: string,
-    period?: string | BuildingFinancialSummaryPeriodFilter,
-  ): Promise<FinancialSummaryDto> {
-    // 1. Validate building
-    await this.validators.validateBuildingBelongsToTenant(
-      tenantId,
-      buildingId,
-    );
-
-    // Load tenant to get currency
-    const tenant = await this.prisma.tenant.findUniqueOrThrow({
-      where: { id: tenantId },
-      select: { currency: true },
-    });
-
-    // Build filters
-    const where: Prisma.ChargeWhereInput = {
-      tenantId,
-      buildingId,
-      canceledAt: null,
-    };
-
-    if (typeof period === 'string') {
-      where.period = period;
-    } else if (period?.periods?.length) {
-      where.period = { in: period.periods };
-    } else if (period?.period) {
-      where.period = period.period;
-    }
-
-    // 2. Get all charges and allocations
-    const charges = await this.prisma.charge.findMany({
-      where,
-      include: {
-        paymentAllocations: {
-          include: {
-            payment: true,
-          },
-        },
-      },
-    });
-
-    // 3. Calculate totals using approved/reconciled payments across ALL charges
-    const chargesAnnotated = charges.map((c) => {
-      const allocated = c.paymentAllocations.reduce((asum, a) => {
-        return asum + (this.isEffectivePaymentStatus(a.payment?.status) ? a.amount : 0);
-      }, 0);
-
-      return {
-        charge: c,
-        allocated,
-        outstanding: calculateChargeOutstandingMinor(c),
-      };
-    });
-
-    // totalPaid = sum of ALL approved allocations across ALL charges
-    const totalPaid = chargesAnnotated.reduce(
-      (sum, item) => sum + item.allocated,
-      0,
-    );
-    // totalCharges = sum of ALL charge amounts
-    const totalCharges = chargesAnnotated.reduce(
-      (sum, item) => sum + item.charge.amount,
-      0,
-    );
-    const totalOutstanding = Math.max(0, totalCharges - totalPaid);
-
-    // Charges with outstanding > 0 for delinquent unit analysis
-    const chargesWithOutstanding = chargesAnnotated.filter(
-      (item) => item.outstanding > 0,
-    );
-
-    // 4. Find delinquent units by real outstanding
-    const delinquentCharges = chargesWithOutstanding;
-
-    const delinquentByUnit = new Map<string, number>();
-    for (const item of delinquentCharges) {
-      const charge = item.charge;
-      const outstanding = item.outstanding;
-      delinquentByUnit.set(
-        charge.unitId,
-        (delinquentByUnit.get(charge.unitId) || 0) + outstanding,
-      );
-    }
-
-    // Get unit info for delinquent units
-    const unitIds = Array.from(delinquentByUnit.keys());
-    const units = await this.prisma.unit.findMany({
-      where: { id: { in: unitIds } },
-      include: { building: true },
-    });
-    const unitInfoMap = new Map(units.map(u => [u.id, { label: u.label, buildingId: u.buildingId, buildingName: u.building.name }]));
-
-    const delinquentUnitsCount = delinquentByUnit.size;
-    const topDelinquentUnits = Array.from(delinquentByUnit.entries())
-      .map(([unitId, outstanding]) => {
-        const info = unitInfoMap.get(unitId);
-        return {
-          unitId,
-          unitLabel: info?.label || unitId,
-          buildingId: info?.buildingId || '',
-          buildingName: info?.buildingName || '',
-          outstanding,
-        };
-      })
-      .sort((a, b) => b.outstanding - a.outstanding)
-      .slice(0, 10); // Top 10
-
-    return {
-      totalCharges,
-      totalPaid,
-      totalOutstanding,
-      delinquentUnitsCount,
-      topDelinquentUnits,
-      currency: tenant.currency,
-    };
-  }
-
-  /**
-   * Return a server-side paginated operational delinquency list for one building.
-   *
-   * A unit is included only when it has an outstanding balance for the selected
-   * period. Its accumulated balance and overdue-period count include only charges
-   * from that period or an earlier period.
-   */
   async getBuildingDelinquency(
     tenantId: string,
     buildingId: string,
@@ -2694,13 +2561,7 @@ export class FinanzasService {
     userRoles: string[] = [],
     userId?: string,
   ): Promise<FinancialSummaryDto> {
-    // Load tenant to get currency
-    const tenant = await this.prisma.tenant.findUniqueOrThrow({
-      where: { id: tenantId },
-      select: { currency: true },
-    });
-
-    // 1. Build where clause: ALL charges for this tenant (no buildingId filter)
+    // Build where clause: ALL charges for this tenant (no buildingId filter)
     const chargeWhere: Prisma.ChargeWhereInput = {
       tenantId,
       canceledAt: null,
@@ -2709,12 +2570,11 @@ export class FinanzasService {
       const unitIds = await this.validators.getUserUnitIds(tenantId, userId!);
       if (unitIds.length === 0) {
         return {
-          totalCharges: 0,
-          totalPaid: 0,
-          totalOutstanding: 0,
+          totalChargesByCurrency: [],
+          totalPaidByCurrency: [],
+          totalOutstandingByCurrency: [],
           delinquentUnitsCount: 0,
           topDelinquentUnits: [],
-          currency: tenant.currency,
         };
       }
       chargeWhere.unitId = { in: unitIds };
@@ -2727,93 +2587,145 @@ export class FinanzasService {
       chargeWhere.period = period.period;
     }
 
-    // 2. Get all charges (aggregate by status, sum amounts)
+    return this.computeFinancialSummary(chargeWhere);
+  }
+
+  async getBuildingFinancialSummary(
+    tenantId: string,
+    buildingId: string,
+    period?: string | BuildingFinancialSummaryPeriodFilter,
+  ): Promise<FinancialSummaryDto> {
+    // 1. Validate building
+    await this.validators.validateBuildingBelongsToTenant(
+      tenantId,
+      buildingId,
+    );
+
+    // Build filters
+    const where: Prisma.ChargeWhereInput = {
+      tenantId,
+      buildingId,
+      canceledAt: null,
+    };
+    if (typeof period === 'string') {
+      where.period = period;
+    } else if (period?.periods?.length) {
+      where.period = { in: period.periods };
+    } else if (period?.period) {
+      where.period = period.period;
+    }
+
+    return this.computeFinancialSummary(where);
+  }
+
+  /**
+   * Currency-safe charge-side summary: buckets per currency (canonical
+   * first, legacy after) and a deterministic NON-monetary delinquent list
+   * (earliest overdue dueDate ASC, then unitId ASC). Delinquency is a
+   * current snapshot (dueDate < now) — amounts in different currencies are
+   * never compared or summed.
+   */
+  private async computeFinancialSummary(
+    where: Prisma.ChargeWhereInput,
+  ): Promise<FinancialSummaryDto> {
     const charges = await this.prisma.charge.findMany({
-      where: chargeWhere,
+      where,
       include: {
-        paymentAllocations: {
-          include: {
-            payment: true,
+        unit: {
+          select: {
+            id: true,
+            label: true,
+            building: { select: { id: true, name: true } },
           },
+        },
+        paymentAllocations: {
+          include: { payment: { select: { status: true } } },
         },
       },
     });
 
-    // 3. Calculate totals using the original charge amount and the approved allocations
-    const chargesAnnotated = charges.map((c) => {
-      const allocated = c.paymentAllocations.reduce((asum, a) => {
-        return asum + (this.isEffectivePaymentStatus(a.payment?.status) ? a.amount : 0);
-      }, 0);
+    const totalsByCurrency = new Map<
+      string,
+      { charges: number; paid: number; outstanding: number }
+    >();
+    const delinquentByUnit = new Map<
+      string,
+      {
+        unitId: string;
+        unitLabel: string;
+        buildingId: string;
+        buildingName: string;
+        earliestDue: Date;
+        entries: Array<{ currency: string; amountMinor: number }>;
+      }
+    >();
+    const now = new Date();
 
-      return {
-        charge: c,
-        allocated,
-        outstanding: calculateChargeOutstandingMinor(c),
+    for (const charge of charges) {
+      const outstanding = calculateChargeOutstandingMinor(charge);
+      const paid = charge.amount - outstanding;
+
+      const acc = totalsByCurrency.get(charge.currency) ?? {
+        charges: 0,
+        paid: 0,
+        outstanding: 0,
       };
-    });
+      acc.charges += charge.amount;
+      acc.paid += paid;
+      acc.outstanding += outstanding;
+      totalsByCurrency.set(charge.currency, acc);
 
-    const totalCharges = chargesAnnotated.reduce(
-      (sum, item) => sum + item.charge.amount,
-      0,
-    );
-
-    const totalPaid = chargesAnnotated.reduce(
-      (sum, item) => sum + item.allocated,
-      0,
-    );
-
-    const totalOutstanding = Math.max(
-      0,
-      chargesAnnotated.reduce((sum, item) => sum + item.outstanding, 0),
-    );
-
-    const chargesWithOutstanding = chargesAnnotated.filter(
-      (item) => item.outstanding > 0,
-    );
-
-    // 4. Find delinquent units by real outstanding
-    const delinquentCharges = chargesWithOutstanding;
-
-    const delinquentByUnit = new Map<string, number>();
-    for (const item of delinquentCharges) {
-      const charge = item.charge;
-      const outstanding = item.outstanding;
-      delinquentByUnit.set(
-        charge.unitId,
-        (delinquentByUnit.get(charge.unitId) || 0) + outstanding,
-      );
+      if (charge.dueDate < now && outstanding > 0) {
+        const existing = delinquentByUnit.get(charge.unitId);
+        if (existing) {
+          existing.entries.push({ currency: charge.currency, amountMinor: outstanding });
+          if (charge.dueDate < existing.earliestDue) {
+            existing.earliestDue = charge.dueDate;
+          }
+        } else {
+          delinquentByUnit.set(charge.unitId, {
+            unitId: charge.unitId,
+            unitLabel: charge.unit?.label || charge.unitId,
+            buildingId: charge.unit?.building?.id || '',
+            buildingName: charge.unit?.building?.name || '',
+            earliestDue: charge.dueDate,
+            entries: [{ currency: charge.currency, amountMinor: outstanding }],
+          });
+        }
+      }
     }
 
-    // Get unit and building info for delinquent units
-    const unitIds = Array.from(delinquentByUnit.keys());
-    const units = await this.prisma.unit.findMany({
-      where: { id: { in: unitIds } },
-      include: { building: true },
-    });
-    const unitInfoMap = new Map(units.map(u => [u.id, { label: u.label, buildingId: u.buildingId, buildingName: u.building.name }]));
+    const bucket = (
+      pick: (acc: { charges: number; paid: number; outstanding: number }) => number,
+    ) =>
+      aggregateReportBuckets(
+        Array.from(totalsByCurrency.entries(), ([currency, acc]) => ({
+          currency,
+          amountMinor: pick(acc),
+        })),
+      );
 
-    const delinquentUnitsCount = delinquentByUnit.size;
-    const topDelinquentUnits = Array.from(delinquentByUnit.entries())
-      .map(([unitId, outstanding]) => {
-        const info = unitInfoMap.get(unitId);
-        return {
-          unitId,
-          unitLabel: info?.label || unitId,
-          buildingId: info?.buildingId || '',
-          buildingName: info?.buildingName || '',
-          outstanding,
-        };
+    const topDelinquentUnits = Array.from(delinquentByUnit.values())
+      .sort((a, b) => {
+        const dueDiff = a.earliestDue.getTime() - b.earliestDue.getTime();
+        if (dueDiff !== 0) return dueDiff;
+        return a.unitId.localeCompare(b.unitId);
       })
-      .sort((a, b) => b.outstanding - a.outstanding)
-      .slice(0, 10); // Top 10
+      .slice(0, 10)
+      .map((item) => ({
+        unitId: item.unitId,
+        unitLabel: item.unitLabel,
+        buildingId: item.buildingId,
+        buildingName: item.buildingName,
+        outstandingByCurrency: aggregateReportBuckets(item.entries),
+      }));
 
     return {
-      totalCharges,
-      totalPaid,
-      totalOutstanding,
-      delinquentUnitsCount,
+      totalChargesByCurrency: bucket((a) => a.charges),
+      totalPaidByCurrency: bucket((a) => a.paid),
+      totalOutstandingByCurrency: bucket((a) => a.outstanding),
+      delinquentUnitsCount: delinquentByUnit.size,
       topDelinquentUnits,
-      currency: tenant.currency,
     };
   }
 
@@ -2890,8 +2802,14 @@ export class FinanzasService {
       periods.push(`${year}-${month}`);
     }
 
-    // For each period, get summary
-    const trend: { period: string; totalCharges: number; totalPaid: number; totalOutstanding: number; collectionRate: number }[] = [];
+    // For each period, get summary (currency-safe buckets per period)
+    const trend: {
+      period: string;
+      totalChargesByCurrency: ReportCurrencyAmountBucket[];
+      totalPaidByCurrency: ReportCurrencyAmountBucket[];
+      totalOutstandingByCurrency: ReportCurrencyAmountBucket[];
+      collectionRateByCurrency: Array<{ currency: string; rate: number }>;
+    }[] = [];
     for (const period of periods) {
       let summary;
       if (buildingId) {
@@ -2900,16 +2818,23 @@ export class FinanzasService {
         summary = await this.getTenantFinancialSummary(tenantId, period);
       }
 
-      const collectionRate = summary.totalCharges > 0
-        ? (summary.totalPaid / summary.totalCharges) * 100
-        : 0;
-
       trend.push({
         period,
-        totalCharges: summary.totalCharges,
-        totalPaid: summary.totalPaid,
-        totalOutstanding: summary.totalOutstanding,
-        collectionRate: Math.round(collectionRate * 10) / 10, // 1 decimal
+        totalChargesByCurrency: summary.totalChargesByCurrency,
+        totalPaidByCurrency: summary.totalPaidByCurrency,
+        totalOutstandingByCurrency: summary.totalOutstandingByCurrency,
+        collectionRateByCurrency: summary.totalChargesByCurrency.map((bucket) => {
+          const paid = summary.totalPaidByCurrency.find(
+            (b) => b.currency === bucket.currency,
+          );
+          return {
+            currency: bucket.currency,
+            rate:
+              bucket.amountMinor > 0
+                ? Math.round(((paid?.amountMinor ?? 0) / bucket.amountMinor) * 1000) / 10
+                : 0,
+          };
+        }),
       });
     }
 

--- a/apps/api/src/inbox/inbox.service.ts
+++ b/apps/api/src/inbox/inbox.service.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
+import { calculateChargeOutstandingMinor } from '../finanzas/charge-aggregation';
+import { aggregateReportBuckets } from '../finanzas/currency-buckets';
 import {
   InboxSummaryResponse,
   TicketSummary,
@@ -261,7 +263,8 @@ export class InboxService {
 
   /**
    * Get delinquent units (units with past-due, unpaid charges)
-   * Sorted by outstanding amount descending
+   * NON-monetary ordering: earliest overdue dueDate ASC, then unitId ASC.
+   * Amounts in different currencies are never compared or summed.
    */
   private async getDelinquentUnits(
     tenantId: string,
@@ -287,44 +290,45 @@ export class InboxService {
       },
     });
 
-    // Calculate real outstanding per unit (only from APPROVED/RECONCILED payments)
-    const unitOutstanding: Record<
+    // Aggregate per unit with explicit per-currency buckets and the
+    // earliest delinquency date.
+    const unitOutstanding = new Map<
       string,
       {
         unit: ChargeWithInboxRelations['unit'];
         building: ChargeWithInboxRelations['building'];
-        amount: number;
+        earliestDue: Date;
+        entries: Array<{ currency: string; amountMinor: number }>;
       }
-    > = {};
+    >();
 
     for (const charge of chargesWithAllocations) {
-      const key = charge.unitId;
-      // Only count allocations from APPROVED or RECONCILED payments
-      const allocatedApproved = charge.paymentAllocations.reduce((sum, pa) => {
-        const paymentStatus = pa.payment?.status;
-        if (paymentStatus === 'APPROVED' || paymentStatus === 'RECONCILED') {
-          return sum + pa.amount;
-        }
-        return sum;
-      }, 0);
-      const outstanding = charge.amount - allocatedApproved;
+      const outstanding = calculateChargeOutstandingMinor(charge);
+      if (outstanding <= 0) continue;
 
-      // Only include charges with actual outstanding
-      if (outstanding > 0) {
-        if (!unitOutstanding[key]) {
-          unitOutstanding[key] = {
-            unit: charge.unit,
-            building: charge.building,
-            amount: 0,
-          };
+      const existing = unitOutstanding.get(charge.unitId);
+      if (existing) {
+        existing.entries.push({ currency: charge.currency, amountMinor: outstanding });
+        if (charge.dueDate < existing.earliestDue) {
+          existing.earliestDue = charge.dueDate;
         }
-        unitOutstanding[key].amount += outstanding;
+      } else {
+        unitOutstanding.set(charge.unitId, {
+          unit: charge.unit,
+          building: charge.building,
+          earliestDue: charge.dueDate,
+          entries: [{ currency: charge.currency, amountMinor: outstanding }],
+        });
       }
     }
 
-    // Sort by amount descending and return top 5
-    const sorted = Object.values(unitOutstanding)
-      .sort((a, b) => b.amount - a.amount)
+    // Non-monetary ordering (earliest dueDate ASC, then unitId ASC), top 5.
+    const sorted = Array.from(unitOutstanding.values())
+      .sort((a, b) => {
+        const dueDiff = a.earliestDue.getTime() - b.earliestDue.getTime();
+        if (dueDiff !== 0) return dueDiff;
+        return a.unit.id.localeCompare(b.unit.id);
+      })
       .slice(0, 5);
 
     return sorted.map((item) => ({
@@ -332,7 +336,7 @@ export class InboxService {
       buildingName: item.building.name,
       unitId: item.unit.id,
       unitCode: item.unit.code,
-      outstanding: item.amount,
+      outstandingByCurrency: aggregateReportBuckets(item.entries),
     }));
   }
 }

--- a/apps/api/src/inbox/inbox.types.ts
+++ b/apps/api/src/inbox/inbox.types.ts
@@ -2,6 +2,8 @@
  * Unified inbox response types
  */
 
+import type { ReportCurrencyAmountBucket } from '../finanzas/currency-buckets';
+
 export type TicketSummary = {
   id: string;
   buildingId: string;
@@ -42,7 +44,7 @@ export type DelinquentUnit = {
   buildingName: string;
   unitId: string;
   unitCode: string;
-  outstanding: number;
+  outstandingByCurrency: ReportCurrencyAmountBucket[];
 };
 
 export type AlertSummary = {

--- a/apps/web/app/(tenant)/[tenantId]/inbox/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/inbox/page.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import { useAuth } from '@/features/auth/useAuth';
 import { useContextManager } from '@/features/context/useContext';
 import { useInboxSummary } from '@/features/inbox/useInboxSummary';
+import { formatCurrency } from '@/shared/lib/format/money';
 import { ContextSelector } from '@/features/context/components/ContextSelector';
 import Button from '@/shared/components/ui/Button';
 import Card from '@/shared/components/ui/Card';
@@ -323,13 +324,9 @@ export default function InboxPage({ params }: InboxPageProps) {
                                 {unit.buildingName} - {unit.unitCode}:
                               </span>
                               <span className="text-orange-600 ml-2">
-                                {(unit.outstanding / 100).toLocaleString(
-                                  'pt-BR',
-                                  {
-                                    style: 'currency',
-                                    currency: 'BRL',
-                                  },
-                                )}
+                                {unit.outstandingByCurrency
+                                  .map((b) => formatCurrency(b.amountMinor, b.currency))
+                                  .join(' · ')}
                               </span>
                             </div>
                           ))}

--- a/apps/web/features/finance/components/BuildingsFinanceSummary.test.tsx
+++ b/apps/web/features/finance/components/BuildingsFinanceSummary.test.tsx
@@ -32,16 +32,31 @@ function createDeferred<T>() {
   return { promise, resolve, reject };
 }
 
+const summaryJune = {
+  totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 100000 }],
+  totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 30000 }],
+  totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 70000 }],
+  delinquentUnitsCount: 1,
+  topDelinquentUnits: [] as never[],
+};
+
+const summaryJuly = {
+  totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 120000 }],
+  totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 50000 }],
+  totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 70000 }],
+  delinquentUnitsCount: 1,
+  topDelinquentUnits: [] as never[],
+};
+
 describe('BuildingsFinanceSummary', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockedGetFinancialSummary.mockResolvedValue({
-      totalCharges: 100000,
-      totalPaid: 30000,
-      totalOutstanding: 70000,
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 100000 }],
+      totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 30000 }],
+      totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 70000 }],
       delinquentUnitsCount: 1,
       topDelinquentUnits: [],
-      currency: 'ARS',
     });
   });
 
@@ -59,18 +74,17 @@ describe('BuildingsFinanceSummary', () => {
       expect(mockedGetFinancialSummary).toHaveBeenCalledWith('building-a', '2026-07');
     });
     expect(await screen.findByText('Torre Sur')).toBeTruthy();
-    expect(await screen.findByText('ARS 100.000')).toBeTruthy();
-    expect(await screen.findByText('ARS 30.000')).toBeTruthy();
-    expect(await screen.findByText('ARS 70.000')).toBeTruthy();
-    expect(await screen.findByText('30%')).toBeTruthy();
+    expect(await screen.findByText((content) => content.includes('1.000,00'))).toBeTruthy();
+    expect(await screen.findByText((content) => content.includes('300,00'))).toBeTruthy();
+    expect(await screen.findByText((content) => content.includes('700,00'))).toBeTruthy();
+    expect(await screen.findByText((content) => content.includes('30% ARS'))).toBeTruthy();
 
     mockedGetFinancialSummary.mockResolvedValueOnce({
-      totalCharges: 120000,
-      totalPaid: 50000,
-      totalOutstanding: 70000,
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 120000 }],
+      totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 50000 }],
+      totalOutstandingByCurrency: [{ currency: 'ARS', amountMinor: 70000 }],
       delinquentUnitsCount: 1,
       topDelinquentUnits: [],
-      currency: 'ARS',
     });
 
     rerender(
@@ -88,22 +102,8 @@ describe('BuildingsFinanceSummary', () => {
   });
 
   it('keeps the latest period summary when an older request resolves later', async () => {
-    const june = createDeferred<{
-      totalCharges: number;
-      totalPaid: number;
-      totalOutstanding: number;
-      delinquentUnitsCount: number;
-      topDelinquentUnits: never[];
-      currency: string;
-    }>();
-    const july = createDeferred<{
-      totalCharges: number;
-      totalPaid: number;
-      totalOutstanding: number;
-      delinquentUnitsCount: number;
-      topDelinquentUnits: never[];
-      currency: string;
-    }>();
+    const june = createDeferred<typeof summaryJune>();
+    const july = createDeferred<typeof summaryJuly>();
 
     mockedGetFinancialSummary
       .mockImplementationOnce(() => june.promise)
@@ -128,51 +128,23 @@ describe('BuildingsFinanceSummary', () => {
     );
 
     await act(async () => {
-      july.resolve({
-        totalCharges: 120000,
-        totalPaid: 50000,
-        totalOutstanding: 70000,
-        delinquentUnitsCount: 1,
-        topDelinquentUnits: [],
-        currency: 'ARS',
-      });
+      july.resolve(summaryJuly);
     });
 
-    expect(await screen.findByText('ARS 120.000')).toBeTruthy();
-    expect(screen.queryByText('ARS 100.000')).toBeNull();
+    expect(await screen.findByText((content) => content.includes('1.200,00'))).toBeTruthy();
+    expect(screen.queryByText((content) => content.includes('1.000,00'))).toBeNull();
 
     await act(async () => {
-      june.resolve({
-        totalCharges: 100000,
-        totalPaid: 30000,
-        totalOutstanding: 70000,
-        delinquentUnitsCount: 1,
-        topDelinquentUnits: [],
-        currency: 'ARS',
-      });
+      june.resolve(summaryJune);
     });
 
-    expect(screen.getByText('ARS 120.000')).toBeTruthy();
-    expect(screen.queryByText('ARS 100.000')).toBeNull();
+    expect(screen.getByText((content) => content.includes('1.200,00'))).toBeTruthy();
+    expect(screen.queryByText((content) => content.includes('1.000,00'))).toBeNull();
   });
 
   it('keeps a stale error from replacing a newer summary', async () => {
-    const june = createDeferred<{
-      totalCharges: number;
-      totalPaid: number;
-      totalOutstanding: number;
-      delinquentUnitsCount: number;
-      topDelinquentUnits: never[];
-      currency: string;
-    }>();
-    const july = createDeferred<{
-      totalCharges: number;
-      totalPaid: number;
-      totalOutstanding: number;
-      delinquentUnitsCount: number;
-      topDelinquentUnits: never[];
-      currency: string;
-    }>();
+    const june = createDeferred<typeof summaryJune>();
+    const july = createDeferred<typeof summaryJuly>();
 
     mockedGetFinancialSummary
       .mockImplementationOnce(() => june.promise)
@@ -197,23 +169,16 @@ describe('BuildingsFinanceSummary', () => {
     );
 
     await act(async () => {
-      july.resolve({
-        totalCharges: 120000,
-        totalPaid: 50000,
-        totalOutstanding: 70000,
-        delinquentUnitsCount: 1,
-        topDelinquentUnits: [],
-        currency: 'ARS',
-      });
+      july.resolve(summaryJuly);
     });
 
-    expect(await screen.findByText('ARS 120.000')).toBeTruthy();
+    expect(await screen.findByText((content) => content.includes('1.200,00'))).toBeTruthy();
 
     await act(async () => {
       june.reject(new Error('Periodo anterior falló'));
     });
 
-    expect(screen.getByText('ARS 120.000')).toBeTruthy();
+    expect(screen.getByText((content) => content.includes('1.200,00'))).toBeTruthy();
     expect(screen.queryByText(/Error al cargar datos/i)).toBeNull();
   });
 });

--- a/apps/web/features/finance/components/BuildingsFinanceSummary.tsx
+++ b/apps/web/features/finance/components/BuildingsFinanceSummary.tsx
@@ -4,15 +4,16 @@ import { useState, useEffect, useRef } from 'react';
 import { financeApi } from '../services/finance.api';
 import { Skeleton } from '@/shared/components/ui';
 import { Table, THead, TBody, TR, TH, TD } from '@/shared/components/ui/Table';
-import { useTenantCurrency } from '@/features/tenancy/hooks/useTenantBranding';
+import { formatCurrencyBuckets } from '@/shared/lib/format/currency-buckets';
+import type { CurrencyAmountBucket, CollectionRateBucket } from '../services/finance.api';
 
 interface BuildingFinanceSummary {
   buildingId: string;
   buildingName: string;
-  totalCharges: number | null;
-  totalPaid: number | null;
-  totalOutstanding: number | null;
-  collectionRate: number | null;
+  totalChargesByCurrency: CurrencyAmountBucket[] | null;
+  totalPaidByCurrency: CurrencyAmountBucket[] | null;
+  totalOutstandingByCurrency: CurrencyAmountBucket[] | null;
+  collectionRateByCurrency: CollectionRateBucket[] | null;
   errorMessage?: string;
 }
 
@@ -23,14 +24,13 @@ interface BuildingsFinanceSummaryProps {
   buildingNames: Record<string, string>;
 }
 
-const formatPercentage = (val: number) => `${Math.round(val)}%`;
+
 
 export function BuildingsFinanceSummary({
   buildingIds,
   buildingNames,
   period,
 }: BuildingsFinanceSummaryProps) {
-  const { format } = useTenantCurrency();
   const [summaries, setSummaries] = useState<BuildingFinanceSummary[]>([]);
   const [loading, setLoading] = useState(buildingIds.length > 0);
   const [error, setError] = useState<Error | null>(null);
@@ -51,22 +51,28 @@ export function BuildingsFinanceSummary({
               return {
                 buildingId: bId,
                 buildingName: buildingNames[bId] || bId,
-                totalCharges: summary.totalCharges,
-                totalPaid: summary.totalPaid,
-                totalOutstanding: summary.totalOutstanding,
-                collectionRate:
-                  summary.totalCharges > 0
-                    ? (summary.totalPaid / summary.totalCharges) * 100
-                    : 0,
+                totalChargesByCurrency: summary.totalChargesByCurrency,
+                totalPaidByCurrency: summary.totalPaidByCurrency,
+                totalOutstandingByCurrency: summary.totalOutstandingByCurrency,
+                collectionRateByCurrency: summary.totalChargesByCurrency.map((bucket) => {
+                  const paid = summary.totalPaidByCurrency.find((b) => b.currency === bucket.currency);
+                  return {
+                    currency: bucket.currency,
+                    rate:
+                      bucket.amountMinor > 0
+                        ? (paid?.amountMinor ?? 0) / bucket.amountMinor
+                        : 0,
+                  };
+                }),
               };
             } catch {
               return {
                 buildingId: bId,
                 buildingName: buildingNames[bId] || bId,
-                totalCharges: null,
-                totalPaid: null,
-                totalOutstanding: null,
-                collectionRate: null,
+                totalChargesByCurrency: null,
+                totalPaidByCurrency: null,
+                totalOutstandingByCurrency: null,
+                collectionRateByCurrency: null,
                 errorMessage: 'No disponible',
               };
             }
@@ -132,9 +138,13 @@ export function BuildingsFinanceSummary({
     );
   }
 
-  const formatCurrencyValue = (value: number | null) =>
-    value === null ? '—' : format(value);
+  const formatBuckets = (value: CurrencyAmountBucket[] | null) =>
+    value === null ? '—' : formatCurrencyBuckets(value);
 
+  const formatRates = (value: CollectionRateBucket[] | null) =>
+    value === null
+      ? '—'
+      : value.map((r) => `${Math.round(r.rate * 100)}% ${r.currency}`).join(' · ');
   return (
     <div className="space-y-6">
       <div className="mb-4">
@@ -176,32 +186,16 @@ export function BuildingsFinanceSummary({
                   {summary.buildingName}
                 </TD>
                 <TD className="px-6 py-4 text-right text-sm font-medium text-gray-900">
-                  {formatCurrencyValue(summary.totalCharges)}
+                  {formatBuckets(summary.totalChargesByCurrency)}
                 </TD>
                 <TD className="px-6 py-4 text-right text-sm font-medium text-green-600">
-                  {formatCurrencyValue(summary.totalPaid)}
+                  {formatBuckets(summary.totalPaidByCurrency)}
                 </TD>
                 <TD className="px-6 py-4 text-right text-sm font-medium text-red-600">
-                  {formatCurrencyValue(summary.totalOutstanding)}
+                  {formatBuckets(summary.totalOutstandingByCurrency)}
                 </TD>
                 <TD className="px-6 py-4 text-right text-sm font-medium">
-                  {summary.collectionRate === null ? (
-                    <span className="text-gray-500">—</span>
-                  ) : (
-                    <div className="flex items-center">
-                      <div className="relative w-24 h-2.5 bg-gray-200 rounded-full">
-                        <div
-                          className="absolute left-0 h-full rounded-full bg-blue-600"
-                          style={{
-                            width: `${Math.min(summary.collectionRate, 100)}%`,
-                          }}
-                        />
-                      </div>
-                      <span className="ml-2 text-xs font-semibold text-gray-900">
-                        {formatPercentage(summary.collectionRate)}
-                      </span>
-                    </div>
-                  )}
+                  {formatRates(summary.collectionRateByCurrency)}
                 </TD>
               </TR>
             ))}

--- a/apps/web/features/finance/components/DelinquentUnitsList.tsx
+++ b/apps/web/features/finance/components/DelinquentUnitsList.tsx
@@ -5,29 +5,28 @@ import Skeleton from '@/shared/components/ui/Skeleton';
 import EmptyState from '@/shared/components/ui/EmptyState';
 import { Table, THead, TBody, TR, TH, TD } from '@/shared/components/ui/Table';
 import { AlertCircle } from 'lucide-react';
-import { formatCurrency } from '@/shared/lib/format/money';
+import { formatCurrencyBuckets } from '@/shared/lib/format/currency-buckets';
+import type { CurrencyAmountBucket } from '@/features/finance/services/finance.api';
 
 interface DelinquentUnit {
   unitId: string;
   unitLabel: string;
   buildingName: string;
-  outstanding: number;
+  outstandingByCurrency: CurrencyAmountBucket[];
 }
 
 interface DelinquentUnitsListProps {
   units: DelinquentUnit[];
   loading: boolean;
-  currency: string;
 }
 
 /**
- * DelinquentUnitsList: Display units with outstanding payments
- * NOTE: outstanding is in minor units (cents), formatCurrency handles conversion
+ * DelinquentUnitsList: Display units with outstanding payments per currency.
+ * Amounts are in minor units; each currency is shown explicitly.
  */
 export function DelinquentUnitsList({
   units,
   loading,
-  currency,
 }: DelinquentUnitsListProps) {
   if (!loading && units.length === 0) {
     return (
@@ -62,7 +61,7 @@ export function DelinquentUnitsList({
                 <TD className="font-medium text-sm">{unit.buildingName}</TD>
                 <TD className="font-medium">{unit.unitLabel}</TD>
                 <TD className="text-right font-semibold text-red-600">
-                  {formatCurrency(unit.outstanding, currency)}
+                  {formatCurrencyBuckets(unit.outstandingByCurrency)}
                 </TD>
               </TR>
             ))}

--- a/apps/web/features/finance/components/FinanceChartsPanel.tsx
+++ b/apps/web/features/finance/components/FinanceChartsPanel.tsx
@@ -15,6 +15,8 @@ import {
 } from 'recharts';
 import { useFinanceSummary } from '../hooks/useFinanceSummary';
 import { useFinanceTrend } from '../hooks/useFinanceTrend';
+import { formatCurrency } from '@/shared/lib/format/money';
+import { formatCurrencyBuckets } from '@/shared/lib/format/currency-buckets';
 import Skeleton from '@/shared/components/ui/Skeleton';
 import Card from '@/shared/components/ui/Card';
 
@@ -23,13 +25,9 @@ interface FinanceChartsPanelProps {
   period?: string;
 }
 
-// Format ARS currency (divide by 100, two decimals)
-const formatARS = (cents: number) =>
-  new Intl.NumberFormat('es-AR', {
-    style: 'currency',
-    currency: 'ARS',
-    maximumFractionDigits: 0,
-  }).format(cents / 100);
+// Format money with its explicit currency (minor units). Never guesses.
+const formatMoney = (cents: number, currency: string) =>
+  formatCurrency(cents, currency);
 
 const formatPercentage = (val: number) => `${Math.round(val)}%`;
 
@@ -44,22 +42,60 @@ export function FinanceChartsPanel({ buildingId, period }: FinanceChartsPanelPro
     useFinanceSummary(buildingId, period);
   const { data: trend, isPending: trendLoading, error: trendError } = useFinanceTrend(buildingId, 6);
 
+  // One bar-group per currency; currencies are never mixed in a bar.
   const barChartData = useMemo(() => {
     if (!summary) return [];
-    return [
-      {
-        name: 'Cargos vs Pagos',
-        Cargos: summary.totalCharges / 100,
-        Pagado: summary.totalPaid / 100,
-        Pendiente: summary.totalOutstanding / 100,
-      },
-    ];
+    return summary.totalChargesByCurrency.map((bucket) => {
+      const paid = summary.totalPaidByCurrency.find((b) => b.currency === bucket.currency);
+      const outstanding = summary.totalOutstandingByCurrency.find((b) => b.currency === bucket.currency);
+      return {
+        name: bucket.currency,
+        Cargos: bucket.amountMinor / 100,
+        Pagado: (paid?.amountMinor ?? 0) / 100,
+        Pendiente: (outstanding?.amountMinor ?? 0) / 100,
+      };
+    });
   }, [summary]);
 
-  const collectionRate = useMemo(() => {
-    if (!summary || summary.totalCharges === 0) return 0;
-    return (summary.totalPaid / summary.totalCharges) * 100;
+  const collectionRateByCurrency = useMemo(() => {
+    if (!summary) return [];
+    return summary.totalChargesByCurrency.map((bucket) => {
+      const paid = summary.totalPaidByCurrency.find((b) => b.currency === bucket.currency);
+      return {
+        currency: bucket.currency,
+        rate:
+          bucket.amountMinor > 0
+            ? ((paid?.amountMinor ?? 0) / bucket.amountMinor) * 100
+            : 0,
+      };
+    });
   }, [summary]);
+
+  // Trend rows: one series per currency for paid amounts.
+  const trendData = useMemo(() => {
+    if (!trend) return [];
+    const currencies = new Set<string>();
+    trend.forEach((t) =>
+      t.totalPaidByCurrency.forEach((b) => currencies.add(b.currency)),
+    );
+    return trend.map((t) => {
+      const row: Record<string, string | number> = { period: t.period };
+      for (const c of currencies) {
+        const paid = t.totalPaidByCurrency.find((b) => b.currency === c);
+        row[`paid_${c}`] = (paid?.amountMinor ?? 0) / 100;
+      }
+      return row;
+    });
+  }, [trend]);
+
+  const trendCurrencies = useMemo(() => {
+    if (!trend) return [];
+    const currencies = new Set<string>();
+    trend.forEach((t) =>
+      t.totalPaidByCurrency.forEach((b) => currencies.add(b.currency)),
+    );
+    return Array.from(currencies);
+  }, [trend]);
 
   if (summaryError || trendError) {
     const errorMessage = summaryError || trendError || 'Error al cargar gráficos';
@@ -111,7 +147,7 @@ export function FinanceChartsPanel({ buildingId, period }: FinanceChartsPanelPro
                 tick={{ fontSize: 12 }}
               />
               <Tooltip
-                formatter={(val) => formatARS((val as number) * 100)}
+                formatter={(val) => String(val)}
                 contentStyle={{
                   backgroundColor: '#fff',
                   border: '1px solid #e5e7eb',
@@ -136,15 +172,21 @@ export function FinanceChartsPanel({ buildingId, period }: FinanceChartsPanelPro
             <div>
               <div className="mb-2 flex items-center justify-between">
                 <span className="text-2xl font-bold text-gray-900">
-                  {formatPercentage(collectionRate)}
+                  {collectionRateByCurrency.length === 0
+                    ? '—'
+                    : collectionRateByCurrency
+                        .map((r) => formatPercentage(r.rate))
+                        .join(' · ')}
                 </span>
-                <span className="text-xs text-gray-500">cobrado</span>
+                <span className="text-xs text-gray-500">cobrado por moneda</span>
               </div>
-              <div className="h-3 w-full rounded-full bg-gray-200">
-                <div
-                  className="h-full rounded-full bg-green-500 transition-all"
-                  style={{ width: `${Math.min(collectionRate, 100)}%` }}
-                />
+              <div className="space-y-1 text-xs text-gray-500">
+                {collectionRateByCurrency.map((r) => (
+                  <div key={r.currency} className="flex justify-between">
+                    <span>{r.currency}</span>
+                    <span className="font-semibold text-gray-700">{formatPercentage(r.rate)}</span>
+                  </div>
+                ))}
               </div>
             </div>
 
@@ -152,18 +194,18 @@ export function FinanceChartsPanel({ buildingId, period }: FinanceChartsPanelPro
             <div className="space-y-2 text-sm">
               <div className="flex justify-between">
                 <span className="text-gray-600">Cargos totales:</span>
-                <span className="font-semibold">{formatARS(summary.totalCharges)}</span>
+                <span className="font-semibold">{formatCurrencyBuckets(summary.totalChargesByCurrency)}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-gray-600">Pagado:</span>
                 <span className="font-semibold text-green-600">
-                  {formatARS(summary.totalPaid)}
+                  {formatCurrencyBuckets(summary.totalPaidByCurrency)}
                 </span>
               </div>
               <div className="flex justify-between">
                 <span className="text-gray-600">Pendiente:</span>
                 <span className="font-semibold text-red-600">
-                  {formatARS(summary.totalOutstanding)}
+                  {formatCurrencyBuckets(summary.totalOutstandingByCurrency)}
                 </span>
               </div>
               <div className="border-t border-gray-200 pt-2">
@@ -185,7 +227,7 @@ export function FinanceChartsPanel({ buildingId, period }: FinanceChartsPanelPro
           Evolución últimos 6 meses
         </h3>
         <ResponsiveContainer width="100%" height={300}>
-          <LineChart data={trend}>
+          <LineChart data={trendData}>
             <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
             <XAxis
               dataKey="period"
@@ -195,11 +237,11 @@ export function FinanceChartsPanel({ buildingId, period }: FinanceChartsPanelPro
               height={80}
             />
             <YAxis
-              tickFormatter={(val) => `$${(val / 100000).toFixed(0)}k`}
+              tickFormatter={(val) => `${val.toLocaleString('es-AR')}`}
               tick={{ fontSize: 12 }}
             />
             <Tooltip
-              formatter={(val) => formatARS((val as number))}
+              formatter={(val) => String(val)}
               labelFormatter={(label) => `Período: ${label}`}
               contentStyle={{
                 backgroundColor: '#fff',
@@ -208,22 +250,17 @@ export function FinanceChartsPanel({ buildingId, period }: FinanceChartsPanelPro
               }}
             />
             <Legend />
-            <Line
-              type="monotone"
-              dataKey="totalPaid"
-              stroke="#10b981"
-              strokeWidth={2}
-              name="Pagado"
-              dot={{ r: 4 }}
-            />
-            <Line
-              type="monotone"
-              dataKey="totalOutstanding"
-              stroke="#ef4444"
-              strokeWidth={2}
-              name="Pendiente"
-              dot={{ r: 4 }}
-            />
+            {trendCurrencies.map((c, i) => (
+              <Line
+                key={c}
+                type="monotone"
+                dataKey={`paid_${c}`}
+                stroke={['#10b981', '#3b82f6', '#f59e0b', '#8b5cf6', '#ef4444'][i % 5]}
+                strokeWidth={2}
+                name={`Pagado ${c}`}
+                dot={{ r: 4 }}
+              />
+            ))}
           </LineChart>
         </ResponsiveContainer>
       </div>

--- a/apps/web/features/finance/components/FinanceDashboard.tsx
+++ b/apps/web/features/finance/components/FinanceDashboard.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
+import { useTenantCurrency } from '@/features/tenancy/hooks/useTenantBranding';
 import { useFinanceSummary } from '../hooks/useFinanceSummary';
 import { useCharges } from '../hooks/useCharges';
 import { usePaymentsReview, usePaymentHistory } from '../hooks/usePaymentsReview';
@@ -39,6 +40,7 @@ type TabType =
  * Displays KPI cards and three tabs: Pending Payments, Charges, Delinquent Units
  */
 export function FinanceDashboard({ buildingId, tenantId }: FinanceDashboardProps) {
+  const { currency: tenantCurrency } = useTenantCurrency();
   const [activeTab, setActiveTab] = useState<TabType>('rubros');
   const currentMonth = new Date().toISOString().slice(0, 7); // YYYY-MM
   const router = useRouter();
@@ -209,7 +211,7 @@ export function FinanceDashboard({ buildingId, tenantId }: FinanceDashboardProps
             tenantId={tenantId}
             buildingId={buildingId}
             period={period}
-            currency={summary?.currency || 'ARS'}
+            currency={tenantCurrency}
           />
         )}
 

--- a/apps/web/features/finance/components/FinanceSummaryCards.tsx
+++ b/apps/web/features/finance/components/FinanceSummaryCards.tsx
@@ -4,7 +4,7 @@ import Card from '@/shared/components/ui/Card';
 import Skeleton from '@/shared/components/ui/Skeleton';
 import Button from '@/shared/components/ui/Button';
 import { FinancialSummary } from '../services/finance.api';
-import { formatCurrency } from '@/shared/lib/format/money';
+import { formatCurrencyBuckets } from '@/shared/lib/format/currency-buckets';
 
 interface FinanceSummaryCardsProps {
   summary: FinancialSummary | null;
@@ -50,13 +50,10 @@ export function FinanceSummaryCards({
     );
   }
 
-  // Format currency using the standardized helper (amounts are stored in cents)
-  const formatCurrencyValue = (cents: number): string => formatCurrency(cents, summary.currency);
-
   const cards = [
     {
       label: 'Total cargado del período',
-      value: formatCurrencyValue(summary.totalCharges),
+      value: formatCurrencyBuckets(summary.totalChargesByCurrency),
       description: 'Suma de los cargos generados para el mes seleccionado.',
       color: 'text-blue-600 dark:text-blue-400',
       bgColor: 'bg-blue-50 dark:bg-blue-950/40',
@@ -64,7 +61,7 @@ export function FinanceSummaryCards({
     },
     {
       label: 'Total cobrado del período',
-      value: formatCurrencyValue(summary.totalPaid),
+      value: formatCurrencyBuckets(summary.totalPaidByCurrency),
       description: 'Pagos aplicados a los cargos del mes seleccionado.',
       color: 'text-green-600 dark:text-green-400',
       bgColor: 'bg-green-50 dark:bg-green-950/40',
@@ -72,7 +69,7 @@ export function FinanceSummaryCards({
     },
     {
       label: 'Saldo pendiente del período',
-      value: formatCurrencyValue(summary.totalOutstanding),
+      value: formatCurrencyBuckets(summary.totalOutstandingByCurrency),
       description: 'Deuda pendiente de los cargos del mes seleccionado.',
       color: 'text-orange-600 dark:text-orange-400',
       bgColor: 'bg-orange-50 dark:bg-orange-950/40',

--- a/apps/web/features/finance/components/TenantDelinquentUnitsList.tsx
+++ b/apps/web/features/finance/components/TenantDelinquentUnitsList.tsx
@@ -1,22 +1,20 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import Card from '@/shared/components/ui/Card';
 import { Table, THead, TBody, TR, TH, TD } from '@/shared/components/ui/Table';
-import EmptyState from '@/shared/components/ui/EmptyState';
 import Skeleton from '@/shared/components/ui/Skeleton';
 import { AlertCircle, TrendingUp } from 'lucide-react';
-import { formatCurrency } from '@/shared/lib/format/money';
+import { formatCurrencyBuckets } from '@/shared/lib/format/currency-buckets';
+import type { CurrencyAmountBucket } from '@/features/finance/services/finance.api';
 
 interface TenantDelinquentUnitsListProps {
   tenantId: string;
-  currency?: string;
   delinquent: Array<{
     unitId: string;
     unitLabel: string;
     buildingId: string;
     buildingName: string;
-    outstanding: number;
+    outstandingByCurrency: CurrencyAmountBucket[];
   }>;
   loading: boolean;
 }
@@ -27,7 +25,6 @@ interface TenantDelinquentUnitsListProps {
  */
 export const TenantDelinquentUnitsList = ({ 
   tenantId, 
-  currency = 'USD', 
   delinquent, 
   loading 
 }: TenantDelinquentUnitsListProps) => {
@@ -46,8 +43,9 @@ export const TenantDelinquentUnitsList = ({
     );
   }
 
-  // Sort by outstanding amount descending to show highest debt first
-  const sortedDelinquent = [...delinquent].sort((a, b) => b.outstanding - a.outstanding);
+  // Ordering is provided by the backend (non-monetary: earliest dueDate
+  // then unitId). Never re-sort by amount across currencies.
+  const sortedDelinquent = delinquent;
 
   return (
     <div className="space-y-4">
@@ -101,7 +99,7 @@ export const TenantDelinquentUnitsList = ({
                 <TD className="px-4 py-4 text-center text-sm font-medium">
                   <div className="inline-flex items-center gap-1">
                     <span className="font-semibold text-red-600">
-                      {formatCurrency(item.outstanding, currency)}
+                      {formatCurrencyBuckets(item.outstandingByCurrency)}
                     </span>
                     <TrendingUp className="w-4 h-4 text-red-600" />
                   </div>

--- a/apps/web/features/finance/components/TenantFinanceDashboard.tsx
+++ b/apps/web/features/finance/components/TenantFinanceDashboard.tsx
@@ -320,7 +320,6 @@ export const TenantFinanceDashboard = () => {
         {activeTab === 'delinquent' && (
           <TenantDelinquentUnitsList 
             tenantId={tenantId || ''} 
-            currency={summary?.currency || 'USD'}
             delinquent={summary?.topDelinquentUnits || []} 
             loading={loading} 
           />

--- a/apps/web/features/finance/services/finance.api.ts
+++ b/apps/web/features/finance/services/finance.api.ts
@@ -125,27 +125,36 @@ export interface PaymentAllocation {
   };
 }
 
+export interface CurrencyAmountBucket {
+  readonly currency: string;
+  readonly amountMinor: number;
+}
+
+export interface CollectionRateBucket {
+  readonly currency: string;
+  readonly rate: number;
+}
+
 export interface MonthlyTrendDto {
   period: string;
-  totalCharges: number;
-  totalPaid: number;
-  totalOutstanding: number;
-  collectionRate: number;
+  totalChargesByCurrency: CurrencyAmountBucket[];
+  totalPaidByCurrency: CurrencyAmountBucket[];
+  totalOutstandingByCurrency: CurrencyAmountBucket[];
+  collectionRateByCurrency: CollectionRateBucket[];
 }
 
 export interface FinancialSummary {
-  totalCharges: number;
-  totalPaid: number;
-  totalOutstanding: number;
+  totalChargesByCurrency: CurrencyAmountBucket[];
+  totalPaidByCurrency: CurrencyAmountBucket[];
+  totalOutstandingByCurrency: CurrencyAmountBucket[];
   delinquentUnitsCount: number;
   topDelinquentUnits: Array<{
     unitId: string;
     unitLabel: string;
     buildingId: string;
     buildingName: string;
-    outstanding: number;
+    outstandingByCurrency: CurrencyAmountBucket[];
   }>;
-  currency: string;
 }
 
 export type BuildingDelinquencyAging = 'ALL' | 'ONE_PERIOD' | 'TWO_TO_THREE_PERIODS' | 'MORE_THAN_THREE_PERIODS';

--- a/apps/web/features/inbox/inbox.types.ts
+++ b/apps/web/features/inbox/inbox.types.ts
@@ -42,7 +42,7 @@ export type DelinquentUnit = {
   buildingName: string;
   unitId: string;
   unitCode: string;
-  outstanding: number;
+  outstandingByCurrency: Array<{ currency: string; amountMinor: number }>;
 };
 
 export type AlertSummary = {

--- a/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
@@ -33,11 +33,14 @@ interface UnitLedgerResponse {
 }
 
 interface FinancialSummaryResponse {
-  totalCharges: number;
-  totalPaid: number;
-  totalOutstanding: number;
+  totalChargesByCurrency: Array<{ currency: string; amountMinor: number }>;
+  totalPaidByCurrency: Array<{ currency: string; amountMinor: number }>;
+  totalOutstandingByCurrency: Array<{ currency: string; amountMinor: number }>;
   delinquentUnitsCount: number;
-  currency: string;
+}
+
+function arsAmount(buckets: Array<{ currency: string; amountMinor: number }> | undefined): number {
+  return (buckets ?? []).find((b) => b.currency === 'ARS')?.amountMinor ?? 0;
 }
 
 async function getMeContext(page: Page, tenantId: string): Promise<ResidentContextResponse> {
@@ -434,8 +437,8 @@ test.describe('Resident finance oldest-first flow', () => {
     const residentLedgerBefore = await getUnitLedger(page, residentTenantId, unitId);
     expect(residentLedgerBefore.totals.balance).toBe(30000);
     const summaryBefore = await getBuildingSummary(adminPage, residentTenantId, buildingId);
-    expect(summaryBefore.totalOutstanding).toBe(10000);
-    expect(summaryBefore.totalPaid).toBe(0);
+    expect(arsAmount(summaryBefore.totalOutstandingByCurrency)).toBe(10000);
+    expect(arsAmount(summaryBefore.totalPaidByCurrency)).toBe(0);
     expect(summaryBefore.delinquentUnitsCount).toBe(1);
 
     const firstPaymentProofFileId = await createPaymentProofDocument(
@@ -474,8 +477,8 @@ test.describe('Resident finance oldest-first flow', () => {
     expect(residentLedgerSubmitted.totals.totalAllocated).toBe(0);
 
     const summarySubmitted = await getBuildingSummary(adminPage, residentTenantId, buildingId);
-    expect(summarySubmitted.totalOutstanding).toBe(10000);
-    expect(summarySubmitted.totalPaid).toBe(0);
+    expect(arsAmount(summarySubmitted.totalOutstandingByCurrency)).toBe(10000);
+    expect(arsAmount(summarySubmitted.totalPaidByCurrency)).toBe(0);
     expect(summarySubmitted.delinquentUnitsCount).toBe(1);
 
     await adminPage.goto(`/${residentTenantId}/finanzas?tab=payments`);
@@ -497,8 +500,8 @@ test.describe('Resident finance oldest-first flow', () => {
     expect(residentLedgerApproved.totals.totalAllocated).toBe(20000);
 
     const summaryApproved = await getBuildingSummary(adminPage, residentTenantId, buildingId);
-    expect(summaryApproved.totalOutstanding).toBe(10000);
-    expect(summaryApproved.totalPaid).toBe(0);
+    expect(arsAmount(summaryApproved.totalOutstandingByCurrency)).toBe(10000);
+    expect(arsAmount(summaryApproved.totalPaidByCurrency)).toBe(0);
     expect(summaryApproved.delinquentUnitsCount).toBe(1);
 
     const augustPaymentProofFileId = await createPaymentProofDocument(
@@ -539,8 +542,8 @@ test.describe('Resident finance oldest-first flow', () => {
     expect(residentLedgerRejected.totals.totalAllocated).toBe(20000);
 
     const summaryRejected = await getBuildingSummary(adminPage, residentTenantId, buildingId);
-    expect(summaryRejected.totalOutstanding).toBe(10000);
-    expect(summaryRejected.totalPaid).toBe(0);
+    expect(arsAmount(summaryRejected.totalOutstandingByCurrency)).toBe(10000);
+    expect(arsAmount(summaryRejected.totalPaidByCurrency)).toBe(0);
     expect(summaryRejected.delinquentUnitsCount).toBe(1);
 
     const delinquencyCount = await getTenantDelinquencyCount(adminPage, residentTenantId, buildingId);

--- a/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
@@ -8,6 +8,21 @@ const PRISMA = new PrismaClient();
 const TEST_REFERENCE = 'E2E-FIN-01';
 const FIAT_PERIODS = ['2026-06', '2026-07', '2026-08'] as const;
 
+/**
+ * Deterministic relative dates: overdue semantics (dueDate < now) must not
+ * depend on the calendar day the CI run happens. Delinquency is
+ * overdue-only, so fixtures that must be delinquent use a clear past date
+ * and fixtures that must NOT be delinquent use a clear future date with a
+ * wide margin (weeks, not minutes).
+ */
+function dateOffset(days: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+const pastDate = (daysAgo: number): string => dateOffset(-daysAgo);
+const futureDate = (daysFromNow: number): string => dateOffset(daysFromNow);
+
 interface ResidentContextResponse {
   activeBuildingId: string | null;
   activeUnitId: string | null;
@@ -411,9 +426,9 @@ test.describe('Resident finance oldest-first flow', () => {
     expect(adminTenantId).toBe(residentTenantId);
 
     const createdCharges = await Promise.all([
-      createCharge(adminPage, residentTenantId, buildingId, unitId, '2026-06', '2026-06-15', 'Expensas Junio 2026', 10000),
-      createCharge(adminPage, residentTenantId, buildingId, unitId, '2026-07', '2026-07-15', 'Expensas Julio 2026', 10000),
-      createCharge(adminPage, residentTenantId, buildingId, unitId, '2026-08', '2026-08-15', 'Expensas Agosto 2026', 10000),
+      createCharge(adminPage, residentTenantId, buildingId, unitId, '2026-06', pastDate(90), 'Expensas Junio 2026', 10000),
+      createCharge(adminPage, residentTenantId, buildingId, unitId, '2026-07', pastDate(60), 'Expensas Julio 2026', 10000),
+      createCharge(adminPage, residentTenantId, buildingId, unitId, '2026-08', futureDate(30), 'Expensas Agosto 2026', 10000),
     ]);
 
     expect(createdCharges.map((charge) => charge.period)).toEqual(['2026-06', '2026-07', '2026-08']);
@@ -424,7 +439,7 @@ test.describe('Resident finance oldest-first flow', () => {
       buildingId,
       otherUnit.id,
       '2026-09',
-      '2026-09-20',
+      futureDate(60),
       `${TEST_REFERENCE} - Expensas Unidad Vecina`,
       5000,
     );
@@ -439,7 +454,7 @@ test.describe('Resident finance oldest-first flow', () => {
     const summaryBefore = await getBuildingSummary(adminPage, residentTenantId, buildingId);
     expect(arsAmount(summaryBefore.totalOutstandingByCurrency)).toBe(10000);
     expect(arsAmount(summaryBefore.totalPaidByCurrency)).toBe(0);
-    expect(summaryBefore.delinquentUnitsCount).toBe(0); // 3F5: overdue-only (Aug charge due 08-15)
+    expect(summaryBefore.delinquentUnitsCount).toBe(0); // 3F5: overdue-only (Aug charge due in the future)
 
     const firstPaymentProofFileId = await createPaymentProofDocument(
       page,

--- a/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
@@ -439,7 +439,7 @@ test.describe('Resident finance oldest-first flow', () => {
     const summaryBefore = await getBuildingSummary(adminPage, residentTenantId, buildingId);
     expect(arsAmount(summaryBefore.totalOutstandingByCurrency)).toBe(10000);
     expect(arsAmount(summaryBefore.totalPaidByCurrency)).toBe(0);
-    expect(summaryBefore.delinquentUnitsCount).toBe(1);
+    expect(summaryBefore.delinquentUnitsCount).toBe(0); // 3F5: overdue-only (Aug charge due 08-15)
 
     const firstPaymentProofFileId = await createPaymentProofDocument(
       page,
@@ -479,7 +479,7 @@ test.describe('Resident finance oldest-first flow', () => {
     const summarySubmitted = await getBuildingSummary(adminPage, residentTenantId, buildingId);
     expect(arsAmount(summarySubmitted.totalOutstandingByCurrency)).toBe(10000);
     expect(arsAmount(summarySubmitted.totalPaidByCurrency)).toBe(0);
-    expect(summarySubmitted.delinquentUnitsCount).toBe(1);
+    expect(summarySubmitted.delinquentUnitsCount).toBe(0); // 3F5: overdue-only
 
     await adminPage.goto(`/${residentTenantId}/finanzas?tab=payments`);
     await expect(adminPage.getByRole('heading', { name: /finanzas del conjunto/i })).toBeVisible();
@@ -502,7 +502,7 @@ test.describe('Resident finance oldest-first flow', () => {
     const summaryApproved = await getBuildingSummary(adminPage, residentTenantId, buildingId);
     expect(arsAmount(summaryApproved.totalOutstandingByCurrency)).toBe(10000);
     expect(arsAmount(summaryApproved.totalPaidByCurrency)).toBe(0);
-    expect(summaryApproved.delinquentUnitsCount).toBe(1);
+    expect(summaryApproved.delinquentUnitsCount).toBe(0); // 3F5: overdue-only
 
     const augustPaymentProofFileId = await createPaymentProofDocument(
       page,
@@ -544,7 +544,7 @@ test.describe('Resident finance oldest-first flow', () => {
     const summaryRejected = await getBuildingSummary(adminPage, residentTenantId, buildingId);
     expect(arsAmount(summaryRejected.totalOutstandingByCurrency)).toBe(10000);
     expect(arsAmount(summaryRejected.totalPaidByCurrency)).toBe(0);
-    expect(summaryRejected.delinquentUnitsCount).toBe(1);
+    expect(summaryRejected.delinquentUnitsCount).toBe(0); // 3F5: overdue-only
 
     const delinquencyCount = await getTenantDelinquencyCount(adminPage, residentTenantId, buildingId);
     expect(delinquencyCount).toBe(1);


### PR DESCRIPTION
## Summary

Closes #159

Phase 3F5 makes delinquency, inbox and assistant debt surfaces currency-safe.

## Currency contract

Aggregated debt is represented as currency buckets:

```ts
[
  { currency: string, amountMinor: number }
]
```

Canonical currencies come first (USD, VES, ARS, COP); historical legacy currencies follow deterministically. No nominal total is ever produced across currencies.

## Delinquency

- tenant/building financial summaries expose totalChargesByCurrency, totalPaidByCurrency, totalOutstandingByCurrency and delinquent units with outstandingByCurrency
- lists use deterministic non-monetary ordering: earliest overdue dueDate ASC, then stable unitId ASC
- counts are exact (no pre-limit corrupts them); previews are capped (top 10 / top 5)
- the old `currency: tenant.currency` label for mixed aggregates is removed

## Inbox

- delinquency payload exposes outstandingByCurrency
- no amount-based cross-currency ordering
- the web inbox renders each currency explicitly (previously it hardcoded a currency symbol)

## Assistant

- calculator produces buckets (calculateOutstandingByCurrency / calculateOutstandingByUnit)
- tenant debt summary uses outstandingByCurrency always (no dual scalar/bucket contract)
- chat answers enumerate currencies explicitly, never a mixed "deuda total: $X"
- averages are computed per currency only
- the formatter never guesses a currency (no VES/ARS fallback; money-like numbers without a known currency are rendered plainly)
- building_delinquents intent (decision B):
  - default list: non-monetary ordering with buckets
  - minAmount/maxAmount/monetary sort require an explicit `currency` filter
  - without a currency the intent asks for clarification and the monetary comparison never executes
  - with a currency, filters and ranking compare ONLY that currency's bucket

## Validation

- assistant calculator 8/8 PASS
- building_delinquents decision tests 5/5 PASS
- query executors 14/14 PASS
- read-only resolvers 6/6 PASS
- tools 8/8 PASS
- response formatter 15/15 PASS
- assistant service 153/153 PASS
- finanzas service 118/118 PASS
- API full 2532 PASS / 0 failed
- WEB typecheck/lint/build PASS
- WEB finance consumer tests PASS
- git diff --check PASS
- no live FX
- no DB mutation

## Safety

- schema untouched
- migrations untouched
- 3F6 untouched
- 3F7 untouched
- 3F3/3F4 contracts unchanged (only shared helper imports refactored)
- no ExchangeRate lookup
- no staging/production changes
