### PR TITLE
feat(finance): add versioned income policies

### DIFF
--- a/apps/api/prisma/migrations/20260816000000_add_income_policies/migration.sql
+++ b/apps/api/prisma/migrations/20260816000000_add_income_policies/migration.sql
@@ -1,0 +1,78 @@
+-- FIN-05: IncomePolicy + Version + Rule (configuración por categoría)
+-- ADITIVA: no altera datos financieros existentes.
+
+-- CreateEnum
+CREATE TYPE "IncomePolicyVersionStatus" AS ENUM ('ACTIVE', 'INACTIVE');
+
+-- AlterEnum AuditAction
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'INCOME_POLICY_CREATE';
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'INCOME_POLICY_VERSION_CREATE';
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'INCOME_POLICY_DEACTIVATE';
+
+-- AlterTable IncomeApplication (provenance de política)
+ALTER TABLE "IncomeApplication" ADD COLUMN     "policyVersionId" TEXT;
+
+-- CreateTable IncomePolicy
+CREATE TABLE "IncomePolicy" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "categoryId" TEXT NOT NULL,
+    "createdByMembershipId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "IncomePolicy_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable IncomePolicyVersion
+CREATE TABLE "IncomePolicyVersion" (
+    "id" TEXT NOT NULL,
+    "policyId" TEXT NOT NULL,
+    "version" INTEGER NOT NULL,
+    "status" "IncomePolicyVersionStatus" NOT NULL DEFAULT 'ACTIVE',
+    "createdByMembershipId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "IncomePolicyVersion_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable IncomePolicyRule
+CREATE TABLE "IncomePolicyRule" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "versionId" TEXT NOT NULL,
+    "destinationType" "IncomeApplicationDestination" NOT NULL,
+    "fundId" TEXT,
+    "percentageBasisPoints" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "IncomePolicyRule_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "IncomePolicyRule_percentage_bp_range" CHECK ("percentageBasisPoints" > 0 AND "percentageBasisPoints" <= 10000),
+    CONSTRAINT "IncomePolicyRule_destination_fund_invariant" CHECK (
+      ("destinationType" = 'FUND' AND "fundId" IS NOT NULL)
+      OR
+      ("destinationType" IN ('OFFSET_EXPENSES', 'CARRY_FORWARD') AND "fundId" IS NULL)
+    )
+);
+
+-- AddForeignKey
+ALTER TABLE "IncomeApplication" ADD CONSTRAINT "IncomeApplication_policyVersionId_fkey" FOREIGN KEY ("policyVersionId") REFERENCES "IncomePolicyVersion"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+ALTER TABLE "IncomePolicy" ADD CONSTRAINT "IncomePolicy_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "IncomePolicy" ADD CONSTRAINT "IncomePolicy_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "ExpenseLedgerCategory"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "IncomePolicy" ADD CONSTRAINT "IncomePolicy_createdByMembershipId_fkey" FOREIGN KEY ("createdByMembershipId") REFERENCES "Membership"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "IncomePolicyVersion" ADD CONSTRAINT "IncomePolicyVersion_policyId_fkey" FOREIGN KEY ("policyId") REFERENCES "IncomePolicy"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "IncomePolicyVersion" ADD CONSTRAINT "IncomePolicyVersion_createdByMembershipId_fkey" FOREIGN KEY ("createdByMembershipId") REFERENCES "Membership"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+ALTER TABLE "IncomePolicyRule" ADD CONSTRAINT "IncomePolicyRule_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "IncomePolicyRule" ADD CONSTRAINT "IncomePolicyRule_versionId_fkey" FOREIGN KEY ("versionId") REFERENCES "IncomePolicyVersion"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "IncomePolicyRule" ADD CONSTRAINT "IncomePolicyRule_fundId_fkey" FOREIGN KEY ("fundId") REFERENCES "Fund"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "IncomePolicy_tenantId_categoryId_key" ON "IncomePolicy"("tenantId", "categoryId");
+CREATE INDEX "IncomePolicy_tenantId_idx" ON "IncomePolicy"("tenantId");
+CREATE UNIQUE INDEX "IncomePolicyVersion_policyId_version_key" ON "IncomePolicyVersion"("policyId", "version");
+CREATE INDEX "IncomePolicyVersion_policyId_status_idx" ON "IncomePolicyVersion"("policyId", "status");
+CREATE UNIQUE INDEX "IncomePolicyVersion_single_active_key" ON "IncomePolicyVersion"("policyId") WHERE "status" = 'ACTIVE';
+CREATE INDEX "IncomePolicyRule_tenantId_versionId_idx" ON "IncomePolicyRule"("tenantId", "versionId");
+CREATE UNIQUE INDEX "IncomePolicyRule_versionId_nonfund_key" ON "IncomePolicyRule"("versionId", "destinationType") WHERE "destinationType" IN ('OFFSET_EXPENSES', 'CARRY_FORWARD');
+CREATE UNIQUE INDEX "IncomePolicyRule_versionId_fundId_key" ON "IncomePolicyRule"("versionId", "fundId") WHERE "fundId" IS NOT NULL;
+CREATE INDEX "IncomeApplication_tenantId_policyVersionId_idx" ON "IncomeApplication"("tenantId", "policyVersionId");

--- a/apps/api/prisma/migrations/20260816000001_income_policy_createdby_setnull/migration.sql
+++ b/apps/api/prisma/migrations/20260816000001_income_policy_createdby_setnull/migration.sql
@@ -1,0 +1,22 @@
+-- AlterTable: createdByMembershipId nullable en el árbol de policies para
+-- no bloquear el tenant delete lifecycle (mismo patrón que FundArchivedBy).
+ALTER TABLE "IncomePolicy" ALTER COLUMN "createdByMembershipId" DROP NOT NULL;
+ALTER TABLE "IncomePolicyVersion" ALTER COLUMN "createdByMembershipId" DROP NOT NULL;
+
+-- DropForeignKey
+ALTER TABLE "IncomePolicy" DROP CONSTRAINT "IncomePolicy_createdByMembershipId_fkey";
+
+-- AlterTable
+ALTER TABLE "IncomePolicy" ALTER COLUMN "createdByMembershipId" SET DEFAULT NULL;
+
+-- AddForeignKey
+ALTER TABLE "IncomePolicy" ADD CONSTRAINT "IncomePolicy_createdByMembershipId_fkey" FOREIGN KEY ("createdByMembershipId") REFERENCES "Membership"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- DropForeignKey
+ALTER TABLE "IncomePolicyVersion" DROP CONSTRAINT "IncomePolicyVersion_createdByMembershipId_fkey";
+
+-- AlterTable
+ALTER TABLE "IncomePolicyVersion" ALTER COLUMN "createdByMembershipId" SET DEFAULT NULL;
+
+-- AddForeignKey
+ALTER TABLE "IncomePolicyVersion" ADD CONSTRAINT "IncomePolicyVersion_createdByMembershipId_fkey" FOREIGN KEY ("createdByMembershipId") REFERENCES "Membership"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -145,6 +145,15 @@ enum IncomeApplicationDestination {
   CARRY_FORWARD    // Clasifica dinero retenido para uso futuro
 }
 
