### PR TITLE
feat(finance): add auditable funds ledger

### DIFF
--- a/apps/api/prisma/migrations/20260814000000_add_funds_ledger/migration.sql
+++ b/apps/api/prisma/migrations/20260814000000_add_funds_ledger/migration.sql
@@ -1,0 +1,98 @@
+-- FIN-02: Funds + FundTransactions (ledger auditable por moneda)
+-- ADITIVA: no altera datos financieros existentes.
+
+-- CreateEnum
+CREATE TYPE "FundScopeType" AS ENUM ('TENANT', 'BUILDING');
+
+-- CreateEnum
+CREATE TYPE "FundType" AS ENUM ('RESERVE', 'SPECIAL', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "FundStatus" AS ENUM ('ACTIVE', 'ARCHIVED');
+
+-- CreateEnum
+CREATE TYPE "FundTransactionDirection" AS ENUM ('CREDIT', 'DEBIT');
+
+-- AlterEnum AuditAction (valores FUND_*)
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'FUND_CREATE';
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'FUND_UPDATE';
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'FUND_ARCHIVE';
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'FUND_TRANSACTION_CREATE';
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'FUND_TRANSACTION_REVERSE';
+
+-- CreateTable Fund
+CREATE TABLE "Fund" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "buildingId" TEXT,
+    "scopeType" "FundScopeType" NOT NULL,
+    "type" "FundType" NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "status" "FundStatus" NOT NULL DEFAULT 'ACTIVE',
+    "createdByMembershipId" TEXT NOT NULL,
+    "archivedByMembershipId" TEXT,
+    "archivedAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Fund_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable FundTransaction
+CREATE TABLE "FundTransaction" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "fundId" TEXT NOT NULL,
+    "direction" "FundTransactionDirection" NOT NULL,
+    "amountMinor" INTEGER NOT NULL,
+    "currencyCode" TEXT NOT NULL,
+    "occurredAt" TIMESTAMP(3) NOT NULL,
+    "description" TEXT,
+    "createdByMembershipId" TEXT NOT NULL,
+    "idempotencyKey" TEXT,
+    "reversalOfTransactionId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FundTransaction_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey Fund
+ALTER TABLE "Fund" ADD CONSTRAINT "Fund_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "Fund" ADD CONSTRAINT "Fund_buildingId_fkey" FOREIGN KEY ("buildingId") REFERENCES "Building"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Fund" ADD CONSTRAINT "Fund_createdByMembershipId_fkey" FOREIGN KEY ("createdByMembershipId") REFERENCES "Membership"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "Fund" ADD CONSTRAINT "Fund_archivedByMembershipId_fkey" FOREIGN KEY ("archivedByMembershipId") REFERENCES "Membership"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey FundTransaction
+ALTER TABLE "FundTransaction" ADD CONSTRAINT "FundTransaction_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "FundTransaction" ADD CONSTRAINT "FundTransaction_fundId_fkey" FOREIGN KEY ("fundId") REFERENCES "Fund"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "FundTransaction" ADD CONSTRAINT "FundTransaction_createdByMembershipId_fkey" FOREIGN KEY ("createdByMembershipId") REFERENCES "Membership"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "FundTransaction" ADD CONSTRAINT "FundTransaction_reversalOfTransactionId_fkey" FOREIGN KEY ("reversalOfTransactionId") REFERENCES "FundTransaction"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- CreateIndex Fund
+CREATE INDEX "Fund_tenantId_idx" ON "Fund"("tenantId");
+CREATE INDEX "Fund_tenantId_buildingId_idx" ON "Fund"("tenantId", "buildingId");
+CREATE INDEX "Fund_tenantId_status_idx" ON "Fund"("tenantId", "status");
+CREATE INDEX "Fund_tenantId_scopeType_idx" ON "Fund"("tenantId", "scopeType");
+
+-- Unique activo por nombre normalizado (FIN-02R)
+-- Protección DB contra duplicados concurrentes del MISMO nombre activo en el
+-- mismo scope. Normalización: trim + lower + colapso de espacios internos
+-- (misma semántica que el service assertNoActiveDuplicateName). Se permiten:
+-- mismo nombre en edificios distintos, y reutilizar un nombre cuyo fondo
+-- anterior esté ARCHIVED.
+CREATE UNIQUE INDEX "Fund_active_name_tenant_key"
+ON "Fund" ("tenantId", lower(regexp_replace(trim("name"), '\s+', ' ', 'g')))
+WHERE "scopeType" = 'TENANT' AND "status" = 'ACTIVE';
+
+CREATE UNIQUE INDEX "Fund_active_name_building_key"
+ON "Fund" ("tenantId", "buildingId", lower(regexp_replace(trim("name"), '\s+', ' ', 'g')))
+WHERE "scopeType" = 'BUILDING' AND "status" = 'ACTIVE';
+
+-- CreateIndex FundTransaction
+CREATE UNIQUE INDEX "FundTransaction_tenantId_idempotencyKey_key" ON "FundTransaction"("tenantId", "idempotencyKey");
+CREATE UNIQUE INDEX "FundTransaction_reversalOfTransactionId_key" ON "FundTransaction"("reversalOfTransactionId");
+CREATE INDEX "FundTransaction_tenantId_fundId_idx" ON "FundTransaction"("tenantId", "fundId");
+CREATE INDEX "FundTransaction_tenantId_fundId_createdAt_idx" ON "FundTransaction"("tenantId", "fundId", "createdAt");
+CREATE INDEX "FundTransaction_tenantId_fundId_currencyCode_idx" ON "FundTransaction"("tenantId", "fundId", "currencyCode");
+CREATE INDEX "FundTransaction_tenantId_currencyCode_idx" ON "FundTransaction"("tenantId", "currencyCode");

--- a/apps/api/prisma/migrations/20260814000000_add_funds_ledger/migration.sql
+++ b/apps/api/prisma/migrations/20260814000000_add_funds_ledger/migration.sql
@@ -54,7 +54,16 @@ CREATE TABLE "FundTransaction" (
     "reversalOfTransactionId" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
 
-    CONSTRAINT "FundTransaction_pkey" PRIMARY KEY ("id")
+    CONSTRAINT "FundTransaction_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "FundTransaction_amountMinor_positive" CHECK ("amountMinor" > 0)
+);
+
+-- CheckConstraint Fund scope invariant (FIN-02Q)
+-- scopeType TENANT => buildingId NULL; scopeType BUILDING => buildingId NOT NULL
+ALTER TABLE "Fund" ADD CONSTRAINT "Fund_scope_building_invariant" CHECK (
+  ("scopeType" = 'TENANT' AND "buildingId" IS NULL)
+  OR
+  ("scopeType" = 'BUILDING' AND "buildingId" IS NOT NULL)
 );
 
 -- AddForeignKey Fund

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -147,6 +147,31 @@ enum LiquidationValuationMode {
   LEGACY_NOMINAL
 }
 
+// ============================================================================
+// FINANZAS: Funds (Fondos financieros del condominio — FIN-02)
+// ============================================================================
+
+enum FundScopeType {
+  TENANT    // Fondo a nivel tenant (compartido entre edificios)
+  BUILDING  // Fondo específico de un edificio
+}
+
+enum FundType {
+  RESERVE   // Fondo de reserva
+  SPECIAL   // Fondo específico (ascensores, emergencias, fachada, etc.)
+  OTHER     // Otros fondos personalizados
+}
+
+enum FundStatus {
+  ACTIVE
+  ARCHIVED
+}
+
+enum FundTransactionDirection {
+  CREDIT    // Aumenta el saldo del fondo
+  DEBIT     // Disminuye el saldo del fondo
+}
+
 enum LeadStatus {
   NEW
   CONTACTED
@@ -267,6 +292,8 @@ model Tenant {
   unitBalanceSnapshots  UnitBalanceMonthlySnapshot[]
   buildingBalanceSnapshots BuildingBalanceMonthlySnapshot[]
   exchangeRates         ExchangeRate[]
+  funds                 Fund[]
+  fundTransactions      FundTransaction[]
 }
 
 model User {
@@ -338,6 +365,9 @@ model Membership {
   aiActionEvents        AiActionEvent[]
   planChangeRequests    PlanChangeRequest[]   @relation("PlanRequestRequestedBy")
   exchangeRatesCreated  ExchangeRate[]        @relation("ExchangeRateCreatedBy")
+  fundsCreated          Fund[]                @relation("FundCreatedBy")
+  fundsArchived         Fund[]                @relation("FundArchivedBy")
+  fundTransactionsCreated FundTransaction[]   @relation("FundTransactionCreatedBy")
 
   @@unique([userId, tenantId])
   @@index([tenantId])
@@ -474,6 +504,7 @@ model Building {
   unitGroupMembers    UnitGroupMember[]
   liquidations         Liquidation[]
   adjustments          Adjustment[]
+  funds                Fund[]
   unitAssociations     UnitAssociation[]
   balanceSnapshots     BuildingBalanceMonthlySnapshot[]
   unitBalanceSnapshots UnitBalanceMonthlySnapshot[]
@@ -772,6 +803,12 @@ enum AuditAction {
   INCOME_RECORD
   INCOME_VOID
   INCOME_ALLOCATION_CREATE
+  // FUNDS (FIN-02)
+  FUND_CREATE
+  FUND_UPDATE
+  FUND_ARCHIVE
+  FUND_TRANSACTION_CREATE
+  FUND_TRANSACTION_REVERSE
   // UNIT GROUPS & ALLOCATIONS
   UNIT_GROUP_CREATE
   UNIT_GROUP_DELETE
@@ -2041,6 +2078,67 @@ model UnitGroupMember {
   @@index([tenantId, buildingId])
   @@index([unitGroupId])
   @@index([unitId])
+}
+
+// ============================================================================
+// FINANZAS: Fund + FundTransaction (Ledger auditable por moneda — FIN-02)
+// ============================================================================
+// El saldo de un fondo NO se persiste como cifra mutable: se deriva siempre
+// de la suma del ledger (CREDIT suma, DEBIT resta) por moneda.
+// ============================================================================
+model Fund {
+  id                       String       @id @default(cuid())
+  tenantId                 String
+  buildingId               String?      // REQUIRED si scopeType=BUILDING; null si TENANT
+  scopeType                FundScopeType
+  type                     FundType
+  name                     String
+  description              String?
+  status                   FundStatus   @default(ACTIVE)
+  createdByMembershipId    String
+  archivedByMembershipId   String?
+  archivedAt               DateTime?
+  createdAt                DateTime     @default(now())
+  updatedAt                DateTime     @updatedAt
+
+  tenant     Tenant             @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  building   Building?          @relation(fields: [buildingId], references: [id], onDelete: Restrict)
+  createdBy  Membership         @relation("FundCreatedBy", fields: [createdByMembershipId], references: [id], onDelete: Restrict)
+  archivedBy Membership?        @relation("FundArchivedBy", fields: [archivedByMembershipId], references: [id], onDelete: SetNull)
+  transactions FundTransaction[]
+
+  @@index([tenantId])
+  @@index([tenantId, buildingId])
+  @@index([tenantId, status])
+  @@index([tenantId, scopeType])
+}
+
+model FundTransaction {
+  id                       String                    @id @default(cuid())
+  tenantId                 String
+  fundId                   String
+  direction                FundTransactionDirection
+  amountMinor              Int                       // Siempre > 0 (el signo lo da direction)
+  currencyCode             String                    // ISO: USD, VES, ARS, COP (contrato CANONICAL_CURRENCIES)
+  occurredAt               DateTime                  // Fecha económica del movimiento
+  description              String?
+  createdByMembershipId    String
+  idempotencyKey           String?                   // Retry-safe: (tenantId, idempotencyKey) único
+  reversalOfTransactionId  String?                   // Si es un reversal, referencia al movimiento original
+  createdAt                DateTime                  @default(now())
+
+  fund      Fund             @relation(fields: [fundId], references: [id], onDelete: Restrict)
+  tenant    Tenant           @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  createdBy Membership       @relation("FundTransactionCreatedBy", fields: [createdByMembershipId], references: [id], onDelete: Restrict)
+  reversalOf FundTransaction? @relation("FundTransactionReversal", fields: [reversalOfTransactionId], references: [id], onDelete: Restrict)
+  reversals  FundTransaction[] @relation("FundTransactionReversal")
+
+  @@unique([tenantId, idempotencyKey])
+  @@unique([reversalOfTransactionId])
+  @@index([tenantId, fundId])
+  @@index([tenantId, fundId, createdAt])
+  @@index([tenantId, fundId, currencyCode])
+  @@index([tenantId, currencyCode])
 }
 
 // ============================================================================

--- a/apps/api/src/finanzas/finanzas.module.ts
+++ b/apps/api/src/finanzas/finanzas.module.ts
@@ -42,6 +42,8 @@ import { MulticurrencyController } from './multicurrency.controller';
 import { MulticurrencyService } from './multicurrency.service';
 import { CurrencyConversionService } from './currency-conversion.service';
 import { AppConfigModule } from '../config/config.module';
+import { FundsController } from './funds.controller';
+import { FundsService } from './funds.service';
 
 import { VendorPreferenceController } from './vendor-preference.controller';
 import { VendorPreferenceService } from './vendor-preference.service';
@@ -88,6 +90,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     TenantRecurringExpenseController,
     PaymentWebhookController,
     MulticurrencyController,
+    FundsController,
   ],
   providers: [
     FinanzasService,
@@ -129,6 +132,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     SignatureGuard,
     MulticurrencyService,
     CurrencyConversionService,
+    FundsService,
   ],
   exports: [
     FinanzasService,
@@ -147,6 +151,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     FinanceSummaryService,
     PaymentReceiptService,
     CurrencyConversionService,
+    FundsService,
   ],
 })
 export class FinanzasModule {}

--- a/apps/api/src/finanzas/funds-concurrency.postgres.spec.ts
+++ b/apps/api/src/finanzas/funds-concurrency.postgres.spec.ts
@@ -33,6 +33,21 @@ describePostgres('Funds ledger PostgreSQL concurrency', () => {
     return new FundsService(prisma, audit, validators);
   }
 
+  /**
+   * Igual que buildService pero con un AuditService cuyo createLogRequired
+   * lanza un error controlado (para probar rollback real de la transacción).
+   */
+  function buildServiceWithFailingAudit(client: PrismaClient): FundsService {
+    const prisma = client as unknown as PrismaService;
+    const audit = {
+      createLogRequired: async () => {
+        throw new Error('FORCED_AUDIT_FAILURE');
+      },
+    } as unknown as AuditService;
+    const validators = new FinanzasValidators(prisma);
+    return new FundsService(prisma, audit, validators);
+  }
+
   beforeAll(async () => {
     if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required');
     observer = new PrismaClient();
@@ -386,23 +401,33 @@ describePostgres('Funds ledger PostgreSQL concurrency', () => {
     const firstService = buildService(firstClient);
     const secondService = buildService(secondClient);
     const key = `idem-diff-${Date.now()}`;
+    const firstAmount = 50000;
+    const secondAmount = 99999; // operación materialmente diferente
 
+    // La carrera es indeterminada: exactamente UNO persiste y el otro recibe
+    // ConflictException (sin importar quién gane).
     const [a, b] = await Promise.all([
       firstService.createTransaction(ctx.tenant.id, ctx.fund.id, ctx.membership.id, ['TENANT_ADMIN'], {
         direction: FundTransactionDirection.CREDIT,
-        amountMinor: 50000,
-        currencyCode: 'USD',
-        occurredAt: new Date().toISOString(),
-        idempotencyKey: key,
-      }).then((r) => ({ ok: true as const, id: r.id })),
-      secondService.createTransaction(ctx.tenant.id, ctx.fund.id, ctx.membership.id, ['TENANT_ADMIN'], {
-        direction: FundTransactionDirection.CREDIT,
-        amountMinor: 99999, // operación materialmente diferente
+        amountMinor: firstAmount,
         currencyCode: 'USD',
         occurredAt: new Date().toISOString(),
         idempotencyKey: key,
       }).then(
-        () => ({ ok: true as const }),
+        (r) => ({ ok: true as const, id: r.id, amount: firstAmount }),
+        (error: unknown) => ({
+          ok: false as const,
+          conflict: error instanceof Error && error.message.includes('idempotencyKey'),
+        }),
+      ),
+      secondService.createTransaction(ctx.tenant.id, ctx.fund.id, ctx.membership.id, ['TENANT_ADMIN'], {
+        direction: FundTransactionDirection.CREDIT,
+        amountMinor: secondAmount,
+        currencyCode: 'USD',
+        occurredAt: new Date().toISOString(),
+        idempotencyKey: key,
+      }).then(
+        (r) => ({ ok: true as const, id: r.id, amount: secondAmount }),
         (error: unknown) => ({
           ok: false as const,
           conflict: error instanceof Error && error.message.includes('idempotencyKey'),
@@ -410,20 +435,24 @@ describePostgres('Funds ledger PostgreSQL concurrency', () => {
       ),
     ]);
 
-    expect(a.ok).toBe(true);
-    expect(b.ok).toBe(false);
-    expect(b.conflict).toBe(true);
+    const winners = [a, b].filter((r) => r.ok);
+    const losers = [a, b].filter((r) => !r.ok);
+    expect(winners).toHaveLength(1);
+    expect(losers).toHaveLength(1);
+    expect(losers[0]!.conflict).toBe(true);
 
     const rowCount = await observer.fundTransaction.count({
       where: { tenantId: ctx.tenant.id, fundId: ctx.fund.id, idempotencyKey: key },
     });
     expect(rowCount).toBe(1);
 
+    // El balance refleja exactamente el monto de la operación ganadora.
     const balanceRows = await observer.$queryRaw<Array<{ total: bigint | null }>>`
       SELECT COALESCE(SUM(CASE WHEN direction = 'CREDIT' THEN "amountMinor" ELSE -"amountMinor" END), 0) AS total
       FROM "FundTransaction" WHERE "fundId" = ${ctx.fund.id} AND "tenantId" = ${ctx.tenant.id}
     `;
-    expect(Number(balanceRows[0]?.total ?? 0)).toBe(50000);
+    const balance = Number(balanceRows[0]?.total ?? 0);
+    expect([firstAmount, secondAmount]).toContain(balance);
   }, 20000);
 
   it('enforces amountMinor > 0 at the database level', async () => {
@@ -496,5 +525,51 @@ describePostgres('Funds ledger PostgreSQL concurrency', () => {
     expect(
       await observer.fund.count({ where: { tenantId: ctx.tenant.id } }),
     ).toBe(2); // 1 fixture TENANT + 1 BUILDING válido
+  }, 20000);
+
+  it('rolls back Fund creation when the required FUND_CREATE audit fails', async () => {
+    const ctx = await fixture('audit-create-rollback');
+    const failingService = buildServiceWithFailingAudit(firstClient);
+    const name = `Audit Rollback ${Date.now()}`;
+
+    await expect(
+      failingService.createFund(ctx.tenant.id, ctx.membership.id, ['TENANT_ADMIN'], {
+        scopeType: 'TENANT',
+        type: 'RESERVE',
+        name,
+      }),
+    ).rejects.toThrow('FORCED_AUDIT_FAILURE');
+
+    // El Fund NO debe persistir: rollback real del create dentro del tx.
+    const count = await observer.fund.count({
+      where: { tenantId: ctx.tenant.id, name },
+    });
+    expect(count).toBe(0);
+  }, 20000);
+
+  it('rolls back Fund metadata changes when the required FUND_UPDATE audit fails', async () => {
+    const ctx = await fixture('audit-update-rollback');
+    const originalName = `Reserva original ${Date.now()}`;
+    const fund = await observer.fund.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        scopeType: 'TENANT',
+        type: 'RESERVE',
+        name: originalName,
+        createdByMembershipId: ctx.membership.id,
+      },
+    });
+
+    const failingService = buildServiceWithFailingAudit(firstClient);
+    await expect(
+      failingService.updateFund(ctx.tenant.id, fund.id, ctx.membership.id, ['TENANT_ADMIN'], {
+        name: 'Reserva modificada',
+      }),
+    ).rejects.toThrow('FORCED_AUDIT_FAILURE');
+
+    // El name original debe persistir: rollback real del update dentro del tx.
+    const after = await observer.fund.findUniqueOrThrow({ where: { id: fund.id } });
+    expect(after.name).toBe(originalName);
+    expect(after.name).not.toBe('Reserva modificada');
   }, 20000);
 });

--- a/apps/api/src/finanzas/funds-concurrency.postgres.spec.ts
+++ b/apps/api/src/finanzas/funds-concurrency.postgres.spec.ts
@@ -1,4 +1,8 @@
 import { FundTransactionDirection, PrismaClient, TenantType } from '@prisma/client';
+import { FundsService } from './funds.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { PrismaService } from '../prisma/prisma.service';
 
 const ACCEPTANCE_DATABASES = new Set(['buildingos_fin02_acceptance']);
 const expectedDatabaseName = process.env.POSTGRES_TEST_DB_NAME;
@@ -13,9 +17,21 @@ describePostgres('Funds ledger PostgreSQL concurrency', () => {
   let observer: PrismaClient;
   let firstClient: PrismaClient;
   let secondClient: PrismaClient;
+  let service: FundsService;
   const tenantIds: string[] = [];
   const userIds: string[] = [];
   const membershipIds: string[] = [];
+
+  /**
+   * Instancia FundsService real sobre un PrismaClient real de la DB de
+   * aceptación (gated). El auditoría es real: escribe AuditLog en el tenant.
+   */
+  function buildService(client: PrismaClient): FundsService {
+    const prisma = client as unknown as PrismaService;
+    const audit = new AuditService(prisma);
+    const validators = new FinanzasValidators(prisma);
+    return new FundsService(prisma, audit, validators);
+  }
 
   beforeAll(async () => {
     if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required');
@@ -27,6 +43,7 @@ describePostgres('Funds ledger PostgreSQL concurrency', () => {
     if (database?.name !== expectedDatabaseName || !ACCEPTANCE_DATABASES.has(database.name)) {
       throw new Error(`Refusing destructive test database ${database?.name ?? 'unknown'}`);
     }
+    service = buildService(firstClient);
   });
 
   afterEach(async () => {
@@ -77,17 +94,6 @@ describePostgres('Funds ledger PostgreSQL concurrency', () => {
       },
     });
     return { tenant, membership, fund };
-  }
-
-  async function waitUntilBlocked(pid: number): Promise<void> {
-    for (let attempt = 0; attempt < 100; attempt += 1) {
-      const [activity] = await observer.$queryRaw<Array<{ wait_event_type: string | null }>>`
-        SELECT wait_event_type FROM pg_stat_activity WHERE pid = ${pid}
-      `;
-      if (activity?.wait_event_type === 'Lock') return;
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-    throw new Error(`Backend ${pid} did not reach a database lock wait`);
   }
 
   async function waitUntilBlocked(pid: number): Promise<void> {
@@ -276,5 +282,219 @@ describePostgres('Funds ledger PostgreSQL concurrency', () => {
       observer.building.delete({ where: { id: building.id } }),
     ).rejects.toThrow(/foreign key|Foreign key|constraint/);
     expect(await observer.fund.count({ where: { buildingId: building.id } })).toBe(1);
+  }, 20000);
+
+  it('serializes archiveFund against a concurrent CREDIT (never ARCHIVED with non-zero balance)', async () => {
+    const ctx = await fixture('archive-race');
+
+    // 5 iteraciones: el resultado permitido es serializable (archive gana → credit
+    // falla y balance 0; o credit gana → archive falla y balance 100). Prohibido:
+    // fund ARCHIVED con balance != 0.
+    for (let iteration = 0; iteration < 5; iteration += 1) {
+      const raceService = buildService(firstClient);
+      const creditService = buildService(secondClient);
+
+      const [archiveResult, creditResult] = await Promise.all([
+        raceService.archiveFund(ctx.tenant.id, ctx.fund.id, ctx.membership.id, ['TENANT_ADMIN']).then(
+          () => ({ ok: true as const }),
+          (error: unknown) => ({ ok: false as const, message: error instanceof Error ? error.message : String(error) }),
+        ),
+        creditService.createTransaction(ctx.tenant.id, ctx.fund.id, ctx.membership.id, ['TENANT_ADMIN'], {
+          direction: FundTransactionDirection.CREDIT,
+          amountMinor: 100,
+          currencyCode: 'USD',
+          occurredAt: new Date().toISOString(),
+        }).then(
+          () => ({ ok: true as const }),
+          (error: unknown) => ({ ok: false as const, message: error instanceof Error ? error.message : String(error) }),
+        ),
+      ]);
+
+      const fund = await observer.fund.findUniqueOrThrow({ where: { id: ctx.fund.id } });
+      const balanceRows = await observer.$queryRaw<Array<{ total: bigint | null }>>`
+        SELECT COALESCE(SUM(CASE WHEN direction = 'CREDIT' THEN "amountMinor" ELSE -"amountMinor" END), 0) AS total
+        FROM "FundTransaction" WHERE "fundId" = ${ctx.fund.id} AND "tenantId" = ${ctx.tenant.id}
+      `;
+      const balance = Number(balanceRows[0]?.total ?? 0);
+
+      const archiveWon = archiveResult.ok;
+      const creditWon = creditResult.ok;
+      if (archiveWon) {
+        // archive gana → credit debe fallar y balance 0
+        expect(fund.status).toBe('ARCHIVED');
+        expect(creditWon).toBe(false);
+        expect(balance).toBe(0);
+      } else {
+        // credit gana → archive falla (saldo != 0) y fund ACTIVE con balance 100
+        expect(fund.status).toBe('ACTIVE');
+        expect(creditWon).toBe(true);
+        expect(balance).toBe(100);
+      }
+      expect(archiveWon || creditWon).toBe(true);
+
+      // Reset para la siguiente iteración: restaurar fund ACTIVE con balance 0
+      // (el escenario original) borrando el ledger y el estado archivado.
+      await observer.fundTransaction.deleteMany({ where: { fundId: ctx.fund.id } });
+      await observer.fund.update({
+        where: { id: ctx.fund.id },
+        data: { status: 'ACTIVE', archivedAt: null, archivedByMembershipId: null },
+      });
+    }
+  }, 30000);
+
+  it('dedupes concurrent same-operation idempotencyKey (one persisted row, balance applied once)', async () => {
+    const ctx = await fixture('idem-same');
+    const firstService = buildService(firstClient);
+    const secondService = buildService(secondClient);
+    const key = `idem-same-${Date.now()}`;
+
+    const [a, b] = await Promise.all([
+      firstService.createTransaction(ctx.tenant.id, ctx.fund.id, ctx.membership.id, ['TENANT_ADMIN'], {
+        direction: FundTransactionDirection.CREDIT,
+        amountMinor: 50000,
+        currencyCode: 'USD',
+        occurredAt: new Date().toISOString(),
+        idempotencyKey: key,
+      }).then((r) => ({ ok: true as const, id: r.id })),
+      secondService.createTransaction(ctx.tenant.id, ctx.fund.id, ctx.membership.id, ['TENANT_ADMIN'], {
+        direction: FundTransactionDirection.CREDIT,
+        amountMinor: 50000,
+        currencyCode: 'USD',
+        occurredAt: new Date().toISOString(),
+        idempotencyKey: key,
+      }).then((r) => ({ ok: true as const, id: r.id })),
+    ]);
+
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(true);
+    expect(a.id).toBe(b.id);
+
+    const rowCount = await observer.fundTransaction.count({
+      where: { tenantId: ctx.tenant.id, fundId: ctx.fund.id, idempotencyKey: key },
+    });
+    expect(rowCount).toBe(1);
+
+    const balanceRows = await observer.$queryRaw<Array<{ total: bigint | null }>>`
+      SELECT COALESCE(SUM(CASE WHEN direction = 'CREDIT' THEN "amountMinor" ELSE -"amountMinor" END), 0) AS total
+      FROM "FundTransaction" WHERE "fundId" = ${ctx.fund.id} AND "tenantId" = ${ctx.tenant.id}
+    `;
+    expect(Number(balanceRows[0]?.total ?? 0)).toBe(50000);
+  }, 20000);
+
+  it('rejects concurrent different-operation on the same idempotencyKey (ConflictException)', async () => {
+    const ctx = await fixture('idem-diff');
+    const firstService = buildService(firstClient);
+    const secondService = buildService(secondClient);
+    const key = `idem-diff-${Date.now()}`;
+
+    const [a, b] = await Promise.all([
+      firstService.createTransaction(ctx.tenant.id, ctx.fund.id, ctx.membership.id, ['TENANT_ADMIN'], {
+        direction: FundTransactionDirection.CREDIT,
+        amountMinor: 50000,
+        currencyCode: 'USD',
+        occurredAt: new Date().toISOString(),
+        idempotencyKey: key,
+      }).then((r) => ({ ok: true as const, id: r.id })),
+      secondService.createTransaction(ctx.tenant.id, ctx.fund.id, ctx.membership.id, ['TENANT_ADMIN'], {
+        direction: FundTransactionDirection.CREDIT,
+        amountMinor: 99999, // operación materialmente diferente
+        currencyCode: 'USD',
+        occurredAt: new Date().toISOString(),
+        idempotencyKey: key,
+      }).then(
+        () => ({ ok: true as const }),
+        (error: unknown) => ({
+          ok: false as const,
+          conflict: error instanceof Error && error.message.includes('idempotencyKey'),
+        }),
+      ),
+    ]);
+
+    expect(a.ok).toBe(true);
+    expect(b.ok).toBe(false);
+    expect(b.conflict).toBe(true);
+
+    const rowCount = await observer.fundTransaction.count({
+      where: { tenantId: ctx.tenant.id, fundId: ctx.fund.id, idempotencyKey: key },
+    });
+    expect(rowCount).toBe(1);
+
+    const balanceRows = await observer.$queryRaw<Array<{ total: bigint | null }>>`
+      SELECT COALESCE(SUM(CASE WHEN direction = 'CREDIT' THEN "amountMinor" ELSE -"amountMinor" END), 0) AS total
+      FROM "FundTransaction" WHERE "fundId" = ${ctx.fund.id} AND "tenantId" = ${ctx.tenant.id}
+    `;
+    expect(Number(balanceRows[0]?.total ?? 0)).toBe(50000);
+  }, 20000);
+
+  it('enforces amountMinor > 0 at the database level', async () => {
+    const ctx = await fixture('amount-minor');
+    const base = {
+      tenantId: ctx.tenant.id,
+      fundId: ctx.fund.id,
+      direction: FundTransactionDirection.CREDIT,
+      currencyCode: 'USD',
+      occurredAt: new Date(),
+      createdByMembershipId: ctx.membership.id,
+    } as const;
+
+    await expect(
+      observer.fundTransaction.create({ data: { ...base, amountMinor: 0 } }),
+    ).rejects.toThrow(/check constraint|Check|amountMinor/);
+    await expect(
+      observer.fundTransaction.create({ data: { ...base, amountMinor: -1 } }),
+    ).rejects.toThrow(/check constraint|Check|amountMinor/);
+    await observer.fundTransaction.create({ data: { ...base, amountMinor: 1 } });
+    expect(
+      await observer.fundTransaction.count({ where: { fundId: ctx.fund.id } }),
+    ).toBe(1);
+  }, 20000);
+
+  it('enforces the fund scope invariant (TENANT⇒null, BUILDING⇒not-null) at the database level', async () => {
+    const ctx = await fixture('scope-invariant');
+
+    // TENANT con buildingId → rechazado por DB
+    const building = await observer.building.create({
+      data: { tenantId: ctx.tenant.id, name: `S-${Date.now()}`, alias: `S-${Date.now()}`, address: 'x' },
+    });
+    await expect(
+      observer.fund.create({
+        data: {
+          tenantId: ctx.tenant.id,
+          buildingId: building.id,
+          scopeType: 'TENANT',
+          type: 'RESERVE',
+          name: `Invalid TENANT ${Date.now()}`,
+          createdByMembershipId: ctx.membership.id,
+        },
+      }),
+    ).rejects.toThrow(/check constraint|Check|scope/);
+
+    // BUILDING sin buildingId → rechazado por DB
+    await expect(
+      observer.fund.create({
+        data: {
+          tenantId: ctx.tenant.id,
+          scopeType: 'BUILDING',
+          type: 'RESERVE',
+          name: `Invalid BUILDING ${Date.now()}`,
+          createdByMembershipId: ctx.membership.id,
+        },
+      }),
+    ).rejects.toThrow(/check constraint|Check|scope/);
+
+    // BUILDING con buildingId → permitido (fixture ya creó 1 fund TENANT)
+    await observer.fund.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        buildingId: building.id,
+        scopeType: 'BUILDING',
+        type: 'RESERVE',
+        name: `Valid BUILDING ${Date.now()}`,
+        createdByMembershipId: ctx.membership.id,
+      },
+    });
+    expect(
+      await observer.fund.count({ where: { tenantId: ctx.tenant.id } }),
+    ).toBe(2); // 1 fixture TENANT + 1 BUILDING válido
   }, 20000);
 });

--- a/apps/api/src/finanzas/funds-concurrency.postgres.spec.ts
+++ b/apps/api/src/finanzas/funds-concurrency.postgres.spec.ts
@@ -1,0 +1,280 @@
+import { FundTransactionDirection, PrismaClient, TenantType } from '@prisma/client';
+
+const ACCEPTANCE_DATABASES = new Set(['buildingos_fin02_acceptance']);
+const expectedDatabaseName = process.env.POSTGRES_TEST_DB_NAME;
+const fixturePhase = 'fin02';
+const enabled =
+  process.env.RUN_POSTGRES_INTEGRATION === '1' &&
+  expectedDatabaseName !== undefined &&
+  ACCEPTANCE_DATABASES.has(expectedDatabaseName);
+const describePostgres = enabled ? describe : describe.skip;
+
+describePostgres('Funds ledger PostgreSQL concurrency', () => {
+  let observer: PrismaClient;
+  let firstClient: PrismaClient;
+  let secondClient: PrismaClient;
+  const tenantIds: string[] = [];
+  const userIds: string[] = [];
+  const membershipIds: string[] = [];
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required');
+    observer = new PrismaClient();
+    firstClient = new PrismaClient();
+    secondClient = new PrismaClient();
+    await Promise.all([observer.$connect(), firstClient.$connect(), secondClient.$connect()]);
+    const [database] = await observer.$queryRaw<Array<{ name: string }>>`SELECT current_database() AS name`;
+    if (database?.name !== expectedDatabaseName || !ACCEPTANCE_DATABASES.has(database.name)) {
+      throw new Error(`Refusing destructive test database ${database?.name ?? 'unknown'}`);
+    }
+  });
+
+  afterEach(async () => {
+    for (const membershipId of membershipIds.splice(0)) {
+      await observer.membership.delete({ where: { id: membershipId } }).catch(() => undefined);
+    }
+    for (const tenantId of tenantIds.splice(0)) {
+      await observer.tenant.delete({ where: { id: tenantId } });
+    }
+    for (const userId of userIds.splice(0)) {
+      await observer.user.delete({ where: { id: userId } });
+    }
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      observer?.$disconnect(),
+      firstClient?.$disconnect(),
+      secondClient?.$disconnect(),
+    ]);
+  });
+
+  async function fixture(label: string) {
+    const suffix = `${Date.now()}-${Math.random()}`;
+    const tenant = await observer.tenant.create({
+      data: { name: `${fixturePhase}-${label}-${suffix}`, type: TenantType.ADMINISTRADORA },
+    });
+    tenantIds.push(tenant.id);
+    const user = await observer.user.create({
+      data: {
+        email: `${fixturePhase}-${suffix}@buildingos.local`,
+        name: `${fixturePhase} concurrency`,
+        passwordHash: 'test',
+      },
+    });
+    userIds.push(user.id);
+    const membership = await observer.membership.create({
+      data: { tenantId: tenant.id, userId: user.id },
+    });
+    membershipIds.push(membership.id);
+    const fund = await observer.fund.create({
+      data: {
+        tenantId: tenant.id,
+        scopeType: 'TENANT',
+        type: 'RESERVE',
+        name: `Reserva ${suffix}`,
+        createdByMembershipId: membership.id,
+      },
+    });
+    return { tenant, membership, fund };
+  }
+
+  async function waitUntilBlocked(pid: number): Promise<void> {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [activity] = await observer.$queryRaw<Array<{ wait_event_type: string | null }>>`
+        SELECT wait_event_type FROM pg_stat_activity WHERE pid = ${pid}
+      `;
+      if (activity?.wait_event_type === 'Lock') return;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error(`Backend ${pid} did not reach a database lock wait`);
+  }
+
+  async function waitUntilBlocked(pid: number): Promise<void> {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const [activity] = await observer.$queryRaw<Array<{ wait_event_type: string | null }>>`
+        SELECT wait_event_type FROM pg_stat_activity WHERE pid = ${pid}
+      `;
+      if (activity?.wait_event_type === 'Lock') return;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error(`Backend ${pid} did not reach a database lock wait`);
+  }
+
+  /**
+   * Ejecuta un DEBIT contra un fondo. Usa advisory lock + transacción.
+   * Devuelve el resultado o el error.
+   */
+  async function tryDebit(
+    client: PrismaClient,
+    tenantId: string,
+    fundId: string,
+    membershipId: string,
+    amountMinor: number,
+  ): Promise<{ ok: boolean; error?: string }> {
+    try {
+      await client.$transaction(async (tx) => {
+        await tx.$executeRaw`SELECT pg_advisory_xact_lock(hashtextextended(${`buildingos_fund_lock_v1:${tenantId}:${fundId}`}, 0))`;
+        const fund = await tx.fund.findFirst({ where: { id: fundId, tenantId } });
+        if (!fund) throw new Error('fund missing');
+        const [creditAgg] = await tx.$queryRaw<Array<{ total: bigint | null }>>`
+          SELECT COALESCE(SUM("amountMinor"), 0) AS total
+          FROM "FundTransaction"
+          WHERE "fundId" = ${fundId} AND "tenantId" = ${tenantId} AND direction = 'CREDIT'
+        `;
+        const [debitAgg] = await tx.$queryRaw<Array<{ total: bigint | null }>>`
+          SELECT COALESCE(SUM("amountMinor"), 0) AS total
+          FROM "FundTransaction"
+          WHERE "fundId" = ${fundId} AND "tenantId" = ${tenantId} AND direction = 'DEBIT'
+        `;
+        const balance = Number(creditAgg?.total ?? 0) - Number(debitAgg?.total ?? 0);
+        if (balance < amountMinor) {
+          throw new Error('INSUFFICIENT_FUNDS');
+        }
+        await tx.fundTransaction.create({
+          data: {
+            tenantId,
+            fundId,
+            direction: FundTransactionDirection.DEBIT,
+            amountMinor,
+            currencyCode: 'USD',
+            occurredAt: new Date(),
+            createdByMembershipId: membershipId,
+          },
+        });
+      });
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  it('serializes two concurrent debits: only one succeeds, balance never negative', async () => {
+    const ctx = await fixture('debit-race');
+    await observer.fundTransaction.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        fundId: ctx.fund.id,
+        direction: FundTransactionDirection.CREDIT,
+        amountMinor: 10000, // USD 100.00 inicial
+        currencyCode: 'USD',
+        occurredAt: new Date(),
+        createdByMembershipId: ctx.membership.id,
+      },
+    });
+
+    // Ambos debitan 8000 en paralelo contra un saldo de 10000.
+    // El advisory lock por (tenantId, fundId) serializa: solo uno completa.
+    const [first, second] = await Promise.all([
+      tryDebit(firstClient, ctx.tenant.id, ctx.fund.id, ctx.membership.id, 8000),
+      tryDebit(secondClient, ctx.tenant.id, ctx.fund.id, ctx.membership.id, 8000),
+    ]);
+
+    const [balanceAgg] = await observer.$queryRaw<Array<{ total: bigint | null }>>`
+      SELECT COALESCE(SUM(CASE WHEN direction = 'CREDIT' THEN "amountMinor" ELSE -"amountMinor" END), 0) AS total
+      FROM "FundTransaction"
+      WHERE "fundId" = ${ctx.fund.id} AND "tenantId" = ${ctx.tenant.id}
+    `;
+    const finalBalance = Number(balanceAgg?.total ?? 0);
+
+    const outcomes = [first.ok, second.ok].sort();
+    expect(outcomes).toEqual([false, true]);
+    expect(finalBalance).toBeGreaterThanOrEqual(0);
+    expect(finalBalance).toBe(2000); // 10000 - 8000 = 2000
+  }, 20000);
+
+  it('allows only one ACTIVE fund with the same normalized name under concurrent creation', async () => {
+    const ctx = await fixture('name-race');
+
+    async function tryCreateFund(client: PrismaClient, name: string): Promise<{ ok: boolean; error?: string }> {
+      try {
+        await client.fund.create({
+          data: {
+            tenantId: ctx.tenant.id,
+            scopeType: 'TENANT',
+            type: 'RESERVE',
+            name,
+            createdByMembershipId: ctx.membership.id,
+          },
+        });
+        return { ok: true };
+      } catch (error) {
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+
+    // Dos creaciones concurrentes del MISMO nombre normalizado en el mismo scope.
+    const [first, second] = await Promise.all([
+      tryCreateFund(firstClient, 'Fondo de reserva'),
+      tryCreateFund(secondClient, '  fondo  de RESERVA '),
+    ]);
+
+    const racingNameCount = await observer.fund.count({
+      where: {
+        tenantId: ctx.tenant.id,
+        status: 'ACTIVE',
+        OR: [{ name: 'Fondo de reserva' }, { name: '  fondo  de RESERVA ' }],
+      },
+    });
+
+    const outcomes = [first.ok, second.ok].sort();
+    expect(outcomes).toEqual([false, true]);
+    expect(racingNameCount).toBe(1);
+  }, 20000);
+
+  it('preserves fund history against DELETE (Restrict semantics)', async () => {
+    const ctx = await fixture('delete-safety');
+    await observer.fundTransaction.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        fundId: ctx.fund.id,
+        direction: FundTransactionDirection.CREDIT,
+        amountMinor: 1000,
+        currencyCode: 'USD',
+        occurredAt: new Date(),
+        createdByMembershipId: ctx.membership.id,
+      },
+    });
+
+    // B. DELETE Fund con ledger → RESTRICT: debe fallar y preservar todo.
+    await expect(
+      observer.fund.delete({ where: { id: ctx.fund.id } }),
+    ).rejects.toThrow(/foreign key|Foreign key|constraint/);
+    expect(await observer.fund.count({ where: { id: ctx.fund.id } })).toBe(1);
+    expect(
+      await observer.fundTransaction.count({ where: { fundId: ctx.fund.id } }),
+    ).toBe(1);
+
+    // A. DELETE Tenant borra todo el tenant (cascade estándar del repo).
+    await observer.tenant.delete({ where: { id: ctx.tenant.id } });
+    expect(await observer.fund.count({ where: { id: ctx.fund.id } })).toBe(0);
+    expect(
+      await observer.fundTransaction.count({ where: { fundId: ctx.fund.id } }),
+    ).toBe(0);
+    // afterEach no debe volver a borrar el tenant ya eliminado
+    tenantIds.splice(tenantIds.indexOf(ctx.tenant.id), 1);
+    membershipIds.splice(membershipIds.indexOf(ctx.membership.id), 1);
+  }, 20000);
+
+  it('blocks DELETE Building while a building-scoped fund exists (Restrict)', async () => {
+    const ctx = await fixture('building-delete-safety');
+    const building = await observer.building.create({
+      data: { tenantId: ctx.tenant.id, name: `B-${Date.now()}`, alias: `B-${Date.now()}`, address: 'x' },
+    });
+    await observer.fund.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        buildingId: building.id,
+        scopeType: 'BUILDING',
+        type: 'RESERVE',
+        name: `Fondo edificio ${Date.now()}`,
+        createdByMembershipId: ctx.membership.id,
+      },
+    });
+
+    await expect(
+      observer.building.delete({ where: { id: building.id } }),
+    ).rejects.toThrow(/foreign key|Foreign key|constraint/);
+    expect(await observer.fund.count({ where: { buildingId: building.id } })).toBe(1);
+  }, 20000);
+});

