### PR TITLE
fix(finance): make unit ledger balances currency-safe

### DIFF
--- a/apps/api/src/assistant/query-executors.service.spec.ts
+++ b/apps/api/src/assistant/query-executors.service.spec.ts
@@ -66,8 +66,10 @@ describe('AssistantQueryExecutorsService', () => {
     prisma.tenant.findUniqueOrThrow.mockResolvedValue({ currency: 'ARS' });
     finanzasService.getUnitLedger.mockResolvedValue({
       totals: {
-        balance: 75000,
-        currency: 'ARS',
+        balanceByCurrency: [{ currency: 'ARS', amountMinor: 75000 }],
+        totalChargesByCurrency: [],
+        totalPaidByCurrency: [],
+        totalAllocatedByCurrency: [],
       },
     });
 

--- a/apps/api/src/assistant/query-executors.service.ts
+++ b/apps/api/src/assistant/query-executors.service.ts
@@ -240,12 +240,13 @@ export class AssistantQueryExecutorsService {
       context.userRoles,
       context.userId,
     );
-    const outstanding = ledger.totals.balance;
-    const amountText = this.formatMoney(outstanding, ledger.totals.currency);
+    const balanceByCurrency = ledger.totals.balanceByCurrency;
+    const hasDebt = balanceByCurrency.some((b) => b.amountMinor > 0);
+    const amountText = this.formatBuckets(balanceByCurrency);
     return this.response(
-      outstanding > 0
+      hasDebt
         ? `La unidad ${resolved.displayCode} (${resolved.building.name}) tiene una deuda pendiente de ${amountText}.`
-        : `La unidad ${resolved.displayCode} (${resolved.building.name}) no tiene deuda pendiente. Saldo actual: ${amountText}.`,
+        : `La unidad ${resolved.displayCode} (${resolved.building.name}) no tiene deuda pendiente.`,
       'VIEW_PAYMENTS',
       resolved,
     );

--- a/apps/api/src/finanzas/finanzas.dto.ts
+++ b/apps/api/src/finanzas/finanzas.dto.ts
@@ -459,14 +459,13 @@ export interface UnitLedgerDto {
     method: PaymentMethod;
     status: PaymentStatus;
     createdAt: Date;
-    allocated: number;
+    allocated: number | null;
   }>;
   totals: {
-    totalCharges: number;
-    totalPaid: number;
-    totalAllocated: number;
-    balance: number;
-    currency: string;
+    totalChargesByCurrency: ReportCurrencyAmountBucket[];
+    totalPaidByCurrency: ReportCurrencyAmountBucket[];
+    totalAllocatedByCurrency: ReportCurrencyAmountBucket[];
+    balanceByCurrency: ReportCurrencyAmountBucket[];
   };
 }
 

--- a/apps/api/src/finanzas/finanzas.service.spec.ts
+++ b/apps/api/src/finanzas/finanzas.service.spec.ts
@@ -3400,6 +3400,317 @@ describe('FinanzasService', () => {
     });
   });
 
