### PR TITLE
fix(finance): make expense reports currency-safe

### DIFF
--- a/apps/api/src/finanzas/expense-reports.service.spec.ts
+++ b/apps/api/src/finanzas/expense-reports.service.spec.ts
@@ -1,0 +1,372 @@
+import { ExpenseReportsService } from './expense-reports.service';
+import type { PrismaService } from '../prisma/prisma.service';
+import type { FinanzasValidators } from './finanzas.validators';
+
+function makeService(prisma: unknown): ExpenseReportsService {
+  const validators = {
+    isAdminOrOperator: () => true,
+  } as unknown as FinanzasValidators;
+  return new ExpenseReportsService(prisma as PrismaService, validators);
+}
+
+function makeHistoryPrisma(
+  buildingRows: unknown[],
+  sharedExpenses: unknown[],
+  buildings: unknown[],
+) {
+  return {
+    expense: {
+      groupBy: async () => buildingRows,
+      findMany: async () => sharedExpenses,
+    },
+    building: { findMany: async () => buildings },
+  };
+}
+
+function expenseRow(o: {
+  period: string;
+  buildingId?: string | null;
+  currencyCode: string;
+  amountMinor: number;
+  allocations?: Array<{ buildingId: string | null; amountMinor: number | null; percentage: number | null }>;
+}) {
+  return {
+    period: o.period,
+    buildingId: o.buildingId ?? null,
+    currencyCode: o.currencyCode,
+    amountMinor: o.amountMinor,
+    allocations: o.allocations ?? [],
+  };
+}
+
+describe('ExpenseReportsService.getExpenseHistory (3F6 buckets)', () => {
+  it('single USD -> only USD bucket', async () => {
+    const svc = makeService(
+      makeHistoryPrisma(
+        [{ period: '2026-07', buildingId: 'b-1', currencyCode: 'USD', _sum: { amountMinor: 10000 } }],
+        [],
+        [{ id: 'b-1', name: 'B1' }],
+      ),
+    );
+
+    const [report] = await svc.getExpenseHistory('t-1', ['TENANT_ADMIN']);
+
+    expect(report.byBuilding[0]!.buildingExpensesByCurrency).toEqual([
+      { currency: 'USD', amountMinor: 10000 },
+    ]);
+    expect(report.totalTenantByCurrency).toEqual([{ currency: 'USD', amountMinor: 10000 }]);
+  });
+
+  it('single ARS -> only ARS bucket', async () => {
+    const svc = makeService(
+      makeHistoryPrisma(
+        [{ period: '2026-07', buildingId: 'b-1', currencyCode: 'ARS', _sum: { amountMinor: 2000000 } }],
+        [],
+        [{ id: 'b-1', name: 'B1' }],
+      ),
+    );
+
+    const [report] = await svc.getExpenseHistory('t-1', ['TENANT_ADMIN']);
+
+    expect(report.byBuilding[0]!.buildingExpensesByCurrency).toEqual([
+      { currency: 'ARS', amountMinor: 2000000 },
+    ]);
+  });
+
+  it('single COP -> COP bucket ONLY, never labelled ARS', async () => {
+    const svc = makeService(
+      makeHistoryPrisma(
+        [{ period: '2026-07', buildingId: 'b-1', currencyCode: 'COP', _sum: { amountMinor: 5000000 } }],
+        [],
+        [{ id: 'b-1', name: 'B1' }],
+      ),
+    );
+
+    const [report] = await svc.getExpenseHistory('t-1', ['TENANT_ADMIN']);
+
+    expect(report.byBuilding[0]!.buildingExpensesByCurrency).toEqual([
+      { currency: 'COP', amountMinor: 5000000 },
+    ]);
+    // No ARS bucket is invented for COP data.
+    expect(report.byBuilding[0]!.buildingExpensesByCurrency).not.toContainEqual(
+      expect.objectContaining({ currency: 'ARS' }),
+    );
+  });
+
+  it('COP regression: COP and ARS stay in separate buckets', async () => {
+    const svc = makeService(
+      makeHistoryPrisma(
+        [
+          { period: '2026-07', buildingId: 'b-1', currencyCode: 'COP', _sum: { amountMinor: 5000000 } },
+          { period: '2026-07', buildingId: 'b-1', currencyCode: 'ARS', _sum: { amountMinor: 2000000 } },
+        ],
+        [],
+        [{ id: 'b-1', name: 'B1' }],
+      ),
+    );
+
+    const [report] = await svc.getExpenseHistory('t-1', ['TENANT_ADMIN']);
+
+    expect(report.byBuilding[0]!.buildingExpensesByCurrency).toEqual([
+      { currency: 'ARS', amountMinor: 2000000 },
+      { currency: 'COP', amountMinor: 5000000 },
+    ]);
+  });
+
+  it('multi USD+VES+ARS+COP -> four separate buckets in canonical order', async () => {
+    const svc = makeService(
+      makeHistoryPrisma(
+        [
+          { period: '2026-07', buildingId: 'b-1', currencyCode: 'ARS', _sum: { amountMinor: 100 } },
+          { period: '2026-07', buildingId: 'b-1', currencyCode: 'COP', _sum: { amountMinor: 400 } },
+          { period: '2026-07', buildingId: 'b-1', currencyCode: 'USD', _sum: { amountMinor: 200 } },
+          { period: '2026-07', buildingId: 'b-1', currencyCode: 'VES', _sum: { amountMinor: 300 } },
+        ],
+        [],
+        [{ id: 'b-1', name: 'B1' }],
+      ),
+    );
+
+    const [report] = await svc.getExpenseHistory('t-1', ['TENANT_ADMIN']);
+
+    expect(report.byBuilding[0]!.buildingExpensesByCurrency.map((b) => b.currency)).toEqual([
+      'USD',
+      'VES',
+      'ARS',
+      'COP',
+    ]);
+  });
+
+  it('same-currency aggregation: multiple ARS expenses sum only within ARS', async () => {
+    const svc = makeService(
+      makeHistoryPrisma(
+        [
+          { period: '2026-07', buildingId: 'b-1', currencyCode: 'ARS', _sum: { amountMinor: 10000 } },
+          { period: '2026-07', buildingId: 'b-1', currencyCode: 'ARS', _sum: { amountMinor: 20000 } },
+          { period: '2026-07', buildingId: 'b-1', currencyCode: 'USD', _sum: { amountMinor: 5000 } },
+        ],
+        [],
+        [{ id: 'b-1', name: 'B1' }],
+      ),
+    );
+
+    const [report] = await svc.getExpenseHistory('t-1', ['TENANT_ADMIN']);
+
+    expect(report.byBuilding[0]!.buildingExpensesByCurrency).toEqual([
+      { currency: 'USD', amountMinor: 5000 },
+      { currency: 'ARS', amountMinor: 30000 },
+    ]);
+  });
+
+  it('legacy UYU -> independent UYU bucket (no ARS fallback)', async () => {
+    const svc = makeService(
+      makeHistoryPrisma(
+        [{ period: '2026-07', buildingId: 'b-1', currencyCode: 'UYU', _sum: { amountMinor: 500000 } }],
+        [],
+        [{ id: 'b-1', name: 'B1' }],
+      ),
+    );
+
+    const [report] = await svc.getExpenseHistory('t-1', ['TENANT_ADMIN']);
+
+    expect(report.byBuilding[0]!.buildingExpensesByCurrency).toEqual([
+      { currency: 'UYU', amountMinor: 500000 },
+    ]);
+  });
+
+  it('canonical first, legacy lexicographic after', async () => {
+    const svc = makeService(
+      makeHistoryPrisma(
+        [
+          { period: '2026-07', buildingId: 'b-1', currencyCode: 'UYU', _sum: { amountMinor: 100 } },
+          { period: '2026-07', buildingId: 'b-1', currencyCode: 'BRL', _sum: { amountMinor: 200 } },
+          { period: '2026-07', buildingId: 'b-1', currencyCode: 'COP', _sum: { amountMinor: 300 } },
+          { period: '2026-07', buildingId: 'b-1', currencyCode: 'USD', _sum: { amountMinor: 400 } },
+        ],
+        [],
+        [{ id: 'b-1', name: 'B1' }],
+      ),
+    );
+
+    const [report] = await svc.getExpenseHistory('t-1', ['TENANT_ADMIN']);
+
+    expect(report.byBuilding[0]!.buildingExpensesByCurrency.map((b) => b.currency)).toEqual([
+      'USD',
+      'COP',
+      'BRL',
+      'UYU',
+    ]);
+  });
+
+  it('tenant isolation: expenses from another tenant never enter', async () => {
+    // groupBy where clause is tenant-scoped; the mock returns only t-1 rows.
+    const groupBy = jest.fn().mockResolvedValue([
+      { period: '2026-07', buildingId: 'b-1', currencyCode: 'USD', _sum: { amountMinor: 10000 } },
+    ]);
+    const svc = makeService({
+      expense: { groupBy, findMany: async () => [] },
+      building: { findMany: async () => [{ id: 'b-1', name: 'B1' }] },
+    });
+
+    const [report] = await svc.getExpenseHistory('t-1', ['TENANT_ADMIN']);
+
+    expect(groupBy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ tenantId: 't-1' }),
+      }),
+    );
+    expect(report.totalTenantByCurrency).toEqual([{ currency: 'USD', amountMinor: 10000 }]);
+  });
+
+  it('building scope: each building only sees its own expenses', async () => {
+    const svc = makeService(
+      makeHistoryPrisma(
+        [
+          { period: '2026-07', buildingId: 'b-1', currencyCode: 'ARS', _sum: { amountMinor: 10000 } },
+          { period: '2026-07', buildingId: 'b-2', currencyCode: 'ARS', _sum: { amountMinor: 90000 } },
+        ],
+        [],
+        [
+          { id: 'b-1', name: 'B1' },
+          { id: 'b-2', name: 'B2' },
+        ],
+      ),
+    );
+
+    const [report] = await svc.getExpenseHistory('t-1', ['TENANT_ADMIN']);
+
+    const b1 = report.byBuilding.find((b) => b.buildingId === 'b-1')!;
+    const b2 = report.byBuilding.find((b) => b.buildingId === 'b-2')!;
+    expect(b1.buildingExpensesByCurrency).toEqual([{ currency: 'ARS', amountMinor: 10000 }]);
+    expect(b2.buildingExpensesByCurrency).toEqual([{ currency: 'ARS', amountMinor: 90000 }]);
+    expect(report.totalTenantByCurrency).toEqual([{ currency: 'ARS', amountMinor: 100000 }]);
+  });
+
+  it('amount scale: minor units preserved (10000 = 100.00)', async () => {
+    const svc = makeService(
+      makeHistoryPrisma(
+        [{ period: '2026-07', buildingId: 'b-1', currencyCode: 'USD', _sum: { amountMinor: 12345 } }],
+        [],
+        [{ id: 'b-1', name: 'B1' }],
+      ),
+    );
+
+    const [report] = await svc.getExpenseHistory('t-1', ['TENANT_ADMIN']);
+
+    expect(report.byBuilding[0]!.buildingExpensesByCurrency[0]!.amountMinor).toBe(12345);
+  });
+
+  it('shared expenses produce per-currency buckets and totals', async () => {
+    const svc = makeService(
+      makeHistoryPrisma(
+        [],
+        [
+          expenseRow({
+            period: '2026-07',
+            currencyCode: 'USD',
+            amountMinor: 10000,
+            allocations: [{ buildingId: 'b-1', amountMinor: 5000, percentage: null }],
+          }),
+          expenseRow({
+            period: '2026-07',
+            currencyCode: 'ARS',
+            amountMinor: 20000,
+            allocations: [{ buildingId: 'b-1', amountMinor: 20000, percentage: null }],
+          }),
+        ],
+        [{ id: 'b-1', name: 'B1' }],
+      ),
+    );
+
+    const [report] = await svc.getExpenseHistory('t-1', ['TENANT_ADMIN']);
+
+    expect(report.sharedTotalByCurrency).toEqual([
+      { currency: 'USD', amountMinor: 10000 },
+      { currency: 'ARS', amountMinor: 20000 },
+    ]);
+    expect(report.byBuilding[0]!.sharedPortionByCurrency).toEqual([
+      { currency: 'USD', amountMinor: 5000 },
+      { currency: 'ARS', amountMinor: 20000 },
+    ]);
+    // No mixed scalar total anywhere.
+    expect(report).not.toHaveProperty('totalTenant');
+    expect(report).not.toHaveProperty('sharedTotal');
+  });
+
+  it('empty period -> empty buckets, no invented currencies', async () => {
+    const svc = makeService(makeHistoryPrisma([], [], [{ id: 'b-1', name: 'B1' }]));
+
+    const reports = await svc.getExpenseHistory('t-1', ['TENANT_ADMIN']);
+
+    expect(reports).toEqual([]);
+  });
+});
+
+describe('ExpenseReportsService.getNotasRevelatorias (3F6 line items)', () => {
+  function makeNotasPrisma(commonExps: unknown[]) {
+    return {
+      tenant: { findUnique: async () => ({ name: 'T1' }) },
+      building: { findMany: async () => [{ id: 'b-1', name: 'B1' }] },
+      income: { findMany: async () => [] },
+      expense: {
+        findMany: async (args: { where: { scopeType: string } }) =>
+          args.where.scopeType === 'TENANT_SHARED' ? commonExps : [],
+      },
+      unitCategory: { findMany: async () => [] },
+      liquidation: { findMany: async () => [] },
+      adjustment: { findMany: async () => [] },
+    };
+  }
+
+  function notaExpense(o: { currencyCode: string; amountMinor: number; invoiceDate?: Date }) {
+    return {
+      id: 'e-1',
+      currencyCode: o.currencyCode,
+      amountMinor: o.amountMinor,
+      description: 'Exp',
+      invoiceDate: o.invoiceDate ?? new Date('2026-07-02T00:00:00Z'),
+    };
+  }
+
+  it('COP line item keeps its own currency (never becomes pesos/ARS)', async () => {
+    const svc = makeService(
+      makeNotasPrisma([
+        notaExpense({ currencyCode: 'COP', amountMinor: 5000000 }),
+        notaExpense({ currencyCode: 'USD', amountMinor: 10000 }),
+        notaExpense({ currencyCode: 'ARS', amountMinor: 2000000 }),
+        notaExpense({ currencyCode: 'UYU', amountMinor: 500000 }),
+      ]),
+    );
+
+    const report = await svc.getNotasRevelatorias('t-1', '2026-07', ['TENANT_ADMIN']);
+
+    const amounts = report.commonExpenses.map((i) => i.amountByCurrency);
+    expect(amounts).toEqual([
+      [{ currency: 'COP', amountMinor: 5000000 }],
+      [{ currency: 'USD', amountMinor: 10000 }],
+      [{ currency: 'ARS', amountMinor: 2000000 }],
+      [{ currency: 'UYU', amountMinor: 500000 }],
+    ]);
+    expect(report.commonTotals.byCurrency.map((b) => b.currency)).toEqual([
+      'USD',
+      'ARS',
+      'COP',
+      'UYU',
+    ]);
+  });
+
+  it('alícuota section is explicitly labelled USD (deliberate single-currency contract)', async () => {
+    const svc = makeService(
+      makeNotasPrisma([
+        notaExpense({ currencyCode: 'USD', amountMinor: 10000 }),
+        notaExpense({ currencyCode: 'ARS', amountMinor: 2000000 }),
+      ]),
+    );
+
+    const report = await svc.getNotasRevelatorias('t-1', '2026-07', ['TENANT_ADMIN']);
+
+    for (const alicuota of report.alicuotas) {
+      expect(alicuota.baseCurrency).toBe('USD');
+    }
+  });
+});