+// ============================================================================
+// FINANZAS: IncomePolicy (política configurable por categoría — FIN-05)
+// ============================================================================
+
+enum IncomePolicyVersionStatus {
+  ACTIVE    // Versión current de la política
+  INACTIVE  // Versión histórica (permanece consultable)
+}
+
 enum LiquidationStatus {
   DRAFT
   REVIEWED
@@ -305,6 +314,8 @@ model Tenant {
   funds                 Fund[]
   fundTransactions      FundTransaction[]
   incomeApplications    IncomeApplication[]
+  incomePolicies        IncomePolicy[]
+  incomePolicyRules     IncomePolicyRule[]
 }
 
 model User {
@@ -380,6 +391,8 @@ model Membership {
   fundsArchived         Fund[]                @relation("FundArchivedBy")
   fundTransactionsCreated FundTransaction[]   @relation("FundTransactionCreatedBy")
   incomeApplicationsCreated IncomeApplication[] @relation("IncomeApplicationCreatedBy")
+  incomePoliciesCreated   IncomePolicy[]        @relation("IncomePolicyCreatedBy")
+  incomePolicyVersionsCreated IncomePolicyVersion[] @relation("IncomePolicyVersionCreatedBy")
 
   @@unique([userId, tenantId])
   @@index([tenantId])
@@ -816,6 +829,9 @@ enum AuditAction {
   INCOME_VOID
   INCOME_ALLOCATION_CREATE
   INCOME_APPLICATIONS_CREATE
+  INCOME_POLICY_CREATE
+  INCOME_POLICY_VERSION_CREATE
+  INCOME_POLICY_DEACTIVATE
   // FUNDS (FIN-02)
   FUND_CREATE
   FUND_UPDATE
@@ -1843,6 +1859,7 @@ model ExpenseLedgerCategory {
   isActive     Boolean      @default(true)
   createdAt    DateTime     @default(now())
   updatedAt    DateTime     @updatedAt
+  incomePolicies       IncomePolicy[]
 
   tenant               Tenant               @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   expenses             Expense[]
@@ -2048,9 +2065,71 @@ model IncomeApplication {
   fund       Fund?              @relation(fields: [fundId], references: [id], onDelete: Restrict)
   createdBy  Membership         @relation("IncomeApplicationCreatedBy", fields: [createdByMembershipId], references: [id], onDelete: Restrict)
   fundTransaction FundTransaction? @relation("FundTransactionIncomeApplication")
+  policyVersion IncomePolicyVersion? @relation(fields: [policyVersionId], references: [id], onDelete: SetNull)
 
   @@index([tenantId, incomeId])
   @@index([tenantId, fundId])
+  @@index([tenantId, policyVersionId])
+
+  policyVersionId String? // FIN-05: provenance — versión de política que generó esta aplicación (null = manual)
+}
+
+// ============================================================================
+// FINANZAS: IncomePolicy + Version + Rule (configuración por categoría — FIN-05)
+// ============================================================================
+// La política define el plan DEFAULT propuesto para Incomes RECORDED futuros.
+// NO es verdad histórica: las IncomeApplications ya publicadas NO cambian
+// cuando la política cambia. Versiones inmutables preservan historia.
+// ============================================================================
+
+model IncomePolicy {
+  id                    String   @id @default(cuid())
+  tenantId              String
+  categoryId            String   // ExpenseLedgerCategory (movementType = INCOME)
+  createdByMembershipId String?
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+
+  tenant     Tenant                @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  category   ExpenseLedgerCategory @relation(fields: [categoryId], references: [id], onDelete: Restrict)
+  createdBy  Membership?           @relation("IncomePolicyCreatedBy", fields: [createdByMembershipId], references: [id], onDelete: SetNull)
+  versions   IncomePolicyVersion[]
+
+  @@unique([tenantId, categoryId])
+  @@index([tenantId])
+}
+
+model IncomePolicyVersion {
+  id                    String                     @id @default(cuid())
+  policyId              String
+  version               Int                        // 1, 2, 3...
+  status                IncomePolicyVersionStatus  @default(ACTIVE)
+  createdByMembershipId String?
+  createdAt             DateTime                   @default(now())
+
+  policy    IncomePolicy       @relation(fields: [policyId], references: [id], onDelete: Cascade)
+  createdBy Membership?        @relation("IncomePolicyVersionCreatedBy", fields: [createdByMembershipId], references: [id], onDelete: SetNull)
+  rules     IncomePolicyRule[]
+  applications IncomeApplication[]
+
+  @@unique([policyId, version])
+  @@index([policyId, status])
+}
+
+model IncomePolicyRule {
+  id                     String   @id @default(cuid())
+  tenantId               String
+  versionId              String
+  destinationType        IncomeApplicationDestination
+  fundId                 String?  // Obligatorio solo si FUND
+  percentageBasisPoints  Int      // 100% = 10000 bp
+  createdAt              DateTime @default(now())
+
+  tenant    Tenant                @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  version   IncomePolicyVersion   @relation(fields: [versionId], references: [id], onDelete: Cascade)
+  fund      Fund?                 @relation(fields: [fundId], references: [id], onDelete: Restrict)
+
+  @@index([tenantId, versionId])
 }
 
 // ============================================================================
@@ -2151,6 +2230,7 @@ model Fund {
   archivedBy Membership?        @relation("FundArchivedBy", fields: [archivedByMembershipId], references: [id], onDelete: SetNull)
   transactions FundTransaction[]
   incomeApplications IncomeApplication[]
+  incomePolicyRules  IncomePolicyRule[]
 
   @@index([tenantId])
   @@index([tenantId, buildingId])

--- a/apps/api/src/finanzas/finanzas.module.ts
+++ b/apps/api/src/finanzas/finanzas.module.ts
@@ -46,6 +46,8 @@ import { FundsController } from './funds.controller';
 import { FundsService } from './funds.service';
 import { IncomeApplicationsController } from './income-applications.controller';
 import { IncomeApplicationsService } from './income-applications.service';
+import { IncomePoliciesController } from './income-policies.controller';
+import { IncomePoliciesService } from './income-policies.service';
 
 import { VendorPreferenceController } from './vendor-preference.controller';
 import { VendorPreferenceService } from './vendor-preference.service';
@@ -94,6 +96,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     MulticurrencyController,
     FundsController,
     IncomeApplicationsController,
+    IncomePoliciesController,
   ],
   providers: [
     FinanzasService,
@@ -137,6 +140,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     CurrencyConversionService,
     FundsService,
     IncomeApplicationsService,
+    IncomePoliciesService,
   ],
   exports: [
     FinanzasService,
@@ -157,6 +161,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     CurrencyConversionService,
     FundsService,
     IncomeApplicationsService,
+    IncomePoliciesService,
   ],
 })
 export class FinanzasModule {}

--- a/apps/api/src/finanzas/income-applications.service.spec.ts
+++ b/apps/api/src/finanzas/income-applications.service.spec.ts
@@ -69,6 +69,7 @@ describe('IncomeApplicationsService', () => {
     income: { findFirst: jest.fn() },
     incomeApplication: { findMany: jest.fn(), create: jest.fn() },
     fund: { findMany: jest.fn() },
+    incomePolicy: { findUnique: jest.fn() },
     fundTransaction: { create: jest.fn() },
     $transaction: jest.fn(),
     $executeRaw: jest.fn(),
@@ -81,6 +82,7 @@ describe('IncomeApplicationsService', () => {
         incomeApplication: prismaValue.incomeApplication,
         fund: prismaValue.fund,
         fundTransaction: prismaValue.fundTransaction,
+        incomePolicy: prismaValue.incomePolicy,
         auditLog: { create: jest.fn() },
         $executeRaw: prismaValue.$executeRaw,
       }),
@@ -574,6 +576,141 @@ describe('IncomeApplicationsService', () => {
         ])),
       ).rejects.toThrow('FORCED_AUDIT_FAILURE');
       // el error se propaga → la transacción (mock) haría rollback real en PostgreSQL
+    });
+  });
+
+  // ── applyPolicy (FIN-05) ────────────────────────────────────────────────
+
+  describe('applyPolicy', () => {
+    const policyVersion = {
+      id: 'policy-version-1',
+      version: 1,
+      status: 'ACTIVE',
+      rules: [
+        { id: 'r1', destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, fundId: null, percentageBasisPoints: 7000 },
+        { id: 'r2', destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', percentageBasisPoints: 3000 },
+      ],
+    };
+
+    beforeEach(() => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.incomePolicy.findUnique as jest.Mock).mockResolvedValue({
+        id: 'policy-1',
+        tenantId: 'tenant-1',
+        categoryId: 'cat-1',
+        versions: [policyVersion],
+      });
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([{ id: 'fund-1', status: FundStatus.ACTIVE }]);
+      (prisma.incomeApplication.create as jest.Mock).mockImplementation(({ data }) =>
+        Promise.resolve(makeApplication({
+          id: 'app-' + data.destinationType + '-' + (data.fundId ?? 'nf'),
+          destinationType: data.destinationType,
+          fundId: data.fundId,
+          amountMinor: data.amountMinor,
+          policyVersionId: data.policyVersionId,
+          fundTransaction: data.destinationType === IncomeApplicationDestination.FUND ? { id: 'ft-' + data.fundId } : null,
+        })),
+      );
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValue({ id: 'ft-1' });
+    });
+
+    it('applies a policy to a RECORDED income generating exact amounts', async () => {
+      const result = await service.applyPolicy('tenant-1', 'income-1', 'member-1', roles);
+
+      expect(result.totalAmountMinor).toBe(10000);
+      expect(prisma.incomeApplication.create).toHaveBeenCalledTimes(2);
+      expect(prisma.fundTransaction.create).toHaveBeenCalledTimes(1);
+      const calls = (prisma.incomeApplication.create as jest.Mock).mock.calls.map((c: [{ data: Record<string, unknown> }]) => c[0].data);
+      const fundCall = calls.find((d) => d.destinationType === 'FUND');
+      const offsetCall = calls.find((d) => d.destinationType === 'OFFSET_EXPENSES');
+      expect(fundCall?.amountMinor).toBe(3000);
+      expect(fundCall?.policyVersionId).toBe('policy-version-1');
+      expect(offsetCall?.amountMinor).toBe(7000);
+      expect(offsetCall?.policyVersionId).toBe('policy-version-1');
+    });
+
+    it('applies a 100% CARRY_FORWARD policy with no FundTransaction', async () => {
+      (prisma.incomePolicy.findUnique as jest.Mock).mockResolvedValue({
+        id: 'policy-1',
+        versions: [{ id: 'pv2', version: 1, status: 'ACTIVE', rules: [{ id: 'r1', destinationType: IncomeApplicationDestination.CARRY_FORWARD, fundId: null, percentageBasisPoints: 10000 }] }],
+      });
+      (prisma.incomeApplication.create as jest.Mock).mockImplementation(({ data }) =>
+        Promise.resolve(makeApplication({ id: 'app-carry', destinationType: data.destinationType, fundId: data.fundId, amountMinor: data.amountMinor, policyVersionId: data.policyVersionId })),
+      );
+
+      const result = await service.applyPolicy('tenant-1', 'income-1', 'member-1', roles);
+
+      expect(result.applications[0]!.amountMinor).toBe(10000);
+      expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects a DRAFT income', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome({ status: IncomeStatus.DRAFT }));
+      await expect(service.applyPolicy('tenant-1', 'income-1', 'member-1', roles)).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects a VOID income', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome({ status: IncomeStatus.VOID }));
+      await expect(service.applyPolicy('tenant-1', 'income-1', 'member-1', roles)).rejects.toThrow(BadRequestException);
+    });
+
+    it('rejects when there is no ACTIVE policy for the category', async () => {
+      (prisma.incomePolicy.findUnique as jest.Mock).mockResolvedValue({ id: 'policy-1', versions: [] });
+      await expect(service.applyPolicy('tenant-1', 'income-1', 'member-1', roles)).rejects.toThrow(BadRequestException);
+    });
+
+    it('is idempotent when the existing plan equals the policy-generated plan', async () => {
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([
+        makeApplication({ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 }),
+        makeApplication({ id: 'app-2', destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', amountMinor: 3000, fundTransaction: { id: 'ft-1' } }),
+      ]);
+
+      const result = await service.applyPolicy('tenant-1', 'income-1', 'member-1', roles);
+
+      expect(result.applications).toHaveLength(2);
+      expect(prisma.incomeApplication.create).not.toHaveBeenCalled();
+      expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects a conflicting existing plan', async () => {
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([
+        makeApplication({ destinationType: IncomeApplicationDestination.CARRY_FORWARD, amountMinor: 10000 }),
+      ]);
+      await expect(service.applyPolicy('tenant-1', 'income-1', 'member-1', roles)).rejects.toThrow(ConflictException);
+    });
+
+    it('rejects when a small income makes a rule zero (rounding guard)', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome({ amountMinor: 1 }));
+      await expect(service.applyPolicy('tenant-1', 'income-1', 'member-1', roles)).rejects.toThrow(BadRequestException);
+    });
+
+    it('handles the 10001 rounding case deterministically (largest remainder)', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome({ amountMinor: 10001 }));
+      (prisma.incomeApplication.create as jest.Mock).mockImplementation(({ data }) =>
+        Promise.resolve(makeApplication({ id: 'app-x', destinationType: data.destinationType, fundId: data.fundId, amountMinor: data.amountMinor, policyVersionId: data.policyVersionId, fundTransaction: data.destinationType === IncomeApplicationDestination.FUND ? { id: 'ft-1' } : null })),
+      );
+
+      const result = await service.applyPolicy('tenant-1', 'income-1', 'member-1', roles);
+
+      const amounts = result.applications.map((a) => a.amountMinor).sort((x, y) => x - y);
+      expect(amounts).toEqual([3000, 7001]); // 7000.7→7000 + remainder 1 → 7001; 3000.3→3000
+      expect(result.totalAmountMinor).toBe(10001);
+    });
+
+    it('rejects when the policy references an archived fund at apply time', async () => {
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([{ id: 'fund-1', status: FundStatus.ARCHIVED }]);
+      await expect(service.applyPolicy('tenant-1', 'income-1', 'member-1', roles)).rejects.toThrow(BadRequestException);
+    });
+
+    it('persists policyVersionId provenance on the FundTransaction audit', async () => {
+      await service.applyPolicy('tenant-1', 'income-1', 'member-1', roles);
+
+      const txAuditCalls = (audit.createLogRequired as jest.Mock).mock.calls.filter(
+        (call: [{ action: string }]) => call[0].action === 'FUND_TRANSACTION_CREATE',
+      );
+      expect(txAuditCalls).toHaveLength(1);
+      expect(txAuditCalls[0]![0].metadata.policyVersionId).toBe('policy-version-1');
     });
   });
 });

--- a/apps/api/src/finanzas/income-applications.service.ts
+++ b/apps/api/src/finanzas/income-applications.service.ts
@@ -123,173 +123,332 @@ export class IncomeApplicationsService {
         );
       }
 