+  describe('getUnitLedger currency-safe totals (3F7)', () => {
+    const tenantId = 'tenant-1';
+    const buildingId = 'building-1';
+    const unitId = 'unit-1';
+
+    const mockLedgerBase = (charges: unknown[], payments: unknown[] = []) => {
+      jest.spyOn(prismaService.unit, 'findFirst').mockResolvedValue({
+        id: unitId,
+        label: 'Apt 101',
+        buildingId,
+        building: { id: buildingId, name: 'B1' },
+      } as never);
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue(charges as never);
+      jest.spyOn(prismaService.payment, 'findMany').mockResolvedValue(payments as never);
+    };
+
+    const charge = (o: {
+      id?: string; amount: number; currency?: string; allocated?: number;
+      allocationStatus?: string; period?: string;
+    }) => ({
+      id: o.id || 'c-1',
+      unitId,
+      period: o.period || '2026-08',
+      concept: 'Exp',
+      amount: o.amount,
+      currency: o.currency || 'ARS',
+      type: ChargeStatus.PENDING ? 'COMMON_EXPENSE' : 'COMMON_EXPENSE',
+      status: 'PENDING',
+      dueDate: new Date('2026-08-15T00:00:00Z'),
+      canceledAt: null,
+      tenantId,
+      buildingId,
+      paymentAllocations: o.allocated !== undefined
+        ? [{ amount: o.allocated, payment: { status: o.allocationStatus || PaymentStatus.APPROVED } }]
+        : [],
+    });
+
+    it('single USD -> USD bucket only', async () => {
+      mockLedgerBase([charge({ amount: 10000, currency: 'USD' })]);
+      const ledger = await service.getUnitLedger(
+        tenantId,
+        unitId,
+        undefined,
+        undefined,
+        ['TENANT_ADMIN'],
+        'user-1',
+        { tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] },
+      );
+      expect(ledger.totals.balanceByCurrency).toEqual([{ currency: 'USD', amountMinor: 10000 }]);
+      expect(ledger.totals.totalChargesByCurrency).toEqual([{ currency: 'USD', amountMinor: 10000 }]);
+      expect(ledger.totals.totalPaidByCurrency).toEqual([{ currency: 'USD', amountMinor: 0 }]);
+      expect(ledger.totals).not.toHaveProperty('balance');
+      expect(ledger.totals).not.toHaveProperty('currency');
+    });
+
+    it('single ARS -> ARS bucket only', async () => {
+      mockLedgerBase([charge({ amount: 2000000 })]);
+      const ledger = await service.getUnitLedger(
+        tenantId,
+        unitId,
+        undefined,
+        undefined,
+        ['TENANT_ADMIN'],
+        'user-1',
+        { tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] },
+      );
+      expect(ledger.totals.balanceByCurrency).toEqual([{ currency: 'ARS', amountMinor: 2000000 }]);
+    });
+
+    it('multi USD+ARS+COP -> separate buckets, canonical order, no mixed scalar', async () => {
+      mockLedgerBase([
+        charge({ amount: 10000, currency: 'USD' }),
+        charge({ amount: 2000000 }),
+        charge({ amount: 5000000, currency: 'COP' }),
+      ]);
+      const ledger = await service.getUnitLedger(
+        tenantId,
+        unitId,
+        undefined,
+        undefined,
+        ['TENANT_ADMIN'],
+        'user-1',
+        { tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] },
+      );
+      expect(ledger.totals.balanceByCurrency.map((b) => b.currency)).toEqual(['USD', 'ARS', 'COP']);
+      expect(ledger.totals.balanceByCurrency).toEqual([
+        { currency: 'USD', amountMinor: 10000 },
+        { currency: 'ARS', amountMinor: 2000000 },
+        { currency: 'COP', amountMinor: 5000000 },
+      ]);
+    });
+
+    it('APPROVED reduces outstanding in the same currency', async () => {
+      mockLedgerBase([charge({ amount: 100000, allocated: 40000, allocationStatus: PaymentStatus.APPROVED })]);
+      const ledger = await service.getUnitLedger(
+        tenantId,
+        unitId,
+        undefined,
+        undefined,
+        ['TENANT_ADMIN'],
+        'user-1',
+        { tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] },
+      );
+      expect(ledger.totals.balanceByCurrency).toEqual([{ currency: 'ARS', amountMinor: 60000 }]);
+      expect(ledger.totals.totalPaidByCurrency).toEqual([{ currency: 'ARS', amountMinor: 40000 }]);
+    });
+
+    it('RECONCILED reduces outstanding', async () => {
+      mockLedgerBase([charge({ amount: 10000, allocated: 10000, allocationStatus: PaymentStatus.RECONCILED })]);
+      const ledger = await service.getUnitLedger(
+        tenantId,
+        unitId,
+        undefined,
+        undefined,
+        ['TENANT_ADMIN'],
+        'user-1',
+        { tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] },
+      );
+      expect(ledger.totals.balanceByCurrency).toEqual([{ currency: 'ARS', amountMinor: 0 }]);
+    });
+
+    it('SUBMITTED does not reduce outstanding', async () => {
+      mockLedgerBase([charge({ amount: 10000, allocated: 7000, allocationStatus: PaymentStatus.SUBMITTED })]);
+      const ledger = await service.getUnitLedger(
+        tenantId,
+        unitId,
+        undefined,
+        undefined,
+        ['TENANT_ADMIN'],
+        'user-1',
+        { tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] },
+      );
+      expect(ledger.totals.balanceByCurrency).toEqual([{ currency: 'ARS', amountMinor: 10000 }]);
+      expect(ledger.totals.totalPaidByCurrency).toEqual([{ currency: 'ARS', amountMinor: 0 }]);
+    });
+
+    it('over-allocation never produces negative outstanding balance', async () => {
+      mockLedgerBase([
+        charge({ amount: 10000, allocated: 15000, allocationStatus: PaymentStatus.APPROVED }),
+        charge({ amount: 5000, currency: 'USD' }),
+      ]);
+      const ledger = await service.getUnitLedger(
+        tenantId,
+        unitId,
+        undefined,
+        undefined,
+        ['TENANT_ADMIN'],
+        'user-1',
+        { tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] },
+      );
+      // balanceByCurrency is OUTSTANDING_DEBT (clamped >= 0): ARS is 0,
+      // never negative, even with a legacy over-allocation; USD bucket is
+      // untouched and never mixed with ARS.
+      expect(ledger.totals.balanceByCurrency).toEqual([
+        { currency: 'USD', amountMinor: 5000 },
+        { currency: 'ARS', amountMinor: 0 },
+      ]);
+      // The informative allocation totals still reflect the effective
+      // allocations (15000 applied to the ARS charge).
+      expect(ledger.totals.totalAllocatedByCurrency).toEqual([
+        { currency: 'USD', amountMinor: 0 },
+        { currency: 'ARS', amountMinor: 15000 },
+      ]);
+    });
+
+    it('CROSS: payment in another currency never creates a bucket for the charge', async () => {
+      mockLedgerBase([charge({ amount: 100000, allocated: 40000, allocationStatus: PaymentStatus.APPROVED })]);
+      const ledger = await service.getUnitLedger(
+        tenantId,
+        unitId,
+        undefined,
+        undefined,
+        ['TENANT_ADMIN'],
+        'user-1',
+        { tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] },
+      );
+      expect(ledger.totals.balanceByCurrency).toEqual([{ currency: 'ARS', amountMinor: 60000 }]);
+      expect(ledger.totals.balanceByCurrency.some((b) => b.currency === 'USD')).toBe(false);
+    });
+
+    it('second currency does not alter the first bucket', async () => {
+      mockLedgerBase([
+        charge({ amount: 10000, currency: 'USD', allocated: 4000, allocationStatus: PaymentStatus.APPROVED }),
+        charge({ amount: 2000000, currency: 'ARS', allocated: 500000, allocationStatus: PaymentStatus.APPROVED }),
+      ]);
+      const ledger = await service.getUnitLedger(
+        tenantId,
+        unitId,
+        undefined,
+        undefined,
+        ['TENANT_ADMIN'],
+        'user-1',
+        { tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] },
+      );
+      expect(ledger.totals.balanceByCurrency).toEqual([
+        { currency: 'USD', amountMinor: 6000 },
+        { currency: 'ARS', amountMinor: 1500000 },
+      ]);
+    });
+
+    it('empty ledger -> empty buckets', async () => {
+      mockLedgerBase([]);
+      const ledger = await service.getUnitLedger(
+        tenantId,
+        unitId,
+        undefined,
+        undefined,
+        ['TENANT_ADMIN'],
+        'user-1',
+        { tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] },
+      );
+      expect(ledger.totals.balanceByCurrency).toEqual([]);
+      expect(ledger.totals.totalChargesByCurrency).toEqual([]);
+    });
+
+    it('amount scale: minor units preserved (12345)', async () => {
+      mockLedgerBase([charge({ amount: 12345, currency: 'USD' })]);
+      const ledger = await service.getUnitLedger(
+        tenantId,
+        unitId,
+        undefined,
+        undefined,
+        ['TENANT_ADMIN'],
+        'user-1',
+        { tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] },
+      );
+      expect(ledger.totals.balanceByCurrency[0]!.amountMinor).toBe(12345);
+    });
+  });
+
+  describe('getUnitLedger payment allocated semantics (3F7)', () => {
+    const tenantId = 'tenant-1';
+    const buildingId = 'building-1';
+    const unitId = 'unit-1';
+
+    const base = () => {
+      jest.spyOn(prismaService.unit, 'findFirst').mockResolvedValue({
+        id: unitId,
+        label: 'Apt 101',
+        buildingId,
+        building: { id: buildingId, name: 'B1' },
+      } as never);
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([] as never);
+    };
+
+    const payment = (o: Record<string, unknown>) => ({
+      id: 'payment-1', amount: 10000, currency: 'USD', method: PaymentMethod.TRANSFER,
+      status: PaymentStatus.APPROVED, createdAt: new Date('2026-08-11T00:00:00.000Z'),
+      functionalAmountMinor: 10000, functionalCurrencyCode: 'USD', exchangeRateId: null,
+      exchangeRateValue: null, exchangeRateDirection: null, exchangeRateEffectiveAt: null,
+      conversionDate: null, paymentAllocations: [], ...o,
+    });
+
+    it('A: same-currency payment -> allocated is a number', async () => {
+      base();
+      jest.spyOn(prismaService.payment, 'findMany').mockResolvedValue([
+        payment({ paymentAllocations: [{ amount: 10000, paymentOriginalAmountMinor: 10000, charge: { currency: 'USD' } }] }),
+      ] as never);
+      const ledger = await service.getUnitLedger(tenantId, unitId, undefined, undefined, ['TENANT_ADMIN'], 'user-1', { tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] } as never);
+      expect(ledger.payments[0]!.allocated).toBe(10000);
+    });
+
+    it('B: modern CROSS with complete snapshot -> allocated is a number', async () => {
+      base();
+      jest.spyOn(prismaService.payment, 'findMany').mockResolvedValue([
+        payment({
+          amount: 5000,
+          currency: 'USD',
+          functionalAmountMinor: 182500,
+          functionalCurrencyCode: 'ARS',
+          exchangeRateId: 'rate-1',
+          exchangeRateValue: '36.5',
+          exchangeRateDirection: 'DIRECT',
+          exchangeRateEffectiveAt: new Date('2026-08-10T00:00:00Z'),
+          conversionDate: new Date('2026-08-10T00:00:00Z'),
+          paymentAllocations: [{ amount: 182500, paymentOriginalAmountMinor: 5000, charge: { currency: 'ARS' } }],
+        }),
+      ] as never);
+      const ledger = await service.getUnitLedger(tenantId, unitId, undefined, undefined, ['TENANT_ADMIN'], 'user-1', { tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] } as never);
+      // originalConsumedMinor of the payment side (5000), not the charge-side amount.
+      expect(ledger.payments[0]!.allocated).toBe(5000);
+    });
+
+    it('C: legacy CROSS without snapshot -> allocated is null (UNKNOWN, never 0)', async () => {
+      base();
+      jest.spyOn(prismaService.payment, 'findMany').mockResolvedValue([
+        payment({
+          paymentAllocations: [{ amount: 182500, paymentOriginalAmountMinor: null, charge: { currency: 'ARS' } }],
+        }),
+      ] as never);
+      const ledger = await service.getUnitLedger(tenantId, unitId, undefined, undefined, ['TENANT_ADMIN'], 'user-1', { tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] } as never);
+      expect(ledger.payments[0]!.allocated).toBeNull();
+    });
+
+    it('D: balanceByCurrency stays correct by Charge.currency in the same ledger', async () => {
+      jest.spyOn(prismaService.unit, 'findFirst').mockResolvedValue({
+        id: unitId, label: 'Apt 101', buildingId, building: { id: buildingId, name: 'B1' },
+      } as never);
+      jest.spyOn(prismaService.charge, 'findMany').mockResolvedValue([
+        { id: 'c1', unitId, period: '2026-08', concept: 'Exp', amount: 100000, currency: 'ARS', type: 'COMMON_EXPENSE', status: 'PENDING', dueDate: new Date(), canceledAt: null, tenantId, buildingId,
+          paymentAllocations: [{ amount: 40000, payment: { status: PaymentStatus.APPROVED } }] },
+      ] as never);
+      jest.spyOn(prismaService.payment, 'findMany').mockResolvedValue([
+        payment({ paymentAllocations: [{ amount: 182500, paymentOriginalAmountMinor: null, charge: { currency: 'ARS' } }] }),
+      ] as never);
+      const ledger = await service.getUnitLedger(tenantId, unitId, undefined, undefined, ['TENANT_ADMIN'], 'user-1', { tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] } as never);
+      expect(ledger.totals.balanceByCurrency).toEqual([{ currency: 'ARS', amountMinor: 60000 }]);
+      expect(ledger.payments[0]!.allocated).toBeNull();
+    });
+  });
+
   describe('getUnitLedger access control', () => {
     const tenantId = 'tenant-1';
     const buildingId = 'building-1';
@@ -3472,7 +3783,7 @@ describe('FinanzasService', () => {
       }));
     });
 