--- a/apps/api/src/finanzas/expense-reports.service.ts
+++ b/apps/api/src/finanzas/expense-reports.service.ts
@@ -1,6 +1,12 @@
 import { Injectable, ForbiddenException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { FinanzasValidators } from './finanzas.validators';
+import {
+  aggregateReportBuckets,
+  compareReportCurrencies,
+  type ReportCurrencyAmountBucket,
+  type ReportCurrencyInput,
+} from './currency-buckets';
 
 // ── Types for Notas Revelatorias ──────────────────────────────────────────
 
@@ -14,27 +20,21 @@ export interface BuildingIncomeSection {
   buildingId: string;
   buildingName: string;
   entries: IncomeEntry[];
-  totalUSD: number;
-  totalVES: number;
-  totalPesos: number;
+  totalByCurrency: ReportCurrencyAmountBucket[];
 }
 
 export interface ExpenseLineItem {
   itemNumber: number;
   date: string;       // "2-Feb"
   description: string;
-  usdAmount: number;  // in minor units
-  vesAmount: number;
-  pesosAmount: number;
+  amountByCurrency: ReportCurrencyAmountBucket[]; // minor units, per currency
 }
 
 export interface BuildingExpenseSection {
   buildingId: string;
   buildingName: string;
   items: ExpenseLineItem[];
-  totalUSD: number;
-  totalVES: number;
-  totalPesos: number;
+  totalByCurrency: ReportCurrencyAmountBucket[];
 }
 
 export interface AlicuotaRow {
@@ -53,6 +53,11 @@ export interface BuildingAlicuota {
   buildingName: string;
   rows: AlicuotaRow[];
   grandTotal: number;  // USD minor — sum of all totalToRecaudar
+  // The Notas Revelatorias alícuota section is deliberately expressed in
+  // USD (document header: EXPRESADA DE DÓLARES AMERICANOS); non-USD
+  // expenses are reported separately (per-currency buckets) and liquidated
+  // per baseCurrency in their own liquidations.
+  baseCurrency: 'USD';
 }
 
 export interface NotasRevelatoriasReport {
@@ -62,13 +67,13 @@ export interface NotasRevelatoriasReport {
   periodLabel: string;  // "FEBRERO 2026"
   buildingIncomes: BuildingIncomeSection[];
   commonExpenses: ExpenseLineItem[];
-  commonTotals: { usd: number; ves: number; pesos: number };
+  commonTotals: { byCurrency: ReportCurrencyAmountBucket[] };
   buildingExpenses: BuildingExpenseSection[];
-  reservaLegal: { buildingName: string; usd: number; ves: number }[];
+  reservaLegal: { buildingName: string; byCurrency: ReportCurrencyAmountBucket[] }[];
   alicuotas: BuildingAlicuota[];
   // NEW: Ajustes retroactivos
   adjustments: AdjustmentLineItem[];
-  adjustmentTotals: { usd: number; ves: number; pesos: number };
+  adjustmentTotals: { byCurrency: ReportCurrencyAmountBucket[] };
 }
 
 export interface AdjustmentLineItem {
@@ -78,23 +83,21 @@ export interface AdjustmentLineItem {
   date: string;
   description: string;
   reason: string;
-  usdAmount: number;
-  vesAmount: number;
-  pesosAmount: number;
+  amountByCurrency: ReportCurrencyAmountBucket[];
 }
 
 export interface BuildingPeriodSummary {
   buildingId: string;
   buildingName: string;
-  buildingExpenses: number;  // BUILDING-scope only
-  sharedPortion: number;     // allocated share of TENANT_SHARED
-  total: number;
+  buildingExpensesByCurrency: ReportCurrencyAmountBucket[]; // BUILDING-scope only
+  sharedPortionByCurrency: ReportCurrencyAmountBucket[];    // allocated share of TENANT_SHARED
+  totalByCurrency: ReportCurrencyAmountBucket[];
 }
 
 export interface ExpensePeriodReport {
   period: string;            // YYYY-MM
-  totalTenant: number;       // sum of all building totals
-  sharedTotal: number;       // raw TENANT_SHARED expenses total
+  totalTenantByCurrency: ReportCurrencyAmountBucket[];   // per-currency totals
+  sharedTotalByCurrency: ReportCurrencyAmountBucket[];   // raw TENANT_SHARED per currency
   byBuilding: BuildingPeriodSummary[];
 }
 
@@ -113,19 +116,20 @@ export class ExpenseReportsService {
       throw new ForbiddenException('Solo administradores pueden ver reportes');
     }
 
-    // 1. BUILDING expenses grouped by period + building
+    // 1. BUILDING expenses grouped by period + building + CURRENCY
     const buildingRows = await this.prisma.expense.groupBy({
-      by: ['period', 'buildingId'],
+      by: ['period', 'buildingId', 'currencyCode'],
       where: { tenantId, status: 'VALIDATED', scopeType: 'BUILDING' },
       _sum: { amountMinor: true },
     });
 
-    // 2. TENANT_SHARED expenses with their allocations
+    // 2. TENANT_SHARED expenses with their allocations (per currency)
     const sharedExpenses = await this.prisma.expense.findMany({
       where: { tenantId, status: 'VALIDATED', scopeType: 'TENANT_SHARED' },
       select: {
         period: true,
         amountMinor: true,
+        currencyCode: true,
         allocations: {
           select: { buildingId: true, amountMinor: true, percentage: true },
         },
@@ -148,22 +152,28 @@ export class ExpenseReportsService {
     ].sort().reverse(); // newest first
 
     return periods.map((period): ExpensePeriodReport => {
-      // Building-scope rows for this period
+      // Building-scope rows for this period (per building + currency)
       const bRows = buildingRows.filter((r) => r.period === period);
 
       // Shared expenses for this period and their per-building allocations
       const sharedPeriod = sharedExpenses.filter((e) => e.period === period);
-      const sharedTotal = sharedPeriod.reduce((s, e) => s + e.amountMinor, 0);
+      const sharedTotalByCurrency = aggregateReportBuckets(
+        sharedPeriod.map((e) => ({ currency: e.currencyCode, amountMinor: e.amountMinor })),
+      );
 
-      const sharedByBuilding: Record<string, number> = {};
+      const sharedByBuilding = new Map<
+        string,
+        Array<{ currency: string; amountMinor: number }>
+      >();
       for (const exp of sharedPeriod) {
         for (const alloc of exp.allocations) {
           if (!alloc.buildingId) continue;
           const amount =
             alloc.amountMinor ??
             Math.floor(exp.amountMinor * ((alloc.percentage ?? 0) / 100));
-          sharedByBuilding[alloc.buildingId] =
-            (sharedByBuilding[alloc.buildingId] ?? 0) + amount;
+          const entries = sharedByBuilding.get(alloc.buildingId) ?? [];
+          entries.push({ currency: exp.currencyCode, amountMinor: amount });
+          sharedByBuilding.set(alloc.buildingId, entries);
         }
       }
 
@@ -171,26 +181,46 @@ export class ExpenseReportsService {
       const buildingIds = [
         ...new Set([
           ...bRows.map((r) => r.buildingId).filter(Boolean) as string[],
-          ...Object.keys(sharedByBuilding),
+          ...Array.from(sharedByBuilding.keys()),
         ]),
       ];
 
       const byBuilding = buildingIds.map((buildingId): BuildingPeriodSummary => {
-        const buildingExpenses =
-          bRows.find((r) => r.buildingId === buildingId)?._sum.amountMinor ?? 0;
-        const sharedPortion = sharedByBuilding[buildingId] ?? 0;
+        const buildingExpensesByCurrency = aggregateReportBuckets(
+          bRows
+            .filter((r) => r.buildingId === buildingId)
+            .map((r) => ({
+              currency: r.currencyCode,
+              amountMinor: r._sum.amountMinor ?? 0,
+            })),
+        );
+        const sharedPortionByCurrency = aggregateReportBuckets(
+          sharedByBuilding.get(buildingId) ?? [],
+        );
+        const totalByCurrency = aggregateReportBuckets([
+          ...buildingExpensesByCurrency.map((b) => ({
+            currency: b.currency,
+            amountMinor: b.amountMinor,
+          })),
+          ...sharedPortionByCurrency.map((b) => ({
+            currency: b.currency,
+            amountMinor: b.amountMinor,
+          })),
+        ]);
         return {
           buildingId,
           buildingName: buildingNames[buildingId] ?? buildingId,
-          buildingExpenses,
-          sharedPortion,
-          total: buildingExpenses + sharedPortion,
+          buildingExpensesByCurrency,
+          sharedPortionByCurrency,
+          totalByCurrency,
         };
       });
 
-      const totalTenant = byBuilding.reduce((s, b) => s + b.total, 0);
+      const totalTenantByCurrency = aggregateReportBuckets(
+        byBuilding.flatMap((b) => b.totalByCurrency.map((x) => ({ currency: x.currency, amountMinor: x.amountMinor }))),
+      );
 
-      return { period, totalTenant, sharedTotal, byBuilding };
+      return { period, totalTenantByCurrency, sharedTotalByCurrency, byBuilding };
     });
   }
 
@@ -267,9 +297,9 @@ export class ExpenseReportsService {
         buildingId: b.id,
         buildingName: b.name,
         entries,
-        totalUSD: this.sumByCurrency(bIncomes, 'USD'),
-        totalVES: this.sumByCurrency(bIncomes, 'VES'),
-        totalPesos: this.sumByCurrency(bIncomes, 'ARS'),
+        totalByCurrency: aggregateReportBuckets(
+          bIncomes.map((i) => ({ currency: i.currencyCode, amountMinor: i.amountMinor })),
+        ),
       };
     });
 
@@ -284,9 +314,9 @@ export class ExpenseReportsService {
           currencyCode: i.currencyCode,
           amountMinor: i.amountMinor,
         })),
-        totalUSD: this.sumByCurrency(tenantLevelIncomes, 'USD'),
-        totalVES: this.sumByCurrency(tenantLevelIncomes, 'VES'),
-        totalPesos: this.sumByCurrency(tenantLevelIncomes, 'ARS'),
+        totalByCurrency: aggregateReportBuckets(
+          tenantLevelIncomes.map((i) => ({ currency: i.currencyCode, amountMinor: i.amountMinor })),
+        ),
       });
     }
 
