### PR TITLE
feat(finance): add auditable income applications

### DIFF
--- a/apps/api/prisma/migrations/20260815000000_add_income_applications/migration.sql
+++ b/apps/api/prisma/migrations/20260815000000_add_income_applications/migration.sql
@@ -1,0 +1,46 @@
+-- FIN-03: IncomeApplication (plan explícito de qué se hace con un Income)
+-- ADITIVA: no altera datos financieros existentes.
+
+-- CreateEnum
+CREATE TYPE "IncomeApplicationDestination" AS ENUM ('OFFSET_EXPENSES', 'FUND', 'CARRY_FORWARD');
+
+-- AlterEnum AuditAction
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'INCOME_APPLICATIONS_CREATE';
+
+-- AlterTable FundTransaction (linkage 1:1 a IncomeApplication)
+ALTER TABLE "FundTransaction" ADD COLUMN     "incomeApplicationId" TEXT;
+
+-- CreateTable IncomeApplication
+CREATE TABLE "IncomeApplication" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "incomeId" TEXT NOT NULL,
+    "destinationType" "IncomeApplicationDestination" NOT NULL,
+    "fundId" TEXT,
+    "amountMinor" INTEGER NOT NULL,
+    "currencyCode" TEXT NOT NULL,
+    "createdByMembershipId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "IncomeApplication_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "IncomeApplication_amountMinor_positive" CHECK ("amountMinor" > 0),
+    CONSTRAINT "IncomeApplication_destination_fund_invariant" CHECK (
+      ("destinationType" = 'FUND' AND "fundId" IS NOT NULL)
+      OR
+      ("destinationType" IN ('OFFSET_EXPENSES', 'CARRY_FORWARD') AND "fundId" IS NULL)
+    )
+);
+
+-- AddForeignKey
+ALTER TABLE "IncomeApplication" ADD CONSTRAINT "IncomeApplication_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "IncomeApplication" ADD CONSTRAINT "IncomeApplication_incomeId_fkey" FOREIGN KEY ("incomeId") REFERENCES "Income"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "IncomeApplication" ADD CONSTRAINT "IncomeApplication_fundId_fkey" FOREIGN KEY ("fundId") REFERENCES "Fund"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "IncomeApplication" ADD CONSTRAINT "IncomeApplication_createdByMembershipId_fkey" FOREIGN KEY ("createdByMembershipId") REFERENCES "Membership"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "FundTransaction" ADD CONSTRAINT "FundTransaction_incomeApplicationId_fkey" FOREIGN KEY ("incomeApplicationId") REFERENCES "IncomeApplication"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE INDEX "IncomeApplication_tenantId_incomeId_idx" ON "IncomeApplication"("tenantId", "incomeId");
+CREATE INDEX "IncomeApplication_tenantId_fundId_idx" ON "IncomeApplication"("tenantId", "fundId");
+CREATE UNIQUE INDEX "IncomeApplication_incomeId_fundId_key" ON "IncomeApplication"("incomeId", "fundId") WHERE "fundId" IS NOT NULL;
+CREATE UNIQUE INDEX "IncomeApplication_incomeId_nonfund_key" ON "IncomeApplication"("incomeId", "destinationType") WHERE "destinationType" IN ('OFFSET_EXPENSES', 'CARRY_FORWARD');
+CREATE UNIQUE INDEX "FundTransaction_incomeApplicationId_key" ON "FundTransaction"("incomeApplicationId");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -135,6 +135,16 @@ enum IncomeDestination {
   SPECIAL_FUND       // Fase 2
 }
 
