### PR TITLE
fix(finance): omit null fund audit metadata

### DIFF
--- a/apps/api/src/finanzas/funds-concurrency.postgres.spec.ts
+++ b/apps/api/src/finanzas/funds-concurrency.postgres.spec.ts
@@ -572,4 +572,105 @@ describePostgres('Funds ledger PostgreSQL concurrency', () => {
     expect(after.name).toBe(originalName);
     expect(after.name).not.toBe('Reserva modificada');
   }, 20000);
+
+  // ── Real AuditService metadata contract (FIN-02T) ───────────────────────
+
+  it('FUND_CREATE with real AuditService succeeds for a TENANT fund and omits buildingId', async () => {
+    const ctx = await fixture('real-audit-tenant');
+    const realService = buildService(firstClient); // AuditService REAL
+
+    const fund = await realService.createFund(ctx.tenant.id, ctx.membership.id, ['TENANT_ADMIN'], {
+      scopeType: 'TENANT',
+      type: 'RESERVE',
+      name: `Fondo TENANT ${Date.now()}`,
+    });
+
+    expect(fund.status).toBe('ACTIVE');
+    expect(await observer.fund.count({ where: { tenantId: ctx.tenant.id } })).toBe(2); // fixture + nuevo
+
+    const auditLog = await observer.auditLog.findFirst({
+      where: { tenantId: ctx.tenant.id, action: 'FUND_CREATE', entityId: fund.id },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(auditLog).not.toBeNull();
+    const metadata = auditLog!.metadata as Record<string, unknown>;
+    expect('buildingId' in metadata).toBe(false);
+    expect(metadata.scopeType).toBe('TENANT');
+    expect(metadata.type).toBe('RESERVE');
+    expect(metadata.name).toBe(fund.name);
+  }, 20000);
+
+  it('FUND_CREATE with real AuditService includes buildingId for a BUILDING fund', async () => {
+    const ctx = await fixture('real-audit-building');
+    const building = await observer.building.create({
+      data: { tenantId: ctx.tenant.id, name: `B-${Date.now()}`, alias: `B-${Date.now()}`, address: 'x' },
+    });
+    const realService = buildService(firstClient);
+
+    const fund = await realService.createFund(ctx.tenant.id, ctx.membership.id, ['TENANT_ADMIN'], {
+      scopeType: 'BUILDING',
+      buildingId: building.id,
+      type: 'RESERVE',
+      name: `Fondo BUILDING ${Date.now()}`,
+    });
+
+    expect(fund.buildingId).toBe(building.id);
+    const auditLog = await observer.auditLog.findFirst({
+      where: { tenantId: ctx.tenant.id, action: 'FUND_CREATE', entityId: fund.id },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(auditLog).not.toBeNull();
+    const metadata = auditLog!.metadata as Record<string, unknown>;
+    expect(metadata.buildingId).toBe(building.id);
+  }, 20000);
+
+  it('FUND_TRANSACTION_CREATE without idempotencyKey omits it from metadata (real AuditService)', async () => {
+    const ctx = await fixture('real-audit-no-key');
+    const realService = buildService(firstClient);
+
+    await realService.createTransaction(ctx.tenant.id, ctx.fund.id, ctx.membership.id, ['TENANT_ADMIN'], {
+      direction: FundTransactionDirection.CREDIT,
+      amountMinor: 100,
+      currencyCode: 'USD',
+      occurredAt: new Date().toISOString(),
+    });
+
+    expect(await observer.fundTransaction.count({ where: { fundId: ctx.fund.id } })).toBe(1);
+    const balanceRows = await observer.$queryRaw<Array<{ total: bigint | null }>>`
+      SELECT COALESCE(SUM(CASE WHEN direction = 'CREDIT' THEN "amountMinor" ELSE -"amountMinor" END), 0) AS total
+      FROM "FundTransaction" WHERE "fundId" = ${ctx.fund.id} AND "tenantId" = ${ctx.tenant.id}
+    `;
+    expect(Number(balanceRows[0]?.total ?? 0)).toBe(100);
+
+    const auditLog = await observer.auditLog.findFirst({
+      where: { tenantId: ctx.tenant.id, action: 'FUND_TRANSACTION_CREATE' },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(auditLog).not.toBeNull();
+    const metadata = auditLog!.metadata as Record<string, unknown>;
+    expect('idempotencyKey' in metadata).toBe(false);
+    expect(metadata.amountMinor).toBe(100);
+  }, 20000);
+
+  it('FUND_TRANSACTION_CREATE with idempotencyKey keeps it in metadata (real AuditService)', async () => {
+    const ctx = await fixture('real-audit-with-key');
+    const realService = buildService(firstClient);
+    const key = `fin02t-real-audit-${Date.now()}`;
+
+    await realService.createTransaction(ctx.tenant.id, ctx.fund.id, ctx.membership.id, ['TENANT_ADMIN'], {
+      direction: FundTransactionDirection.CREDIT,
+      amountMinor: 100,
+      currencyCode: 'USD',
+      occurredAt: new Date().toISOString(),
+      idempotencyKey: key,
+    });
+
+    const auditLog = await observer.auditLog.findFirst({
+      where: { tenantId: ctx.tenant.id, action: 'FUND_TRANSACTION_CREATE' },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(auditLog).not.toBeNull();
+    const metadata = auditLog!.metadata as Record<string, unknown>;
+    expect(metadata.idempotencyKey).toBe(key);
+  }, 20000);
 });

--- a/apps/api/src/finanzas/funds.service.spec.ts
+++ b/apps/api/src/finanzas/funds.service.spec.ts
@@ -878,4 +878,93 @@ describe('FundsService', () => {
       ).rejects.toThrow('FORCED_AUDIT_FAILURE');
     });
   });
+
+  // ── Audit metadata null contract (FIN-02T) ──────────────────────────────
+
+  describe('audit metadata null contract', () => {
+    /** Devuelve el metadata del primer createLogRequired invocado. */
+    function lastAuditMetadata(): Record<string, unknown> {
+      expect(audit.createLogRequired).toHaveBeenCalledTimes(1);
+      const call = (audit.createLogRequired as jest.Mock).mock.calls[0] as [
+        { metadata: Record<string, unknown> },
+      ];
+      return call[0].metadata;
+    }
+
+    it('omits buildingId from FUND_CREATE metadata for a TENANT fund (property absent)', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.fund.create as jest.Mock).mockResolvedValue(
+        makeFund({ buildingId: null, scopeType: 'TENANT' }),
+      );
+
+      await service.createFund('tenant-1', 'member-1', roles, {
+        scopeType: 'TENANT',
+        type: 'RESERVE',
+        name: 'Fondo de reserva',
+      });
+
+      const metadata = lastAuditMetadata();
+      expect('buildingId' in metadata).toBe(false);
+      expect(metadata.scopeType).toBe('TENANT');
+      expect(metadata.type).toBe('RESERVE');
+      expect(metadata.name).toBe('Fondo de reserva');
+    });
+
+    it('includes buildingId in FUND_CREATE metadata for a BUILDING fund', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.fund.create as jest.Mock).mockResolvedValue(
+        makeFund({ buildingId: 'building-1', scopeType: 'BUILDING' }),
+      );
+
+      await service.createFund('tenant-1', 'member-1', roles, {
+        scopeType: 'BUILDING',
+        buildingId: 'building-1',
+        type: 'SPECIAL',
+        name: 'Fondo ascensores',
+      });
+
+      const metadata = lastAuditMetadata();
+      expect('buildingId' in metadata).toBe(true);
+      expect(metadata.buildingId).toBe('building-1');
+    });
+
+    it('omits idempotencyKey from FUND_TRANSACTION_CREATE metadata when absent', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      mockLedger([], []);
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValue(
+        makeTransaction({ idempotencyKey: null }),
+      );
+
+      await service.createTransaction('tenant-1', 'fund-1', 'member-1', roles, {
+        direction: FundTransactionDirection.CREDIT,
+        amountMinor: 50000,
+        currencyCode: 'USD',
+        occurredAt: '2026-08-14T00:00:00.000Z',
+      });
+
+      const metadata = lastAuditMetadata();
+      expect('idempotencyKey' in metadata).toBe(false);
+      expect(metadata.amountMinor).toBe(50000);
+    });
+
+    it('includes idempotencyKey in FUND_TRANSACTION_CREATE metadata when provided', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      mockLedger([], []);
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValue(
+        makeTransaction({ idempotencyKey: 'fin02t-key' }),
+      );
+
+      await service.createTransaction('tenant-1', 'fund-1', 'member-1', roles, {
+        direction: FundTransactionDirection.CREDIT,
+        amountMinor: 50000,
+        currencyCode: 'USD',
+        occurredAt: '2026-08-14T00:00:00.000Z',
+        idempotencyKey: 'fin02t-key',
+      });
+
+      const metadata = lastAuditMetadata();
+      expect('idempotencyKey' in metadata).toBe(true);
+      expect(metadata.idempotencyKey).toBe('fin02t-key');
+    });
+  });
 });