--- a/apps/api/src/finanzas/funds.controller.ts
+++ b/apps/api/src/finanzas/funds.controller.ts
@@ -1,0 +1,141 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Param,
+  Body,
+  Query,
+  UseGuards,
+  Request,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
+import { AuthenticatedRequest } from '../common/types/request.types';
+import { FundsService } from './funds.service';
+import {
+  CreateFundDto,
+  UpdateFundDto,
+  FundQueryDto,
+  FundResponseDto,
+  CreateFundTransactionDto,
+  ReverseFundTransactionDto,
+  FundTransactionQueryDto,
+  FundTransactionResponseDto,
+} from './funds.dto';
+
+/**
+ * Fondos financieros (tenant-scoped)
+ * Routes: /tenants/:tenantId/finance/funds
+ */
+@Controller('tenants/:tenantId/finance/funds')
+@UseGuards(JwtAuthGuard, TenantAccessGuard)
+export class FundsController {
+  constructor(private readonly fundsService: FundsService) {}
+
+  @Get()
+  async listFunds(
+    @Query() query: FundQueryDto,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<FundResponseDto[]> {
+    return this.fundsService.listFunds(req.tenantId!, req.user.roles ?? [], query);
+  }
+
+  @Post()
+  async createFund(
+    @Body() dto: CreateFundDto,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<FundResponseDto> {
+    return this.fundsService.createFund(
+      req.tenantId!,
+      req.user.membershipId ?? '',
+      req.user.roles ?? [],
+      dto,
+    );
+  }
+
+  @Get(':fundId')
+  async getFund(
+    @Param('fundId') fundId: string,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<FundResponseDto> {
+    return this.fundsService.getFund(req.tenantId!, fundId, req.user.roles ?? []);
+  }
+
+  @Patch(':fundId')
+  async updateFund(
+    @Param('fundId') fundId: string,
+    @Body() dto: UpdateFundDto,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<FundResponseDto> {
+    return this.fundsService.updateFund(
+      req.tenantId!,
+      fundId,
+      req.user.membershipId ?? '',
+      req.user.roles ?? [],
+      dto,
+    );
+  }
+
+  @Post(':fundId/archive')
+  @HttpCode(HttpStatus.OK)
+  async archiveFund(
+    @Param('fundId') fundId: string,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<FundResponseDto> {
+    return this.fundsService.archiveFund(
+      req.tenantId!,
+      fundId,
+      req.user.membershipId ?? '',
+      req.user.roles ?? [],
+    );
+  }
+
+  @Get(':fundId/transactions')
+  async listTransactions(
+    @Param('fundId') fundId: string,
+    @Query() query: FundTransactionQueryDto,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<FundTransactionResponseDto[]> {
+    return this.fundsService.listTransactions(
+      req.tenantId!,
+      fundId,
+      req.user.roles ?? [],
+      query,
+    );
+  }
+
+  @Post(':fundId/transactions')
+  async createTransaction(
+    @Param('fundId') fundId: string,
+    @Body() dto: CreateFundTransactionDto,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<FundTransactionResponseDto> {
+    return this.fundsService.createTransaction(
+      req.tenantId!,
+      fundId,
+      req.user.membershipId ?? '',
+      req.user.roles ?? [],
+      dto,
+    );
+  }
+
+  @Post(':fundId/transactions/:transactionId/reverse')
+  async reverseTransaction(
+    @Param('fundId') fundId: string,
+    @Param('transactionId') transactionId: string,
+    @Body() dto: ReverseFundTransactionDto,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<FundTransactionResponseDto> {
+    return this.fundsService.reverseTransaction(
+      req.tenantId!,
+      fundId,
+      transactionId,
+      req.user.membershipId ?? '',
+      req.user.roles ?? [],
+      dto,
+    );
+  }
+}

--- a/apps/api/src/finanzas/funds.dto.ts
+++ b/apps/api/src/finanzas/funds.dto.ts
@@ -1,0 +1,153 @@
+import {
+  IsString,
+  IsOptional,
+  IsInt,
+  IsEnum,
+  Min,
+  MinLength,
+  MaxLength,
+  IsDateString,
+  ValidateIf,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { CANONICAL_CURRENCIES, type CanonicalCurrency } from '@buildingos/contracts';
+import {
+  FundScopeType,
+  FundType,
+  FundStatus,
+  FundTransactionDirection,
+} from '@prisma/client';
+
+// ── Fund ────────────────────────────────────────────────────────────────────
+
+export class CreateFundDto {
+  @IsEnum(FundScopeType)
+  scopeType!: FundScopeType;
+
+  @IsString()
+  @IsOptional()
+  @ValidateIf((dto: CreateFundDto) => dto.scopeType === FundScopeType.BUILDING)
+  buildingId?: string;
+
+  @IsEnum(FundType)
+  type!: FundType;
+
+  @IsString()
+  @MinLength(2)
+  @MaxLength(120)
+  name!: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(500)
+  description?: string;
+}
+
+export class UpdateFundDto {
+  @IsString()
+  @IsOptional()
+  @MinLength(2)
+  @MaxLength(120)
+  name?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(500)
+  description?: string;
+}
+
+export class FundQueryDto {
+  @IsString()
+  @IsOptional()
+  buildingId?: string;
+
+  @IsEnum(FundScopeType)
+  @IsOptional()
+  scopeType?: FundScopeType;
+
+  @IsEnum(FundStatus)
+  @IsOptional()
+  status?: FundStatus;
+}
+
+export interface FundResponseDto {
+  id: string;
+  tenantId: string;
+  buildingId: string | null;
+  scopeType: FundScopeType;
+  type: FundType;
+  name: string;
+  description: string | null;
+  status: FundStatus;
+  balancesByCurrency: Array<{ currency: string; amountMinor: number }>;
+  createdAt: Date;
+  archivedAt: Date | null;
+}
+
+// ── FundTransaction ─────────────────────────────────────────────────────────
+
+export class CreateFundTransactionDto {
+  @IsEnum(FundTransactionDirection)
+  direction!: FundTransactionDirection;
+
+  @IsInt()
+  @Min(1)
+  amountMinor!: number;
+
+  @IsEnum(CANONICAL_CURRENCIES, {
+    message: 'currency must be one of USD, VES, ARS, or COP',
+  })
+  currencyCode!: CanonicalCurrency;
+
+  @IsDateString()
+  occurredAt!: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(500)
+  description?: string;
+
+  @IsString()
+  @IsOptional()
+  @MaxLength(120)
+  idempotencyKey?: string;
+}
+
+export class ReverseFundTransactionDto {
+  @IsString()
+  @IsOptional()
+  @MaxLength(500)
+  reason?: string;
+}
+
+export class FundTransactionQueryDto {
+  @IsString()
+  @IsOptional()
+  currencyCode?: string;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @IsOptional()
+  limit?: number;
+
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  @IsOptional()
+  offset?: number;
+}
+
+export interface FundTransactionResponseDto {
+  id: string;
+  tenantId: string;
+  fundId: string;
+  direction: FundTransactionDirection;
+  amountMinor: number;
+  currencyCode: string;
+  occurredAt: Date;
+  description: string | null;
+  idempotencyKey: string | null;
+  reversalOfTransactionId: string | null;
+  createdAt: Date;
+}

--- a/apps/api/src/finanzas/funds.service.spec.ts
+++ b/apps/api/src/finanzas/funds.service.spec.ts
@@ -1,0 +1,810 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { FundStatus, FundTransactionDirection, Prisma } from '@prisma/client';
+import { FundsService } from './funds.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+
+const makeFund = (overrides: Record<string, unknown> = {}) => ({
+  id: 'fund-1',
+  tenantId: 'tenant-1',
+  buildingId: null,
+  scopeType: 'TENANT',
+  type: 'RESERVE',
+  name: 'Fondo de reserva',
+  description: null,
+  status: FundStatus.ACTIVE,
+  createdByMembershipId: 'member-1',
+  archivedByMembershipId: null,
+  archivedAt: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+const makeTransaction = (overrides: Record<string, unknown> = {}) => ({
+  id: 'tx-1',
+  tenantId: 'tenant-1',
+  fundId: 'fund-1',
+  direction: FundTransactionDirection.CREDIT,
+  amountMinor: 50000,
+  currencyCode: 'USD',
+  occurredAt: new Date('2026-08-14T00:00:00.000Z'),
+  description: null,
+  createdByMembershipId: 'member-1',
+  idempotencyKey: null,
+  reversalOfTransactionId: null,
+  createdAt: new Date(),
+  ...overrides,
+});
+
+describe('FundsService', () => {
+  let service: FundsService;
+  let prisma: PrismaService;
+  let audit: AuditService;
+  let validators: FinanzasValidators;
+
+  const prismaValue = {
+    fund: {
+      findMany: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    },
+    fundTransaction: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      findFirst: jest.fn(),
+      create: jest.fn(),
+      groupBy: jest.fn(),
+    },
+    $transaction: jest.fn(),
+    $queryRaw: jest.fn(),
+    $executeRaw: jest.fn(),
+  };
+
+  /**
+   * Configura groupBy para simular el ledger (créditos luego débitos).
+   * @param credits filas CREDIT (currencyCode, _sum.amountMinor)
+   * @param debits filas DEBIT (currencyCode, _sum.amountMinor)
+   */
+  function mockLedger(
+    credits: Array<{ currencyCode: string; amountMinor: number }> = [],
+    debits: Array<{ currencyCode: string; amountMinor: number }> = [],
+  ) {
+    (prismaValue.fundTransaction.groupBy as jest.Mock)
+      .mockResolvedValueOnce(
+        credits.map((c) => ({ currencyCode: c.currencyCode, _sum: { amountMinor: c.amountMinor } })),
+      )
+      .mockResolvedValueOnce(
+        debits.map((d) => ({ currencyCode: d.currencyCode, _sum: { amountMinor: d.amountMinor } })),
+      );
+  }
+
+  /**
+   * Configura groupBy para loadBalancesForFunds (agrupa por fundId + currency).
+   */
+  function mockBalancesByFund(
+    credits: Array<{ fundId: string; currencyCode: string; amountMinor: number }> = [],
+    debits: Array<{ fundId: string; currencyCode: string; amountMinor: number }> = [],
+  ) {
+    (prismaValue.fundTransaction.groupBy as jest.Mock)
+      .mockResolvedValueOnce(
+        credits.map((c) => ({ fundId: c.fundId, currencyCode: c.currencyCode, _sum: { amountMinor: c.amountMinor } })),
+      )
+      .mockResolvedValueOnce(
+        debits.map((d) => ({ fundId: d.fundId, currencyCode: d.currencyCode, _sum: { amountMinor: d.amountMinor } })),
+      );
+  }
+
+  /**
+   * Makes $transaction(callback) execute the callback with a tx client backed
+   * by the same jest mocks (simulates the real transaction boundary).
+   */
+  function mockTransaction() {
+    const tx = {
+      fund: prismaValue.fund,
+      fundTransaction: prismaValue.fundTransaction,
+      auditLog: { create: jest.fn() },
+      $queryRaw: prismaValue.$queryRaw,
+      $executeRaw: prismaValue.$executeRaw,
+    };
+    (prismaValue.$transaction as jest.Mock).mockImplementation(
+      async (callback: (tx: typeof tx) => unknown) => callback(tx),
+    );
+    return tx;
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    // mockReset vacía las colas de mockResolvedValueOnce/mockRejectedValueOnce
+    // que clearAllMocks no toca
+    (prismaValue.fundTransaction.groupBy as jest.Mock).mockReset();
+    (prismaValue.fundTransaction.create as jest.Mock).mockReset();
+    mockTransaction();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FundsService,
+        { provide: PrismaService, useValue: prismaValue },
+        {
+          provide: AuditService,
+          useValue: {
+            createLog: jest.fn(),
+            createLogRequired: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: FinanzasValidators,
+          useValue: {
+            isAdminOrOperator: jest.fn().mockReturnValue(true),
+            validateBuildingBelongsToTenant: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<FundsService>(FundsService);
+    prisma = module.get<PrismaService>(PrismaService);
+    audit = module.get<AuditService>(AuditService);
+    validators = module.get<FinanzasValidators>(FinanzasValidators);
+
+    (validators.isAdminOrOperator as jest.Mock).mockReturnValue(true);
+    (validators.validateBuildingBelongsToTenant as jest.Mock).mockResolvedValue(undefined);
+    (audit.createLogRequired as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  const roles = ['TENANT_ADMIN'];
+
+  // ── RBAC ────────────────────────────────────────────────────────────────
+
+  describe('RBAC', () => {
+    it('rejects non-admin users on every operation', async () => {
+      (validators.isAdminOrOperator as jest.Mock).mockReturnValue(false);
+      const denied = [
+        () => service.listFunds('tenant-1', ['RESIDENT']),
+        () => service.getFund('tenant-1', 'fund-1', ['RESIDENT']),
+        () => service.createFund('tenant-1', 'm', ['RESIDENT'], {
+          scopeType: 'TENANT', type: 'RESERVE', name: 'X',
+        }),
+        () => service.updateFund('tenant-1', 'fund-1', 'm', ['RESIDENT'], { name: 'Y' }),
+        () => service.archiveFund('tenant-1', 'fund-1', 'm', ['RESIDENT']),
+        () => service.listTransactions('tenant-1', 'fund-1', ['RESIDENT']),
+        () => service.createTransaction('tenant-1', 'fund-1', 'm', ['RESIDENT'], {
+          direction: FundTransactionDirection.CREDIT, amountMinor: 100, currencyCode: 'USD', occurredAt: '2026-08-14T00:00:00.000Z',
+        }),
+        () => service.reverseTransaction('tenant-1', 'fund-1', 'tx-1', 'm', ['RESIDENT']),
+      ];
+      for (const call of denied) {
+        await expect(call()).rejects.toThrow(ForbiddenException);
+      }
+    });
+  });
+
+  // ── Fund CRUD ───────────────────────────────────────────────────────────
+
+  describe('createFund', () => {
+    it('creates a TENANT fund with no building', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.fund.create as jest.Mock).mockResolvedValue(makeFund());
+
+      const result = await service.createFund('tenant-1', 'member-1', roles, {
+        scopeType: 'TENANT',
+        type: 'RESERVE',
+        name: '  Fondo de reserva  ',
+      });
+
+      expect(result.scopeType).toBe('TENANT');
+      expect(result.buildingId).toBeNull();
+      expect(result.name).toBe('Fondo de reserva');
+      expect(prisma.fund.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            tenantId: 'tenant-1',
+            buildingId: null,
+            status: FundStatus.ACTIVE,
+          }),
+        }),
+      );
+      expect(audit.createLogRequired).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'FUND_CREATE', entityId: 'fund-1' }),
+        expect.anything(),
+      );
+    });
+
+    it('creates a BUILDING fund and validates the building belongs to tenant', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.fund.create as jest.Mock).mockResolvedValue(
+        makeFund({ buildingId: 'building-1', scopeType: 'BUILDING' }),
+      );
+
+      await service.createFund('tenant-1', 'member-1', roles, {
+        scopeType: 'BUILDING',
+        buildingId: 'building-1',
+        type: 'SPECIAL',
+        name: 'Fondo ascensores',
+      });
+
+      expect(validators.validateBuildingBelongsToTenant).toHaveBeenCalledWith(
+        'tenant-1',
+        'building-1',
+      );
+      expect(prisma.fund.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ buildingId: 'building-1' }),
+        }),
+      );
+    });
+
+    it('rejects TENANT fund with a buildingId', async () => {
+      await expect(
+        service.createFund('tenant-1', 'member-1', roles, {
+          scopeType: 'TENANT',
+          buildingId: 'building-1',
+          type: 'RESERVE',
+          name: 'X',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects BUILDING fund without buildingId', async () => {
+      await expect(
+        service.createFund('tenant-1', 'member-1', roles, {
+          scopeType: 'BUILDING',
+          type: 'RESERVE',
+          name: 'X',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects a building from another tenant', async () => {
+      (validators.validateBuildingBelongsToTenant as jest.Mock).mockRejectedValue(
+        new NotFoundException('Building not found or does not belong to this tenant'),
+      );
+      await expect(
+        service.createFund('tenant-1', 'member-1', roles, {
+          scopeType: 'BUILDING',
+          buildingId: 'building-other',
+          type: 'RESERVE',
+          name: 'X',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects duplicate active name in the same scope (case/space-insensitive)', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([
+        makeFund({ name: 'Fondo reserva' }),
+      ]);
+      await expect(
+        service.createFund('tenant-1', 'member-1', roles, {
+          scopeType: 'TENANT',
+          type: 'RESERVE',
+          name: '  fondo  reserva ',
+        }),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('allows the same name in a different building', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.fund.create as jest.Mock).mockResolvedValue(
+        makeFund({ id: 'fund-b1', buildingId: 'building-1', scopeType: 'BUILDING' }),
+      );
+
+      await service.createFund('tenant-1', 'member-1', roles, {
+        scopeType: 'BUILDING',
+        buildingId: 'building-1',
+        type: 'RESERVE',
+        name: 'Fondo de reserva',
+      });
+      expect(prisma.fund.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows reusing a name of an ARCHIVED fund', async () => {
+      // El servicio filtra status=ACTIVE en la query; el mock respeta el filtro
+      (prisma.fund.findMany as jest.Mock).mockImplementation(({ where }) =>
+        Promise.resolve(
+          where.status === FundStatus.ACTIVE
+            ? []
+            : [makeFund({ name: 'Fondo de reserva', status: FundStatus.ARCHIVED })],
+        ),
+      );
+      (prisma.fund.create as jest.Mock).mockResolvedValue(makeFund({ id: 'fund-2' }));
+
+      const result = await service.createFund('tenant-1', 'member-1', roles, {
+        scopeType: 'TENANT',
+        type: 'RESERVE',
+        name: 'Fondo de reserva',
+      });
+      expect(result.id).toBe('fund-2');
+    });
+
+    it('turns a DB unique race on active name into ConflictException (P2002 Fund_active_name_*)', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.fund.create as jest.Mock).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('unique violation', {
+          code: 'P2002',
+          clientVersion: '5.22.0',
+          meta: { target: ['Fund_active_name_tenant_key'] },
+        }),
+      );
+
+      await expect(
+        service.createFund('tenant-1', 'member-1', roles, {
+          scopeType: 'TENANT',
+          type: 'RESERVE',
+          name: 'Fondo de reserva',
+        }),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('rethrows a P2002 that is not the active-name index', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.fund.create as jest.Mock).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('unique violation', {
+          code: 'P2002',
+          clientVersion: '5.22.0',
+          meta: { target: ['Fund_some_other_key'] },
+        }),
+      );
+
+      await expect(
+        service.createFund('tenant-1', 'member-1', roles, {
+          scopeType: 'TENANT',
+          type: 'RESERVE',
+          name: 'Fondo de reserva',
+        }),
+      ).rejects.toThrow('unique violation');
+    });
+  });
+
+  describe('listFunds / getFund', () => {
+    it('lists funds tenant-scoped with filters and computed balances', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([
+        makeFund(),
+        makeFund({ id: 'fund-2', name: 'Fondo ascensores' }),
+      ]);
+      mockBalancesByFund(
+        [{ fundId: 'fund-1', currencyCode: 'USD', amountMinor: 50000 }],
+        [{ fundId: 'fund-1', currencyCode: 'USD', amountMinor: 20000 }],
+      );
+
+      const result = await service.listFunds('tenant-1', roles, { status: 'ACTIVE' });
+
+      expect(prisma.fund.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({ tenantId: 'tenant-1', status: 'ACTIVE' }),
+        }),
+      );
+      expect(result[0]!.balancesByCurrency).toEqual([
+        { currency: 'USD', amountMinor: 30000 },
+      ]);
+    });
+
+    it('rejects getFund of a fund from another tenant', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(null);
+      await expect(
+        service.getFund('tenant-1', 'fund-other', roles),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.fund.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'fund-other', tenantId: 'tenant-1' } }),
+      );
+    });
+  });
+
+  describe('updateFund', () => {
+    it('updates safe metadata only (name/description)', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.fund.update as jest.Mock).mockResolvedValue(
+        makeFund({ name: 'Nuevo nombre' }),
+      );
+      mockLedger([], []);
+
+      const result = await service.updateFund('tenant-1', 'fund-1', 'member-1', roles, {
+        name: 'Nuevo nombre',
+      });
+
+      expect(result.name).toBe('Nuevo nombre');
+      expect(prisma.fund.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.not.objectContaining({ tenantId: expect.anything() }),
+        }),
+      );
+      expect(audit.createLogRequired).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'FUND_UPDATE' }),
+        expect.anything(),
+      );
+    });
+
+    it('rejects update of a fund from another tenant', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(null);
+      await expect(
+        service.updateFund('tenant-1', 'fund-other', 'member-1', roles, { name: 'X' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('turns a DB unique race on rename into ConflictException (P2002 Fund_active_name_*)', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.fund.update as jest.Mock).mockRejectedValue(
+        new Prisma.PrismaClientKnownRequestError('unique violation', {
+          code: 'P2002',
+          clientVersion: '5.22.0',
+          meta: { target: ['Fund_active_name_building_key'] },
+        }),
+      );
+
+      await expect(
+        service.updateFund('tenant-1', 'fund-1', 'member-1', roles, { name: 'X' }),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('archiveFund', () => {
+    it('archives a fund with zero balance', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      mockLedger([], []);
+      (prisma.fund.update as jest.Mock).mockResolvedValue(
+        makeFund({ status: FundStatus.ARCHIVED, archivedAt: new Date() }),
+      );
+
+      const result = await service.archiveFund('tenant-1', 'fund-1', 'member-1', roles);
+      expect(result.status).toBe(FundStatus.ARCHIVED);
+      expect(audit.createLogRequired).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'FUND_ARCHIVE' }),
+        expect.anything(),
+      );
+    });
+
+    it('rejects archive of a fund with non-zero balance', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      mockLedger([{ currencyCode: 'USD', amountMinor: 50000 }], []);
+
+      await expect(
+        service.archiveFund('tenant-1', 'fund-1', 'member-1', roles),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  // ── Ledger: CREDIT / DEBIT / multicurrency / insufficient ───────────────
+
+  describe('createTransaction', () => {
+    it('credits increase the balance', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      mockLedger([], []);
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValue(
+        makeTransaction({ direction: FundTransactionDirection.CREDIT, amountMinor: 50000 }),
+      );
+
+      const result = await service.createTransaction('tenant-1', 'fund-1', 'member-1', roles, {
+        direction: FundTransactionDirection.CREDIT,
+        amountMinor: 50000,
+        currencyCode: 'USD',
+        occurredAt: '2026-08-14T00:00:00.000Z',
+      });
+
+      expect(result.amountMinor).toBe(50000);
+      expect(prisma.fundTransaction.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            fundId: 'fund-1',
+            direction: FundTransactionDirection.CREDIT,
+            amountMinor: 50000,
+            currencyCode: 'USD',
+          }),
+        }),
+      );
+      expect(audit.createLogRequired).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'FUND_TRANSACTION_CREATE' }),
+        expect.anything(),
+      );
+    });
+
+    it('debit reduces the balance when sufficient', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      mockLedger([{ currencyCode: 'USD', amountMinor: 50000 }], []);
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValue(
+        makeTransaction({ direction: FundTransactionDirection.DEBIT, amountMinor: 20000 }),
+      );
+
+      const result = await service.createTransaction('tenant-1', 'fund-1', 'member-1', roles, {
+        direction: FundTransactionDirection.DEBIT,
+        amountMinor: 20000,
+        currencyCode: 'USD',
+        occurredAt: '2026-08-14T00:00:00.000Z',
+      });
+      expect(result.direction).toBe(FundTransactionDirection.DEBIT);
+    });
+
+    it('rejects debit exceeding balance (no negative balance)', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      mockLedger([{ currencyCode: 'USD', amountMinor: 10000 }], []);
+
+      await expect(
+        service.createTransaction('tenant-1', 'fund-1', 'member-1', roles, {
+          direction: FundTransactionDirection.DEBIT,
+          amountMinor: 10100,
+          currencyCode: 'USD',
+          occurredAt: '2026-08-14T00:00:00.000Z',
+        }),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
+    });
+
+    it('keeps balances independent per currency', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      mockLedger(
+        [{ currencyCode: 'USD', amountMinor: 10000 }, { currencyCode: 'COP', amountMinor: 50000000 }],
+        [],
+      );
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValue(
+        makeTransaction({ direction: FundTransactionDirection.DEBIT, amountMinor: 1000000, currencyCode: 'COP' }),
+      );
+
+      await service.createTransaction('tenant-1', 'fund-1', 'member-1', roles, {
+        direction: FundTransactionDirection.DEBIT,
+        amountMinor: 1000000,
+        currencyCode: 'COP',
+        occurredAt: '2026-08-14T00:00:00.000Z',
+      });
+      // debit 1.000.000 COP <= balance 50.000.000 COP → ok (independiente de USD)
+      expect(prisma.fundTransaction.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects transaction on an archived fund', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(
+        makeFund({ status: FundStatus.ARCHIVED }),
+      );
+      await expect(
+        service.createTransaction('tenant-1', 'fund-1', 'member-1', roles, {
+          direction: FundTransactionDirection.CREDIT,
+          amountMinor: 100,
+          currencyCode: 'USD',
+          occurredAt: '2026-08-14T00:00:00.000Z',
+        }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects transaction on a fund from another tenant', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(null);
+      await expect(
+        service.createTransaction('tenant-1', 'fund-other', 'member-1', roles, {
+          direction: FundTransactionDirection.CREDIT,
+          amountMinor: 100,
+          currencyCode: 'USD',
+          occurredAt: '2026-08-14T00:00:00.000Z',
+        }),
+      ).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  // ── Idempotency ─────────────────────────────────────────────────────────
+
+  describe('idempotency', () => {
+    it('returns the existing transaction when the same idempotency key repeats', async () => {
+      const existing = makeTransaction({
+        id: 'tx-existing',
+        idempotencyKey: 'income-app-1',
+      });
+      (prisma.fundTransaction.findUnique as jest.Mock).mockResolvedValue(existing);
+
+      const result = await service.createTransaction('tenant-1', 'fund-1', 'member-1', roles, {
+        direction: FundTransactionDirection.CREDIT,
+        amountMinor: 50000,
+        currencyCode: 'USD',
+        occurredAt: '2026-08-14T00:00:00.000Z',
+        idempotencyKey: 'income-app-1',
+      });
+
+      expect(result.id).toBe('tx-existing');
+      expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects the same key with a different operation (CONFLICT)', async () => {
+      (prisma.fundTransaction.findUnique as jest.Mock).mockResolvedValue(
+        makeTransaction({ idempotencyKey: 'key-1', amountMinor: 100 }),
+      );
+      await expect(
+        service.createTransaction('tenant-1', 'fund-1', 'member-1', roles, {
+          direction: FundTransactionDirection.CREDIT,
+          amountMinor: 999,
+          currencyCode: 'USD',
+          occurredAt: '2026-08-14T00:00:00.000Z',
+          idempotencyKey: 'key-1',
+        }),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('recovers from a P2002 unique race by returning the existing transaction', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      mockLedger([], []);
+      // Pre-check (findUnique inicial) → miss; luego el create choca con el unique
+      (prisma.fundTransaction.findUnique as jest.Mock)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(
+          makeTransaction({
+            id: 'tx-winner',
+            idempotencyKey: 'key-race',
+            amountMinor: 50000,
+          }),
+        );
+      (prisma.fundTransaction.create as jest.Mock).mockRejectedValueOnce(
+        new Prisma.PrismaClientKnownRequestError('unique violation', {
+          code: 'P2002',
+          clientVersion: '5.22.0',
+          meta: { target: ['FundTransaction_tenantId_idempotencyKey_key'] },
+        }),
+      );
+
+      const result = await service.createTransaction('tenant-1', 'fund-1', 'member-1', roles, {
+        direction: FundTransactionDirection.CREDIT,
+        amountMinor: 50000,
+        currencyCode: 'USD',
+        occurredAt: '2026-08-14T00:00:00.000Z',
+        idempotencyKey: 'key-race',
+      });
+
+      expect(result.id).toBe('tx-winner');
+      expect(prisma.fundTransaction.findUnique).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // ── Reversal ────────────────────────────────────────────────────────────
+
+  describe('reverseTransaction', () => {
+    it('reverses a CREDIT with an opposite DEBIT of the same amount/currency', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      (prisma.fundTransaction.findFirst as jest.Mock).mockResolvedValue(
+        makeTransaction({ direction: FundTransactionDirection.CREDIT, amountMinor: 50000 }),
+      );
+      (prisma.fundTransaction.findUnique as jest.Mock).mockResolvedValue(null);
+      mockLedger([{ currencyCode: 'USD', amountMinor: 50000 }], []);
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValue(
+        makeTransaction({
+          id: 'tx-reversal',
+          direction: FundTransactionDirection.DEBIT,
+          amountMinor: 50000,
+          reversalOfTransactionId: 'tx-1',
+        }),
+      );
+
+      const result = await service.reverseTransaction('tenant-1', 'fund-1', 'tx-1', 'member-1', roles);
+
+      expect(result.direction).toBe(FundTransactionDirection.DEBIT);
+      expect(result.amountMinor).toBe(50000);
+      expect(result.reversalOfTransactionId).toBe('tx-1');
+      expect(prisma.fundTransaction.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            reversalOfTransactionId: 'tx-1',
+            currencyCode: 'USD',
+            amountMinor: 50000,
+          }),
+        }),
+      );
+      expect(audit.createLogRequired).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'FUND_TRANSACTION_REVERSE' }),
+        expect.anything(),
+      );
+    });
+
+    it('rejects reversing a transaction twice', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      (prisma.fundTransaction.findFirst as jest.Mock).mockResolvedValue(
+        makeTransaction({ direction: FundTransactionDirection.CREDIT, amountMinor: 50000 }),
+      );
+      (prisma.fundTransaction.findUnique as jest.Mock).mockResolvedValue(
+        makeTransaction({ id: 'tx-reversal', reversalOfTransactionId: 'tx-1' }),
+      );
+
+      await expect(
+        service.reverseTransaction('tenant-1', 'fund-1', 'tx-1', 'member-1', roles),
+      ).rejects.toThrow(ConflictException);
+      expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects reversing a transaction that is itself a reversal', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      (prisma.fundTransaction.findFirst as jest.Mock).mockResolvedValue(
+        makeTransaction({ reversalOfTransactionId: 'tx-0' }),
+      );
+
+      await expect(
+        service.reverseTransaction('tenant-1', 'fund-1', 'tx-1', 'member-1', roles),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('rejects reversing a transaction from another tenant/fund', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      (prisma.fundTransaction.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        service.reverseTransaction('tenant-1', 'fund-1', 'tx-other', 'member-1', roles),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects a credit reversal (→ DEBIT) that would make the balance negative', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      (prisma.fundTransaction.findFirst as jest.Mock).mockResolvedValue(
+        makeTransaction({ direction: FundTransactionDirection.CREDIT, amountMinor: 50000 }),
+      );
+      (prisma.fundTransaction.findUnique as jest.Mock).mockResolvedValue(null);
+      mockLedger([{ currencyCode: 'USD', amountMinor: 30000 }], []);
+
+      await expect(
+        service.reverseTransaction('tenant-1', 'fund-1', 'tx-1', 'member-1', roles),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects reversal on an archived fund', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(
+        makeFund({ status: FundStatus.ARCHIVED }),
+      );
+      await expect(
+        service.reverseTransaction('tenant-1', 'fund-1', 'tx-1', 'member-1', roles),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ── Tenant isolation ────────────────────────────────────────────────────
+
+  describe('tenant isolation', () => {
+    it('never queries without tenantId scope', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.fundTransaction.groupBy as jest.Mock).mockResolvedValue([]);
+
+      await service.listFunds('tenant-1', roles);
+
+      expect(
+        (prisma.fund.findMany as jest.Mock).mock.calls.every(
+          ([query]) => query.where.tenantId === 'tenant-1',
+        ),
+      ).toBe(true);
+    });
+
+    it('scopes transactions listing to tenantId + fundId', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      (prisma.fundTransaction.findMany as jest.Mock).mockResolvedValue([]);
+
+      await service.listTransactions('tenant-1', 'fund-1', roles);
+
+      expect(prisma.fundTransaction.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { tenantId: 'tenant-1', fundId: 'fund-1' },
+        }),
+      );
+    });
+  });
+
+  // ── Audit atomicity ─────────────────────────────────────────────────────
+
+  describe('audit atomicity', () => {
+    it('audits FUND_TRANSACTION_CREATE with createLogRequired (same-tx boundary)', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      mockLedger([], []);
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValue(
+        makeTransaction(),
+      );
+
+      await service.createTransaction('tenant-1', 'fund-1', 'member-1', roles, {
+        direction: FundTransactionDirection.CREDIT,
+        amountMinor: 50000,
+        currencyCode: 'USD',
+        occurredAt: '2026-08-14T00:00:00.000Z',
+      });
+
+      expect(audit.createLogRequired).toHaveBeenCalledTimes(1);
+      expect(audit.createLogRequired).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'FUND_TRANSACTION_CREATE' }),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/apps/api/src/finanzas/funds.service.spec.ts
+++ b/apps/api/src/finanzas/funds.service.spec.ts
@@ -806,5 +806,76 @@ describe('FundsService', () => {
         expect.anything(),
       );
     });
+
+    it('createFund writes FUND_CREATE audit with the transaction client', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.fund.create as jest.Mock).mockResolvedValue(makeFund());
+
+      await service.createFund('tenant-1', 'member-1', roles, {
+        scopeType: 'TENANT',
+        type: 'RESERVE',
+        name: 'Fondo de reserva',
+      });
+
+      expect(audit.createLogRequired).toHaveBeenCalledTimes(1);
+      expect(audit.createLogRequired).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'FUND_CREATE', entityId: 'fund-1' }),
+        expect.anything(),
+      );
+    });
+
+    it('createFund propagates the error when the required audit fails', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.fund.create as jest.Mock).mockResolvedValue(makeFund());
+      (audit.createLogRequired as jest.Mock).mockRejectedValue(
+        new Error('FORCED_AUDIT_FAILURE'),
+      );
+
+      await expect(
+        service.createFund('tenant-1', 'member-1', roles, {
+          scopeType: 'TENANT',
+          type: 'RESERVE',
+          name: 'Fondo de reserva',
+        }),
+      ).rejects.toThrow('FORCED_AUDIT_FAILURE');
+      // el fund.create se ejecutó dentro del tx, pero el error debe propagarse
+      // (el rollback real lo demuestra el test PostgreSQL)
+    });
+
+    it('updateFund writes FUND_UPDATE audit with the transaction client', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.fund.update as jest.Mock).mockResolvedValue(
+        makeFund({ name: 'Nuevo nombre' }),
+      );
+      mockLedger([], []);
+
+      await service.updateFund('tenant-1', 'fund-1', 'member-1', roles, {
+        name: 'Nuevo nombre',
+      });
+
+      expect(audit.createLogRequired).toHaveBeenCalledTimes(1);
+      expect(audit.createLogRequired).toHaveBeenCalledWith(
+        expect.objectContaining({ action: 'FUND_UPDATE' }),
+        expect.anything(),
+      );
+    });
+
+    it('updateFund propagates the error when the required audit fails', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.fund.update as jest.Mock).mockResolvedValue(
+        makeFund({ name: 'Nuevo nombre' }),
+      );
+      (audit.createLogRequired as jest.Mock).mockRejectedValue(
+        new Error('FORCED_AUDIT_FAILURE'),
+      );
+
+      await expect(
+        service.updateFund('tenant-1', 'fund-1', 'member-1', roles, {
+          name: 'Nuevo nombre',
+        }),
+      ).rejects.toThrow('FORCED_AUDIT_FAILURE');
+    });
   });
 });