-      // Plan existente → idempotencia
-      const existing = await this.loadApplicationsTx(tx, tenantId, incomeId);
-      if (existing.length > 0) {
-        const existingPlan = new Set(
-          existing.map((app) =>
-            canonicalKey({
-              destinationType: app.destinationType,
-              fundId: app.fundId,
-              amountMinor: app.amountMinor,
-            }),
-          ),
-        );
-        const requestedPlan = new Set(
-          plan.map((app) =>
-            canonicalKey({
-              destinationType: app.destinationType,
-              fundId: app.fundId ?? null,
-              amountMinor: app.amountMinor,
-            }),
-          ),
-        );
-
-        const samePlan =
-          existingPlan.size === requestedPlan.size &&
-          [...requestedPlan].every((key) => existingPlan.has(key));
-
-        if (samePlan) {
-          // Retry del mismo plan: devolver el plan existente, sin nuevas mutaciones.
-          return {
-            incomeId,
-            currencyCode: income.currencyCode,
-            totalAmountMinor: totalRequested,
-            applications: existing.map((app) => this.toDto(app)),
-          };
-        }
-        throw new ConflictException(
-          'Este ingreso ya tiene un plan de aplicaciones diferente',
-        );
-      }
-
-      // Adquirir locks de Funds en orden determinístico ANTES de validar el
-      // estado del fund: evita TOCTOU application vs archive (el archive puede
-      // cambiar ACTIVE→ARCHIVED mientras el plan espera el lock).
-      const fundIds = [...new Set(
-        plan
-          .filter((app) => app.destinationType === IncomeApplicationDestination.FUND)
-          .map((app) => app.fundId as string),
-      )].sort();
-      for (const fundId of fundIds) {
-        await acquireFundLock(tx, tenantId, fundId);
-      }
-
-      // Validar funds CON el lock tomado (estado estable).
-      const funds = await tx.fund.findMany({
-        where: { id: { in: fundIds }, tenantId },
-        select: { id: true, status: true },
+      // Camino interno compartido (FIN-05): misma publicación que apply-policy.
+      return this.publishPlanTx(tx, {
+        tenantId,
+        income,
+        membershipId,
+        plan: plan.map((app) => ({
+          destinationType: app.destinationType,
+          fundId: app.fundId ?? null,
+          amountMinor: app.amountMinor,
+        })),
+        totalAmountMinor: totalRequested,
+        policyVersionId: null,
       });
-      const fundById = new Map(funds.map((f) => [f.id, f]));
-      for (const fundId of fundIds) {
-        const fund = fundById.get(fundId);
-        if (!fund) {
-          throw new NotFoundException(`Fondo no encontrado o no pertenece al tenant: ${fundId}`);
-        }
-        if (fund.status !== FundStatus.ACTIVE) {
-          throw new BadRequestException(`El fondo está archivado: ${fundId}`);
-        }
+    });
+  }
+
+  // ── POST apply-policy (FIN-05) ──────────────────────────────────────────
+
+  async applyPolicy(
+    tenantId: string,
+    incomeId: string,
+    membershipId: string,
+    userRoles: string[],
+  ): Promise<IncomeApplicationPlanResponseDto> {
+    this.assertAdminOrOperator(userRoles, 'aplicar política de ingresos');
+
+    return this.prisma.$transaction(async (tx) => {
+      await acquireIncomeLock(tx, tenantId, incomeId);
+
+      const income = await tx.income.findFirst({
+        where: { id: incomeId, tenantId },
+      });
+      if (!income) {
+        throw new NotFoundException('Ingreso no encontrado o no pertenece al tenant');
+      }
+      if (income.status !== IncomeStatus.RECORDED) {
+        throw new BadRequestException(
+          `Solo se pueden aplicar políticas a ingresos RECORDED. Estado actual: ${income.status}`,
+        );
       }
 
-      // Crear aplicaciones + FundTransactions CREDIT (uno a uno)
-      const created: ApplicationRow[] = [];
-      for (const app of plan) {
-        const isFund = app.destinationType === IncomeApplicationDestination.FUND;
-        const application = await tx.incomeApplication.create({
-          data: {
-            tenantId,
-            incomeId,
-            destinationType: app.destinationType,
-            fundId: isFund ? app.fundId! : null,
-            amountMinor: app.amountMinor,
-            currencyCode: income.currencyCode,
-            createdByMembershipId: membershipId,
-          },
-        });
-
-        if (isFund) {
-          // El CREDIT del Fund: determinístico por applicationId (retry-safe).
-          const transaction = await tx.fundTransaction.create({
-            data: {
-              tenantId,
-              fundId: app.fundId!,
-              direction: FundTransactionDirection.CREDIT,
-              amountMinor: app.amountMinor,
-              currencyCode: income.currencyCode,
-              occurredAt: income.receivedDate,
-              description: `Aplicación de ingreso ${incomeId}`,
-              createdByMembershipId: membershipId,
-              idempotencyKey: incomeApplicationFundTransactionKey(application.id),
-              incomeApplicationId: application.id,
-            },
-          });
-
-          // FIN-03R (BLOCKER A): cada CREDIT monetario requiere su propio audit
-          // FUND_TRANSACTION_CREATE dentro de la MISMA transacción. Si falla,
-          // rollback total (application + FundTransaction + plan).
-          await this.auditService.createLogRequired(
-            {
-              tenantId,
-              actorMembershipId: membershipId,
-              action: 'FUND_TRANSACTION_CREATE',
-              entityType: 'FundTransaction',
-              entityId: transaction.id,
-              metadata: {
-                fundId: app.fundId!,
-                direction: FundTransactionDirection.CREDIT,
-                amountMinor: app.amountMinor,
-                currencyCode: income.currencyCode,
-                occurredAt: income.receivedDate.toISOString(),
-                idempotencyKey: incomeApplicationFundTransactionKey(application.id),
-                incomeApplicationId: application.id,
-              },
-            },
-            tx,
-          );
-
-          created.push({
-            ...application,
-            fundTransaction: { id: transaction.id },
-          });
-        } else {
-          created.push({ ...application, fundTransaction: null });
-        }
-      }
-
-      // Audit requerido del plan (atómico con la mutación)
-      await this.auditService.createLogRequired(
-        {
-          tenantId,
-          actorMembershipId: membershipId,
-          action: 'INCOME_APPLICATIONS_CREATE',
-          entityType: 'Income',
-          entityId: incomeId,
-          metadata: {
-            incomeId,
-            currencyCode: income.currencyCode,
-            totalAmountMinor: totalRequested,
-            applications: plan.map((app) => ({
-              destinationType: app.destinationType,
-              ...(app.fundId !== undefined && app.fundId !== null
-                ? { fundId: app.fundId }
-                : {}),
-              amountMinor: app.amountMinor,
-            })),
+      // Resolver la versión ACTIVE de la política de la categoría (tenant-scoped).
+      const policy = await tx.incomePolicy.findUnique({
+        where: { tenantId_categoryId: { tenantId, categoryId: income.categoryId } },
+        include: {
+          versions: {
+            where: { status: 'ACTIVE' },
+            include: { rules: true },
+            orderBy: { version: 'desc' },
+            take: 1,
           },
         },
-        tx,
+      });
+      if (!policy || policy.versions.length === 0) {
+        throw new BadRequestException('No existe una política ACTIVE para la categoría de este ingreso');
+      }
+      const version = policy.versions[0]!;
+
+      // Convertir reglas (basis points) a montos exactos (largest remainder determinístico).
+      const plan = this.allocatePolicyRules(
+        income.amountMinor,
+        version.rules.map((rule) => ({
+          destinationType: rule.destinationType,
+          fundId: rule.fundId,
+          percentageBasisPoints: rule.percentageBasisPoints,
+        })),
       );
 
-      return {
-        incomeId,
-        currencyCode: income.currencyCode,
-        totalAmountMinor: totalRequested,
-        applications: created.map((app) => this.toDto(app)),
-      };
+      // Camino interno compartido (FIN-05): misma publicación que manual plan,
+      // con provenance de la versión de política.
+      return this.publishPlanTx(tx, {
+        tenantId,
+        income,
+        membershipId,
+        plan,
+        totalAmountMinor: income.amountMinor,
+        policyVersionId: version.id,
+      });
     });
   }
 
   // ── Internos ─────────────────────────────────────────────────────────────
+
+  /**
+   * Camino interno compartido (FIN-03/FIN-05): publica un plan de aplicaciones
+   * con todas las invariantes (idempotencia, locks de Funds, CREDITs, audits).
+   * Usado por createPlan (manual) y applyPolicy (generado por política).
+   */
+  private async publishPlanTx(
+    tx: Prisma.TransactionClient,
+    params: {
+      tenantId: string;
+      income: { id: string; amountMinor: number; currencyCode: string; receivedDate: Date; categoryId: string };
+      membershipId: string;
+      plan: Array<{ destinationType: IncomeApplicationDestination; fundId: string | null; amountMinor: number }>;
+      totalAmountMinor: number;
+      policyVersionId: string | null;
+    },
+  ): Promise<IncomeApplicationPlanResponseDto> {
+    const { tenantId, income, membershipId, plan, totalAmountMinor, policyVersionId } = params;
+    const incomeId = income.id;
+
+    // Plan existente → idempotencia (mismo canonical → retorna existente)
+    const existing = await this.loadApplicationsTx(tx, tenantId, incomeId);
+    if (existing.length > 0) {
+      const existingPlan = new Set(
+        existing.map((app) =>
+          canonicalKey({
+            destinationType: app.destinationType,
+            fundId: app.fundId,
+            amountMinor: app.amountMinor,
+          }),
+        ),
+      );
+      const requestedPlan = new Set(
+        plan.map((app) =>
+          canonicalKey({
+            destinationType: app.destinationType,
+            fundId: app.fundId ?? null,
+            amountMinor: app.amountMinor,
+          }),
+        ),
+      );
+
+      const samePlan =
+        existingPlan.size === requestedPlan.size &&
+        [...requestedPlan].every((key) => existingPlan.has(key));
+
+      if (samePlan) {
+        return {
+          incomeId,
+          currencyCode: income.currencyCode,
+          totalAmountMinor: totalAmountMinor,
+          applications: existing.map((app) => this.toDto(app)),
+        };
+      }
+      throw new ConflictException(
+        'Este ingreso ya tiene un plan de aplicaciones diferente',
+      );
+    }
+
+    // Adquirir locks de Funds en orden determinístico ANTES de validar el
+    // estado del fund: evita TOCTOU application vs archive.
+    const fundIds = [...new Set(
+      plan
+        .filter((app) => app.destinationType === IncomeApplicationDestination.FUND)
+        .map((app) => app.fundId as string),
+    )].sort();
+    for (const fundId of fundIds) {
+      await acquireFundLock(tx, tenantId, fundId);
+    }
+
+    // Validar funds CON el lock tomado (estado estable).
+    const funds = await tx.fund.findMany({
+      where: { id: { in: fundIds }, tenantId },
+      select: { id: true, status: true },
+    });
+    const fundById = new Map(funds.map((f) => [f.id, f]));
+    for (const fundId of fundIds) {
+      const fund = fundById.get(fundId);
+      if (!fund) {
+        throw new NotFoundException(`Fondo no encontrado o no pertenece al tenant: ${fundId}`);
+      }
+      if (fund.status !== FundStatus.ACTIVE) {
+        throw new BadRequestException(`El fondo está archivado: ${fundId}`);
+      }
+    }
+
+    // Crear aplicaciones + FundTransactions CREDIT (uno a uno)
+    const created: ApplicationRow[] = [];
+    for (const app of plan) {
+      const isFund = app.destinationType === IncomeApplicationDestination.FUND;
+      const application = await tx.incomeApplication.create({
+        data: {
+          tenantId,
+          incomeId,
+          destinationType: app.destinationType,
+          fundId: isFund ? app.fundId! : null,
+          amountMinor: app.amountMinor,
+          currencyCode: income.currencyCode,
+          createdByMembershipId: membershipId,
+          policyVersionId,
+        },
+      });
+
+      if (isFund) {
+        const transaction = await tx.fundTransaction.create({
+          data: {
+            tenantId,
+            fundId: app.fundId!,
+            direction: FundTransactionDirection.CREDIT,
+            amountMinor: app.amountMinor,
+            currencyCode: income.currencyCode,
+            occurredAt: income.receivedDate,
+            description: `Aplicación de ingreso ${incomeId}`,
+            createdByMembershipId: membershipId,
+            idempotencyKey: incomeApplicationFundTransactionKey(application.id),
+            incomeApplicationId: application.id,
+          },
+        });
+
+        await this.auditService.createLogRequired(
+          {
+            tenantId,
+            actorMembershipId: membershipId,
+            action: 'FUND_TRANSACTION_CREATE',
+            entityType: 'FundTransaction',
+            entityId: transaction.id,
+            metadata: {
+              fundId: app.fundId!,
+              direction: FundTransactionDirection.CREDIT,
+              amountMinor: app.amountMinor,
+              currencyCode: income.currencyCode,
+              occurredAt: income.receivedDate.toISOString(),
+              idempotencyKey: incomeApplicationFundTransactionKey(application.id),
+              incomeApplicationId: application.id,
+              ...(policyVersionId !== null ? { policyVersionId } : {}),
+            },
+          },
+          tx,
+        );
+
+        created.push({
+          ...application,
+          fundTransaction: { id: transaction.id },
+        });
+      } else {
+        created.push({ ...application, fundTransaction: null });
+      }
+    }
+
+    // Audit requerido del plan (atómico con la mutación)
+    await this.auditService.createLogRequired(
+      {
+        tenantId,
+        actorMembershipId: membershipId,
+        action: 'INCOME_APPLICATIONS_CREATE',
+        entityType: 'Income',
+        entityId: incomeId,
+        metadata: {
+          incomeId,
+          currencyCode: income.currencyCode,
+          totalAmountMinor: totalAmountMinor,
+          ...(policyVersionId !== null ? { policyVersionId } : {}),
+          applications: plan.map((app) => ({
+            destinationType: app.destinationType,
+            ...(app.fundId !== undefined && app.fundId !== null
+              ? { fundId: app.fundId }
+              : {}),
+            amountMinor: app.amountMinor,
+          })),
+        },
+      },
+      tx,
+    );
+
+    return {
+      incomeId,
+      currencyCode: income.currencyCode,
+      totalAmountMinor: totalAmountMinor,
+      applications: created.map((app) => this.toDto(app)),
+    };
+  }
+
+  /**
+   * Convierte reglas (basis points) a montos minor exactos con largest
+   * remainder determinístico. Orden estable: destinationType, luego fundId.
+   * Rechaza si alguna regla genera 0 minor units (income demasiado pequeño).
+   */
+  private allocatePolicyRules(
+    amountMinor: number,
+    rules: Array<{ destinationType: IncomeApplicationDestination; fundId: string | null; percentageBasisPoints: number }>,
+  ): Array<{ destinationType: IncomeApplicationDestination; fundId: string | null; amountMinor: number }> {
+    // Orden canónico determinístico para tie-breaks estables.
+    const ordered = [...rules].sort((a, b) => {
+      if (a.destinationType !== b.destinationType) {
+        return a.destinationType.localeCompare(b.destinationType);
+      }
+      return (a.fundId ?? '').localeCompare(b.fundId ?? '');
+    });
+
+    const exact = ordered.map((rule) => ({
+      rule,
+      amount: Math.floor((amountMinor * rule.percentageBasisPoints) / 10000),
+      remainder: (amountMinor * rule.percentageBasisPoints) % 10000,
+    }));
+
+    const allocated = exact.reduce((sum, item) => sum + item.amount, 0);
+    const missing = amountMinor - allocated;
+
+    // Distribuir el remanente (menor a rules.length) por mayor remainder;
+    // tie-break por orden canónico (índice en `ordered`). Se muta el ORIGINAL
+    // en exact[] (no una copia) para que la suma final sea exacta.
+    const byRemainder = exact
+      .map((item, index) => ({ index }))
+      .sort((a, b) => exact[b.index]!.remainder - exact[a.index]!.remainder || a.index - b.index);
+
+    for (let i = 0; i < missing; i += 1) {
+      const target = byRemainder[i];
+      if (target) {
+        exact[target.index]!.amount += 1;
+      }
+    }
+
+    const result = exact.map((item) => {
+      const rule = item.rule;
+      if (item.amount <= 0) {
+        throw new BadRequestException(
+          'El monto del ingreso es demasiado pequeño para la política: una regla generaría 0 unidades',
+        );
+      }
+      return {
+        destinationType: rule.destinationType,
+        fundId: rule.fundId,
+        amountMinor: item.amount,
+      };
+    });
+
+    const total = result.reduce((sum, item) => sum + item.amountMinor, 0);
+    if (total !== amountMinor) {
+      throw new BadRequestException(
+        `Error de asignación: la suma generada (${total}) no coincide con ${amountMinor}`,
+      );
+    }
+    return result;
+  }
 
   private assertAdminOrOperator(userRoles: string[], action: string): void {
     if (!this.validators.isAdminOrOperator(userRoles)) {

--- a/apps/api/src/finanzas/income-policies.controller.ts
+++ b/apps/api/src/finanzas/income-policies.controller.ts
@@ -1,0 +1,84 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
+import { AuthenticatedRequest } from '../common/types/request.types';
+import { IncomePoliciesService } from './income-policies.service';
+import {
+  CreateIncomePolicyDto,
+  CreateIncomePolicyVersionDto,
+  IncomePolicyResponseDto,
+} from './income-policies.dto';
+
+/**
+ * Políticas de ingresos (tenant-scoped)
+ * Routes: /tenants/:tenantId/finance/income-policies
+ */
+@Controller('tenants/:tenantId/finance/income-policies')
+@UseGuards(JwtAuthGuard, TenantAccessGuard)
+export class IncomePoliciesController {
+  constructor(private readonly incomePoliciesService: IncomePoliciesService) {}
+
+  @Get()
+  async listPolicies(
+    @Request() req: AuthenticatedRequest,
+  ): Promise<IncomePolicyResponseDto[]> {
+    return this.incomePoliciesService.listPolicies(req.tenantId!, req.user.roles ?? []);
+  }
+
+  @Get(':categoryId')
+  async getPolicy(
+    @Param('categoryId') categoryId: string,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<IncomePolicyResponseDto> {
+    return this.incomePoliciesService.getPolicy(req.tenantId!, categoryId, req.user.roles ?? []);
+  }
+
+  @Post()
+  async createPolicy(
+    @Body() dto: CreateIncomePolicyDto,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<IncomePolicyResponseDto> {
+    return this.incomePoliciesService.createPolicy(
+      req.tenantId!,
+      req.user.membershipId ?? '',
+      req.user.roles ?? [],
+      dto,
+    );
+  }
+
+  @Post(':categoryId/versions')
+  async createVersion(
+    @Param('categoryId') categoryId: string,
+    @Body() dto: CreateIncomePolicyVersionDto,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<IncomePolicyResponseDto> {
+    return this.incomePoliciesService.createVersion(
+      req.tenantId!,
+      categoryId,
+      req.user.membershipId ?? '',
+      req.user.roles ?? [],
+      dto,
+    );
+  }
+
+  @Post(':categoryId/deactivate')
+  async deactivatePolicy(
+    @Param('categoryId') categoryId: string,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<IncomePolicyResponseDto> {
+    return this.incomePoliciesService.deactivatePolicy(
+      req.tenantId!,
+      categoryId,
+      req.user.membershipId ?? '',
+      req.user.roles ?? [],
+    );
+  }
+}

--- a/apps/api/src/finanzas/income-policies.dto.ts
+++ b/apps/api/src/finanzas/income-policies.dto.ts
@@ -1,0 +1,75 @@
+import {
+  ArrayMaxSize,
+  ArrayNotEmpty,
+  IsArray,
+  IsEnum,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { IncomeApplicationDestination, IncomePolicyVersionStatus } from '@prisma/client';
+
+export const MAX_POLICY_RULES = 20;
+
+export class IncomePolicyRuleInputDto {
+  @IsEnum(IncomeApplicationDestination)
+  destinationType!: IncomeApplicationDestination;
+
+  @IsString()
+  @IsOptional()
+  fundId?: string;
+
+  /** Basis points: 100% = 10000 bp. */
+  @IsInt()
+  @Min(1)
+  @Max(10000)
+  percentageBasisPoints!: number;
+}
+
+export class CreateIncomePolicyDto {
+  @IsString()
+  categoryId!: string;
+
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayMaxSize(MAX_POLICY_RULES)
+  @ValidateNested({ each: true })
+  @Type(() => IncomePolicyRuleInputDto)
+  rules!: IncomePolicyRuleInputDto[];
+}
+
+export class CreateIncomePolicyVersionDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayMaxSize(MAX_POLICY_RULES)
+  @ValidateNested({ each: true })
+  @Type(() => IncomePolicyRuleInputDto)
+  rules!: IncomePolicyRuleInputDto[];
+}
+
+export interface IncomePolicyRuleResponseDto {
+  id: string;
+  destinationType: IncomeApplicationDestination;
+  fundId: string | null;
+  percentageBasisPoints: number;
+}
+
+export interface IncomePolicyVersionResponseDto {
+  id: string;
+  version: number;
+  status: IncomePolicyVersionStatus;
+  rules: IncomePolicyRuleResponseDto[];
+  createdAt: Date;
+}
+
+export interface IncomePolicyResponseDto {
+  id: string;
+  tenantId: string;
+  categoryId: string;
+  currentVersion: IncomePolicyVersionResponseDto | null;
+  versions: IncomePolicyVersionResponseDto[];
+}

--- a/apps/api/src/finanzas/income-policies.postgres.spec.ts
+++ b/apps/api/src/finanzas/income-policies.postgres.spec.ts
@@ -1,0 +1,473 @@
+import {
+  IncomeApplicationDestination,
+  IncomeStatus,
+  PrismaClient,
+  TenantType,
+} from '@prisma/client';
+import { BadRequestException as NestBadRequestException, ConflictException as NestConflictException } from '@nestjs/common';
+import { IncomePoliciesService } from './income-policies.service';
+import { IncomeApplicationsService } from './income-applications.service';
+import { FundsService } from './funds.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { PrismaService } from '../prisma/prisma.service';
+
+const ACCEPTANCE_DATABASES = new Set(['buildingos_fin05_acceptance']);
+const expectedDatabaseName = process.env.POSTGRES_TEST_DB_NAME;
+const fixturePhase = 'fin05';
+const enabled =
+  process.env.RUN_POSTGRES_INTEGRATION === '1' &&
+  expectedDatabaseName !== undefined &&
+  ACCEPTANCE_DATABASES.has(expectedDatabaseName);
+const describePostgres = enabled ? describe : describe.skip;
+
+describePostgres('IncomePolicies PostgreSQL (FIN-05)', () => {
+  let observer: PrismaClient;
+  let clientA: PrismaClient;
+  let clientB: PrismaClient;
+  let policies: IncomePoliciesService;
+  let apps: IncomeApplicationsService;
+  let funds: FundsService;
+  const tenantIds: string[] = [];
+  const userIds: string[] = [];
+  const membershipIds: string[] = [];
+
+  function buildServices(client: PrismaClient) {
+    const prisma = client as unknown as PrismaService;
+    const audit = new AuditService(prisma);
+    const validators = new FinanzasValidators(prisma);
+    return {
+      policies: new IncomePoliciesService(prisma, audit, validators),
+      apps: new IncomeApplicationsService(prisma, audit, validators),
+      funds: new FundsService(prisma, audit, validators),
+    };
+  }
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required');
+    observer = new PrismaClient();
+    clientA = new PrismaClient();
+    clientB = new PrismaClient();
+    await Promise.all([observer.$connect(), clientA.$connect(), clientB.$connect()]);
+    const [database] = await observer.$queryRaw<Array<{ name: string }>>`SELECT current_database() AS name`;
+    if (database?.name !== expectedDatabaseName || !ACCEPTANCE_DATABASES.has(database.name)) {
+      throw new Error(`Refusing destructive test database ${database?.name ?? 'unknown'}`);
+    }
+    const svcA = buildServices(clientA);
+    policies = svcA.policies;
+    apps = svcA.apps;
+    funds = svcA.funds;
+
+    // Limpieza defensiva de fixtures de corridas previas interrumpidas.
+    await observer.tenant.deleteMany({ where: { name: { startsWith: `${fixturePhase}-` } } });
+  });
+
+  afterEach(async () => {
+    for (const membershipId of membershipIds.splice(0)) {
+      await observer.membership.delete({ where: { id: membershipId } }).catch(() => undefined);
+    }
+    for (const tenantId of tenantIds.splice(0)) {
+      await observer.tenant.delete({ where: { id: tenantId } }).catch(() => undefined);
+    }
+    for (const userId of userIds.splice(0)) {
+      await observer.user.delete({ where: { id: userId } }).catch(() => undefined);
+    }
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      observer?.$disconnect(),
+      clientA?.$disconnect(),
+      clientB?.$disconnect(),
+    ]);
+  });
+
+  async function fixture(label: string) {
+    const suffix = `${Date.now()}-${Math.random()}`;
+    const tenant = await observer.tenant.create({
+      data: { name: `${fixturePhase}-${label}-${suffix}`, type: TenantType.ADMINISTRADORA },
+    });
+    tenantIds.push(tenant.id);
+    const user = await observer.user.create({
+      data: { email: `${fixturePhase}-${suffix}@buildingos.local`, name: `${fixturePhase} ${label}`, passwordHash: 'test' },
+    });
+    userIds.push(user.id);
+    const membership = await observer.membership.create({ data: { tenantId: tenant.id, userId: user.id } });
+    membershipIds.push(membership.id);
+    return { tenant, membership };
+  }
+
+  async function incomeCategory(tenantId: string) {
+    return observer.expenseLedgerCategory.create({
+      data: { tenantId, name: `Income Cat ${Date.now()}`, movementType: 'INCOME' },
+    });
+  }
+
+  async function fund(tenantId: string, membershipId: string) {
+    return observer.fund.create({
+      data: { tenantId, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}-${Math.random()}`, createdByMembershipId: membershipId },
+    });
+  }
+
+  async function recordedIncome(tenantId: string, membershipId: string, categoryId: string, amountMinor = 10000) {
+    return observer.income.create({
+      data: {
+        tenantId,
+        period: '2026-08',
+        categoryId,
+        amountMinor,
+        currencyCode: 'USD',
+        receivedDate: new Date('2026-08-10T00:00:00.000Z'),
+        status: IncomeStatus.RECORDED,
+        createdByMembershipId: membershipId,
+      },
+    });
+  }
+
+  const roles = ['TENANT_ADMIN'];
+
+  // ── DB constraints ──────────────────────────────────────────────────────
+
+  it('enforces percentageBasisPoints range at the DB level', async () => {
+    const ctx = await fixture('bp-range');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const f = await fund(ctx.tenant.id, ctx.membership.id);
+    const policy = await observer.incomePolicy.create({
+      data: { tenantId: ctx.tenant.id, categoryId: cat.id, createdByMembershipId: ctx.membership.id },
+    });
+    const version = await observer.incomePolicyVersion.create({
+      data: { policyId: policy.id, version: 1, status: 'ACTIVE', createdByMembershipId: ctx.membership.id },
+    });
+    const base = { tenantId: ctx.tenant.id, versionId: version.id, destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, fundId: null } as const;
+
+    await expect(
+      observer.incomePolicyRule.create({ data: { ...base, percentageBasisPoints: 0 } }),
+    ).rejects.toThrow(/check constraint|Check/);
+    await expect(
+      observer.incomePolicyRule.create({ data: { ...base, percentageBasisPoints: -1 } }),
+    ).rejects.toThrow(/check constraint|Check/);
+    await expect(
+      observer.incomePolicyRule.create({ data: { ...base, percentageBasisPoints: 10001 } }),
+    ).rejects.toThrow(/check constraint|Check/);
+    await observer.incomePolicyRule.create({ data: { ...base, percentageBasisPoints: 10000 } });
+    expect(await observer.incomePolicyRule.count({ where: { versionId: version.id } })).toBe(1);
+  }, 20000);
+
+  it('enforces the destination/fund invariant at the DB level', async () => {
+    const ctx = await fixture('dest-inv');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const f = await fund(ctx.tenant.id, ctx.membership.id);
+    const policy = await observer.incomePolicy.create({
+      data: { tenantId: ctx.tenant.id, categoryId: cat.id, createdByMembershipId: ctx.membership.id },
+    });
+    const version = await observer.incomePolicyVersion.create({
+      data: { policyId: policy.id, version: 1, status: 'ACTIVE', createdByMembershipId: ctx.membership.id },
+    });
+    const base = { tenantId: ctx.tenant.id, versionId: version.id, percentageBasisPoints: 10000 } as const;
+
+    await expect(
+      observer.incomePolicyRule.create({ data: { ...base, destinationType: IncomeApplicationDestination.FUND, fundId: null } }),
+    ).rejects.toThrow(/check constraint|Check/);
+    await expect(
+      observer.incomePolicyRule.create({ data: { ...base, destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, fundId: f.id } }),
+    ).rejects.toThrow(/check constraint|Check/);
+    await observer.incomePolicyRule.create({ data: { ...base, destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, fundId: null } });
+    expect(await observer.incomePolicyRule.count({ where: { versionId: version.id } })).toBe(1);
+  }, 20000);
+
+  it('enforces duplicate DB constraints per version', async () => {
+    const ctx = await fixture('dup-constraints');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const f1 = await fund(ctx.tenant.id, ctx.membership.id);
+    const f2 = await fund(ctx.tenant.id, ctx.membership.id);
+    const policy = await observer.incomePolicy.create({
+      data: { tenantId: ctx.tenant.id, categoryId: cat.id, createdByMembershipId: ctx.membership.id },
+    });
+    const version = await observer.incomePolicyVersion.create({
+      data: { policyId: policy.id, version: 1, status: 'ACTIVE', createdByMembershipId: ctx.membership.id },
+    });
+    const base = { tenantId: ctx.tenant.id, versionId: version.id, percentageBasisPoints: 10000 } as const;
+
+    await observer.incomePolicyRule.create({ data: { ...base, destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, fundId: null } });
+    await expect(
+      observer.incomePolicyRule.create({ data: { ...base, destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, fundId: null } }),
+    ).rejects.toThrow(/unique|duplicate/i);
+    await observer.incomePolicyRule.create({ data: { ...base, destinationType: IncomeApplicationDestination.FUND, fundId: f1.id } });
+    await expect(
+      observer.incomePolicyRule.create({ data: { ...base, destinationType: IncomeApplicationDestination.FUND, fundId: f1.id } }),
+    ).rejects.toThrow(/unique|duplicate/i);
+    await observer.incomePolicyRule.create({ data: { ...base, destinationType: IncomeApplicationDestination.FUND, fundId: f2.id } });
+  }, 20000);
+
+  it('enforces a single ACTIVE version per policy at the DB level', async () => {
+    const ctx = await fixture('single-active');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const policy = await observer.incomePolicy.create({
+      data: { tenantId: ctx.tenant.id, categoryId: cat.id, createdByMembershipId: ctx.membership.id },
+    });
+    await observer.incomePolicyVersion.create({
+      data: { policyId: policy.id, version: 1, status: 'ACTIVE', createdByMembershipId: ctx.membership.id },
+    });
+    await expect(
+      observer.incomePolicyVersion.create({
+        data: { policyId: policy.id, version: 2, status: 'ACTIVE', createdByMembershipId: ctx.membership.id },
+      }),
+    ).rejects.toThrow(/unique|duplicate/i);
+  }, 20000);
+
+  // ── Functional ──────────────────────────────────────────────────────────
+
+  it('creates a 70/30 policy and applies it exactly', async () => {
+    const ctx = await fixture('apply-7030');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const f = await fund(ctx.tenant.id, ctx.membership.id);
+    const policy = await policies.createPolicy(ctx.tenant.id, ctx.membership.id, roles, {
+      categoryId: cat.id,
+      rules: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: f.id, percentageBasisPoints: 3000 },
+      ],
+    });
+    expect(policy.currentVersion?.rules).toHaveLength(2);
+
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, cat.id, 10000);
+    const plan = await apps.applyPolicy(ctx.tenant.id, income.id, ctx.membership.id, roles);
+
+    expect(plan.totalAmountMinor).toBe(10000);
+    const amounts = plan.applications.map((a) => a.amountMinor).sort((a, b) => a - b);
+    expect(amounts).toEqual([3000, 7000]);
+
+    const credit = await observer.fundTransaction.findFirst({
+      where: { fundId: f.id, direction: 'CREDIT' },
+    });
+    expect(credit).not.toBeNull();
+    expect(credit!.amountMinor).toBe(3000);
+    expect(credit!.currencyCode).toBe('USD');
+    const app = await observer.incomeApplication.findUniqueOrThrow({ where: { id: plan.applications.find((a) => a.destinationType === 'FUND')!.id } });
+    expect(app.policyVersionId).toBe(policy.currentVersion!.id);
+
+    const audits = await observer.auditLog.findMany({
+      where: { tenantId: ctx.tenant.id, action: { in: ['INCOME_POLICY_CREATE', 'INCOME_APPLICATIONS_CREATE', 'FUND_TRANSACTION_CREATE'] } },
+    });
+    expect(audits.some((a) => a.action === 'INCOME_POLICY_CREATE')).toBe(true);
+    expect(audits.some((a) => a.action === 'INCOME_APPLICATIONS_CREATE')).toBe(true);
+    expect(audits.some((a) => a.action === 'FUND_TRANSACTION_CREATE')).toBe(true);
+  }, 30000);
+
+  it('rounds 10001 with 70/30 deterministically to exactly 10001', async () => {
+    const ctx = await fixture('rounding');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const f = await fund(ctx.tenant.id, ctx.membership.id);
+    await policies.createPolicy(ctx.tenant.id, ctx.membership.id, roles, {
+      categoryId: cat.id,
+      rules: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: f.id, percentageBasisPoints: 3000 },
+      ],
+    });
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, cat.id, 10001);
+    const plan = await apps.applyPolicy(ctx.tenant.id, income.id, ctx.membership.id, roles);
+
+    expect(plan.totalAmountMinor).toBe(10001);
+    const amounts = plan.applications.map((a) => a.amountMinor).sort((a, b) => a - b);
+    expect(amounts).toEqual([3000, 7001]);
+  }, 30000);
+
+  it('rejects a small income where a rule would become zero', async () => {
+    const ctx = await fixture('small-income');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const f = await fund(ctx.tenant.id, ctx.membership.id);
+    await policies.createPolicy(ctx.tenant.id, ctx.membership.id, roles, {
+      categoryId: cat.id,
+      rules: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: f.id, percentageBasisPoints: 3000 },
+      ],
+    });
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, cat.id, 1);
+
+    await expect(apps.applyPolicy(ctx.tenant.id, income.id, ctx.membership.id, roles)).rejects.toThrow(NestBadRequestException);
+
+    expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(0);
+    expect(await observer.fundTransaction.count({ where: { fundId: f.id } })).toBe(0);
+  }, 30000);
+
+  it('applies a 100% CARRY_FORWARD policy', async () => {
+    const ctx = await fixture('carry-policy');
+    const cat = await incomeCategory(ctx.tenant.id);
+    await policies.createPolicy(ctx.tenant.id, ctx.membership.id, roles, {
+      categoryId: cat.id,
+      rules: [{ destinationType: IncomeApplicationDestination.CARRY_FORWARD, percentageBasisPoints: 10000 }],
+    });
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, cat.id, 10000);
+    const plan = await apps.applyPolicy(ctx.tenant.id, income.id, ctx.membership.id, roles);
+
+    expect(plan.applications).toHaveLength(1);
+    expect(plan.applications[0]!.destinationType).toBe('CARRY_FORWARD');
+    expect(plan.applications[0]!.amountMinor).toBe(10000);
+    expect(await observer.fundTransaction.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+  }, 30000);
+
+  it('keeps v1 applications unchanged after publishing v2 (history immutability)', async () => {
+    const ctx = await fixture('policy-change');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const f = await fund(ctx.tenant.id, ctx.membership.id);
+    const v1 = await policies.createPolicy(ctx.tenant.id, ctx.membership.id, roles, {
+      categoryId: cat.id,
+      rules: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: f.id, percentageBasisPoints: 3000 },
+      ],
+    });
+
+    // Income A aplica v1 (70/30)
+    const incomeA = await recordedIncome(ctx.tenant.id, ctx.membership.id, cat.id, 10000);
+    const planA = await apps.applyPolicy(ctx.tenant.id, incomeA.id, ctx.membership.id, roles);
+    expect(planA.applications.find((a) => a.destinationType === 'OFFSET_EXPENSES')!.amountMinor).toBe(7000);
+
+    // Publish v2 (100% CARRY_FORWARD)
+    await policies.createVersion(ctx.tenant.id, cat.id, ctx.membership.id, roles, {
+      rules: [{ destinationType: IncomeApplicationDestination.CARRY_FORWARD, percentageBasisPoints: 10000 }],
+    });
+
+    // Income A sigue 70/30 (sin mutación histórica)
+    const planAAfter = await apps.getPlan(ctx.tenant.id, incomeA.id, roles);
+    expect(planAAfter.applications.find((a) => a.destinationType === 'OFFSET_EXPENSES')!.amountMinor).toBe(7000);
+
+    // Income B usa v2 (100% CARRY_FORWARD)
+    const incomeB = await recordedIncome(ctx.tenant.id, ctx.membership.id, cat.id, 10000);
+    const planB = await apps.applyPolicy(ctx.tenant.id, incomeB.id, ctx.membership.id, roles);
+    expect(planB.applications[0]!.destinationType).toBe('CARRY_FORWARD');
+    expect(planB.applications[0]!.amountMinor).toBe(10000);
+    const appB = await observer.incomeApplication.findUniqueOrThrow({ where: { id: planB.applications[0]!.id } });
+    const v2 = await observer.incomePolicyVersion.findFirst({ where: { policyId: v1.id, status: 'ACTIVE' } });
+    expect(appB.policyVersionId).toBe(v2!.id);
+  }, 30000);
+
+  it('rejects apply-policy when the referenced fund was archived after publication', async () => {
+    const ctx = await fixture('fund-archived-after');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const f = await fund(ctx.tenant.id, ctx.membership.id);
+    await policies.createPolicy(ctx.tenant.id, ctx.membership.id, roles, {
+      categoryId: cat.id,
+      rules: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: f.id, percentageBasisPoints: 3000 },
+      ],
+    });
+    // Llevar el fund a cero y archivarlo (CREDIT + DEBIT)
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, cat.id, 10000);
+    const plan = await apps.applyPolicy(ctx.tenant.id, income.id, ctx.membership.id, roles);
+    const fundApp = plan.applications.find((a) => a.destinationType === 'FUND')!;
+    await funds.createTransaction(ctx.tenant.id, f.id, ctx.membership.id, roles, {
+      direction: 'DEBIT',
+      amountMinor: fundApp.amountMinor,
+      currencyCode: 'USD',
+      occurredAt: new Date().toISOString(),
+    });
+    await funds.archiveFund(ctx.tenant.id, f.id, ctx.membership.id, roles);
+
+    // Nuevo income: apply-policy debe rechazar (fund ARCHIVED)
+    const income2 = await recordedIncome(ctx.tenant.id, ctx.membership.id, cat.id, 10000);
+    await expect(apps.applyPolicy(ctx.tenant.id, income2.id, ctx.membership.id, roles)).rejects.toThrow(NestBadRequestException);
+    expect(await observer.incomeApplication.count({ where: { incomeId: income2.id } })).toBe(0);
+  }, 30000);
+
+  // ── Concurrency ─────────────────────────────────────────────────────────
+
+  it('serializes concurrent policy version publish (single current version)', async () => {
+    const ctx = await fixture('publish-race');
+    const cat = await incomeCategory(ctx.tenant.id);
+    await policies.createPolicy(ctx.tenant.id, ctx.membership.id, roles, {
+      categoryId: cat.id,
+      rules: [{ destinationType: IncomeApplicationDestination.CARRY_FORWARD, percentageBasisPoints: 10000 }],
+    });
+    const svcB = buildServices(clientB).policies;
+    const newRules = { rules: [{ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 10000 }] };
+
+    const [a, b] = await Promise.all([
+      policies.createVersion(ctx.tenant.id, cat.id, ctx.membership.id, roles, newRules).then(() => ({ ok: true as const })),
+      svcB.createVersion(ctx.tenant.id, cat.id, ctx.membership.id, roles, newRules).then(
+        () => ({ ok: true as const }),
+        (error: unknown) => ({ ok: false as const, conflict: error instanceof NestConflictException }),
+      ),
+    ]);
+
+    const actives = await observer.incomePolicyVersion.findMany({
+      where: { status: 'ACTIVE', policy: { tenantId: ctx.tenant.id, categoryId: cat.id } },
+    });
+    expect(actives).toHaveLength(1);
+    expect(a.ok || b.ok).toBe(true);
+  }, 30000);
+
+  it('applies policy concurrently to the same income exactly once', async () => {
+    const ctx = await fixture('apply-race');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const f = await fund(ctx.tenant.id, ctx.membership.id);
+    await policies.createPolicy(ctx.tenant.id, ctx.membership.id, roles, {
+      categoryId: cat.id,
+      rules: [
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 7000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: f.id, percentageBasisPoints: 3000 },
+      ],
+    });
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, cat.id, 10000);
+    const svcB = buildServices(clientB).apps;
+
+    const [a, b] = await Promise.all([
+      apps.applyPolicy(ctx.tenant.id, income.id, ctx.membership.id, roles).then(() => ({ ok: true as const })),
+      svcB.applyPolicy(ctx.tenant.id, income.id, ctx.membership.id, roles).then(() => ({ ok: true as const })),
+    ]);
+
+    expect(a.ok && b.ok).toBe(true);
+    expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(2);
+    expect(await observer.fundTransaction.count({ where: { fundId: f.id, direction: 'CREDIT' } })).toBe(1);
+  }, 30000);
+
+  // ── Isolation / delete ──────────────────────────────────────────────────
+
+  it('rejects cross-tenant category and fund', async () => {
+    const ctxA = await fixture('iso-a');
+    const ctxB = await fixture('iso-b');
+    const catB = await incomeCategory(ctxB.tenant.id);
+    const fundB = await fund(ctxB.tenant.id, ctxB.membership.id);
+
+    // Categoría de tenant B usada en tenant A → not found
+    await expect(
+      policies.createPolicy(ctxA.tenant.id, ctxA.membership.id, roles, {
+        categoryId: catB.id,
+        rules: [{ destinationType: IncomeApplicationDestination.CARRY_FORWARD, percentageBasisPoints: 10000 }],
+      }),
+    ).rejects.toThrow(/no encontrada|not found/i);
+
+    // Fund de tenant B en política de tenant A → not found
+    const catA = await incomeCategory(ctxA.tenant.id);
+    await expect(
+      policies.createPolicy(ctxA.tenant.id, ctxA.membership.id, roles, {
+        categoryId: catA.id,
+        rules: [{ destinationType: IncomeApplicationDestination.FUND, fundId: fundB.id, percentageBasisPoints: 10000 }],
+      }),
+    ).rejects.toThrow(/no encontrado|not found/i);
+  }, 30000);
+
+  it('preserves tenant delete lifecycle (policy/version/rules cascade)', async () => {
+    const ctx = await fixture('fk-delete');
+    const cat = await incomeCategory(ctx.tenant.id);
+    await policies.createPolicy(ctx.tenant.id, ctx.membership.id, roles, {
+      categoryId: cat.id,
+      rules: [{ destinationType: IncomeApplicationDestination.CARRY_FORWARD, percentageBasisPoints: 10000 }],
+    });
+
+    await observer.tenant.delete({ where: { id: ctx.tenant.id } });
+    expect(await observer.incomePolicy.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+    expect(await observer.incomePolicyVersion.count({ where: { policy: { tenantId: ctx.tenant.id } } })).toBe(0);
+    expect(await observer.incomePolicyRule.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+    tenantIds.splice(tenantIds.indexOf(ctx.tenant.id), 1);
+    membershipIds.splice(membershipIds.indexOf(ctx.membership.id), 1);
+  }, 30000);
+
+  it('leaves no leftovers after the suite', async () => {
+    const leftover = await observer.tenant.count({ where: { name: { startsWith: `${fixturePhase}-` } } });
+    expect(leftover).toBe(0);
+  }, 10000);
+});

--- a/apps/api/src/finanzas/income-policies.service.spec.ts
+++ b/apps/api/src/finanzas/income-policies.service.spec.ts
@@ -1,0 +1,331 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { FundStatus, IncomeApplicationDestination } from '@prisma/client';
+import { IncomePoliciesService } from './income-policies.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+
+describe('IncomePoliciesService', () => {
+  let service: IncomePoliciesService;
+  let prisma: PrismaService;
+  let audit: AuditService;
+  let validators: FinanzasValidators;
+
+  const prismaValue = {
+    incomePolicy: { findMany: jest.fn(), findUnique: jest.fn(), create: jest.fn() },
+    incomePolicyVersion: { findFirst: jest.fn(), findUnique: jest.fn(), updateMany: jest.fn(), create: jest.fn(), findMany: jest.fn() },
+    incomePolicyRule: { create: jest.fn() },
+    expenseLedgerCategory: { findFirst: jest.fn() },
+    fund: { findMany: jest.fn() },
+    $transaction: jest.fn(),
+    $executeRaw: jest.fn(),
+  };
+
+  function mockTransaction() {
+    (prismaValue.$transaction as jest.Mock).mockImplementation(
+      async (callback: (tx: unknown) => unknown) => callback({
+        incomePolicy: prismaValue.incomePolicy,
+        incomePolicyVersion: prismaValue.incomePolicyVersion,
+        incomePolicyRule: prismaValue.incomePolicyRule,
+        expenseLedgerCategory: prismaValue.expenseLedgerCategory,
+        fund: prismaValue.fund,
+        auditLog: { create: jest.fn() },
+        $executeRaw: prismaValue.$executeRaw,
+      }),
+    );
+  }
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    (prismaValue.incomePolicyRule.create as jest.Mock).mockReset();
+    (prismaValue.incomePolicyVersion.create as jest.Mock).mockReset();
+    mockTransaction();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IncomePoliciesService,
+        { provide: PrismaService, useValue: prismaValue },
+        {
+          provide: AuditService,
+          useValue: {
+            createLog: jest.fn(),
+            createLogRequired: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        {
+          provide: FinanzasValidators,
+          useValue: { isAdminOrOperator: jest.fn().mockReturnValue(true) },
+        },
+      ],
+    }).compile();
+
+    service = module.get<IncomePoliciesService>(IncomePoliciesService);
+    prisma = module.get<PrismaService>(PrismaService);
+    audit = module.get<AuditService>(AuditService);
+    validators = module.get<FinanzasValidators>(FinanzasValidators);
+    (audit.createLogRequired as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  const roles = ['TENANT_ADMIN'];
+  const rules = (r: Array<{ destinationType: IncomeApplicationDestination; fundId?: string; percentageBasisPoints: number }>) => ({ rules: r });
+  const makePolicy = (overrides: Record<string, unknown> = {}) => ({
+    id: 'policy-1',
+    tenantId: 'tenant-1',
+    categoryId: 'cat-1',
+    createdByMembershipId: 'member-1',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    (prisma.expenseLedgerCategory.findFirst as jest.Mock).mockResolvedValue({
+      id: 'cat-1',
+      name: 'Parrillera',
+      movementType: 'INCOME',
+    });
+    (prisma.fund.findMany as jest.Mock).mockResolvedValue([{ id: 'fund-1', status: FundStatus.ACTIVE }]);
+    (prisma.incomePolicy.findUnique as jest.Mock).mockResolvedValue(null); // sin política existente
+    (prisma.incomePolicyVersion.findFirst as jest.Mock).mockResolvedValue(null);
+    (prisma.incomePolicyVersion.findUnique as jest.Mock).mockResolvedValue({ id: 'v1', policyId: 'policy-1', version: 1, status: 'ACTIVE', createdAt: new Date(), rules: [] });
+    (prisma.incomePolicyVersion.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+    (prisma.incomePolicyRule.create as jest.Mock).mockImplementation(({ data }) => Promise.resolve({ id: `rule-${data.destinationType}-${data.fundId ?? 'nf'}`, ...data }));
+    (prisma.incomePolicyVersion.create as jest.Mock).mockImplementation(({ data }) => Promise.resolve({ id: `v-${data.version}`, ...data }));
+  });
+
+  // ── RBAC ────────────────────────────────────────────────────────────────
+
+  it('rejects non-admin users', async () => {
+    (validators.isAdminOrOperator as jest.Mock).mockReturnValue(false);
+    await expect(service.listPolicies('tenant-1', ['RESIDENT'])).rejects.toThrow(ForbiddenException);
+    await expect(
+      service.createPolicy('tenant-1', 'm', ['RESIDENT'], rules([{ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 10000 }])),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  // ── Percentage invariant ────────────────────────────────────────────────
+
+  it('creates a 70/30 policy', async () => {
+    (prisma.incomePolicy.create as jest.Mock).mockResolvedValue(makePolicy());
+
+    await service.createPolicy('tenant-1', 'member-1', roles, rules([
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 7000 },
+      { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', percentageBasisPoints: 3000 },
+    ]));
+
+    expect(prisma.incomePolicy.create).toHaveBeenCalledTimes(1);
+    expect(prisma.incomePolicyRule.create).toHaveBeenCalledTimes(2);
+    expect(audit.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'INCOME_POLICY_CREATE' }),
+      expect.anything(),
+    );
+  });
+
+  it('allows sum exactly 10000 bp', async () => {
+    (prisma.incomePolicy.create as jest.Mock).mockResolvedValue(makePolicy());
+    await service.createPolicy('tenant-1', 'member-1', roles, rules([
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 7000 },
+      { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', percentageBasisPoints: 3000 },
+    ]));
+    expect(prisma.incomePolicy.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects sum 9999 bp', async () => {
+    await expect(
+      service.createPolicy('tenant-1', 'member-1', roles, rules([
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 6999 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', percentageBasisPoints: 3000 },
+      ])),
+    ).rejects.toThrow(BadRequestException);
+    expect(prisma.incomePolicy.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects sum 10001 bp', async () => {
+    await expect(
+      service.createPolicy('tenant-1', 'member-1', roles, rules([
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 7001 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', percentageBasisPoints: 3000 },
+      ])),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects 0 bp', async () => {
+    await expect(
+      service.createPolicy('tenant-1', 'member-1', roles, rules([
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 0 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', percentageBasisPoints: 10000 },
+      ])),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects negative bp', async () => {
+    await expect(
+      service.createPolicy('tenant-1', 'member-1', roles, rules([
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: -100 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', percentageBasisPoints: 10100 },
+      ])),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  // ── Duplicates ──────────────────────────────────────────────────────────
+
+  it('rejects duplicate OFFSET rules', async () => {
+    await expect(
+      service.createPolicy('tenant-1', 'member-1', roles, rules([
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 5000 },
+        { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 5000 },
+      ])),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects duplicate CARRY_FORWARD rules', async () => {
+    await expect(
+      service.createPolicy('tenant-1', 'member-1', roles, rules([
+        { destinationType: IncomeApplicationDestination.CARRY_FORWARD, percentageBasisPoints: 5000 },
+        { destinationType: IncomeApplicationDestination.CARRY_FORWARD, percentageBasisPoints: 5000 },
+      ])),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects duplicate FUND rules to the same fund', async () => {
+    await expect(
+      service.createPolicy('tenant-1', 'member-1', roles, rules([
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', percentageBasisPoints: 5000 },
+        { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', percentageBasisPoints: 5000 },
+      ])),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('allows FUND rules to different funds', async () => {
+    (prisma.fund.findMany as jest.Mock).mockResolvedValue([
+      { id: 'fund-1', status: FundStatus.ACTIVE },
+      { id: 'fund-2', status: FundStatus.ACTIVE },
+    ]);
+    (prisma.incomePolicy.create as jest.Mock).mockResolvedValue(makePolicy());
+
+    await service.createPolicy('tenant-1', 'member-1', roles, rules([
+      { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', percentageBasisPoints: 4000 },
+      { destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-2', percentageBasisPoints: 6000 },
+    ]));
+    expect(prisma.incomePolicy.create).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Category / Fund validation ──────────────────────────────────────────
+
+  it('rejects a cross-tenant category (not found)', async () => {
+    (prisma.expenseLedgerCategory.findFirst as jest.Mock).mockResolvedValue(null);
+    await expect(
+      service.createPolicy('tenant-1', 'member-1', roles, rules([{ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 10000 }])),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('rejects a non-INCOME category', async () => {
+    (prisma.expenseLedgerCategory.findFirst as jest.Mock).mockResolvedValue({ id: 'cat-1', name: 'Luz', movementType: 'EXPENSE' });
+    await expect(
+      service.createPolicy('tenant-1', 'member-1', roles, rules([{ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 10000 }])),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects a cross-tenant fund at policy publication', async () => {
+    (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);
+    await expect(
+      service.createPolicy('tenant-1', 'member-1', roles, rules([{ destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-x', percentageBasisPoints: 10000 }])),
+    ).rejects.toThrow(NotFoundException);
+  });
+
+  it('rejects an ARCHIVED fund at policy publication', async () => {
+    (prisma.fund.findMany as jest.Mock).mockResolvedValue([{ id: 'fund-1', status: FundStatus.ARCHIVED }]);
+    await expect(
+      service.createPolicy('tenant-1', 'member-1', roles, rules([{ destinationType: IncomeApplicationDestination.FUND, fundId: 'fund-1', percentageBasisPoints: 10000 }])),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects FUND without fundId', async () => {
+    await expect(
+      service.createPolicy('tenant-1', 'member-1', roles, rules([{ destinationType: IncomeApplicationDestination.FUND, percentageBasisPoints: 10000 }])),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('rejects OFFSET with fundId', async () => {
+    await expect(
+      service.createPolicy('tenant-1', 'member-1', roles, rules([{ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, fundId: 'fund-1', percentageBasisPoints: 10000 }])),
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  // ── Versioning / history ────────────────────────────────────────────────
+
+  it('publishes a new version and deactivates the previous one (history preserved)', async () => {
+    (prisma.incomePolicy.findUnique as jest.Mock).mockResolvedValue(makePolicy());
+    (prisma.incomePolicyVersion.findFirst as jest.Mock).mockResolvedValue({ id: 'v1', policyId: 'policy-1', version: 1, status: 'ACTIVE', createdAt: new Date() });
+    (prisma.incomePolicyVersion.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+    (prisma.incomePolicyVersion.create as jest.Mock).mockImplementation(({ data }) => Promise.resolve({ id: 'v2', ...data }));
+    (prisma.incomePolicyVersion.findMany as jest.Mock).mockResolvedValue([
+      { id: 'v2', policyId: 'policy-1', version: 2, status: 'ACTIVE', createdAt: new Date(), rules: [{ id: 'r1', destinationType: IncomeApplicationDestination.CARRY_FORWARD, fundId: null, percentageBasisPoints: 10000 }] },
+      { id: 'v1', policyId: 'policy-1', version: 1, status: 'INACTIVE', createdAt: new Date(), rules: [{ id: 'r0', destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, fundId: null, percentageBasisPoints: 10000 }] },
+    ]);
+
+    const result = await service.createVersion('tenant-1', 'cat-1', 'member-1', roles, rules([{ destinationType: IncomeApplicationDestination.CARRY_FORWARD, percentageBasisPoints: 10000 }]));
+
+    expect(prisma.incomePolicyVersion.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: 'INACTIVE' } }),
+    );
+    expect(prisma.incomePolicyVersion.create).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ version: 2, status: 'ACTIVE' }) }),
+    );
+    expect(result.versions).toHaveLength(2);
+    expect(result.currentVersion?.version).toBe(2);
+    expect(audit.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'INCOME_POLICY_VERSION_CREATE' }),
+      expect.anything(),
+    );
+  });
+
+  it('rejects creating a policy that already exists', async () => {
+    (prisma.incomePolicy.findUnique as jest.Mock).mockResolvedValue(makePolicy());
+    await expect(
+      service.createPolicy('tenant-1', 'member-1', roles, rules([{ destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 10000 }])),
+    ).rejects.toThrow(ConflictException);
+  });
+
+  it('deactivates the current version (INCOME_POLICY_DEACTIVATE audit)', async () => {
+    (prisma.incomePolicy.findUnique as jest.Mock).mockResolvedValue(makePolicy());
+    (prisma.incomePolicyVersion.updateMany as jest.Mock).mockResolvedValue({ count: 1 });
+    (prisma.incomePolicyVersion.findMany as jest.Mock).mockResolvedValue([
+      { id: 'v1', policyId: 'policy-1', version: 1, status: 'INACTIVE', createdAt: new Date(), rules: [] },
+    ]);
+
+    const result = await service.deactivatePolicy('tenant-1', 'cat-1', 'member-1', roles);
+
+    expect(result.currentVersion).toBeNull();
+    expect(audit.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'INCOME_POLICY_DEACTIVATE' }),
+      expect.anything(),
+    );
+  });
+
+  it('enforces tenant isolation on getPolicy (not found for other tenant)', async () => {
+    (prisma.incomePolicy.findUnique as jest.Mock).mockResolvedValue(null);
+    await expect(service.getPolicy('tenant-1', 'cat-1', roles)).rejects.toThrow(NotFoundException);
+    expect(prisma.incomePolicy.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { tenantId_categoryId: { tenantId: 'tenant-1', categoryId: 'cat-1' } } }),
+    );
+  });
+
+  it('omits nulls from audit metadata (no null/undefined)', async () => {
+    (prisma.incomePolicy.create as jest.Mock).mockResolvedValue(makePolicy());
+
+    await service.createPolicy('tenant-1', 'member-1', roles, rules([
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, percentageBasisPoints: 10000 },
+    ]));
+
+    const call = (audit.createLogRequired as jest.Mock).mock.calls[0] as [{ metadata: Record<string, unknown> }];
+    expect(call[0].action).toBe('INCOME_POLICY_CREATE');
+    expect(call[0].metadata.categoryName).toBe('Parrillera');
+  });
+});

--- a/apps/api/src/finanzas/income-policies.service.ts
+++ b/apps/api/src/finanzas/income-policies.service.ts
@@ -1,0 +1,429 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import {
+  FundStatus,
+  IncomeApplicationDestination,
+  IncomePolicyVersionStatus,
+  Prisma,
+} from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { acquireFundLock } from './fund-locks';
+import {
+  CreateIncomePolicyDto,
+  CreateIncomePolicyVersionDto,
+  IncomePolicyResponseDto,
+  IncomePolicyRuleResponseDto,
+  IncomePolicyVersionResponseDto,
+} from './income-policies.dto';
+
+const INCOME_POLICY_LOCK_TAG = 'buildingos_income_policy_lock_v1';
+
+function incomePolicyLockKey(tenantId: string, categoryId: string): string {
+  return `${INCOME_POLICY_LOCK_TAG}:${tenantId}:${categoryId}`;
+}
+
+type VersionWithRules = Prisma.IncomePolicyVersionGetPayload<Record<string, never>> & {
+  rules: Prisma.IncomePolicyRuleGetPayload<Record<string, never>>[];
+};
+
+@Injectable()
+export class IncomePoliciesService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auditService: AuditService,
+    private readonly validators: FinanzasValidators,
+  ) {}
+
+  // ── List / get ──────────────────────────────────────────────────────────
+
+  async listPolicies(
+    tenantId: string,
+    userRoles: string[],
+  ): Promise<IncomePolicyResponseDto[]> {
+    this.assertAdminOrOperator(userRoles, 'ver políticas de ingresos');
+
+    const policies = await this.prisma.incomePolicy.findMany({
+      where: { tenantId },
+      include: {
+        versions: {
+          include: { rules: true },
+          orderBy: { version: 'desc' },
+        },
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    return policies.map((policy) => this.toPolicyDto(policy));
+  }
+
+  async getPolicy(
+    tenantId: string,
+    categoryId: string,
+    userRoles: string[],
+  ): Promise<IncomePolicyResponseDto> {
+    this.assertAdminOrOperator(userRoles, 'ver políticas de ingresos');
+
+    const policy = await this.prisma.incomePolicy.findUnique({
+      where: { tenantId_categoryId: { tenantId, categoryId } },
+      include: {
+        versions: {
+          include: { rules: true },
+          orderBy: { version: 'desc' },
+        },
+      },
+    });
+    if (!policy) {
+      throw new NotFoundException('No existe política para esta categoría en el tenant');
+    }
+    return this.toPolicyDto(policy);
+  }
+
+  // ── Create policy with initial version ──────────────────────────────────
+
+  async createPolicy(
+    tenantId: string,
+    membershipId: string,
+    userRoles: string[],
+    dto: CreateIncomePolicyDto,
+  ): Promise<IncomePolicyResponseDto> {
+    this.assertAdminOrOperator(userRoles, 'crear políticas de ingresos');
+
+    const category = await this.assertIncomeCategory(tenantId, dto.categoryId);
+    this.assertValidRules(dto.rules);
+
+    return this.prisma.$transaction(async (tx) => {
+      // Lock por tenant+category: serializa creación/versiones concurrentes.
+      await this.acquirePolicyLock(tx, tenantId, dto.categoryId);
+
+      const existing = await tx.incomePolicy.findUnique({
+        where: { tenantId_categoryId: { tenantId, categoryId: dto.categoryId } },
+      });
+      if (existing) {
+        throw new ConflictException('Ya existe una política para esta categoría');
+      }
+
+      const policy = await tx.incomePolicy.create({
+        data: {
+          tenantId,
+          categoryId: dto.categoryId,
+          createdByMembershipId: membershipId,
+        },
+      });
+
+      const version = await this.publishVersionTx(tx, tenantId, policy.id, 1, membershipId, dto.rules);
+
+      await this.auditService.createLogRequired(
+        {
+          tenantId,
+          actorMembershipId: membershipId,
+          action: 'INCOME_POLICY_CREATE',
+          entityType: 'IncomePolicy',
+          entityId: policy.id,
+          metadata: {
+            categoryId: dto.categoryId,
+            categoryName: category.name,
+            version: version.version,
+          },
+        },
+        tx,
+      );
+
+      const withRules = await tx.incomePolicyVersion.findUnique({
+        where: { id: version.id },
+        include: { rules: true },
+      });
+      return this.toPolicyDto({ ...policy, versions: [withRules!] });
+    });
+  }
+
+  // ── Publish a new version ───────────────────────────────────────────────
+
+  async createVersion(
+    tenantId: string,
+    categoryId: string,
+    membershipId: string,
+    userRoles: string[],
+    dto: CreateIncomePolicyVersionDto,
+  ): Promise<IncomePolicyResponseDto> {
+    this.assertAdminOrOperator(userRoles, 'publicar versiones de políticas');
+    this.assertValidRules(dto.rules);
+
+    return this.prisma.$transaction(async (tx) => {
+      await this.acquirePolicyLock(tx, tenantId, categoryId);
+
+      const policy = await tx.incomePolicy.findUnique({
+        where: { tenantId_categoryId: { tenantId, categoryId } },
+      });
+      if (!policy) {
+        throw new NotFoundException('No existe política para esta categoría en el tenant');
+      }
+
+      const lastVersion = await tx.incomePolicyVersion.findFirst({
+        where: { policyId: policy.id },
+        orderBy: { version: 'desc' },
+      });
+      const nextVersion = (lastVersion?.version ?? 0) + 1;
+
+      // Desactivar la versión current (historia preservada, nunca DELETE).
+      await tx.incomePolicyVersion.updateMany({
+        where: { policyId: policy.id, status: IncomePolicyVersionStatus.ACTIVE },
+        data: { status: IncomePolicyVersionStatus.INACTIVE },
+      });
+
+      const version = await this.publishVersionTx(tx, tenantId, policy.id, nextVersion, membershipId, dto.rules);
+
+      await this.auditService.createLogRequired(
+        {
+          tenantId,
+          actorMembershipId: membershipId,
+          action: 'INCOME_POLICY_VERSION_CREATE',
+          entityType: 'IncomePolicyVersion',
+          entityId: version.id,
+          metadata: {
+            categoryId,
+            policyId: policy.id,
+            version: nextVersion,
+            previousVersion: lastVersion?.version ?? null,
+          },
+        },
+        tx,
+      );
+
+      const withRules = await tx.incomePolicyVersion.findUnique({
+        where: { id: version.id },
+        include: { rules: true },
+      });
+      const versions = await tx.incomePolicyVersion.findMany({
+        where: { policyId: policy.id },
+        include: { rules: true },
+        orderBy: { version: 'desc' },
+      });
+      return this.toPolicyDto({ ...policy, versions: [...versions] });
+    });
+  }
+
+  // ── Deactivate ──────────────────────────────────────────────────────────
+
+  async deactivatePolicy(
+    tenantId: string,
+    categoryId: string,
+    membershipId: string,
+    userRoles: string[],
+  ): Promise<IncomePolicyResponseDto> {
+    this.assertAdminOrOperator(userRoles, 'desactivar políticas de ingresos');
+
+    return this.prisma.$transaction(async (tx) => {
+      await this.acquirePolicyLock(tx, tenantId, categoryId);
+
+      const policy = await tx.incomePolicy.findUnique({
+        where: { tenantId_categoryId: { tenantId, categoryId } },
+      });
+      if (!policy) {
+        throw new NotFoundException('No existe política para esta categoría en el tenant');
+      }
+
+      const result = await tx.incomePolicyVersion.updateMany({
+        where: { policyId: policy.id, status: IncomePolicyVersionStatus.ACTIVE },
+        data: { status: IncomePolicyVersionStatus.INACTIVE },
+      });
+
+      await this.auditService.createLogRequired(
+        {
+          tenantId,
+          actorMembershipId: membershipId,
+          action: 'INCOME_POLICY_DEACTIVATE',
+          entityType: 'IncomePolicy',
+          entityId: policy.id,
+          metadata: {
+            categoryId,
+            deactivatedVersions: result.count,
+          },
+        },
+        tx,
+      );
+
+      const versions = await tx.incomePolicyVersion.findMany({
+        where: { policyId: policy.id },
+        include: { rules: true },
+        orderBy: { version: 'desc' },
+      });
+      return this.toPolicyDto({ ...policy, versions });
+    });
+  }
+
+  // ── Internos ────────────────────────────────────────────────────────────
+
+  private async publishVersionTx(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    policyId: string,
+    versionNumber: number,
+    membershipId: string,
+    rules: Array<{ destinationType: IncomeApplicationDestination; fundId?: string; percentageBasisPoints: number }>,
+  ): Promise<Prisma.IncomePolicyVersionGetPayload<Record<string, never>>> {
+    // Validar Funds referenciados (tenant + ACTIVE) con locks en orden determinístico.
+    const fundIds = [...new Set(
+      rules
+        .filter((rule) => rule.destinationType === IncomeApplicationDestination.FUND)
+        .map((rule) => rule.fundId as string),
+    )].sort();
+
+    for (const fundId of fundIds) {
+      await acquireFundLock(tx, tenantId, fundId);
+    }
+
+    if (fundIds.length > 0) {
+      const funds = await tx.fund.findMany({
+        where: { id: { in: fundIds }, tenantId },
+        select: { id: true, status: true },
+      });
+      const fundById = new Map(funds.map((f) => [f.id, f]));
+      for (const fundId of fundIds) {
+        const fund = fundById.get(fundId);
+        if (!fund) {
+          throw new NotFoundException(`Fondo no encontrado o no pertenece al tenant: ${fundId}`);
+        }
+        if (fund.status !== FundStatus.ACTIVE) {
+          throw new BadRequestException(`El fondo está archivado: ${fundId}`);
+        }
+      }
+    }
+
+    const version = await tx.incomePolicyVersion.create({
+      data: {
+        policyId,
+        version: versionNumber,
+        status: IncomePolicyVersionStatus.ACTIVE,
+        createdByMembershipId: membershipId,
+      },
+    });
+
+    for (const rule of rules) {
+      const isFund = rule.destinationType === IncomeApplicationDestination.FUND;
+      await tx.incomePolicyRule.create({
+        data: {
+          tenantId,
+          versionId: version.id,
+          destinationType: rule.destinationType,
+          fundId: isFund ? rule.fundId! : null,
+          percentageBasisPoints: rule.percentageBasisPoints,
+        },
+      });
+    }
+
+    return version;
+  }
+
+  private async acquirePolicyLock(tx: Prisma.TransactionClient, tenantId: string, categoryId: string): Promise<void> {
+    await tx.$executeRaw(
+      Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${incomePolicyLockKey(tenantId, categoryId)}, 0))`,
+    );
+  }
+
+  private assertAdminOrOperator(userRoles: string[], action: string): void {
+    if (!this.validators.isAdminOrOperator(userRoles)) {
+      throw new ForbiddenException(`Solo administradores pueden ${action}`);
+    }
+  }
+
+  private async assertIncomeCategory(
+    tenantId: string,
+    categoryId: string,
+  ): Promise<{ id: string; name: string }> {
+    const category = await this.prisma.expenseLedgerCategory.findFirst({
+      where: { id: categoryId, tenantId },
+      select: { id: true, name: true, movementType: true },
+    });
+    if (!category) {
+      throw new NotFoundException('Categoría no encontrada o no pertenece al tenant');
+    }
+    if (category.movementType !== 'INCOME') {
+      throw new BadRequestException('La categoría no es de tipo INGRESO');
+    }
+    return category;
+  }
+
+  /** Validaciones estáticas: suma exacta 10000 bp, sin duplicados, invariante fund. */
+  private assertValidRules(
+    rules: Array<{ destinationType: IncomeApplicationDestination; fundId?: string; percentageBasisPoints: number }>,
+  ): void {
+    const seenNonFund = new Set<IncomeApplicationDestination>();
+    const seenFund = new Set<string>();
+    let totalBp = 0;
+
+    for (const rule of rules) {
+      if (!Number.isInteger(rule.percentageBasisPoints) || rule.percentageBasisPoints <= 0 || rule.percentageBasisPoints > 10000) {
+        throw new BadRequestException(
+          `percentageBasisPoints debe ser un entero entre 1 y 10000 (recibido: ${rule.percentageBasisPoints})`,
+        );
+      }
+      if (rule.destinationType === IncomeApplicationDestination.FUND) {
+        if (rule.fundId === undefined || rule.fundId === null) {
+          throw new BadRequestException('fundId es obligatorio para destinationType FUND');
+        }
+        if (seenFund.has(rule.fundId)) {
+          throw new BadRequestException(`No puede haber dos reglas FUND hacia el mismo fondo: ${rule.fundId}`);
+        }
+        seenFund.add(rule.fundId);
+      } else {
+        if (rule.fundId !== undefined && rule.fundId !== null) {
+          throw new BadRequestException(`fundId no aplica para destinationType ${rule.destinationType}`);
+        }
+        if (seenNonFund.has(rule.destinationType)) {
+          throw new BadRequestException(`No puede haber dos reglas ${rule.destinationType} en la misma política`);
+        }
+        seenNonFund.add(rule.destinationType);
+      }
+      totalBp += rule.percentageBasisPoints;
+    }
+
+    if (totalBp !== 10000) {
+      throw new BadRequestException(
+        `La suma de porcentajes debe ser exactamente 10000 bp (100%), sumó: ${totalBp}`,
+      );
+    }
+  }
+
+  private toRuleDto(rule: Prisma.IncomePolicyRuleGetPayload<Record<string, never>>): IncomePolicyRuleResponseDto {
+    return {
+      id: rule.id,
+      destinationType: rule.destinationType,
+      fundId: rule.fundId,
+      percentageBasisPoints: rule.percentageBasisPoints,
+    };
+  }
+
+  private toVersionDto(version: VersionWithRules): IncomePolicyVersionResponseDto {
+    return {
+      id: version.id,
+      version: version.version,
+      status: version.status,
+      rules: version.rules.map((rule) => this.toRuleDto(rule)),
+      createdAt: version.createdAt,
+    };
+  }
+
+  private toPolicyDto(policy: {
+    id: string;
+    tenantId: string;
+    categoryId: string;
+    versions: VersionWithRules[];
+  }): IncomePolicyResponseDto {
+    const sorted = [...policy.versions].sort((a, b) => b.version - a.version);
+    const current = sorted.find((v) => v.status === IncomePolicyVersionStatus.ACTIVE) ?? null;
+    return {
+      id: policy.id,
+      tenantId: policy.tenantId,
+      categoryId: policy.categoryId,
+      currentVersion: current ? this.toVersionDto(current) : null,
+      versions: sorted.map((v) => this.toVersionDto(v)),
+    };
+  }
+}

--- a/apps/api/src/finanzas/incomes.controller.ts
+++ b/apps/api/src/finanzas/incomes.controller.ts
@@ -15,6 +15,8 @@ import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
 import { AuthenticatedRequest } from '../common/types/request.types';
 import { IncomesService } from './incomes.service';
+import { IncomeApplicationsService } from './income-applications.service';
+import { IncomeApplicationPlanResponseDto } from './income-applications.dto';
 import {
   CreateIncomeDto,
   UpdateIncomeDto,
@@ -28,7 +30,10 @@ import {
 @Controller('tenants/:tenantId/finance/incomes')
 @UseGuards(JwtAuthGuard, TenantAccessGuard)
 export class IncomesController {
-  constructor(private readonly incomesService: IncomesService) {}
+  constructor(
+    private readonly incomesService: IncomesService,
+    private readonly incomeApplicationsService: IncomeApplicationsService,
+  ) {}
 
   @Get()
   async listIncomes(
@@ -90,6 +95,19 @@ export class IncomesController {
     @Request() req: AuthenticatedRequest,
   ): Promise<IncomeResponseDto> {
     return this.incomesService.recordIncome(
+      req.tenantId!,
+      incomeId,
+      req.user.membershipId ?? '',
+      req.user.roles ?? [],
+    );
+  }
+
+  @Post(':incomeId/apply-policy')
+  async applyPolicy(
+    @Param('incomeId') incomeId: string,
+    @Request() req: AuthenticatedRequest,
+  ): Promise<IncomeApplicationPlanResponseDto> {
+    return this.incomeApplicationsService.applyPolicy(
       req.tenantId!,
       incomeId,
       req.user.membershipId ?? '',


### PR DESCRIPTION
## Descripción

FIN-05: políticas de distribución de ingresos versionadas por categoría (`IncomePolicy` → `IncomePolicyVersion` → `IncomePolicyRule`). Una política define el plan DEFAULT propuesto para Incomes RECORDED futuros de su categoría: las reglas usan basis points (10000 = 100%), con destino `OFFSET_EXPENSES`, `FUND` (fundId obligatorio) o `CARRY_FORWARD`. Cada versión publicada es inmutable y queda como historia; solo puede existir UNA versión ACTIVE por política (invariante reforzado por partial unique index en la DB).

### Arquitectura

- **Modelo versionado**: `IncomePolicy` (1:1 tenant+category) → `IncomePolicyVersion` (version 1,2,3…, status ACTIVE/INACTIVE) → `IncomePolicyRule` (destinationType, fundId, percentageBasisPoints).
- **Basis points enteros** (`Int`, CHECK 1..10000 en DB + validación de suma exacta 10000 en servicio): sin floats, sin drift.
- **Rounding determinístico**: algoritmo largest-remainder sobre basis points; la suma de `amountMinor` generados SIEMPRE es exacta (`sum === income.amountMinor`). Caso 10001/70-30 → 7001+3000 verificado por test.
- **Versiones históricas inmutables**: publicar v2 desactiva v1 (`status → INACTIVE`, nunca DELETE); las `IncomeApplication` existentes conservan su `policyVersionId` y NUNCA se mutan por cambios de política.
- **Invariante current-version**: partial unique index `IncomePolicyVersion_single_active_key` + advisory lock por tenant+category serializan publicaciones concurrentes.
- **Provenance**: `IncomeApplication.policyVersionId` guarda la versión que generó el plan; el CREDIT de `FundTransaction` queda vinculado a la aplicación y el audit log registra `policyVersionId`.
- **Manual override**: `createPlan` (manual) sigue permitido aunque exista política; `applyPolicy` solo se ejecuta si no hay plan previo, y rechaza con Conflict si el plan existente difiere.
- **Reuso del camino FIN-03**: `applyPolicy` publica a través de `publishPlanTx` (mismo camino que el plan manual): idempotencia por canonical plan, locks determinísticos de Funds, CREDITs, audits atómicos.
- **Validación de Fund al aplicar**: los Funds referenciados se validan ACTIVE bajo advisory lock (no TOCTOU application vs archive); política con fund archivado → BadRequest.
- **Aislamiento multi-tenant**: categoría, policy y fund siempre scoped por `tenantId`.
- **Concurrencia**: publish con advisory lock `hashtextextended(tenant+category)`; apply con `acquireIncomeLock` + fund locks ordenados.
- **Audit atómico**: `createLogRequired` dentro de la misma transacción (policy create/version/apply/CREDIT).

### Migraciones (2)

1. `20260816000000_add_income_policies` — aditiva: enum `IncomePolicyVersionStatus`, acciones de audit nuevas, columna `policyVersionId` en `IncomeApplication` (FK SET NULL), 3 tablas con CHECK constraints (bp range, invariant destination/fund), unique parciales (single active, sin duplicados por versión). Sin DROP de datos ni rewrites.
2. `20260816000001_income_policy_createdby_setnull` — corrección de lifecycle descubierta en validación Postgres: `createdByMembershipId` con `ON DELETE RESTRICT` rompía el tenant delete (cascade evalúa el Restrict antes de limpiar policies). Se cambia a nullable + `ON DELETE SET NULL` (mismo patrón que `FundArchivedBy`). Se mantiene separada porque la 1 ya fue validada contra DBs de aceptación.

### Validación de migraciones

- Zero-DB deploy: 94 migraciones aplicadas desde cero ✓
- Upgrade desde origin/main: 92 históricas + 2 FIN-05 al final, orden correcto ✓

### Validación local (counts REALES)

| Suite | Resultado |
|---|---|
| Unit income-policies | 22 passed |
| Unit income-applications | 40 passed |
| Unit funds | 46 passed |
| Unit multicurrency | 25 passed |
| Unit void-atomicity | 6 passed |
| Unit DTO income-applications | 8 passed |
| **Total unit (22+40+46+25+6+8)** | **147 passed** |
| PostgreSQL FIN-05 (4 runs deterministas) | 15 passed / run |
| PostgreSQL FIN-03 regression | 25 passed |
| PostgreSQL FIN-02 regression | 15 passed |
| Payment-allocation postgres | 10 passed |
| Finance unit completo (61 suites) | 1185 passed, 0 failed |
| Full API (180 suites) | 2692 passed, 0 failed |
| Prisma validate / tsc / eslint / build / diff --check | todos OK |

Nota: `liquidation-publication.postgres.spec.ts` tiene 1 fallo pre-existente reproduducido idéntico en origin/main sin este cambio (no introducido por FIN-05).

### Exclusiones explícitas

- No impacta Liquidations, Payments, MovementAllocation ni legacy backfill.
- Sin cambios frontend (`apps/web` intocado).
- Sin cambios en staging ni producción.

## Tipo de cambio

- [x] Nueva funcionalidad

## Checklist de validación local obligatoria

- [x] Tests unitarios pasan
- [x] Tests de integración pasan
- [x] Tests E2E pasan (si aplica)
- [x] Typecheck (`tsc --noEmit`) sin errores
- [x] Lint sin errores nuevos
- [x] Build exitoso
- [x] `git diff --check` limpio
- [x] Confirmé que todos los cambios fueron implementados y probados localmente
- [x] Confirmé que el merge a main activará automáticamente el deploy a staging
- [x] El despliegue automático a staging está autorizado para este PR
- [x] Las migraciones incluidas fueron validadas localmente
- [x] No se requiere preservar ningún archivo temporal dentro del checkout de staging
- [x] La validación funcional en staging está definida para después del merge