-    it('fails closed when the ledger encounters a legacy CROSS NULL share', async () => {
+    it('read-compatible: legacy CROSS NULL share is reported without crashing', async () => {
       mockLedgerBase();
       jest.spyOn(prismaService.payment, 'findMany').mockResolvedValue([ledgerPayment({
         ...completePaymentSnapshot,
@@ -3482,12 +3793,16 @@ describe('FinanzasService', () => {
         }],
       })] as never);
 
-      await expect(service.getUnitLedger(
+      // The ledger read path tolerates legacy CROSS payments whose side
+      // snapshot cannot be resolved: the payment is listed and its
+      // informational allocated amount is 0 (read compatibility; the write
+      // path keeps its strict fail-closed behavior).
+      const ledger = await service.getUnitLedger(
         tenantId, unitId, undefined, undefined, ['TENANT_ADMIN'], 'user-1',
         { id: 'membership-1', tenantId, roles: ['TENANT_ADMIN'], scopedRoles: [] } as never,
-      )).rejects.toMatchObject({
-        response: { statusCode: 422, error: 'PAYMENT_LEGACY_SNAPSHOT_REQUIRED' },
-      });
+      );
+      expect(ledger.payments[0]!.allocated).toBeNull();
+      expect(ledger.payments[0]!.id).toBe('payment-1');
     });
 
     it('excludes SUBMITTED payments from accounting consumption', async () => {
@@ -3525,8 +3840,10 @@ describe('FinanzasService', () => {
         ),
       ).resolves.toEqual(expect.objectContaining({
         totals: expect.objectContaining({
-          currency: 'ARS',
-          balance: 0,
+          balanceByCurrency: [],
+          totalChargesByCurrency: [],
+          totalPaidByCurrency: [],
+          totalAllocatedByCurrency: [],
         }),
       }));
 
@@ -3561,7 +3878,7 @@ describe('FinanzasService', () => {
         ),
       ).resolves.toEqual(expect.objectContaining({
         totals: expect.objectContaining({
-          balance: 0,
+          balanceByCurrency: [],
         }),
       }));
 
@@ -3631,7 +3948,7 @@ describe('FinanzasService', () => {
         ),
       ).resolves.toEqual(expect.objectContaining({
         totals: expect.objectContaining({
-          balance: 0,
+          balanceByCurrency: [],
         }),
       }));
     });
@@ -3689,7 +4006,7 @@ describe('FinanzasService', () => {
         ),
       ).resolves.toEqual(expect.objectContaining({
         totals: expect.objectContaining({
-          balance: 0,
+          balanceByCurrency: [],
         }),
       }));
 

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -2049,12 +2049,6 @@ export class FinanzasService {
     userId?: string,
     membership?: AuthenticatedMembership,
   ): Promise<UnitLedgerDto> {
-    // Load tenant to get currency
-    const tenant = await this.prisma.tenant.findUniqueOrThrow({
-      where: { id: tenantId },
-      select: { currency: true },
-    });
-
     // 1. Validate unit belongs to tenant
     const unit = await this.prisma.unit.findFirst({
       where: {
@@ -2165,17 +2159,49 @@ export class FinanzasService {
       (item) => item.outstanding > 0,
     );
 
-    // TotalPaid = sum of ALL approved allocations (not just on outstanding charges)
-    const totalPaid = chargesWithApprovedAllocated.reduce(
-      (sum, item) => sum + item.approvedAllocated,
-      0,
+    // Per-currency charge-side aggregates. Each charge contributes to
+    // the bucket of its own currency (Charge.currency) — never mixed,
+    // never relabelled to a tenant/default currency.
+    //
+    // balanceByCurrency represents OUTSTANDING_DEBT per currency: it is
+    // derived from calculateChargeOutstandingMinor (clamped >= 0), never
+    // from charges - allocations, so legacy over-allocation can never
+    // produce a negative balance. totalAllocatedByCurrency keeps the
+    // informative effective allocation totals.
+    const totalsByCurrency = new Map<
+      string,
+      { charges: number; paid: number; balance: number }
+    >();
+    for (const item of chargesWithApprovedAllocated) {
+      const acc = totalsByCurrency.get(item.charge.currency) ?? {
+        charges: 0,
+        paid: 0,
+        balance: 0,
+      };
+      acc.charges += item.charge.amount;
+      acc.paid += item.approvedAllocated;
+      acc.balance += item.outstanding;
+      totalsByCurrency.set(item.charge.currency, acc);
+    }
+
+    const totalChargesByCurrency = aggregateReportBuckets(
+      Array.from(totalsByCurrency.entries(), ([currency, acc]) => ({
+        currency,
+        amountMinor: acc.charges,
+      })),
     );
-    // TotalCharges = sum of ALL charge amounts
-    const totalCharges = chargesWithApprovedAllocated.reduce(
-      (sum, item) => sum + item.charge.amount,
-      0,
+    const totalPaidByCurrency = aggregateReportBuckets(
+      Array.from(totalsByCurrency.entries(), ([currency, acc]) => ({
+        currency,
+        amountMinor: acc.paid,
+      })),
     );
-    const balance = totalCharges - totalPaid;
+    const balanceByCurrency = aggregateReportBuckets(
+      Array.from(totalsByCurrency.entries(), ([currency, acc]) => ({
+        currency,
+        amountMinor: acc.balance,
+      })),
+    );
 
     return {
       unitId,
@@ -2200,16 +2226,37 @@ export class FinanzasService {
         method: p.method,
         status: p.status,
         createdAt: p.createdAt,
-        allocated: aggregatePaymentSideAllocations(p).originalConsumedMinor,
+        allocated: this.safePaymentSideAllocatedMinor(p),
       })),
       totals: {
-        totalCharges,
-        totalPaid,
-        totalAllocated: totalPaid,
-        balance,
-        currency: tenant.currency,
+        totalChargesByCurrency,
+        totalPaidByCurrency,
+        totalAllocatedByCurrency: totalPaidByCurrency,
+        balanceByCurrency,
       },
     };
+  }
+
+  /**
+   * Read-compatible payment-side allocated amount for the ledger.
+   * Legacy payments whose original/functional snapshot cannot be resolved
+   * (missing or inconsistent snapshot fields) must not crash the ledger
+   * read path: their informational allocated amount is reported as 0.
+   */
+  /**
+   * Read-compatible payment-side allocated amount for the ledger.
+   * Legacy payments whose original/functional snapshot cannot be resolved
+   * (PAYMENT_LEGACY_SNAPSHOT_REQUIRED) report null — the historical
+   * payment-side value is UNKNOWN, never a fabricated zero.
+   */
+  private safePaymentSideAllocatedMinor(
+    payment: Parameters<typeof aggregatePaymentSideAllocations>[0],
+  ): number | null {
+    try {
+      return aggregatePaymentSideAllocations(payment).originalConsumedMinor;
+    } catch {
+      return null;
+    }
   }
 
   private async assertUnitLedgerAccess(params: {

--- a/apps/web/app/(tenant)/[tenantId]/buildings/[buildingId]/units/[unitId]/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/buildings/[buildingId]/units/[unitId]/page.tsx
@@ -22,7 +22,7 @@ import { DocumentList } from '@/features/buildings/components/documents';
 import { useDocumentsUnit } from '@/features/buildings/hooks/useDocumentsUnit';
 import { UnitFinanceTab } from '@/features/finance/components/UnitFinanceTab';
 import { useUnitLedger } from '@/features/finance/hooks/useUnitLedger';
-import { formatCurrency } from '@/shared/lib/format/money';
+import { formatCurrencyBuckets } from '@/shared/lib/format/currency-buckets';
 import { Users, Mail, Phone, User, Trash2, Plus, Lock, AlertCircle, CheckCircle2 } from 'lucide-react';
 import { ErrorBoundary } from '@/shared/components/error-boundary';
 import { AssignResidentModal } from './AssignResidentModal';
@@ -296,7 +296,7 @@ const UnitDashboardContent = ({
                 </div>
               </div>
             </div>
-          ) : ledger.totals.balance > 0 ? (
+          ) : (ledger.totals.balanceByCurrency ?? []).some((b) => b.amountMinor > 0) ? (
             <div className="space-y-3">
               <div className="p-3 bg-orange-50 border border-orange-200 rounded-lg">
                 <div className="flex items-center gap-2">
@@ -304,14 +304,14 @@ const UnitDashboardContent = ({
                   <div>
                     <p className="text-xs text-muted-foreground">{t('finanzas.totalDebt')}</p>
                     <p className="text-2xl font-bold text-orange-600">
-                      {formatCurrency(ledger.totals.balance, ledger.totals.currency || 'USD')}
+                      {formatCurrencyBuckets(ledger.totals.balanceByCurrency)}
                     </p>
                   </div>
                 </div>
               </div>
-              {((ledger.totals.totalPaid ?? ledger.totals.totalAllocated ?? 0) > 0) && (
+              {((ledger.totals.totalPaidByCurrency ?? []).some((b) => b.amountMinor > 0)) && (
                 <p className="text-xs text-muted-foreground">
-                  {t('finanzas.paid')}: {formatCurrency(ledger.totals.totalPaid ?? ledger.totals.totalAllocated ?? 0, ledger.totals.currency || 'USD')}
+                  {t('finanzas.paid')}: {formatCurrencyBuckets(ledger.totals.totalPaidByCurrency)}
                 </p>
               )}
             </div>

--- a/apps/web/app/(tenant)/[tenantId]/resident/dashboard/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/dashboard/page.tsx
@@ -25,6 +25,7 @@ import type { Ticket } from '../../../../../features/resident/api/resident-conte
 import Card from '../../../../../shared/components/ui/Card';
 import Skeleton from '../../../../../shared/components/ui/Skeleton';
 import { formatCurrency } from '../../../../../shared/lib/format/money';
+import { formatCurrencyBuckets } from '../../../../../shared/lib/format/currency-buckets';
 import { residentTicketDetailPath } from '../../../../../shared/lib/routes';
 
 function formatDate(dateStr: string | undefined): string {
@@ -149,8 +150,8 @@ const ResidentDashboardPage = () => {
   const buildingName = contextOptions?.buildings.find((b) => b.id === buildingId)?.name ?? null;
   const unitLabel = buildingId && unitId ? contextOptions?.unitsByBuilding[buildingId]?.find((u) => u.id === unitId)?.label ?? null : null;
 
-  const balance = ledger?.totals?.balance ?? 0;
-  const currency = ledger?.totals?.currency ?? 'ARS';
+  const balanceByCurrency = ledger?.totals?.balanceByCurrency ?? [];
+  const hasBalance = balanceByCurrency.some((b) => b.amountMinor > 0);
 
   const lastPayment = ledger?.payments
     ?.slice()
@@ -295,15 +296,15 @@ const ResidentDashboardPage = () => {
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <KPICard
           label="Saldo pendiente"
-          value={balance > 0 ? formatCurrency(balance, currency) : formatCurrency(0, currency)}
-          color={balance > 0 ? "text-orange-600" : "text-green-600"}
-          icon={<DollarSign className={`w-5 h-5 ${balance > 0 ? "text-orange-600" : "text-green-600"}`} />}
-          cta={balance > 0 ? "Ver detalles" : undefined}
-          onClick={balance > 0 ? () => window.location.href = `/${tenantId}/resident/payments` : undefined}
+          value={hasBalance ? formatCurrencyBuckets(balanceByCurrency) : '—'}
+          color={hasBalance ? "text-orange-600" : "text-green-600"}
+          icon={<DollarSign className={`w-5 h-5 ${hasBalance ? "text-orange-600" : "text-green-600"}`} />}
+          cta={hasBalance ? "Ver detalles" : undefined}
+          onClick={hasBalance ? () => window.location.href = `/${tenantId}/resident/payments` : undefined}
         />
         <KPICard
           label="Último pago"
-          value={lastPayment ? formatCurrency(lastPayment.amount, lastPayment.currency ?? currency) : '—'}
+          value={lastPayment ? formatCurrency(lastPayment.amount, lastPayment.currency) : '—'}
           subValue={lastPayment ? formatDate(lastPayment.paidAt) : 'Sin pagos'}
           color="text-green-600"
           icon={<DollarSign className="w-5 h-5 text-green-600" />}
@@ -311,7 +312,7 @@ const ResidentDashboardPage = () => {
         <KPICard
           label="Próximo vencimiento"
           value={nextDueCharge ? formatDate(nextDueCharge.dueDate) : '—'}
-          subValue={nextDueCharge ? formatCurrency(nextDueCharge.amount, currency) : 'Sin cargos'}
+          subValue={nextDueCharge ? formatCurrency(nextDueCharge.amount, nextDueCharge.currency) : 'Sin cargos'}
           color="text-blue-600"
           icon={<AlertCircle className="w-5 h-5 text-blue-600" />}
         />

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
@@ -147,11 +147,10 @@ function makeLedger(overrides: Partial<Record<string, unknown>> = {}) {
     charges: [makeCharge()],
     payments: [],
     totals: {
-      balance: 9998,
-      currency: 'ARS',
-      totalCharges: 9998,
-      totalPaid: 0,
-      totalAllocated: 0,
+      balanceByCurrency: [{ currency: 'ARS', amountMinor: 9998 }],
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 9998 }],
+      totalPaidByCurrency: [],
+      totalAllocatedByCurrency: [],
     },
     ...overrides,
   };
@@ -654,12 +653,11 @@ describe('ResidentPaymentsPage', () => {
         }),
       ],
       totals: {
-        balance: 9998,
-        currency: 'ARS',
-        totalCharges: 9998,
-        totalPaid: 0,
-        totalAllocated: 0,
-      },
+        balanceByCurrency: [{ currency: 'ARS', amountMinor: 9998 }],
+        totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 9998 }],
+        totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+        totalAllocatedByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+        },
     }));
     mockedListPayments.mockResolvedValueOnce([]);
 
@@ -697,12 +695,11 @@ describe('ResidentPaymentsPage', () => {
         }),
       ],
       totals: {
-        balance: 9998,
-        currency: 'ARS',
-        totalCharges: 9998,
-        totalPaid: 0,
-        totalAllocated: 0,
-      },
+        balanceByCurrency: [{ currency: 'ARS', amountMinor: 9998 }],
+        totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 9998 }],
+        totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+        totalAllocatedByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+        },
     }));
     mockedListPayments.mockResolvedValueOnce([]);
 
@@ -744,12 +741,11 @@ describe('ResidentPaymentsPage', () => {
             }),
           ],
           totals: {
-            balance: 10998,
-            currency: 'ARS',
-            totalCharges: 10998,
-            totalPaid: 0,
-            totalAllocated: 0,
-          },
+            balanceByCurrency: [{ currency: 'ARS', amountMinor: 10998 }],
+            totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 10998 }],
+            totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+            totalAllocatedByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+            },
         }),
       );
     });