@@ -296,14 +326,12 @@ export class ExpenseReportsService {
       itemNumber: itemCounter++,
       date: this.formatDate(e.invoiceDate),
       description: e.description ?? '',
-      usdAmount: e.currencyCode === 'USD' ? e.amountMinor : 0,
-      vesAmount: e.currencyCode === 'VES' ? e.amountMinor : 0,
-      pesosAmount: !['USD', 'VES'].includes(e.currencyCode) ? e.amountMinor : 0,
+      amountByCurrency: [{ currency: e.currencyCode, amountMinor: e.amountMinor }],
     }));
     const commonTotals = {
-      usd: commonExps.filter((e) => e.currencyCode === 'USD').reduce((s, e) => s + e.amountMinor, 0),
-      ves: commonExps.filter((e) => e.currencyCode === 'VES').reduce((s, e) => s + e.amountMinor, 0),
-      pesos: commonExps.filter((e) => !['USD', 'VES'].includes(e.currencyCode)).reduce((s, e) => s + e.amountMinor, 0),
+      byCurrency: aggregateReportBuckets(
+        commonExps.map((e) => ({ currency: e.currencyCode, amountMinor: e.amountMinor })),
+      ),
     };
 
     // ── Building-specific expenses ─────────────────────────────────────────
@@ -313,17 +341,15 @@ export class ExpenseReportsService {
         itemNumber: itemCounter++,
         date: this.formatDate(e.invoiceDate),
         description: e.description ?? '',
-        usdAmount: e.currencyCode === 'USD' ? e.amountMinor : 0,
-        vesAmount: e.currencyCode === 'VES' ? e.amountMinor : 0,
-        pesosAmount: !['USD', 'VES'].includes(e.currencyCode) ? e.amountMinor : 0,
+        amountByCurrency: [{ currency: e.currencyCode, amountMinor: e.amountMinor }],
       }));
       return {
         buildingId: b.id,
         buildingName: b.name,
         items,
-        totalUSD: this.sumByCurrency(bExps, 'USD'),
-        totalVES: this.sumByCurrency(bExps, 'VES'),
-        totalPesos: this.sumByCurrency(bExps.filter((e) => !['USD', 'VES'].includes(e.currencyCode)), undefined),
+        totalByCurrency: aggregateReportBuckets(
+          bExps.map((e) => ({ currency: e.currencyCode, amountMinor: e.amountMinor })),
+        ),
       };
     });
 
