### PR TITLE
fix(finance): group delinquency totals per currency

### DIFF
--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -2015,7 +2015,14 @@ export class FinanzasService {
               'amountMinor', "accumulatedDebt"
             ) ORDER BY currency
           ) AS "accumulatedDebtByCurrency"
-        FROM unit_rows
+        FROM (
+          SELECT
+            currency,
+            SUM("periodDebt") AS "periodDebt",
+            SUM("accumulatedDebt") AS "accumulatedDebt"
+          FROM unit_rows
+          GROUP BY currency
+        ) AS totals_by_currency
       `),
     ]);
 


### PR DESCRIPTION
Fix post-merge discovered during staging acceptance: totals de getBuildingDelinquency agregaban filas sin agrupar por currency (json_agg sobre unit_rows completo). Ahora agrupa por currency y suma. Cubierto por finanzas.service.spec (133/133) y verificado local contra DB real.