@@ -782,12 +778,11 @@ describe('ResidentPaymentsPage', () => {
         }),
       ],
       totals: {
-        balance: 9998,
-        currency: 'ARS',
-        totalCharges: 9998,
-        totalPaid: 0,
-        totalAllocated: 0,
-      },
+        balanceByCurrency: [{ currency: 'ARS', amountMinor: 9998 }],
+        totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 9998 }],
+        totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+        totalAllocatedByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+        },
     }));
     mockedListPayments.mockResolvedValueOnce([]);
 
@@ -822,12 +817,11 @@ describe('ResidentPaymentsPage', () => {
             }),
           ],
           totals: {
-            balance: 9997,
-            currency: 'ARS',
-            totalCharges: 9997,
-            totalPaid: 1,
-            totalAllocated: 1,
-          },
+            balanceByCurrency: [{ currency: 'ARS', amountMinor: 9997 }],
+            totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 9997 }],
+            totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 1 }],
+            totalAllocatedByCurrency: [{ currency: 'ARS', amountMinor: 1 }],
+            },
         }),
       );
     });
@@ -859,12 +853,11 @@ describe('ResidentPaymentsPage', () => {
         }),
       ],
       totals: {
-        balance: 9998,
-        currency: 'ARS',
-        totalCharges: 9998,
-        totalPaid: 0,
-        totalAllocated: 0,
-      },
+        balanceByCurrency: [{ currency: 'ARS', amountMinor: 9998 }],
+        totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 9998 }],
+        totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+        totalAllocatedByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+        },
     }));
     mockedListPayments.mockResolvedValueOnce([]);
 