--- a/apps/api/src/finanzas/funds.service.ts
+++ b/apps/api/src/finanzas/funds.service.ts
@@ -131,7 +131,9 @@ export class FundsService {
             entityId: created.id,
             metadata: {
               scopeType: dto.scopeType,
-              buildingId: created.buildingId,
+              ...(created.buildingId !== null
+                ? { buildingId: created.buildingId }
+                : {}),
               type: dto.type,
               name: created.name,
             },
@@ -380,7 +382,9 @@ export class FundsService {
               amountMinor: dto.amountMinor,
               currencyCode: dto.currencyCode,
               occurredAt: dto.occurredAt,
-              idempotencyKey: dto.idempotencyKey ?? null,
+              ...(dto.idempotencyKey !== undefined && dto.idempotencyKey !== null
+                ? { idempotencyKey: dto.idempotencyKey }
+                : {}),
             },
           },
           tx,


### PR DESCRIPTION
## Summary

Fixes the FIN-02 staging blocker found during the post-merge functional smoke.

`AuditService` intentionally rejects null/undefined values inside audit metadata. Two FundsService audit producers were sending optional values as explicit nulls:

- `FUND_CREATE` sent `buildingId: null` for TENANT-scoped funds.
- `FUND_TRANSACTION_CREATE` sent `idempotencyKey: null` when no key was supplied.