@@ -331,15 +357,28 @@ export class ExpenseReportsService {
     const reservaLegal = buildings.map((b) => {
       const liq = liquidations.find((l) => l.buildingId === b.id);
       const totalMinor = liq?.totalAmountMinor ?? 0;
-      // Reserva = 10% of total alícuota
-      const reservaUSD = Math.floor(totalMinor * 0.1);
-      // For VES we take 10% of total VES building expenses
+      // Reserva = 10% of the liquidation total, expressed in the liquidation
+      // base currency (never relabelled to a different currency).
+      const reservaByCurrency: ReportCurrencyInput[] = [];
+      if (liq && totalMinor > 0) {
+        reservaByCurrency.push({
+          currency: liq.baseCurrency,
+          amountMinor: Math.floor(totalMinor * 0.1),
+        });
+      }
+      // VES reserve: 10% of total VES building expenses (+ shared share)
       const bVesTotal = buildingExps
         .filter((e) => e.buildingId === b.id && e.currencyCode === 'VES')
         .reduce((s, e) => s + e.amountMinor, 0);
       const sharedVes = commonExps.filter((e) => e.currencyCode === 'VES').reduce((s, e) => s + e.amountMinor, 0);
       const reservaVES = Math.floor((bVesTotal + sharedVes / Math.max(buildings.length, 1)) * 0.1);
-      return { buildingName: b.name, usd: reservaUSD, ves: reservaVES };
+      if (reservaVES > 0) {
+        reservaByCurrency.push({ currency: 'VES', amountMinor: reservaVES });
+      }
+      return {
+        buildingName: b.name,
+        byCurrency: aggregateReportBuckets(reservaByCurrency),
+      };
     });
 
     // ── Alícuotas per building ─────────────────────────────────────────────
@@ -372,7 +411,7 @@ export class ExpenseReportsService {
       });
 
       const grandTotal = rows.reduce((s, r) => s + r.totalToRecaudar, 0);
-      return { buildingId: b.id, buildingName: b.name, rows, grandTotal };
+      return { buildingId: b.id, buildingName: b.name, rows, grandTotal, baseCurrency: 'USD' as const };
     });
 
     // ── Ajustes / Retroactivos ───────────────────────────────────────────────