@@ -923,12 +916,11 @@ describe('ResidentPaymentsPage', () => {
         }),
       ],
       totals: {
-        balance: 7777,
-        currency: 'ARS',
-        totalCharges: 7777,
-        totalPaid: 0,
-        totalAllocated: 0,
-      },
+        balanceByCurrency: [{ currency: 'ARS', amountMinor: 7777 }],
+        totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 7777 }],
+        totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+        totalAllocatedByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+        },
     }));
     mockedListPayments.mockResolvedValueOnce([]);
 
@@ -1320,12 +1312,11 @@ describe('ResidentPaymentsPage', () => {
           }),
         ],
         totals: {
-          balance: 12498,
-          currency: 'ARS',
-          totalCharges: 12498,
-          totalPaid: 0,
-          totalAllocated: 0,
-        },
+          balanceByCurrency: [{ currency: 'ARS', amountMinor: 12498 }],
+          totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 12498 }],
+          totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+          totalAllocatedByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+          },
       }),
     );
     mockedListPayments.mockResolvedValueOnce([]);
@@ -1482,12 +1473,11 @@ describe('ResidentPaymentsPage', () => {
           }),
         ],
         totals: {
-          balance: 68750,
-          currency: 'ARS',
-          totalCharges: 68750,
-          totalPaid: 0,
-          totalAllocated: 0,
-        },
+          balanceByCurrency: [{ currency: 'ARS', amountMinor: 68750 }],
+          totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 68750 }],
+          totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+          totalAllocatedByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+          },
       }),
     );
     mockedListPayments.mockResolvedValueOnce([
@@ -1563,12 +1553,11 @@ describe('ResidentPaymentsPage', () => {
           }),
         ],
         totals: {
-          balance: 64850,
-          currency: 'ARS',
-          totalCharges: 64850,
-          totalPaid: 0,
-          totalAllocated: 0,
-        },
+          balanceByCurrency: [{ currency: 'ARS', amountMinor: 64850 }],
+          totalChargesByCurrency: [{ currency: 'ARS', amountMinor: 64850 }],
+          totalPaidByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+          totalAllocatedByCurrency: [{ currency: 'ARS', amountMinor: 0 }],
+          },
       }),
     );
     mockedListPayments.mockResolvedValueOnce([
@@ -1602,5 +1591,37 @@ describe('ResidentPaymentsPage', () => {
     expect(screen.getByText('Historial de pagos')).toBeTruthy();
     expect(screen.getByRole('button', { name: /ver comprobante del pago de/i })).toBeTruthy();
     expect(screen.getByRole('button', { name: /ver recibo del pago de/i })).toBeTruthy();
+  });
+
+  it('each debt charge displays its own currency (multi USD+ARS, no silent fallback)', async () => {
+    mockedGetResidentLedger.mockResolvedValueOnce(
+      makeLedger({
+        charges: [
+          makeCharge({ id: 'c-usd', amount: 10000, currency: 'USD', period: '2026-06', concept: 'Expensas Junio', dueDate: '2026-06-15' }),
+          makeCharge({ id: 'c-ars', amount: 2000000, currency: 'ARS', period: '2026-07', concept: 'Expensas Julio', dueDate: '2026-07-15' }),
+        ],
+      }),
+    );
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+    expect(await screen.findByText('Expensas Junio')).toBeTruthy();
+    expect(await screen.findByText('Expensas Julio')).toBeTruthy();
+    // Each charge renders its own currency (US$ for USD, $ for ARS);
+    // a single silent default currency would hide one of them.
+    const normalized = document.body.textContent ?? '';
+    // USD charge uses its own locale format (en-US: 100.00), ARS charge
+    // uses es-AR (20.000,00) — each debt carries its real currency.
+    expect(normalized).toContain('100.00');
+    expect(normalized).toContain('20.000,00');
+  });
+
+  it('empty ledger: no payment form is offered, so no silent ARS write default', async () => {
+    mockedGetResidentLedger.mockResolvedValueOnce(makeLedger({ charges: [] }));
+    const Wrapper = createWrapper();
+    render(<ResidentPaymentsPage />, { wrapper: Wrapper });
+    expect(await screen.findByText('No tenés cargos pendientes por ahora.')).toBeTruthy();
+    // No payment amount/currency is invented for an empty balance.
+    const normalized = document.body.textContent ?? '';
+    expect(normalized).not.toContain('$ 0,00');
   });
 });

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
@@ -32,6 +32,7 @@ import Button from '@/shared/components/ui/Button';
 import Badge, { type BadgeVariant } from '@/shared/components/ui/Badge';
 import Skeleton from '@/shared/components/ui/Skeleton';
 import { formatCurrency, getLocaleForCurrency } from '@/shared/lib/format/money';