Because these audits are required and atomic with the financial mutation, the operations correctly rolled back, but TENANT fund creation and non-idempotent fund transactions could not complete.

## Fix

Optional audit metadata is now omitted when absent:

- TENANT Fund → no `buildingId` metadata property
- BUILDING Fund → `buildingId` preserved
- transaction without idempotency key → no `idempotencyKey` metadata property
- transaction with idempotency key → key preserved

`AuditService` was not changed.

## Scope

This PR does NOT change:

- Fund/FundTransaction schema
- migrations
- balance logic
- advisory locks
- idempotency persistence/recovery
- reversals
- Income
- Liquidation
- Payment
- MovementAllocation
- frontend

## Validation

- Funds unit: 44 passed / 0 failed
- PostgreSQL FIN-02: 15 passed / 0 failed
- real AuditService PostgreSQL coverage: 4/4 passed
- finance regression: 601 passed / 0 failed
- API full: 176 suites / 2614 passed / 0 failed
- Prisma validate: PASS
- Typecheck: PASS
- Lint: PASS
- Build: PASS
- git diff --check: CLEAN

## Staging reproduction

Original FIN-02 deployment was healthy and the migration applied successfully, but functional smoke failed on:

TENANT Fund create
→ FUND_CREATE audit
→ metadata.buildingId = null
→ AuditService rejects null
→ transaction rollback

The remainder of the FIN-02 staging smoke will be repeated after this fix is merged and deployed.

---

## Tipo de cambio

- [x] Bug fix
- [ ] Nueva funcionalidad
- [ ] Refactor
- [ ] Cambio de documentación
- [ ] Otro: ___

## Checklist de validación local obligatoria

Antes de abrir este PR, se completó localmente:

- [x] Tests unitarios pasan
- [x] Tests de integración pasan
- [ ] Tests E2E pasan (si aplica)
- [x] Typecheck (`tsc --noEmit`) sin errores
- [x] Lint sin errores nuevos
- [x] Build exitoso
- [x] `git diff --check` limpio
- [x] Confirmé que todos los cambios fueron implementados y probados localmente
- [x] Confirmé que el merge a main activará automáticamente el deploy a staging
- [x] El despliegue automático a staging está autorizado para este PR
- [ ] Las migraciones incluidas fueron validadas localmente
- [x] No se requiere preservar ningún archivo temporal dentro del checkout de staging
- [x] La validación funcional en staging está definida para después del merge