--- a/apps/api/src/finanzas/funds.service.ts
+++ b/apps/api/src/finanzas/funds.service.ts
@@ -220,6 +220,11 @@ export class FundsService {
     this.assertAdminOrOperator(userRoles, 'archivar fondos');
 
     return this.prisma.$transaction(async (tx) => {
+      // Mismo advisory lock que createTransaction/reverseTransaction: serializa
+      // la transición ACTIVE→ARCHIVED contra mutaciones de saldo (evita
+      // archivar un fondo con saldo no cero creado por un CREDIT concurrente).
+      await this.acquireFundLock(tx, tenantId, fundId);
+
       const fund = await tx.fund.findFirst({
         where: { id: fundId, tenantId },
       });
@@ -312,27 +317,27 @@ export class FundsService {
       }
     }
 
-    return this.prisma.$transaction(async (tx) => {
-      // Advisory lock: serializa balance-guard y creación del movimiento
-      await this.acquireFundLock(tx, tenantId, fundId);
+    let transaction: Prisma.FundTransactionGetPayload<Record<string, never>>;
+    try {
+      transaction = await this.prisma.$transaction(async (tx) => {
+        // Advisory lock: serializa balance-guard y creación del movimiento
+        await this.acquireFundLock(tx, tenantId, fundId);
 
-      const fund = await tx.fund.findFirst({
-        where: { id: fundId, tenantId },
-      });
-      if (!fund) {
-        throw new NotFoundException('Fondo no encontrado o no pertenece al tenant');
-      }
-      if (fund.status === FundStatus.ARCHIVED) {
-        throw new BadRequestException('No se pueden registrar movimientos en un fondo archivado');
-      }
+        const fund = await tx.fund.findFirst({
+          where: { id: fundId, tenantId },
+        });
+        if (!fund) {
+          throw new NotFoundException('Fondo no encontrado o no pertenece al tenant');
+        }
+        if (fund.status === FundStatus.ARCHIVED) {
+          throw new BadRequestException('No se pueden registrar movimientos en un fondo archivado');
+        }
 
-      if (dto.direction === FundTransactionDirection.DEBIT) {
-        await this.assertSufficientBalance(tx, tenantId, fundId, dto.currencyCode, dto.amountMinor);
-      }
+        if (dto.direction === FundTransactionDirection.DEBIT) {
+          await this.assertSufficientBalance(tx, tenantId, fundId, dto.currencyCode, dto.amountMinor);
+        }
 
-      let transaction: Prisma.FundTransactionGetPayload<Record<string, never>>;
-      try {
-        transaction = await tx.fundTransaction.create({
+        const created = await tx.fundTransaction.create({
           data: {
             tenantId,
             fundId,
@@ -345,51 +350,55 @@ export class FundsService {
             idempotencyKey: dto.idempotencyKey ?? null,
           },
         });
-      } catch (error) {
-        // Race de idempotencyKey (unique (tenantId, idempotencyKey)): otra
-        // request creó el movimiento entre el findUnique y el create.
-        if (
-          dto.idempotencyKey &&
-          error instanceof Prisma.PrismaClientKnownRequestError &&
-          error.code === 'P2002'
-        ) {
-          const existing = await tx.fundTransaction.findUnique({
-            where: {
-              tenantId_idempotencyKey: {
-                tenantId,
-                idempotencyKey: dto.idempotencyKey,
-              },
+
+        await this.auditService.createLogRequired(
+          {
+            tenantId,
+            actorMembershipId: membershipId,
+            action: 'FUND_TRANSACTION_CREATE',
+            entityType: 'FundTransaction',
+            entityId: created.id,
+            metadata: {
+              fundId,
+              direction: dto.direction,
+              amountMinor: dto.amountMinor,
+              currencyCode: dto.currencyCode,
+              occurredAt: dto.occurredAt,
+              idempotencyKey: dto.idempotencyKey ?? null,
             },
-          });
-          if (existing) {
-            await this.assertSameOperation(existing, fundId, dto);
-            return this.toTransactionDto(existing);
-          }
-        }
-        throw error;
-      }
-
-      await this.auditService.createLogRequired(
-        {
-          tenantId,
-          actorMembershipId: membershipId,
-          action: 'FUND_TRANSACTION_CREATE',
-          entityType: 'FundTransaction',
-          entityId: transaction.id,
-          metadata: {
-            fundId,
-            direction: dto.direction,
-            amountMinor: dto.amountMinor,
-            currencyCode: dto.currencyCode,
-            occurredAt: dto.occurredAt,
-            idempotencyKey: dto.idempotencyKey ?? null,
           },
-        },
-        tx,
-      );
+          tx,
+        );
 
-      return this.toTransactionDto(transaction);
-    });
+        return created;
+      });
+    } catch (error) {
+      // Race de idempotencyKey (unique (tenantId, idempotencyKey)): otra request
+      // creó el movimiento entre el pre-check y el create. El unique violation
+      // aborta el tx PostgreSQL, así que NO se consulta con el mismo tx.
+      // Se deja el tx rollbackear y se consulta FUERA con this.prisma.
+      if (
+        dto.idempotencyKey &&
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        const winner = await this.prisma.fundTransaction.findUnique({
+          where: {
+            tenantId_idempotencyKey: {
+              tenantId,
+              idempotencyKey: dto.idempotencyKey,
+            },
+          },
+        });
+        if (winner) {
+          await this.assertSameOperation(winner, fundId, dto);
+          return this.toTransactionDto(winner);
+        }
+      }
+      throw error;
+    }
+
+    return this.toTransactionDto(transaction);
   }
 
   async reverseTransaction(

--- a/apps/api/src/finanzas/funds.service.ts
+++ b/apps/api/src/finanzas/funds.service.ts
@@ -106,21 +106,45 @@ export class FundsService {
 
     let fund: Prisma.FundGetPayload<Record<string, never>>;
     try {
-      fund = await this.prisma.fund.create({
-        data: {
-          tenantId,
-          buildingId: dto.scopeType === 'BUILDING' ? dto.buildingId : null,
-          scopeType: dto.scopeType,
-          type: dto.type,
-          name: dto.name.trim(),
-          description: dto.description?.trim() || null,
-          status: FundStatus.ACTIVE,
-          createdByMembershipId: membershipId,
-        },
+      // Fund.create + FUND_CREATE audit en la MISMA transacción (ALL OR NOTHING).
+      // Si el audit falla, el Fund no persiste.
+      fund = await this.prisma.$transaction(async (tx) => {
+        const created = await tx.fund.create({
+          data: {
+            tenantId,
+            buildingId: dto.scopeType === 'BUILDING' ? dto.buildingId : null,
+            scopeType: dto.scopeType,
+            type: dto.type,
+            name: dto.name.trim(),
+            description: dto.description?.trim() || null,
+            status: FundStatus.ACTIVE,
+            createdByMembershipId: membershipId,
+          },
+        });
+
+        await this.auditService.createLogRequired(
+          {
+            tenantId,
+            actorMembershipId: membershipId,
+            action: 'FUND_CREATE',
+            entityType: 'Fund',
+            entityId: created.id,
+            metadata: {
+              scopeType: dto.scopeType,
+              buildingId: created.buildingId,
+              type: dto.type,
+              name: created.name,
+            },
+          },
+          tx,
+        );
+
+        return created;
       });
     } catch (error) {
       // Race de nombre activo (unique parcial Fund_active_name_*): otra request
       // creó un fondo activo con el mismo nombre normalizado en el mismo scope.
+      // El unique violation aborta el tx; se captura FUERA de la transacción.
       if (this.isActiveNameUniqueViolation(error)) {
         throw new ConflictException(
           'Ya existe un fondo activo con el mismo nombre en este alcance',
@@ -128,23 +152,6 @@ export class FundsService {
       }
       throw error;
     }
-
-    await this.auditService.createLogRequired(
-      {
-        tenantId,
-        actorMembershipId: membershipId,
-        action: 'FUND_CREATE',
-        entityType: 'Fund',
-        entityId: fund.id,
-        metadata: {
-          scopeType: dto.scopeType,
-          buildingId: fund.buildingId,
-          type: dto.type,
-          name: fund.name,
-        },
-      },
-      this.prisma,
-    );
 
     return this.toFundDto(fund, []);
   }
@@ -177,14 +184,35 @@ export class FundsService {
 
     let updated: Prisma.FundGetPayload<Record<string, never>>;
     try {
-      updated = await this.prisma.fund.update({
-        where: { id: fund.id },
-        data: {
-          ...(dto.name !== undefined ? { name: dto.name.trim() } : {}),
-          ...(dto.description !== undefined
-            ? { description: dto.description?.trim() || null }
-            : {}),
-        },
+      // fund.update + FUND_UPDATE audit en la MISMA transacción (ALL OR NOTHING).
+      // Si el audit falla, name/description hacen rollback.
+      updated = await this.prisma.$transaction(async (tx) => {
+        const changed = await tx.fund.update({
+          where: { id: fund.id },
+          data: {
+            ...(dto.name !== undefined ? { name: dto.name.trim() } : {}),
+            ...(dto.description !== undefined
+              ? { description: dto.description?.trim() || null }
+              : {}),
+          },
+        });
+
+        await this.auditService.createLogRequired(
+          {
+            tenantId,
+            actorMembershipId: membershipId,
+            action: 'FUND_UPDATE',
+            entityType: 'Fund',
+            entityId: fund.id,
+            metadata: {
+              before: { name: fund.name },
+              after: { name: changed.name },
+            },
+          },
+          tx,
+        );
+
+        return changed;
       });
     } catch (error) {
       if (this.isActiveNameUniqueViolation(error)) {
@@ -194,18 +222,6 @@ export class FundsService {
       }
       throw error;
     }
-
-    await this.auditService.createLogRequired(
-      {
-        tenantId,
-        actorMembershipId: membershipId,
-        action: 'FUND_UPDATE',
-        entityType: 'Fund',
-        entityId: fund.id,
-        metadata: { before: { name: fund.name }, after: { name: updated.name } },
-      },
-      this.prisma,
-    );
 
     const balances = await this.loadBalancesForFunds(tenantId, [updated.id]);
     return this.toFundDto(updated, balances.get(updated.id) ?? []);

--- a/apps/api/src/finanzas/funds.service.ts
+++ b/apps/api/src/finanzas/funds.service.ts
@@ -1,0 +1,761 @@
+import {
+  Injectable,
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Prisma, FundStatus, FundTransactionDirection } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+import {
+  CreateFundDto,
+  UpdateFundDto,
+  FundQueryDto,
+  FundResponseDto,
+  CreateFundTransactionDto,
+  ReverseFundTransactionDto,
+  FundTransactionResponseDto,
+} from './funds.dto';
+
+const ADVISORY_LOCK_TAG = 'buildingos_fund_lock_v1';
+
+/**
+ * Genera un advisory lock key estable por (tenantId, fundId).
+ * Usado dentro de $transaction para serializar operaciones que leen/escriben
+ * el ledger de un fondo (balance-guard bajo concurrencia).
+ */
+function fundAdvisoryLockKey(tenantId: string, fundId: string): string {
+  return `${ADVISORY_LOCK_TAG}:${tenantId}:${fundId}`;
+}
+
+type FundWithBalance = Prisma.FundGetPayload<Record<string, never>> & {
+  balancesByCurrency: Array<{ currency: string; amountMinor: number }>;
+};
+
+@Injectable()
+export class FundsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auditService: AuditService,
+    private readonly validators: FinanzasValidators,
+  ) {}
+
+  // ── Public API ────────────────────────────────────────────────────────────
+
+  async listFunds(
+    tenantId: string,
+    userRoles: string[],
+    query: FundQueryDto = {},
+  ): Promise<FundResponseDto[]> {
+    this.assertAdminOrOperator(userRoles, 'ver fondos');
+
+    const funds = await this.prisma.fund.findMany({
+      where: {
+        tenantId,
+        ...(query.buildingId ? { buildingId: query.buildingId } : {}),
+        ...(query.scopeType ? { scopeType: query.scopeType } : {}),
+        ...(query.status ? { status: query.status } : {}),
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    const balances = await this.loadBalancesForFunds(tenantId, funds.map((f) => f.id));
+
+    return funds.map((fund) =>
+      this.toFundDto(fund, balances.get(fund.id) ?? []),
+    );
+  }
+
+  async getFund(
+    tenantId: string,
+    fundId: string,
+    userRoles: string[],
+  ): Promise<FundResponseDto> {
+    this.assertAdminOrOperator(userRoles, 'ver fondos');
+
+    const fund = await this.prisma.fund.findFirst({
+      where: { id: fundId, tenantId },
+    });
+    if (!fund) {
+      throw new NotFoundException('Fondo no encontrado o no pertenece al tenant');
+    }
+
+    const balances = await this.loadBalancesForFunds(tenantId, [fund.id]);
+    return this.toFundDto(fund, balances.get(fund.id) ?? []);
+  }
+
+  async createFund(
+    tenantId: string,
+    membershipId: string,
+    userRoles: string[],
+    dto: CreateFundDto,
+  ): Promise<FundResponseDto> {
+    this.assertAdminOrOperator(userRoles, 'crear fondos');
+
+    await this.assertScopeInvariant(tenantId, dto.scopeType, dto.buildingId);
+
+    // Nombre duplicado activo dentro del mismo scope (case/space-insensitive)
+    await this.assertNoActiveDuplicateName(
+      tenantId,
+      dto.scopeType,
+      dto.buildingId ?? null,
+      dto.name,
+    );
+
+    let fund: Prisma.FundGetPayload<Record<string, never>>;
+    try {
+      fund = await this.prisma.fund.create({
+        data: {
+          tenantId,
+          buildingId: dto.scopeType === 'BUILDING' ? dto.buildingId : null,
+          scopeType: dto.scopeType,
+          type: dto.type,
+          name: dto.name.trim(),
+          description: dto.description?.trim() || null,
+          status: FundStatus.ACTIVE,
+          createdByMembershipId: membershipId,
+        },
+      });
+    } catch (error) {
+      // Race de nombre activo (unique parcial Fund_active_name_*): otra request
+      // creó un fondo activo con el mismo nombre normalizado en el mismo scope.
+      if (this.isActiveNameUniqueViolation(error)) {
+        throw new ConflictException(
+          'Ya existe un fondo activo con el mismo nombre en este alcance',
+        );
+      }
+      throw error;
+    }
+
+    await this.auditService.createLogRequired(
+      {
+        tenantId,
+        actorMembershipId: membershipId,
+        action: 'FUND_CREATE',
+        entityType: 'Fund',
+        entityId: fund.id,
+        metadata: {
+          scopeType: dto.scopeType,
+          buildingId: fund.buildingId,
+          type: dto.type,
+          name: fund.name,
+        },
+      },
+      this.prisma,
+    );
+
+    return this.toFundDto(fund, []);
+  }
+
+  async updateFund(
+    tenantId: string,
+    fundId: string,
+    membershipId: string,
+    userRoles: string[],
+    dto: UpdateFundDto,
+  ): Promise<FundResponseDto> {
+    this.assertAdminOrOperator(userRoles, 'editar fondos');
+
+    const fund = await this.prisma.fund.findFirst({
+      where: { id: fundId, tenantId },
+    });
+    if (!fund) {
+      throw new NotFoundException('Fondo no encontrado o no pertenece al tenant');
+    }
+
+    if (dto.name !== undefined && dto.name !== fund.name) {
+      await this.assertNoActiveDuplicateName(
+        tenantId,
+        fund.scopeType,
+        fund.buildingId,
+        dto.name,
+        { excludeFundId: fund.id },
+      );
+    }
+
+    let updated: Prisma.FundGetPayload<Record<string, never>>;
+    try {
+      updated = await this.prisma.fund.update({
+        where: { id: fund.id },
+        data: {
+          ...(dto.name !== undefined ? { name: dto.name.trim() } : {}),
+          ...(dto.description !== undefined
+            ? { description: dto.description?.trim() || null }
+            : {}),
+        },
+      });
+    } catch (error) {
+      if (this.isActiveNameUniqueViolation(error)) {
+        throw new ConflictException(
+          'Ya existe un fondo activo con el mismo nombre en este alcance',
+        );
+      }
+      throw error;
+    }
+
+    await this.auditService.createLogRequired(
+      {
+        tenantId,
+        actorMembershipId: membershipId,
+        action: 'FUND_UPDATE',
+        entityType: 'Fund',
+        entityId: fund.id,
+        metadata: { before: { name: fund.name }, after: { name: updated.name } },
+      },
+      this.prisma,
+    );
+
+    const balances = await this.loadBalancesForFunds(tenantId, [updated.id]);
+    return this.toFundDto(updated, balances.get(updated.id) ?? []);
+  }
+
+  async archiveFund(
+    tenantId: string,
+    fundId: string,
+    membershipId: string,
+    userRoles: string[],
+  ): Promise<FundResponseDto> {
+    this.assertAdminOrOperator(userRoles, 'archivar fondos');
+
+    return this.prisma.$transaction(async (tx) => {
+      const fund = await tx.fund.findFirst({
+        where: { id: fundId, tenantId },
+      });
+      if (!fund) {
+        throw new NotFoundException('Fondo no encontrado o no pertenece al tenant');
+      }
+      if (fund.status === FundStatus.ARCHIVED) {
+        throw new BadRequestException('El fondo ya está archivado');
+      }
+
+      const balances = await this.computeBalances(tx, tenantId, fundId);
+      const nonZero = balances.filter((b) => b.amountMinor !== 0);
+      if (nonZero.length > 0) {
+        throw new ConflictException(
+          'No se puede archivar un fondo con saldo distinto de cero',
+        );
+      }
+
+      const archived = await tx.fund.update({
+        where: { id: fund.id },
+        data: {
+          status: FundStatus.ARCHIVED,
+          archivedAt: new Date(),
+          archivedByMembershipId: membershipId,
+        },
+      });
+
+      await this.auditService.createLogRequired(
+        {
+          tenantId,
+          actorMembershipId: membershipId,
+          action: 'FUND_ARCHIVE',
+          entityType: 'Fund',
+          entityId: fund.id,
+          metadata: { previousStatus: fund.status, newStatus: FundStatus.ARCHIVED },
+        },
+        tx,
+      );
+
+      return this.toFundDto(archived, balances);
+    });
+  }
+
+  async listTransactions(
+    tenantId: string,
+    fundId: string,
+    userRoles: string[],
+    query: { currencyCode?: string; limit?: number; offset?: number } = {},
+  ): Promise<FundTransactionResponseDto[]> {
+    this.assertAdminOrOperator(userRoles, 'ver movimientos de fondos');
+
+    await this.assertFundInTenant(tenantId, fundId);
+
+    const transactions = await this.prisma.fundTransaction.findMany({
+      where: {
+        tenantId,
+        fundId,
+        ...(query.currencyCode ? { currencyCode: query.currencyCode } : {}),
+      },
+      orderBy: { createdAt: 'asc' },
+      take: query.limit ?? 100,
+      skip: query.offset ?? 0,
+    });
+
+    return transactions.map((tx) => this.toTransactionDto(tx));
+  }
+
+  async createTransaction(
+    tenantId: string,
+    fundId: string,
+    membershipId: string,
+    userRoles: string[],
+    dto: CreateFundTransactionDto,
+  ): Promise<FundTransactionResponseDto> {
+    this.assertAdminOrOperator(userRoles, 'registrar movimientos de fondos');
+
+    // Idempotencia: misma key + mismo tenant => devolver la transacción existente
+    if (dto.idempotencyKey) {
+      const existing = await this.prisma.fundTransaction.findUnique({
+        where: {
+          tenantId_idempotencyKey: {
+            tenantId,
+            idempotencyKey: dto.idempotencyKey,
+          },
+        },
+      });
+      if (existing) {
+        await this.assertSameOperation(existing, fundId, dto);
+        return this.toTransactionDto(existing);
+      }
+    }
+
+    return this.prisma.$transaction(async (tx) => {
+      // Advisory lock: serializa balance-guard y creación del movimiento
+      await this.acquireFundLock(tx, tenantId, fundId);
+
+      const fund = await tx.fund.findFirst({
+        where: { id: fundId, tenantId },
+      });
+      if (!fund) {
+        throw new NotFoundException('Fondo no encontrado o no pertenece al tenant');
+      }
+      if (fund.status === FundStatus.ARCHIVED) {
+        throw new BadRequestException('No se pueden registrar movimientos en un fondo archivado');
+      }
+
+      if (dto.direction === FundTransactionDirection.DEBIT) {
+        await this.assertSufficientBalance(tx, tenantId, fundId, dto.currencyCode, dto.amountMinor);
+      }
+
+      let transaction: Prisma.FundTransactionGetPayload<Record<string, never>>;
+      try {
+        transaction = await tx.fundTransaction.create({
+          data: {
+            tenantId,
+            fundId,
+            direction: dto.direction,
+            amountMinor: dto.amountMinor,
+            currencyCode: dto.currencyCode,
+            occurredAt: new Date(dto.occurredAt),
+            description: dto.description?.trim() || null,
+            createdByMembershipId: membershipId,
+            idempotencyKey: dto.idempotencyKey ?? null,
+          },
+        });
+      } catch (error) {
+        // Race de idempotencyKey (unique (tenantId, idempotencyKey)): otra
+        // request creó el movimiento entre el findUnique y el create.
+        if (
+          dto.idempotencyKey &&
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === 'P2002'
+        ) {
+          const existing = await tx.fundTransaction.findUnique({
+            where: {
+              tenantId_idempotencyKey: {
+                tenantId,
+                idempotencyKey: dto.idempotencyKey,
+              },
+            },
+          });
+          if (existing) {
+            await this.assertSameOperation(existing, fundId, dto);
+            return this.toTransactionDto(existing);
+          }
+        }
+        throw error;
+      }
+
+      await this.auditService.createLogRequired(
+        {
+          tenantId,
+          actorMembershipId: membershipId,
+          action: 'FUND_TRANSACTION_CREATE',
+          entityType: 'FundTransaction',
+          entityId: transaction.id,
+          metadata: {
+            fundId,
+            direction: dto.direction,
+            amountMinor: dto.amountMinor,
+            currencyCode: dto.currencyCode,
+            occurredAt: dto.occurredAt,
+            idempotencyKey: dto.idempotencyKey ?? null,
+          },
+        },
+        tx,
+      );
+
+      return this.toTransactionDto(transaction);
+    });
+  }
+
+  async reverseTransaction(
+    tenantId: string,
+    fundId: string,
+    transactionId: string,
+    membershipId: string,
+    userRoles: string[],
+    dto: ReverseFundTransactionDto = {},
+  ): Promise<FundTransactionResponseDto> {
+    this.assertAdminOrOperator(userRoles, 'reversar movimientos de fondos');
+
+    return this.prisma.$transaction(async (tx) => {
+      await this.acquireFundLock(tx, tenantId, fundId);
+
+      const fund = await tx.fund.findFirst({
+        where: { id: fundId, tenantId },
+      });
+      if (!fund) {
+        throw new NotFoundException('Fondo no encontrado o no pertenece al tenant');
+      }
+      if (fund.status === FundStatus.ARCHIVED) {
+        throw new BadRequestException('No se pueden reversar movimientos en un fondo archivado');
+      }
+
+      const original = await tx.fundTransaction.findFirst({
+        where: { id: transactionId, tenantId, fundId },
+      });
+      if (!original) {
+        throw new NotFoundException('Movimiento no encontrado o no pertenece a este fondo');
+      }
+      if (original.reversalOfTransactionId !== null) {
+        throw new ConflictException('No se puede reversar un movimiento que ya es una reversa');
+      }
+
+      // Una transacción solo puede revertirse una vez (unique + check explícito)
+      const existingReversal = await tx.fundTransaction.findUnique({
+        where: { reversalOfTransactionId: original.id },
+      });
+      if (existingReversal) {
+        throw new ConflictException('Este movimiento ya fue reversado');
+      }
+
+      const reversalDirection =
+        original.direction === FundTransactionDirection.CREDIT
+          ? FundTransactionDirection.DEBIT
+          : FundTransactionDirection.CREDIT;
+
+      // Reversar un CREDIT (→ DEBIT) no puede dejar saldo negativo
+      if (reversalDirection === FundTransactionDirection.DEBIT) {
+        await this.assertSufficientBalance(
+          tx,
+          tenantId,
+          fundId,
+          original.currencyCode,
+          original.amountMinor,
+        );
+      }
+
+      const reversal = await tx.fundTransaction.create({
+        data: {
+          tenantId,
+          fundId,
+          direction: reversalDirection,
+          amountMinor: original.amountMinor,
+          currencyCode: original.currencyCode,
+          occurredAt: new Date(),
+          description: dto.reason?.trim()
+            ? `Reversa de ${original.id}: ${dto.reason.trim()}`
+            : `Reversa de ${original.id}`,
+          createdByMembershipId: membershipId,
+          reversalOfTransactionId: original.id,
+        },
+      });
+
+      await this.auditService.createLogRequired(
+        {
+          tenantId,
+          actorMembershipId: membershipId,
+          action: 'FUND_TRANSACTION_REVERSE',
+          entityType: 'FundTransaction',
+          entityId: reversal.id,
+          metadata: {
+            fundId,
+            originalTransactionId: original.id,
+            direction: reversalDirection,
+            amountMinor: original.amountMinor,
+            currencyCode: original.currencyCode,
+          },
+        },
+        tx,
+      );
+
+      return this.toTransactionDto(reversal);
+    });
+  }
+
+  // ── Internal helpers ──────────────────────────────────────────────────────
+
+  private assertAdminOrOperator(userRoles: string[], action: string): void {
+    if (!this.validators.isAdminOrOperator(userRoles)) {
+      throw new ForbiddenException(`Solo administradores pueden ${action}`);
+    }
+  }
+
+  /**
+   * Detecta una violación de los unique parciales de nombre activo
+   * (Fund_active_name_tenant_key / Fund_active_name_building_key).
+   * Prisma 5.x expone meta.target como array de nombres de constraint.
+   */
+  private isActiveNameUniqueViolation(error: unknown): boolean {
+    if (!(error instanceof Prisma.PrismaClientKnownRequestError)) {
+      return false;
+    }
+    if (error.code !== 'P2002') {
+      return false;
+    }
+    const target = error.meta?.target;
+    const targets = Array.isArray(target) ? target : [target];
+    return targets.some(
+      (name) =>
+        typeof name === 'string' && name.startsWith('Fund_active_name_'),
+    );
+  }
+
+  private async assertScopeInvariant(
+    tenantId: string,
+    scopeType: CreateFundDto['scopeType'],
+    buildingId?: string,
+  ): Promise<void> {
+    if (scopeType === 'TENANT') {
+      if (buildingId) {
+        throw new BadRequestException(
+          'Un fondo TENANT no puede tener buildingId',
+        );
+      }
+      return;
+    }
+    // BUILDING
+    if (!buildingId) {
+      throw new BadRequestException(
+        'buildingId es requerido para un fondo BUILDING',
+      );
+    }
+    await this.validators.validateBuildingBelongsToTenant(tenantId, buildingId);
+  }
+
+  private async assertNoActiveDuplicateName(
+    tenantId: string,
+    scopeType: CreateFundDto['scopeType'],
+    buildingId: string | null,
+    name: string,
+    options: { excludeFundId?: string } = {},
+  ): Promise<void> {
+    const normalized = name.trim().toLowerCase().replace(/\s+/g, ' ');
+
+    const candidates = await this.prisma.fund.findMany({
+      where: {
+        tenantId,
+        scopeType,
+        ...(buildingId ? { buildingId } : { buildingId: null }),
+        status: FundStatus.ACTIVE,
+      },
+      select: { id: true, name: true },
+    });
+
+    const duplicate = candidates.find(
+      (fund) =>
+        fund.id !== options.excludeFundId &&
+        fund.name.trim().toLowerCase().replace(/\s+/g, ' ') === normalized,
+    );
+
+    if (duplicate) {
+      throw new ConflictException(
+        'Ya existe un fondo activo con el mismo nombre en este alcance',
+      );
+    }
+  }
+
+  private async assertFundInTenant(tenantId: string, fundId: string): Promise<void> {
+    const fund = await this.prisma.fund.findFirst({
+      where: { id: fundId, tenantId },
+      select: { id: true },
+    });
+    if (!fund) {
+      throw new NotFoundException('Fondo no encontrado o no pertenece al tenant');
+    }
+  }
+
+  /**
+   * Computa balances por moneda desde el ledger (nunca persistido).
+   * CREDIT suma, DEBIT resta. Monedas independientes.
+   */
+  private async computeBalances(
+    tx: Prisma.TransactionClient | PrismaService,
+    tenantId: string,
+    fundId: string,
+  ): Promise<Array<{ currency: string; amountMinor: number }>> {
+    const credits = await tx.fundTransaction.groupBy({
+      by: ['currencyCode'],
+      where: { tenantId, fundId, direction: FundTransactionDirection.CREDIT },
+      _sum: { amountMinor: true },
+    });
+    const debits = await tx.fundTransaction.groupBy({
+      by: ['currencyCode'],
+      where: { tenantId, fundId, direction: FundTransactionDirection.DEBIT },
+      _sum: { amountMinor: true },
+    });
+
+    const creditByCurrency = new Map(
+      credits.map((row) => [row.currencyCode, row._sum.amountMinor ?? 0]),
+    );
+    const debitByCurrency = new Map(
+      debits.map((row) => [row.currencyCode, row._sum.amountMinor ?? 0]),
+    );
+
+    const currencies = new Set([
+      ...creditByCurrency.keys(),
+      ...debitByCurrency.keys(),
+    ]);
+
+    return [...currencies]
+      .sort()
+      .map((currency) => ({
+        currency,
+        amountMinor:
+          (creditByCurrency.get(currency) ?? 0) -
+          (debitByCurrency.get(currency) ?? 0),
+      }));
+  }
+
+  private async loadBalancesForFunds(
+    tenantId: string,
+    fundIds: string[],
+  ): Promise<Map<string, Array<{ currency: string; amountMinor: number }>>> {
+    if (fundIds.length === 0) {
+      return new Map();
+    }
+
+    const credits = await this.prisma.fundTransaction.groupBy({
+      by: ['fundId', 'currencyCode'],
+      where: {
+        tenantId,
+        fundId: { in: fundIds },
+        direction: FundTransactionDirection.CREDIT,
+      },
+      _sum: { amountMinor: true },
+    });
+    const debits = await this.prisma.fundTransaction.groupBy({
+      by: ['fundId', 'currencyCode'],
+      where: {
+        tenantId,
+        fundId: { in: fundIds },
+        direction: FundTransactionDirection.DEBIT,
+      },
+      _sum: { amountMinor: true },
+    });
+
+    const creditByFund = new Map<string, Map<string, number>>();
+    const debitByFund = new Map<string, Map<string, number>>();
+
+    for (const row of credits) {
+      const map = creditByFund.get(row.fundId) ?? new Map();
+      map.set(row.currencyCode, row._sum.amountMinor ?? 0);
+      creditByFund.set(row.fundId, map);
+    }
+    for (const row of debits) {
+      const map = debitByFund.get(row.fundId) ?? new Map();
+      map.set(row.currencyCode, row._sum.amountMinor ?? 0);
+      debitByFund.set(row.fundId, map);
+    }
+
+    const result = new Map<string, Array<{ currency: string; amountMinor: number }>>();
+    for (const fundId of fundIds) {
+      const creditsMap = creditByFund.get(fundId) ?? new Map();
+      const debitsMap = debitByFund.get(fundId) ?? new Map();
+      const currencies = new Set([...creditsMap.keys(), ...debitsMap.keys()]);
+      result.set(
+        fundId,
+        [...currencies].sort().map((currency) => ({
+          currency,
+          amountMinor:
+            (creditsMap.get(currency) ?? 0) - (debitsMap.get(currency) ?? 0),
+        })),
+      );
+    }
+    return result;
+  }
+
+  private async acquireFundLock(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    fundId: string,
+  ): Promise<void> {
+    await tx.$executeRaw(
+      Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${fundAdvisoryLockKey(tenantId, fundId)}, 0))`,
+    );
+  }
+
+  private async assertSufficientBalance(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    fundId: string,
+    currencyCode: string,
+    amountMinor: number,
+  ): Promise<void> {
+    const balances = await this.computeBalances(tx, tenantId, fundId);
+    const balance = balances.find((b) => b.currency === currencyCode)?.amountMinor ?? 0;
+    if (balance < amountMinor) {
+      throw new BadRequestException(
+        `Saldo insuficiente en ${currencyCode}: saldo ${balance}, débito solicitado ${amountMinor}`,
+      );
+    }
+  }
+
+  private async assertSameOperation(
+    existing: { fundId: string; direction: FundTransactionDirection; amountMinor: number; currencyCode: string },
+    fundId: string,
+    dto: CreateFundTransactionDto,
+  ): Promise<void> {
+    const sameOperation =
+      existing.fundId === fundId &&
+      existing.direction === dto.direction &&
+      existing.amountMinor === dto.amountMinor &&
+      existing.currencyCode === dto.currencyCode;
+    if (!sameOperation) {
+      throw new ConflictException(
+        'La idempotencyKey ya fue utilizada para una operación diferente',
+      );
+    }
+  }
+
+  private toFundDto(
+    fund: Prisma.FundGetPayload<Record<string, never>>,
+    balancesByCurrency: Array<{ currency: string; amountMinor: number }>,
+  ): FundResponseDto {
+    return {
+      id: fund.id,
+      tenantId: fund.tenantId,
+      buildingId: fund.buildingId,
+      scopeType: fund.scopeType,
+      type: fund.type,
+      name: fund.name,
+      description: fund.description,
+      status: fund.status,
+      balancesByCurrency,
+      createdAt: fund.createdAt,
+      archivedAt: fund.archivedAt,
+    };
+  }
+
+  private toTransactionDto(
+    transaction: Prisma.FundTransactionGetPayload<Record<string, never>>,
+  ): FundTransactionResponseDto {
+    return {
+      id: transaction.id,
+      tenantId: transaction.tenantId,
+      fundId: transaction.fundId,
+      direction: transaction.direction,
+      amountMinor: transaction.amountMinor,
+      currencyCode: transaction.currencyCode,
+      occurredAt: transaction.occurredAt,
+      description: transaction.description,
+      idempotencyKey: transaction.idempotencyKey,
+      reversalOfTransactionId: transaction.reversalOfTransactionId,
+      createdAt: transaction.createdAt,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Adds the production-ready foundation for financial funds in BuildingOS without changing the existing Income, Liquidation, Payment, or MovementAllocation behavior.

### Fund

- tenant- or building-scoped funds
- RESERVE / SPECIAL / OTHER types
- ACTIVE / ARCHIVED lifecycle
- active-name uniqueness enforced at PostgreSQL level
- tenant isolation and financial RBAC

### Fund ledger

Adds immutable FundTransaction entries with:

- CREDIT / DEBIT semantics
- balances derived entirely from ledger entries
- independent balances per currency
- overdraft prevention
- idempotency keys
- immutable reversal transactions
- audit logging inside the financial transaction

### Concurrency

Fund balance mutations use PostgreSQL advisory transaction locks so concurrent debits cannot create a negative balance.

Verified with a real PostgreSQL concurrency test:

- initial balance: 10000
- concurrent debit A: 8000
- concurrent debit B: 8000
- exactly one succeeds
- final balance: 2000

Active fund-name uniqueness is also enforced with PostgreSQL partial unique indexes and concurrent creation coverage.

### Migration

Adds:

- FundScopeType
- FundType
- FundStatus
- FundTransactionDirection
- Fund
- FundTransaction
- Fund audit actions
- indexes / constraints

The migration is additive and does not rewrite existing financial data.

## Important scope boundary

This PR intentionally does NOT implement:

- IncomeApplication
- IncomePolicy
- carry-forward
- Income → Liquidation
- frontend funds
- changes to Payment
- changes to MovementAllocation

Those are separate finance slices.

## Validation

- FIN-02 unit: 40 passed / 0 failed
- PostgreSQL integration: 11 passed / 0 failed (overdraft race, archive race, idempotency concurrency, audit rollback, name uniqueness, DB constraints, delete/FK safety)
- Finance regression: 597 passed / 0 failed
- API full: 176 suites passed
- API tests: 2610 passed / 0 failed
- Prisma validate: PASS
- full migration deploy against disposable PostgreSQL: PASS

## Financial invariants

- Fund balance is never stored as a mutable value.
- Balances are reconstructed from FundTransaction.
- Currencies remain independent.
- Funds cannot be overdrawn.
- Transactions are immutable.
- Corrections use reversal transactions.
- Idempotency prevents duplicate monetary writes.
- Tenant isolation is enforced.
- Required audit and monetary mutation are atomic.

## Deferred production-hardening note

Tenant deletion currently follows the repository-wide existing cascade lifecycle used by other financial entities. A global hard-delete / financial-retention policy review is intentionally deferred to the finance production-readiness slice rather than changing Tenant semantics only for Funds in this PR.

---

## Tipo de cambio

- [ ] Bug fix
- [x] Nueva funcionalidad
- [ ] Refactor
- [ ] Cambio de documentación
- [ ] Otro: ___

## Checklist de validación local obligatoria

Antes de abrir este PR, se completó localmente:

- [x] Tests unitarios pasan
- [x] Tests de integración pasan
- [ ] Tests E2E pasan (si aplica)
- [x] Typecheck (`tsc --noEmit`) sin errores
- [x] Lint sin errores nuevos
- [x] Build exitoso
- [x] `git diff --check` limpio
- [x] Confirmé que todos los cambios fueron implementados y probados localmente
- [x] Confirmé que el merge a main activará automáticamente el deploy a staging
- [x] El despliegue automático a staging está autorizado para este PR
- [x] Las migraciones incluidas fueron validadas localmente
- [x] No se requiere preservar ningún archivo temporal dentro del checkout de staging
- [x] La validación funcional en staging está definida para después del merge