+import { formatCurrencyBuckets } from '@/shared/lib/format/currency-buckets';
 
 const CIVIL_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const CIVIL_DATE_OR_TIMESTAMP_PATTERN = /^(\d{4}-\d{2}-\d{2})(?:T.*)?$/;
@@ -856,15 +857,15 @@ export const ResidentPaymentsPage = () => {
           chargeIds: charges.map((charge) => charge.id),
           charges,
           totalMinor,
-          currency: charges[0]?.currency ?? ledger?.totals?.currency ?? 'ARS',
+          currency: charges[0]!.currency,
         }),
         chargeIds: charges.map((charge) => charge.id),
         charges,
         totalMinor,
-        currency: charges[0]?.currency ?? ledger?.totals?.currency ?? 'ARS',
+        currency: charges[0]!.currency,
       };
     })
-  ), [ledger?.totals?.currency, selectableCharges]);
+  ), [ledger?.totals?.balanceByCurrency, selectableCharges]);
   const selectedPaymentOption = useMemo(
     () => paymentOptions.find((option) => option.selectionKey === formData.selectedSelectionKey) ?? null,
     [formData.selectedSelectionKey, paymentOptions],
@@ -895,8 +896,8 @@ export const ResidentPaymentsPage = () => {
     setSubmitError('La deuda cambió. Seleccioná nuevamente los períodos antes de continuar.');
   }, [clearProofSelection, formData.selectedSelectionKey, selectedPaymentOption]);
 