+// ============================================================================
+// FINANZAS: IncomeApplication (qué se hace con el dinero — FIN-03)
+// ============================================================================
+
+enum IncomeApplicationDestination {
+  OFFSET_EXPENSES  // Clasifica para reducir gastos en una futura FIN-06
+  FUND             // Genera CREDIT real en FundTransaction
+  CARRY_FORWARD    // Clasifica dinero retenido para uso futuro
+}
+
 enum LiquidationStatus {
   DRAFT
   REVIEWED
@@ -294,6 +304,7 @@ model Tenant {
   exchangeRates         ExchangeRate[]
   funds                 Fund[]
   fundTransactions      FundTransaction[]
+  incomeApplications    IncomeApplication[]
 }
 
 model User {
@@ -368,6 +379,7 @@ model Membership {
   fundsCreated          Fund[]                @relation("FundCreatedBy")
   fundsArchived         Fund[]                @relation("FundArchivedBy")
   fundTransactionsCreated FundTransaction[]   @relation("FundTransactionCreatedBy")
+  incomeApplicationsCreated IncomeApplication[] @relation("IncomeApplicationCreatedBy")
 
   @@unique([userId, tenantId])
   @@index([tenantId])
@@ -803,6 +815,7 @@ enum AuditAction {
   INCOME_RECORD
   INCOME_VOID
   INCOME_ALLOCATION_CREATE
+  INCOME_APPLICATIONS_CREATE
   // FUNDS (FIN-02)
   FUND_CREATE
   FUND_UPDATE
@@ -2007,6 +2020,37 @@ model Income {
   @@index([tenantId, scopeType])
   @@index([tenantId, destination])
   @@index([tenantId, exchangeRateId])
+
+  applications IncomeApplication[]
+}
+
+// ============================================================================
+// FINANZAS: IncomeApplication (Plan explícito de qué se hace con un Income)
+// ============================================================================
+// RESPONDE: ¿qué se hace con el dinero?
+// (MovementAllocation responde ¿a qué building/scope pertenece el movimiento?)
+// Plan inmutable tras publicación: NO PATCH / NO DELETE individual.
+// SUM(amountMinor) == Income.amountMinor EXACTO (minor units enteras).
+// ============================================================================
+model IncomeApplication {
+  id                       String                       @id @default(cuid())
+  tenantId                 String
+  incomeId                 String
+  destinationType          IncomeApplicationDestination
+  fundId                   String?                      // Obligatorio solo si FUND
+  amountMinor              Int                          // En centavos, positivo
+  currencyCode             String                       // Siempre = Income.currencyCode
+  createdByMembershipId    String
+  createdAt                DateTime                     @default(now())
+
+  tenant     Tenant             @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  income     Income             @relation(fields: [incomeId], references: [id], onDelete: Restrict)
+  fund       Fund?              @relation(fields: [fundId], references: [id], onDelete: Restrict)
+  createdBy  Membership         @relation("IncomeApplicationCreatedBy", fields: [createdByMembershipId], references: [id], onDelete: Restrict)
+  fundTransaction FundTransaction? @relation("FundTransactionIncomeApplication")
+
+  @@index([tenantId, incomeId])
+  @@index([tenantId, fundId])
 }
 
 // ============================================================================
@@ -2106,6 +2150,7 @@ model Fund {
   createdBy  Membership         @relation("FundCreatedBy", fields: [createdByMembershipId], references: [id], onDelete: Restrict)
   archivedBy Membership?        @relation("FundArchivedBy", fields: [archivedByMembershipId], references: [id], onDelete: SetNull)
   transactions FundTransaction[]
+  incomeApplications IncomeApplication[]
 
   @@index([tenantId])
   @@index([tenantId, buildingId])
@@ -2132,6 +2177,9 @@ model FundTransaction {
   createdBy Membership       @relation("FundTransactionCreatedBy", fields: [createdByMembershipId], references: [id], onDelete: Restrict)
   reversalOf FundTransaction? @relation("FundTransactionReversal", fields: [reversalOfTransactionId], references: [id], onDelete: Restrict)
   reversals  FundTransaction[] @relation("FundTransactionReversal")
+  incomeApplication IncomeApplication? @relation("FundTransactionIncomeApplication", fields: [incomeApplicationId], references: [id], onDelete: Restrict)
+
+  incomeApplicationId String? @unique // 1:1 — transacción gestionada por IncomeApplication (voidIncome controla su reversa)
 
   @@unique([tenantId, idempotencyKey])
   @@unique([reversalOfTransactionId])

--- a/apps/api/src/finanzas/finanzas.module.ts
+++ b/apps/api/src/finanzas/finanzas.module.ts
@@ -44,6 +44,8 @@ import { CurrencyConversionService } from './currency-conversion.service';
 import { AppConfigModule } from '../config/config.module';
 import { FundsController } from './funds.controller';
 import { FundsService } from './funds.service';
+import { IncomeApplicationsController } from './income-applications.controller';
+import { IncomeApplicationsService } from './income-applications.service';
 
 import { VendorPreferenceController } from './vendor-preference.controller';
 import { VendorPreferenceService } from './vendor-preference.service';
@@ -91,6 +93,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     PaymentWebhookController,
     MulticurrencyController,
     FundsController,
+    IncomeApplicationsController,
   ],
   providers: [
     FinanzasService,
@@ -133,6 +136,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     MulticurrencyService,
     CurrencyConversionService,
     FundsService,
+    IncomeApplicationsService,
   ],
   exports: [
     FinanzasService,
@@ -152,6 +156,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     PaymentReceiptService,
     CurrencyConversionService,
     FundsService,
+    IncomeApplicationsService,
   ],
 })
 export class FinanzasModule {}

--- a/apps/api/src/finanzas/fund-ledger.ts
+++ b/apps/api/src/finanzas/fund-ledger.ts
@@ -1,0 +1,45 @@
+import { BadRequestException } from '@nestjs/common';
+import { FundTransactionDirection, Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+
+/**
+ * Semántica de saldo compartida (FIN-02/FIN-03).
+ * El saldo SIEMPRE se deriva del ledger: SUM(CREDIT) - SUM(DEBIT) por moneda.
+ * Ningún DEBIT puede producir saldo negativo.
+ */
+
+export async function computeFundBalanceMinor(
+  tx: Prisma.TransactionClient | PrismaService,
+  tenantId: string,
+  fundId: string,
+  currencyCode: string,
+): Promise<number> {
+  const credits = await tx.fundTransaction.groupBy({
+    by: ['currencyCode'],
+    where: { tenantId, fundId, direction: FundTransactionDirection.CREDIT },
+    _sum: { amountMinor: true },
+  });
+  const debits = await tx.fundTransaction.groupBy({
+    by: ['currencyCode'],
+    where: { tenantId, fundId, direction: FundTransactionDirection.DEBIT },
+    _sum: { amountMinor: true },
+  });
+  const credit = credits.find((row) => row.currencyCode === currencyCode)?._sum.amountMinor ?? 0;
+  const debit = debits.find((row) => row.currencyCode === currencyCode)?._sum.amountMinor ?? 0;
+  return credit - debit;
+}
+
+export async function assertSufficientFundBalance(
+  tx: Prisma.TransactionClient | PrismaService,
+  tenantId: string,
+  fundId: string,
+  currencyCode: string,
+  amountMinor: number,
+): Promise<void> {
+  const balance = await computeFundBalanceMinor(tx, tenantId, fundId, currencyCode);
+  if (balance < amountMinor) {
+    throw new BadRequestException(
+      `Saldo insuficiente en ${currencyCode}: saldo ${balance}, débito solicitado ${amountMinor}`,
+    );
+  }
+}

--- a/apps/api/src/finanzas/fund-locks.ts
+++ b/apps/api/src/finanzas/fund-locks.ts
@@ -1,0 +1,41 @@
+import { Prisma } from '@prisma/client';
+
+/**
+ * Locks compartidos del módulo Finanzas (FIN-02/FIN-03).
+ *
+ * Fund lock: serializa mutaciones de balance de un Fund (advisory xact lock).
+ * Income lock: serializa plan de aplicaciones vs void de un Income.
+ *
+ * Ambos son transaction-scoped (se liberan al commit/rollback) y versionados.
+ */
+
+const FUND_LOCK_TAG = 'buildingos_fund_lock_v1';
+const INCOME_LOCK_TAG = 'buildingos_income_lock_v1';
+
+export function fundAdvisoryLockKey(tenantId: string, fundId: string): string {
+  return `${FUND_LOCK_TAG}:${tenantId}:${fundId}`;
+}
+
+export function incomeAdvisoryLockKey(tenantId: string, incomeId: string): string {
+  return `${INCOME_LOCK_TAG}:${tenantId}:${incomeId}`;
+}
+
+export async function acquireFundLock(
+  tx: Prisma.TransactionClient,
+  tenantId: string,
+  fundId: string,
+): Promise<void> {
+  await tx.$executeRaw(
+    Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${fundAdvisoryLockKey(tenantId, fundId)}, 0))`,
+  );
+}
+
+export async function acquireIncomeLock(
+  tx: Prisma.TransactionClient,
+  tenantId: string,
+  incomeId: string,
+): Promise<void> {
+  await tx.$executeRaw(
+    Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${incomeAdvisoryLockKey(tenantId, incomeId)}, 0))`,
+  );
+}

--- a/apps/api/src/finanzas/funds.service.spec.ts
+++ b/apps/api/src/finanzas/funds.service.spec.ts
@@ -40,6 +40,7 @@ const makeTransaction = (overrides: Record<string, unknown> = {}) => ({
   createdByMembershipId: 'member-1',
   idempotencyKey: null,
   reversalOfTransactionId: null,
+  incomeApplicationId: null,
   createdAt: new Date(),
   ...overrides,
 });
@@ -727,6 +728,47 @@ describe('FundsService', () => {
       await expect(
         service.reverseTransaction('tenant-1', 'fund-1', 'tx-other', 'member-1', roles),
       ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects a generic reversal of a transaction owned by an IncomeApplication', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      (prisma.fundTransaction.findFirst as jest.Mock).mockResolvedValue(
+        makeTransaction({
+          direction: FundTransactionDirection.CREDIT,
+          amountMinor: 3000,
+          incomeApplicationId: 'app-1',
+        }),
+      );
+
+      await expect(
+        service.reverseTransaction('tenant-1', 'fund-1', 'tx-1', 'member-1', roles),
+      ).rejects.toThrow(ConflictException);
+      expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
+    });
+
+    it('still allows a generic reversal of a manual FundTransaction (no incomeApplicationId)', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      (prisma.fundTransaction.findFirst as jest.Mock).mockResolvedValue(
+        makeTransaction({
+          direction: FundTransactionDirection.CREDIT,
+          amountMinor: 50000,
+          incomeApplicationId: null,
+        }),
+      );
+      (prisma.fundTransaction.findUnique as jest.Mock).mockResolvedValue(null);
+      mockLedger([{ currencyCode: 'USD', amountMinor: 50000 }], []);
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValue(
+        makeTransaction({
+          id: 'tx-reversal',
+          direction: FundTransactionDirection.DEBIT,
+          amountMinor: 50000,
+          reversalOfTransactionId: 'tx-1',
+        }),
+      );
+
+      const result = await service.reverseTransaction('tenant-1', 'fund-1', 'tx-1', 'member-1', roles);
+      expect(result.reversalOfTransactionId).toBe('tx-1');
+      expect(prisma.fundTransaction.create).toHaveBeenCalledTimes(1);
     });
 
     it('rejects a credit reversal (→ DEBIT) that would make the balance negative', async () => {

--- a/apps/api/src/finanzas/funds.service.ts
+++ b/apps/api/src/finanzas/funds.service.ts
@@ -18,17 +18,9 @@ import {
   ReverseFundTransactionDto,
   FundTransactionResponseDto,
 } from './funds.dto';
-
-const ADVISORY_LOCK_TAG = 'buildingos_fund_lock_v1';
-
-/**
- * Genera un advisory lock key estable por (tenantId, fundId).
- * Usado dentro de $transaction para serializar operaciones que leen/escriben
- * el ledger de un fondo (balance-guard bajo concurrencia).
- */
-function fundAdvisoryLockKey(tenantId: string, fundId: string): string {
-  return `${ADVISORY_LOCK_TAG}:${tenantId}:${fundId}`;
-}
+import {
+  acquireFundLock,
+} from './fund-locks';
 
 type FundWithBalance = Prisma.FundGetPayload<Record<string, never>> & {
   balancesByCurrency: Array<{ currency: string; amountMinor: number }>;
@@ -241,7 +233,7 @@ export class FundsService {
       // Mismo advisory lock que createTransaction/reverseTransaction: serializa
       // la transición ACTIVE→ARCHIVED contra mutaciones de saldo (evita
       // archivar un fondo con saldo no cero creado por un CREDIT concurrente).
-      await this.acquireFundLock(tx, tenantId, fundId);
+      await acquireFundLock(tx, tenantId, fundId);
 
       const fund = await tx.fund.findFirst({
         where: { id: fundId, tenantId },
@@ -339,7 +331,7 @@ export class FundsService {
     try {
       transaction = await this.prisma.$transaction(async (tx) => {
         // Advisory lock: serializa balance-guard y creación del movimiento
-        await this.acquireFundLock(tx, tenantId, fundId);
+        await acquireFundLock(tx, tenantId, fundId);
 
         const fund = await tx.fund.findFirst({
           where: { id: fundId, tenantId },
@@ -432,7 +424,7 @@ export class FundsService {
     this.assertAdminOrOperator(userRoles, 'reversar movimientos de fondos');
 
     return this.prisma.$transaction(async (tx) => {
-      await this.acquireFundLock(tx, tenantId, fundId);
+      await acquireFundLock(tx, tenantId, fundId);
 
       const fund = await tx.fund.findFirst({
         where: { id: fundId, tenantId },
@@ -452,6 +444,14 @@ export class FundsService {
       }
       if (original.reversalOfTransactionId !== null) {
         throw new ConflictException('No se puede reversar un movimiento que ya es una reversa');
+      }
+      // FIN-03: un FundTransaction gestionado por IncomeApplication NO puede
+      // reversarse por el endpoint genérico de Funds. Su reversa la controla
+      // voidIncome (void del Income). Evita desbalancear un plan publicado.
+      if (original.incomeApplicationId !== null) {
+        throw new ConflictException(
+          'Este movimiento pertenece a una aplicación de ingreso; reversar vía void del Income',
+        );
       }
 
       // Una transacción solo puede revertirse una vez (unique + check explícito)
@@ -706,16 +706,6 @@ export class FundsService {
       );
     }
     return result;
-  }
-
-  private async acquireFundLock(
-    tx: Prisma.TransactionClient,
-    tenantId: string,
-    fundId: string,
-  ): Promise<void> {
-    await tx.$executeRaw(
-      Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${fundAdvisoryLockKey(tenantId, fundId)}, 0))`,
-    );
   }
 
   private async assertSufficientBalance(

--- a/apps/api/src/finanzas/funds.service.ts
+++ b/apps/api/src/finanzas/funds.service.ts
@@ -21,6 +21,7 @@ import {
 import {
   acquireFundLock,
 } from './fund-locks';
+import { assertSufficientFundBalance } from './fund-ledger';
 
 type FundWithBalance = Prisma.FundGetPayload<Record<string, never>> & {
   balancesByCurrency: Array<{ currency: string; amountMinor: number }>;
@@ -715,13 +716,8 @@ export class FundsService {
     currencyCode: string,
     amountMinor: number,
   ): Promise<void> {
-    const balances = await this.computeBalances(tx, tenantId, fundId);
-    const balance = balances.find((b) => b.currency === currencyCode)?.amountMinor ?? 0;
-    if (balance < amountMinor) {
-      throw new BadRequestException(
-        `Saldo insuficiente en ${currencyCode}: saldo ${balance}, débito solicitado ${amountMinor}`,
-      );
-    }
+    // Semántica FIN-02 compartida (fund-ledger.ts): balance = SUM(CREDIT)-SUM(DEBIT)
+    await assertSufficientFundBalance(tx, tenantId, fundId, currencyCode, amountMinor);
   }
 
   private async assertSameOperation(

--- a/apps/api/src/finanzas/income-applications.controller.ts
+++ b/apps/api/src/finanzas/income-applications.controller.ts
@@ -1,0 +1,54 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
+import { AuthenticatedRequest } from '../common/types/request.types';
+import { IncomeApplicationsService } from './income-applications.service';
+import {
+  CreateIncomeApplicationsDto,
+  IncomeApplicationPlanResponseDto,
+} from './income-applications.dto';
+
+/**
+ * Plan de aplicaciones de un Income (tenant-scoped)
+ * Routes: /tenants/:tenantId/finance/incomes/:incomeId/applications
+ */
+@Controller('tenants/:tenantId/finance/incomes/:incomeId/applications')
+@UseGuards(JwtAuthGuard, TenantAccessGuard)
+export class IncomeApplicationsController {
+  constructor(private readonly incomeApplicationsService: IncomeApplicationsService) {}
+
+  @Get()
+  async getPlan(
+    @Param('incomeId') incomeId: string,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<IncomeApplicationPlanResponseDto> {
+    return this.incomeApplicationsService.getPlan(
+      req.tenantId!,
+      incomeId,
+      req.user.roles ?? [],
+    );
+  }
+
+  @Post()
+  async createPlan(
+    @Param('incomeId') incomeId: string,
+    @Body() dto: CreateIncomeApplicationsDto,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<IncomeApplicationPlanResponseDto> {
+    return this.incomeApplicationsService.createPlan(
+      req.tenantId!,
+      incomeId,
+      req.user.membershipId ?? '',
+      req.user.roles ?? [],
+      dto,
+    );
+  }
+}

--- a/apps/api/src/finanzas/income-applications.dto.spec.ts
+++ b/apps/api/src/finanzas/income-applications.dto.spec.ts
@@ -1,0 +1,73 @@
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
+import { IncomeApplicationDestination } from '@prisma/client';
+import {
+  CreateIncomeApplicationsDto,
+  MAX_APPLICATIONS_PER_PLAN,
+} from './income-applications.dto';
+
+const validate = (input: Record<string, unknown>) =>
+  validateSync(plainToInstance(CreateIncomeApplicationsDto, input), {
+    whitelist: true,
+    forbidUnknownValues: true,
+  });
+
+const makeApp = (overrides: Record<string, unknown> = {}) => ({
+  destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+  amountMinor: 10000,
+  ...overrides,
+});
+
+describe('CreateIncomeApplicationsDto (FIN-03R BLOCKER C)', () => {
+  it('accepts 1 valid application', () => {
+    expect(validate({ applications: [makeApp()] })).toHaveLength(0);
+  });
+
+  it('accepts 2 valid applications', () => {
+    expect(
+      validate({
+        applications: [
+          makeApp({ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 }),
+          makeApp({ destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000 }),
+        ],
+      }),
+    ).toHaveLength(0);
+  });
+
+  it('accepts up to MAX_APPLICATIONS_PER_PLAN items (boundary)', () => {
+    const many = Array.from({ length: MAX_APPLICATIONS_PER_PLAN }, (_, i) =>
+      makeApp({ destinationType: IncomeApplicationDestination.FUND, fundId: `fund-${i}`, amountMinor: 1 }),
+    );
+    expect(validate({ applications: many })).toHaveLength(0);
+  });
+
+  it('rejects more than MAX_APPLICATIONS_PER_PLAN items', () => {
+    const tooMany = Array.from({ length: MAX_APPLICATIONS_PER_PLAN + 1 }, (_, i) =>
+      makeApp({ destinationType: IncomeApplicationDestination.FUND, fundId: `fund-${i}`, amountMinor: 1 }),
+    );
+    const errors = validate({ applications: tooMany });
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((e) => e.property === 'applications')).toBe(true);
+  });
+
+  it('rejects amountMinor = 0 (nested validation)', () => {
+    const errors = validate({ applications: [makeApp({ amountMinor: 0 })] });
+    expect(errors.some((e) => e.property === 'applications')).toBe(true);
+  });
+
+  it('rejects an invalid destinationType enum', () => {
+    const errors = validate({ applications: [makeApp({ destinationType: 'NOT_A_DESTINATION' })] });
+    expect(errors.some((e) => e.property === 'applications')).toBe(true);
+  });
+
+  it('rejects an empty array', () => {
+    const errors = validate({ applications: [] });
+    expect(errors.some((e) => e.property === 'applications')).toBe(true);
+  });
+
+  it('rejects missing applications', () => {
+    const errors = validate({});
+    expect(errors.some((e) => e.property === 'applications')).toBe(true);
+  });
+});

--- a/apps/api/src/finanzas/income-applications.dto.ts
+++ b/apps/api/src/finanzas/income-applications.dto.ts
@@ -1,0 +1,56 @@
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { IncomeApplicationDestination } from '@prisma/client';
+
+export const MAX_APPLICATIONS_PER_PLAN = 20;
+
+export class IncomeApplicationInputDto {
+  @IsEnum(IncomeApplicationDestination)
+  destinationType!: IncomeApplicationDestination;
+
+  @IsString()
+  @IsOptional()
+  fundId?: string;
+
+  @IsInt()
+  @Min(1)
+  amountMinor!: number;
+}
+
+export class CreateIncomeApplicationsDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @Max(MAX_APPLICATIONS_PER_PLAN)
+  @ValidateNested({ each: true })
+  @Type(() => IncomeApplicationInputDto)
+  applications!: IncomeApplicationInputDto[];
+}
+
+export interface IncomeApplicationResponseDto {
+  id: string;
+  tenantId: string;
+  incomeId: string;
+  destinationType: IncomeApplicationDestination;
+  fundId: string | null;
+  amountMinor: number;
+  currencyCode: string;
+  fundTransactionId: string | null;
+  createdAt: Date;
+}
+
+export interface IncomeApplicationPlanResponseDto {
+  incomeId: string;
+  currencyCode: string;
+  totalAmountMinor: number;
+  applications: IncomeApplicationResponseDto[];
+}

--- a/apps/api/src/finanzas/income-applications.dto.ts
+++ b/apps/api/src/finanzas/income-applications.dto.ts
@@ -1,11 +1,11 @@
 import {
+  ArrayMaxSize,
   ArrayNotEmpty,
   IsArray,
   IsEnum,
   IsInt,
   IsOptional,
   IsString,
-  Max,
   Min,
   ValidateNested,
 } from 'class-validator';
@@ -30,7 +30,7 @@ export class IncomeApplicationInputDto {
 export class CreateIncomeApplicationsDto {
   @IsArray()
   @ArrayNotEmpty()
-  @Max(MAX_APPLICATIONS_PER_PLAN)
+  @ArrayMaxSize(MAX_APPLICATIONS_PER_PLAN)
   @ValidateNested({ each: true })
   @Type(() => IncomeApplicationInputDto)
   applications!: IncomeApplicationInputDto[];

--- a/apps/api/src/finanzas/income-applications.postgres.spec.ts
+++ b/apps/api/src/finanzas/income-applications.postgres.spec.ts
@@ -1,0 +1,649 @@
+import {
+  FundStatus,
+  FundTransactionDirection,
+  IncomeApplicationDestination,
+  IncomeStatus,
+  PrismaClient,
+  TenantType,
+} from '@prisma/client';
+import {
+  BadRequestException as NestBadRequestException,
+  ConflictException as NestConflictException,
+} from '@nestjs/common';
+import { IncomeApplicationsService } from './income-applications.service';
+import { IncomesService } from './incomes.service';
+import { FundsService } from './funds.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { PrismaService } from '../prisma/prisma.service';
+import { MovementAllocationService } from './movement-allocation.service';
+import { CurrencyConversionService } from './currency-conversion.service';
+
+const ACCEPTANCE_DATABASES = new Set(['buildingos_fin03_acceptance']);
+const expectedDatabaseName = process.env.POSTGRES_TEST_DB_NAME;
+const fixturePhase = 'fin03';
+const enabled =
+  process.env.RUN_POSTGRES_INTEGRATION === '1' &&
+  expectedDatabaseName !== undefined &&
+  ACCEPTANCE_DATABASES.has(expectedDatabaseName);
+const describePostgres = enabled ? describe : describe.skip;
+
+describePostgres('IncomeApplications PostgreSQL (FIN-03)', () => {
+  let observer: PrismaClient;
+  let clientA: PrismaClient;
+  let clientB: PrismaClient;
+  let appsService: IncomeApplicationsService;
+  let fundsService: FundsService;
+  let incomesService: IncomesService;
+  const tenantIds: string[] = [];
+  const userIds: string[] = [];
+  const membershipIds: string[] = [];
+
+  function buildServices(client: PrismaClient) {
+    const prisma = client as unknown as PrismaService;
+    const audit = new AuditService(prisma);
+    const validators = new FinanzasValidators(prisma);
+    return {
+      apps: new IncomeApplicationsService(prisma, audit, validators),
+      funds: new FundsService(prisma, audit, validators),
+      incomes: new IncomesService(
+        prisma,
+        audit,
+        validators,
+        new MovementAllocationService(prisma, audit, validators),
+        new CurrencyConversionService(prisma),
+      ),
+    };
+  }
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required');
+    observer = new PrismaClient();
+    clientA = new PrismaClient();
+    clientB = new PrismaClient();
+    await Promise.all([observer.$connect(), clientA.$connect(), clientB.$connect()]);
+    const [database] = await observer.$queryRaw<Array<{ name: string }>>`SELECT current_database() AS name`;
+    if (database?.name !== expectedDatabaseName || !ACCEPTANCE_DATABASES.has(database.name)) {
+      throw new Error(`Refusing destructive test database ${database?.name ?? 'unknown'}`);
+    }
+    const svcA = buildServices(clientA);
+    appsService = svcA.apps;
+    fundsService = svcA.funds;
+    incomesService = svcA.incomes;
+  });
+
+  afterEach(async () => {
+    for (const membershipId of membershipIds.splice(0)) {
+      await observer.membership.delete({ where: { id: membershipId } }).catch(() => undefined);
+    }
+    for (const tenantId of tenantIds.splice(0)) {
+      await observer.tenant.delete({ where: { id: tenantId } }).catch(() => undefined);
+    }
+    for (const userId of userIds.splice(0)) {
+      await observer.user.delete({ where: { id: userId } }).catch(() => undefined);
+    }
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      observer?.$disconnect(),
+      clientA?.$disconnect(),
+      clientB?.$disconnect(),
+    ]);
+  });
+
+  async function fixture(label: string) {
+    const suffix = `${Date.now()}-${Math.random()}`;
+    const tenant = await observer.tenant.create({
+      data: { name: `${fixturePhase}-${label}-${suffix}`, type: TenantType.ADMINISTRADORA },
+    });
+    tenantIds.push(tenant.id);
+    const user = await observer.user.create({
+      data: {
+        email: `${fixturePhase}-${suffix}@buildingos.local`,
+        name: `${fixturePhase} ${label}`,
+        passwordHash: 'test',
+      },
+    });
+    userIds.push(user.id);
+    const membership = await observer.membership.create({
+      data: { tenantId: tenant.id, userId: user.id },
+    });
+    membershipIds.push(membership.id);
+    return { tenant, membership };
+  }
+
+  async function recordedIncome(tenantId: string, amountMinor = 10000, currencyCode = 'USD') {
+    const income = await observer.income.create({
+      data: {
+        tenantId,
+        period: '2026-08',
+        categoryId: await ensureIncomeCategory(tenantId),
+        amountMinor,
+        currencyCode,
+        receivedDate: new Date('2026-08-10T00:00:00.000Z'),
+        status: IncomeStatus.RECORDED,
+        createdByMembershipId: membershipIds[membershipIds.length - 1]!,
+        scopeType: 'BUILDING',
+      },
+    });
+    return income;
+  }
+
+  async function ensureIncomeCategory(tenantId: string) {
+    let category = await observer.expenseLedgerCategory.findFirst({
+      where: { tenantId, movementType: 'INCOME' },
+    });
+    if (!category) {
+      category = await observer.expenseLedgerCategory.create({
+        data: { tenantId, name: `Income Cat ${Date.now()}`, movementType: 'INCOME' },
+      });
+    }
+    return category.id;
+  }
+
+  const roles = ['TENANT_ADMIN'];
+
+  // ── DB constraints ──────────────────────────────────────────────────────
+
+  it('enforces amountMinor > 0 at the database level', async () => {
+    const ctx = await fixture('amount-minor');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const base = {
+      tenantId: ctx.tenant.id,
+      incomeId: income.id,
+      destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+      fundId: null,
+      currencyCode: 'USD',
+      createdByMembershipId: ctx.membership.id,
+    } as const;
+
+    await expect(
+      observer.incomeApplication.create({ data: { ...base, amountMinor: 0 } }),
+    ).rejects.toThrow(/check constraint|Check/);
+    await expect(
+      observer.incomeApplication.create({ data: { ...base, amountMinor: -1 } }),
+    ).rejects.toThrow(/check constraint|Check/);
+    await observer.incomeApplication.create({ data: { ...base, amountMinor: 1 } });
+    expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(1);
+  }, 20000);
+
+  it('enforces the destination/fund invariant at the database level', async () => {
+    const ctx = await fixture('dest-invariant');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const base = {
+      tenantId: ctx.tenant.id,
+      incomeId: income.id,
+      currencyCode: 'USD',
+      createdByMembershipId: ctx.membership.id,
+    } as const;
+
+    // FUND + fundId null → reject
+    await expect(
+      observer.incomeApplication.create({
+        data: { ...base, destinationType: IncomeApplicationDestination.FUND, fundId: null, amountMinor: 10000 },
+      }),
+    ).rejects.toThrow(/check constraint|Check/);
+    // OFFSET + fundId → reject
+    await expect(
+      observer.incomeApplication.create({
+        data: { ...base, destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, fundId: 'x', amountMinor: 10000 },
+      }),
+    ).rejects.toThrow(/check constraint|Check/);
+    // CARRY + fundId → reject
+    await expect(
+      observer.incomeApplication.create({
+        data: { ...base, destinationType: IncomeApplicationDestination.CARRY_FORWARD, fundId: 'x', amountMinor: 10000 },
+      }),
+    ).rejects.toThrow(/check constraint|Check/);
+    // valid combos → allowed
+    await observer.incomeApplication.create({
+      data: { ...base, destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, fundId: null, amountMinor: 10000 },
+    });
+    expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(1);
+  }, 20000);
+
+  it('enforces duplicate DB constraints (one OFFSET, one CARRY, one FUND per fund)', async () => {
+    const ctx = await fixture('dup-constraints');
+    const income = await recordedIncome(ctx.tenant.id, 30000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    const base = {
+      tenantId: ctx.tenant.id,
+      incomeId: income.id,
+      currencyCode: 'USD',
+      createdByMembershipId: ctx.membership.id,
+    } as const;
+
+    await observer.incomeApplication.create({
+      data: { ...base, destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 10000 },
+    });
+    await observer.incomeApplication.create({
+      data: { ...base, destinationType: IncomeApplicationDestination.CARRY_FORWARD, amountMinor: 10000 },
+    });
+    await observer.incomeApplication.create({
+      data: { ...base, destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 10000 },
+    });
+
+    // duplicates → reject (partial unique)
+    await expect(
+      observer.incomeApplication.create({
+        data: { ...base, destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 10000 },
+      }),
+    ).rejects.toThrow(/unique|duplicate/);
+    await expect(
+      observer.incomeApplication.create({
+        data: { ...base, destinationType: IncomeApplicationDestination.CARRY_FORWARD, amountMinor: 10000 },
+      }),
+    ).rejects.toThrow(/unique|duplicate/);
+    await expect(
+      observer.incomeApplication.create({
+        data: { ...base, destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 10000 },
+      }),
+    ).rejects.toThrow(/unique|duplicate/);
+  }, 20000);
+
+  // ── Functional: exact plan + Fund CREDIT + rollbacks ────────────────────
+
+  it('creates an exact 70/30 plan with a real Fund CREDIT', async () => {
+    const ctx = await fixture('exact-split');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+
+    const result = await appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+      ],
+    });
+
+    expect(result.applications).toHaveLength(2);
+    expect(result.totalAmountMinor).toBe(10000);
+
+    const credits = await observer.fundTransaction.findMany({
+      where: { fundId: fund.id, direction: FundTransactionDirection.CREDIT },
+    });
+    expect(credits).toHaveLength(1);
+    expect(credits[0]!.amountMinor).toBe(3000);
+    expect(credits[0]!.currencyCode).toBe('USD');
+    expect(credits[0]!.incomeApplicationId).not.toBeNull();
+    const app = await observer.incomeApplication.findUniqueOrThrow({ where: { id: result.applications.find((a) => a.destinationType === 'FUND')!.id } });
+    expect(app.fundId).toBe(fund.id);
+
+    // balance del fund
+    const fundAfter = await fundsService.getFund(ctx.tenant.id, fund.id, roles);
+    expect(fundAfter.balancesByCurrency).toEqual([{ currency: 'USD', amountMinor: 3000 }]);
+  }, 20000);
+
+  it('rolls back on underallocation (no applications, no FundTransactions)', async () => {
+    const ctx = await fixture('underalloc');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+
+    await expect(
+      appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+        applications: [
+          { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+          { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 2999 },
+        ],
+      }),
+    ).rejects.toThrow(NestBadRequestException);
+
+    expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(0);
+    expect(await observer.fundTransaction.count({ where: { fundId: fund.id } })).toBe(0);
+  }, 20000);
+
+  it('rolls back on overallocation (no applications, no FundTransactions)', async () => {
+    const ctx = await fixture('overalloc');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+
+    await expect(
+      appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+        applications: [
+          { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+          { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3001 },
+        ],
+      }),
+    ).rejects.toThrow(NestBadRequestException);
+
+    expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(0);
+    expect(await observer.fundTransaction.count({ where: { fundId: fund.id } })).toBe(0);
+  }, 20000);
+
+  // ── Real AuditService + nullable metadata ───────────────────────────────
+
+  it('creates a plan with real AuditService (no null metadata error)', async () => {
+    const ctx = await fixture('real-audit');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+
+    const result = await appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+      ],
+    });
+    expect(result.applications).toHaveLength(2);
+
+    const audit = await observer.auditLog.findFirst({
+      where: { tenantId: ctx.tenant.id, action: 'INCOME_APPLICATIONS_CREATE', entityId: income.id },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(audit).not.toBeNull();
+    const metadata = audit!.metadata as Record<string, unknown>;
+    expect(metadata.applications).toHaveLength(2);
+  }, 20000);
+
+  // ── Idempotency / conflict ──────────────────────────────────────────────
+
+  it('returns the same plan on a concurrent same-plan retry (no double credit)', async () => {
+    const ctx = await fixture('idem-same');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    const svcB = buildServices(clientB).apps;
+    const plan = {
+      applications: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+      ],
+    };
+
+    const [a, b] = await Promise.all([
+      appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, plan),
+      svcB.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, plan),
+    ]);
+
+    expect(a.applications).toHaveLength(2);
+    expect(b.applications).toHaveLength(2);
+    expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(2);
+    expect(await observer.fundTransaction.count({ where: { fundId: fund.id, direction: FundTransactionDirection.CREDIT } })).toBe(1);
+  }, 30000);
+
+  it('only one concurrent different plan wins (Conflict for the other)', async () => {
+    const ctx = await fixture('idem-diff');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    const svcB = buildServices(clientB).apps;
+
+    const planA = { applications: [{ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 }, { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 }] };
+    const planB = { applications: [{ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 6000 }, { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 }, { destinationType: IncomeApplicationDestination.CARRY_FORWARD, amountMinor: 1000 }] };
+
+    const [a, b] = await Promise.all([
+      appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, planA).then(() => ({ ok: true as const })),
+      svcB.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, planB).then(
+        () => ({ ok: true as const }),
+        (error: unknown) => ({ ok: false as const, conflict: error instanceof NestConflictException }),
+      ),
+    ]);
+
+    const winners = [a, b].filter((r) => r.ok);
+    const losers = [a, b].filter((r) => !r.ok);
+    expect(winners).toHaveLength(1);
+    expect(losers).toHaveLength(1);
+    expect(losers[0]!.conflict).toBe(true);
+    expect(await observer.fundTransaction.count({ where: { fundId: fund.id, direction: FundTransactionDirection.CREDIT } })).toBe(1);
+  }, 30000);
+
+  // ── Void / reversal / double-void ───────────────────────────────────────
+
+  it('void reverses the application CREDIT and makes the fund net zero', async () => {
+    const ctx = await fixture('void-reversal');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    await appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+      ],
+    });
+
+    await incomesService.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles);
+
+    const incomeAfter = await observer.income.findUniqueOrThrow({ where: { id: income.id } });
+    expect(incomeAfter.status).toBe(IncomeStatus.VOID);
+
+    // CREDIT original permanece + reversal DEBIT
+    const txs = await observer.fundTransaction.findMany({ where: { fundId: fund.id }, orderBy: { createdAt: 'asc' } });
+    expect(txs).toHaveLength(2);
+    expect(txs[0]!.direction).toBe(FundTransactionDirection.CREDIT);
+    expect(txs[1]!.direction).toBe(FundTransactionDirection.DEBIT);
+    expect(txs[1]!.reversalOfTransactionId).toBe(txs[0]!.id);
+
+    const fundAfter = await fundsService.getFund(ctx.tenant.id, fund.id, roles);
+    expect(fundAfter.balancesByCurrency).toEqual([{ currency: 'USD', amountMinor: 0 }]);
+  }, 30000);
+
+  it('double void does not create a second reversal', async () => {
+    const ctx = await fixture('double-void');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    await appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+      ],
+    });
+
+    await incomesService.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles);
+    await incomesService.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles);
+
+    const txs = await observer.fundTransaction.findMany({ where: { fundId: fund.id } });
+    expect(txs).toHaveLength(2); // CREDIT + 1 reversal (no second)
+  }, 30000);
+
+  // ── Generic reversal protection ─────────────────────────────────────────
+
+  it('rejects a generic Fund reversal of an application-owned CREDIT', async () => {
+    const ctx = await fixture('gen-rev-protect');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    const plan = await appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+      ],
+    });
+    const fundApp = plan.applications.find((a) => a.destinationType === 'FUND')!;
+
+    await expect(
+      fundsService.reverseTransaction(ctx.tenant.id, fund.id, fundApp.fundTransactionId!, ctx.membership.id, roles, { reason: 'generic attempt' }),
+    ).rejects.toThrow(NestConflictException);
+
+    const txs = await observer.fundTransaction.findMany({ where: { fundId: fund.id } });
+    expect(txs).toHaveLength(1); // sin reversal genérica
+  }, 30000);
+
+  // ── Application vs void race ────────────────────────────────────────────
+
+  it('serializes application vs void (only serializable outcomes)', async () => {
+    const ctx = await fixture('app-void-race');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    const svcB = buildServices(clientB);
+
+    const [planResult, voidResult] = await Promise.all([
+      appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+        applications: [
+          { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+          { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+        ],
+      }).then(() => ({ ok: true as const })),
+      svcB.incomes.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles).then(
+        () => ({ ok: true as const }),
+        (error: unknown) => ({ ok: false as const, error: error instanceof Error ? error.message : String(error) }),
+      ),
+    ]);
+
+    const incomeAfter = await observer.income.findUniqueOrThrow({ where: { id: income.id } });
+    const credits = await observer.fundTransaction.count({ where: { fundId: fund.id, direction: FundTransactionDirection.CREDIT } });
+    const debits = await observer.fundTransaction.count({ where: { fundId: fund.id, direction: FundTransactionDirection.DEBIT } });
+    const net = credits - debits;
+
+    // Outcome 1: plan primero → void reversa → VOID + net 0
+    // Outcome 2: void primero → plan rechaza → VOID + net 0
+    // Nunca: crédito efectivo posterior a VOID
+    expect(incomeAfter.status).toBe(IncomeStatus.VOID);
+    if (net > 0) {
+      // Si quedó crédito sin reversar, el plan habría ganado Y void fallado:
+      // solo válido si el Income NO quedó VOID.
+      expect(planResult.ok).toBe(true);
+      expect(voidResult.ok).toBe(false);
+    } else {
+      expect(net).toBe(0);
+    }
+    // Invariante crítico: no puede haber CREDIT efectivo sin reversal con Income VOID
+    if (incomeAfter.status === IncomeStatus.VOID) {
+      const balanceRows = await observer.$queryRaw<Array<{ total: bigint | null }>>`
+        SELECT COALESCE(SUM(CASE WHEN direction = 'CREDIT' THEN "amountMinor" ELSE -"amountMinor" END), 0) AS total
+        FROM "FundTransaction" WHERE "fundId" = ${fund.id} AND "tenantId" = ${ctx.tenant.id}
+      `;
+      expect(Number(balanceRows[0]?.total ?? 0)).toBe(0);
+    }
+  }, 30000);
+
+  // ── Multi-fund deterministic locks ──────────────────────────────────────
+
+  it('handles a multi-fund plan without deadlock', async () => {
+    const ctx = await fixture('multi-fund');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund1 = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F1 ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    const fund2 = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F2 ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    const fund3 = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F3 ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+
+    const result = await appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund1.id, amountMinor: 3000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund2.id, amountMinor: 3000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund3.id, amountMinor: 4000 },
+      ],
+    });
+
+    expect(result.applications).toHaveLength(3);
+    expect(await observer.fundTransaction.count({ where: { fundId: { in: [fund1.id, fund2.id, fund3.id] } } })).toBe(3);
+  }, 30000);
+
+  // ── Tenant isolation ────────────────────────────────────────────────────
+
+  it('denies access to a plan of another tenant', async () => {
+    const ctxA = await fixture('iso-a');
+    const ctxB = await fixture('iso-b');
+    const income = await recordedIncome(ctxA.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctxA.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctxA.membership.id },
+    });
+    await appsService.createPlan(ctxA.tenant.id, income.id, ctxA.membership.id, roles, {
+      applications: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+      ],
+    });
+
+    const svcB = buildServices(clientB).apps;
+    await expect(svcB.getPlan(ctxB.tenant.id, income.id, roles)).rejects.toThrow(/no encontrado|not found/i);
+  }, 30000);
+
+  // ── FK / delete safety ──────────────────────────────────────────────────
+
+  it('does not break the tenant delete lifecycle (IncomeApplication cascade)', async () => {
+    const ctx = await fixture('fk-delete');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    await appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+      ],
+    });
+
+    // DELETE del Income → Restrict (plan protegido)
+    await expect(observer.income.delete({ where: { id: income.id } })).rejects.toThrow(/foreign key/i);
+
+    // DELETE del Tenant → cascade completo (lifecycle del repo intacto)
+    await observer.tenant.delete({ where: { id: ctx.tenant.id } });
+    expect(await observer.incomeApplication.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+    expect(await observer.fundTransaction.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+    tenantIds.splice(tenantIds.indexOf(ctx.tenant.id), 1);
+    membershipIds.splice(membershipIds.indexOf(ctx.membership.id), 1);
+  }, 30000);
+
+  // ── Application vs Fund archive race ────────────────────────────────────
+
+  it('serializes application vs Fund archive (never ARCHIVED with new CREDIT)', async () => {
+    const ctx = await fixture('app-archive-race');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    const svcB = buildServices(clientB);
+
+    const [planResult, archiveResult] = await Promise.all([
+      appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+        applications: [
+          { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+          { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+        ],
+      }).then(
+        () => ({ ok: true as const }),
+        (error: unknown) => ({ ok: false as const, error: error instanceof Error ? error.message : String(error) }),
+      ),
+      svcB.funds.archiveFund(ctx.tenant.id, fund.id, ctx.membership.id, roles).then(
+        () => ({ ok: true as const }),
+        (error: unknown) => ({ ok: false as const, error: error instanceof Error ? error.message : String(error) }),
+      ),
+    ]);
+
+    const fundAfter = await observer.fund.findUniqueOrThrow({ where: { id: fund.id } });
+    const credits = await observer.fundTransaction.count({ where: { fundId: fund.id, direction: FundTransactionDirection.CREDIT } });
+
+    if (fundAfter.status === FundStatus.ARCHIVED) {
+      // archive ganó → application debió fallar → sin CREDIT
+      expect(planResult.ok).toBe(false);
+      expect(credits).toBe(0);
+    } else {
+      // application ganó → CREDIT existe → archive debió fallar por saldo != 0
+      expect(archiveResult.ok).toBe(false);
+      expect(credits).toBe(1);
+    }
+    // Invariante: nunca ARCHIVED con CREDIT posterior efectivo
+    if (fundAfter.status === FundStatus.ARCHIVED) {
+      expect(credits).toBe(0);
+    }
+  }, 30000);
+
+  // ── No leftovers ────────────────────────────────────────────────────────
+
+  it('leaves no leftovers after the suite', async () => {
+    const leftover = await observer.tenant.count({ where: { name: { startsWith: `${fixturePhase}-` } } });
+    expect(leftover).toBe(0);
+  }, 10000);
+});

--- a/apps/api/src/finanzas/income-applications.postgres.spec.ts
+++ b/apps/api/src/finanzas/income-applications.postgres.spec.ts
@@ -383,7 +383,10 @@ describePostgres('IncomeApplications PostgreSQL (FIN-03)', () => {
     const planB = { applications: [{ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 6000 }, { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 }, { destinationType: IncomeApplicationDestination.CARRY_FORWARD, amountMinor: 1000 }] };
 
     const [a, b] = await Promise.all([
-      appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, planA).then(() => ({ ok: true as const })),
+      appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, planA).then(
+        () => ({ ok: true as const }),
+        (error: unknown) => ({ ok: false as const, conflict: error instanceof NestConflictException }),
+      ),
       svcB.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, planB).then(
         () => ({ ok: true as const }),
         (error: unknown) => ({ ok: false as const, conflict: error instanceof NestConflictException }),
@@ -489,7 +492,10 @@ describePostgres('IncomeApplications PostgreSQL (FIN-03)', () => {
           { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
           { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
         ],
-      }).then(() => ({ ok: true as const })),
+      }).then(
+        () => ({ ok: true as const }),
+        (error: unknown) => ({ ok: false as const, error: error instanceof Error ? error.message : String(error) }),
+      ),
       svcB.incomes.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles).then(
         () => ({ ok: true as const }),
         (error: unknown) => ({ ok: false as const, error: error instanceof Error ? error.message : String(error) }),
@@ -497,29 +503,33 @@ describePostgres('IncomeApplications PostgreSQL (FIN-03)', () => {
     ]);
 
     const incomeAfter = await observer.income.findUniqueOrThrow({ where: { id: income.id } });
-    const credits = await observer.fundTransaction.count({ where: { fundId: fund.id, direction: FundTransactionDirection.CREDIT } });
-    const debits = await observer.fundTransaction.count({ where: { fundId: fund.id, direction: FundTransactionDirection.DEBIT } });
-    const net = credits - debits;
+    const balanceRows = await observer.$queryRaw<Array<{ total: bigint | null }>>`
+      SELECT COALESCE(SUM(CASE WHEN direction = 'CREDIT' THEN "amountMinor" ELSE -"amountMinor" END), 0) AS total
+      FROM "FundTransaction" WHERE "fundId" = ${fund.id} AND "tenantId" = ${ctx.tenant.id}
+    `;
+    const balance = Number(balanceRows[0]?.total ?? 0);
 
-    // Outcome 1: plan primero → void reversa → VOID + net 0
-    // Outcome 2: void primero → plan rechaza → VOID + net 0
-    // Nunca: crédito efectivo posterior a VOID
+    // El lock del Income serializa. Quien corre segundo completa su operación:
+    // - plan primero → void corre después → reversa → Income VOID, balance 0
+    // - void primero → plan corre después → rechaza (RECORDED requerido) → Income VOID, balance 0
+    // Resultado SIEMPRE: Income VOID, balance 0, void ok, plan ok o rechazado.
     expect(incomeAfter.status).toBe(IncomeStatus.VOID);
-    if (net > 0) {
-      // Si quedó crédito sin reversar, el plan habría ganado Y void fallado:
-      // solo válido si el Income NO quedó VOID.
-      expect(planResult.ok).toBe(true);
-      expect(voidResult.ok).toBe(false);
+    expect(balance).toBe(0);
+    expect(voidResult.ok).toBe(true);
+    expect(balance).toBeGreaterThanOrEqual(0);
+
+    // Serializabilidad: si el plan ganó (ok), el CREDIT creado fue reversado por
+    // void (balance 0). Si el plan perdió, fue rechazado por estado VOID.
+    // Ambas ramas terminan en Income VOID + balance 0 (verificado arriba).
+    const txs = await observer.fundTransaction.findMany({ where: { fundId: fund.id } });
+    if (planResult.ok) {
+      // plan primero: CREDIT + reversal DEBIT (2 txs)
+      expect(txs).toHaveLength(2);
+      expect(txs[0]!.direction).toBe(FundTransactionDirection.CREDIT);
+      expect(txs[1]!.direction).toBe(FundTransactionDirection.DEBIT);
     } else {
-      expect(net).toBe(0);
-    }
-    // Invariante crítico: no puede haber CREDIT efectivo sin reversal con Income VOID
-    if (incomeAfter.status === IncomeStatus.VOID) {
-      const balanceRows = await observer.$queryRaw<Array<{ total: bigint | null }>>`
-        SELECT COALESCE(SUM(CASE WHEN direction = 'CREDIT' THEN "amountMinor" ELSE -"amountMinor" END), 0) AS total
-        FROM "FundTransaction" WHERE "fundId" = ${fund.id} AND "tenantId" = ${ctx.tenant.id}
-      `;
-      expect(Number(balanceRows[0]?.total ?? 0)).toBe(0);
+      // void primero: 0 txs (plan rechazado)
+      expect(txs).toHaveLength(0);
     }
   }, 30000);
 

--- a/apps/api/src/finanzas/income-applications.postgres.spec.ts
+++ b/apps/api/src/finanzas/income-applications.postgres.spec.ts
@@ -646,4 +646,263 @@ describePostgres('IncomeApplications PostgreSQL (FIN-03)', () => {
     const leftover = await observer.tenant.count({ where: { name: { startsWith: `${fixturePhase}-` } } });
     expect(leftover).toBe(0);
   }, 10000);
+
+  // ── FIN-03R BLOCKER A: real FUND_TRANSACTION_CREATE audits ─────────────
+
+  it('emits real FUND_TRANSACTION_CREATE audits for every application CREDIT', async () => {
+    const ctx = await fixture('real-credit-audit');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund1 = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F1 ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    const fund2 = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F2 ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+
+    const plan = await appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 4000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund1.id, amountMinor: 3000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund2.id, amountMinor: 3000 },
+      ],
+    });
+
+    // INCOME_APPLICATIONS_CREATE = 1
+    expect(
+      await observer.auditLog.count({ where: { tenantId: ctx.tenant.id, action: 'INCOME_APPLICATIONS_CREATE', entityId: income.id } }),
+    ).toBe(1);
+
+    // FUND_TRANSACTION_CREATE = 2 (uno por CREDIT), con metadata exacta
+    const fundApps = plan.applications.filter((a) => a.destinationType === 'FUND');
+    expect(fundApps).toHaveLength(2);
+    for (const fundApp of fundApps) {
+      const audit = await observer.auditLog.findFirst({
+        where: { tenantId: ctx.tenant.id, action: 'FUND_TRANSACTION_CREATE', entityId: fundApp.fundTransactionId! },
+        orderBy: { createdAt: 'desc' },
+      });
+      expect(audit).not.toBeNull();
+      expect(audit!.entity).toBe('FundTransaction');
+      const metadata = audit!.metadata as Record<string, unknown>;
+      expect(metadata.direction).toBe('CREDIT');
+      expect(metadata.amountMinor).toBe(fundApp.amountMinor);
+      expect(metadata.currencyCode).toBe('USD');
+      expect(metadata.idempotencyKey).toBe(`income-application:${fundApp.id}`);
+      expect(metadata.incomeApplicationId).toBe(fundApp.id);
+    }
+  }, 30000);
+
+  // ── FIN-03R BLOCKER B: void balance/archive safety ──────────────────────
+
+  it('rejects void when the fund was spent (insufficient balance)', async () => {
+    const ctx = await fixture('void-spent');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    await appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+      ],
+    });
+    // Gasto legítimo del CREDIT completo → balance 0
+    await fundsService.createTransaction(ctx.tenant.id, fund.id, ctx.membership.id, roles, {
+      direction: FundTransactionDirection.DEBIT,
+      amountMinor: 3000,
+      currencyCode: 'USD',
+      occurredAt: new Date().toISOString(),
+    });
+
+    await expect(
+      incomesService.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles),
+    ).rejects.toThrow(/Saldo insuficiente|insuficiente/i);
+
+    // Income sigue RECORDED; ledger intacto (CREDIT original + DEBIT manual); sin reversal; balance 0
+    const incomeAfter = await observer.income.findUniqueOrThrow({ where: { id: income.id } });
+    expect(incomeAfter.status).toBe(IncomeStatus.RECORDED);
+    const txs = await observer.fundTransaction.findMany({ where: { fundId: fund.id } });
+    expect(txs).toHaveLength(2);
+    expect(txs.filter((t) => t.direction === 'DEBIT' && t.reversalOfTransactionId !== null)).toHaveLength(0);
+    expect(await observer.auditLog.count({ where: { tenantId: ctx.tenant.id, action: 'INCOME_VOID' } })).toBe(0);
+    expect(await observer.auditLog.count({ where: { tenantId: ctx.tenant.id, action: 'FUND_TRANSACTION_REVERSE' } })).toBe(0);
+  }, 30000);
+
+  it('rejects void when the fund was partially spent', async () => {
+    const ctx = await fixture('void-partial');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    await appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+      ],
+    });
+    await fundsService.createTransaction(ctx.tenant.id, fund.id, ctx.membership.id, roles, {
+      direction: FundTransactionDirection.DEBIT,
+      amountMinor: 2000,
+      currencyCode: 'USD',
+      occurredAt: new Date().toISOString(),
+    });
+
+    await expect(
+      incomesService.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles),
+    ).rejects.toThrow(/Saldo insuficiente|insuficiente/i);
+
+    const incomeAfter = await observer.income.findUniqueOrThrow({ where: { id: income.id } });
+    expect(incomeAfter.status).toBe(IncomeStatus.RECORDED);
+    const fundAfter = await fundsService.getFund(ctx.tenant.id, fund.id, roles);
+    expect(fundAfter.balancesByCurrency).toEqual([{ currency: 'USD', amountMinor: 1000 }]);
+  }, 30000);
+
+  it('rejects void when the fund is ARCHIVED', async () => {
+    const ctx = await fixture('void-archived');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    await appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+      ],
+    });
+    // Llevar a cero y archivar: gastar el CREDIT de aplicación (balance 0),
+    // archivar el fund, y luego void → rechazado por ARCHIVED.
+    await fundsService.createTransaction(ctx.tenant.id, fund.id, ctx.membership.id, roles, {
+      direction: FundTransactionDirection.DEBIT,
+      amountMinor: 3000,
+      currencyCode: 'USD',
+      occurredAt: new Date().toISOString(),
+    });
+    await fundsService.archiveFund(ctx.tenant.id, fund.id, ctx.membership.id, roles);
+
+    await expect(
+      incomesService.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles),
+    ).rejects.toThrow(/archivado/i);
+
+    const incomeAfter = await observer.income.findUniqueOrThrow({ where: { id: income.id } });
+    expect(incomeAfter.status).toBe(IncomeStatus.RECORDED);
+    const txs = await observer.fundTransaction.count({ where: { fundId: fund.id } });
+    expect(txs).toBe(2); // CREDIT app + DEBIT manual (sin reversal de void)
+  }, 30000);
+
+  it('void succeeds when other valid credits keep the balance sufficient', async () => {
+    const ctx = await fixture('void-sufficient');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    await appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+      ],
+    });
+    await fundsService.createTransaction(ctx.tenant.id, fund.id, ctx.membership.id, roles, {
+      direction: FundTransactionDirection.CREDIT,
+      amountMinor: 2000,
+      currencyCode: 'USD',
+      occurredAt: new Date().toISOString(),
+    });
+
+    await incomesService.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles);
+
+    const incomeAfter = await observer.income.findUniqueOrThrow({ where: { id: income.id } });
+    expect(incomeAfter.status).toBe(IncomeStatus.VOID);
+    const fundAfter = await fundsService.getFund(ctx.tenant.id, fund.id, roles);
+    expect(fundAfter.balancesByCurrency).toEqual([{ currency: 'USD', amountMinor: 2000 }]);
+  }, 30000);
+
+  it('void is all-or-nothing across multiple funds (one insufficient → reject everything)', async () => {
+    const ctx = await fixture('void-multi');
+    const income = await recordedIncome(ctx.tenant.id, 20000);
+    const fundA = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `FA ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    const fundB = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `FB ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    await appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fundA.id, amountMinor: 10000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fundB.id, amountMinor: 10000 },
+      ],
+    });
+    // Gastar completamente fundB → insuficiente para su reversal
+    await fundsService.createTransaction(ctx.tenant.id, fundB.id, ctx.membership.id, roles, {
+      direction: FundTransactionDirection.DEBIT,
+      amountMinor: 10000,
+      currencyCode: 'USD',
+      occurredAt: new Date().toISOString(),
+    });
+
+    await expect(
+      incomesService.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles),
+    ).rejects.toThrow(/Saldo insuficiente|insuficiente/i);
+
+    // ALL OR NOTHING: ningún reversal en A ni B; Income RECORDED
+    const incomeAfter = await observer.income.findUniqueOrThrow({ where: { id: income.id } });
+    expect(incomeAfter.status).toBe(IncomeStatus.RECORDED);
+    const reversalsA = await observer.fundTransaction.count({ where: { fundId: fundA.id, reversalOfTransactionId: { not: null } } });
+    const reversalsB = await observer.fundTransaction.count({ where: { fundId: fundB.id, reversalOfTransactionId: { not: null } } });
+    expect(reversalsA).toBe(0);
+    expect(reversalsB).toBe(0);
+  }, 30000);
+
+  // ── FIN-03R: void vs concurrent manual debit race ───────────────────────
+
+  it('serializes void vs concurrent manual debit (never negative, never partial void)', async () => {
+    const ctx = await fixture('void-debit-race');
+    const income = await recordedIncome(ctx.tenant.id, 10000);
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    await appsService.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+      ],
+    });
+    const svcB = buildServices(clientB);
+
+    const [voidResult, debitResult] = await Promise.all([
+      incomesService.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles).then(
+        () => ({ ok: true as const }),
+        (error: unknown) => ({ ok: false as const, error: error instanceof Error ? error.message : String(error) }),
+      ),
+      svcB.funds.createTransaction(ctx.tenant.id, fund.id, ctx.membership.id, roles, {
+        direction: FundTransactionDirection.DEBIT,
+        amountMinor: 3000,
+        currencyCode: 'USD',
+        occurredAt: new Date().toISOString(),
+      }).then(
+        () => ({ ok: true as const }),
+        (error: unknown) => ({ ok: false as const, error: error instanceof Error ? error.message : String(error) }),
+      ),
+    ]);
+
+    const incomeAfter = await observer.income.findUniqueOrThrow({ where: { id: income.id } });
+    const balanceRows = await observer.$queryRaw<Array<{ total: bigint | null }>>`
+      SELECT COALESCE(SUM(CASE WHEN direction = 'CREDIT' THEN "amountMinor" ELSE -"amountMinor" END), 0) AS total
+      FROM "FundTransaction" WHERE "fundId" = ${fund.id} AND "tenantId" = ${ctx.tenant.id}
+    `;
+    const balance = Number(balanceRows[0]?.total ?? 0);
+
+    // Nunca balance negativo
+    expect(balance).toBeGreaterThanOrEqual(0);
+
+    if (incomeAfter.status === IncomeStatus.VOID) {
+      // void ganó → reversal DEBIT aplicado → manual debit debió fallar (saldo 0)
+      expect(voidResult.ok).toBe(true);
+      expect(debitResult.ok).toBe(false);
+      expect(balance).toBe(0);
+    } else {
+      // manual debit ganó → void detecta insuficiente → Income RECORDED
+      expect(incomeAfter.status).toBe(IncomeStatus.RECORDED);
+      expect(voidResult.ok).toBe(false);
+      expect(balance).toBe(0);
+    }
+  }, 30000);
 });

--- a/apps/api/src/finanzas/income-applications.service.spec.ts
+++ b/apps/api/src/finanzas/income-applications.service.spec.ts
@@ -1,0 +1,473 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  FundStatus,
+  FundTransactionDirection,
+  IncomeApplicationDestination,
+  IncomeStatus,
+  Prisma,
+} from '@prisma/client';
+import { IncomeApplicationsService } from './income-applications.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+
+const makeIncome = (overrides: Record<string, unknown> = {}) => ({
+  id: 'income-1',
+  tenantId: 'tenant-1',
+  buildingId: null,
+  period: '2026-08',
+  categoryId: 'cat-1',
+  amountMinor: 10000,
+  currencyCode: 'USD',
+  receivedDate: new Date('2026-08-10T00:00:00.000Z'),
+  postedAt: new Date(),
+  description: null,
+  attachmentFileKey: null,
+  status: IncomeStatus.RECORDED,
+  scopeType: 'BUILDING',
+  destination: 'APPLY_TO_EXPENSES',
+  unitGroupId: null,
+  functionalAmountMinor: null,
+  functionalCurrencyCode: null,
+  exchangeRateId: null,
+  exchangeRateValue: null,
+  exchangeRateDirection: null,
+  exchangeRateEffectiveAt: null,
+  conversionDate: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+const makeApplication = (overrides: Record<string, unknown> = {}) => ({
+  id: 'app-1',
+  tenantId: 'tenant-1',
+  incomeId: 'income-1',
+  destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+  fundId: null,
+  amountMinor: 7000,
+  currencyCode: 'USD',
+  createdByMembershipId: 'member-1',
+  createdAt: new Date(),
+  fundTransaction: null,
+  ...overrides,
+});
+
+describe('IncomeApplicationsService', () => {
+  let service: IncomeApplicationsService;
+  let prisma: PrismaService;
+  let audit: AuditService;
+  let validators: FinanzasValidators;
+
+  const prismaValue = {
+    income: { findFirst: jest.fn() },
+    incomeApplication: { findMany: jest.fn(), create: jest.fn() },
+    fund: { findMany: jest.fn() },
+    fundTransaction: { create: jest.fn() },
+    $transaction: jest.fn(),
+    $executeRaw: jest.fn(),
+  };
+
+  function mockTransaction() {
+    (prismaValue.$transaction as jest.Mock).mockImplementation(
+      async (callback: (tx: unknown) => unknown) => callback({
+        income: prismaValue.income,
+        incomeApplication: prismaValue.incomeApplication,
+        fund: prismaValue.fund,
+        fundTransaction: prismaValue.fundTransaction,
+        auditLog: { create: jest.fn() },
+        $executeRaw: prismaValue.$executeRaw,
+      }),
+    );
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    (prismaValue.incomeApplication.create as jest.Mock).mockReset();
+    (prismaValue.fundTransaction.create as jest.Mock).mockReset();
+    mockTransaction();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IncomeApplicationsService,
+        { provide: PrismaService, useValue: prismaValue },
+        {
+          provide: AuditService,
+          useValue: {
+            createLog: jest.fn(),
+            createLogRequired: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: FinanzasValidators,
+          useValue: {
+            isAdminOrOperator: jest.fn().mockReturnValue(true),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<IncomeApplicationsService>(IncomeApplicationsService);
+    prisma = module.get<PrismaService>(PrismaService);
+    audit = module.get<AuditService>(AuditService);
+    validators = module.get<FinanzasValidators>(FinanzasValidators);
+
+    (audit.createLogRequired as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  const roles = ['TENANT_ADMIN'];
+
+  const plan = (apps: Array<{ destinationType: IncomeApplicationDestination; fundId?: string; amountMinor: number }>) =>
+    ({ applications: apps });
+
+  // ── RBAC ────────────────────────────────────────────────────────────────
+
+  describe('RBAC', () => {
+    it('rejects non-admin users', async () => {
+      (validators.isAdminOrOperator as jest.Mock).mockReturnValue(false);
+      await expect(service.getPlan('tenant-1', 'income-1', ['RESIDENT'])).rejects.toThrow(ForbiddenException);
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'm', ['RESIDENT'], plan([{ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 10000 }])),
+      ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  // ── Lifecycle guards ────────────────────────────────────────────────────
+
+  describe('lifecycle guards', () => {
+    it('rejects a DRAFT income', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome({ status: IncomeStatus.DRAFT }));
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([{ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 10000 }])),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects a VOID income', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome({ status: IncomeStatus.VOID }));
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([{ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 10000 }])),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects income from another tenant (not found)', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(null);
+      await expect(
+        service.createPlan('tenant-1', 'income-x', 'member-1', roles, plan([{ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 10000 }])),
+      ).rejects.toThrow(NotFoundException);
+      expect(prisma.income.findFirst).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: 'income-x', tenantId: 'tenant-1' } }),
+      );
+    });
+  });
+
+  // ── Exact sum invariant ─────────────────────────────────────────────────
+
+  describe('exact sum invariant', () => {
+    beforeEach(() => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([]);
+    });
+
+    it('accepts an exact 70/30 split', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([{ id: 'fund-1', status: FundStatus.ACTIVE }]);
+      (prisma.incomeApplication.create as jest.Mock).mockResolvedValueOnce(
+        makeApplication({ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 }),
+      );
+      (prisma.incomeApplication.create as jest.Mock).mockResolvedValueOnce(
+        makeApplication({ id: 'app-2', destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000, fundTransaction: { id: 'ft-1' } }),
+      );
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValue({ id: 'ft-1' });
+
+      const result = await service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000 },
+      ]));
+
+      expect(result.totalAmountMinor).toBe(10000);
+      expect(prisma.incomeApplication.create).toHaveBeenCalledTimes(2);
+      expect(prisma.fundTransaction.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects an underallocation (sum < income)', async () => {
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+          { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+          { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 2999 },
+        ])),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.incomeApplication.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects an overallocation (sum > income)', async () => {
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+          { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+          { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3001 },
+        ])),
+      ).rejects.toThrow(BadRequestException);
+      expect(prisma.incomeApplication.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects amountMinor = 0', async () => {
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+          { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 0 },
+          { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 10000 },
+        ])),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects negative amountMinor', async () => {
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+          { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: -100 },
+          { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 10100 },
+        ])),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ── Duplicate destinations ──────────────────────────────────────────────
+
+  describe('duplicate destinations', () => {
+    beforeEach(() => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+    });
+
+    it('rejects two OFFSET_EXPENSES', async () => {
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+          { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 5000 },
+          { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 5000 },
+        ])),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects two CARRY_FORWARD', async () => {
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+          { destinationType: IncomeApplicationDestination.CARRY_FORWARD, amountMinor: 5000 },
+          { destinationType: IncomeApplicationDestination.CARRY_FORWARD, amountMinor: 5000 },
+        ])),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects two FUND towards the same fundId', async () => {
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+          { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 5000 },
+          { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 5000 },
+        ])),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('allows FUND to different funds', async () => {
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([
+        { id: 'fund-1', status: FundStatus.ACTIVE },
+        { id: 'fund-2', status: FundStatus.ACTIVE },
+      ]);
+      (prisma.incomeApplication.create as jest.Mock).mockResolvedValueOnce(makeApplication({ id: 'a1', destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 4000, fundTransaction: { id: 'ft1' } }));
+      (prisma.incomeApplication.create as jest.Mock).mockResolvedValueOnce(makeApplication({ id: 'a2', destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-2', amountMinor: 6000, fundTransaction: { id: 'ft2' } }));
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValueOnce({ id: 'ft1' });
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValueOnce({ id: 'ft2' });
+
+      const result = await service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 4000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-2', amountMinor: 6000 },
+      ]));
+
+      expect(result.applications).toHaveLength(2);
+    });
+  });
+
+  // ── Fund target validation ──────────────────────────────────────────────
+
+  describe('fund target validation', () => {
+    beforeEach(() => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([]);
+    });
+
+    it('rejects FUND without fundId', async () => {
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+          { destinationType: IncomeApplicationDestination.FUND, amountMinor: 10000 },
+        ])),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects OFFSET_EXPENSES with fundId', async () => {
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+          { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, fundId: 'fund-1', amountMinor: 10000 },
+        ])),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects a cross-tenant fund (not found in tenant)', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+          { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-other', amountMinor: 10000 },
+        ])),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('rejects an ARCHIVED fund', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([{ id: 'fund-1', status: FundStatus.ARCHIVED }]);
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+          { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 10000 },
+        ])),
+      ).rejects.toThrow(BadRequestException);
+    });
+  });
+
+  // ── Plan idempotency ────────────────────────────────────────────────────
+
+  describe('plan idempotency', () => {
+    beforeEach(() => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+    });
+
+    const existingPlan = () => [
+      makeApplication({ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 }),
+      makeApplication({ id: 'app-2', destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000, fundTransaction: { id: 'ft-1' } }),
+    ];
+
+    it('returns the existing plan on the same-plan retry (no new mutations)', async () => {
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue(existingPlan());
+
+      const result = await service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000 },
+      ]));
+
+      expect(result.applications).toHaveLength(2);
+      expect(prisma.incomeApplication.create).not.toHaveBeenCalled();
+      expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
+    });
+
+    it('is order-insensitive for the same plan', async () => {
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue(existingPlan());
+
+      const result = await service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000 },
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+      ]));
+
+      expect(result.applications).toHaveLength(2);
+      expect(prisma.incomeApplication.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects a different plan with 409 Conflict', async () => {
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue(existingPlan());
+
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+          { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 6000 },
+          { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000 },
+          { destinationType: IncomeApplicationDestination.CARRY_FORWARD, amountMinor: 1000 },
+        ])),
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  // ── Destination behavior ────────────────────────────────────────────────
+
+  describe('destination behavior', () => {
+    beforeEach(() => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([]);
+    });
+
+    it('OFFSET_EXPENSES creates no FundTransaction', async () => {
+      (prisma.incomeApplication.create as jest.Mock).mockResolvedValue(makeApplication());
+
+      await service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 10000 },
+      ]));
+
+      expect(prisma.incomeApplication.create).toHaveBeenCalledTimes(1);
+      expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
+    });
+
+    it('CARRY_FORWARD creates no FundTransaction', async () => {
+      (prisma.incomeApplication.create as jest.Mock).mockResolvedValue(
+        makeApplication({ destinationType: IncomeApplicationDestination.CARRY_FORWARD }),
+      );
+
+      await service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+        { destinationType: IncomeApplicationDestination.CARRY_FORWARD, amountMinor: 10000 },
+      ]));
+
+      expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
+    });
+
+    it('FUND creates an exact CREDIT linked to the application', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([{ id: 'fund-1', status: FundStatus.ACTIVE }]);
+      (prisma.incomeApplication.create as jest.Mock)
+        .mockResolvedValueOnce(makeApplication({ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 }))
+        .mockResolvedValueOnce(
+          makeApplication({ id: 'app-x', destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000, fundTransaction: { id: 'ft-x' } }),
+        );
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValue({ id: 'ft-x' });
+
+      await service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000 },
+      ]));
+
+      expect(prisma.fundTransaction.create).toHaveBeenCalledTimes(1);
+      const call = (prisma.fundTransaction.create as jest.Mock).mock.calls[0] as [{ data: Record<string, unknown> }];
+      expect(call[0].data).toEqual(expect.objectContaining({
+        tenantId: 'tenant-1',
+        fundId: 'fund-1',
+        direction: FundTransactionDirection.CREDIT,
+        amountMinor: 3000,
+        currencyCode: 'USD', // == income.currencyCode
+        incomeApplicationId: 'app-x',
+        idempotencyKey: 'income-application:app-x',
+        occurredAt: new Date('2026-08-10T00:00:00.000Z'), // == income.receivedDate
+      }));
+    });
+
+    it('persists application currencyCode == income.currencyCode', async () => {
+      (prisma.incomeApplication.create as jest.Mock).mockResolvedValue(makeApplication());
+
+      await service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 10000 },
+      ]));
+
+      const call = (prisma.incomeApplication.create as jest.Mock).mock.calls[0] as [{ data: Record<string, unknown> }];
+      expect(call[0].data.currencyCode).toBe('USD');
+    });
+  });
+
+  // ── Audit metadata null contract ────────────────────────────────────────
+
+  describe('audit metadata null contract', () => {
+    it('omits fundId from audit metadata when absent', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.incomeApplication.create as jest.Mock).mockResolvedValue(makeApplication());
+
+      await service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 10000 },
+      ]));
+
+      expect(audit.createLogRequired).toHaveBeenCalledTimes(1);
+      const call = (audit.createLogRequired as jest.Mock).mock.calls[0] as [{ metadata: Record<string, unknown> }];
+      expect(call[0].action).toBe('INCOME_APPLICATIONS_CREATE');
+      const apps = (call[0].metadata.applications as Array<Record<string, unknown>>);
+      expect('fundId' in apps[0]!).toBe(false);
+    });
+  });
+});

--- a/apps/api/src/finanzas/income-applications.service.spec.ts
+++ b/apps/api/src/finanzas/income-applications.service.spec.ts
@@ -470,4 +470,110 @@ describe('IncomeApplicationsService', () => {
       expect('fundId' in apps[0]!).toBe(false);
     });
   });
+
+  // ── Required FUND CREDIT audit (FIN-03R BLOCKER A) ─────────────────────
+
+  describe('required fund credit audit', () => {
+    beforeEach(() => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([]);
+    });
+
+    it('emits exactly one FUND_TRANSACTION_CREATE per FUND destination plus the plan audit', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([{ id: 'fund-1', status: FundStatus.ACTIVE }]);
+      (prisma.incomeApplication.create as jest.Mock)
+        .mockResolvedValueOnce(makeApplication({ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 }))
+        .mockResolvedValueOnce(
+          makeApplication({ id: 'app-x', destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000, fundTransaction: { id: 'ft-x' } }),
+        );
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValue({ id: 'ft-x' });
+
+      await service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000 },
+      ]));
+
+      const calls = (audit.createLogRequired as jest.Mock).mock.calls.map(
+        (call: [{ action: string; entityId: string; metadata: Record<string, unknown> }]) => ({
+          action: call[0].action,
+          entityId: call[0].entityId,
+          metadata: call[0].metadata,
+        }),
+      );
+      expect(calls).toHaveLength(2);
+      const txAudit = calls.find((c) => c.action === 'FUND_TRANSACTION_CREATE');
+      expect(txAudit).toBeDefined();
+      expect(txAudit!.entityId).toBe('ft-x');
+      expect(txAudit!.metadata.fundId).toBe('fund-1');
+      expect(txAudit!.metadata.direction).toBe('CREDIT');
+      expect(txAudit!.metadata.amountMinor).toBe(3000);
+      expect(txAudit!.metadata.currencyCode).toBe('USD');
+      expect(txAudit!.metadata.idempotencyKey).toBe('income-application:app-x');
+      expect(txAudit!.metadata.incomeApplicationId).toBe('app-x');
+      const planAudit = calls.find((c) => c.action === 'INCOME_APPLICATIONS_CREATE');
+      expect(planAudit).toBeDefined();
+    });
+
+    it('emits 3 FUND_TRANSACTION_CREATE for a 3-FUND plan plus the plan audit', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([
+        { id: 'fund-1', status: FundStatus.ACTIVE },
+        { id: 'fund-2', status: FundStatus.ACTIVE },
+        { id: 'fund-3', status: FundStatus.ACTIVE },
+      ]);
+      (prisma.incomeApplication.create as jest.Mock)
+        .mockResolvedValueOnce(makeApplication({ id: 'a1', destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000, fundTransaction: { id: 'ft1' } }))
+        .mockResolvedValueOnce(makeApplication({ id: 'a2', destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-2', amountMinor: 3000, fundTransaction: { id: 'ft2' } }))
+        .mockResolvedValueOnce(makeApplication({ id: 'a3', destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-3', amountMinor: 4000, fundTransaction: { id: 'ft3' } }));
+      (prisma.fundTransaction.create as jest.Mock)
+        .mockResolvedValueOnce({ id: 'ft1' })
+        .mockResolvedValueOnce({ id: 'ft2' })
+        .mockResolvedValueOnce({ id: 'ft3' });
+
+      await service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-2', amountMinor: 3000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-3', amountMinor: 4000 },
+      ]));
+
+      const actions = (audit.createLogRequired as jest.Mock).mock.calls.map(
+        (call: [{ action: string }]) => call[0].action,
+      );
+      expect(actions.filter((a) => a === 'FUND_TRANSACTION_CREATE')).toHaveLength(3);
+      expect(actions.filter((a) => a === 'INCOME_APPLICATIONS_CREATE')).toHaveLength(1);
+    });
+
+    it('does not emit FUND_TRANSACTION_CREATE audits on a same-plan retry', async () => {
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([
+        makeApplication({ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 }),
+        makeApplication({ id: 'app-2', destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000, fundTransaction: { id: 'ft-1' } }),
+      ]);
+
+      await service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000 },
+      ]));
+
+      expect(audit.createLogRequired).not.toHaveBeenCalled();
+      expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
+    });
+
+    it('rolls back everything when the required FUND_TRANSACTION_CREATE audit fails', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([{ id: 'fund-1', status: FundStatus.ACTIVE }]);
+      (prisma.incomeApplication.create as jest.Mock)
+        .mockResolvedValueOnce(makeApplication({ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 }))
+        .mockResolvedValueOnce(
+          makeApplication({ id: 'app-x', destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000, fundTransaction: { id: 'ft-x' } }),
+        );
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValue({ id: 'ft-x' });
+      (audit.createLogRequired as jest.Mock).mockRejectedValue(new Error('FORCED_AUDIT_FAILURE'));
+
+      await expect(
+        service.createPlan('tenant-1', 'income-1', 'member-1', roles, plan([
+          { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+          { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000 },
+        ])),
+      ).rejects.toThrow('FORCED_AUDIT_FAILURE');
+      // el error se propaga → la transacción (mock) haría rollback real en PostgreSQL
+    });
+  });
 });

--- a/apps/api/src/finanzas/income-applications.service.ts
+++ b/apps/api/src/finanzas/income-applications.service.ts
@@ -1,0 +1,354 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  FundStatus,
+  FundTransactionDirection,
+  IncomeApplicationDestination,
+  IncomeStatus,
+  Prisma,
+} from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+import {
+  acquireFundLock,
+  acquireIncomeLock,
+} from './fund-locks';
+import {
+  CreateIncomeApplicationsDto,
+  IncomeApplicationPlanResponseDto,
+} from './income-applications.dto';
+
+/** Idempotency determinística del CREDIT generado por una aplicación FUND. */
+export function incomeApplicationFundTransactionKey(applicationId: string): string {
+  return `income-application:${applicationId}`;
+}
+
+type ApplicationRow = Prisma.IncomeApplicationGetPayload<Record<string, never>> & {
+  fundTransaction: { id: string } | null;
+};
+
+/** Identidad canónica de una aplicación: orden-insensible para idempotencia. */
+function canonicalKey(app: {
+  destinationType: IncomeApplicationDestination;
+  fundId: string | null;
+  amountMinor: number;
+}): string {
+  return `${app.destinationType}:${app.fundId ?? ''}:${app.amountMinor}`;
+}
+
+@Injectable()
+export class IncomeApplicationsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auditService: AuditService,
+    private readonly validators: FinanzasValidators,
+  ) {}
+
+  // ── GET plan ─────────────────────────────────────────────────────────────
+
+  async getPlan(
+    tenantId: string,
+    incomeId: string,
+    userRoles: string[],
+  ): Promise<IncomeApplicationPlanResponseDto> {
+    this.assertAdminOrOperator(userRoles, 'ver aplicaciones de ingresos');
+
+    const income = await this.prisma.income.findFirst({
+      where: { id: incomeId, tenantId },
+    });
+    if (!income) {
+      throw new NotFoundException('Ingreso no encontrado o no pertenece al tenant');
+    }
+
+    const applications = await this.loadApplications(tenantId, incomeId);
+    return {
+      incomeId,
+      currencyCode: income.currencyCode,
+      totalAmountMinor: applications.reduce((sum, app) => sum + app.amountMinor, 0),
+      applications: applications.map((app) => this.toDto(app)),
+    };
+  }
+
+  // ── POST plan (creación publicada, inmutable, idempotente) ──────────────
+
+  async createPlan(
+    tenantId: string,
+    incomeId: string,
+    membershipId: string,
+    userRoles: string[],
+    dto: CreateIncomeApplicationsDto,
+  ): Promise<IncomeApplicationPlanResponseDto> {
+    this.assertAdminOrOperator(userRoles, 'crear aplicaciones de ingresos');
+
+    const plan = dto.applications;
+
+    // Validaciones estáticas del plan (antes de locks)
+    for (const app of plan) {
+      if (!Number.isInteger(app.amountMinor) || app.amountMinor <= 0) {
+        throw new BadRequestException(
+          `amountMinor debe ser un entero positivo (recibido: ${app.amountMinor})`,
+        );
+      }
+    }
+    this.assertNoDuplicateDestinations(plan);
+
+    const totalRequested = plan.reduce((sum, app) => sum + app.amountMinor, 0);
+
+    return this.prisma.$transaction(async (tx) => {
+      // Lock del Income: serializa application vs application y application vs void
+      await acquireIncomeLock(tx, tenantId, incomeId);
+
+      const income = await tx.income.findFirst({
+        where: { id: incomeId, tenantId },
+      });
+      if (!income) {
+        throw new NotFoundException('Ingreso no encontrado o no pertenece al tenant');
+      }
+      if (income.status !== IncomeStatus.RECORDED) {
+        throw new BadRequestException(
+          `Solo se pueden aplicar ingresos RECORDED. Estado actual: ${income.status}`,
+        );
+      }
+
+      // Suma exacta
+      if (totalRequested !== income.amountMinor) {
+        throw new BadRequestException(
+          `La suma de aplicaciones (${totalRequested}) debe ser exactamente ${income.amountMinor}`,
+        );
+      }
+
+      // Plan existente → idempotencia
+      const existing = await this.loadApplicationsTx(tx, tenantId, incomeId);
+      if (existing.length > 0) {
+        const existingPlan = new Set(
+          existing.map((app) =>
+            canonicalKey({
+              destinationType: app.destinationType,
+              fundId: app.fundId,
+              amountMinor: app.amountMinor,
+            }),
+          ),
+        );
+        const requestedPlan = new Set(
+          plan.map((app) =>
+            canonicalKey({
+              destinationType: app.destinationType,
+              fundId: app.fundId ?? null,
+              amountMinor: app.amountMinor,
+            }),
+          ),
+        );
+
+        const samePlan =
+          existingPlan.size === requestedPlan.size &&
+          [...requestedPlan].every((key) => existingPlan.has(key));
+
+        if (samePlan) {
+          // Retry del mismo plan: devolver el plan existente, sin nuevas mutaciones.
+          return {
+            incomeId,
+            currencyCode: income.currencyCode,
+            totalAmountMinor: totalRequested,
+            applications: existing.map((app) => this.toDto(app)),
+          };
+        }
+        throw new ConflictException(
+          'Este ingreso ya tiene un plan de aplicaciones diferente',
+        );
+      }
+
+      // Adquirir locks de Funds en orden determinístico ANTES de validar el
+      // estado del fund: evita TOCTOU application vs archive (el archive puede
+      // cambiar ACTIVE→ARCHIVED mientras el plan espera el lock).
+      const fundIds = [...new Set(
+        plan
+          .filter((app) => app.destinationType === IncomeApplicationDestination.FUND)
+          .map((app) => app.fundId as string),
+      )].sort();
+      for (const fundId of fundIds) {
+        await acquireFundLock(tx, tenantId, fundId);
+      }
+
+      // Validar funds CON el lock tomado (estado estable).
+      const funds = await tx.fund.findMany({
+        where: { id: { in: fundIds }, tenantId },
+        select: { id: true, status: true },
+      });
+      const fundById = new Map(funds.map((f) => [f.id, f]));
+      for (const fundId of fundIds) {
+        const fund = fundById.get(fundId);
+        if (!fund) {
+          throw new NotFoundException(`Fondo no encontrado o no pertenece al tenant: ${fundId}`);
+        }
+        if (fund.status !== FundStatus.ACTIVE) {
+          throw new BadRequestException(`El fondo está archivado: ${fundId}`);
+        }
+      }
+
+      // Crear aplicaciones + FundTransactions CREDIT (uno a uno)
+      const created: ApplicationRow[] = [];
+      for (const app of plan) {
+        const isFund = app.destinationType === IncomeApplicationDestination.FUND;
+        const application = await tx.incomeApplication.create({
+          data: {
+            tenantId,
+            incomeId,
+            destinationType: app.destinationType,
+            fundId: isFund ? app.fundId! : null,
+            amountMinor: app.amountMinor,
+            currencyCode: income.currencyCode,
+            createdByMembershipId: membershipId,
+          },
+        });
+
+        if (isFund) {
+          // El CREDIT del Fund: determinístico por applicationId (retry-safe).
+          const transaction = await tx.fundTransaction.create({
+            data: {
+              tenantId,
+              fundId: app.fundId!,
+              direction: FundTransactionDirection.CREDIT,
+              amountMinor: app.amountMinor,
+              currencyCode: income.currencyCode,
+              occurredAt: income.receivedDate,
+              description: `Aplicación de ingreso ${incomeId}`,
+              createdByMembershipId: membershipId,
+              idempotencyKey: incomeApplicationFundTransactionKey(application.id),
+              incomeApplicationId: application.id,
+            },
+          });
+          created.push({
+            ...application,
+            fundTransaction: { id: transaction.id },
+          });
+        } else {
+          created.push({ ...application, fundTransaction: null });
+        }
+      }
+
+      // Audit requerido del plan (atómico con la mutación)
+      await this.auditService.createLogRequired(
+        {
+          tenantId,
+          actorMembershipId: membershipId,
+          action: 'INCOME_APPLICATIONS_CREATE',
+          entityType: 'Income',
+          entityId: incomeId,
+          metadata: {
+            incomeId,
+            currencyCode: income.currencyCode,
+            totalAmountMinor: totalRequested,
+            applications: plan.map((app) => ({
+              destinationType: app.destinationType,
+              ...(app.fundId !== undefined && app.fundId !== null
+                ? { fundId: app.fundId }
+                : {}),
+              amountMinor: app.amountMinor,
+            })),
+          },
+        },
+        tx,
+      );
+
+      return {
+        incomeId,
+        currencyCode: income.currencyCode,
+        totalAmountMinor: totalRequested,
+        applications: created.map((app) => this.toDto(app)),
+      };
+    });
+  }
+
+  // ── Internos ─────────────────────────────────────────────────────────────
+
+  private assertAdminOrOperator(userRoles: string[], action: string): void {
+    if (!this.validators.isAdminOrOperator(userRoles)) {
+      throw new ForbiddenException(`Solo administradores pueden ${action}`);
+    }
+  }
+
+  /**
+   * No permitir dos OFFSET_EXPENSES, dos CARRY_FORWARD ni dos FUND hacia el
+   * mismo fundId dentro del mismo Income.
+   */
+  private assertNoDuplicateDestinations(
+    plan: Array<{ destinationType: IncomeApplicationDestination; fundId?: string }>,
+  ): void {
+    const seenNonFund = new Set<IncomeApplicationDestination>();
+    const seenFund = new Set<string>();
+    for (const app of plan) {
+      if (app.destinationType === IncomeApplicationDestination.FUND) {
+        if (app.fundId === undefined || app.fundId === null) {
+          throw new BadRequestException('fundId es obligatorio para destinationType FUND');
+        }
+        if (seenFund.has(app.fundId)) {
+          throw new BadRequestException(
+            `No puede haber dos aplicaciones FUND hacia el mismo fondo: ${app.fundId}`,
+          );
+        }
+        seenFund.add(app.fundId);
+      } else {
+        if (app.fundId !== undefined && app.fundId !== null) {
+          throw new BadRequestException(
+            `fundId no aplica para destinationType ${app.destinationType}`,
+          );
+        }
+        if (seenNonFund.has(app.destinationType)) {
+          throw new BadRequestException(
+            `No puede haber dos aplicaciones ${app.destinationType} en el mismo ingreso`,
+          );
+        }
+        seenNonFund.add(app.destinationType);
+      }
+    }
+  }
+
+  private async loadApplications(
+    tenantId: string,
+    incomeId: string,
+  ): Promise<ApplicationRow[]> {
+    return this.loadApplicationsTx(this.prisma, tenantId, incomeId);
+  }
+
+  private async loadApplicationsTx(
+    tx: Prisma.TransactionClient | PrismaService,
+    tenantId: string,
+    incomeId: string,
+  ): Promise<ApplicationRow[]> {
+    return tx.incomeApplication.findMany({
+      where: { tenantId, incomeId },
+      include: { fundTransaction: { select: { id: true } } },
+      orderBy: [{ destinationType: 'asc' }, { fundId: 'asc' }, { amountMinor: 'asc' }],
+    }) as Promise<ApplicationRow[]>;
+  }
+
+  private toDto(app: ApplicationRow): {
+    id: string;
+    tenantId: string;
+    incomeId: string;
+    destinationType: IncomeApplicationDestination;
+    fundId: string | null;
+    amountMinor: number;
+    currencyCode: string;
+    fundTransactionId: string | null;
+    createdAt: Date;
+  } {
+    return {
+      id: app.id,
+      tenantId: app.tenantId,
+      incomeId: app.incomeId,
+      destinationType: app.destinationType,
+      fundId: app.fundId,
+      amountMinor: app.amountMinor,
+      currencyCode: app.currencyCode,
+      fundTransactionId: app.fundTransaction?.id ?? null,
+      createdAt: app.createdAt,
+    };
+  }
+}

--- a/apps/api/src/finanzas/income-applications.service.ts
+++ b/apps/api/src/finanzas/income-applications.service.ts
@@ -223,6 +223,30 @@ export class IncomeApplicationsService {
               incomeApplicationId: application.id,
             },
           });
+
+          // FIN-03R (BLOCKER A): cada CREDIT monetario requiere su propio audit
+          // FUND_TRANSACTION_CREATE dentro de la MISMA transacción. Si falla,
+          // rollback total (application + FundTransaction + plan).
+          await this.auditService.createLogRequired(
+            {
+              tenantId,
+              actorMembershipId: membershipId,
+              action: 'FUND_TRANSACTION_CREATE',
+              entityType: 'FundTransaction',
+              entityId: transaction.id,
+              metadata: {
+                fundId: app.fundId!,
+                direction: FundTransactionDirection.CREDIT,
+                amountMinor: app.amountMinor,
+                currencyCode: income.currencyCode,
+                occurredAt: income.receivedDate.toISOString(),
+                idempotencyKey: incomeApplicationFundTransactionKey(application.id),
+                incomeApplicationId: application.id,
+              },
+            },
+            tx,
+          );
+
           created.push({
             ...application,
             fundTransaction: { id: transaction.id },

--- a/apps/api/src/finanzas/incomes.service.ts
+++ b/apps/api/src/finanzas/incomes.service.ts
@@ -4,7 +4,7 @@ import {
   NotFoundException,
   ForbiddenException,
 } from '@nestjs/common';
-import { FundTransactionDirection, IncomeStatus } from '@prisma/client';
+import { FundStatus, FundTransactionDirection, IncomeStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { FinanzasValidators } from './finanzas.validators';
@@ -19,6 +19,7 @@ import {
   acquireFundLock,
   acquireIncomeLock,
 } from './fund-locks';
+import { assertSufficientFundBalance } from './fund-ledger';
 
 @Injectable()
 export class IncomesService {
@@ -415,10 +416,55 @@ export class IncomesService {
           .filter((fundId): fundId is string => fundId !== null),
       )].sort();
 
+      // Adquirir locks de Funds en orden determinístico ANTES de validar estado.
       for (const fundId of fundIds) {
         await acquireFundLock(tx, tenantId, fundId);
       }
 
+      // FIN-03R (BLOCKER B): validar cada Fund CON el lock tomado.
+      // ARCHIVED no acepta nuevos movimientos (FIN-02) → rechazar el void completo.
+      if (fundIds.length > 0) {
+        const funds = await tx.fund.findMany({
+          where: { id: { in: fundIds }, tenantId },
+          select: { id: true, status: true },
+        });
+        const fundById = new Map(funds.map((f) => [f.id, f]));
+        for (const fundId of fundIds) {
+          const fund = fundById.get(fundId);
+          if (!fund) {
+            throw new NotFoundException(`Fondo no encontrado o no pertenece al tenant: ${fundId}`);
+          }
+          if (fund.status !== FundStatus.ACTIVE) {
+            throw new BadRequestException(
+              `No se puede anular el ingreso: el fondo está archivado (${fundId})`,
+            );
+          }
+        }
+      }
+
+      // Pre-validar saldo suficiente para TODOS los reversals DEBIT antes de
+      // escribir cualquiera (all-or-nothing: sin reversals parciales).
+      for (const app of applications) {
+        const txRow = app.fundTransaction;
+        if (!txRow || txRow.reversalOfTransactionId !== null) {
+          continue; // sin CREDIT asociado o ya reversado (no duplicar)
+        }
+        const reversalDirection =
+          txRow.direction === FundTransactionDirection.CREDIT
+            ? FundTransactionDirection.DEBIT
+            : FundTransactionDirection.CREDIT;
+        if (reversalDirection === FundTransactionDirection.DEBIT) {
+          await assertSufficientFundBalance(
+            tx,
+            tenantId,
+            txRow.fundId,
+            txRow.currencyCode,
+            txRow.amountMinor,
+          );
+        }
+      }
+
+      let fundReversalCount = 0;
       for (const app of applications) {
         const txRow = app.fundTransaction;
         if (!txRow || txRow.reversalOfTransactionId !== null) {
@@ -442,6 +488,7 @@ export class IncomesService {
             reversalOfTransactionId: txRow.id,
           },
         });
+        fundReversalCount += 1;
 
         await this.auditService.createLogRequired(
           {
@@ -483,7 +530,8 @@ export class IncomesService {
           metadata: {
             previousStatus: income.status,
             newStatus: 'VOID',
-            ...(applications.length > 0 ? { reversedApplications: applications.length } : {}),
+            applicationCount: applications.length,
+            ...(fundReversalCount > 0 ? { fundReversalCount } : {}),
           },
         },
         tx,

--- a/apps/api/src/finanzas/incomes.service.ts
+++ b/apps/api/src/finanzas/incomes.service.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   ForbiddenException,
 } from '@nestjs/common';
+import { FundTransactionDirection, IncomeStatus } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { FinanzasValidators } from './finanzas.validators';
@@ -14,6 +15,10 @@ import {
   UpdateIncomeDto,
   IncomeResponseDto,
 } from './expense-ledger.dto';
+import {
+  acquireFundLock,
+  acquireIncomeLock,
+} from './fund-locks';
 
 @Injectable()
 export class IncomesService {
@@ -380,35 +385,112 @@ export class IncomesService {
       throw new ForbiddenException('Solo administradores pueden anular ingresos');
     }
 
-    const income = await this.prisma.income.findFirst({
-      where: { id: incomeId, tenantId },
-      include: { category: true },
+    return this.prisma.$transaction(async (tx) => {
+      // Lock del Income: serializa void contra creación de plan de aplicaciones.
+      await acquireIncomeLock(tx, tenantId, incomeId);
+
+      const income = await tx.income.findFirst({
+        where: { id: incomeId, tenantId },
+        include: { category: true },
+      });
+      if (!income) {
+        throw new NotFoundException(`Ingreso no encontrado: ${incomeId}`);
+      }
+
+      // Idempotencia: un Income ya VOID se devuelve sin nuevas mutaciones.
+      if (income.status === IncomeStatus.VOID) {
+        return this.toDto(income as unknown as Parameters<typeof this.toDto>[0]);
+      }
+
+      // Reversar automáticamente los FundTransactions CREDIT generados por
+      // IncomeApplication FUND (ledger inmutable: reversa nueva, original intacto).
+      const applications = await tx.incomeApplication.findMany({
+        where: { tenantId, incomeId },
+        include: { fundTransaction: true },
+      });
+
+      const fundIds = [...new Set(
+        applications
+          .map((app) => app.fundId)
+          .filter((fundId): fundId is string => fundId !== null),
+      )].sort();
+
+      for (const fundId of fundIds) {
+        await acquireFundLock(tx, tenantId, fundId);
+      }
+
+      for (const app of applications) {
+        const txRow = app.fundTransaction;
+        if (!txRow || txRow.reversalOfTransactionId !== null) {
+          continue; // sin CREDIT asociado o ya reversado (no duplicar)
+        }
+        const reversalDirection =
+          txRow.direction === FundTransactionDirection.CREDIT
+            ? FundTransactionDirection.DEBIT
+            : FundTransactionDirection.CREDIT;
+
+        const reversal = await tx.fundTransaction.create({
+          data: {
+            tenantId,
+            fundId: txRow.fundId,
+            direction: reversalDirection,
+            amountMinor: txRow.amountMinor,
+            currencyCode: txRow.currencyCode,
+            occurredAt: new Date(),
+            description: `Void de ingreso ${incomeId} (aplicación ${app.id})`,
+            createdByMembershipId: membershipId,
+            reversalOfTransactionId: txRow.id,
+          },
+        });
+
+        await this.auditService.createLogRequired(
+          {
+            tenantId,
+            actorMembershipId: membershipId,
+            action: 'FUND_TRANSACTION_REVERSE',
+            entityType: 'FundTransaction',
+            entityId: reversal.id,
+            metadata: {
+              fundId: txRow.fundId,
+              originalTransactionId: txRow.id,
+              direction: reversalDirection,
+              amountMinor: txRow.amountMinor,
+              currencyCode: txRow.currencyCode,
+            },
+          },
+          tx,
+        );
+      }
+
+      const updated = await tx.income.update({
+        where: { id: incomeId },
+        data: {
+          status: 'VOID',
+          voidedByMembershipId: membershipId,
+          voidedAt: new Date(),
+        },
+        include: { category: true },
+      });
+
+      // INCOME_VOID required en la misma transacción cuando hay efectos financieros.
+      await this.auditService.createLogRequired(
+        {
+          tenantId,
+          actorMembershipId: membershipId,
+          action: 'INCOME_VOID',
+          entityType: 'Income',
+          entityId: incomeId,
+          metadata: {
+            previousStatus: income.status,
+            newStatus: 'VOID',
+            ...(applications.length > 0 ? { reversedApplications: applications.length } : {}),
+          },
+        },
+        tx,
+      );
+
+      return this.toDto(updated);
     });
-
-    if (!income) {
-      throw new NotFoundException(`Ingreso no encontrado: ${incomeId}`);
-    }
-
-    const updated = await this.prisma.income.update({
-      where: { id: incomeId },
-      data: {
-        status: 'VOID',
-        voidedByMembershipId: membershipId,
-        voidedAt: new Date(),
-      },
-      include: { category: true },
-    });
-
-    void this.auditService.createLog({
-      tenantId,
-      actorMembershipId: membershipId,
-      action: 'INCOME_VOID',
-      entityType: 'Income',
-      entityId: incomeId,
-      metadata: { previousStatus: income.status, newStatus: 'VOID' },
-    });
-
-    return this.toDto(updated);
   }
 
   private toDto(income: {

--- a/apps/api/src/finanzas/incomes.void-atomicity.spec.ts
+++ b/apps/api/src/finanzas/incomes.void-atomicity.spec.ts
@@ -46,7 +46,8 @@ describe('IncomesService voidIncome atomicity (FIN-03)', () => {
   const prismaValue = {
     income: { findFirst: jest.fn(), update: jest.fn() },
     incomeApplication: { findMany: jest.fn() },
-    fundTransaction: { create: jest.fn() },
+    fund: { findMany: jest.fn() },
+    fundTransaction: { create: jest.fn(), groupBy: jest.fn() },
     tenant: { findFirst: jest.fn() },
     exchangeRate: { findFirst: jest.fn() },
     expenseLedgerCategory: { findFirst: jest.fn() },
@@ -60,6 +61,7 @@ describe('IncomesService voidIncome atomicity (FIN-03)', () => {
       async (callback: (tx: unknown) => unknown) => callback({
         income: prismaValue.income,
         incomeApplication: prismaValue.incomeApplication,
+        fund: prismaValue.fund,
         fundTransaction: prismaValue.fundTransaction,
         tenant: prismaValue.tenant,
         exchangeRate: prismaValue.exchangeRate,
@@ -141,6 +143,10 @@ describe('IncomesService voidIncome atomicity (FIN-03)', () => {
 
   it('reverses FUND application CREDITs on void (ledger immutable, reversal created)', async () => {
     (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+    (prisma.fund.findMany as jest.Mock).mockResolvedValue([{ id: 'fund-1', status: 'ACTIVE' }]);
+    (prisma.fundTransaction.groupBy as jest.Mock)
+      .mockResolvedValueOnce([{ currencyCode: 'USD', _sum: { amountMinor: 3000 } }])
+      .mockResolvedValueOnce([]);
     (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([
       {
         id: 'app-1',
@@ -181,6 +187,7 @@ describe('IncomesService voidIncome atomicity (FIN-03)', () => {
 
   it('does not double-reverse an already-reversed transaction', async () => {
     (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+    (prisma.fund.findMany as jest.Mock).mockResolvedValue([{ id: 'fund-1', status: 'ACTIVE' }]);
     (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([
       {
         id: 'app-1',

--- a/apps/api/src/finanzas/incomes.void-atomicity.spec.ts
+++ b/apps/api/src/finanzas/incomes.void-atomicity.spec.ts
@@ -1,0 +1,205 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConflictException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { FundTransactionDirection, IncomeStatus } from '@prisma/client';
+import { IncomesService } from './incomes.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { MovementAllocationService } from './movement-allocation.service';
+import { CurrencyConversionService } from './currency-conversion.service';
+
+const makeIncome = (overrides: Record<string, unknown> = {}) => ({
+  id: 'income-1',
+  tenantId: 'tenant-1',
+  buildingId: null,
+  period: '2026-08',
+  categoryId: 'cat-1',
+  amountMinor: 10000,
+  currencyCode: 'USD',
+  receivedDate: new Date('2026-08-10T00:00:00.000Z'),
+  postedAt: new Date(),
+  description: null,
+  attachmentFileKey: null,
+  status: IncomeStatus.RECORDED,
+  scopeType: 'BUILDING',
+  destination: 'APPLY_TO_EXPENSES',
+  unitGroupId: null,
+  functionalAmountMinor: null,
+  functionalCurrencyCode: null,
+  exchangeRateId: null,
+  exchangeRateValue: null,
+  exchangeRateDirection: null,
+  exchangeRateEffectiveAt: null,
+  conversionDate: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  category: { name: 'Parking' },
+  ...overrides,
+});
+
+describe('IncomesService voidIncome atomicity (FIN-03)', () => {
+  let service: IncomesService;
+  let prisma: PrismaService;
+  let audit: AuditService;
+  let validators: FinanzasValidators;
+
+  const prismaValue = {
+    income: { findFirst: jest.fn(), update: jest.fn() },
+    incomeApplication: { findMany: jest.fn() },
+    fundTransaction: { create: jest.fn() },
+    tenant: { findFirst: jest.fn() },
+    exchangeRate: { findFirst: jest.fn() },
+    expenseLedgerCategory: { findFirst: jest.fn() },
+    unitGroup: { findFirst: jest.fn() },
+    $transaction: jest.fn(),
+    $executeRaw: jest.fn(),
+  };
+
+  function mockTransaction() {
+    (prismaValue.$transaction as jest.Mock).mockImplementation(
+      async (callback: (tx: unknown) => unknown) => callback({
+        income: prismaValue.income,
+        incomeApplication: prismaValue.incomeApplication,
+        fundTransaction: prismaValue.fundTransaction,
+        tenant: prismaValue.tenant,
+        exchangeRate: prismaValue.exchangeRate,
+        expenseLedgerCategory: prismaValue.expenseLedgerCategory,
+        unitGroup: prismaValue.unitGroup,
+        auditLog: { create: jest.fn() },
+        $executeRaw: prismaValue.$executeRaw,
+      }),
+    );
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    (prismaValue.fundTransaction.create as jest.Mock).mockReset();
+    mockTransaction();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IncomesService,
+        { provide: PrismaService, useValue: prismaValue },
+        {
+          provide: AuditService,
+          useValue: {
+            createLog: jest.fn(),
+            createLogRequired: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: FinanzasValidators,
+          useValue: { isAdminOrOperator: jest.fn().mockReturnValue(true) },
+        },
+        { provide: MovementAllocationService, useValue: {} },
+        { provide: CurrencyConversionService, useValue: { convert: jest.fn() } },
+      ],
+    }).compile();
+
+    service = module.get<IncomesService>(IncomesService);
+    prisma = module.get<PrismaService>(PrismaService);
+    audit = module.get<AuditService>(AuditService);
+    validators = module.get<FinanzasValidators>(FinanzasValidators);
+
+    (audit.createLogRequired as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  const roles = ['TENANT_ADMIN'];
+
+  it('rejects non-admin users', async () => {
+    (validators.isAdminOrOperator as jest.Mock).mockReturnValue(false);
+    await expect(service.voidIncome('tenant-1', 'income-1', 'm', ['RESIDENT'])).rejects.toThrow(ForbiddenException);
+  });
+
+  it('rejects income from another tenant (not found)', async () => {
+    (prisma.income.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(service.voidIncome('tenant-1', 'income-x', 'm', roles)).rejects.toThrow(NotFoundException);
+  });
+
+  it('is idempotent when the income is already VOID (no new mutations)', async () => {
+    (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome({ status: IncomeStatus.VOID }));
+
+    const result = await service.voidIncome('tenant-1', 'income-1', 'member-1', roles);
+
+    expect(result.status).toBe('VOID');
+    expect(prisma.incomeApplication.findMany).not.toHaveBeenCalled();
+    expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
+    expect(audit.createLogRequired).not.toHaveBeenCalled();
+  });
+
+  it('voids an income without applications (no fund mutations)', async () => {
+    (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+    (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.income.update as jest.Mock).mockResolvedValue(makeIncome({ status: IncomeStatus.VOID }));
+
+    const result = await service.voidIncome('tenant-1', 'income-1', 'member-1', roles);
+
+    expect(result.status).toBe('VOID');
+    expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
+    expect(audit.createLogRequired).toHaveBeenCalledTimes(1); // INCOME_VOID
+  });
+
+  it('reverses FUND application CREDITs on void (ledger immutable, reversal created)', async () => {
+    (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+    (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'app-1',
+        fundId: 'fund-1',
+        fundTransaction: {
+          id: 'ft-1',
+          fundId: 'fund-1',
+          direction: FundTransactionDirection.CREDIT,
+          amountMinor: 3000,
+          currencyCode: 'USD',
+          reversalOfTransactionId: null,
+        },
+      },
+    ]);
+    (prisma.fundTransaction.create as jest.Mock).mockResolvedValue({ id: 'ft-rev' });
+    (prisma.income.update as jest.Mock).mockResolvedValue(makeIncome({ status: IncomeStatus.VOID }));
+
+    await service.voidIncome('tenant-1', 'income-1', 'member-1', roles);
+
+    expect(prisma.fundTransaction.create).toHaveBeenCalledTimes(1);
+    const call = (prisma.fundTransaction.create as jest.Mock).mock.calls[0] as [{ data: Record<string, unknown> }];
+    expect(call[0].data).toEqual(expect.objectContaining({
+      tenantId: 'tenant-1',
+      fundId: 'fund-1',
+      direction: FundTransactionDirection.DEBIT, // opuesto al CREDIT original
+      amountMinor: 3000,
+      currencyCode: 'USD',
+      reversalOfTransactionId: 'ft-1',
+    }));
+    // FUND_TRANSACTION_REVERSE + INCOME_VOID audits required
+    expect(audit.createLogRequired).toHaveBeenCalledTimes(2);
+    const actions = (audit.createLogRequired as jest.Mock).mock.calls.map(
+      (call: [{ action: string }]) => call[0].action,
+    );
+    expect(actions).toContain('FUND_TRANSACTION_REVERSE');
+    expect(actions).toContain('INCOME_VOID');
+  });
+
+  it('does not double-reverse an already-reversed transaction', async () => {
+    (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+    (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([
+      {
+        id: 'app-1',
+        fundId: 'fund-1',
+        fundTransaction: {
+          id: 'ft-1',
+          fundId: 'fund-1',
+          direction: FundTransactionDirection.CREDIT,
+          amountMinor: 3000,
+          currencyCode: 'USD',
+          reversalOfTransactionId: 'ft-rev-existing', // ya reversado
+        },
+      },
+    ]);
+    (prisma.income.update as jest.Mock).mockResolvedValue(makeIncome({ status: IncomeStatus.VOID }));
+
+    await service.voidIncome('tenant-1', 'income-1', 'member-1', roles);
+
+    expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
+    expect(audit.createLogRequired).toHaveBeenCalledTimes(1); // solo INCOME_VOID
+  });
+});


### PR DESCRIPTION
## Summary

Adds `IncomeApplication`, an explicit, immutable plan describing what is done financially with an `Income` — without changing any existing Income/Liquidation/Payment/MovementAllocation behavior.

### Architecture

Strictly separated from `MovementAllocation`:

- `MovementAllocation` answers: to which building/scope does the movement belong?
- `IncomeApplication` answers: what is done with the money?

### Destinations

- `OFFSET_EXPENSES` — classifies money to reduce expenses (consumed in a future FIN-06; no effect on Liquidation in this PR)
- `FUND` — generates a real `CREDIT` in `FundTransaction`
- `CARRY_FORWARD` — classifies retained money for future use (no consumption yet)

### Exact amount invariant

`SUM(IncomeApplication.amountMinor) == Income.amountMinor` **exactly** (integer minor units). No percentages, no tolerance, no floats. Under/over-allocation rolls back the whole plan (0 applications, 0 FundTransactions).

`application.currencyCode` is always `Income.currencyCode` (derived server-side; no client-supplied currency, no automatic conversion).

### Fund ledger integration

- Each `FUND` application produces exactly one `FundTransaction CREDIT` linked 1:1 via `incomeApplicationId` (unique DB constraint).
- Deterministic idempotency key: `income-application:<applicationId>` — retries never duplicate credits.
- `occurredAt = Income.receivedDate` (economic event date).
- **Generic reversal protection**: `FundsService.reverseTransaction` rejects reversal of any transaction owned by an `IncomeApplication` — the reversal is controlled exclusively by `voidIncome`. Manual FundTransaction reversals are unaffected.

### Immutable plan

- After creation: no PATCH, no DELETE of individual applications.
- Same-plan retry (order-insensitive canonical multiset) → returns the existing plan, no new mutations.
- Different plan → 409 Conflict.

### voidIncome (atomic)

- Voiding an income with `FUND` applications reverses each application CREDIT (new reversal row, original ledger intact), then sets `Income.status = VOID` — ALL OR NOTHING in one transaction with required audits (`FUND_TRANSACTION_REVERSE` + `INCOME_VOID`).
- Double-void is idempotent (no second reversal).

### Concurrency

- `buildingos_income_lock_v1:{tenantId}:{incomeId}` — serializes plan creation vs void.
- Fund locks reused from FIN-02 (`buildingos_fund_lock_v1`, extracted to `fund-locks.ts` shared helper, same namespace — no behavior change).
- Multi-fund plans acquire locks in deterministic order (no deadlock).
- Application vs Fund archive race fixed by validating fund ACTIVE status **after** acquiring the fund lock (TOCTOU).
- PostgreSQL tests prove: same-plan concurrency (1 credit), different-plan concurrency (1 winner + Conflict), application-vs-void race (only serializable outcomes), application-vs-archive race (never ARCHIVED with new CREDIT).

### DB constraints

- `amountMinor > 0` CHECK
- destination/fund invariant CHECK (FUND ⇒ fundId NOT NULL; OFFSET/CARRY ⇒ fundId NULL)
- partial unique: one non-FUND per destinationType per Income; one FUND per fundId per Income
- unique `FundTransaction.incomeApplicationId` (1:1)

### Legacy compatibility

- `Income.destination` (`APPLY_TO_EXPENSES`/`RESERVE_FUND`/`SPECIAL_FUND`) untouched — no rename, no reinterpretation, no backfill (FIN-04).
- Applications only for `RECORDED` incomes (DRAFT/VOID rejected).
- Tenant isolation: fund targets must belong to the same tenant; cross-tenant rejected.

### Audit

- `INCOME_APPLICATIONS_CREATE` required audit, atomic with the plan mutation.
- All new audit metadata omits absent optional fields (no null/undefined — AuditService contract from the FIN-02 incident).

## Scope exclusions

- Liquidation behavior: NOT changed (OFFSET_EXPENSES has no Liquidation effect; FIN-06)
- IncomePolicy: NOT implemented (FIN-05)
- Legacy backfill: NOT performed (FIN-04)
- Frontend: NOT touched (FIN-07)
- Payment semantics: unchanged
- MovementAllocation semantics: unchanged

## Validation

- FIN-03 unit: 114 passed / 0 failed (funds 46, incomes.multicurrency 25, income-applications 29, void-atomicity 6, DTO validation 8)
- PostgreSQL FIN-03 (real AuditService, real locks): 25 passed / 0 failed (incl. real FUND_TRANSACTION_CREATE audits, void balance/archive safety, multi-fund void, void-vs-debit race)
- FIN-02 PostgreSQL regression: 15 passed / 0 failed
- Finance regression: 646 passed / 0 failed
- API full: 179 suites / 2659 passed / 64 skipped / 0 failed
- Prisma validate: PASS
- Migration: additive; zero-DB deploy PASS; upgrade-from-main deploy PASS
- Typecheck: PASS · Lint: PASS · Build: PASS · git diff --check: CLEAN

## PM review hardening

Post-review fixes (second commit):

- **Required FUND_TRANSACTION_CREATE audit**: every application CREDIT now emits its own required audit inside the same transaction (fundId, direction=CREDIT, amountMinor, currencyCode, occurredAt, idempotencyKey, incomeApplicationId). Audit failure rolls back everything (no application, no FundTransaction, no plan).
- **void balance protection**: voidIncome now validates each target Fund is ACTIVE (after acquiring its lock) and asserts sufficient balance before writing any reversal. Spent, partially spent, or archived funds reject the void with no partial reversals (all-or-nothing across funds).
- **void-vs-debit and void-vs-archive races**: covered by real PostgreSQL tests (never negative balance, never Income VOID with an impossible reversal, never ARCHIVED with new CREDIT).
- **Corrected DTO array bound**: @Max replaced with @ArrayMaxSize(20); DTO validation proven via class-transformer/class-validator (1/2/20 items pass, 21 items reject, amountMinor 0 reject, invalid enum reject).
- **Audit metadata accuracy**: INCOME_VOID now reports applicationCount and fundReversalCount (not a misleading reversedApplications count that included non-FUND applications).
- **Shared ledger helper**: fund-ledger.ts (compute/assert balance) reused by FundsService and voidIncome — same FIN-02 semantics, no observable change (FIN-02 PostgreSQL 15/15).
## Staging note

Not deployed yet. Deployment and full staging smoke will follow after review/merge.

---

## Tipo de cambio

- [x] Nueva funcionalidad
- [ ] Bug fix
- [ ] Refactor
- [ ] Cambio de documentación
- [ ] Otro: ___

## Checklist de validación local obligatoria

Antes de abrir este PR, se completó localmente:

- [x] Tests unitarios pasan
- [x] Tests de integración pasan
- [ ] Tests E2E pasan (si aplica)
- [x] Typecheck (`tsc --noEmit`) sin errores
- [x] Lint sin errores nuevos
- [x] Build exitoso
- [x] `git diff --check` limpio
- [x] Confirmé que todos los cambios fueron implementados y probados localmente
- [x] Confirmé que el merge a main activará automáticamente el deploy a staging
- [x] El despliegue automático a staging está autorizado para este PR
- [x] Las migraciones incluidas fueron validadas localmente
- [x] No se requiere preservar ningún archivo temporal dentro del checkout de staging
- [x] La validación funcional en staging está definida para después del merge