@@ -384,14 +423,16 @@ export class ExpenseReportsService {
       date: this.formatDate(adj.sourceInvoiceDate),
       description: `${adj.categoryId} - Ajuste por ${adj.sourcePeriod}`,
       reason: adj.reason,
-      usdAmount: adj.currencyCode === 'USD' ? adj.amountMinor : 0,
-      vesAmount: adj.currencyCode === 'VES' ? adj.amountMinor : 0,
-      pesosAmount: !['USD', 'VES'].includes(adj.currencyCode) ? adj.amountMinor : 0,
+      amountByCurrency: adj.currencyCode
+        ? [{ currency: adj.currencyCode, amountMinor: adj.amountMinor }]
+        : [],
     }));
     const adjustmentTotals = {
-      usd: adjustments.filter((a) => a.currencyCode === 'USD').reduce((s, a) => s + a.amountMinor, 0),
-      ves: adjustments.filter((a) => a.currencyCode === 'VES').reduce((s, a) => s + a.amountMinor, 0),
-      pesos: adjustments.filter((a) => !['USD', 'VES'].includes(a.currencyCode)).reduce((s, a) => s + a.amountMinor, 0),
+      byCurrency: aggregateReportBuckets(
+        adjustments
+          .filter((a) => a.currencyCode)
+          .map((a) => ({ currency: a.currencyCode as string, amountMinor: a.amountMinor })),
+      ),
     };
 
     return {
@@ -411,15 +452,6 @@ export class ExpenseReportsService {
   }
 
   // ── Helpers ───────────────────────────────────────────────────────────────
-
-  private sumByCurrency(
-    records: { amountMinor: number; currencyCode?: string }[],
-    currency: string | undefined,
-  ): number {
-    return records
-      .filter((r) => (currency ? r.currencyCode === currency : true))
-      .reduce((s, r) => s + r.amountMinor, 0);
-  }
 
   private formatDate(date: Date | string): string {
     const d = new Date(date);

--- a/apps/web/features/finance/components/ExpenseHistoryReport.tsx
+++ b/apps/web/features/finance/components/ExpenseHistoryReport.tsx
@@ -11,12 +11,11 @@ interface Props {
   tenantId: string;
 }
 
-function formatAmount(minor: number, currency = 'ARS') {
-  return new Intl.NumberFormat('es-AR', {
-    style: 'currency',
-    currency,
-    maximumFractionDigits: 0,
-  }).format(minor / 100);
+import { formatCurrencyBuckets } from '@/shared/lib/format/currency-buckets';
+import type { CurrencyAmountBucket } from '../services/expense-ledger.api';
+
+function formatBuckets(buckets: CurrencyAmountBucket[] | undefined): string {
+  return formatCurrencyBuckets(buckets ?? []);
 }
 
 function formatPeriod(period: string) {
@@ -26,25 +25,33 @@ function formatPeriod(period: string) {
 }
 
 function exportCsv(reports: ExpensePeriodReport[]) {
+  // One row per (building, currency) — amounts are never mixed across
+  // currencies and every monetary row carries an explicit currency column.
   const rows: string[] = [
-    'Período,Edificio,Gastos propios,Porción comunes,Total',
+    'Período,Edificio,Currency,Gastos propios,Porción comunes,Total',
   ];
 
   for (const r of reports) {
     for (const b of r.byBuilding) {
-      rows.push(
-        [
-          r.period,
-          `"${b.buildingName}"`,
-          (b.buildingExpenses / 100).toFixed(2),
-          (b.sharedPortion / 100).toFixed(2),
-          (b.total / 100).toFixed(2),
-        ].join(','),
-      );
+      const currencies = new Set([
+        ...b.totalByCurrency.map((x) => x.currency),
+      ]);
+      for (const currency of currencies) {
+        const own = b.buildingExpensesByCurrency.find((x) => x.currency === currency);
+        const shared = b.sharedPortionByCurrency.find((x) => x.currency === currency);
+        const total = b.totalByCurrency.find((x) => x.currency === currency);
+        rows.push(
+          [
+            r.period,
+            `"${b.buildingName}"`,
+            currency,
+            ((own?.amountMinor ?? 0) / 100).toFixed(2),
+            ((shared?.amountMinor ?? 0) / 100).toFixed(2),
+            ((total?.amountMinor ?? 0) / 100).toFixed(2),
+          ].join(','),
+        );
+      }
     }
-    rows.push(
-      [r.period, '"TOTAL"', '', '', (r.totalTenant / 100).toFixed(2)].join(','),
-    );
   }
 
   const blob = new Blob([rows.join('\n')], { type: 'text/csv;charset=utf-8;' });
@@ -143,11 +150,11 @@ export function ExpenseHistoryReport({ tenantId }: Props) {
                 </div>
                 <div className="text-right">
                   <p className="font-semibold tabular-nums">
-                    {formatAmount(report.totalTenant)}
+                    {formatBuckets(report.totalTenantByCurrency)}
                   </p>
-                  {report.sharedTotal > 0 && (
+                  {report.sharedTotalByCurrency.length > 0 && (
                     <p className="text-xs text-muted-foreground">
-                      incl. {formatAmount(report.sharedTotal)} comunes
+                      incl. {formatBuckets(report.sharedTotalByCurrency)} comunes
                     </p>
                   )}
                 </div>
@@ -177,15 +184,15 @@ export function ExpenseHistoryReport({ tenantId }: Props) {
                         <tr key={b.buildingId} className="border-t hover:bg-muted/20">
                           <td className="px-4 py-2">{b.buildingName}</td>
                           <td className="px-4 py-2 text-right tabular-nums">
-                            {formatAmount(b.buildingExpenses)}
+                            {formatBuckets(b.buildingExpensesByCurrency)}
                           </td>
                           <td className="px-4 py-2 text-right tabular-nums text-muted-foreground">
-                            {b.sharedPortion > 0
-                              ? formatAmount(b.sharedPortion)
+                            {b.sharedPortionByCurrency.length > 0
+                              ? formatBuckets(b.sharedPortionByCurrency)
                               : '—'}
                           </td>
                           <td className="px-4 py-2 text-right tabular-nums font-medium">
-                            {formatAmount(b.total)}
+                            {formatBuckets(b.totalByCurrency)}
                           </td>
                         </tr>
                       ))}
@@ -195,7 +202,7 @@ export function ExpenseHistoryReport({ tenantId }: Props) {
                         <td className="px-4 py-2">Total</td>
                         <td colSpan={2} />
                         <td className="px-4 py-2 text-right tabular-nums">
-                          {formatAmount(report.totalTenant)}
+                          {formatBuckets(report.totalTenantByCurrency)}
                         </td>
                       </tr>
                     </tfoot>

--- a/apps/web/features/finance/components/NotasRevelatoriasPDF.tsx
+++ b/apps/web/features/finance/components/NotasRevelatoriasPDF.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import {
   Document,
   Page,
@@ -8,7 +8,6 @@ import {
   View,
   StyleSheet,
   pdf,
-  Font,
 } from '@react-pdf/renderer';
 import type {
   NotasRevelatoriasReport,
@@ -80,14 +79,41 @@ const S = StyleSheet.create({
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function fmtUSD(minor: number): string {
+function fmt(minor: number, currency: string): string {
   if (!minor) return '-';
-  return (minor / 100).toLocaleString('es-VE', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+  try {
+    return new Intl.NumberFormat('es-VE', {
+      style: 'currency',
+      currency,
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(minor / 100);
+  } catch {
+    return (minor / 100).toFixed(2) + ' ' + currency;
+  }
 }
 
-function fmtVES(minor: number): string {
-  if (!minor) return '-';
-  return (minor / 100).toLocaleString('es-VE', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+const CURRENCY_LABEL: Record<string, string> = {
+  USD: 'DÓLARES',
+  VES: 'BOLÍVARES',
+};
+
+function currencyLabel(currency: string): string {
+  return CURRENCY_LABEL[currency] ?? currency;
+}
+
+function bucketAmount(
+  buckets: ReadonlyArray<{ currency: string; amountMinor: number }> | undefined,
+  currency: string,
+): number {
+  return buckets?.find((b) => b.currency === currency)?.amountMinor ?? 0;
+}
+
+// Dynamic per-currency column widths: description keeps a base width, the
+// remaining space is split among the currencies present.
+function currencyCols(currencies: string[]): Array<{ currency: string; width: string }> {
+  const per = Math.max(8, Math.floor((100 - 55) / Math.max(currencies.length, 1)));
+  return currencies.map((currency) => ({ currency, width: per + '%' }));
 }
 
 function nextMonth(period: string): string {
@@ -125,43 +151,44 @@ function IncomeTable({ report }: { report: NotasRevelatoriasReport }) {
   return (
     <>
       <Text style={S.sectionTitle}>INGRESOS ORDINARIOS</Text>
-      {report.buildingIncomes.map((building, idx) => (
-        <View key={building.buildingId}>
-          <Text style={S.notaTitle}>NOTA NRO {idx + 1}</Text>
-          <Text style={S.buildingTitle}>Ingresos {building.buildingName}</Text>
-          <View style={S.table}>
-            {/* Header */}
-            <View style={S.headerRow}>
-              <Text style={[S.cell, S.colIncomeDesc]} />
-              <Text style={[S.cellBold, S.colIncomeVES, S.center]}>BOLÍVARES</Text>
-              <Text style={[S.cellBold, S.colIncomeUSD, S.center]}>DÓLARES</Text>
-              <Text style={[S.cellBold, S.colIncomePesos, S.center]}>PESOS</Text>
-            </View>
-            {/* Rows */}
-            {building.entries.map((entry, i) => (
-              <View key={i} style={S.row}>
-                <Text style={[S.cell, S.colIncomeDesc]}>{entry.description}</Text>
-                <Text style={[S.cell, S.colIncomeVES]}>
-                  {entry.currencyCode === 'VES' ? fmtVES(entry.amountMinor) : '-'}
-                </Text>
-                <Text style={[S.cell, S.colIncomeUSD]}>
-                  {entry.currencyCode === 'USD' ? fmtUSD(entry.amountMinor) : '-'}
-                </Text>
-                <Text style={[S.cell, S.colIncomePesos]}>
-                  {!['USD', 'VES'].includes(entry.currencyCode) ? fmtUSD(entry.amountMinor) : '-'}
-                </Text>
+      {report.buildingIncomes.map((building, idx) => {
+        const currencies = building.totalByCurrency.map((b) => b.currency);
+        const cols = currencyCols(currencies);
+        return (
+          <View key={building.buildingId}>
+            <Text style={S.notaTitle}>NOTA NRO {idx + 1}</Text>
+            <Text style={S.buildingTitle}>Ingresos {building.buildingName}</Text>
+            <View style={S.table}>
+              <View style={S.headerRow}>
+                <Text style={[S.cellBold, S.colIncomeDesc]} />
+                {cols.map((c) => (
+                  <Text key={c.currency} style={[S.cellBold, { width: c.width, textAlign: 'right' }, S.center]}>
+                    {currencyLabel(c.currency)}
+                  </Text>
+                ))}
               </View>
-            ))}
-            {/* Total */}
-            <View style={S.totalRow}>
-              <Text style={[S.cellBold, S.colIncomeDesc]}>Total de Ingresos {building.buildingName}</Text>
-              <Text style={[S.cellBold, S.colIncomeVES]}>{fmtVES(building.totalVES)}</Text>
-              <Text style={[S.cellBold, S.colIncomeUSD]}>{fmtUSD(building.totalUSD)}</Text>
-              <Text style={[S.cellBold, S.colIncomePesos]}>{building.totalPesos ? fmtUSD(building.totalPesos) : '-'}</Text>
+              {building.entries.map((entry, i) => (
+                <View key={i} style={S.row}>
+                  <Text style={[S.cell, S.colIncomeDesc]}>{entry.description}</Text>
+                  {cols.map((c) => (
+                    <Text key={c.currency} style={[S.cell, { width: c.width, textAlign: 'right' }]}>
+                      {entry.currencyCode === c.currency ? fmt(entry.amountMinor, c.currency) : '-'}
+                    </Text>
+                  ))}
+                </View>
+              ))}
+              <View style={S.totalRow}>
+                <Text style={[S.cellBold, S.colIncomeDesc]}>Total de Ingresos {building.buildingName}</Text>
+                {cols.map((c) => (
+                  <Text key={c.currency} style={[S.cellBold, { width: c.width, textAlign: 'right' }]}>
+                    {fmt(bucketAmount(building.totalByCurrency, c.currency), c.currency)}
+                  </Text>
+                ))}
+              </View>
             </View>
           </View>
-        </View>
-      ))}
+        );
+      })}
     </>
   );
 }
@@ -172,9 +199,11 @@ function CommonExpensesTable({
   startNota,
 }: {
   items: ExpenseLineItem[];
-  totals: { usd: number; ves: number; pesos: number };
+  totals: { byCurrency: Array<{ currency: string; amountMinor: number }> };
   startNota: number;
 }) {
+  const currencies = totals.byCurrency.map((b) => b.currency);
+  const cols = currencyCols(currencies);
   return (
     <>
       <Text style={S.sectionTitle}>GASTOS</Text>
@@ -185,27 +214,35 @@ function CommonExpensesTable({
           <Text style={[S.cellBold, S.colNum, S.center]}>#</Text>
           <Text style={[S.cellBold, S.colDate, S.center]}>FECHA</Text>
           <Text style={[S.cellBold, S.colDesc]}>DESCRIPCIÓN</Text>
-          <Text style={[S.cellBold, S.colUSD]}>DÓLARES</Text>
-          <Text style={[S.cellBold, S.colVES]}>BOLÍVARES</Text>
-          <Text style={[S.cellBold, S.colPesos]}>PESOS</Text>
+          {cols.map((c) => (
+            <Text key={c.currency} style={[S.cellBold, { width: c.width, textAlign: 'right' }]}>
+              {currencyLabel(c.currency)}
+            </Text>
+          ))}
         </View>
         {items.map((item) => (
           <View key={item.itemNumber} style={S.row}>
             <Text style={[S.cell, S.colNum, S.center]}>{item.itemNumber}</Text>
             <Text style={[S.cell, S.colDate]}>{item.date}</Text>
             <Text style={[S.cell, S.colDesc]}>{item.description}</Text>
-            <Text style={[S.cell, S.colUSD]}>{item.usdAmount ? fmtUSD(item.usdAmount) : '-'}</Text>
-            <Text style={[S.cell, S.colVES]}>{item.vesAmount ? fmtVES(item.vesAmount) : '-'}</Text>
-            <Text style={[S.cell, S.colPesos]}>{item.pesosAmount ? fmtUSD(item.pesosAmount) : '-'}</Text>
+            {cols.map((c) => (
+              <Text key={c.currency} style={[S.cell, { width: c.width, textAlign: 'right' }]}>
+                {bucketAmount(item.amountByCurrency, c.currency)
+                  ? fmt(bucketAmount(item.amountByCurrency, c.currency), c.currency)
+                  : '-'}
+              </Text>
+            ))}
           </View>
         ))}
         <View style={S.totalRow}>
           <Text style={[S.cellBold, S.colNum]} />
           <Text style={[S.cellBold, S.colDate]} />
           <Text style={[S.cellBold, S.colDesc]} />
-          <Text style={[S.cellBold, S.colUSD]}>{fmtUSD(totals.usd)}</Text>
-          <Text style={[S.cellBold, S.colVES]}>{fmtVES(totals.ves)}</Text>
-          <Text style={[S.cellBold, S.colPesos]}>{totals.pesos ? fmtUSD(totals.pesos) : '-'}</Text>
+          {cols.map((c) => (
+            <Text key={c.currency} style={[S.cellBold, { width: c.width, textAlign: 'right' }]}>
+              {fmt(bucketAmount(totals.byCurrency, c.currency), c.currency)}
+            </Text>
+          ))}
         </View>
       </View>
     </>
@@ -222,40 +259,52 @@ function BuildingExpenseTables({
   return (
     <>
       <Text style={S.sectionTitle}>GASTOS PROPIOS</Text>
-      {buildings.map((b, idx) => (
-        <View key={b.buildingId}>
-          <Text style={S.sectionTitle}>GASTOS PROPIOS {b.buildingName.toUpperCase()}</Text>
-          <Text style={S.notaTitle}>NOTA NRO {startNota + idx}</Text>
-          <View style={S.table}>
-            <View style={S.headerRow}>
-              <Text style={[S.cellBold, S.colNum, S.center]}>#</Text>
-              <Text style={[S.cellBold, S.colDate, S.center]}>FECHA</Text>
-              <Text style={[S.cellBold, S.colDesc]}>DESCRIPCIÓN</Text>
-              <Text style={[S.cellBold, S.colUSD]}>DÓLARES</Text>
-              <Text style={[S.cellBold, S.colVES]}>BOLÍVARES</Text>
-              <Text style={[S.cellBold, S.colPesos]}>PESOS</Text>
-            </View>
-            {b.items.map((item) => (
-              <View key={item.itemNumber} style={S.row}>
-                <Text style={[S.cell, S.colNum, S.center]}>{item.itemNumber}</Text>
-                <Text style={[S.cell, S.colDate]}>{item.date}</Text>
-                <Text style={[S.cell, S.colDesc]}>{item.description}</Text>
-                <Text style={[S.cell, S.colUSD]}>{item.usdAmount ? fmtUSD(item.usdAmount) : '-'}</Text>
-                <Text style={[S.cell, S.colVES]}>{item.vesAmount ? fmtVES(item.vesAmount) : '-'}</Text>
-                <Text style={[S.cell, S.colPesos]}>{item.pesosAmount ? fmtUSD(item.pesosAmount) : '-'}</Text>
+      {buildings.map((b, idx) => {
+        const currencies = b.totalByCurrency.map((x) => x.currency);
+        const cols = currencyCols(currencies);
+        return (
+          <View key={b.buildingId}>
+            <Text style={S.sectionTitle}>GASTOS PROPIOS {b.buildingName.toUpperCase()}</Text>
+            <Text style={S.notaTitle}>NOTA NRO {startNota + idx}</Text>
+            <View style={S.table}>
+              <View style={S.headerRow}>
+                <Text style={[S.cellBold, S.colNum, S.center]}>#</Text>
+                <Text style={[S.cellBold, S.colDate, S.center]}>FECHA</Text>
+                <Text style={[S.cellBold, S.colDesc]}>DESCRIPCIÓN</Text>
+                {cols.map((c) => (
+                  <Text key={c.currency} style={[S.cellBold, { width: c.width, textAlign: 'right' }]}>
+                    {currencyLabel(c.currency)}
+                  </Text>
+                ))}
               </View>
-            ))}
-            <View style={S.totalRow}>
-              <Text style={[S.cellBold, S.colNum]} />
-              <Text style={[S.cellBold, S.colDate]} />
-              <Text style={[S.cellBold, S.colDesc]} />
-              <Text style={[S.cellBold, S.colUSD]}>{fmtUSD(b.totalUSD)}</Text>
-              <Text style={[S.cellBold, S.colVES]}>{fmtVES(b.totalVES)}</Text>
-              <Text style={[S.cellBold, S.colPesos]}>{b.totalPesos ? fmtUSD(b.totalPesos) : '-'}</Text>
+              {b.items.map((item) => (
+                <View key={item.itemNumber} style={S.row}>
+                  <Text style={[S.cell, S.colNum, S.center]}>{item.itemNumber}</Text>
+                  <Text style={[S.cell, S.colDate]}>{item.date}</Text>
+                  <Text style={[S.cell, S.colDesc]}>{item.description}</Text>
+                  {cols.map((c) => (
+                    <Text key={c.currency} style={[S.cell, { width: c.width, textAlign: 'right' }]}>
+                      {bucketAmount(item.amountByCurrency, c.currency)
+                        ? fmt(bucketAmount(item.amountByCurrency, c.currency), c.currency)
+                        : '-'}
+                    </Text>
+                  ))}
+                </View>
+              ))}
+              <View style={S.totalRow}>
+                <Text style={[S.cellBold, S.colNum]} />
+                <Text style={[S.cellBold, S.colDate]} />
+                <Text style={[S.cellBold, S.colDesc]} />
+                {cols.map((c) => (
+                  <Text key={c.currency} style={[S.cellBold, { width: c.width, textAlign: 'right' }]}>
+                    {fmt(bucketAmount(b.totalByCurrency, c.currency), c.currency)}
+                  </Text>
+                ))}
+              </View>
             </View>
           </View>
-        </View>
-      ))}
+        );
+      })}
     </>
   );
 }
@@ -264,28 +313,33 @@ function ReservaLegalSection({
   reservaLegal,
   startNota,
 }: {
-  reservaLegal: { buildingName: string; usd: number; ves: number }[];
+  reservaLegal: Array<{ buildingName: string; byCurrency: Array<{ currency: string; amountMinor: number }> }>;
   startNota: number;
 }) {
   return (
     <>
       <Text style={S.sectionTitle}>RESERVA LEGAL</Text>
-      {reservaLegal.map((r, idx) => (
-        <View key={r.buildingName}>
-          <Text style={S.notaTitle}>NOTA NRO {startNota + idx}</Text>
-          <Text style={[S.buildingTitle, { textAlign: 'center' }]}>
-            RESERVA LEGAL {r.buildingName.toUpperCase()}
-          </Text>
-          <View style={[S.table, { marginBottom: 6 }]}>
-            <View style={S.totalRow}>
-              <Text style={[S.cellBold, S.colIncomeDesc]} />
-              <Text style={[S.cellBold, S.colIncomeVES]}>{fmtVES(r.ves)}</Text>
-              <Text style={[S.cellBold, S.colIncomeUSD]}>{fmtUSD(r.usd)}</Text>
-              <Text style={[S.cellBold, S.colIncomePesos]}>-</Text>
+      {reservaLegal.map((r, idx) => {
+        const cols = currencyCols(r.byCurrency.map((b) => b.currency));
+        return (
+          <View key={r.buildingName}>
+            <Text style={S.notaTitle}>NOTA NRO {startNota + idx}</Text>
+            <Text style={[S.buildingTitle, { textAlign: 'center' }]}>
+              RESERVA LEGAL {r.buildingName.toUpperCase()}
+            </Text>
+            <View style={[S.table, { marginBottom: 6 }]}>
+              <View style={S.totalRow}>
+                <Text style={[S.cellBold, S.colIncomeDesc]} />
+                {cols.map((c) => (
+                  <Text key={c.currency} style={[S.cellBold, { width: c.width, textAlign: 'right' }]}>
+                    {fmt(bucketAmount(r.byCurrency, c.currency), c.currency)}
+                  </Text>
+                ))}
+              </View>
             </View>
           </View>
-        </View>
-      ))}
+        );
+      })}
     </>
   );
 }
@@ -322,11 +376,11 @@ function AlicuotaPage({
           <View key={row.categoryName} style={S.row}>
             <Text style={[S.cell, S.colAliCat]}>Alícuota {row.categoryName}</Text>
             <Text style={[S.cell, S.colAliCoef]}>{row.coefficient.toFixed(6)}</Text>
-            <Text style={[S.cell, S.colAliComunes]}>{fmtUSD(row.gastosComunesPerUnit)}</Text>
-            <Text style={[S.cell, S.colAliPropios]}>{fmtUSD(row.gastosPropiosPerUnit)}</Text>
-            <Text style={[S.cell, S.colAliReserva]}>{fmtUSD(row.reservaPerUnit)}</Text>
-            <Text style={[S.cell, S.colAliTotal]}>{fmtUSD(row.totalPerUnit)}</Text>
-            <Text style={[S.cell, S.colAliRecaudar]}>{fmtUSD(row.totalToRecaudar)}</Text>
+            <Text style={[S.cell, S.colAliComunes]}>{fmt(row.gastosComunesPerUnit, 'USD')}</Text>
+            <Text style={[S.cell, S.colAliPropios]}>{fmt(row.gastosPropiosPerUnit, 'USD')}</Text>
+            <Text style={[S.cell, S.colAliReserva]}>{fmt(row.reservaPerUnit, 'USD')}</Text>
+            <Text style={[S.cell, S.colAliTotal]}>{fmt(row.totalPerUnit, 'USD')}</Text>
+            <Text style={[S.cell, S.colAliRecaudar]}>{fmt(row.totalToRecaudar, 'USD')}</Text>
           </View>
         ))}
 
@@ -337,7 +391,7 @@ function AlicuotaPage({
           <Text style={[S.cellBold, S.colAliPropios]} />
           <Text style={[S.cellBold, S.colAliReserva]} />
           <Text style={[S.cellBold, S.colAliTotal]}>TOTAL ALÍCUOTA</Text>
-          <Text style={[S.cellBold, S.colAliRecaudar]}>{fmtUSD(building.grandTotal)}</Text>
+          <Text style={[S.cellBold, S.colAliRecaudar]}>{fmt(building.grandTotal, 'USD')}</Text>
         </View>
       </View>
 

--- a/apps/web/features/finance/components/NotasRevelatoriasPanel.tsx
+++ b/apps/web/features/finance/components/NotasRevelatoriasPanel.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 import Card from '@/shared/components/ui/Card';
 import { Skeleton } from '@/shared/components/ui';
 import { useNotasRevelatorias } from '../hooks/useExpenseLedger';
+import { formatCurrencyBuckets } from '@/shared/lib/format/currency-buckets';
 
 // react-pdf usa APIs del browser — importar solo en cliente
 const NotasRevelatoriasPDF = dynamic(
@@ -72,12 +73,14 @@ export function NotasRevelatoriasPanel({ tenantId }: Props) {
       {!isLoading && report && (
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
           <StatCard
-            label="Ingresos totales (USD)"
-            value={`$${(report.buildingIncomes.reduce((s, b) => s + b.totalUSD, 0) / 100).toFixed(2)}`}
+            label="Ingresos totales"
+            value={formatCurrencyBuckets(
+              report.buildingIncomes.flatMap((b) => b.totalByCurrency),
+            )}
           />
           <StatCard
-            label="Gastos comunes (USD)"
-            value={`$${(report.commonTotals.usd / 100).toFixed(2)}`}
+            label="Gastos comunes"
+            value={formatCurrencyBuckets(report.commonTotals.byCurrency)}
           />
           <StatCard
             label="Notas registradas"

--- a/apps/web/features/finance/services/expense-ledger.api.ts
+++ b/apps/web/features/finance/services/expense-ledger.api.ts
@@ -687,18 +687,23 @@ export async function getVendorSuggestion(
 
 // ── Expense Reports ───────────────────────────────────────────────────────
 
+export interface CurrencyAmountBucket {
+  readonly currency: string;
+  readonly amountMinor: number;
+}
+
 export interface BuildingPeriodSummary {
   buildingId: string;
   buildingName: string;
-  buildingExpenses: number;
-  sharedPortion: number;
-  total: number;
+  buildingExpensesByCurrency: CurrencyAmountBucket[];
+  sharedPortionByCurrency: CurrencyAmountBucket[];
+  totalByCurrency: CurrencyAmountBucket[];
 }
 
 export interface ExpensePeriodReport {
   period: string;
-  totalTenant: number;
-  sharedTotal: number;
+  totalTenantByCurrency: CurrencyAmountBucket[];
+  sharedTotalByCurrency: CurrencyAmountBucket[];
   byBuilding: BuildingPeriodSummary[];
 }
 
@@ -721,27 +726,21 @@ export interface BuildingIncomeSection {
   buildingId: string;
   buildingName: string;
   entries: IncomeEntry[];
-  totalUSD: number;
-  totalVES: number;
-  totalPesos: number;
+  totalByCurrency: CurrencyAmountBucket[];
 }
 
 export interface ExpenseLineItem {
   itemNumber: number;
   date: string;
   description: string;
-  usdAmount: number;
-  vesAmount: number;
-  pesosAmount: number;
+  amountByCurrency: CurrencyAmountBucket[];
 }
 
 export interface BuildingExpenseSection {
   buildingId: string;
   buildingName: string;
   items: ExpenseLineItem[];
-  totalUSD: number;
-  totalVES: number;
-  totalPesos: number;
+  totalByCurrency: CurrencyAmountBucket[];
 }
 
 export interface AlicuotaRow {
@@ -760,6 +759,7 @@ export interface BuildingAlicuota {
   buildingName: string;
   rows: AlicuotaRow[];
   grandTotal: number;
+  baseCurrency: 'USD';
 }
 
 export interface NotasRevelatoriasReport {
@@ -769,9 +769,9 @@ export interface NotasRevelatoriasReport {
   periodLabel: string;
   buildingIncomes: BuildingIncomeSection[];
   commonExpenses: ExpenseLineItem[];
-  commonTotals: { usd: number; ves: number; pesos: number };
+  commonTotals: { byCurrency: CurrencyAmountBucket[] };
   buildingExpenses: BuildingExpenseSection[];
-  reservaLegal: { buildingName: string; usd: number; ves: number }[];
+  reservaLegal: { buildingName: string; byCurrency: CurrencyAmountBucket[] }[];
   alicuotas: BuildingAlicuota[];
 }
 


### PR DESCRIPTION
## Summary

Closes #163

Phase 3F6 makes expense reports and notas revelatorias currency-safe.

## Root cause

Expense reports used fixed USD / VES / "pesos" fields; any currency other than USD or VES was routed into "pesos", so COP, UYU and legacy currencies were labelled ARS. The expense history report produced nominal totals with no currency dimension.

## Fix

- getExpenseHistory aggregates per (period, building, currencyCode) with per-currency buckets
- notas revelatorias line items expose amountByCurrency[]; totals use byCurrency buckets; reserve follows liquidation baseCurrency
- web history renders buckets per currency; CSV emits per-(building, currency) rows with explicit Currency column (no mixed TOTAL)
- panel renders bucket totals; PDF renders dynamic per-currency columns

## Contract

- Expense.currencyCode is the currency authority; amountMinor is minor units
- canonical order USD, VES, ARS, COP; legacy lexicographic after
- COP stays COP (never ARS); UYU stays UYU (no fallback)
- no mixed nominal totals, no live FX, no functional conversion

## Alícuota

Deliberately USD-only (document header declares DÓLARES AMERICANOS; liquidations are single-currency per baseCurrency). Now explicitly labelled: BuildingAlicuota.baseCurrency = 'USD'.

## Validation

- expense reports spec 15/15 PASS
- API full 2550 PASS / 0 failed
- API/WEB typecheck, lint, build PASS
- runtime harness against compiled bundle PASS
- git diff --check PASS

## Scope

- expense reports service/tests
- web consumers (history, panel, PDF)
- contract types
- schema untouched, migrations untouched, 3F7 untouched