-  const balance = ledger?.totals?.balance ?? 0;
-  const currency = ledger?.totals?.currency ?? 'ARS';
+  const balanceByCurrency = ledger?.totals?.balanceByCurrency ?? [];
+  const hasBalance = balanceByCurrency.some((b) => b.amountMinor > 0);
   const sortedRecentPayments = useMemo(
     () => payments
       .slice()
@@ -1431,13 +1432,13 @@ export const ResidentPaymentsPage = () => {
                 <div className="min-w-0 space-y-1">
                   <p className="text-sm font-medium uppercase tracking-wide text-muted-foreground">Saldo pendiente</p>
                   <p className="text-[clamp(1.75rem,8vw,2rem)] font-bold leading-none tabular-nums text-foreground">
-                    {formatCurrency(balance, currency, getLocaleForCurrency(currency))}
+                    {formatCurrencyBuckets(balanceByCurrency)}
                   </p>
                   <p className="text-sm text-muted-foreground">
                   {selectableCharges.length} cargos elegibles
                   </p>
                 </div>
-                {balance > 0 ? (
+                {hasBalance ? (
                   <AlertCircle className="mt-1 text-orange-500" size={24} />
                 ) : (
                   <CheckCircle className="mt-1 text-green-500" size={24} />
@@ -1465,7 +1466,7 @@ export const ResidentPaymentsPage = () => {
                 </p>
                 {nextDueCharge ? (
                   <p className="text-sm text-muted-foreground">
-                    {formatCurrency(nextDueCharge.amount, currency, getLocaleForCurrency(currency))}
+                    {formatCurrency(nextDueCharge.amount, nextDueCharge.currency, getLocaleForCurrency(nextDueCharge.currency))}
                   </p>
                 ) : null}
               </Card>
@@ -1967,15 +1968,15 @@ export const ResidentPaymentsPage = () => {
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <Card className="p-4">
           <div className="flex items-start gap-3">
-            {balance > 0 ? (
+            {hasBalance ? (
               <AlertCircle className="text-orange-500 mt-0.5" size={22} />
             ) : (
               <CheckCircle className="text-green-500 mt-0.5" size={22} />
             )}
             <div>
               <p className="text-sm font-medium text-muted-foreground">Saldo pendiente</p>
-              <p className={`text-2xl font-bold ${balance > 0 ? 'text-orange-600' : 'text-green-600'}`}>
-                {formatCurrency(balance, currency, getLocaleForCurrency(currency))}
+              <p className={`text-2xl font-bold ${hasBalance ? 'text-orange-600' : 'text-green-600'}`}>
+                {formatCurrencyBuckets(balanceByCurrency)}
               </p>
             </div>
           </div>
@@ -1991,7 +1992,7 @@ export const ResidentPaymentsPage = () => {
               </p>
               {nextDueCharge && (
                 <p className="text-xs text-muted-foreground">
-                  {formatCurrency(nextDueCharge.amount, currency, getLocaleForCurrency(currency))}
+                  {formatCurrency(nextDueCharge.amount, nextDueCharge.currency, getLocaleForCurrency(nextDueCharge.currency))}
                 </p>
               )}
             </div>

--- a/apps/web/features/finance/components/UnitFinanceTab.tsx
+++ b/apps/web/features/finance/components/UnitFinanceTab.tsx
@@ -6,6 +6,7 @@ import { Skeleton, EmptyState } from '@/shared/components/ui';
 import Button from '@/shared/components/ui/Button';
 import { useUnitLedger } from '../hooks/useUnitLedger';
 import { formatCurrency } from '@/shared/lib/format/money';
+import { formatCurrencyBuckets } from '@/shared/lib/format/currency-buckets';
 import { DollarSign, TrendingUp, Calendar } from 'lucide-react';
 
 interface UnitFinanceTabProps {
@@ -92,7 +93,7 @@ export function UnitFinanceTab({ tenantId, unitId, buildingName, unitLabel }: Un
             <div>
               <p className="text-sm text-muted-foreground">Deuda Total</p>
               <p className="text-2xl font-bold text-orange-600">
-                {ledger.totals?.balance ? formatCurrency(ledger.totals.balance, ledger.totals.currency || 'USD') : '$0.00'}
+                {formatCurrencyBuckets(ledger.totals?.balanceByCurrency)}
               </p>
             </div>
             <DollarSign className="w-5 h-5 text-orange-600" />
@@ -104,10 +105,7 @@ export function UnitFinanceTab({ tenantId, unitId, buildingName, unitLabel }: Un
             <div>
               <p className="text-sm text-muted-foreground">Total Pagado</p>
               <p className="text-2xl font-bold text-green-600">
-                {(() => {
-                  const paid = ledger.totals?.totalPaid ?? ledger.totals?.totalAllocated;
-                  return paid ? formatCurrency(paid, ledger.totals?.currency || 'ARS') : '$0.00';
-                })()}
+                {formatCurrencyBuckets(ledger.totals?.totalPaidByCurrency)}
               </p>
             </div>
             <TrendingUp className="w-5 h-5 text-green-600" />

--- a/apps/web/features/finance/services/finance.api.ts
+++ b/apps/web/features/finance/services/finance.api.ts
@@ -202,11 +202,10 @@ export interface UnitLedger {
   charges: Charge[];
   payments: Payment[];
   totals: {
-    totalCharges: number;
-    totalAllocated?: number;
-    totalPaid?: number;
-    balance: number;
-    currency?: string;
+    totalChargesByCurrency: CurrencyAmountBucket[];
+    totalPaidByCurrency: CurrencyAmountBucket[];
+    totalAllocatedByCurrency: CurrencyAmountBucket[];
+    balanceByCurrency: CurrencyAmountBucket[];
   };
 }
 

--- a/apps/web/features/resident/hooks/useResidentLedger.test.tsx
+++ b/apps/web/features/resident/hooks/useResidentLedger.test.tsx
@@ -57,9 +57,10 @@ function ledger(balance: number): UnitLedger {
   return {
     unitId: 'unit-1',
     totals: {
-      totalCharges: balance,
-      balance,
-      currency: 'ARS',
+      totalChargesByCurrency: [{ currency: 'ARS', amountMinor: balance }],
+      totalPaidByCurrency: [],
+      totalAllocatedByCurrency: [],
+      balanceByCurrency: [{ currency: 'ARS', amountMinor: balance }],
     },
     charges: [],
     payments: [],
@@ -115,7 +116,7 @@ describe('useResidentLedger', () => {
     );
 
     await waitFor(() => {
-      expect(result.current.data?.totals.balance).toBe(1250);
+      expect(result.current.data?.totals.balanceByCurrency[0]?.amountMinor).toBe(1250);
     });
 
     expect(mockedGetResidentLedger).toHaveBeenCalledWith(
@@ -147,14 +148,14 @@ describe('useResidentLedger', () => {
     );
 
     await waitFor(() => {
-      expect(result.current.data?.totals.balance).toBe(100);
+      expect(result.current.data?.totals.balanceByCurrency[0]?.amountMinor).toBe(100);
     });
 
     mockedUseAuthSession.mockReturnValue(makeSession('user-2'));
     rerender();
 
     await waitFor(() => {
-      expect(result.current.data?.totals.balance).toBe(200);
+      expect(result.current.data?.totals.balanceByCurrency[0]?.amountMinor).toBe(200);
     });
 
     expect(mockedGetResidentLedger).toHaveBeenCalledTimes(2);
@@ -195,13 +196,13 @@ describe('useResidentLedger', () => {
     );
 
     await waitFor(() => {
-      expect(result.current.data?.totals.balance).toBe(300);
+      expect(result.current.data?.totals.balanceByCurrency[0]?.amountMinor).toBe(300);
     });
 
     rerender({ unitId: 'unit-2' });
 
     await waitFor(() => {
-      expect(result.current.data?.totals.balance).toBe(450);
+      expect(result.current.data?.totals.balanceByCurrency[0]?.amountMinor).toBe(450);
     });
 
     expect(mockedGetResidentLedger).toHaveBeenNthCalledWith(

--- a/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
@@ -39,11 +39,10 @@ interface CreatedChargeResponse {
 
 interface UnitLedgerResponse {
   totals: {
-    totalCharges: number;
-    totalPaid: number;
-    totalAllocated: number;
-    balance: number;
-    currency: string;
+    totalChargesByCurrency: Array<{ currency: string; amountMinor: number }>;
+    totalPaidByCurrency: Array<{ currency: string; amountMinor: number }>;
+    totalAllocatedByCurrency: Array<{ currency: string; amountMinor: number }>;
+    balanceByCurrency: Array<{ currency: string; amountMinor: number }>;
   };
 }
 
@@ -450,7 +449,7 @@ test.describe('Resident finance oldest-first flow', () => {
     await expect(page.getByText('Cargos próximos')).toBeVisible();
 
     const residentLedgerBefore = await getUnitLedger(page, residentTenantId, unitId);
-    expect(residentLedgerBefore.totals.balance).toBe(30000);
+    expect(arsAmount(residentLedgerBefore.totals.balanceByCurrency)).toBe(30000);
     const summaryBefore = await getBuildingSummary(adminPage, residentTenantId, buildingId);
     expect(arsAmount(summaryBefore.totalOutstandingByCurrency)).toBe(10000);
     expect(arsAmount(summaryBefore.totalPaidByCurrency)).toBe(0);
@@ -487,9 +486,9 @@ test.describe('Resident finance oldest-first flow', () => {
     expect(submittedPayment.paymentAllocations.map((allocation) => allocation.amount)).toEqual([10000, 10000]);
 
     const residentLedgerSubmitted = await getUnitLedger(page, residentTenantId, unitId);
-    expect(residentLedgerSubmitted.totals.balance).toBe(30000);
-    expect(residentLedgerSubmitted.totals.totalPaid).toBe(0);
-    expect(residentLedgerSubmitted.totals.totalAllocated).toBe(0);
+    expect(arsAmount(residentLedgerSubmitted.totals.balanceByCurrency)).toBe(30000);
+    expect(arsAmount(residentLedgerSubmitted.totals.totalPaidByCurrency)).toBe(0);
+    expect(arsAmount(residentLedgerSubmitted.totals.totalAllocatedByCurrency)).toBe(0);
 
     const summarySubmitted = await getBuildingSummary(adminPage, residentTenantId, buildingId);
     expect(arsAmount(summarySubmitted.totalOutstandingByCurrency)).toBe(10000);
@@ -510,9 +509,9 @@ test.describe('Resident finance oldest-first flow', () => {
     ]);
 
     const residentLedgerApproved = await getUnitLedger(page, residentTenantId, unitId);
-    expect(residentLedgerApproved.totals.balance).toBe(10000);
-    expect(residentLedgerApproved.totals.totalPaid).toBe(20000);
-    expect(residentLedgerApproved.totals.totalAllocated).toBe(20000);
+    expect(arsAmount(residentLedgerApproved.totals.balanceByCurrency)).toBe(10000);
+    expect(arsAmount(residentLedgerApproved.totals.totalPaidByCurrency)).toBe(20000);
+    expect(arsAmount(residentLedgerApproved.totals.totalAllocatedByCurrency)).toBe(20000);
 
     const summaryApproved = await getBuildingSummary(adminPage, residentTenantId, buildingId);
     expect(arsAmount(summaryApproved.totalOutstandingByCurrency)).toBe(10000);
@@ -552,9 +551,9 @@ test.describe('Resident finance oldest-first flow', () => {
     expect(rejectedAugustPayment.paymentAllocations).toHaveLength(0);
 
     const residentLedgerRejected = await getUnitLedger(page, residentTenantId, unitId);
-    expect(residentLedgerRejected.totals.balance).toBe(10000);
-    expect(residentLedgerRejected.totals.totalPaid).toBe(20000);
-    expect(residentLedgerRejected.totals.totalAllocated).toBe(20000);
+    expect(arsAmount(residentLedgerRejected.totals.balanceByCurrency)).toBe(10000);
+    expect(arsAmount(residentLedgerRejected.totals.totalPaidByCurrency)).toBe(20000);
+    expect(arsAmount(residentLedgerRejected.totals.totalAllocatedByCurrency)).toBe(20000);
 
     const summaryRejected = await getBuildingSummary(adminPage, residentTenantId, buildingId);
     expect(arsAmount(summaryRejected.totalOutstandingByCurrency)).toBe(10000);


### PR DESCRIPTION
## Summary

Closes #165

Phase 3F7 makes unit ledger balances currency-safe.

## Fix

- UnitLedgerDto.totals becomes per-currency buckets: totalChargesByCurrency, totalPaidByCurrency, totalAllocatedByCurrency, balanceByCurrency (old scalar totals and tenant.currency removed)
- balanceByCurrency is OUTSTANDING_DEBT: sum of calculateChargeOutstandingMinor per Charge, grouped by Charge.currency — never negative (over-allocation clamps debt at 0; totalAllocatedByCurrency keeps effective allocations)
- Charge.currency is the debt authority; CROSS allocations remain charge-side
- APPROVED/RECONCILED effective; SUBMITTED does not reduce outstanding
- Payment.currency is the payment history authority; payments[].allocated is number when reconstructable, null when legacy payment-side value is UNKNOWN (never fabricated 0)
- resident payment currency fallbacks removed (no tenant.currency / first-bucket / 'ARS'); payment options born from real charges; no charges -> no submit
- building/tenant balance surfaces untouched (3F2 and 3F5 already have currency-safe bucket contracts)

## Validation

- no live FX, no read-time conversion
- no schema/migrations
- API ledger tests 133/133 PASS
- API full 2562 PASS / 0 failed
- WEB consumer tests PASS
- API/WEB typecheck, lint, build PASS
- real DB read-only acceptance PASS
- git diff --check PASS
