### PR TITLE
feat(finance): apply income offsets to liquidations

### DIFF
--- a/apps/api/prisma/migrations/20260816000002_income_offsets_to_liquidations/migration.sql
+++ b/apps/api/prisma/migrations/20260816000002_income_offsets_to_liquidations/migration.sql
@@ -1,0 +1,42 @@
+-- FIN-06: IncomeApplication OFFSET_EXPENSES → Liquidation net distributable
+-- ADITIVA: columnas nullable en Liquidation (legacy rows no se reescriben)
+-- y tabla relacional LiquidationIncomeOffset (void-safety + provenance).
+
+-- AlterTable Liquidation (resumen financiero FIN-06, nullable = pre-FIN-06)
+ALTER TABLE "Liquidation" ADD COLUMN     "grossExpenseAmountMinor" INTEGER,
+ADD COLUMN     "adjustmentAmountMinor" INTEGER,
+ADD COLUMN     "preIncomeAmountMinor" INTEGER,
+ADD COLUMN     "incomeOffsetAmountMinor" INTEGER,
+ADD COLUMN     "netDistributableAmountMinor" INTEGER,
+ADD COLUMN     "incomeOffsetSnapshot" JSONB,
+ADD COLUMN     "incomeOffsetsByCurrency" JSONB;
+
+-- CreateTable LiquidationIncomeOffset
+CREATE TABLE "LiquidationIncomeOffset" (
+    "id" TEXT NOT NULL,
+    "tenantId" TEXT NOT NULL,
+    "liquidationId" TEXT NOT NULL,
+    "incomeApplicationId" TEXT NOT NULL,
+    "buildingId" TEXT NOT NULL,
+    "originalAmountMinor" INTEGER NOT NULL,
+    "currencyCode" TEXT NOT NULL,
+    "valuedAmountMinor" INTEGER NOT NULL,
+    "baseCurrency" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "LiquidationIncomeOffset_pkey" PRIMARY KEY ("id"),
+    CONSTRAINT "LiquidationIncomeOffset_original_amount_positive" CHECK ("originalAmountMinor" > 0),
+    CONSTRAINT "LiquidationIncomeOffset_valued_amount_positive" CHECK ("valuedAmountMinor" > 0)
+);
+
+-- AddForeignKey
+ALTER TABLE "LiquidationIncomeOffset" ADD CONSTRAINT "LiquidationIncomeOffset_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "LiquidationIncomeOffset" ADD CONSTRAINT "LiquidationIncomeOffset_liquidationId_fkey" FOREIGN KEY ("liquidationId") REFERENCES "Liquidation"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "LiquidationIncomeOffset" ADD CONSTRAINT "LiquidationIncomeOffset_incomeApplicationId_fkey" FOREIGN KEY ("incomeApplicationId") REFERENCES "IncomeApplication"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "LiquidationIncomeOffset_liquidationId_incomeApplicationId_key" ON "LiquidationIncomeOffset"("liquidationId", "incomeApplicationId");
+CREATE INDEX "LiquidationIncomeOffset_tenantId_idx" ON "LiquidationIncomeOffset"("tenantId");
+CREATE INDEX "LiquidationIncomeOffset_incomeApplicationId_idx" ON "LiquidationIncomeOffset"("incomeApplicationId");
+CREATE INDEX "LiquidationIncomeOffset_liquidationId_idx" ON "LiquidationIncomeOffset"("liquidationId");
+CREATE INDEX "LiquidationIncomeOffset_tenantId_liquidationId_idx" ON "LiquidationIncomeOffset"("tenantId", "liquidationId");

--- a/apps/api/prisma/migrations/20260816000003_liquidation_income_offset_invariants/migration.sql
+++ b/apps/api/prisma/migrations/20260816000003_liquidation_income_offset_invariants/migration.sql
@@ -1,0 +1,28 @@
+-- FIN-06R: invariantes DB de las ecuaciones resumen FIN-06 (nullable-safe).
+-- Legacy rows (todos los campos FIN-06 null) siguen permitidas.
+-- Rows FIN-06 deben tener el set completo y reconciliado:
+--   gross + adjustment = preIncome
+--   preIncome - offset = net
+--   net = totalAmountMinor
+-- Cada campo >= 0 (Adjustment del repo es positivo).
+
+ALTER TABLE "Liquidation" ADD CONSTRAINT "Liquidation_fin06_summary_non_negative"
+CHECK (
+  ("grossExpenseAmountMinor" IS NULL AND "adjustmentAmountMinor" IS NULL AND "preIncomeAmountMinor" IS NULL AND "incomeOffsetAmountMinor" IS NULL AND "netDistributableAmountMinor" IS NULL)
+  OR
+  (
+    "grossExpenseAmountMinor" >= 0
+    AND "adjustmentAmountMinor" >= 0
+    AND "preIncomeAmountMinor" >= 0
+    AND "incomeOffsetAmountMinor" >= 0
+    AND "netDistributableAmountMinor" >= 0
+    AND "grossExpenseAmountMinor" IS NOT NULL
+    AND "adjustmentAmountMinor" IS NOT NULL
+    AND "preIncomeAmountMinor" IS NOT NULL
+    AND "incomeOffsetAmountMinor" IS NOT NULL
+    AND "netDistributableAmountMinor" IS NOT NULL
+    AND "grossExpenseAmountMinor" + "adjustmentAmountMinor" = "preIncomeAmountMinor"
+    AND "preIncomeAmountMinor" - "incomeOffsetAmountMinor" = "netDistributableAmountMinor"
+    AND "netDistributableAmountMinor" = "totalAmountMinor"
+  )
+);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -295,6 +295,7 @@ model Tenant {
   movementAllocations      MovementAllocation[]
   unitGroups               UnitGroup[]
   liquidations             Liquidation[]
+  liquidationIncomeOffsets LiquidationIncomeOffset[]
   adjustments              Adjustment[]
   tenantMembers         TenantMember[]
   tenantInvitations     TenantInvitation[]
@@ -2066,6 +2067,7 @@ model IncomeApplication {
   createdBy  Membership         @relation("IncomeApplicationCreatedBy", fields: [createdByMembershipId], references: [id], onDelete: Restrict)
   fundTransaction FundTransaction? @relation("FundTransactionIncomeApplication")
   policyVersion IncomePolicyVersion? @relation(fields: [policyVersionId], references: [id], onDelete: SetNull)
+  liquidationOffsets LiquidationIncomeOffset[]
 
   @@index([tenantId, incomeId])
   @@index([tenantId, fundId])
@@ -2281,7 +2283,7 @@ model Liquidation {
   status                   LiquidationStatus @default(DRAFT)
   valuationMode            LiquidationValuationMode? // NULL = histórico pre-3D / legacy
   baseCurrency             String            // Moneda base de liquidación
-  totalAmountMinor         Int               // Total en centavos derivado de gastos VALIDATED
+  totalAmountMinor         Int               // Neto distributable (gross + adjustments - income offsets)
   totalsByCurrency         Json              // Snapshot: { "ARS": 150000, "USD": 5000 }
   expenseSnapshot          Json              // Array de { expenseId, amountMinor, currencyCode, type: "EXPENSE"|"ADJUSTMENT" }
   publicationSnapshot      Json?             // Immutable snapshot persisted when published
@@ -2297,14 +2299,54 @@ model Liquidation {
   createdAt                DateTime          @default(now())
   updatedAt                DateTime          @updatedAt
 
+  // FIN-06: desglose financiero del neto distributable (nullable = legacy pre-FIN-06)
+  grossExpenseAmountMinor    Int?   // Valor de expenses (nominal o funcional según valuationMode)
+  adjustmentAmountMinor      Int?   // Valor de adjustments (mismo criterio)
+  preIncomeAmountMinor       Int?   // gross + adjustments
+  incomeOffsetAmountMinor    Int?   // IncomeApplications OFFSET_EXPENSES elegibles (valorado)
+  netDistributableAmountMinor Int?  // preIncome - incomeOffset (debe ser == totalAmountMinor)
+  incomeOffsetSnapshot       Json?  // FIN-06: fuentes OFFSET congeladas al crear el draft
+  incomeOffsetsByCurrency    Json?  // FIN-06: { baseCurrency: totalOffsetValued }
+
   tenant   Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
   building Building @relation(fields: [buildingId], references: [id], onDelete: Cascade)
   charges  Charge[]
+  incomeOffsets LiquidationIncomeOffset[]
 
   @@index([tenantId, buildingId, period, status])
   @@index([tenantId, buildingId])
   @@index([tenantId, status])
   @@index([tenantId, buildingId, chargePeriod, status])
+}
+
+// ============================================================================
+// FINANZAS: LiquidationIncomeOffset (FIN-06)
+// Referencia relacional entre una Liquidation y las IncomeApplications
+// OFFSET_EXPENSES que redujeron su neto distributable.
+// Proporciona void-safety: un Income con OFFSET referenciado por una
+// liquidación activa/publicada no puede anularse (la historia ya se distribuyó).
+// ============================================================================
+model LiquidationIncomeOffset {
+  id                   String   @id @default(cuid())
+  tenantId             String
+  liquidationId        String
+  incomeApplicationId  String
+  buildingId           String
+  originalAmountMinor  Int      // Porción de la aplicación en su moneda original asignada al building
+  currencyCode         String   // Moneda original de la aplicación
+  valuedAmountMinor    Int      // Porción valorada (funcional o nominal) asignada al building
+  baseCurrency         String   // Moneda base de la liquidación
+  createdAt            DateTime @default(now())
+
+  tenant            Tenant            @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  liquidation       Liquidation       @relation(fields: [liquidationId], references: [id], onDelete: Cascade)
+  incomeApplication IncomeApplication @relation(fields: [incomeApplicationId], references: [id], onDelete: Cascade)
+
+  @@unique([liquidationId, incomeApplicationId])
+  @@index([tenantId])
+  @@index([incomeApplicationId])
+  @@index([liquidationId])
+  @@index([tenantId, liquidationId])
 }
 
 // ============================================================================

--- a/apps/api/src/finanzas/expense-ledger.dto.ts
+++ b/apps/api/src/finanzas/expense-ledger.dto.ts
@@ -294,6 +294,12 @@ export interface LiquidationResponseDto {
   publishedAt: Date | null;
   canceledAt: Date | null;
   createdAt: Date;
+  // FIN-06: desglose read-only del neto distributable (solo drafts FIN-06)
+  grossExpenseAmountMinor?: number | null;
+  adjustmentAmountMinor?: number | null;
+  preIncomeAmountMinor?: number | null;
+  incomeOffsetAmountMinor?: number | null;
+  netDistributableAmountMinor?: number | null;
 }
 
 export interface LiquidationDetailDto extends LiquidationResponseDto {

--- a/apps/api/src/finanzas/finanzas.module.ts
+++ b/apps/api/src/finanzas/finanzas.module.ts
@@ -23,6 +23,7 @@ import { ExpenseLedgerCategoriesService } from './expense-ledger-categories.serv
 import { ExpensesService } from './expenses.service';
 import { IncomesService } from './incomes.service';
 import { LiquidationsService } from './liquidations.service';
+import { LiquidationIncomeOffsetsService } from './liquidation-income-offsets.service';
 import { LiquidationEngineService } from './liquidation-engine.service';
 import { LiquidationEngineController } from './liquidation-engine.controller';
 import { MovementAllocationService } from './movement-allocation.service';
@@ -125,6 +126,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
         ),
     },
     LiquidationsService,
+    LiquidationIncomeOffsetsService,
     MovementAllocationService,
     UnitGroupService,
     LiquidationEngineService,
@@ -151,6 +153,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     ExpensesService,
     IncomesService,
     LiquidationsService,
+    LiquidationIncomeOffsetsService,
     MovementAllocationService,
     UnitGroupService,
     LiquidationEngineService,

--- a/apps/api/src/finanzas/income-offset-allocation.spec.ts
+++ b/apps/api/src/finanzas/income-offset-allocation.spec.ts
@@ -75,6 +75,40 @@ describe('income-offset-allocation (FIN-06)', () => {
         distributeMinorByWeights(-1, [{ buildingId: 'a', amountMinor: 1 }]),
       ).toThrow();
     });
+
+    it('handles intermediate products above MAX_SAFE_INTEGER exactly', () => {
+      // total * weight = 2_000_000_000 * 2_000_000_000 > MAX_SAFE_INTEGER
+      const result = distributeMinorByWeights(2_000_000_000, [
+        { buildingId: 'a', amountMinor: 1_500_000_000 },
+        { buildingId: 'b', amountMinor: 1_500_000_000 },
+        { buildingId: 'c', amountMinor: 1 },
+      ]);
+
+      const sum = result.reduce((acc, item) => acc + item.amountMinor, 0);
+      expect(sum).toBe(2_000_000_000);
+      // expected exact: a = floor(2e9 * 1.5e9 / 3.000000001e9) = 999_999_999 (remainder .66)
+      // b = 999_999_999, c = floor(0.66) = 0 → remainder 2 → a, b
+      expect(result).toEqual([
+        { buildingId: 'a', amountMinor: 1_000_000_000 },
+        { buildingId: 'b', amountMinor: 1_000_000_000 },
+        { buildingId: 'c', amountMinor: 0 },
+      ]);
+    });
+
+    it('is stable across 10 repeated large-value runs', () => {
+      const weights = [
+        { buildingId: 'a', amountMinor: 2_000_000_000 },
+        { buildingId: 'b', amountMinor: 2_000_000_000 },
+      ];
+      const runs = Array.from({ length: 10 }, () =>
+        distributeMinorByWeights(3_000_000_001, weights),
+      );
+
+      for (const run of runs) {
+        expect(run).toEqual(runs[0]);
+        expect(run.reduce((acc, item) => acc + item.amountMinor, 0)).toBe(3_000_000_001);
+      }
+    });
   });
 
   describe('deriveApplicationFunctionalValues', () => {
@@ -122,6 +156,47 @@ describe('income-offset-allocation (FIN-06)', () => {
 
       expect(first).toEqual(second);
       expect(first.map((item) => item.applicationId)).toEqual(['a', 'z']);
+    });
+
+    it('handles intermediate products above MAX_SAFE_INTEGER exactly', () => {
+      // totalFunctional * weight = 2_000_000_000 * 1_500_000_001 > MAX_SAFE_INTEGER
+      const result = deriveApplicationFunctionalValues({
+        incomeFunctionalAmountMinor: 2_000_000_000,
+        applications: [
+          { id: 'a', amountMinor: 1_500_000_001 },
+          { id: 'b', amountMinor: 1_499_999_999 },
+        ],
+      });
+
+      const sum = result.reduce((acc, item) => acc + item.functionalAmountMinor, 0);
+      expect(sum).toBe(2_000_000_000);
+      // expected exact: a = floor(2e9 * 1500000001 / 3000000000) = floor(1000000000.66...) = 1000000000
+      // b = floor(2e9 * 1499999999 / 3e9) = floor(999999999.33...) = 999999999 → remainder 1 → a
+      expect(result).toEqual([
+        { applicationId: 'a', functionalAmountMinor: 1_000_000_001 },
+        { applicationId: 'b', functionalAmountMinor: 999_999_999 },
+      ]);
+    });
+
+    it('is stable across 10 repeated large-value runs', () => {
+      const applications = [
+        { id: 'x', amountMinor: 2_000_000_000 },
+        { id: 'y', amountMinor: 2_000_000_000 },
+        { id: 'z', amountMinor: 1 },
+      ];
+      const runs = Array.from({ length: 10 }, () =>
+        deriveApplicationFunctionalValues({
+          incomeFunctionalAmountMinor: 3_000_000_001,
+          applications,
+        }),
+      );
+
+      for (const run of runs) {
+        expect(run).toEqual(runs[0]);
+        expect(run.reduce((acc, item) => acc + item.functionalAmountMinor, 0)).toBe(
+          3_000_000_001,
+        );
+      }
     });
   });
 

--- a/apps/api/src/finanzas/income-offset-allocation.spec.ts
+++ b/apps/api/src/finanzas/income-offset-allocation.spec.ts
@@ -1,0 +1,331 @@
+import {
+  LIQUIDATION_INCOME_OFFSET_CURRENCY_MISMATCH,
+  LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED,
+  LIQUIDATION_INCOME_OFFSETS_EXCEED_GROSS,
+  deriveApplicationFunctionalValues,
+  distributeMinorByWeights,
+  resolveIncomeOffsetBuildingShare,
+  valueIncomeOffsetForLiquidation,
+  buildIncomeOffsetExceedsGrossError,
+} from './income-offset-allocation';
+
+describe('income-offset-allocation (FIN-06)', () => {
+  describe('distributeMinorByWeights', () => {
+    it('distributes exactly with integer weights (60/40)', () => {
+      const result = distributeMinorByWeights(7000, [
+        { buildingId: 'a', amountMinor: 6000 },
+        { buildingId: 'b', amountMinor: 4000 },
+      ]);
+
+      expect(result).toEqual([
+        { buildingId: 'a', amountMinor: 4200 },
+        { buildingId: 'b', amountMinor: 2800 },
+      ]);
+    });
+
+    it('preserves exact total with rounding remainders', () => {
+      const result = distributeMinorByWeights(10001, [
+        { buildingId: 'a', amountMinor: 6000 },
+        { buildingId: 'b', amountMinor: 4000 },
+      ]);
+
+      const total = result.reduce((sum, item) => sum + item.amountMinor, 0);
+      expect(total).toBe(10001);
+      expect(result).toEqual([
+        { buildingId: 'a', amountMinor: 6001 },
+        { buildingId: 'b', amountMinor: 4000 },
+      ]);
+    });
+
+    it('is deterministic across repeated calls', () => {
+      const weights = [
+        { buildingId: 'x', amountMinor: 3333 },
+        { buildingId: 'y', amountMinor: 3333 },
+        { buildingId: 'z', amountMinor: 3334 },
+      ];
+      const first = distributeMinorByWeights(10001, weights);
+      const second = distributeMinorByWeights(10001, weights);
+
+      expect(first).toEqual(second);
+      expect(first.reduce((sum, item) => sum + item.amountMinor, 0)).toBe(10001);
+    });
+
+    it('tie-breaks by buildingId deterministically', () => {
+      const result = distributeMinorByWeights(1, [
+        { buildingId: 'b', amountMinor: 1 },
+        { buildingId: 'a', amountMinor: 1 },
+      ]);
+
+      expect(result).toEqual([
+        { buildingId: 'a', amountMinor: 1 },
+        { buildingId: 'b', amountMinor: 0 },
+      ]);
+    });
+
+    it('returns zero shares for zero total', () => {
+      const result = distributeMinorByWeights(0, [
+        { buildingId: 'a', amountMinor: 100 },
+      ]);
+
+      expect(result).toEqual([{ buildingId: 'a', amountMinor: 0 }]);
+    });
+
+    it('throws on negative total', () => {
+      expect(() =>
+        distributeMinorByWeights(-1, [{ buildingId: 'a', amountMinor: 1 }]),
+      ).toThrow();
+    });
+  });
+
+  describe('deriveApplicationFunctionalValues', () => {
+    it('allocates functional value proportionally and exactly', () => {
+      const result = deriveApplicationFunctionalValues({
+        incomeFunctionalAmountMinor: 2500,
+        applications: [
+          { id: 'offset', amountMinor: 7000 },
+          { id: 'fund', amountMinor: 3000 },
+        ],
+      });
+
+      expect(result).toEqual([
+        { applicationId: 'fund', functionalAmountMinor: 750 },
+        { applicationId: 'offset', functionalAmountMinor: 1750 },
+      ]);
+    });
+
+    it('reconciles to income functional total with remainder', () => {
+      const result = deriveApplicationFunctionalValues({
+        incomeFunctionalAmountMinor: 2501,
+        applications: [
+          { id: 'offset', amountMinor: 7000 },
+          { id: 'fund', amountMinor: 3000 },
+        ],
+      });
+
+      const total = result.reduce((sum, item) => sum + item.functionalAmountMinor, 0);
+      expect(total).toBe(2501);
+    });
+
+    it('is deterministic and sorted by application id', () => {
+      const applications = [
+        { id: 'z', amountMinor: 5000 },
+        { id: 'a', amountMinor: 5000 },
+      ];
+      const first = deriveApplicationFunctionalValues({
+        incomeFunctionalAmountMinor: 1000,
+        applications,
+      });
+      const second = deriveApplicationFunctionalValues({
+        incomeFunctionalAmountMinor: 1000,
+        applications,
+      });
+
+      expect(first).toEqual(second);
+      expect(first.map((item) => item.applicationId)).toEqual(['a', 'z']);
+    });
+  });
+
+  describe('resolveIncomeOffsetBuildingShare', () => {
+    const base = {
+      applicationAmountMinor: 7000,
+      liquidationBuildingId: 'building-a',
+    };
+
+    it('BUILDING scope: full share when income belongs to the building', () => {
+      expect(
+        resolveIncomeOffsetBuildingShare({
+          ...base,
+          applicationScopeType: 'BUILDING' as const,
+          incomeBuildingId: 'building-a',
+          allocationWeights: [],
+        }),
+      ).toBe(7000);
+    });
+
+    it('BUILDING scope: zero when income belongs to another building', () => {
+      expect(
+        resolveIncomeOffsetBuildingShare({
+          ...base,
+          applicationScopeType: 'BUILDING' as const,
+          incomeBuildingId: 'building-b',
+          allocationWeights: [],
+        }),
+      ).toBe(0);
+    });
+
+    it('TENANT_SHARED: proportional share by persisted allocation weights', () => {
+      expect(
+        resolveIncomeOffsetBuildingShare({
+          ...base,
+          applicationScopeType: 'TENANT_SHARED' as const,
+          incomeBuildingId: null,
+          allocationWeights: [
+            { buildingId: 'building-a', amountMinor: 6000 },
+            { buildingId: 'building-b', amountMinor: 4000 },
+          ],
+        }),
+      ).toBe(4200);
+    });
+
+    it('TENANT_SHARED: zero when the income is not allocated to the building', () => {
+      expect(
+        resolveIncomeOffsetBuildingShare({
+          ...base,
+          applicationScopeType: 'TENANT_SHARED' as const,
+          incomeBuildingId: null,
+          allocationWeights: [
+            { buildingId: 'building-c', amountMinor: 6000 },
+          ],
+        }),
+      ).toBe(0);
+    });
+
+    it('TENANT_SHARED: zero when no allocations persisted', () => {
+      expect(
+        resolveIncomeOffsetBuildingShare({
+          ...base,
+          applicationScopeType: 'TENANT_SHARED' as const,
+          incomeBuildingId: null,
+          allocationWeights: [],
+        }),
+      ).toBe(0);
+    });
+
+    it('UNIT_GROUP: same proportional behavior as TENANT_SHARED', () => {
+      expect(
+        resolveIncomeOffsetBuildingShare({
+          ...base,
+          applicationScopeType: 'UNIT_GROUP' as const,
+          incomeBuildingId: null,
+          allocationWeights: [
+            { buildingId: 'building-a', amountMinor: 1000 },
+            { buildingId: 'building-b', amountMinor: 9000 },
+          ],
+        }),
+      ).toBe(700);
+    });
+
+    it('keeps shares of all buildings summing to application amount', () => {
+      const shares = distributeMinorByWeights(7000, [
+        { buildingId: 'building-a', amountMinor: 6000 },
+        { buildingId: 'building-b', amountMinor: 4000 },
+      ]);
+      expect(shares.reduce((sum, item) => sum + item.amountMinor, 0)).toBe(7000);
+    });
+  });
+
+  describe('valueIncomeOffsetForLiquidation', () => {
+    const baseApplication = {
+      id: 'app-1',
+      amountMinor: 7000,
+      currencyCode: 'ARS',
+      functionalAmountMinor: null,
+      functionalCurrencyCode: null,
+    };
+
+    it('LEGACY_NOMINAL: same currency accepted', () => {
+      expect(
+        valueIncomeOffsetForLiquidation({
+          application: baseApplication,
+          valuationMode: 'LEGACY_NOMINAL' as const,
+          baseCurrency: 'ARS',
+        }),
+      ).toBe(7000);
+    });
+
+    it('LEGACY_NOMINAL: other currency rejected with mismatch error', () => {
+      const action = () =>
+        valueIncomeOffsetForLiquidation({
+          application: { ...baseApplication, currencyCode: 'USD' },
+          valuationMode: 'LEGACY_NOMINAL' as const,
+          baseCurrency: 'ARS',
+        });
+
+      expect(action).toThrow();
+      try {
+        action();
+      } catch (error) {
+        expect((error as { getResponse(): { error: string } }).getResponse().error).toBe(
+          LIQUIDATION_INCOME_OFFSET_CURRENCY_MISMATCH,
+        );
+      }
+    });
+
+    it('FUNCTIONAL: uses frozen functional snapshot', () => {
+      expect(
+        valueIncomeOffsetForLiquidation({
+          application: {
+            ...baseApplication,
+            functionalAmountMinor: 1750,
+            functionalCurrencyCode: 'ARS',
+          },
+          valuationMode: 'FUNCTIONAL' as const,
+          baseCurrency: 'ARS',
+        }),
+      ).toBe(1750);
+    });
+
+    it('FUNCTIONAL: missing snapshot rejected', () => {
+      const action = () =>
+        valueIncomeOffsetForLiquidation({
+          application: baseApplication,
+          valuationMode: 'FUNCTIONAL' as const,
+          baseCurrency: 'ARS',
+        });
+
+      expect(action).toThrow();
+      try {
+        action();
+      } catch (error) {
+        expect((error as { getResponse(): { error: string } }).getResponse().error).toBe(
+          LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED,
+        );
+      }
+    });
+
+    it('FUNCTIONAL: functional currency mismatch rejected', () => {
+      const action = () =>
+        valueIncomeOffsetForLiquidation({
+          application: {
+            ...baseApplication,
+            functionalAmountMinor: 1750,
+            functionalCurrencyCode: 'USD',
+          },
+          valuationMode: 'FUNCTIONAL' as const,
+          baseCurrency: 'ARS',
+        });
+
+      expect(action).toThrow();
+      try {
+        action();
+      } catch (error) {
+        expect((error as { getResponse(): { error: string } }).getResponse().error).toBe(
+          LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED,
+        );
+      }
+    });
+  });
+
+  describe('error builders', () => {
+    it('builds exceeds-gross error', () => {
+      const error = buildIncomeOffsetExceedsGrossError({
+        incomeOffsetAmountMinor: 12000,
+        preIncomeAmountMinor: 10000,
+      });
+
+      expect(error.getStatus()).toBe(422);
+      expect((error.getResponse() as { error: string }).error).toBe(
+        LIQUIDATION_INCOME_OFFSETS_EXCEED_GROSS,
+      );
+    });
+
+    it('exports the expected error codes', () => {
+      expect(LIQUIDATION_INCOME_OFFSET_CURRENCY_MISMATCH).toBe(
+        'LIQUIDATION_INCOME_OFFSET_CURRENCY_MISMATCH',
+      );
+      expect(LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED).toBe(
+        'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+      );
+    });
+  });
+});

--- a/apps/api/src/finanzas/income-offset-allocation.ts
+++ b/apps/api/src/finanzas/income-offset-allocation.ts
@@ -1,0 +1,288 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+import { IncomeApplicationDestination, MovementScope } from '@prisma/client';
+
+/**
+ * FIN-06: helpers puros para valuar y distribuir IncomeApplications
+ * OFFSET_EXPENSES hacia el building de una Liquidation.
+ *
+ * Principios:
+ * - Sin FX live: se usa únicamente el snapshot congelado del Income (record).
+ * - Sin float drift: todas las distribuciones usan integer largest remainder.
+ * - MovementAllocation decide A QUÉ building pertenece el movimiento;
+ *   IncomeApplication decide QUÉ se hace con el dinero.
+ * - SUM(building shares de una aplicación) == application.amountMinor.
+ */
+
+export const LIQUIDATION_INCOME_OFFSET_CURRENCY_MISMATCH =
+  'LIQUIDATION_INCOME_OFFSET_CURRENCY_MISMATCH';
+export const LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED =
+  'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED';
+export const LIQUIDATION_INCOME_OFFSETS_EXCEED_GROSS =
+  'LIQUIDATION_INCOME_OFFSETS_EXCEED_GROSS';
+export const LIQUIDATION_INCOME_SOURCE_DRIFT = 'LIQUIDATION_INCOME_SOURCE_DRIFT';
+
+export interface IncomeOffsetApplicationRow {
+  readonly id: string;
+  readonly incomeId: string;
+  readonly destinationType: IncomeApplicationDestination;
+  readonly amountMinor: number;
+  readonly currencyCode: string;
+  readonly policyVersionId: string | null;
+  readonly buildingId: string | null;
+  readonly period: string;
+  readonly scopeType: MovementScope;
+  readonly status: 'DRAFT' | 'RECORDED' | 'VOID';
+  readonly functionalAmountMinor: number | null;
+  readonly functionalCurrencyCode: string | null;
+  readonly exchangeRateId: string | null;
+  readonly exchangeRateValue: string | null;
+  readonly exchangeRateDirection: string | null;
+  readonly exchangeRateEffectiveAt: Date | null;
+  readonly conversionDate: Date | null;
+  readonly receivedDate: Date;
+  readonly categoryName?: string | null;
+}
+
+export interface BuildingAllocationWeight {
+  readonly buildingId: string;
+  readonly amountMinor: number;
+}
+
+/**
+ * Distribuye un total en minor units entre buckets usando weights enteros
+ * con largest remainder determinístico (tie-break: buildingId).
+ *
+ * Garantías: SUM(resultado) === total; enteros; determinístico.
+ */
+export function distributeMinorByWeights(
+  total: number,
+  weights: readonly BuildingAllocationWeight[],
+): Array<{ buildingId: string; amountMinor: number }> {
+  if (!Number.isSafeInteger(total) || total < 0) {
+    throw new Error(`distributeMinorByWeights requires a non-negative safe integer total (${total})`);
+  }
+  if (weights.length === 0) {
+    if (total === 0) return [];
+    throw new Error('distributeMinorByWeights requires weights for a positive total');
+  }
+
+  const sortedWeights = [...weights]
+    .filter((weight) => weight.amountMinor > 0)
+    .sort((a, b) => a.buildingId.localeCompare(b.buildingId));
+  const totalWeight = sortedWeights.reduce((sum, weight) => sum + weight.amountMinor, 0);
+
+  if (totalWeight <= 0) {
+    if (total === 0) {
+      return weights
+        .map((weight) => ({ buildingId: weight.buildingId, amountMinor: 0 }))
+        .sort((a, b) => a.buildingId.localeCompare(b.buildingId));
+    }
+    throw new Error('distributeMinorByWeights requires positive weights for a positive total');
+  }
+
+  const raw = sortedWeights.map((weight) => ({
+    buildingId: weight.buildingId,
+    exact: (total * weight.amountMinor) / totalWeight,
+    floor: Math.floor((total * weight.amountMinor) / totalWeight),
+    fraction: 0,
+  }));
+  raw.forEach((item) => {
+    item.fraction = item.exact - item.floor;
+  });
+
+  let allocated = raw.reduce((sum, item) => sum + item.floor, 0);
+  const remainder = total - allocated;
+
+  const winners = [...raw]
+    .sort((a, b) => {
+      if (b.fraction !== a.fraction) return b.fraction - a.fraction;
+      return a.buildingId.localeCompare(b.buildingId);
+    })
+    .slice(0, remainder);
+
+  for (const winner of winners) {
+    winner.floor += 1;
+  }
+
+  const finalTotal = raw.reduce((sum, item) => sum + item.floor, 0);
+  if (finalTotal !== total) {
+    throw new Error(`distributeMinorByWeights failed to reconcile (${finalTotal} !== ${total})`);
+  }
+
+  return raw
+    .map((item) => ({ buildingId: item.buildingId, amountMinor: item.floor }))
+    .sort((a, b) => a.buildingId.localeCompare(b.buildingId));
+}
+
+/**
+ * Determina la porción de una IncomeApplication OFFSET que corresponde al
+ * building de la liquidación.
+ *
+ * BUILDING: la aplicación completa pertenece al building del Income.
+ * TENANT_SHARED / UNIT_GROUP: se distribuye por MovementAllocation weights.
+ */
+export function resolveIncomeOffsetBuildingShare(params: {
+  applicationAmountMinor: number;
+  applicationScopeType: MovementScope;
+  incomeBuildingId: string | null;
+  liquidationBuildingId: string;
+  allocationWeights: readonly BuildingAllocationWeight[];
+}): number {
+  const { applicationAmountMinor, applicationScopeType, incomeBuildingId, liquidationBuildingId, allocationWeights } =
+    params;
+
+  if (applicationScopeType === 'BUILDING') {
+    return incomeBuildingId === liquidationBuildingId ? applicationAmountMinor : 0;
+  }
+
+  if (applicationScopeType === 'TENANT_SHARED' || applicationScopeType === 'UNIT_GROUP') {
+    if (allocationWeights.length === 0) {
+      // Sin allocation persistida no hay evidencia de pertenencia al building.
+      return 0;
+    }
+
+    const relevantWeights = allocationWeights.filter(
+      (weight) => weight.buildingId === liquidationBuildingId,
+    );
+
+    if (relevantWeights.length === 0) {
+      return 0;
+    }
+
+    const shares = distributeMinorByWeights(applicationAmountMinor, allocationWeights);
+    const ownShare = shares.find((share) => share.buildingId === liquidationBuildingId);
+    return ownShare?.amountMinor ?? 0;
+  }
+
+  // MovementScope desconocido: conservador, sin reducción.
+  return 0;
+}
+
+/**
+ * Deriva el functional amount minor de CADA IncomeApplication
+ * proporcionalmente a application.amountMinor (integer largest remainder).
+ *
+ * Garantía: SUM(applicationFunctionalValues) === incomeFunctionalAmountMinor.
+ */
+export function deriveApplicationFunctionalValues(params: {
+  incomeFunctionalAmountMinor: number;
+  applications: ReadonlyArray<{ id: string; amountMinor: number }>;
+}): Array<{ applicationId: string; functionalAmountMinor: number }> {
+  const { incomeFunctionalAmountMinor, applications } = params;
+  if (!Number.isSafeInteger(incomeFunctionalAmountMinor) || incomeFunctionalAmountMinor < 0) {
+    throw new Error('deriveApplicationFunctionalValues requires non-negative safe integer');
+  }
+  if (applications.length === 0) {
+    if (incomeFunctionalAmountMinor === 0) return [];
+    throw new Error('deriveApplicationFunctionalValues requires applications for a positive total');
+  }
+
+  const sorted = [...applications].sort((a, b) => a.id.localeCompare(b.id));
+  const totalAmount = sorted.reduce((sum, app) => sum + app.amountMinor, 0);
+
+  if (totalAmount <= 0) {
+    throw new Error('deriveApplicationFunctionalValues requires positive application amounts');
+  }
+
+  const raw = sorted.map((app) => ({
+    applicationId: app.id,
+    exact: (incomeFunctionalAmountMinor * app.amountMinor) / totalAmount,
+    floor: Math.floor((incomeFunctionalAmountMinor * app.amountMinor) / totalAmount),
+    fraction: 0,
+  }));
+  raw.forEach((item) => {
+    item.fraction = item.exact - item.floor;
+  });
+
+  let allocated = raw.reduce((sum, item) => sum + item.floor, 0);
+  const remainder = incomeFunctionalAmountMinor - allocated;
+
+  const winners = [...raw]
+    .sort((a, b) => {
+      if (b.fraction !== a.fraction) return b.fraction - a.fraction;
+      return a.applicationId.localeCompare(b.applicationId);
+    })
+    .slice(0, remainder);
+
+  for (const winner of winners) {
+    winner.floor += 1;
+  }
+
+  const finalTotal = raw.reduce((sum, item) => sum + item.floor, 0);
+  if (finalTotal !== incomeFunctionalAmountMinor) {
+    throw new Error(
+      `deriveApplicationFunctionalValues failed to reconcile (${finalTotal} !== ${incomeFunctionalAmountMinor})`,
+    );
+  }
+
+  return raw
+    .map((item) => ({ applicationId: item.applicationId, functionalAmountMinor: item.floor }))
+    .sort((a, b) => a.applicationId.localeCompare(b.applicationId));
+}
+
+/**
+ * Valida el modo de valuación de una IncomeApplication OFFSET respecto a la
+ * liquidación y devuelve el monto valorado que reduce el neto distributable.
+ *
+ * LEGACY_NOMINAL: currencyCode === baseCurrency (si difiere → mismatch).
+ * FUNCTIONAL: usa el snapshot funcional congelado del Income.
+ */
+export function valueIncomeOffsetForLiquidation(params: {
+  application: {
+    id: string;
+    amountMinor: number;
+    currencyCode: string;
+    functionalAmountMinor: number | null;
+    functionalCurrencyCode: string | null;
+  };
+  valuationMode: 'FUNCTIONAL' | 'LEGACY_NOMINAL';
+  baseCurrency: string;
+}): number {
+  const { application, valuationMode, baseCurrency } = params;
+
+  if (valuationMode === 'LEGACY_NOMINAL') {
+    if (application.currencyCode !== baseCurrency) {
+      throw new UnprocessableEntityException({
+        statusCode: 422,
+        error: LIQUIDATION_INCOME_OFFSET_CURRENCY_MISMATCH,
+        message: `La aplicación OFFSET ${application.id} está en ${application.currencyCode}, ` +
+          `se esperaba la moneda base de la liquidación (${baseCurrency})`,
+      });
+    }
+    return application.amountMinor;
+  }
+
+  if (
+    application.functionalAmountMinor === null ||
+    application.functionalCurrencyCode !== baseCurrency
+  ) {
+    throw new UnprocessableEntityException({
+      statusCode: 422,
+      error: LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED,
+      message: `La aplicación OFFSET ${application.id} no converge a la moneda funcional (${baseCurrency})`,
+    });
+  }
+
+  return application.functionalAmountMinor;
+}
+
+export function buildIncomeOffsetExceedsGrossError(params: {
+  incomeOffsetAmountMinor: number;
+  preIncomeAmountMinor: number;
+}): UnprocessableEntityException {
+  return new UnprocessableEntityException({
+    statusCode: 422,
+    error: LIQUIDATION_INCOME_OFFSETS_EXCEED_GROSS,
+    message:
+      `Los offsets de ingresos (${params.incomeOffsetAmountMinor}) superan el monto ` +
+      `pre-ingreso (${params.preIncomeAmountMinor}); no se puede crear una liquidación negativa`,
+  });
+}
+
+export function buildIncomeSourceDriftError(message: string): UnprocessableEntityException {
+  return new UnprocessableEntityException({
+    statusCode: 422,
+    error: LIQUIDATION_INCOME_SOURCE_DRIFT,
+    message,
+  });
+}

--- a/apps/api/src/finanzas/income-offset-allocation.ts
+++ b/apps/api/src/finanzas/income-offset-allocation.ts
@@ -1,5 +1,5 @@
 import { UnprocessableEntityException } from '@nestjs/common';
-import { IncomeApplicationDestination, MovementScope } from '@prisma/client';
+import { IncomeApplicationDestination, MovementScope, Prisma } from '@prisma/client';
 
 /**
  * FIN-06: helpers puros para valuar y distribuir IncomeApplications
@@ -7,10 +7,14 @@ import { IncomeApplicationDestination, MovementScope } from '@prisma/client';
  *
  * Principios:
  * - Sin FX live: se usa únicamente el snapshot congelado del Income (record).
- * - Sin float drift: todas las distribuciones usan integer largest remainder.
+ * - Aritmética EXACTA: todas las distribuciones usan Prisma.Decimal
+ *   (mul/div con ROUND_DOWN + largest remainder), nunca Number multiplication
+ *   sobre productos que pueden exceder Number.MAX_SAFE_INTEGER.
  * - MovementAllocation decide A QUÉ building pertenece el movimiento;
  *   IncomeApplication decide QUÉ se hace con el dinero.
  * - SUM(building shares de una aplicación) == application.amountMinor.
+ * - Fail-closed: un OFFSET elegible sin snapshot funcional convergente
+ *   NUNCA se omite silenciosamente → 422.
  */
 
 export const LIQUIDATION_INCOME_OFFSET_CURRENCY_MISMATCH =
@@ -50,9 +54,10 @@ export interface BuildingAllocationWeight {
 
 /**
  * Distribuye un total en minor units entre buckets usando weights enteros
- * con largest remainder determinístico (tie-break: buildingId).
+ * con largest remainder y aritmética decimal EXACTA (tie-break: buildingId).
  *
- * Garantías: SUM(resultado) === total; enteros; determinístico.
+ * Garantías: SUM(resultado) === total; enteros; determinístico; sin
+ * multiplicación Number que pierda precisión sobre MAX_SAFE_INTEGER.
  */
 export function distributeMinorByWeights(
   total: number,
@@ -69,9 +74,8 @@ export function distributeMinorByWeights(
   const sortedWeights = [...weights]
     .filter((weight) => weight.amountMinor > 0)
     .sort((a, b) => a.buildingId.localeCompare(b.buildingId));
-  const totalWeight = sortedWeights.reduce((sum, weight) => sum + weight.amountMinor, 0);
 
-  if (totalWeight <= 0) {
+  if (sortedWeights.length === 0) {
     if (total === 0) {
       return weights
         .map((weight) => ({ buildingId: weight.buildingId, amountMinor: 0 }))
@@ -80,22 +84,39 @@ export function distributeMinorByWeights(
     throw new Error('distributeMinorByWeights requires positive weights for a positive total');
   }
 
-  const raw = sortedWeights.map((weight) => ({
-    buildingId: weight.buildingId,
-    exact: (total * weight.amountMinor) / totalWeight,
-    floor: Math.floor((total * weight.amountMinor) / totalWeight),
-    fraction: 0,
-  }));
-  raw.forEach((item) => {
-    item.fraction = item.exact - item.floor;
+  const totalDecimal = new Prisma.Decimal(total);
+  const weightDecimals = sortedWeights.map((weight) => new Prisma.Decimal(weight.amountMinor));
+  const totalWeight = weightDecimals.reduce(
+    (sum, weight) => sum.add(weight),
+    new Prisma.Decimal(0),
+  );
+
+  if (totalWeight.isZero()) {
+    throw new Error('distributeMinorByWeights requires positive weights for a positive total');
+  }
+
+  // Largest remainder con aritmética decimal exacta.
+  const raw = sortedWeights.map((weight) => {
+    const exact = totalDecimal.mul(weight.amountMinor).div(totalWeight);
+    const floor = exact.toDecimalPlaces(0, Prisma.Decimal.ROUND_DOWN);
+    return {
+      buildingId: weight.buildingId,
+      floor: floor.toNumber(),
+      fraction: exact.sub(floor),
+    };
   });
 
   let allocated = raw.reduce((sum, item) => sum + item.floor, 0);
   const remainder = total - allocated;
 
+  if (!Number.isSafeInteger(remainder) || remainder < 0) {
+    throw new Error('distributeMinorByWeights failed to reconcile (remainder)');
+  }
+
   const winners = [...raw]
     .sort((a, b) => {
-      if (b.fraction !== a.fraction) return b.fraction - a.fraction;
+      const fractionComparison = b.fraction.comparedTo(a.fraction);
+      if (fractionComparison !== 0) return fractionComparison;
       return a.buildingId.localeCompare(b.buildingId);
     })
     .slice(0, remainder);
@@ -160,7 +181,7 @@ export function resolveIncomeOffsetBuildingShare(params: {
 
 /**
  * Deriva el functional amount minor de CADA IncomeApplication
- * proporcionalmente a application.amountMinor (integer largest remainder).
+ * proporcionalmente a application.amountMinor (largest remainder EXACTO).
  *
  * Garantía: SUM(applicationFunctionalValues) === incomeFunctionalAmountMinor.
  */
@@ -184,22 +205,30 @@ export function deriveApplicationFunctionalValues(params: {
     throw new Error('deriveApplicationFunctionalValues requires positive application amounts');
   }
 
-  const raw = sorted.map((app) => ({
-    applicationId: app.id,
-    exact: (incomeFunctionalAmountMinor * app.amountMinor) / totalAmount,
-    floor: Math.floor((incomeFunctionalAmountMinor * app.amountMinor) / totalAmount),
-    fraction: 0,
-  }));
-  raw.forEach((item) => {
-    item.fraction = item.exact - item.floor;
+  const totalDecimal = new Prisma.Decimal(incomeFunctionalAmountMinor);
+  const totalAmountDecimal = new Prisma.Decimal(totalAmount);
+
+  const raw = sorted.map((app) => {
+    const exact = totalDecimal.mul(app.amountMinor).div(totalAmountDecimal);
+    const floor = exact.toDecimalPlaces(0, Prisma.Decimal.ROUND_DOWN);
+    return {
+      applicationId: app.id,
+      floor: floor.toNumber(),
+      fraction: exact.sub(floor),
+    };
   });
 
   let allocated = raw.reduce((sum, item) => sum + item.floor, 0);
   const remainder = incomeFunctionalAmountMinor - allocated;
 
+  if (!Number.isSafeInteger(remainder) || remainder < 0) {
+    throw new Error('deriveApplicationFunctionalValues failed to reconcile (remainder)');
+  }
+
   const winners = [...raw]
     .sort((a, b) => {
-      if (b.fraction !== a.fraction) return b.fraction - a.fraction;
+      const fractionComparison = b.fraction.comparedTo(a.fraction);
+      if (fractionComparison !== 0) return fractionComparison;
       return a.applicationId.localeCompare(b.applicationId);
     })
     .slice(0, remainder);
@@ -221,11 +250,46 @@ export function deriveApplicationFunctionalValues(params: {
 }
 
 /**
+ * Fail-closed: valida que el snapshot funcional del Income OFFSET converja a
+ * la moneda base de la liquidación. Un OFFSET elegible sin snapshot funcional
+ * válido NUNCA se omite silenciosamente.
+ */
+export function assertFunctionalSnapshotForLiquidation(params: {
+  incomeId: string;
+  functionalAmountMinor: number | null;
+  functionalCurrencyCode: string | null;
+  baseCurrency: string;
+}): void {
+  const { incomeId, functionalAmountMinor, functionalCurrencyCode, baseCurrency } = params;
+
+  if (
+    functionalAmountMinor === null ||
+    functionalAmountMinor === undefined ||
+    functionalAmountMinor <= 0
+  ) {
+    throw new UnprocessableEntityException({
+      statusCode: 422,
+      error: LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED,
+      message: `El ingreso ${incomeId} no posee un snapshot funcional válido (${baseCurrency}); no se puede valuar su OFFSET`,
+    });
+  }
+
+  if (functionalCurrencyCode !== baseCurrency) {
+    throw new UnprocessableEntityException({
+      statusCode: 422,
+      error: LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED,
+      message: `El ingreso ${incomeId} está en ${functionalCurrencyCode ?? 'null'}, ` +
+        `se esperaba la moneda funcional (${baseCurrency}); no se puede valuar su OFFSET`,
+    });
+  }
+}
+
+/**
  * Valida el modo de valuación de una IncomeApplication OFFSET respecto a la
  * liquidación y devuelve el monto valorado que reduce el neto distributable.
  *
  * LEGACY_NOMINAL: currencyCode === baseCurrency (si difiere → mismatch).
- * FUNCTIONAL: usa el snapshot funcional congelado del Income.
+ * FUNCTIONAL: usa el snapshot funcional congelado del Income (fail-closed).
  */
 export function valueIncomeOffsetForLiquidation(params: {
   application: {
@@ -254,6 +318,7 @@ export function valueIncomeOffsetForLiquidation(params: {
 
   if (
     application.functionalAmountMinor === null ||
+    application.functionalAmountMinor <= 0 ||
     application.functionalCurrencyCode !== baseCurrency
   ) {
     throw new UnprocessableEntityException({

--- a/apps/api/src/finanzas/incomes.service.ts
+++ b/apps/api/src/finanzas/incomes.service.ts
@@ -1,6 +1,7 @@
 import {
   Injectable,
   BadRequestException,
+  ConflictException,
   NotFoundException,
   ForbiddenException,
 } from '@nestjs/common';
@@ -401,6 +402,35 @@ export class IncomesService {
       // Idempotencia: un Income ya VOID se devuelve sin nuevas mutaciones.
       if (income.status === IncomeStatus.VOID) {
         return this.toDto(income as unknown as Parameters<typeof this.toDto>[0]);
+      }
+
+      // ── FIN-06: void-safety de IncomeApplications OFFSET usadas ──────────
+      // Una IncomeApplication OFFSET referenciada por una liquidación
+      // DRAFT/REVIEWED/PUBLISHED no puede desaparecer con el void del Income:
+      // la historia ya se distribuyó o está comprometida en un draft.
+      const offsetReferences = await tx.liquidationIncomeOffset.findMany({
+        where: {
+          tenantId,
+          incomeApplication: { incomeId },
+        },
+        select: {
+          liquidation: {
+            select: { id: true, status: true, period: true },
+          },
+        },
+      });
+
+      const blockingReferences = offsetReferences.filter(
+        (reference) => reference.liquidation !== null && reference.liquidation.status !== 'CANCELED',
+      );
+
+      if (blockingReferences.length > 0) {
+        const statuses = [...new Set(blockingReferences.map((r) => r.liquidation!.status))];
+        const message =
+          statuses.includes('PUBLISHED')
+            ? `No se puede anular el ingreso: una liquidación publicada ya distribuyó sus offsets (${blockingReferences.length}); la corrección requiere compensación/ajuste, no void destructivo`
+            : `No se puede anular el ingreso: sus offsets están referenciados por ${blockingReferences.length} liquidación(es) activa(s) (${statuses.join(', ')}); cancelá la liquidación primero`;
+        throw new ConflictException(message);
       }
 
       // Reversar automáticamente los FundTransactions CREDIT generados por

--- a/apps/api/src/finanzas/incomes.void-atomicity.spec.ts
+++ b/apps/api/src/finanzas/incomes.void-atomicity.spec.ts
@@ -52,6 +52,7 @@ describe('IncomesService voidIncome atomicity (FIN-03)', () => {
     exchangeRate: { findFirst: jest.fn() },
     expenseLedgerCategory: { findFirst: jest.fn() },
     unitGroup: { findFirst: jest.fn() },
+    liquidationIncomeOffset: { findMany: jest.fn() },
     $transaction: jest.fn(),
     $executeRaw: jest.fn(),
   };
@@ -67,6 +68,7 @@ describe('IncomesService voidIncome atomicity (FIN-03)', () => {
         exchangeRate: prismaValue.exchangeRate,
         expenseLedgerCategory: prismaValue.expenseLedgerCategory,
         unitGroup: prismaValue.unitGroup,
+        liquidationIncomeOffset: prismaValue.liquidationIncomeOffset,
         auditLog: { create: jest.fn() },
         $executeRaw: prismaValue.$executeRaw,
       }),
@@ -76,6 +78,7 @@ describe('IncomesService voidIncome atomicity (FIN-03)', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     (prismaValue.fundTransaction.create as jest.Mock).mockReset();
+    (prismaValue.liquidationIncomeOffset.findMany as jest.Mock).mockResolvedValue([]);
     mockTransaction();
 
     const module: TestingModule = await Test.createTestingModule({
@@ -208,5 +211,104 @@ describe('IncomesService voidIncome atomicity (FIN-03)', () => {
 
     expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
     expect(audit.createLogRequired).toHaveBeenCalledTimes(1); // solo INCOME_VOID
+  });
+
+  describe('FIN-06 void safety (LiquidationIncomeOffset references)', () => {
+    const referencedBy = (status: string) => [
+      { liquidation: { id: 'liq-1', status, period: '2026-08' } },
+    ];
+
+    it('rejects void when a DRAFT liquidation references an OFFSET', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+      (prisma.liquidationIncomeOffset.findMany as jest.Mock).mockResolvedValue(
+        referencedBy('DRAFT'),
+      );
+
+      await expect(
+        service.voidIncome('tenant-1', 'income-1', 'member-1', roles),
+      ).rejects.toThrow(ConflictException);
+
+      expect(prisma.incomeApplication.findMany).not.toHaveBeenCalled();
+      expect(prisma.income.update).not.toHaveBeenCalled();
+    });
+
+    it('rejects void when a REVIEWED liquidation references an OFFSET', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+      (prisma.liquidationIncomeOffset.findMany as jest.Mock).mockResolvedValue(
+        referencedBy('REVIEWED'),
+      );
+
+      await expect(
+        service.voidIncome('tenant-1', 'income-1', 'member-1', roles),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('rejects void when a PUBLISHED liquidation references an OFFSET', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+      (prisma.liquidationIncomeOffset.findMany as jest.Mock).mockResolvedValue(
+        referencedBy('PUBLISHED'),
+      );
+
+      await expect(
+        service.voidIncome('tenant-1', 'income-1', 'member-1', roles),
+      ).rejects.toThrow(ConflictException);
+    });
+
+    it('rejects the whole void when OFFSET is published even if FUND would be reversible (all-or-nothing)', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+      (prisma.liquidationIncomeOffset.findMany as jest.Mock).mockResolvedValue(
+        referencedBy('PUBLISHED'),
+      );
+
+      await expect(
+        service.voidIncome('tenant-1', 'income-1', 'member-1', roles),
+      ).rejects.toThrow(ConflictException);
+
+      expect(prisma.fundTransaction.create).not.toHaveBeenCalled();
+    });
+
+    it('allows void when the only referencing liquidation is CANCELED', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+      (prisma.liquidationIncomeOffset.findMany as jest.Mock).mockResolvedValue(
+        referencedBy('CANCELED'),
+      );
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.income.update as jest.Mock).mockResolvedValue(makeIncome({ status: IncomeStatus.VOID }));
+
+      const result = await service.voidIncome('tenant-1', 'income-1', 'member-1', roles);
+
+      expect(result.status).toBe('VOID');
+      expect(audit.createLogRequired).toHaveBeenCalledTimes(1); // INCOME_VOID
+    });
+
+    it('allows void when no liquidation references exist (FUND-only income unchanged)', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+      (prisma.liquidationIncomeOffset.findMany as jest.Mock).mockResolvedValue([]);
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([
+        {
+          id: 'app-fund',
+          fundId: 'fund-1',
+          fundTransaction: {
+            id: 'ft-1',
+            fundId: 'fund-1',
+            direction: FundTransactionDirection.CREDIT,
+            amountMinor: 3000,
+            currencyCode: 'USD',
+            reversalOfTransactionId: null,
+          },
+        },
+      ]);
+      (prisma.fund.findMany as jest.Mock).mockResolvedValue([{ id: 'fund-1', status: 'ACTIVE' }]);
+      (prisma.fundTransaction.groupBy as jest.Mock)
+        .mockResolvedValueOnce([{ currencyCode: 'USD', _sum: { amountMinor: 3000 } }])
+        .mockResolvedValueOnce([]);
+      (prisma.fundTransaction.create as jest.Mock).mockResolvedValue({ id: 'ft-rev' });
+      (prisma.income.update as jest.Mock).mockResolvedValue(makeIncome({ status: IncomeStatus.VOID }));
+
+      await service.voidIncome('tenant-1', 'income-1', 'member-1', roles);
+
+      expect(prisma.fundTransaction.create).toHaveBeenCalledTimes(1);
+      expect(prisma.income.update).toHaveBeenCalled();
+    });
   });
 });

--- a/apps/api/src/finanzas/liquidation-income-offsets.postgres.spec.ts
+++ b/apps/api/src/finanzas/liquidation-income-offsets.postgres.spec.ts
@@ -1,0 +1,1120 @@
+import {
+  BadRequestException,
+  ConflictException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import {
+  IncomeApplicationDestination,
+  IncomeStatus,
+  MovementScope,
+  PrismaClient,
+  TenantType,
+} from '@prisma/client';
+import { AuditService } from '../audit/audit.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { ResidentAccessService } from '../resident-access/resident-access.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { LiquidationsService } from './liquidations.service';
+import { LiquidationIncomeOffsetsService } from './liquidation-income-offsets.service';
+import { IncomesService } from './incomes.service';
+import { IncomeApplicationsService } from './income-applications.service';
+import { FundsService } from './funds.service';
+import { CurrencyConversionService } from './currency-conversion.service';
+import { MovementAllocationService } from './movement-allocation.service';
+import {
+  createLiquidationWorkflowDependencies,
+  LiquidationPublicationUseCase,
+} from './liquidation-publication.use-case';
+
+const ACCEPTANCE_DATABASES = new Set(['buildingos_fin06_acceptance']);
+const expectedDatabaseName = process.env.POSTGRES_TEST_DB_NAME;
+const fixturePhase = 'fin06';
+const enabled =
+  process.env.RUN_POSTGRES_INTEGRATION === '1' &&
+  expectedDatabaseName !== undefined &&
+  ACCEPTANCE_DATABASES.has(expectedDatabaseName);
+const describePostgres = enabled ? describe : describe.skip;
+
+describePostgres('FIN-06 income offsets → liquidation (PostgreSQL)', () => {
+  let observer: PrismaClient;
+  let liquidations: LiquidationsService;
+  let incomes: IncomesService;
+  let apps: IncomeApplicationsService;
+  let funds: FundsService;
+  const tenantIds: string[] = [];
+  const userIds: string[] = [];
+  const membershipIds: string[] = [];
+
+  const roles = ['TENANT_ADMIN'];
+
+  function buildServices(client: PrismaClient) {
+    const prisma = client as unknown as PrismaService;
+    const audit = new AuditService(prisma);
+    const validators = new FinanzasValidators(
+      prisma,
+      new ResidentAccessService(prisma),
+    );
+    const notifications = {
+      createNotification: () => Promise.resolve({ id: 'n' }),
+    } as unknown as NotificationsService;
+    const useCase = new LiquidationPublicationUseCase(
+      createLiquidationWorkflowDependencies({
+        prisma,
+        auditService: audit,
+        validators,
+        notificationsService: notifications,
+      }),
+    );
+    return {
+      liquidations: new LiquidationsService(
+        prisma,
+        audit,
+        validators,
+        useCase,
+        new LiquidationIncomeOffsetsService(prisma),
+      ),
+      incomes: new IncomesService(
+        prisma,
+        audit,
+        validators,
+        new MovementAllocationService(prisma, audit, validators),
+        new CurrencyConversionService(prisma),
+      ),
+      apps: new IncomeApplicationsService(prisma, audit, validators),
+      funds: new FundsService(prisma, audit, validators),
+    };
+  }
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required');
+    observer = new PrismaClient();
+    await observer.$connect();
+    const [database] = await observer.$queryRaw<Array<{ name: string }>>`SELECT current_database() AS name`;
+    if (database?.name !== expectedDatabaseName || !ACCEPTANCE_DATABASES.has(database.name)) {
+      throw new Error(`Refusing destructive test database ${database?.name ?? 'unknown'}`);
+    }
+    const svc = buildServices(observer);
+    liquidations = svc.liquidations;
+    incomes = svc.incomes;
+    apps = svc.apps;
+    funds = svc.funds;
+    await observer.tenant.deleteMany({ where: { name: { startsWith: `${fixturePhase}-` } } });
+  });
+
+  afterEach(async () => {
+    for (const membershipId of membershipIds.splice(0)) {
+      await observer.membership.delete({ where: { id: membershipId } }).catch(() => undefined);
+    }
+    for (const tenantId of tenantIds.splice(0)) {
+      await observer.tenant.delete({ where: { id: tenantId } }).catch(() => undefined);
+    }
+    for (const userId of userIds.splice(0)) {
+      await observer.user.delete({ where: { id: userId } }).catch(() => undefined);
+    }
+  });
+
+  afterAll(async () => observer?.$disconnect());
+
+  async function fixture(label: string) {
+    const suffix = `${Date.now()}-${Math.random()}`;
+    const tenant = await observer.tenant.create({
+      data: {
+        name: `${fixturePhase}-${label}-${suffix}`,
+        type: TenantType.ADMINISTRADORA,
+        functionalCurrency: 'ARS',
+      },
+    });
+    tenantIds.push(tenant.id);
+    const user = await observer.user.create({
+      data: {
+        email: `${fixturePhase}-${suffix}@buildingos.local`,
+        name: `${fixturePhase} ${label}`,
+        passwordHash: 'test',
+      },
+    });
+    userIds.push(user.id);
+    const membership = await observer.membership.create({ data: { tenantId: tenant.id, userId: user.id } });
+    membershipIds.push(membership.id);
+    await observer.membershipRole.create({
+      data: { tenantId: tenant.id, membershipId: membership.id, role: 'TENANT_ADMIN', scopeType: 'TENANT' },
+    });
+    return { tenant, membership };
+  }
+
+  async function building(tenantId: string, label: string) {
+    return observer.building.create({
+      data: {
+        tenantId,
+        name: `Building ${label} ${Date.now()}`,
+        alias: `B-${label}-${Date.now().toString(36)}`,
+      },
+    });
+  }
+
+  async function units(tenantId: string, buildingId: string, count = 2) {
+    return Promise.all(
+      Array.from({ length: count }, (_, i) =>
+        observer.unit.create({
+          data: {
+            tenantId,
+            buildingId,
+            code: `U-${i + 1}-${Date.now().toString(36)}`,
+            label: `Unit ${i + 1}`,
+            unitType: 'APARTAMENTO',
+            occupancyStatus: 'OCCUPIED',
+            isBillable: true,
+          },
+        }),
+      ),
+    );
+  }
+
+  async function incomeCategory(tenantId: string) {
+    return observer.expenseLedgerCategory.create({
+      data: { tenantId, name: `Inc ${Date.now()}`, movementType: 'INCOME' },
+    });
+  }
+
+  async function expenseCategory(tenantId: string) {
+    return observer.expenseLedgerCategory.create({
+      data: { tenantId, name: `Exp ${Date.now()}`, movementType: 'EXPENSE' },
+    });
+  }
+
+  async function validatedExpense(
+    tenantId: string,
+    buildingId: string,
+    categoryId: string,
+    amountMinor: number,
+    functional?: { functionalAmountMinor: number; functionalCurrencyCode: string },
+  ) {
+    return observer.expense.create({
+      data: {
+        tenantId,
+        buildingId,
+        period: '2026-08',
+        categoryId,
+        amountMinor,
+        currencyCode: 'ARS',
+        invoiceDate: new Date('2026-08-05T00:00:00.000Z'),
+        status: 'VALIDATED',
+        scopeType: 'BUILDING',
+        createdByMembershipId: membershipIds[membershipIds.length - 1]!,
+        ...(functional
+          ? {
+              functionalAmountMinor: functional.functionalAmountMinor,
+              functionalCurrencyCode: functional.functionalCurrencyCode,
+              exchangeRateValue: '1',
+              exchangeRateDirection: 'IDENTITY',
+              conversionDate: new Date('2026-08-05T00:00:00.000Z'),
+            }
+          : {}),
+      },
+    });
+  }
+
+  async function recordedIncome(
+    tenantId: string,
+    membershipId: string,
+    categoryId: string,
+    params: {
+      amountMinor: number;
+      period?: string;
+      buildingId?: string | null;
+      scopeType?: MovementScope;
+      functionalAmountMinor?: number | null;
+      functionalCurrencyCode?: string | null;
+      currencyCode?: string;
+      status?: IncomeStatus;
+    } = { amountMinor: 10000 },
+  ) {
+    const income = await observer.income.create({
+      data: {
+        tenantId,
+        period: params.period ?? '2026-08',
+        categoryId,
+        amountMinor: params.amountMinor,
+        currencyCode: params.currencyCode ?? 'ARS',
+        receivedDate: new Date('2026-08-10T00:00:00.000Z'),
+        status: IncomeStatus.RECORDED,
+        scopeType: params.scopeType ?? MovementScope.BUILDING,
+        buildingId: params.buildingId ?? null,
+        functionalAmountMinor: params.functionalAmountMinor ?? null,
+        functionalCurrencyCode: params.functionalCurrencyCode ?? null,
+        createdByMembershipId: membershipId,
+        ...(params.status ? { status: params.status } : {}),
+      },
+    });
+    return income;
+  }
+
+  async function allocateIncome(tenantId: string, incomeId: string, allocations: Array<{ buildingId: string; amountMinor: number }>) {
+    await observer.movementAllocation.createMany({
+      data: allocations.map((allocation) => ({
+        tenantId,
+        incomeId,
+        buildingId: allocation.buildingId,
+        amountMinor: allocation.amountMinor,
+      })),
+    });
+  }
+
+  async function createOffsetApplications(tenantId: string, incomeId: string, appsData: Array<{
+    destinationType: IncomeApplicationDestination;
+    amountMinor: number;
+    fundId?: string | null;
+    policyVersionId?: string | null;
+    currencyCode?: string;
+  }>) {
+    for (const app of appsData) {
+      await observer.incomeApplication.create({
+        data: {
+          tenantId,
+          incomeId,
+          destinationType: app.destinationType,
+          fundId: app.fundId ?? null,
+          amountMinor: app.amountMinor,
+          currencyCode: app.currencyCode ?? 'ARS',
+          createdByMembershipId: membershipIds[membershipIds.length - 1]!,
+          policyVersionId: app.policyVersionId ?? null,
+        },
+      });
+    }
+  }
+
+  async function createLiquidationFlow(
+    tenantId: string,
+    buildingId: string,
+    membershipId: string,
+    period = '2026-08',
+  ) {
+    const draft = await liquidations.createDraft(tenantId, membershipId, {
+      buildingId,
+      period,
+      baseCurrency: 'ARS',
+    });
+    const reviewed = await liquidations.reviewLiquidation(tenantId, draft.id, membershipId);
+    return { draft, reviewed };
+  }
+
+  // ── A. schema constraints ────────────────────────────────────────────────
+
+  it('A. enforces positive reference amounts at the DB level', async () => {
+    const ctx = await fixture('db-constraints');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, cat.id, { amountMinor: 1000 });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 1000 },
+    ]);
+    const liq = await observer.liquidation.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        buildingId: buildingA.id,
+        period: '2026-08',
+        baseCurrency: 'ARS',
+        totalAmountMinor: 0,
+        totalsByCurrency: { ARS: 0 },
+        expenseSnapshot: [],
+        unitCount: 1,
+        generatedByMembershipId: ctx.membership.id,
+        grossExpenseAmountMinor: 1000,
+        adjustmentAmountMinor: 0,
+        preIncomeAmountMinor: 1000,
+        incomeOffsetAmountMinor: 1000,
+        netDistributableAmountMinor: 0,
+      },
+    });
+
+    await expect(
+      observer.liquidationIncomeOffset.create({
+        data: {
+          tenantId: ctx.tenant.id,
+          liquidationId: liq.id,
+          incomeApplicationId: (
+            await observer.incomeApplication.findFirstOrThrow({ where: { incomeId: income.id } })
+          ).id,
+          buildingId: buildingA.id,
+          originalAmountMinor: -1,
+          currencyCode: 'ARS',
+          valuedAmountMinor: 1000,
+          baseCurrency: 'ARS',
+        },
+      }),
+    ).rejects.toThrow();
+  }, 20000);
+
+  it('B. FK/delete lifecycle: tenant hard-delete removes offset references', async () => {
+    const ctx = await fixture('fk-delete');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, cat.id, { amountMinor: 1000 });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 1000 },
+    ]);
+    const liq = await observer.liquidation.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        buildingId: buildingA.id,
+        period: '2026-08',
+        baseCurrency: 'ARS',
+        totalAmountMinor: 0,
+        totalsByCurrency: { ARS: 0 },
+        expenseSnapshot: [],
+        unitCount: 1,
+        generatedByMembershipId: ctx.membership.id,
+      },
+    });
+    const app = await observer.incomeApplication.findFirstOrThrow({ where: { incomeId: income.id } });
+    await observer.liquidationIncomeOffset.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        liquidationId: liq.id,
+        incomeApplicationId: app.id,
+        buildingId: buildingA.id,
+        originalAmountMinor: 1000,
+        currencyCode: 'ARS',
+        valuedAmountMinor: 1000,
+        baseCurrency: 'ARS',
+      },
+    });
+
+    await observer.tenant.delete({ where: { id: ctx.tenant.id } });
+
+    expect(await observer.liquidationIncomeOffset.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+    tenantIds.splice(tenantIds.indexOf(ctx.tenant.id), 1);
+    membershipIds.splice(membershipIds.indexOf(ctx.membership.id), 1);
+    userIds.splice(userIds.indexOf(ctx.userId), 1);
+  }, 30000);
+
+  // ── C–R. Functional flow ────────────────────────────────────────────────
+
+  it('C. building income offset reduces the liquidation net', async () => {
+    const ctx = await fixture('building-offset');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingA.id,
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+    ]);
+
+    const { draft } = await createLiquidationFlow(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    expect(draft.totalAmountMinor).toBe(3000);
+    expect(draft.grossExpenseAmountMinor).toBe(10000);
+    expect(draft.incomeOffsetAmountMinor).toBe(7000);
+    expect(draft.netDistributableAmountMinor).toBe(3000);
+    expect(await observer.liquidationIncomeOffset.count({ where: { liquidationId: draft.id } })).toBe(1);
+  }, 30000);
+
+  it('D. shared income 6000/4000 allocates 4200/2800 across buildings', async () => {
+    const ctx = await fixture('shared-60-40');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const buildingB = await building(ctx.tenant.id, 'B');
+    await units(ctx.tenant.id, buildingA.id);
+    await units(ctx.tenant.id, buildingB.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    await validatedExpense(ctx.tenant.id, buildingB.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      scopeType: MovementScope.TENANT_SHARED,
+    });
+    const fund = await observer.fund.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        scopeType: 'TENANT',
+        type: 'RESERVE',
+        name: `Fund D ${Date.now()}`,
+        createdByMembershipId: ctx.membership.id,
+      },
+    });
+    await allocateIncome(ctx.tenant.id, income.id, [
+      { buildingId: buildingA.id, amountMinor: 6000 },
+      { buildingId: buildingB.id, amountMinor: 4000 },
+    ]);
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+      { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+    ]);
+
+    const liqA = await liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+      buildingId: buildingA.id,
+      period: '2026-08',
+      baseCurrency: 'ARS',
+    });
+    const liqB = await liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+      buildingId: buildingB.id,
+      period: '2026-08',
+      baseCurrency: 'ARS',
+    });
+
+    expect(liqA.incomeOffsetAmountMinor).toBe(4200);
+    expect(liqA.totalAmountMinor).toBe(5800);
+    expect(liqB.incomeOffsetAmountMinor).toBe(2800);
+    expect(liqB.totalAmountMinor).toBe(7200);
+
+    const refs = await observer.liquidationIncomeOffset.findMany({
+      where: { tenantId: ctx.tenant.id },
+    });
+    expect(refs.reduce((sum, ref) => sum + ref.valuedAmountMinor, 0)).toBe(7000);
+  }, 30000);
+
+  it('E. shared rounding is deterministic with odd allocation values', async () => {
+    const ctx = await fixture('shared-rounding');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const buildingB = await building(ctx.tenant.id, 'B');
+    await units(ctx.tenant.id, buildingA.id);
+    await units(ctx.tenant.id, buildingB.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10001);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10001,
+      scopeType: MovementScope.TENANT_SHARED,
+    });
+    await allocateIncome(ctx.tenant.id, income.id, [
+      { buildingId: buildingA.id, amountMinor: 6000 },
+      { buildingId: buildingB.id, amountMinor: 4000 },
+    ]);
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 10001 },
+    ]);
+
+    const liqA = await liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+      buildingId: buildingA.id,
+      period: '2026-08',
+      baseCurrency: 'ARS',
+    });
+    expect(liqA.incomeOffsetAmountMinor).toBeGreaterThan(0);
+    expect(liqA.incomeOffsetAmountMinor).toBeLessThanOrEqual(10001);
+
+    // determinismo: cancelar el draft y repetir con el mismo estado → mismo resultado
+    await liquidations.cancelLiquidation(ctx.tenant.id, liqA.id, ctx.membership.id);
+    const liqA2 = await liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+      buildingId: buildingA.id,
+      period: '2026-08',
+      baseCurrency: 'ARS',
+    });
+    expect(liqA2.incomeOffsetAmountMinor).toBe(liqA.incomeOffsetAmountMinor);
+  }, 30000);
+
+  it('F. legacy nominal: same currency offset works', async () => {
+    const ctx = await fixture('nominal-same-currency');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 7000,
+      buildingId: buildingA.id,
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+    ]);
+
+    const { draft } = await createLiquidationFlow(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    expect(draft.incomeOffsetAmountMinor).toBe(7000);
+    expect(draft.totalAmountMinor).toBe(3000);
+  }, 30000);
+
+  it('G. legacy nominal: cross-currency offset rejected', async () => {
+    const ctx = await fixture('nominal-cross-currency');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 7000,
+      buildingId: buildingA.id,
+      currencyCode: 'USD',
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000, currencyCode: 'USD' },
+    ]);
+
+    await expect(
+      liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+        buildingId: buildingA.id,
+        period: '2026-08',
+        baseCurrency: 'ARS',
+      }),
+    ).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_INCOME_OFFSET_CURRENCY_MISMATCH' },
+    });
+  }, 30000);
+
+  it('H. FUNCTIONAL: foreign income with frozen snapshot values exactly', async () => {
+    const ctx = await fixture('functional-frozen');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 2500, {
+      functionalAmountMinor: 2500,
+      functionalCurrencyCode: 'ARS',
+    });
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const fx = await observer.exchangeRate.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        baseCurrency: 'USD',
+        quoteCurrency: 'ARS',
+        rate: '0.25',
+        effectiveAt: new Date('2026-08-10T00:00:00.000Z'),
+        source: 'fixture-fin06-h',
+      },
+    });
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingA.id,
+      currencyCode: 'USD',
+      functionalAmountMinor: 2500,
+      functionalCurrencyCode: 'ARS',
+    });
+    await observer.income.update({
+      where: { id: income.id },
+      data: {
+        exchangeRateId: fx.id,
+        exchangeRateValue: '0.25',
+        exchangeRateDirection: 'INVERSE',
+        exchangeRateEffectiveAt: new Date('2026-08-10T00:00:00.000Z'),
+        conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+      },
+    });
+    const fund = await observer.fund.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        scopeType: 'TENANT',
+        type: 'RESERVE',
+        name: `Fund H ${Date.now()}`,
+        createdByMembershipId: ctx.membership.id,
+      },
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000, currencyCode: 'USD' },
+      { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000, currencyCode: 'USD' },
+    ]);
+
+    const { draft } = await createLiquidationFlow(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    expect(draft.incomeOffsetAmountMinor).toBe(1750);
+    expect(draft.totalAmountMinor).toBe(750);
+  }, 30000);
+
+  it('I. mutating live ExchangeRate after record does not change the liquidation', async () => {
+    const ctx = await fixture('fx-frozen-proof');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 2500, {
+      functionalAmountMinor: 2500,
+      functionalCurrencyCode: 'ARS',
+    });
+    const incCat = await incomeCategory(ctx.tenant.id);
+
+    const fx = await observer.exchangeRate.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        baseCurrency: 'USD',
+        quoteCurrency: 'ARS',
+        rate: '0.25',
+        effectiveAt: new Date('2026-08-10T00:00:00.000Z'),
+        source: 'fixture-fin06',
+      },
+    });
+
+    const income = await observer.income.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        period: '2026-08',
+        categoryId: incCat.id,
+        amountMinor: 10000,
+        currencyCode: 'USD',
+        receivedDate: new Date('2026-08-10T00:00:00.000Z'),
+        status: IncomeStatus.RECORDED,
+        scopeType: MovementScope.BUILDING,
+        buildingId: buildingA.id,
+        functionalAmountMinor: 2500,
+        functionalCurrencyCode: 'ARS',
+        exchangeRateId: fx.id,
+        exchangeRateValue: '0.25',
+        exchangeRateDirection: 'INVERSE',
+        exchangeRateEffectiveAt: new Date('2026-08-10T00:00:00.000Z'),
+        conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+        createdByMembershipId: ctx.membership.id,
+      },
+    });
+    const fund = await observer.fund.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        scopeType: 'TENANT',
+        type: 'RESERVE',
+        name: `Fund I ${Date.now()}`,
+        createdByMembershipId: ctx.membership.id,
+      },
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000, currencyCode: 'USD' },
+      { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000, currencyCode: 'USD' },
+    ]);
+
+    const first = await liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+      buildingId: buildingA.id,
+      period: '2026-08',
+      baseCurrency: 'ARS',
+    });
+    expect(first.incomeOffsetAmountMinor).toBe(1750);
+
+    // Cambiar el ExchangeRate live posterior: el resultado no debe cambiar.
+    await observer.exchangeRate.update({
+      where: { id: fx.id },
+      data: { rate: '0.50' },
+    });
+
+    await liquidations.cancelLiquidation(ctx.tenant.id, first.id, ctx.membership.id);
+    const second = await liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+      buildingId: buildingA.id,
+      period: '2026-08',
+      baseCurrency: 'ARS',
+    });
+    expect(second.incomeOffsetAmountMinor).toBe(1750);
+  }, 30000);
+
+  it('J. multiple offset incomes sum exactly with individual provenance', async () => {
+    const ctx = await fixture('multiple-offsets');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 12000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income1 = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 5000,
+      buildingId: buildingA.id,
+    });
+    const income2 = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 2000,
+      buildingId: buildingA.id,
+    });
+    await createOffsetApplications(ctx.tenant.id, income1.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 5000 },
+    ]);
+    await createOffsetApplications(ctx.tenant.id, income2.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 2000 },
+    ]);
+
+    const { draft } = await createLiquidationFlow(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    expect(draft.incomeOffsetAmountMinor).toBe(7000);
+    expect(draft.totalAmountMinor).toBe(5000);
+    const refs = await observer.liquidationIncomeOffset.findMany({
+      where: { liquidationId: draft.id },
+      orderBy: { incomeApplicationId: 'asc' },
+    });
+    expect(refs).toHaveLength(2);
+    expect(refs.map((ref) => ref.originalAmountMinor).sort((a, b) => a - b)).toEqual([2000, 5000]);
+  }, 30000);
+
+  it('K. policy v1 application keeps policyVersionId in snapshot after v2 published', async () => {
+    const ctx = await fixture('policy-provenance');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingA.id,
+    });
+
+    const policy = await observer.incomePolicy.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        categoryId: incCat.id,
+        createdByMembershipId: ctx.membership.id,
+      },
+    });
+    const v1 = await observer.incomePolicyVersion.create({
+      data: { policyId: policy.id, version: 1, createdByMembershipId: ctx.membership.id },
+    });
+    await observer.incomePolicyRule.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        versionId: v1.id,
+        destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+        percentageBasisPoints: 10000,
+        fundId: null,
+      },
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000, policyVersionId: v1.id },
+    ]);
+
+    // Publicar v2: el snapshot del draft debe conservar policyVersionId v1.
+    await observer.incomePolicyVersion.updateMany({
+      where: { policyId: policy.id, status: 'ACTIVE' },
+      data: { status: 'INACTIVE' },
+    });
+    const v2 = await observer.incomePolicyVersion.create({
+      data: { policyId: policy.id, version: 2, createdByMembershipId: ctx.membership.id },
+    });
+    await observer.incomePolicyRule.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        versionId: v2.id,
+        destinationType: IncomeApplicationDestination.CARRY_FORWARD,
+        percentageBasisPoints: 10000,
+        fundId: null,
+      },
+    });
+
+    const { draft } = await createLiquidationFlow(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    expect(draft.incomeOffsetAmountMinor).toBe(7000);
+    const liq = await observer.liquidation.findUniqueOrThrow({ where: { id: draft.id } });
+    const snapshot = liq.incomeOffsetSnapshot as unknown as Array<{ policyVersionId: string | null }>;
+    expect(snapshot[0]!.policyVersionId).toBe(v1.id);
+  }, 30000);
+
+  it('L. manual application (policyVersionId null) works identically', async () => {
+    const ctx = await fixture('manual-application');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingA.id,
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+    ]);
+
+    const { draft } = await createLiquidationFlow(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    expect(draft.incomeOffsetAmountMinor).toBe(7000);
+    const liq = await observer.liquidation.findUniqueOrThrow({ where: { id: draft.id } });
+    const snapshot = liq.incomeOffsetSnapshot as unknown as Array<{ policyVersionId: string | null }>;
+    expect(snapshot[0]!.policyVersionId).toBeNull();
+  }, 30000);
+
+  it('M. offset > gross rolls back without creating rows', async () => {
+    const ctx = await fixture('offset-exceeds-gross');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 5000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingA.id,
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+    ]);
+
+    await expect(
+      liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+        buildingId: buildingA.id,
+        period: '2026-08',
+        baseCurrency: 'ARS',
+      }),
+    ).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_INCOME_OFFSETS_EXCEED_GROSS' },
+    });
+
+    expect(await observer.liquidation.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+    expect(await observer.liquidationIncomeOffset.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+  }, 30000);
+
+  it('N. exact zero net: draft → review → publish with no positive charges', async () => {
+    const ctx = await fixture('zero-net');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingA.id,
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 10000 },
+    ]);
+
+    const { draft, reviewed } = await createLiquidationFlow(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    expect(draft.totalAmountMinor).toBe(0);
+    expect(draft.netDistributableAmountMinor).toBe(0);
+
+    const published = await liquidations.publishLiquidation(ctx.tenant.id, reviewed.id, ctx.membership.id, {
+      dueDate: '2026-09-10',
+    });
+    expect(published.status).toBe('PUBLISHED');
+
+    const charges = await observer.charge.findMany({ where: { liquidationId: published.id } });
+    expect(charges).toHaveLength(0);
+
+    const liq = await observer.liquidation.findUniqueOrThrow({ where: { id: published.id } });
+    const snapshot = liq.publicationSnapshot as unknown as { version: number; netDistributableAmountMinor: number; allocations: Array<{ amountMinor: number }> };
+    expect(snapshot.version).toBe(3);
+    expect(snapshot.netDistributableAmountMinor).toBe(0);
+    expect(snapshot.allocations.every((a) => a.amountMinor === 0)).toBe(true);
+  }, 30000);
+
+  it('O. draft vs void concurrency: serializable, no draft on voided income', async () => {
+    const ctx = await fixture('draft-void-race');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingA.id,
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+    ]);
+
+    // Void primero → el draft no debe usar el income.
+    await incomes.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles);
+
+    const draft = await liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+      buildingId: buildingA.id,
+      period: '2026-08',
+      baseCurrency: 'ARS',
+    });
+
+    expect(draft.incomeOffsetAmountMinor).toBe(0);
+    expect(draft.totalAmountMinor).toBe(10000);
+  }, 30000);
+
+  it('P. DRAFT reference blocks void', async () => {
+    const ctx = await fixture('draft-blocks-void');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingA.id,
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+    ]);
+    await liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+      buildingId: buildingA.id,
+      period: '2026-08',
+      baseCurrency: 'ARS',
+    });
+
+    await expect(
+      incomes.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles),
+    ).rejects.toThrow(ConflictException);
+  }, 30000);
+
+  it('Q. cancel then void succeeds', async () => {
+    const ctx = await fixture('cancel-then-void');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingA.id,
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+    ]);
+    const { draft } = await createLiquidationFlow(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    await liquidations.cancelLiquidation(ctx.tenant.id, draft.id, ctx.membership.id);
+
+    const result = await incomes.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles);
+    expect(result.status).toBe('VOID');
+  }, 30000);
+
+  it('R. publish then void is rejected permanently; snapshot and charges intact', async () => {
+    const ctx = await fixture('publish-then-void');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingA.id,
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+    ]);
+    const { reviewed } = await createLiquidationFlow(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    await liquidations.publishLiquidation(ctx.tenant.id, reviewed.id, ctx.membership.id, {
+      dueDate: '2026-09-10',
+    });
+
+    await expect(
+      incomes.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles),
+    ).rejects.toThrow(ConflictException);
+
+    const liq = await observer.liquidation.findUniqueOrThrow({ where: { id: reviewed.id } });
+    expect(liq.status).toBe('PUBLISHED');
+    expect(liq.publicationSnapshot).not.toBeNull();
+    expect(await observer.charge.count({ where: { liquidationId: reviewed.id } })).toBe(2);
+  }, 30000);
+
+  it('S. mixed OFFSET+FUND: published offset blocks whole void, Fund ledger untouched', async () => {
+    const ctx = await fixture('mixed-void');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingA.id,
+    });
+    const fund = await observer.fund.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        scopeType: 'TENANT',
+        type: 'RESERVE',
+        name: `Fund S ${Date.now()}`,
+        createdByMembershipId: ctx.membership.id,
+      },
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+      { destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 3000 },
+    ]);
+
+    // Aplicar la política manualmente no aplica; publicar el plan con createPlan no existe
+    // aquí — usamos applyPolicy del servicio para crear el CREDIT del FUND.
+    const { reviewed } = await createLiquidationFlow(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    await liquidations.publishLiquidation(ctx.tenant.id, reviewed.id, ctx.membership.id, {
+      dueDate: '2026-09-10',
+    });
+
+    const fundTxBefore = await observer.fundTransaction.count({ where: { tenantId: ctx.tenant.id } });
+
+    await expect(
+      incomes.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles),
+    ).rejects.toThrow(ConflictException);
+
+    expect(await observer.fundTransaction.count({ where: { tenantId: ctx.tenant.id } })).toBe(fundTxBefore);
+  }, 30000);
+
+  it('T. publication source drift: manual corruption blocks publish', async () => {
+    const ctx = await fixture('source-drift');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingA.id,
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+    ]);
+    const { reviewed } = await createLiquidationFlow(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    // Corrupción controlada en DB disposable: la aplicación ya no es OFFSET.
+    await observer.incomeApplication.updateMany({
+      where: { incomeId: income.id },
+      data: { destinationType: IncomeApplicationDestination.CARRY_FORWARD, fundId: null },
+    });
+
+    await expect(
+      liquidations.publishLiquidation(ctx.tenant.id, reviewed.id, ctx.membership.id, {
+        dueDate: '2026-09-10',
+      }),
+    ).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_INCOME_SOURCE_DRIFT' },
+    });
+
+    expect(
+      await observer.liquidation.findUniqueOrThrow({ where: { id: reviewed.id } }),
+    ).toMatchObject({ status: 'REVIEWED' });
+  }, 30000);
+
+  it('U. duplicate same liquidation/application reference rejected by DB', async () => {
+    const ctx = await fixture('dup-reference');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, cat.id, { amountMinor: 1000 });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 1000 },
+    ]);
+    const liq = await observer.liquidation.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        buildingId: buildingA.id,
+        period: '2026-08',
+        baseCurrency: 'ARS',
+        totalAmountMinor: 0,
+        totalsByCurrency: { ARS: 0 },
+        expenseSnapshot: [],
+        unitCount: 1,
+        generatedByMembershipId: ctx.membership.id,
+      },
+    });
+    const app = await observer.incomeApplication.findFirstOrThrow({ where: { incomeId: income.id } });
+    const base = {
+      tenantId: ctx.tenant.id,
+      liquidationId: liq.id,
+      incomeApplicationId: app.id,
+      buildingId: buildingA.id,
+      originalAmountMinor: 1000,
+      currencyCode: 'ARS',
+      valuedAmountMinor: 1000,
+      baseCurrency: 'ARS',
+    };
+    await observer.liquidationIncomeOffset.create({ data: base });
+
+    await expect(observer.liquidationIncomeOffset.create({ data: base })).rejects.toThrow(/unique|duplicate/i);
+  }, 20000);
+
+  it('V. tenant isolation: cross-tenant income never offsets', async () => {
+    const ctxA = await fixture('iso-a');
+    const ctxB = await fixture('iso-b');
+    const buildingA = await building(ctxA.tenant.id, 'A');
+    await units(ctxA.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctxA.tenant.id);
+    await validatedExpense(ctxA.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCatB = await incomeCategory(ctxB.tenant.id);
+    const incomeB = await recordedIncome(ctxB.tenant.id, ctxB.membership.id, incCatB.id, {
+      amountMinor: 7000,
+      buildingId: buildingA.id, // building del tenant A pero income del tenant B
+    });
+    await createOffsetApplications(ctxB.tenant.id, incomeB.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+    ]);
+
+    const { draft } = await createLiquidationFlow(ctxA.tenant.id, buildingA.id, ctxA.membership.id);
+
+    expect(draft.incomeOffsetAmountMinor).toBe(0);
+    expect(draft.totalAmountMinor).toBe(10000);
+    expect(await observer.liquidationIncomeOffset.count({ where: { tenantId: ctxA.tenant.id } })).toBe(0);
+  }, 30000);
+
+  it('W. leaves no leftovers after the suite', async () => {
+    const leftover = await observer.tenant.count({ where: { name: { startsWith: `${fixturePhase}-` } } });
+    expect(leftover).toBe(0);
+  }, 10000);
+});

--- a/apps/api/src/finanzas/liquidation-income-offsets.postgres.spec.ts
+++ b/apps/api/src/finanzas/liquidation-income-offsets.postgres.spec.ts
@@ -1778,4 +1778,85 @@ describePostgres('FIN-06 income offsets → liquidation (PostgreSQL)', () => {
       await observer.liquidation.findUniqueOrThrow({ where: { id: reviewed.id } }),
     ).toMatchObject({ status: 'REVIEWED' });
   }, 30000);
+
+  // ── R3. Relational references classify FIN-06 (final bypass closure) ────
+
+  it('R3.A. all summary+JSON null with LiquidationIncomeOffset rows remaining is rejected, never legacy', async () => {
+    const setup = await setupFin06WithOffsets();
+
+    // Corrupción TOTAL del modelo FIN-06 salvo las referencias relacionales:
+    // summary todo NULL + JSON todo NULL. La rama legacy del CHECK lo permite,
+    // pero las LiquidationIncomeOffset rows deben clasificar como FIN-06.
+    const { reviewed } = await corruptAndReview(setup, {
+      grossExpenseAmountMinor: null,
+      adjustmentAmountMinor: null,
+      preIncomeAmountMinor: null,
+      incomeOffsetAmountMinor: null,
+      netDistributableAmountMinor: null,
+      incomeOffsetSnapshot: null,
+      incomeOffsetsByCurrency: null,
+    });
+
+    // Confirmar que la referencia relacional sigue existiendo.
+    const refCount = await observer.liquidationIncomeOffset.count({
+      where: { tenantId: setup.ctx.tenant.id },
+    });
+    expect(refCount).toBeGreaterThan(0);
+
+    await expect(
+      liquidations.publishLiquidation(setup.ctx.tenant.id, reviewed.id, setup.ctx.membership.id, {
+        dueDate: '2026-09-10',
+      }),
+    ).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_INCOME_SOURCE_DRIFT' },
+    });
+
+    // V2 imposible: la row sigue REVIEWED, sin snapshot ni cargos.
+    const row = await observer.liquidation.findUniqueOrThrow({ where: { id: reviewed.id } });
+    expect(row.status).toBe('REVIEWED');
+    expect(row.publicationSnapshot).toBeNull();
+    expect(await observer.charge.count({ where: { liquidationId: reviewed.id } })).toBe(0);
+  }, 30000);
+
+  it('R3.B. true legacy liquidation (no summary, no JSON, no refs) keeps historical V1/V2 behavior', async () => {
+    const ctx = await fixture('r3-legacy-control');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+
+    // Legacy: crear el draft y vaciar el modelo FIN-06 (todo null, sin refs).
+    const draft = await liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+      buildingId: buildingA.id,
+      period: '2026-08',
+      baseCurrency: 'ARS',
+    });
+    await observer.liquidation.update({
+      where: { id: draft.id },
+      data: {
+        grossExpenseAmountMinor: null,
+        adjustmentAmountMinor: null,
+        preIncomeAmountMinor: null,
+        incomeOffsetAmountMinor: null,
+        netDistributableAmountMinor: null,
+        incomeOffsetSnapshot: null,
+        incomeOffsetsByCurrency: null,
+      },
+    });
+    expect(
+      await observer.liquidationIncomeOffset.count({ where: { tenantId: ctx.tenant.id } }),
+    ).toBe(0);
+
+    const reviewed = await liquidations.reviewLiquidation(ctx.tenant.id, draft.id, ctx.membership.id);
+    const published = await liquidations.publishLiquidation(ctx.tenant.id, reviewed.id, ctx.membership.id, {
+      dueDate: '2026-09-10',
+    });
+
+    expect(published.status).toBe('PUBLISHED');
+    const row = await observer.liquidation.findUniqueOrThrow({ where: { id: published.id } });
+    const snapshot = row.publicationSnapshot as unknown as { version: number };
+    // Legacy sin evidencia FIN-06 → V2 (histórico).
+    expect(snapshot.version).toBe(2);
+    expect(await observer.charge.count({ where: { liquidationId: published.id } })).toBe(2);
+  }, 30000);
 });

--- a/apps/api/src/finanzas/liquidation-income-offsets.postgres.spec.ts
+++ b/apps/api/src/finanzas/liquidation-income-offsets.postgres.spec.ts
@@ -345,6 +345,103 @@ describePostgres('FIN-06 income offsets → liquidation (PostgreSQL)', () => {
     ).rejects.toThrow();
   }, 20000);
 
+  // ── A2. DB summary invariants (FIN-06R hardening migration) ─────────────
+
+  const summaryBase = {
+    tenantId: '',
+    buildingId: '',
+    period: '2026-08',
+    baseCurrency: 'ARS',
+    totalAmountMinor: 5000,
+    totalsByCurrency: { ARS: 10000 },
+    expenseSnapshot: [],
+    unitCount: 1,
+    generatedByMembershipId: '',
+    grossExpenseAmountMinor: 10000,
+    adjustmentAmountMinor: 0,
+    preIncomeAmountMinor: 10000,
+    incomeOffsetAmountMinor: 5000,
+    netDistributableAmountMinor: 5000,
+  };
+
+  async function createSummaryLiquidation(overrides: Record<string, unknown>) {
+    const ctx = await fixture('db-summary');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    return observer.liquidation.create({
+      data: {
+        ...summaryBase,
+        tenantId: ctx.tenant.id,
+        buildingId: buildingA.id,
+        generatedByMembershipId: ctx.membership.id,
+        ...overrides,
+      },
+    });
+  }
+
+  it('A2.1 legacy row with all FIN-06 fields null is allowed', async () => {
+    const liq = await createSummaryLiquidation({
+      grossExpenseAmountMinor: null,
+      adjustmentAmountMinor: null,
+      preIncomeAmountMinor: null,
+      incomeOffsetAmountMinor: null,
+      netDistributableAmountMinor: null,
+    });
+
+    expect(liq.id).toBeDefined();
+  }, 20000);
+
+  it('A2.2 valid FIN-06 equation is allowed', async () => {
+    const liq = await createSummaryLiquidation({});
+    expect(liq.id).toBeDefined();
+  }, 20000);
+
+  it('A2.3 negative gross is rejected', async () => {
+    await expect(
+      createSummaryLiquidation({ grossExpenseAmountMinor: -1 }),
+    ).rejects.toThrow(/check constraint|Check/);
+  }, 20000);
+
+  it('A2.4 negative offset is rejected', async () => {
+    await expect(
+      createSummaryLiquidation({ incomeOffsetAmountMinor: -5 }),
+    ).rejects.toThrow(/check constraint|Check/);
+  }, 20000);
+
+  it('A2.5 negative net is rejected', async () => {
+    await expect(
+      createSummaryLiquidation({ netDistributableAmountMinor: -5 }),
+    ).rejects.toThrow(/check constraint|Check/);
+  }, 20000);
+
+  it('A2.6 gross + adjustment != preIncome is rejected', async () => {
+    await expect(
+      createSummaryLiquidation({ preIncomeAmountMinor: 9000 }),
+    ).rejects.toThrow(/check constraint|Check/);
+  }, 20000);
+
+  it('A2.7 preIncome - offset != net is rejected', async () => {
+    await expect(
+      createSummaryLiquidation({ netDistributableAmountMinor: 4000 }),
+    ).rejects.toThrow(/check constraint|Check/);
+  }, 20000);
+
+  it('A2.8 net != totalAmountMinor is rejected', async () => {
+    await expect(
+      createSummaryLiquidation({ totalAmountMinor: 4000 }),
+    ).rejects.toThrow(/check constraint|Check/);
+  }, 20000);
+
+  it('A2.9 partial FIN-06 summary fields are rejected', async () => {
+    await expect(
+      createSummaryLiquidation({
+        grossExpenseAmountMinor: null,
+        adjustmentAmountMinor: null,
+        preIncomeAmountMinor: null,
+        incomeOffsetAmountMinor: null,
+      }),
+    ).rejects.toThrow(/check constraint|Check/);
+  }, 20000);
+
   it('B. FK/delete lifecycle: tenant hard-delete removes offset references', async () => {
     const ctx = await fixture('fk-delete');
     const buildingA = await building(ctx.tenant.id, 'A');
@@ -690,6 +787,270 @@ describePostgres('FIN-06 income offsets → liquidation (PostgreSQL)', () => {
     });
     expect(second.incomeOffsetAmountMinor).toBe(1750);
   }, 30000);
+
+  // ── H2. FUNCTIONAL fail-closed matrix (FIN-06R) ─────────────────────────
+
+  async function setupFunctionalFailClosed(ctx: { tenant: { id: string }; membership: { id: string } }) {
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 2500, {
+      functionalAmountMinor: 2500,
+      functionalCurrencyCode: 'ARS',
+    });
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingA.id,
+      currencyCode: 'USD',
+    });
+    return { buildingA, income };
+  }
+
+  it('H2.B. FUNCTIONAL: functionalAmountMinor NULL → 422, no liquidation, no references', async () => {
+    const ctx = await fixture('func-null-amount');
+    const { buildingA, income } = await setupFunctionalFailClosed(ctx);
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000, currencyCode: 'USD' },
+    ]);
+
+    await expect(
+      liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+        buildingId: buildingA.id,
+        period: '2026-08',
+        baseCurrency: 'ARS',
+      }),
+    ).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED' },
+    });
+
+    expect(await observer.liquidation.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+    expect(await observer.liquidationIncomeOffset.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+  }, 30000);
+
+  it('H2.C. FUNCTIONAL: functionalCurrencyCode NULL → 422, no liquidation, no references', async () => {
+    const ctx = await fixture('func-null-currency');
+    const { buildingA, income } = await setupFunctionalFailClosed(ctx);
+    await observer.income.update({
+      where: { id: income.id },
+      data: { functionalAmountMinor: 2500, functionalCurrencyCode: null },
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000, currencyCode: 'USD' },
+    ]);
+
+    await expect(
+      liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+        buildingId: buildingA.id,
+        period: '2026-08',
+        baseCurrency: 'ARS',
+      }),
+    ).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED' },
+    });
+
+    expect(await observer.liquidation.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+    expect(await observer.liquidationIncomeOffset.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+  }, 30000);
+
+  it('H2.D. FUNCTIONAL: functionalCurrencyCode != baseCurrency → 422, no liquidation, no references', async () => {
+    const ctx = await fixture('func-mismatch');
+    const { buildingA, income } = await setupFunctionalFailClosed(ctx);
+    await observer.income.update({
+      where: { id: income.id },
+      data: { functionalAmountMinor: 2500, functionalCurrencyCode: 'USD' },
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000, currencyCode: 'USD' },
+    ]);
+
+    await expect(
+      liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+        buildingId: buildingA.id,
+        period: '2026-08',
+        baseCurrency: 'ARS',
+      }),
+    ).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED' },
+    });
+
+    expect(await observer.liquidation.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+    expect(await observer.liquidationIncomeOffset.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+  }, 30000);
+
+  // ── T2. Source drift matrix (FIN-06R) ───────────────────────────────────
+
+  async function setupDriftDraft() {
+    const ctx = await fixture('drift-matrix');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingA.id,
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000 },
+    ]);
+    const { reviewed } = await createLiquidationFlow(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    const reference = await observer.liquidationIncomeOffset.findFirstOrThrow({
+      where: { tenantId: ctx.tenant.id },
+    });
+    const snapshot = (
+      await observer.liquidation.findUniqueOrThrow({ where: { id: reviewed.id } })
+    ).incomeOffsetSnapshot as unknown as Array<Record<string, unknown>>;
+    return { ctx, buildingA, income, reviewed, reference, snapshot };
+  }
+
+  const driftMatrixCases: Array<{
+    label: string;
+    mutate: (ctx: Awaited<ReturnType<typeof setupDriftDraft>>) => Promise<void>;
+  }> = [
+    {
+      label: '1. application destination OFFSET → CARRY',
+      mutate: async ({ ctx, income }) => {
+        await observer.incomeApplication.updateMany({
+          where: { incomeId: income.id },
+          data: { destinationType: IncomeApplicationDestination.CARRY_FORWARD },
+        });
+      },
+    },
+    {
+      label: '2. application amount changes',
+      mutate: async ({ ctx, income }) => {
+        await observer.incomeApplication.updateMany({
+          where: { incomeId: income.id },
+          data: { amountMinor: 6500 },
+        });
+      },
+    },
+    {
+      label: '3. application currency changes',
+      mutate: async ({ ctx, income }) => {
+        await observer.incomeApplication.updateMany({
+          where: { incomeId: income.id },
+          data: { currencyCode: 'USD' },
+        });
+      },
+    },
+    {
+      label: '4. parent Income status changes',
+      mutate: async ({ income }) => {
+        await observer.income.update({
+          where: { id: income.id },
+          data: { status: IncomeStatus.VOID },
+        });
+      },
+    },
+    {
+      label: '5. reference valuedAmount changes',
+      mutate: async ({ reference }) => {
+        await observer.liquidationIncomeOffset.update({
+          where: { id: reference.id },
+          data: { valuedAmountMinor: 6500 },
+        });
+      },
+    },
+    {
+      label: '6. reference originalAmount changes',
+      mutate: async ({ reference }) => {
+        await observer.liquidationIncomeOffset.update({
+          where: { id: reference.id },
+          data: { originalAmountMinor: 6500 },
+        });
+      },
+    },
+    {
+      label: '7. reference baseCurrency changes',
+      mutate: async ({ reference }) => {
+        await observer.liquidationIncomeOffset.update({
+          where: { id: reference.id },
+          data: { baseCurrency: 'USD' },
+        });
+      },
+    },
+    {
+      label: '8. reference buildingId changes',
+      mutate: async ({ ctx, reference, buildingA }) => {
+        const other = await building(ctx.tenant.id, 'OTHER');
+        await observer.liquidationIncomeOffset.update({
+          where: { id: reference.id },
+          data: { buildingId: other.id },
+        });
+      },
+    },
+    {
+      label: '9. delete a reference row',
+      mutate: async ({ reference }) => {
+        await observer.liquidationIncomeOffset.delete({ where: { id: reference.id } });
+      },
+    },
+    {
+      label: '10. alter snapshot applicationAmountMinor',
+      mutate: async ({ ctx, reviewed, reference, snapshot }) => {
+        const updated = [...snapshot];
+        updated[0] = { ...updated[0]!, applicationAmountMinor: 6500 };
+        await observer.liquidation.update({
+          where: { id: reviewed.id },
+          data: { incomeOffsetSnapshot: updated as never },
+        });
+      },
+    },
+    {
+      label: '11. alter snapshot valuedAmountMinor',
+      mutate: async ({ ctx, reviewed, reference, snapshot }) => {
+        const updated = [...snapshot];
+        updated[0] = { ...updated[0]!, valuedAmountMinor: 6500 };
+        await observer.liquidation.update({
+          where: { id: reviewed.id },
+          data: { incomeOffsetSnapshot: updated as never },
+        });
+      },
+    },
+    {
+      label: '12. alter snapshot policyVersionId',
+      mutate: async ({ ctx, reviewed, reference, snapshot }) => {
+        const updated = [...snapshot];
+        updated[0] = { ...updated[0]!, policyVersionId: 'corrupted-pv' };
+        await observer.liquidation.update({
+          where: { id: reviewed.id },
+          data: { incomeOffsetSnapshot: updated as never },
+        });
+      },
+    },
+    {
+      label: '13. alter incomeOffsetsByCurrency',
+      mutate: async ({ ctx, reviewed }) => {
+        await observer.liquidation.update({
+          where: { id: reviewed.id },
+          data: { incomeOffsetsByCurrency: { ARS: 1 } as never },
+        });
+      },
+    },
+  ];
+
+  it.each(driftMatrixCases)(
+    'T2. source drift — $label → 422 LIQUIDATION_INCOME_SOURCE_DRIFT, liquidation stays REVIEWED',
+    async ({ mutate }) => {
+      const setup = await setupDriftDraft();
+      await mutate(setup);
+
+      await expect(
+        liquidations.publishLiquidation(setup.ctx.tenant.id, setup.reviewed.id, setup.ctx.membership.id, {
+          dueDate: '2026-09-10',
+        }),
+      ).rejects.toMatchObject({
+        response: { statusCode: 422, error: 'LIQUIDATION_INCOME_SOURCE_DRIFT' },
+      });
+
+      expect(
+        await observer.liquidation.findUniqueOrThrow({ where: { id: setup.reviewed.id } }),
+      ).toMatchObject({ status: 'REVIEWED' });
+    },
+    30000,
+  );
 
   it('J. multiple offset incomes sum exactly with individual provenance', async () => {
     const ctx = await fixture('multiple-offsets');

--- a/apps/api/src/finanzas/liquidation-income-offsets.postgres.spec.ts
+++ b/apps/api/src/finanzas/liquidation-income-offsets.postgres.spec.ts
@@ -1478,4 +1478,304 @@ describePostgres('FIN-06 income offsets → liquidation (PostgreSQL)', () => {
     const leftover = await observer.tenant.count({ where: { name: { startsWith: `${fixturePhase}-` } } });
     expect(leftover).toBe(0);
   }, 10000);
+
+  // ── R2. Building eligibility before FUNCTIONAL validation (PG) ──────────
+
+  it('R2.A. unrelated BUILDING income with invalid FUNCTIONAL snapshot does not block this building', async () => {
+    const ctx = await fixture('r2-building-isolation');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const buildingB = await building(ctx.tenant.id, 'B');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 2500, {
+      functionalAmountMinor: 2500,
+      functionalCurrencyCode: 'ARS',
+    });
+    const incCat = await incomeCategory(ctx.tenant.id);
+    // Income en Building B con OFFSET y snapshot funcional NULL (inválido).
+    const incomeB = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingB.id,
+      currencyCode: 'USD',
+      functionalAmountMinor: null,
+    });
+    await createOffsetApplications(ctx.tenant.id, incomeB.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000, currencyCode: 'USD' },
+    ]);
+
+    const { draft } = await createLiquidationFlow(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    expect(draft.incomeOffsetAmountMinor).toBe(0);
+    expect(draft.totalAmountMinor).toBe(2500);
+  }, 30000);
+
+  it('R2.B. TENANT_SHARED income allocated only to Building B with invalid snapshot does not block Building A', async () => {
+    const ctx = await fixture('r2-shared-isolation');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const buildingB = await building(ctx.tenant.id, 'B');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 2500, {
+      functionalAmountMinor: 2500,
+      functionalCurrencyCode: 'ARS',
+    });
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      scopeType: MovementScope.TENANT_SHARED,
+      currencyCode: 'USD',
+      functionalAmountMinor: null,
+    });
+    await allocateIncome(ctx.tenant.id, income.id, [
+      { buildingId: buildingB.id, amountMinor: 10000 },
+    ]);
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000, currencyCode: 'USD' },
+    ]);
+
+    const { draft } = await createLiquidationFlow(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    expect(draft.incomeOffsetAmountMinor).toBe(0);
+    expect(draft.totalAmountMinor).toBe(2500);
+  }, 30000);
+
+  it('R2.C. TENANT_SHARED income with Building A share > 0 and invalid snapshot rejects 422', async () => {
+    const ctx = await fixture('r2-shared-relevant');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const buildingB = await building(ctx.tenant.id, 'B');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 2500, {
+      functionalAmountMinor: 2500,
+      functionalCurrencyCode: 'ARS',
+    });
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      scopeType: MovementScope.TENANT_SHARED,
+      currencyCode: 'USD',
+      functionalAmountMinor: null,
+    });
+    await allocateIncome(ctx.tenant.id, income.id, [
+      { buildingId: buildingA.id, amountMinor: 6000 },
+      { buildingId: buildingB.id, amountMinor: 4000 },
+    ]);
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 7000, currencyCode: 'USD' },
+    ]);
+
+    await expect(
+      liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+        buildingId: buildingA.id,
+        period: '2026-08',
+        baseCurrency: 'ARS',
+      }),
+    ).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED' },
+    });
+
+    expect(await observer.liquidation.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+  }, 30000);
+
+  // ── R2. Zero-offset V3 lifecycle ─────────────────────────────────────────
+
+  it('R2.D. zero-offset FIN-06 draft publishes V3 with empty offsets and correct audit', async () => {
+    const ctx = await fixture('r2-zero-offset-v3');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+
+    const { draft, reviewed } = await createLiquidationFlow(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    expect(draft.grossExpenseAmountMinor).toBe(10000);
+    expect(draft.adjustmentAmountMinor).toBe(0);
+    expect(draft.preIncomeAmountMinor).toBe(10000);
+    expect(draft.incomeOffsetAmountMinor).toBe(0);
+    expect(draft.netDistributableAmountMinor).toBe(10000);
+    expect(draft.totalAmountMinor).toBe(10000);
+
+    const draftRow = await observer.liquidation.findUniqueOrThrow({ where: { id: draft.id } });
+    expect(draftRow.incomeOffsetSnapshot).toEqual([]);
+    expect(draftRow.incomeOffsetsByCurrency).toEqual({});
+
+    const published = await liquidations.publishLiquidation(ctx.tenant.id, reviewed.id, ctx.membership.id, {
+      dueDate: '2026-09-10',
+    });
+    expect(published.status).toBe('PUBLISHED');
+
+    const row = await observer.liquidation.findUniqueOrThrow({ where: { id: published.id } });
+    const snapshot = row.publicationSnapshot as unknown as {
+      version: number;
+      incomeOffsets: unknown[];
+      incomeOffsetsByCurrency: Record<string, number>;
+      totalAmountMinor: number;
+    };
+    expect(snapshot.version).toBe(3);
+    expect(snapshot.incomeOffsets).toEqual([]);
+    expect(snapshot.incomeOffsetsByCurrency).toEqual({});
+    expect(snapshot.totalAmountMinor).toBe(10000);
+
+    const charges = await observer.charge.findMany({ where: { liquidationId: published.id } });
+    expect(charges).toHaveLength(2);
+    expect(charges.reduce((sum, c) => sum + c.amount, 0)).toBe(10000);
+
+    const audit = await observer.auditLog.findFirst({
+      where: { tenantId: ctx.tenant.id, action: 'LIQUIDATION_PUBLISH' },
+      orderBy: { createdAt: 'desc' },
+    });
+    expect(audit).not.toBeNull();
+    const metadata = audit!.metadata as Record<string, unknown>;
+    expect(metadata.snapshotVersion).toBe(3);
+    expect(metadata.incomeOffsetCount).toBe(0);
+  }, 30000);
+
+  // ── R2. Tamper bypass / classification tests ─────────────────────────────
+
+  async function setupFin06WithOffsets() {
+    const ctx = await fixture('r2-tamper');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await recordedIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      buildingId: buildingA.id,
+    });
+    await createOffsetApplications(ctx.tenant.id, income.id, [
+      { destinationType: IncomeApplicationDestination.OFFSET_EXPENSES, amountMinor: 3000 },
+    ]);
+    // Draft en estado DRAFT (inmutable solo desde REVIEWED por trigger de la DB).
+    const draft = await liquidations.createDraft(ctx.tenant.id, ctx.membership.id, {
+      buildingId: buildingA.id,
+      period: '2026-08',
+      baseCurrency: 'ARS',
+    });
+    expect(draft.incomeOffsetAmountMinor).toBe(3000);
+    const reference = await observer.liquidationIncomeOffset.findFirstOrThrow({
+      where: { tenantId: ctx.tenant.id },
+    });
+    expect(reference).toBeDefined();
+    return { ctx, buildingA, draft, reference };
+  }
+
+  async function corruptAndReview(setup: Awaited<ReturnType<typeof setupFin06WithOffsets>>, data: Record<string, unknown>) {
+    await observer.liquidation.update({
+      where: { id: setup.draft.id },
+      data,
+    });
+    const reviewed = await liquidations.reviewLiquidation(setup.ctx.tenant.id, setup.draft.id, setup.ctx.membership.id);
+    return { ...setup, reviewed };
+  }
+
+  it('R2.E. offset→0 consistent tamper (equation-valid) is rejected, never V2', async () => {
+    const setup = await setupFin06WithOffsets();
+
+    // Corrupción CONSISTENTE: offset 0, net 10000, total 10000 (equations OK).
+    const { reviewed } = await corruptAndReview(setup, {
+      incomeOffsetAmountMinor: 0,
+      netDistributableAmountMinor: 10000,
+      totalAmountMinor: 10000,
+    });
+
+    await expect(
+      liquidations.publishLiquidation(setup.ctx.tenant.id, reviewed.id, setup.ctx.membership.id, {
+        dueDate: '2026-09-10',
+      }),
+    ).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_INCOME_SOURCE_DRIFT' },
+    });
+
+    const row = await observer.liquidation.findUniqueOrThrow({ where: { id: reviewed.id } });
+    expect(row.status).toBe('REVIEWED');
+    expect(row.publicationSnapshot).toBeNull();
+    expect(await observer.charge.count({ where: { liquidationId: reviewed.id } })).toBe(0);
+  }, 30000);
+
+  it('R2.F. all-summary-null with artifacts intact is rejected, never legacy', async () => {
+    const setup = await setupFin06WithOffsets();
+
+    // Todos los summary FIN-06 a NULL (la rama legacy-null del CHECK permite esto),
+    // pero los artifacts (snapshot JSON + relational refs) permanecen.
+    const { reviewed } = await corruptAndReview(setup, {
+      grossExpenseAmountMinor: null,
+      adjustmentAmountMinor: null,
+      preIncomeAmountMinor: null,
+      incomeOffsetAmountMinor: null,
+      netDistributableAmountMinor: null,
+    });
+
+    await expect(
+      liquidations.publishLiquidation(setup.ctx.tenant.id, reviewed.id, setup.ctx.membership.id, {
+        dueDate: '2026-09-10',
+      }),
+    ).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_INCOME_SOURCE_DRIFT' },
+    });
+
+    expect(
+      await observer.liquidation.findUniqueOrThrow({ where: { id: reviewed.id } }),
+    ).toMatchObject({ status: 'REVIEWED' });
+  }, 30000);
+
+  it('R2.G. missing incomeOffsetSnapshot artifact is rejected', async () => {
+    const setup = await setupFin06WithOffsets();
+
+    const { reviewed } = await corruptAndReview(setup, { incomeOffsetSnapshot: null });
+
+    await expect(
+      liquidations.publishLiquidation(setup.ctx.tenant.id, reviewed.id, setup.ctx.membership.id, {
+        dueDate: '2026-09-10',
+      }),
+    ).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_INCOME_SOURCE_DRIFT' },
+    });
+
+    expect(
+      await observer.liquidation.findUniqueOrThrow({ where: { id: reviewed.id } }),
+    ).toMatchObject({ status: 'REVIEWED' });
+  }, 30000);
+
+  it('R2.H. missing incomeOffsetsByCurrency artifact is rejected', async () => {
+    const setup = await setupFin06WithOffsets();
+
+    const { reviewed } = await corruptAndReview(setup, { incomeOffsetsByCurrency: null });
+
+    await expect(
+      liquidations.publishLiquidation(setup.ctx.tenant.id, reviewed.id, setup.ctx.membership.id, {
+        dueDate: '2026-09-10',
+      }),
+    ).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_INCOME_SOURCE_DRIFT' },
+    });
+
+    expect(
+      await observer.liquidation.findUniqueOrThrow({ where: { id: reviewed.id } }),
+    ).toMatchObject({ status: 'REVIEWED' });
+  }, 30000);
+
+  it('R2.I. zero-offset with unexpected reference or snapshot items is rejected', async () => {
+    const setup = await setupFin06WithOffsets();
+
+    // Draft legítimo con offset 3000, pero corrompemos el summary a offset 0
+    // manteniendo snapshot con items y reference: debe rechazar.
+    const { reviewed } = await corruptAndReview(setup, {
+      incomeOffsetAmountMinor: 0,
+      netDistributableAmountMinor: 10000,
+      totalAmountMinor: 10000,
+    });
+
+    await expect(
+      liquidations.publishLiquidation(setup.ctx.tenant.id, reviewed.id, setup.ctx.membership.id, {
+        dueDate: '2026-09-10',
+      }),
+    ).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_INCOME_SOURCE_DRIFT' },
+    });
+
+    expect(
+      await observer.liquidation.findUniqueOrThrow({ where: { id: reviewed.id } }),
+    ).toMatchObject({ status: 'REVIEWED' });
+  }, 30000);
 });

--- a/apps/api/src/finanzas/liquidation-income-offsets.service.spec.ts
+++ b/apps/api/src/finanzas/liquidation-income-offsets.service.spec.ts
@@ -352,23 +352,57 @@ describe('computeIncomeOffsetsForLiquidation (FIN-06)', () => {
     expect(result.items[0]!.valuedAmountMinor).toBe(1050);
   });
 
-  it('FUNCTIONAL: missing functional snapshot yields no offset', () => {
-    const result = computeIncomeOffsetsForLiquidation(
-      [
-        makeIncome({
-          functionalAmountMinor: null,
-          applications: [makeApplication()],
-        }),
-      ],
-      {
-        ...params,
-        valuationMode: 'FUNCTIONAL',
-        baseCurrency: 'ARS',
-      },
-    );
+  it('FUNCTIONAL: missing functional snapshot raises 422 (fail-closed)', () => {
+    const action = () =>
+      computeIncomeOffsetsForLiquidation(
+        [
+          makeIncome({
+            functionalAmountMinor: null,
+            applications: [makeApplication()],
+          }),
+        ],
+        {
+          ...params,
+          valuationMode: 'FUNCTIONAL',
+          baseCurrency: 'ARS',
+        },
+      );
 
-    expect(result.items).toEqual([]);
-    expect(result.incomeOffsetAmountMinor).toBe(0);
+    expect(action).toThrow();
+    try {
+      action();
+    } catch (error) {
+      expect((error as { getResponse(): { error: string } }).getResponse().error).toBe(
+        'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+      );
+    }
+  });
+
+  it('FUNCTIONAL: valid functional amount but currency mismatch raises 422 (fail-closed)', () => {
+    const action = () =>
+      computeIncomeOffsetsForLiquidation(
+        [
+          makeIncome({
+            functionalAmountMinor: 2500,
+            functionalCurrencyCode: 'USD',
+            applications: [makeApplication()],
+          }),
+        ],
+        {
+          ...params,
+          valuationMode: 'FUNCTIONAL',
+          baseCurrency: 'ARS',
+        },
+      );
+
+    expect(action).toThrow();
+    try {
+      action();
+    } catch (error) {
+      expect((error as { getResponse(): { error: string } }).getResponse().error).toBe(
+        'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+      );
+    }
   });
 
   it('LEGACY_NOMINAL: cross-currency offset raises currency mismatch', () => {

--- a/apps/api/src/finanzas/liquidation-income-offsets.service.spec.ts
+++ b/apps/api/src/finanzas/liquidation-income-offsets.service.spec.ts
@@ -459,4 +459,98 @@ describe('computeIncomeOffsetsForLiquidation (FIN-06)', () => {
     expect(result.incomeOffsetAmountMinor).toBe(0);
     expect(result.incomeOffsetsByCurrency).toEqual({});
   });
+
+  describe('FIN-06R2 building eligibility before FUNCTIONAL validation', () => {
+    const functionalParams = {
+      ...params,
+      valuationMode: 'FUNCTIONAL' as const,
+      baseCurrency: 'ARS',
+    };
+
+    it('CASE A: unrelated BUILDING income with invalid FUNCTIONAL snapshot does not block', () => {
+      const result = computeIncomeOffsetsForLiquidation(
+        [
+          makeIncome({
+            buildingId: 'building-b',
+            functionalAmountMinor: null,
+            applications: [makeApplication()],
+          }),
+        ],
+        functionalParams,
+      );
+
+      expect(result.items).toEqual([]);
+      expect(result.incomeOffsetAmountMinor).toBe(0);
+    });
+
+    it('CASE B: TENANT_SHARED income allocated only to another building with invalid FUNCTIONAL snapshot does not block', () => {
+      const result = computeIncomeOffsetsForLiquidation(
+        [
+          makeIncome({
+            buildingId: null,
+            scopeType: 'TENANT_SHARED',
+            functionalAmountMinor: null,
+            allocations: [{ buildingId: 'building-b', amountMinor: 10000 }],
+            applications: [makeApplication()],
+          }),
+        ],
+        functionalParams,
+      );
+
+      expect(result.items).toEqual([]);
+      expect(result.incomeOffsetAmountMinor).toBe(0);
+    });
+
+    it('CASE C: TENANT_SHARED income with share > 0 in this building and invalid snapshot raises 422', () => {
+      const action = () =>
+        computeIncomeOffsetsForLiquidation(
+          [
+            makeIncome({
+              buildingId: null,
+              scopeType: 'TENANT_SHARED',
+              functionalAmountMinor: null,
+              allocations: [
+                { buildingId: 'building-a', amountMinor: 6000 },
+                { buildingId: 'building-b', amountMinor: 4000 },
+              ],
+              applications: [makeApplication()],
+            }),
+          ],
+          functionalParams,
+        );
+
+      expect(action).toThrow();
+      try {
+        action();
+      } catch (error) {
+        expect((error as { getResponse(): { error: string } }).getResponse().error).toBe(
+          'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+        );
+      }
+    });
+
+    it('CASE D: BUILDING income with share > 0 and functional currency mismatch raises 422', () => {
+      const action = () =>
+        computeIncomeOffsetsForLiquidation(
+          [
+            makeIncome({
+              buildingId: 'building-a',
+              functionalAmountMinor: 2500,
+              functionalCurrencyCode: 'USD',
+              applications: [makeApplication()],
+            }),
+          ],
+          functionalParams,
+        );
+
+      expect(action).toThrow();
+      try {
+        action();
+      } catch (error) {
+        expect((error as { getResponse(): { error: string } }).getResponse().error).toBe(
+          'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+        );
+      }
+    });
+  });
 });

--- a/apps/api/src/finanzas/liquidation-income-offsets.service.spec.ts
+++ b/apps/api/src/finanzas/liquidation-income-offsets.service.spec.ts
@@ -1,0 +1,428 @@
+import { IncomeApplicationDestination } from '@prisma/client';
+import {
+  computeIncomeOffsetsForLiquidation,
+  type IncomeWithApplications,
+} from './liquidation-income-offsets.service';
+import { distributeMinorByWeights } from './income-offset-allocation';
+
+function makeIncome(overrides: Partial<IncomeWithApplications> = {}): IncomeWithApplications {
+  return {
+    id: 'income-1',
+    buildingId: 'building-a',
+    period: '2026-08',
+    scopeType: 'BUILDING',
+    status: 'RECORDED',
+    functionalAmountMinor: null,
+    functionalCurrencyCode: null,
+    exchangeRateId: null,
+    exchangeRateValue: null,
+    exchangeRateDirection: null,
+    exchangeRateEffectiveAt: null,
+    conversionDate: null,
+    receivedDate: new Date('2026-08-10T00:00:00.000Z'),
+    categoryId: 'cat-1',
+    category: { name: 'Parrillera' },
+    allocations: [],
+    applications: [],
+    ...overrides,
+  };
+}
+
+function makeApplication(overrides: Partial<IncomeWithApplications['applications'][number]> = {}) {
+  return {
+    id: 'app-offset',
+    destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+    amountMinor: 7000,
+    currencyCode: 'USD',
+    policyVersionId: null,
+    ...overrides,
+  };
+}
+
+const params = {
+  tenantId: 'tenant-1',
+  buildingId: 'building-a',
+  period: '2026-08',
+  valuationMode: 'LEGACY_NOMINAL' as const,
+  baseCurrency: 'USD',
+};
+
+describe('computeIncomeOffsetsForLiquidation (FIN-06)', () => {
+  it('returns empty when income has no OFFSET applications', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          applications: [
+            { ...makeApplication(), destinationType: IncomeApplicationDestination.FUND },
+          ],
+        }),
+      ],
+      params,
+    );
+
+    expect(result.items).toEqual([]);
+    expect(result.incomeOffsetAmountMinor).toBe(0);
+  });
+
+  it('OFFSET reduces net (nominal)', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          applications: [makeApplication()],
+        }),
+      ],
+      params,
+    );
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]!.valuedAmountMinor).toBe(7000);
+    expect(result.incomeOffsetAmountMinor).toBe(7000);
+  });
+
+  it('FUND applications do not reduce net', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          applications: [
+            { ...makeApplication(), id: 'app-fund', destinationType: IncomeApplicationDestination.FUND },
+          ],
+        }),
+      ],
+      params,
+    );
+
+    expect(result.items).toEqual([]);
+    expect(result.incomeOffsetAmountMinor).toBe(0);
+  });
+
+  it('CARRY_FORWARD applications do not reduce net', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          applications: [
+            { ...makeApplication(), id: 'app-carry', destinationType: IncomeApplicationDestination.CARRY_FORWARD },
+          ],
+        }),
+      ],
+      params,
+    );
+
+    expect(result.items).toEqual([]);
+    expect(result.incomeOffsetAmountMinor).toBe(0);
+  });
+
+  it('sums multiple offset applications', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          applications: [
+            makeApplication({ id: 'off-1', amountMinor: 4000 }),
+            makeApplication({ id: 'off-2', amountMinor: 3000 }),
+          ],
+        }),
+      ],
+      params,
+    );
+
+    expect(result.items).toHaveLength(2);
+    expect(result.incomeOffsetAmountMinor).toBe(7000);
+  });
+
+  it('ignores applications from another period', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          period: '2026-07',
+          applications: [makeApplication()],
+        }),
+      ],
+      params,
+    );
+
+    expect(result.items).toEqual([]);
+  });
+
+  it('ignores applications from a VOID income', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          status: 'VOID',
+          applications: [makeApplication()],
+        }),
+      ],
+      params,
+    );
+
+    expect(result.items).toEqual([]);
+  });
+
+  it('ignores applications from a DRAFT income', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          status: 'DRAFT',
+          applications: [makeApplication()],
+        }),
+      ],
+      params,
+    );
+
+    expect(result.items).toEqual([]);
+  });
+
+  it('BUILDING scope: offset for the matching building', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          buildingId: 'building-a',
+          applications: [makeApplication()],
+        }),
+      ],
+      params,
+    );
+
+    expect(result.incomeOffsetAmountMinor).toBe(7000);
+  });
+
+  it('BUILDING scope: offset for another building is ignored', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          buildingId: 'building-b',
+          applications: [makeApplication()],
+        }),
+      ],
+      params,
+    );
+
+    expect(result.items).toEqual([]);
+    expect(result.incomeOffsetAmountMinor).toBe(0);
+  });
+
+  it('TENANT_SHARED 60/40: building-a gets 4200', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          buildingId: null,
+          scopeType: 'TENANT_SHARED',
+          allocations: [
+            { buildingId: 'building-a', amountMinor: 6000 },
+            { buildingId: 'building-b', amountMinor: 4000 },
+          ],
+          applications: [
+            makeApplication({ amountMinor: 7000 }),
+            makeApplication({ id: 'app-fund', destinationType: IncomeApplicationDestination.FUND, amountMinor: 3000 }),
+          ],
+        }),
+      ],
+      params,
+    );
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]!.buildingAmountMinor).toBe(4200);
+    expect(result.items[0]!.valuedAmountMinor).toBe(4200);
+    expect(result.incomeOffsetAmountMinor).toBe(4200);
+  });
+
+  it('TENANT_SHARED deterministic rounding with odd totals', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          buildingId: null,
+          scopeType: 'TENANT_SHARED',
+          allocations: [
+            { buildingId: 'building-a', amountMinor: 6000 },
+            { buildingId: 'building-b', amountMinor: 4000 },
+          ],
+          applications: [makeApplication({ amountMinor: 10001 })],
+        }),
+      ],
+      params,
+    );
+
+    // La share de building-a debe ser 6001 (largest remainder sobre 6000/4000)
+    // y la suma de todas las shares del building == monto de la aplicación.
+    expect(result.items[0]!.buildingAmountMinor).toBe(6001);
+    const allShares = distributeMinorByWeights(10001, [
+      { buildingId: 'building-a', amountMinor: 6000 },
+      { buildingId: 'building-b', amountMinor: 4000 },
+    ]);
+    expect(allShares.reduce((sum, item) => sum + item.amountMinor, 0)).toBe(10001);
+    expect(result.incomeOffsetAmountMinor).toBe(6001);
+  });
+
+  it('manual application (policyVersionId null) works', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          applications: [makeApplication({ policyVersionId: null })],
+        }),
+      ],
+      params,
+    );
+
+    expect(result.items[0]!.policyVersionId).toBeNull();
+    expect(result.incomeOffsetAmountMinor).toBe(7000);
+  });
+
+  it('policy application preserves policyVersionId provenance', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          applications: [makeApplication({ policyVersionId: 'pv-1' })],
+        }),
+      ],
+      params,
+    );
+
+    expect(result.items[0]!.policyVersionId).toBe('pv-1');
+  });
+
+  it('FUNCTIONAL: uses frozen functional snapshot per application', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          functionalAmountMinor: 2500,
+          functionalCurrencyCode: 'ARS',
+          applications: [
+            makeApplication({ amountMinor: 7000 }),
+            makeApplication({ id: 'app-fund', destinationType: IncomeApplicationDestination.FUND, amountMinor: 3000 }),
+          ],
+        }),
+      ],
+      {
+        ...params,
+        valuationMode: 'FUNCTIONAL',
+        baseCurrency: 'ARS',
+      },
+    );
+
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]!.valuedAmountMinor).toBe(1750);
+    expect(result.incomeOffsetAmountMinor).toBe(1750);
+  });
+
+  it('FUNCTIONAL: functional allocation is exact across applications', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          functionalAmountMinor: 2501,
+          functionalCurrencyCode: 'ARS',
+          applications: [
+            makeApplication({ amountMinor: 7000 }),
+            makeApplication({ id: 'app-fund', destinationType: IncomeApplicationDestination.FUND, amountMinor: 3000 }),
+          ],
+        }),
+      ],
+      {
+        ...params,
+        valuationMode: 'FUNCTIONAL',
+        baseCurrency: 'ARS',
+      },
+    );
+
+    expect(result.incomeOffsetAmountMinor).toBeGreaterThan(0);
+  });
+
+  it('FUNCTIONAL: shared income distributes functional value by building', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          buildingId: null,
+          scopeType: 'TENANT_SHARED',
+          functionalAmountMinor: 2500,
+          functionalCurrencyCode: 'ARS',
+          allocations: [
+            { buildingId: 'building-a', amountMinor: 6000 },
+            { buildingId: 'building-b', amountMinor: 4000 },
+          ],
+          applications: [
+            makeApplication({ amountMinor: 7000 }),
+            makeApplication({ id: 'app-fund', destinationType: IncomeApplicationDestination.FUND, amountMinor: 3000 }),
+          ],
+        }),
+      ],
+      {
+        ...params,
+        valuationMode: 'FUNCTIONAL',
+        baseCurrency: 'ARS',
+      },
+    );
+
+    expect(result.items[0]!.valuedAmountMinor).toBe(1050);
+  });
+
+  it('FUNCTIONAL: missing functional snapshot yields no offset', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          functionalAmountMinor: null,
+          applications: [makeApplication()],
+        }),
+      ],
+      {
+        ...params,
+        valuationMode: 'FUNCTIONAL',
+        baseCurrency: 'ARS',
+      },
+    );
+
+    expect(result.items).toEqual([]);
+    expect(result.incomeOffsetAmountMinor).toBe(0);
+  });
+
+  it('LEGACY_NOMINAL: cross-currency offset raises currency mismatch', () => {
+    const action = () =>
+      computeIncomeOffsetsForLiquidation(
+        [
+          makeIncome({
+            applications: [makeApplication({ currencyCode: 'USD' })],
+          }),
+        ],
+        {
+          ...params,
+          baseCurrency: 'ARS',
+        },
+      );
+
+    expect(action).toThrow();
+    try {
+      action();
+    } catch (error) {
+      expect((error as { getResponse(): { error: string } }).getResponse().error).toBe(
+        'LIQUIDATION_INCOME_OFFSET_CURRENCY_MISMATCH',
+      );
+    }
+  });
+
+  it('produces relational references with valued amounts', () => {
+    const result = computeIncomeOffsetsForLiquidation(
+      [
+        makeIncome({
+          applications: [makeApplication()],
+        }),
+      ],
+      params,
+    );
+
+    expect(result.references).toEqual([
+      {
+        incomeApplicationId: 'app-offset',
+        buildingId: 'building-a',
+        originalAmountMinor: 7000,
+        currencyCode: 'USD',
+        valuedAmountMinor: 7000,
+        baseCurrency: 'USD',
+      },
+    ]);
+  });
+
+  it('returns empty result for no incomes', () => {
+    const result = computeIncomeOffsetsForLiquidation([], params);
+
+    expect(result.items).toEqual([]);
+    expect(result.references).toEqual([]);
+    expect(result.incomeOffsetAmountMinor).toBe(0);
+    expect(result.incomeOffsetsByCurrency).toEqual({});
+  });
+});

--- a/apps/api/src/finanzas/liquidation-income-offsets.service.ts
+++ b/apps/api/src/finanzas/liquidation-income-offsets.service.ts
@@ -1,7 +1,8 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnprocessableEntityException } from '@nestjs/common';
 import { IncomeApplicationDestination, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import {
+  assertFunctionalSnapshotForLiquidation,
   deriveApplicationFunctionalValues,
   distributeMinorByWeights,
   resolveIncomeOffsetBuildingShare,
@@ -117,16 +118,24 @@ export function computeIncomeOffsetsForLiquidation(
       continue;
     }
 
+    // Fail-closed (FIN-06R): en modo FUNCTIONAL, un income con OFFSET elegible
+    // debe poseer snapshot funcional convergente; si no → 422. El dinero
+    // elegible NUNCA desaparece silenciosamente.
+    if (params.valuationMode === 'FUNCTIONAL') {
+      assertFunctionalSnapshotForLiquidation({
+        incomeId: income.id,
+        functionalAmountMinor: income.functionalAmountMinor,
+        functionalCurrencyCode: income.functionalCurrencyCode,
+        baseCurrency: params.baseCurrency,
+      });
+    }
+
     // Valuación funcional por aplicación (todas las apps del income, incl.
     // FUND/CARRY) para reconciliar exactamente a income.functionalAmountMinor.
     let functionalByApplicationId = new Map<string, number>();
-    if (
-      params.valuationMode === 'FUNCTIONAL' &&
-      income.functionalAmountMinor !== null &&
-      income.functionalAmountMinor > 0
-    ) {
+    if (params.valuationMode === 'FUNCTIONAL') {
       const derived = deriveApplicationFunctionalValues({
-        incomeFunctionalAmountMinor: income.functionalAmountMinor,
+        incomeFunctionalAmountMinor: income.functionalAmountMinor as number,
         applications: income.applications,
       });
       functionalByApplicationId = new Map(
@@ -160,11 +169,16 @@ export function computeIncomeOffsetsForLiquidation(
         const applicationFunctionalValue = functionalByApplicationId.get(application.id);
 
         if (applicationFunctionalValue === undefined || applicationFunctionalValue <= 0) {
-          continue; // sin snapshot funcional convergente → no valora
+          // Fail-closed: nunca omitir silenciosamente una aplicación elegible.
+          throw new UnprocessableEntityException({
+            statusCode: 422,
+            error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+            message: `La aplicación OFFSET ${application.id} no posee valor funcional válido`,
+          });
         }
 
         // Distribuir el valor funcional de la aplicación entre buildings con
-        // los mismos weights (largest remainder determinístico).
+        // los mismos weights (largest remainder determinístico exacto).
         const functionalShares =
           allocationWeights.length > 0
             ? distributeMinorByWeights(applicationFunctionalValue, allocationWeights)

--- a/apps/api/src/finanzas/liquidation-income-offsets.service.ts
+++ b/apps/api/src/finanzas/liquidation-income-offsets.service.ts
@@ -118,9 +118,40 @@ export function computeIncomeOffsetsForLiquidation(
       continue;
     }
 
-    // Fail-closed (FIN-06R): en modo FUNCTIONAL, un income con OFFSET elegible
-    // debe poseer snapshot funcional convergente; si no → 422. El dinero
-    // elegible NUNCA desaparece silenciosamente.
+    const allocationWeights: BuildingAllocationWeight[] = income.allocations
+      .filter((allocation) => allocation.amountMinor !== null && allocation.amountMinor > 0)
+      .map((allocation) => ({
+        buildingId: allocation.buildingId,
+        amountMinor: allocation.amountMinor as number,
+      }));
+
+    // FIN-06R2: la elegibilidad del building se determina ANTES de la
+    // validación funcional. Un Income cuyos OFFSET no participan en este
+    // building (share 0 en todos) se ignora para esta liquidación, aunque su
+    // snapshot funcional esté dañado: el dinero de otro building no puede
+    // bloquear esta liquidación.
+    const buildingShares = offsetApplications.map((application) => ({
+      application,
+      buildingAmountMinor: resolveIncomeOffsetBuildingShare({
+        applicationAmountMinor: application.amountMinor,
+        applicationScopeType: income.scopeType,
+        incomeBuildingId: income.buildingId,
+        liquidationBuildingId: params.buildingId,
+        allocationWeights,
+      }),
+    }));
+
+    const relevantApplications = buildingShares.filter(
+      (entry) => entry.buildingAmountMinor > 0,
+    );
+
+    if (relevantApplications.length === 0) {
+      continue; // este income no participa en el building de la liquidación
+    }
+
+    // Fail-closed (FIN-06R): SOLO cuando el income realmente participa en este
+    // building, en modo FUNCTIONAL, el snapshot funcional debe converger;
+    // si no → 422. El dinero elegible NUNCA desaparece silenciosamente.
     if (params.valuationMode === 'FUNCTIONAL') {
       assertFunctionalSnapshotForLiquidation({
         incomeId: income.id,
@@ -143,26 +174,7 @@ export function computeIncomeOffsetsForLiquidation(
       );
     }
 
-    const allocationWeights: BuildingAllocationWeight[] = income.allocations
-      .filter((allocation) => allocation.amountMinor !== null && allocation.amountMinor > 0)
-      .map((allocation) => ({
-        buildingId: allocation.buildingId,
-        amountMinor: allocation.amountMinor as number,
-      }));
-
-    for (const application of offsetApplications) {
-      const buildingAmountMinor = resolveIncomeOffsetBuildingShare({
-        applicationAmountMinor: application.amountMinor,
-        applicationScopeType: income.scopeType,
-        incomeBuildingId: income.buildingId,
-        liquidationBuildingId: params.buildingId,
-        allocationWeights,
-      });
-
-      if (buildingAmountMinor <= 0) {
-        continue; // la aplicación no pertenece a este building
-      }
-
+    for (const { application, buildingAmountMinor } of relevantApplications) {
       let valuedAmountMinor: number;
 
       if (params.valuationMode === 'FUNCTIONAL') {
@@ -259,15 +271,16 @@ export class LiquidationIncomeOffsetsService {
 
   /**
    * Selecciona los Incomes con OFFSET elegibles para el draft, toma los income
-   * locks en orden determinístico y revalida después del lock
-   * (race void vs draft → serializable; void que gana excluye el income).
+   * locks en orden determinístico y RE-CARGA el estado completo DESPUÉS del
+   * lock (race void vs draft → serializable; void que gana excluye el income;
+   * sin estado stale pre-lock).
    */
   async collectEligibleOffsets(
     tx: Prisma.TransactionClient,
     params: ComputeIncomeOffsetsInput,
   ): Promise<LiquidationIncomeOffsetsResult> {
-    // 1. Incomes RECORDED del período con al menos una aplicación OFFSET.
-    const incomes = await tx.income.findMany({
+    // 1. Query inicial SOLO para descubrir incomeIds candidatos.
+    const candidateIds = await tx.income.findMany({
       where: {
         tenantId: params.tenantId,
         period: params.period,
@@ -278,6 +291,35 @@ export class LiquidationIncomeOffsetsService {
             destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
           },
         },
+      },
+      select: { id: true },
+    });
+
+    const incomeIds = candidateIds.map((income) => income.id).sort();
+
+    if (incomeIds.length === 0) {
+      return {
+        items: [],
+        references: [],
+        incomeOffsetAmountMinor: 0,
+        incomeOffsetsByCurrency: {},
+      };
+    }
+
+    // 2. Income locks en orden determinístico por incomeId (void vs draft).
+    for (const incomeId of incomeIds) {
+      await acquireIncomeLock(tx, params.tenantId, incomeId);
+    }
+
+    // 3. POST-LOCK: cargar el estado COMPLETO necesario (income + status +
+    //    period + scope + building + snapshot funcional + category +
+    //    allocations + applications). Nunca calcular sobre lectura pre-lock.
+    const reloaded = await tx.income.findMany({
+      where: {
+        tenantId: params.tenantId,
+        id: { in: incomeIds },
+        status: 'RECORDED',
+        period: params.period,
       },
       include: {
         category: { select: { name: true } },
@@ -298,35 +340,8 @@ export class LiquidationIncomeOffsetsService {
       },
     });
 
-    if (incomes.length === 0) {
-      return {
-        items: [],
-        references: [],
-        incomeOffsetAmountMinor: 0,
-        incomeOffsetsByCurrency: {},
-      };
-    }
-
-    // 2. Income locks en orden determinístico por incomeId (void vs draft).
-    const incomeIds = incomes.map((income) => income.id).sort();
-    for (const incomeId of incomeIds) {
-      await acquireIncomeLock(tx, params.tenantId, incomeId);
-    }
-
-    // 3. Revalidación post-lock: income debe seguir RECORDED con el mismo período.
-    const lockedIncomes = await tx.income.findMany({
-      where: { tenantId: params.tenantId, id: { in: incomeIds } },
-      select: { id: true, status: true, period: true },
-    });
-    const incomeById = new Map(lockedIncomes.map((income) => [income.id, income]));
-
-    const revalidated = incomes.filter((income) => {
-      const locked = incomeById.get(income.id);
-      return locked !== undefined && locked.status === 'RECORDED' && locked.period === params.period;
-    });
-
     return computeIncomeOffsetsForLiquidation(
-      revalidated as unknown as IncomeWithApplications[],
+      reloaded as unknown as IncomeWithApplications[],
       params,
     );
   }

--- a/apps/api/src/finanzas/liquidation-income-offsets.service.ts
+++ b/apps/api/src/finanzas/liquidation-income-offsets.service.ts
@@ -1,0 +1,319 @@
+import { Injectable } from '@nestjs/common';
+import { IncomeApplicationDestination, Prisma } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import {
+  deriveApplicationFunctionalValues,
+  distributeMinorByWeights,
+  resolveIncomeOffsetBuildingShare,
+  valueIncomeOffsetForLiquidation,
+  type BuildingAllocationWeight,
+} from './income-offset-allocation';
+import { acquireIncomeLock } from './fund-locks';
+
+/**
+ * FIN-06: selección y valuación de IncomeApplications OFFSET_EXPENSES
+ * para una Liquidation (draft-time snapshot + referencias relacionales).
+ *
+ * El draft congela las fuentes: nunca se recalculan contra estado live al
+ * publicar. La referencia relacional LiquidationIncomeOffset protege el void.
+ *
+ * Movimiento ↔ aplicación:
+ * - MovementAllocation decide A QUÉ building pertenece el movimiento.
+ * - IncomeApplication decide QUÉ se hace con el dinero (OFFSET/FUND/CARRY).
+ */
+
+export interface IncomeOffsetSnapshotItem extends Prisma.InputJsonObject {
+  incomeId: string;
+  incomeApplicationId: string;
+  categoryId: string;
+  categoryName: string | null;
+  policyVersionId: string | null;
+  scopeType: string;
+  currencyCode: string;
+  applicationAmountMinor: number;
+  buildingAmountMinor: number;
+  valuedAmountMinor: number;
+  functionalCurrencyCode: string | null;
+  exchangeRateId: string | null;
+  exchangeRateValue: string | null;
+  exchangeRateDirection: string | null;
+  exchangeRateEffectiveAt: string | null;
+  conversionDate: string | null;
+  receivedDate: string;
+  period: string;
+}
+
+export interface LiquidationIncomeOffsetsResult {
+  readonly items: IncomeOffsetSnapshotItem[];
+  readonly references: Array<{
+    incomeApplicationId: string;
+    buildingId: string;
+    originalAmountMinor: number;
+    currencyCode: string;
+    valuedAmountMinor: number;
+    baseCurrency: string;
+  }>;
+  readonly incomeOffsetAmountMinor: number;
+  readonly incomeOffsetsByCurrency: Record<string, number>;
+}
+
+interface IncomeWithApplications {
+  id: string;
+  buildingId: string | null;
+  period: string;
+  scopeType: 'BUILDING' | 'TENANT_SHARED' | 'UNIT_GROUP';
+  status: 'DRAFT' | 'RECORDED' | 'VOID';
+  functionalAmountMinor: number | null;
+  functionalCurrencyCode: string | null;
+  exchangeRateId: string | null;
+  exchangeRateValue: Prisma.Decimal | string | null;
+  exchangeRateDirection: string | null;
+  exchangeRateEffectiveAt: Date | null;
+  conversionDate: Date | null;
+  receivedDate: Date;
+  categoryId: string;
+  category: { name: string } | null;
+  allocations: Array<{
+    buildingId: string;
+    amountMinor: number | null;
+  }>;
+  applications: Array<{
+    id: string;
+    destinationType: IncomeApplicationDestination;
+    amountMinor: number;
+    currencyCode: string;
+    policyVersionId: string | null;
+  }>;
+}
+
+export interface ComputeIncomeOffsetsInput {
+  readonly tenantId: string;
+  readonly buildingId: string;
+  readonly period: string;
+  readonly valuationMode: 'FUNCTIONAL' | 'LEGACY_NOMINAL';
+  readonly baseCurrency: string;
+}
+
+export function computeIncomeOffsetsForLiquidation(
+  incomes: readonly IncomeWithApplications[],
+  params: ComputeIncomeOffsetsInput,
+): LiquidationIncomeOffsetsResult {
+  const items: IncomeOffsetSnapshotItem[] = [];
+  const references: LiquidationIncomeOffsetsResult['references'] = [];
+  let incomeOffsetAmountMinor = 0;
+
+  for (const income of incomes) {
+    // Defensivo: solo incomes RECORDED del período de la liquidación.
+    if (income.status !== 'RECORDED' || income.period !== params.period) {
+      continue;
+    }
+
+    const offsetApplications = income.applications.filter(
+      (application) =>
+        application.destinationType === IncomeApplicationDestination.OFFSET_EXPENSES,
+    );
+
+    if (offsetApplications.length === 0) {
+      continue;
+    }
+
+    // Valuación funcional por aplicación (todas las apps del income, incl.
+    // FUND/CARRY) para reconciliar exactamente a income.functionalAmountMinor.
+    let functionalByApplicationId = new Map<string, number>();
+    if (
+      params.valuationMode === 'FUNCTIONAL' &&
+      income.functionalAmountMinor !== null &&
+      income.functionalAmountMinor > 0
+    ) {
+      const derived = deriveApplicationFunctionalValues({
+        incomeFunctionalAmountMinor: income.functionalAmountMinor,
+        applications: income.applications,
+      });
+      functionalByApplicationId = new Map(
+        derived.map((item) => [item.applicationId, item.functionalAmountMinor]),
+      );
+    }
+
+    const allocationWeights: BuildingAllocationWeight[] = income.allocations
+      .filter((allocation) => allocation.amountMinor !== null && allocation.amountMinor > 0)
+      .map((allocation) => ({
+        buildingId: allocation.buildingId,
+        amountMinor: allocation.amountMinor as number,
+      }));
+
+    for (const application of offsetApplications) {
+      const buildingAmountMinor = resolveIncomeOffsetBuildingShare({
+        applicationAmountMinor: application.amountMinor,
+        applicationScopeType: income.scopeType,
+        incomeBuildingId: income.buildingId,
+        liquidationBuildingId: params.buildingId,
+        allocationWeights,
+      });
+
+      if (buildingAmountMinor <= 0) {
+        continue; // la aplicación no pertenece a este building
+      }
+
+      let valuedAmountMinor: number;
+
+      if (params.valuationMode === 'FUNCTIONAL') {
+        const applicationFunctionalValue = functionalByApplicationId.get(application.id);
+
+        if (applicationFunctionalValue === undefined || applicationFunctionalValue <= 0) {
+          continue; // sin snapshot funcional convergente → no valora
+        }
+
+        // Distribuir el valor funcional de la aplicación entre buildings con
+        // los mismos weights (largest remainder determinístico).
+        const functionalShares =
+          allocationWeights.length > 0
+            ? distributeMinorByWeights(applicationFunctionalValue, allocationWeights)
+            : [{ buildingId: params.buildingId, amountMinor: applicationFunctionalValue }];
+
+        valuedAmountMinor =
+          functionalShares.find((share) => share.buildingId === params.buildingId)?.amountMinor ??
+          0;
+
+        if (valuedAmountMinor <= 0) {
+          continue;
+        }
+      } else {
+        // LEGACY_NOMINAL: moneda debe coincidir con baseCurrency.
+        valueIncomeOffsetForLiquidation({
+          application: {
+            id: application.id,
+            amountMinor: application.amountMinor,
+            currencyCode: application.currencyCode,
+            functionalAmountMinor: null,
+            functionalCurrencyCode: null,
+          },
+          valuationMode: params.valuationMode,
+          baseCurrency: params.baseCurrency,
+        });
+        valuedAmountMinor = buildingAmountMinor;
+      }
+
+      items.push({
+        incomeId: income.id,
+        incomeApplicationId: application.id,
+        categoryId: income.categoryId,
+        categoryName: income.category?.name ?? null,
+        policyVersionId: application.policyVersionId,
+        scopeType: income.scopeType,
+        currencyCode: application.currencyCode,
+        applicationAmountMinor: application.amountMinor,
+        buildingAmountMinor,
+        valuedAmountMinor,
+        functionalCurrencyCode: income.functionalCurrencyCode,
+        exchangeRateId: income.exchangeRateId,
+        exchangeRateValue:
+          income.exchangeRateValue === null || income.exchangeRateValue === undefined
+            ? null
+            : income.exchangeRateValue.toString(),
+        exchangeRateDirection: income.exchangeRateDirection,
+        exchangeRateEffectiveAt: income.exchangeRateEffectiveAt?.toISOString() ?? null,
+        conversionDate: income.conversionDate?.toISOString() ?? null,
+        receivedDate: income.receivedDate.toISOString(),
+        period: income.period,
+      });
+
+      references.push({
+        incomeApplicationId: application.id,
+        buildingId: params.buildingId,
+        originalAmountMinor: buildingAmountMinor,
+        currencyCode: application.currencyCode,
+        valuedAmountMinor,
+        baseCurrency: params.baseCurrency,
+      });
+
+      incomeOffsetAmountMinor += valuedAmountMinor;
+    }
+  }
+
+  return {
+    items,
+    references,
+    incomeOffsetAmountMinor,
+    incomeOffsetsByCurrency:
+      incomeOffsetAmountMinor > 0 ? { [params.baseCurrency]: incomeOffsetAmountMinor } : {},
+  };
+}
+
+@Injectable()
+export class LiquidationIncomeOffsetsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Selecciona los Incomes con OFFSET elegibles para el draft, toma los income
+   * locks en orden determinístico y revalida después del lock
+   * (race void vs draft → serializable; void que gana excluye el income).
+   */
+  async collectEligibleOffsets(
+    tx: Prisma.TransactionClient,
+    params: ComputeIncomeOffsetsInput,
+  ): Promise<LiquidationIncomeOffsetsResult> {
+    // 1. Incomes RECORDED del período con al menos una aplicación OFFSET.
+    const incomes = await tx.income.findMany({
+      where: {
+        tenantId: params.tenantId,
+        period: params.period,
+        status: 'RECORDED',
+        applications: {
+          some: {
+            tenantId: params.tenantId,
+            destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+          },
+        },
+      },
+      include: {
+        category: { select: { name: true } },
+        allocations: {
+          where: { tenantId: params.tenantId },
+          select: { buildingId: true, amountMinor: true },
+        },
+        applications: {
+          where: { tenantId: params.tenantId },
+          select: {
+            id: true,
+            destinationType: true,
+            amountMinor: true,
+            currencyCode: true,
+            policyVersionId: true,
+          },
+        },
+      },
+    });
+
+    if (incomes.length === 0) {
+      return {
+        items: [],
+        references: [],
+        incomeOffsetAmountMinor: 0,
+        incomeOffsetsByCurrency: {},
+      };
+    }
+
+    // 2. Income locks en orden determinístico por incomeId (void vs draft).
+    const incomeIds = incomes.map((income) => income.id).sort();
+    for (const incomeId of incomeIds) {
+      await acquireIncomeLock(tx, params.tenantId, incomeId);
+    }
+
+    // 3. Revalidación post-lock: income debe seguir RECORDED con el mismo período.
+    const lockedIncomes = await tx.income.findMany({
+      where: { tenantId: params.tenantId, id: { in: incomeIds } },
+      select: { id: true, status: true, period: true },
+    });
+    const incomeById = new Map(lockedIncomes.map((income) => [income.id, income]));
+
+    const revalidated = incomes.filter((income) => {
+      const locked = incomeById.get(income.id);
+      return locked !== undefined && locked.status === 'RECORDED' && locked.period === params.period;
+    });
+
+    return computeIncomeOffsetsForLiquidation(
+      revalidated as unknown as IncomeWithApplications[],
+      params,
+    );
+  }
+}

--- a/apps/api/src/finanzas/liquidation-publication-snapshot.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication-snapshot.spec.ts
@@ -2,6 +2,7 @@ import { BadRequestException, UnprocessableEntityException } from '@nestjs/commo
 import {
   assertLiquidationMovementCurrency,
   buildLiquidationPublicationSnapshot,
+  buildLiquidationPublicationSnapshotV3,
   distributeLiquidationAmountByLargestRemainder,
   parseLiquidationPublicationSnapshot,
 } from './liquidation-publication-snapshot';
@@ -441,6 +442,151 @@ describe('liquidation publication snapshot', () => {
 
       const parsed = parseLiquidationPublicationSnapshot(legacyV1);
       expect(parsed).toMatchObject({ version: 1, totalAmountMinor: 50 });
+    });
+  });
+
+  describe('publication snapshot v3 (FIN-06)', () => {
+    const v3Input = {
+      liquidationId: 'liq-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      period: '2026-08',
+      baseCurrency: 'ARS',
+      totalAmountMinor: 3000,
+      totalsByCurrency: { ARS: 10000 },
+      grossExpenseAmountMinor: 10000,
+      adjustmentAmountMinor: 0,
+      preIncomeAmountMinor: 10000,
+      incomeOffsetAmountMinor: 7000,
+      netDistributableAmountMinor: 3000,
+      incomeOffsetsByCurrency: { ARS: 7000 },
+      valuationMode: 'LEGACY_NOMINAL' as const,
+      expenses: [
+        {
+          expenseId: 'exp-1',
+          categoryName: 'Maintenance',
+          vendorName: null,
+          amountMinor: 10000,
+          currencyCode: 'ARS',
+          invoiceDate: '2026-08-05T00:00:00.000Z',
+          description: null,
+          type: 'EXPENSE' as const,
+        },
+      ],
+      incomeOffsets: [
+        {
+          incomeId: 'income-1',
+          incomeApplicationId: 'app-offset-1',
+          categoryId: 'cat-1',
+          categoryName: 'Parrillera',
+          policyVersionId: 'pv-1',
+          scopeType: 'BUILDING',
+          currencyCode: 'ARS',
+          applicationAmountMinor: 7000,
+          buildingAmountMinor: 7000,
+          valuedAmountMinor: 7000,
+          functionalCurrencyCode: null,
+          exchangeRateId: null,
+          exchangeRateValue: null,
+          exchangeRateDirection: null,
+          exchangeRateEffectiveAt: null,
+          conversionDate: null,
+          receivedDate: '2026-08-10T00:00:00.000Z',
+          period: '2026-08',
+        },
+      ],
+      allocations: [
+        { unitId: 'unit-1', unitCode: '1A', unitLabel: '1A', amountMinor: 3000 },
+      ],
+      dueDate: new Date('2026-09-10T00:00:00.000Z'),
+      publishedAt: new Date('2026-08-16T00:00:00.000Z'),
+    };
+
+    it('builds version 3 with income offsets and reconciliation', () => {
+      const snapshot = buildLiquidationPublicationSnapshotV3(v3Input);
+
+      expect(snapshot).toMatchObject({
+        version: 3,
+        valuationMode: 'LEGACY_NOMINAL',
+        grossExpenseAmountMinor: 10000,
+        incomeOffsetAmountMinor: 7000,
+        netDistributableAmountMinor: 3000,
+        totalAmountMinor: 3000,
+      });
+      expect(snapshot.incomeOffsets).toHaveLength(1);
+      expect(snapshot.incomeOffsets[0]).toMatchObject({
+        incomeApplicationId: 'app-offset-1',
+        policyVersionId: 'pv-1',
+        valuedAmountMinor: 7000,
+      });
+    });
+
+    it('parses version 3 back with full provenance', () => {
+      const snapshot = buildLiquidationPublicationSnapshotV3(v3Input);
+      const parsed = parseLiquidationPublicationSnapshot(snapshot);
+
+      expect(parsed).toMatchObject({
+        version: 3,
+        grossExpenseAmountMinor: 10000,
+        preIncomeAmountMinor: 10000,
+        incomeOffsetAmountMinor: 7000,
+        netDistributableAmountMinor: 3000,
+        totalAmountMinor: 3000,
+      });
+      expect(parsed?.incomeOffsets[0]).toMatchObject({
+        incomeId: 'income-1',
+        policyVersionId: 'pv-1',
+        applicationAmountMinor: 7000,
+      });
+    });
+
+    it('rejects v3 when expense sources do not match pre-income', () => {
+      expect(() =>
+        buildLiquidationPublicationSnapshotV3({
+          ...v3Input,
+          grossExpenseAmountMinor: 9000,
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('rejects v3 when income offsets do not match the offset total', () => {
+      expect(() =>
+        buildLiquidationPublicationSnapshotV3({
+          ...v3Input,
+          incomeOffsetAmountMinor: 6000,
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('rejects v3 when allocations do not match the net total', () => {
+      expect(() =>
+        buildLiquidationPublicationSnapshotV3({
+          ...v3Input,
+          allocations: [
+            { unitId: 'unit-1', unitCode: '1A', unitLabel: '1A', amountMinor: 3001 },
+          ],
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('rejects v3 when total differs from net distributable', () => {
+      expect(() =>
+        buildLiquidationPublicationSnapshotV3({
+          ...v3Input,
+          totalAmountMinor: 3001,
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('parses a tampered v3 total as invalid', () => {
+      const snapshot = buildLiquidationPublicationSnapshotV3(v3Input);
+      const tampered = {
+        ...snapshot,
+        totalAmountMinor: 4000,
+        netDistributableAmountMinor: 4000,
+      };
+
+      expect(() => parseLiquidationPublicationSnapshot(tampered)).toThrow(BadRequestException);
     });
   });
 });

--- a/apps/api/src/finanzas/liquidation-publication-snapshot.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication-snapshot.spec.ts
@@ -588,5 +588,68 @@ describe('liquidation publication snapshot', () => {
 
       expect(() => parseLiquidationPublicationSnapshot(tampered)).toThrow(BadRequestException);
     });
+
+    it('rejects v3 when incomeOffsetsByCurrency does not match the offset total', () => {
+      expect(() =>
+        buildLiquidationPublicationSnapshotV3({
+          ...v3Input,
+          incomeOffsetsByCurrency: { ARS: 6000 },
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('rejects v3 when incomeOffsetsByCurrency uses a wrong currency', () => {
+      expect(() =>
+        buildLiquidationPublicationSnapshotV3({
+          ...v3Input,
+          incomeOffsetsByCurrency: { USD: 7000 },
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('rejects v3 when incomeOffsetsByCurrency has an extra currency', () => {
+      expect(() =>
+        buildLiquidationPublicationSnapshotV3({
+          ...v3Input,
+          incomeOffsetsByCurrency: { ARS: 7000, USD: 100 },
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('rejects v3 when incomeOffsetsByCurrency is non-empty for zero offsets', () => {
+      expect(() =>
+        buildLiquidationPublicationSnapshotV3({
+          ...v3Input,
+          incomeOffsetAmountMinor: 0,
+          netDistributableAmountMinor: 10000,
+          incomeOffsetsByCurrency: { ARS: 1 },
+        }),
+      ).toThrow(BadRequestException);
+    });
+
+    it('parses a tampered v3 incomeOffsetsByCurrency as invalid', () => {
+      const snapshot = buildLiquidationPublicationSnapshotV3(v3Input);
+      const tampered = { ...snapshot, incomeOffsetsByCurrency: { ARS: 1 } };
+
+      expect(() => parseLiquidationPublicationSnapshot(tampered)).toThrow(BadRequestException);
+    });
+
+    it('accepts empty incomeOffsetsByCurrency for zero offsets', () => {
+      const zeroInput = {
+        ...v3Input,
+        adjustmentAmountMinor: 0,
+        incomeOffsetAmountMinor: 0,
+        netDistributableAmountMinor: 10000,
+        totalAmountMinor: 10000,
+        incomeOffsetsByCurrency: {},
+        incomeOffsets: [],
+        allocations: [
+          { unitId: 'unit-1', unitCode: '1A', unitLabel: '1A', amountMinor: 10000 },
+        ],
+      };
+
+      const snapshot = buildLiquidationPublicationSnapshotV3(zeroInput);
+      expect(snapshot).toMatchObject({ version: 3, totalAmountMinor: 10000 });
+    });
   });
 });

--- a/apps/api/src/finanzas/liquidation-publication-snapshot.ts
+++ b/apps/api/src/finanzas/liquidation-publication-snapshot.ts
@@ -58,9 +58,54 @@ export interface LiquidationPublicationSnapshotV2 {
   publishedAt: string;
 }
 
+export interface PublishedIncomeOffsetSnapshot {
+  incomeId: string;
+  incomeApplicationId: string;
+  categoryId: string;
+  categoryName: string | null;
+  policyVersionId: string | null;
+  scopeType: string;
+  currencyCode: string;
+  applicationAmountMinor: number;
+  buildingAmountMinor: number;
+  valuedAmountMinor: number;
+  functionalCurrencyCode: string | null;
+  exchangeRateId: string | null;
+  exchangeRateValue: string | null;
+  exchangeRateDirection: string | null;
+  exchangeRateEffectiveAt: string | null;
+  conversionDate: string | null;
+  receivedDate: string;
+  period: string;
+}
+
+export interface LiquidationPublicationSnapshotV3 {
+  version: 3;
+  valuationMode: 'FUNCTIONAL' | 'LEGACY_NOMINAL';
+  liquidationId: string;
+  tenantId: string;
+  buildingId: string;
+  period: string;
+  baseCurrency: string;
+  totalAmountMinor: number;
+  totalsByCurrency: Record<string, number>;
+  grossExpenseAmountMinor: number;
+  adjustmentAmountMinor: number;
+  preIncomeAmountMinor: number;
+  incomeOffsetAmountMinor: number;
+  netDistributableAmountMinor: number;
+  incomeOffsetsByCurrency: Record<string, number>;
+  expenses: readonly PublishedExpenseSnapshot[];
+  incomeOffsets: readonly PublishedIncomeOffsetSnapshot[];
+  allocations: readonly PublishedAllocationSnapshot[];
+  dueDate: string;
+  publishedAt: string;
+}
+
 export type LiquidationPublicationSnapshot =
   | LiquidationPublicationSnapshotV1
-  | LiquidationPublicationSnapshotV2;
+  | LiquidationPublicationSnapshotV2
+  | LiquidationPublicationSnapshotV3;
 
 export interface BuildLiquidationPublicationSnapshotInput {
   liquidationId: string;
@@ -207,6 +252,140 @@ export function buildLiquidationPublicationSnapshot(
   });
 }
 
+export interface BuildLiquidationPublicationSnapshotV3Input {
+  liquidationId: string;
+  tenantId: string;
+  buildingId: string;
+  period: string;
+  baseCurrency: string;
+  totalAmountMinor: number;
+  totalsByCurrency: Record<string, number>;
+  grossExpenseAmountMinor: number;
+  adjustmentAmountMinor: number;
+  preIncomeAmountMinor: number;
+  incomeOffsetAmountMinor: number;
+  netDistributableAmountMinor: number;
+  incomeOffsetsByCurrency: Record<string, number>;
+  expenses: readonly PublishedExpenseSnapshot[];
+  incomeOffsets: readonly PublishedIncomeOffsetSnapshot[];
+  allocations: readonly PublishedAllocationSnapshot[];
+  dueDate: Date;
+  publishedAt: Date;
+  valuationMode: 'FUNCTIONAL' | 'LEGACY_NOMINAL';
+}
+
+/**
+ * FIN-06 snapshot V3: incluye income offsets congelados y el desglose
+ * gross + adjustments - offsets = net distributable.
+ */
+export function buildLiquidationPublicationSnapshotV3(
+  input: BuildLiquidationPublicationSnapshotV3Input,
+): Prisma.InputJsonObject {
+  assertSafeIntegerNonNegative(input.totalAmountMinor, 'totalAmountMinor');
+  assertSafeIntegerNonNegative(input.grossExpenseAmountMinor, 'grossExpenseAmountMinor');
+  assertSafeIntegerNonNegative(input.incomeOffsetAmountMinor, 'incomeOffsetAmountMinor');
+  assertSafeIntegerNonNegative(input.netDistributableAmountMinor, 'netDistributableAmountMinor');
+  assertNonEmpty(input.liquidationId, 'liquidationId');
+  assertNonEmpty(input.tenantId, 'tenantId');
+  assertNonEmpty(input.buildingId, 'buildingId');
+  assertNonEmpty(input.period, 'period');
+  assertNonEmpty(input.baseCurrency, 'baseCurrency');
+  assertIsoDate(input.dueDate, 'dueDate');
+  assertIsoDate(input.publishedAt, 'publishedAt');
+
+  const totalsByCurrency = normalizeTotalsByCurrency(input.totalsByCurrency);
+  const expenses = input.expenses.map(normalizeExpenseSnapshot);
+  const allocations = input.allocations.map(normalizeAllocationSnapshot);
+  const incomeOffsets = input.incomeOffsets.map(normalizeIncomeOffsetSnapshot);
+  const expenseTotalsByCurrency = sumByCurrency(expenses);
+  const allocationTotal = allocations.reduce(
+    (sum, allocation) =>
+      safeAddMinor(sum, allocation.amountMinor, 'allocations.totalAmountMinor'),
+    0,
+  );
+  const valuedTotal =
+    input.valuationMode === 'FUNCTIONAL'
+      ? sumFunctionalAmount(expenses, input.valuationMode)
+      : expenseTotalsByCurrency[input.baseCurrency];
+
+  if (valuedTotal === undefined) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot must include the base currency total',
+    );
+  }
+
+  const preIncomeAmountMinor = input.grossExpenseAmountMinor + input.adjustmentAmountMinor;
+  const netDistributable =
+    preIncomeAmountMinor - input.incomeOffsetAmountMinor;
+
+  if (preIncomeAmountMinor !== input.preIncomeAmountMinor) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot pre-income total is inconsistent',
+    );
+  }
+
+  if (netDistributable !== input.netDistributableAmountMinor) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot net distributable is inconsistent',
+    );
+  }
+
+  if (netDistributable !== input.totalAmountMinor) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot total must equal net distributable',
+    );
+  }
+
+  if (valuedTotal !== preIncomeAmountMinor) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot expense sources must match pre-income total',
+    );
+  }
+
+  if (allocationTotal !== input.totalAmountMinor) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot allocations must match the liquidation total',
+    );
+  }
+
+  const incomeOffsetValuedTotal = incomeOffsets.reduce(
+    (sum, offset) =>
+      safeAddMinor(sum, offset.valuedAmountMinor, 'incomeOffsets.valuedAmountMinor'),
+    0,
+  );
+
+  if (incomeOffsetValuedTotal !== input.incomeOffsetAmountMinor) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot income offsets must match the offset total',
+    );
+  }
+
+  assertCurrencyTotalsMatch(totalsByCurrency, expenseTotalsByCurrency);
+
+  return createJsonObject({
+    version: 3,
+    valuationMode: input.valuationMode,
+    liquidationId: input.liquidationId,
+    tenantId: input.tenantId,
+    buildingId: input.buildingId,
+    period: input.period,
+    baseCurrency: input.baseCurrency,
+    totalAmountMinor: input.totalAmountMinor,
+    totalsByCurrency,
+    grossExpenseAmountMinor: input.grossExpenseAmountMinor,
+    adjustmentAmountMinor: input.adjustmentAmountMinor,
+    preIncomeAmountMinor,
+    incomeOffsetAmountMinor: input.incomeOffsetAmountMinor,
+    netDistributableAmountMinor: input.netDistributableAmountMinor,
+    incomeOffsetsByCurrency: normalizeTotalsByCurrency(input.incomeOffsetsByCurrency),
+    expenses: createJsonArray(expenses.map(toExpenseJsonObject)),
+    incomeOffsets: createJsonArray(incomeOffsets.map(toIncomeOffsetJsonObject)),
+    allocations: createJsonArray(allocations.map(toAllocationJsonObject)),
+    dueDate: input.dueDate.toISOString(),
+    publishedAt: input.publishedAt.toISOString(),
+  });
+}
+
 export function distributeLiquidationAmountByLargestRemainder(
   units: readonly LiquidationDistributionUnit[],
   totalAmountMinor: number,
@@ -329,7 +508,7 @@ export function parseLiquidationPublicationSnapshot(
     throw new BadRequestException('Liquidation publication snapshot is invalid');
   }
 
-  if (value.version !== 1 && value.version !== 2) {
+  if (value.version !== 1 && value.version !== 2 && value.version !== 3) {
     throw new BadRequestException('Liquidation publication snapshot version is invalid');
   }
 
@@ -343,9 +522,9 @@ export function parseLiquidationPublicationSnapshot(
   const dueDate = parseIsoDateString(value.dueDate, 'dueDate');
   const publishedAt = parseIsoDateString(value.publishedAt, 'publishedAt');
   const valuationMode =
-    value.version === 2
-      ? parseValuationMode(value.valuationMode)
-      : ('LEGACY_NOMINAL' as const);
+    value.version === 1
+      ? ('LEGACY_NOMINAL' as const)
+      : parseValuationMode(value.valuationMode);
 
   if (!Array.isArray(value.expenses)) {
     throw new BadRequestException('Liquidation publication snapshot expenses are invalid');
@@ -374,12 +553,6 @@ export function parseLiquidationPublicationSnapshot(
     );
   }
 
-  if (valuedTotal !== totalAmountMinor) {
-    throw new BadRequestException(
-      'Liquidation publication snapshot totals must match the liquidation total',
-    );
-  }
-
   if (allocationTotal !== totalAmountMinor) {
     throw new BadRequestException(
       'Liquidation publication snapshot allocations must match the liquidation total',
@@ -387,6 +560,99 @@ export function parseLiquidationPublicationSnapshot(
   }
 
   assertCurrencyTotalsMatch(totalsByCurrency, expenseTotalsByCurrency);
+
+  if (value.version === 3) {
+    const grossExpenseAmountMinor = parseSafeIntegerNonNegative(
+      value.grossExpenseAmountMinor,
+      'grossExpenseAmountMinor',
+    );
+    const adjustmentAmountMinor = parseSafeIntegerNonNegative(
+      value.adjustmentAmountMinor,
+      'adjustmentAmountMinor',
+    );
+    const preIncomeAmountMinor = parseSafeIntegerNonNegative(
+      value.preIncomeAmountMinor,
+      'preIncomeAmountMinor',
+    );
+    const incomeOffsetAmountMinor = parseSafeIntegerNonNegative(
+      value.incomeOffsetAmountMinor,
+      'incomeOffsetAmountMinor',
+    );
+    const netDistributableAmountMinor = parseSafeIntegerNonNegative(
+      value.netDistributableAmountMinor,
+      'netDistributableAmountMinor',
+    );
+
+    if (grossExpenseAmountMinor + adjustmentAmountMinor !== preIncomeAmountMinor) {
+      throw new BadRequestException(
+        'Liquidation publication snapshot pre-income total is inconsistent',
+      );
+    }
+
+    if (preIncomeAmountMinor - incomeOffsetAmountMinor !== netDistributableAmountMinor) {
+      throw new BadRequestException(
+        'Liquidation publication snapshot net distributable is inconsistent',
+      );
+    }
+
+    if (netDistributableAmountMinor !== totalAmountMinor) {
+      throw new BadRequestException(
+        'Liquidation publication snapshot total must equal net distributable',
+      );
+    }
+
+    if (valuedTotal !== preIncomeAmountMinor) {
+      throw new BadRequestException(
+        'Liquidation publication snapshot expense sources must match pre-income total',
+      );
+    }
+
+    if (!Array.isArray(value.incomeOffsets)) {
+      throw new BadRequestException('Liquidation publication snapshot incomeOffsets are invalid');
+    }
+
+    const incomeOffsets = value.incomeOffsets.map(parseIncomeOffsetSnapshot);
+    const incomeOffsetValuedTotal = incomeOffsets.reduce(
+      (sum, offset) =>
+        safeAddMinor(sum, offset.valuedAmountMinor, 'incomeOffsets.valuedAmountMinor'),
+      0,
+    );
+
+    if (incomeOffsetValuedTotal !== incomeOffsetAmountMinor) {
+      throw new BadRequestException(
+        'Liquidation publication snapshot income offsets must match the offset total',
+      );
+    }
+
+    return {
+      version: 3,
+      valuationMode,
+      liquidationId,
+      tenantId,
+      buildingId,
+      period,
+      baseCurrency,
+      totalAmountMinor,
+      totalsByCurrency,
+      grossExpenseAmountMinor,
+      adjustmentAmountMinor,
+      preIncomeAmountMinor,
+      incomeOffsetAmountMinor,
+      netDistributableAmountMinor,
+      incomeOffsetsByCurrency: parseTotalsByCurrency(value.incomeOffsetsByCurrency),
+      expenses,
+      incomeOffsets,
+      allocations,
+      dueDate,
+      publishedAt,
+    };
+  }
+
+  if (valuedTotal !== totalAmountMinor) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot totals must match the liquidation total',
+    );
+  }
 
   if (valuationMode === 'LEGACY_NOMINAL') {
     return {
@@ -506,6 +772,132 @@ function normalizeExpenseSnapshot(value: PublishedExpenseSnapshot): PublishedExp
     ...(value.conversionDate !== null && value.conversionDate !== undefined
       ? { conversionDate: value.conversionDate }
       : {}),
+  };
+}
+
+function normalizeIncomeOffsetSnapshot(
+  value: PublishedIncomeOffsetSnapshot,
+): PublishedIncomeOffsetSnapshot {
+  assertNonEmpty(value.incomeId, 'incomeId');
+  assertNonEmpty(value.incomeApplicationId, 'incomeApplicationId');
+  assertNonEmpty(value.currencyCode, 'currencyCode');
+  assertNonEmpty(value.scopeType, 'scopeType');
+  assertSafeIntegerNonNegative(value.applicationAmountMinor, 'applicationAmountMinor');
+  assertSafeIntegerNonNegative(value.buildingAmountMinor, 'buildingAmountMinor');
+  assertSafeIntegerNonNegative(value.valuedAmountMinor, 'valuedAmountMinor');
+  parseIsoDateString(value.receivedDate, 'receivedDate');
+  assertNonEmpty(value.period, 'period');
+  if (value.policyVersionId !== null) {
+    assertNonEmpty(value.policyVersionId, 'policyVersionId');
+  }
+  if (value.categoryId) {
+    assertNonEmpty(value.categoryId, 'categoryId');
+  }
+
+  return value;
+}
+
+function toIncomeOffsetJsonObject(value: PublishedIncomeOffsetSnapshot): Prisma.InputJsonObject {
+  return createJsonObject({
+    incomeId: value.incomeId,
+    incomeApplicationId: value.incomeApplicationId,
+    categoryId: value.categoryId,
+    categoryName: value.categoryName,
+    policyVersionId: value.policyVersionId,
+    scopeType: value.scopeType,
+    currencyCode: value.currencyCode,
+    applicationAmountMinor: value.applicationAmountMinor,
+    buildingAmountMinor: value.buildingAmountMinor,
+    valuedAmountMinor: value.valuedAmountMinor,
+    functionalCurrencyCode: value.functionalCurrencyCode,
+    exchangeRateId: value.exchangeRateId,
+    exchangeRateValue: value.exchangeRateValue,
+    exchangeRateDirection: value.exchangeRateDirection,
+    exchangeRateEffectiveAt: value.exchangeRateEffectiveAt,
+    conversionDate: value.conversionDate,
+    receivedDate: value.receivedDate,
+    period: value.period,
+  });
+}
+
+function parseIncomeOffsetSnapshot(value: unknown): PublishedIncomeOffsetSnapshot {
+  if (!isPlainObject(value)) {
+    throw new BadRequestException('Liquidation publication snapshot income offset is invalid');
+  }
+
+  const incomeId = parseNonEmptyString(value.incomeId, 'incomeId');
+  const incomeApplicationId = parseNonEmptyString(value.incomeApplicationId, 'incomeApplicationId');
+  const categoryId = value.categoryId === null || value.categoryId === undefined
+    ? ''
+    : parseNonEmptyString(value.categoryId, 'categoryId');
+  const categoryName =
+    value.categoryName === null || value.categoryName === undefined
+      ? null
+      : parseNullableString(value.categoryName, 'categoryName');
+  const policyVersionId =
+    value.policyVersionId === null || value.policyVersionId === undefined
+      ? null
+      : parseNullableString(value.policyVersionId, 'policyVersionId');
+  const scopeType = parseNonEmptyString(value.scopeType, 'scopeType');
+  const currencyCode = parseNonEmptyString(value.currencyCode, 'currencyCode');
+  const applicationAmountMinor = parseSafeIntegerNonNegative(
+    value.applicationAmountMinor,
+    'applicationAmountMinor',
+  );
+  const buildingAmountMinor = parseSafeIntegerNonNegative(
+    value.buildingAmountMinor,
+    'buildingAmountMinor',
+  );
+  const valuedAmountMinor = parseSafeIntegerNonNegative(
+    value.valuedAmountMinor,
+    'valuedAmountMinor',
+  );
+  const functionalCurrencyCode =
+    value.functionalCurrencyCode === null || value.functionalCurrencyCode === undefined
+      ? null
+      : parseNullableString(value.functionalCurrencyCode, 'functionalCurrencyCode');
+  const exchangeRateId =
+    value.exchangeRateId === null || value.exchangeRateId === undefined
+      ? null
+      : parseNullableString(value.exchangeRateId, 'exchangeRateId');
+  const exchangeRateValue =
+    value.exchangeRateValue === null || value.exchangeRateValue === undefined
+      ? null
+      : parseNullableString(String(value.exchangeRateValue), 'exchangeRateValue');
+  const exchangeRateDirection =
+    value.exchangeRateDirection === null || value.exchangeRateDirection === undefined
+      ? null
+      : parseNullableString(value.exchangeRateDirection, 'exchangeRateDirection');
+  const exchangeRateEffectiveAt =
+    value.exchangeRateEffectiveAt === null || value.exchangeRateEffectiveAt === undefined
+      ? null
+      : parseIsoDateString(value.exchangeRateEffectiveAt, 'exchangeRateEffectiveAt');
+  const conversionDate =
+    value.conversionDate === null || value.conversionDate === undefined
+      ? null
+      : parseIsoDateString(value.conversionDate, 'conversionDate');
+  const receivedDate = parseIsoDateString(value.receivedDate, 'receivedDate');
+  const period = parseNonEmptyString(value.period, 'period');
+
+  return {
+    incomeId,
+    incomeApplicationId,
+    categoryId,
+    categoryName,
+    policyVersionId,
+    scopeType,
+    currencyCode,
+    applicationAmountMinor,
+    buildingAmountMinor,
+    valuedAmountMinor,
+    functionalCurrencyCode,
+    exchangeRateId,
+    exchangeRateValue,
+    exchangeRateDirection,
+    exchangeRateEffectiveAt,
+    conversionDate,
+    receivedDate,
+    period,
   };
 }
 

--- a/apps/api/src/finanzas/liquidation-publication-snapshot.ts
+++ b/apps/api/src/finanzas/liquidation-publication-snapshot.ts
@@ -360,6 +360,25 @@ export function buildLiquidationPublicationSnapshotV3(
     );
   }
 
+  // FIN-06R: incomeOffsetsByCurrency debe reconciliar exactamente a
+  // { baseCurrency: incomeOffsetAmountMinor } cuando offset > 0.
+  const incomeOffsetsByCurrency = normalizeTotalsByCurrency(input.incomeOffsetsByCurrency);
+  if (input.incomeOffsetAmountMinor > 0) {
+    const expected = { [input.baseCurrency]: input.incomeOffsetAmountMinor };
+    const isExact =
+      Object.keys(incomeOffsetsByCurrency).length === 1 &&
+      incomeOffsetsByCurrency[input.baseCurrency] === expected[input.baseCurrency];
+    if (!isExact) {
+      throw new BadRequestException(
+        'Liquidation publication snapshot incomeOffsetsByCurrency must match the offset total in base currency',
+      );
+    }
+  } else if (Object.keys(incomeOffsetsByCurrency).length > 0) {
+    throw new BadRequestException(
+      'Liquidation publication snapshot incomeOffsetsByCurrency must be empty for zero offsets',
+    );
+  }
+
   assertCurrencyTotalsMatch(totalsByCurrency, expenseTotalsByCurrency);
 
   return createJsonObject({
@@ -377,7 +396,7 @@ export function buildLiquidationPublicationSnapshotV3(
     preIncomeAmountMinor,
     incomeOffsetAmountMinor: input.incomeOffsetAmountMinor,
     netDistributableAmountMinor: input.netDistributableAmountMinor,
-    incomeOffsetsByCurrency: normalizeTotalsByCurrency(input.incomeOffsetsByCurrency),
+    incomeOffsetsByCurrency,
     expenses: createJsonArray(expenses.map(toExpenseJsonObject)),
     incomeOffsets: createJsonArray(incomeOffsets.map(toIncomeOffsetJsonObject)),
     allocations: createJsonArray(allocations.map(toAllocationJsonObject)),
@@ -624,6 +643,25 @@ export function parseLiquidationPublicationSnapshot(
       );
     }
 
+    // FIN-06R: incomeOffsetsByCurrency debe reconciliar exactamente a
+    // { baseCurrency: incomeOffsetAmountMinor } cuando offset > 0.
+    const incomeOffsetsByCurrency = parseTotalsByCurrency(value.incomeOffsetsByCurrency);
+    if (incomeOffsetAmountMinor > 0) {
+      const expected = { [baseCurrency]: incomeOffsetAmountMinor };
+      const isExact =
+        Object.keys(incomeOffsetsByCurrency).length === 1 &&
+        incomeOffsetsByCurrency[baseCurrency] === expected[baseCurrency];
+      if (!isExact) {
+        throw new BadRequestException(
+          'Liquidation publication snapshot incomeOffsetsByCurrency must match the offset total in base currency',
+        );
+      }
+    } else if (Object.keys(incomeOffsetsByCurrency).length > 0) {
+      throw new BadRequestException(
+        'Liquidation publication snapshot incomeOffsetsByCurrency must be empty for zero offsets',
+      );
+    }
+
     return {
       version: 3,
       valuationMode,
@@ -639,7 +677,7 @@ export function parseLiquidationPublicationSnapshot(
       preIncomeAmountMinor,
       incomeOffsetAmountMinor,
       netDistributableAmountMinor,
-      incomeOffsetsByCurrency: parseTotalsByCurrency(value.incomeOffsetsByCurrency),
+      incomeOffsetsByCurrency,
       expenses,
       incomeOffsets,
       allocations,

--- a/apps/api/src/finanzas/liquidation-publication.postgres.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication.postgres.spec.ts
@@ -12,6 +12,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { FinanzasValidators } from './finanzas.validators';
 import { ResidentAccessService } from '../resident-access/resident-access.service';
 import { LiquidationsService } from './liquidations.service';
+import { LiquidationIncomeOffsetsService } from './liquidation-income-offsets.service';
 import {
   createLiquidationWorkflowDependencies,
   createLiquidationDraftRecord,
@@ -244,7 +245,6 @@ describePostgresIntegration('Liquidation publication PostgreSQL integration', ()
       prisma as unknown as PrismaService,
       auditService,
       validators,
-      notificationsService,
       new LiquidationPublicationUseCase(
         createLiquidationWorkflowDependencies({
           prisma: prisma as unknown as PrismaService,
@@ -253,6 +253,7 @@ describePostgresIntegration('Liquidation publication PostgreSQL integration', ()
           notificationsService,
         }),
       ),
+      new LiquidationIncomeOffsetsService(prisma as unknown as PrismaService),
     );
   }
 

--- a/apps/api/src/finanzas/liquidation-publication.postgres.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication.postgres.spec.ts
@@ -340,7 +340,7 @@ describePostgresIntegration('Liquidation publication PostgreSQL integration', ()
     expect(second.id).not.toBe(first.id);
   });
 
-  it('publishes through the real PostgreSQL transaction, writes snapshot V1, audit, and charges', async () => {
+  it('publishes through the real PostgreSQL transaction, writes snapshot V2, audit, and charges', async () => {
     const ctx = await createFinanceContext('publish');
     const reviewed = await createDraftAndReview({
       tenantId: ctx.tenant.id,
@@ -366,7 +366,8 @@ describePostgresIntegration('Liquidation publication PostgreSQL integration', ()
     expect(persisted.status).toBe('PUBLISHED');
     expect(persisted.publicationSnapshot).toEqual(
       expect.objectContaining({
-        version: 1,
+        version: 2,
+        valuationMode: 'LEGACY_NOMINAL',
         liquidationId: reviewed.id,
         dueDate: '2026-10-10T00:00:00.000Z',
       }),

--- a/apps/api/src/finanzas/liquidation-publication.use-case.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.spec.ts
@@ -574,9 +574,11 @@ describe('LiquidationPublicationUseCase', () => {
 
     const validApplication = {
       id: 'app-offset-1',
+      incomeId: 'income-1',
       destinationType: 'OFFSET_EXPENSES',
       amountMinor: 7000,
       currencyCode: 'ARS',
+      policyVersionId: 'pv-1',
       income: {
         id: 'income-1',
         status: 'RECORDED',
@@ -671,6 +673,18 @@ describe('LiquidationPublicationUseCase', () => {
 
       expect(result.status).toBe('PUBLISHED');
       expect(tx.charge.createMany).not.toHaveBeenCalled();
+      // FIN-06R: zero-net audit debe reportar chargesCount = 0 (sin cargos reales)
+      // y allocationCount = 2 (unidades del building).
+      expect(deps.createAuditLogRequired).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            chargesCount: 0,
+            allocationCount: 2,
+            snapshotVersion: 3,
+          }),
+        }),
+        tx,
+      );
     });
 
     it('rejects publication when the offset source drifted from the draft snapshot', async () => {
@@ -720,6 +734,8 @@ describe('LiquidationPublicationUseCase', () => {
 
     it('rejects publication when the expense sources do not match pre-income', async () => {
       tx.liquidation.findFirst.mockReset();
+      tx.liquidationIncomeOffset.findMany.mockReset();
+      tx.incomeApplication.findMany.mockReset();
       const drifted = {
         ...incomeOffsetLiquidation,
         expenseSnapshot: [
@@ -737,6 +753,8 @@ describe('LiquidationPublicationUseCase', () => {
       };
 
       tx.liquidation.findFirst.mockResolvedValueOnce(drifted).mockResolvedValueOnce(null);
+      tx.liquidationIncomeOffset.findMany.mockResolvedValueOnce([validReference]);
+      tx.incomeApplication.findMany.mockResolvedValueOnce([validApplication]);
 
       await expect(
         useCase.execute('tenant-1', 'liq-1', 'member-1', { dueDate: '2026-09-10' }),

--- a/apps/api/src/finanzas/liquidation-publication.use-case.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.spec.ts
@@ -54,7 +54,7 @@ describe('LiquidationPublicationUseCase', () => {
     unit: { findMany: jest.Mock };
     charge: { findMany: jest.Mock; createMany: jest.Mock };
     auditLog: { create: jest.Mock };
-    liquidationIncomeOffset: { findMany: jest.Mock };
+    liquidationIncomeOffset: { findMany: jest.Mock; count: jest.Mock };
     incomeApplication: { findMany: jest.Mock };
   };
   let deps: LiquidationWorkflowDependencies;
@@ -95,6 +95,7 @@ describe('LiquidationPublicationUseCase', () => {
       auditLog: { create: jest.fn().mockResolvedValue(undefined) },
       liquidationIncomeOffset: {
         findMany: jest.fn().mockResolvedValue([]),
+        count: jest.fn().mockResolvedValue(0),
       },
       incomeApplication: {
         findMany: jest.fn().mockResolvedValue([]),
@@ -598,6 +599,7 @@ describe('LiquidationPublicationUseCase', () => {
           status: 'PUBLISHED',
           publishedAt: new Date('2026-08-16T00:00:00.000Z'),
         });
+      tx.liquidationIncomeOffset.count.mockResolvedValueOnce(1);
       tx.liquidationIncomeOffset.findMany.mockResolvedValueOnce([validReference]);
       tx.incomeApplication.findMany.mockResolvedValueOnce([validApplication]);
 
@@ -656,6 +658,7 @@ describe('LiquidationPublicationUseCase', () => {
           status: 'PUBLISHED',
           publishedAt: new Date('2026-08-16T00:00:00.000Z'),
         });
+      tx.liquidationIncomeOffset.count.mockResolvedValueOnce(1);
       tx.liquidationIncomeOffset.findMany.mockResolvedValueOnce([
         {
           ...validReference,
@@ -694,6 +697,7 @@ describe('LiquidationPublicationUseCase', () => {
       tx.liquidation.findFirst
         .mockResolvedValueOnce(incomeOffsetLiquidation)
         .mockResolvedValueOnce(null);
+      tx.liquidationIncomeOffset.count.mockResolvedValueOnce(1);
       tx.liquidationIncomeOffset.findMany.mockResolvedValueOnce([validReference]);
       tx.incomeApplication.findMany.mockResolvedValueOnce([
         { ...validApplication, destinationType: 'FUND' },
@@ -717,6 +721,7 @@ describe('LiquidationPublicationUseCase', () => {
       tx.liquidation.findFirst
         .mockResolvedValueOnce(incomeOffsetLiquidation)
         .mockResolvedValueOnce(null);
+      tx.liquidationIncomeOffset.count.mockResolvedValueOnce(1);
       tx.liquidationIncomeOffset.findMany.mockResolvedValueOnce([validReference]);
       tx.incomeApplication.findMany.mockResolvedValueOnce([
         { ...validApplication, income: { id: 'income-1', status: 'VOID', period: '2026-08' } },
@@ -753,6 +758,7 @@ describe('LiquidationPublicationUseCase', () => {
       };
 
       tx.liquidation.findFirst.mockResolvedValueOnce(drifted).mockResolvedValueOnce(null);
+      tx.liquidationIncomeOffset.count.mockResolvedValueOnce(1);
       tx.liquidationIncomeOffset.findMany.mockResolvedValueOnce([validReference]);
       tx.incomeApplication.findMany.mockResolvedValueOnce([validApplication]);
 

--- a/apps/api/src/finanzas/liquidation-publication.use-case.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.spec.ts
@@ -54,6 +54,8 @@ describe('LiquidationPublicationUseCase', () => {
     unit: { findMany: jest.Mock };
     charge: { findMany: jest.Mock; createMany: jest.Mock };
     auditLog: { create: jest.Mock };
+    liquidationIncomeOffset: { findMany: jest.Mock };
+    incomeApplication: { findMany: jest.Mock };
   };
   let deps: LiquidationWorkflowDependencies;
   let useCase: LiquidationPublicationUseCase;
@@ -91,6 +93,12 @@ describe('LiquidationPublicationUseCase', () => {
         createMany: jest.fn().mockResolvedValue({ count: 2 }),
       },
       auditLog: { create: jest.fn().mockResolvedValue(undefined) },
+      liquidationIncomeOffset: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      incomeApplication: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
     };
 
     deps = {
@@ -504,6 +512,240 @@ describe('LiquidationPublicationUseCase', () => {
         },
       });
       expect(tx.charge.createMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('FIN-06 income offset publication', () => {
+    const incomeOffsetLiquidation = {
+      ...baseLiquidation,
+      period: '2026-08',
+      totalAmountMinor: 3000,
+      totalsByCurrency: { ARS: 10000 },
+      expenseSnapshot: [
+        {
+          expenseId: 'exp-1',
+          categoryName: 'Water',
+          vendorName: null,
+          amountMinor: 10000,
+          currencyCode: 'ARS',
+          invoiceDate: '2026-08-05T00:00:00.000Z',
+          description: null,
+          type: 'EXPENSE',
+        },
+      ],
+      grossExpenseAmountMinor: 10000,
+      adjustmentAmountMinor: 0,
+      preIncomeAmountMinor: 10000,
+      incomeOffsetAmountMinor: 7000,
+      netDistributableAmountMinor: 3000,
+      incomeOffsetSnapshot: [
+        {
+          incomeId: 'income-1',
+          incomeApplicationId: 'app-offset-1',
+          categoryId: 'cat-1',
+          categoryName: 'Parrillera',
+          policyVersionId: 'pv-1',
+          scopeType: 'BUILDING',
+          currencyCode: 'ARS',
+          applicationAmountMinor: 7000,
+          buildingAmountMinor: 7000,
+          valuedAmountMinor: 7000,
+          functionalCurrencyCode: null,
+          exchangeRateId: null,
+          exchangeRateValue: null,
+          exchangeRateDirection: null,
+          exchangeRateEffectiveAt: null,
+          conversionDate: null,
+          receivedDate: '2026-08-10T00:00:00.000Z',
+          period: '2026-08',
+        },
+      ],
+      incomeOffsetsByCurrency: { ARS: 7000 },
+    };
+
+    const validReference = {
+      incomeApplicationId: 'app-offset-1',
+      buildingId: 'building-1',
+      originalAmountMinor: 7000,
+      currencyCode: 'ARS',
+      valuedAmountMinor: 7000,
+      baseCurrency: 'ARS',
+    };
+
+    const validApplication = {
+      id: 'app-offset-1',
+      destinationType: 'OFFSET_EXPENSES',
+      amountMinor: 7000,
+      currencyCode: 'ARS',
+      income: {
+        id: 'income-1',
+        status: 'RECORDED',
+        period: '2026-08',
+      },
+    };
+
+    it('publishes an income-offset liquidation with a version 3 snapshot and no zero charges', async () => {
+      tx.liquidation.findFirst.mockReset();
+      tx.liquidationIncomeOffset.findMany.mockReset();
+      tx.incomeApplication.findMany.mockReset();
+      tx.liquidation.findFirst
+        .mockResolvedValueOnce(incomeOffsetLiquidation)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          ...incomeOffsetLiquidation,
+          status: 'PUBLISHED',
+          publishedAt: new Date('2026-08-16T00:00:00.000Z'),
+        });
+      tx.liquidationIncomeOffset.findMany.mockResolvedValueOnce([validReference]);
+      tx.incomeApplication.findMany.mockResolvedValueOnce([validApplication]);
+
+      const result = await useCase.execute('tenant-1', 'liq-1', 'member-1', {
+        dueDate: '2026-09-10',
+      });
+
+      expect(result.status).toBe('PUBLISHED');
+      expect(deps.createAuditLogRequired).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadata: expect.objectContaining({
+            snapshotVersion: 3,
+            incomeOffsetAmountMinor: 7000,
+            incomeOffsetCount: 1,
+          }),
+        }),
+        tx,
+      );
+      const publishedSnapshot = tx.liquidation.updateMany.mock.calls[0]![0]!.data
+        .publicationSnapshot as Record<string, unknown>;
+      expect(publishedSnapshot.version).toBe(3);
+      expect(publishedSnapshot.incomeOffsetAmountMinor).toBe(7000);
+      expect(publishedSnapshot.netDistributableAmountMinor).toBe(3000);
+      expect(tx.charge.createMany).toHaveBeenCalledWith({
+        data: expect.arrayContaining([
+          expect.objectContaining({ amount: 1500, unitId: 'unit-1', liquidationId: 'liq-1' }),
+        ]),
+      });
+    });
+
+    it('publishes a zero-net liquidation without creating positive charges', async () => {
+      const zeroNetLiquidation = {
+        ...incomeOffsetLiquidation,
+        totalAmountMinor: 0,
+        incomeOffsetAmountMinor: 10000,
+        netDistributableAmountMinor: 0,
+        incomeOffsetSnapshot: [
+          {
+            ...incomeOffsetLiquidation.incomeOffsetSnapshot[0],
+            valuedAmountMinor: 10000,
+            buildingAmountMinor: 10000,
+            applicationAmountMinor: 10000,
+          },
+        ],
+        incomeOffsetsByCurrency: { ARS: 10000 },
+      };
+
+      tx.liquidation.findFirst.mockReset();
+      tx.liquidationIncomeOffset.findMany.mockReset();
+      tx.incomeApplication.findMany.mockReset();
+      tx.liquidation.findFirst
+        .mockResolvedValueOnce(zeroNetLiquidation)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce({
+          ...zeroNetLiquidation,
+          status: 'PUBLISHED',
+          publishedAt: new Date('2026-08-16T00:00:00.000Z'),
+        });
+      tx.liquidationIncomeOffset.findMany.mockResolvedValueOnce([
+        {
+          ...validReference,
+          originalAmountMinor: 10000,
+          valuedAmountMinor: 10000,
+        },
+      ]);
+      tx.incomeApplication.findMany.mockResolvedValueOnce([
+        { ...validApplication, amountMinor: 10000 },
+      ]);
+
+      const result = await useCase.execute('tenant-1', 'liq-1', 'member-1', {
+        dueDate: '2026-09-10',
+      });
+
+      expect(result.status).toBe('PUBLISHED');
+      expect(tx.charge.createMany).not.toHaveBeenCalled();
+    });
+
+    it('rejects publication when the offset source drifted from the draft snapshot', async () => {
+      tx.liquidation.findFirst.mockReset();
+      tx.liquidationIncomeOffset.findMany.mockReset();
+      tx.incomeApplication.findMany.mockReset();
+      tx.liquidation.findFirst
+        .mockResolvedValueOnce(incomeOffsetLiquidation)
+        .mockResolvedValueOnce(null);
+      tx.liquidationIncomeOffset.findMany.mockResolvedValueOnce([validReference]);
+      tx.incomeApplication.findMany.mockResolvedValueOnce([
+        { ...validApplication, destinationType: 'FUND' },
+      ]);
+
+      await expect(
+        useCase.execute('tenant-1', 'liq-1', 'member-1', { dueDate: '2026-09-10' }),
+      ).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+        },
+      });
+      expect(tx.charge.createMany).not.toHaveBeenCalled();
+    });
+
+    it('rejects publication when the income is no longer RECORDED', async () => {
+      tx.liquidation.findFirst.mockReset();
+      tx.liquidationIncomeOffset.findMany.mockReset();
+      tx.incomeApplication.findMany.mockReset();
+      tx.liquidation.findFirst
+        .mockResolvedValueOnce(incomeOffsetLiquidation)
+        .mockResolvedValueOnce(null);
+      tx.liquidationIncomeOffset.findMany.mockResolvedValueOnce([validReference]);
+      tx.incomeApplication.findMany.mockResolvedValueOnce([
+        { ...validApplication, income: { id: 'income-1', status: 'VOID', period: '2026-08' } },
+      ]);
+
+      await expect(
+        useCase.execute('tenant-1', 'liq-1', 'member-1', { dueDate: '2026-09-10' }),
+      ).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+        },
+      });
+    });
+
+    it('rejects publication when the expense sources do not match pre-income', async () => {
+      tx.liquidation.findFirst.mockReset();
+      const drifted = {
+        ...incomeOffsetLiquidation,
+        expenseSnapshot: [
+          {
+            expenseId: 'exp-1',
+            categoryName: 'Water',
+            vendorName: null,
+            amountMinor: 9999,
+            currencyCode: 'ARS',
+            invoiceDate: '2026-08-05T00:00:00.000Z',
+            description: null,
+            type: 'EXPENSE',
+          },
+        ],
+      };
+
+      tx.liquidation.findFirst.mockResolvedValueOnce(drifted).mockResolvedValueOnce(null);
+
+      await expect(
+        useCase.execute('tenant-1', 'liq-1', 'member-1', { dueDate: '2026-09-10' }),
+      ).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_PUBLICATION_SOURCE_DRIFT',
+        },
+      });
     });
   });
 });

--- a/apps/api/src/finanzas/liquidation-publication.use-case.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.ts
@@ -412,6 +412,8 @@ export async function createLiquidationDraftRecord(
 
   // FIN-06: referencias relacionales de las aplicaciones OFFSET usadas
   // (void-safety + provenance; una por liquidación/aplicación).
+  // Sin skipDuplicates: una referencia duplicada es un bug financiero y debe
+  // hacer rollback (el unique de la DB es la última barrera).
   if (input.createIncomeOffsetReferences && input.createIncomeOffsetReferences.length > 0) {
     await tx.liquidationIncomeOffset.createMany({
       data: input.createIncomeOffsetReferences.map((reference) => ({
@@ -424,7 +426,6 @@ export async function createLiquidationDraftRecord(
         valuedAmountMinor: reference.valuedAmountMinor,
         baseCurrency: reference.baseCurrency,
       })),
-      skipDuplicates: true,
     });
   }
 
@@ -632,8 +633,14 @@ export class LiquidationPublicationUseCase {
               });
             }
 
-            // Validación de integridad de sources mediante las referencias
-            // relacionales (protege contra corrupción / cambios manuales).
+            // FIN-06R: reconciliación EXACTA snapshot ↔ relations ↔ current.
+            const snapshotOffsets = parseIncomeOffsetSnapshotItems(
+              current.incomeOffsetSnapshot,
+            );
+            const snapshotByApplicationId = new Map(
+              snapshotOffsets.map((offset) => [offset.incomeApplicationId, offset]),
+            );
+
             incomeOffsetReferences = await tx.liquidationIncomeOffset.findMany({
               where: { tenantId, liquidationId },
               select: {
@@ -646,34 +653,81 @@ export class LiquidationPublicationUseCase {
               },
             });
 
-            const applicationIds = incomeOffsetReferences.map(
-              (reference) => reference.incomeApplicationId,
+            const referenceByApplicationId = new Map(
+              incomeOffsetReferences.map((reference) => [
+                reference.incomeApplicationId,
+                reference,
+              ]),
             );
 
+            // Cardinalidad: snapshot count == reference count == unique IDs.
+            const snapshotIds = snapshotOffsets.map((offset) => offset.incomeApplicationId);
+            const referenceIds = incomeOffsetReferences.map(
+              (reference) => reference.incomeApplicationId,
+            );
+            const snapshotIdSet = new Set(snapshotIds);
+            const referenceIdSet = new Set(referenceIds);
+
+            if (
+              snapshotIds.length !== snapshotIdSet.size ||
+              referenceIds.length !== referenceIdSet.size ||
+              snapshotIdSet.size !== referenceIdSet.size ||
+              ![...snapshotIdSet].every((id) => referenceIdSet.has(id))
+            ) {
+              throw new UnprocessableEntityException({
+                statusCode: 422,
+                error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+                message:
+                  'El snapshot de income offsets no reconcilia cardinalidad con las referencias; no se publica',
+              });
+            }
+
+            const applicationIds = referenceIds;
             const applications = await tx.incomeApplication.findMany({
               where: { tenantId, id: { in: applicationIds } },
               select: {
                 id: true,
+                incomeId: true,
                 destinationType: true,
                 amountMinor: true,
                 currencyCode: true,
+                policyVersionId: true,
                 income: { select: { id: true, status: true, period: true } },
               },
             });
-
             const applicationById = new Map(applications.map((app) => [app.id, app]));
 
+            let relationalValuedTotal = 0;
+
             for (const reference of incomeOffsetReferences) {
+              const snapshot = snapshotByApplicationId.get(reference.incomeApplicationId);
               const application = applicationById.get(reference.incomeApplicationId);
 
+              if (!snapshot || !application) {
+                throw new UnprocessableEntityException({
+                  statusCode: 422,
+                  error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+                  message: `La fuente de income offset ${reference.incomeApplicationId} no reconcilia; no se publica`,
+                });
+              }
+
+              // Equality estricta contra el snapshot (no comparaciones parciales).
               if (
-                !application ||
+                snapshot.incomeApplicationId !== reference.incomeApplicationId ||
+                snapshot.buildingAmountMinor !== reference.originalAmountMinor ||
+                snapshot.valuedAmountMinor !== reference.valuedAmountMinor ||
+                snapshot.currencyCode !== reference.currencyCode ||
+                snapshot.period !== current.period ||
+                reference.buildingId !== current.buildingId ||
+                reference.baseCurrency !== current.baseCurrency ||
                 application.destinationType !== 'OFFSET_EXPENSES' ||
+                application.amountMinor !== snapshot.applicationAmountMinor ||
+                application.currencyCode !== snapshot.currencyCode ||
+                application.policyVersionId !== snapshot.policyVersionId ||
                 application.income === null ||
+                application.income.id !== snapshot.incomeId ||
                 application.income.status !== 'RECORDED' ||
-                application.income.period !== current.period ||
-                application.amountMinor < reference.originalAmountMinor ||
-                application.currencyCode !== reference.currencyCode
+                application.income.period !== current.period
               ) {
                 throw new UnprocessableEntityException({
                   statusCode: 422,
@@ -681,6 +735,61 @@ export class LiquidationPublicationUseCase {
                   message: `La fuente de income offset ${reference.incomeApplicationId} cambió desde el draft; no se publica`,
                 });
               }
+
+              relationalValuedTotal += reference.valuedAmountMinor;
+            }
+
+            // Reconciliación relacional del total valorado.
+            if (relationalValuedTotal !== current.incomeOffsetAmountMinor) {
+              throw new UnprocessableEntityException({
+                statusCode: 422,
+                error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+                message:
+                  'La suma valorada de referencias no coincide con el total de income offsets; no se publica',
+              });
+            }
+
+            const snapshotValuedTotal = snapshotOffsets.reduce(
+              (sum, offset) => sum + offset.valuedAmountMinor,
+              0,
+            );
+            if (snapshotValuedTotal !== current.incomeOffsetAmountMinor) {
+              throw new UnprocessableEntityException({
+                statusCode: 422,
+                error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+                message:
+                  'La suma valorada del snapshot no coincide con el total de income offsets; no se publica',
+              });
+            }
+
+            // FIN-06R: incomeOffsetsByCurrency debe reconciliar exactamente a
+            // { baseCurrency: incomeOffsetAmountMinor } cuando offset > 0.
+            const incomeOffsetsByCurrency = parseTotalsByCurrency(
+              current.incomeOffsetsByCurrency,
+            );
+            if (current.incomeOffsetAmountMinor > 0) {
+              const expected = {
+                [current.baseCurrency]: current.incomeOffsetAmountMinor,
+              };
+              const isExact =
+                Object.keys(incomeOffsetsByCurrency).length === 1 &&
+                incomeOffsetsByCurrency[current.baseCurrency] ===
+                  expected[current.baseCurrency];
+              if (!isExact) {
+                throw new UnprocessableEntityException({
+                  statusCode: 422,
+                  error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+                  message:
+                    'incomeOffsetsByCurrency no reconcilia con el total de income offsets; no se publica',
+                });
+              }
+            } else if (Object.keys(incomeOffsetsByCurrency).length > 0) {
+              throw new UnprocessableEntityException({
+                statusCode: 422,
+                error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+                message:
+                  'incomeOffsetsByCurrency no es consistente con offset cero; no se publica',
+              });
             }
           }
 
@@ -945,7 +1054,8 @@ export class LiquidationPublicationUseCase {
               metadata: {
                 period: current.period,
                 buildingId: current.buildingId,
-                chargesCount: distribution.length,
+                chargesCount: expectedCharges.length,
+                allocationCount: distribution.length,
                 totalAmountMinor: current.totalAmountMinor,
                 baseCurrency: current.baseCurrency,
                 snapshotVersion,

--- a/apps/api/src/finanzas/liquidation-publication.use-case.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.ts
@@ -624,11 +624,20 @@ export class LiquidationPublicationUseCase {
             current.preIncomeAmountMinor != null ||
             current.incomeOffsetAmountMinor != null ||
             current.netDistributableAmountMinor != null;
-          const hasFin06Artifacts =
+          const hasFin06JsonArtifacts =
             current.incomeOffsetSnapshot != null ||
             current.incomeOffsetsByCurrency != null;
 
-          const isFin06Liquidation = hasFin06Summary || hasFin06Artifacts;
+          // FIN-06R3: las referencias relacionales también clasifican FIN-06.
+          // Una row corrompida a summary+JSON null pero con LiquidationIncomeOffset
+          // rows NO puede degradarse a legacy.
+          const fin06ReferenceCount = await tx.liquidationIncomeOffset.count({
+            where: { tenantId, liquidationId },
+          });
+          const hasFin06RelationalArtifacts = fin06ReferenceCount > 0;
+
+          const isFin06Liquidation =
+            hasFin06Summary || hasFin06JsonArtifacts || hasFin06RelationalArtifacts;
 
           let incomeOffsetReferences: Array<{
             incomeApplicationId: string;

--- a/apps/api/src/finanzas/liquidation-publication.use-case.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.ts
@@ -382,6 +382,13 @@ export async function createLiquidationDraftRecord(
   deps: Pick<LiquidationWorkflowDependencies, 'createAuditLogRequired'>,
   input: DraftLiquidationInput,
 ): Promise<LiquidationRecord> {
+  const isFin06Input =
+    input.grossExpenseAmountMinor !== undefined ||
+    input.adjustmentAmountMinor !== undefined ||
+    input.preIncomeAmountMinor !== undefined ||
+    input.incomeOffsetAmountMinor !== undefined ||
+    input.netDistributableAmountMinor !== undefined;
+
   const liquidation = await tx.liquidation.create({
     data: {
       tenantId: input.tenantId,
@@ -400,12 +407,16 @@ export async function createLiquidationDraftRecord(
       preIncomeAmountMinor: input.preIncomeAmountMinor ?? null,
       incomeOffsetAmountMinor: input.incomeOffsetAmountMinor ?? null,
       netDistributableAmountMinor: input.netDistributableAmountMinor ?? null,
-      ...(input.incomeOffsetSnapshot && input.incomeOffsetSnapshot.length > 0
-        ? { incomeOffsetSnapshot: input.incomeOffsetSnapshot as Prisma.InputJsonArray }
-        : {}),
-      ...(input.incomeOffsetsByCurrency &&
-      Object.keys(input.incomeOffsetsByCurrency).length > 0
-        ? { incomeOffsetsByCurrency: input.incomeOffsetsByCurrency as Prisma.InputJsonObject }
+      // FIN-06R2: los drafts del motor FIN-06 persisten SIEMPRE los JSON,
+      // incluso vacíos ([] / {}), para clasificarse como FIN-06 en publish.
+      // Solo liquidaciones históricas pre-FIN-06 mantienen null.
+      ...(isFin06Input
+        ? {
+            incomeOffsetSnapshot: (input.incomeOffsetSnapshot ??
+              []) as Prisma.InputJsonArray,
+            incomeOffsetsByCurrency: (input.incomeOffsetsByCurrency ??
+              {}) as Prisma.InputJsonObject,
+          }
         : {}),
     },
   });
@@ -603,10 +614,21 @@ export class LiquidationPublicationUseCase {
             valuationMode,
           );
 
-          // FIN-06: liquidación con income offsets → snapshot V3.
-          const isIncomeOffsetLiquidation =
-            current.incomeOffsetAmountMinor !== null &&
-            current.incomeOffsetAmountMinor > 0;
+          // FIN-06R2: clasificación por PRESENCIA del modelo FIN-06, nunca por
+          // offset > 0. Un draft FIN-06 legítimo puede tener offset 0, y una
+          // row corrompida a offset 0 no debe degradarse a legacy/V2.
+          // `!= null` trata null y undefined como ausencia (legacy).
+          const hasFin06Summary =
+            current.grossExpenseAmountMinor != null ||
+            current.adjustmentAmountMinor != null ||
+            current.preIncomeAmountMinor != null ||
+            current.incomeOffsetAmountMinor != null ||
+            current.netDistributableAmountMinor != null;
+          const hasFin06Artifacts =
+            current.incomeOffsetSnapshot != null ||
+            current.incomeOffsetsByCurrency != null;
+
+          const isFin06Liquidation = hasFin06Summary || hasFin06Artifacts;
 
           let incomeOffsetReferences: Array<{
             incomeApplicationId: string;
@@ -617,19 +639,20 @@ export class LiquidationPublicationUseCase {
             baseCurrency: string;
           }> = [];
 
-          if (isIncomeOffsetLiquidation) {
+          if (isFin06Liquidation) {
+            // Contrato FIN-06 completo: todos los summary fields presentes.
             if (
-              current.preIncomeAmountMinor === null ||
               current.grossExpenseAmountMinor === null ||
               current.adjustmentAmountMinor === null ||
-              current.netDistributableAmountMinor === null ||
-              current.incomeOffsetSnapshot === null
+              current.preIncomeAmountMinor === null ||
+              current.incomeOffsetAmountMinor === null ||
+              current.netDistributableAmountMinor === null
             ) {
               throw new UnprocessableEntityException({
                 statusCode: 422,
                 error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
                 message:
-                  'La liquidación con income offsets carece del snapshot FIN-06; no se publica',
+                  'La liquidación posee evidencia FIN-06 pero su resumen está incompleto; no se publica',
               });
             }
 
@@ -764,6 +787,14 @@ export class LiquidationPublicationUseCase {
 
             // FIN-06R: incomeOffsetsByCurrency debe reconciliar exactamente a
             // { baseCurrency: incomeOffsetAmountMinor } cuando offset > 0.
+            if (current.incomeOffsetsByCurrency === null) {
+              throw new UnprocessableEntityException({
+                statusCode: 422,
+                error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+                message:
+                  'incomeOffsetsByCurrency falta en una liquidación FIN-06; no se publica',
+              });
+            }
             const incomeOffsetsByCurrency = parseTotalsByCurrency(
               current.incomeOffsetsByCurrency,
             );
@@ -811,7 +842,7 @@ export class LiquidationPublicationUseCase {
           }
 
           // FIN-06: gross + adjustments = preIncome; preIncome - offsets = net.
-          if (isIncomeOffsetLiquidation) {
+          if (isFin06Liquidation) {
             if (
               valuedSourceTotal !== current.preIncomeAmountMinor ||
               (current.preIncomeAmountMinor ?? 0) -
@@ -860,7 +891,7 @@ export class LiquidationPublicationUseCase {
           let publicationSnapshot: Prisma.InputJsonObject;
           let snapshotVersion: number;
 
-          if (isIncomeOffsetLiquidation) {
+          if (isFin06Liquidation) {
             const incomeOffsets = parseIncomeOffsetSnapshotItems(
               current.incomeOffsetSnapshot,
             );
@@ -1061,7 +1092,7 @@ export class LiquidationPublicationUseCase {
                 snapshotVersion,
                 dueDate: dueDate.toISOString().slice(0, 10),
                 publishedAt: now.toISOString(),
-                ...(isIncomeOffsetLiquidation
+                ...(isFin06Liquidation
                   ? {
                       grossExpenseAmountMinor: current.grossExpenseAmountMinor,
                       adjustmentAmountMinor: current.adjustmentAmountMinor,

--- a/apps/api/src/finanzas/liquidation-publication.use-case.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.ts
@@ -15,7 +15,9 @@ import { FinanzasValidators } from './finanzas.validators';
 import {
   assertLiquidationMovementCurrency,
   buildLiquidationPublicationSnapshot,
+  buildLiquidationPublicationSnapshotV3,
   type PublishedExpenseSnapshot,
+  type PublishedIncomeOffsetSnapshot,
 } from './liquidation-publication-snapshot';
 import {
   type LiquidationResponseDto,
@@ -151,9 +153,19 @@ type LiquidationRecord = {
   publishedAt: Date | null;
   canceledAt: Date | null;
   createdAt: Date;
+  grossExpenseAmountMinor: number | null;
+  adjustmentAmountMinor: number | null;
+  preIncomeAmountMinor: number | null;
+  incomeOffsetAmountMinor: number | null;
+  netDistributableAmountMinor: number | null;
+  incomeOffsetSnapshot: unknown;
+  incomeOffsetsByCurrency: unknown;
 };
 
-type LiquidationResponseRecord = Omit<LiquidationRecord, 'expenseSnapshot' | 'publicationSnapshot'>;
+type LiquidationResponseRecord = Omit<
+  LiquidationRecord,
+  'expenseSnapshot' | 'publicationSnapshot' | 'incomeOffsetSnapshot' | 'incomeOffsetsByCurrency'
+>;
 
 export interface DraftLiquidationInput {
   readonly tenantId: string;
@@ -167,6 +179,22 @@ export interface DraftLiquidationInput {
   readonly expenseSnapshot: Prisma.InputJsonArray;
   readonly unitCount: number;
   readonly generatedByMembershipId: string;
+  // FIN-06: desglose del neto distributable (opcional = legacy pre-FIN-06)
+  readonly grossExpenseAmountMinor?: number;
+  readonly adjustmentAmountMinor?: number;
+  readonly preIncomeAmountMinor?: number;
+  readonly incomeOffsetAmountMinor?: number;
+  readonly netDistributableAmountMinor?: number;
+  readonly incomeOffsetSnapshot?: Prisma.InputJsonArray;
+  readonly incomeOffsetsByCurrency?: Prisma.InputJsonObject;
+  readonly createIncomeOffsetReferences?: ReadonlyArray<{
+    incomeApplicationId: string;
+    buildingId: string;
+    originalAmountMinor: number;
+    currencyCode: string;
+    valuedAmountMinor: number;
+    baseCurrency: string;
+  }>;
 }
 
 export async function requireFinanceMembership(
@@ -225,6 +253,11 @@ export function toLiquidationResponseDto(
     publishedAt: liquidation.publishedAt,
     canceledAt: liquidation.canceledAt,
     createdAt: liquidation.createdAt,
+    grossExpenseAmountMinor: liquidation.grossExpenseAmountMinor ?? null,
+    adjustmentAmountMinor: liquidation.adjustmentAmountMinor ?? null,
+    preIncomeAmountMinor: liquidation.preIncomeAmountMinor ?? null,
+    incomeOffsetAmountMinor: liquidation.incomeOffsetAmountMinor ?? null,
+    netDistributableAmountMinor: liquidation.netDistributableAmountMinor ?? null,
   };
 }
 
@@ -362,8 +395,38 @@ export async function createLiquidationDraftRecord(
       expenseSnapshot: input.expenseSnapshot,
       unitCount: input.unitCount,
       generatedByMembershipId: input.generatedByMembershipId,
+      grossExpenseAmountMinor: input.grossExpenseAmountMinor ?? null,
+      adjustmentAmountMinor: input.adjustmentAmountMinor ?? null,
+      preIncomeAmountMinor: input.preIncomeAmountMinor ?? null,
+      incomeOffsetAmountMinor: input.incomeOffsetAmountMinor ?? null,
+      netDistributableAmountMinor: input.netDistributableAmountMinor ?? null,
+      ...(input.incomeOffsetSnapshot && input.incomeOffsetSnapshot.length > 0
+        ? { incomeOffsetSnapshot: input.incomeOffsetSnapshot as Prisma.InputJsonArray }
+        : {}),
+      ...(input.incomeOffsetsByCurrency &&
+      Object.keys(input.incomeOffsetsByCurrency).length > 0
+        ? { incomeOffsetsByCurrency: input.incomeOffsetsByCurrency as Prisma.InputJsonObject }
+        : {}),
     },
   });
+
+  // FIN-06: referencias relacionales de las aplicaciones OFFSET usadas
+  // (void-safety + provenance; una por liquidación/aplicación).
+  if (input.createIncomeOffsetReferences && input.createIncomeOffsetReferences.length > 0) {
+    await tx.liquidationIncomeOffset.createMany({
+      data: input.createIncomeOffsetReferences.map((reference) => ({
+        tenantId: input.tenantId,
+        liquidationId: liquidation.id,
+        incomeApplicationId: reference.incomeApplicationId,
+        buildingId: reference.buildingId,
+        originalAmountMinor: reference.originalAmountMinor,
+        currencyCode: reference.currencyCode,
+        valuedAmountMinor: reference.valuedAmountMinor,
+        baseCurrency: reference.baseCurrency,
+      })),
+      skipDuplicates: true,
+    });
+  }
 
   await deps.createAuditLogRequired(
     {
@@ -378,6 +441,24 @@ export async function createLiquidationDraftRecord(
         totalAmountMinor: input.totalAmountMinor,
         baseCurrency: input.baseCurrency,
         expenseCount: input.expenseSnapshot.length,
+        ...(input.grossExpenseAmountMinor !== undefined
+          ? { grossExpenseAmountMinor: input.grossExpenseAmountMinor }
+          : {}),
+        ...(input.adjustmentAmountMinor !== undefined
+          ? { adjustmentAmountMinor: input.adjustmentAmountMinor }
+          : {}),
+        ...(input.preIncomeAmountMinor !== undefined
+          ? { preIncomeAmountMinor: input.preIncomeAmountMinor }
+          : {}),
+        ...(input.incomeOffsetAmountMinor !== undefined
+          ? { incomeOffsetAmountMinor: input.incomeOffsetAmountMinor }
+          : {}),
+        ...(input.netDistributableAmountMinor !== undefined
+          ? { netDistributableAmountMinor: input.netDistributableAmountMinor }
+          : {}),
+        ...(input.incomeOffsetSnapshot !== undefined
+          ? { incomeOffsetCount: input.incomeOffsetSnapshot.length }
+          : {}),
       },
     },
     tx,
@@ -521,6 +602,88 @@ export class LiquidationPublicationUseCase {
             valuationMode,
           );
 
+          // FIN-06: liquidación con income offsets → snapshot V3.
+          const isIncomeOffsetLiquidation =
+            current.incomeOffsetAmountMinor !== null &&
+            current.incomeOffsetAmountMinor > 0;
+
+          let incomeOffsetReferences: Array<{
+            incomeApplicationId: string;
+            buildingId: string;
+            originalAmountMinor: number;
+            currencyCode: string;
+            valuedAmountMinor: number;
+            baseCurrency: string;
+          }> = [];
+
+          if (isIncomeOffsetLiquidation) {
+            if (
+              current.preIncomeAmountMinor === null ||
+              current.grossExpenseAmountMinor === null ||
+              current.adjustmentAmountMinor === null ||
+              current.netDistributableAmountMinor === null ||
+              current.incomeOffsetSnapshot === null
+            ) {
+              throw new UnprocessableEntityException({
+                statusCode: 422,
+                error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+                message:
+                  'La liquidación con income offsets carece del snapshot FIN-06; no se publica',
+              });
+            }
+
+            // Validación de integridad de sources mediante las referencias
+            // relacionales (protege contra corrupción / cambios manuales).
+            incomeOffsetReferences = await tx.liquidationIncomeOffset.findMany({
+              where: { tenantId, liquidationId },
+              select: {
+                incomeApplicationId: true,
+                buildingId: true,
+                originalAmountMinor: true,
+                currencyCode: true,
+                valuedAmountMinor: true,
+                baseCurrency: true,
+              },
+            });
+
+            const applicationIds = incomeOffsetReferences.map(
+              (reference) => reference.incomeApplicationId,
+            );
+
+            const applications = await tx.incomeApplication.findMany({
+              where: { tenantId, id: { in: applicationIds } },
+              select: {
+                id: true,
+                destinationType: true,
+                amountMinor: true,
+                currencyCode: true,
+                income: { select: { id: true, status: true, period: true } },
+              },
+            });
+
+            const applicationById = new Map(applications.map((app) => [app.id, app]));
+
+            for (const reference of incomeOffsetReferences) {
+              const application = applicationById.get(reference.incomeApplicationId);
+
+              if (
+                !application ||
+                application.destinationType !== 'OFFSET_EXPENSES' ||
+                application.income === null ||
+                application.income.status !== 'RECORDED' ||
+                application.income.period !== current.period ||
+                application.amountMinor < reference.originalAmountMinor ||
+                application.currencyCode !== reference.currencyCode
+              ) {
+                throw new UnprocessableEntityException({
+                  statusCode: 422,
+                  error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+                  message: `La fuente de income offset ${reference.incomeApplicationId} cambió desde el draft; no se publica`,
+                });
+              }
+            }
+          }
+
           const valuedSourceTotal =
             valuationMode === 'FUNCTIONAL'
               ? publicationExpenses.reduce(
@@ -529,10 +692,32 @@ export class LiquidationPublicationUseCase {
                 )
               : publicationExpenses.reduce((sum, expense) => sum + expense.amountMinor, 0);
 
-          if (
-            !Number.isSafeInteger(valuedSourceTotal) ||
-            valuedSourceTotal !== current.totalAmountMinor
-          ) {
+          if (!Number.isSafeInteger(valuedSourceTotal)) {
+            throw new UnprocessableEntityException({
+              statusCode: 422,
+              error: 'LIQUIDATION_PUBLICATION_SOURCE_DRIFT',
+              message:
+                'El snapshot de fuentes de la liquidación no reconcilia con su total; no se publica',
+            });
+          }
+
+          // FIN-06: gross + adjustments = preIncome; preIncome - offsets = net.
+          if (isIncomeOffsetLiquidation) {
+            if (
+              valuedSourceTotal !== current.preIncomeAmountMinor ||
+              (current.preIncomeAmountMinor ?? 0) -
+                (current.incomeOffsetAmountMinor ?? 0) !==
+                current.totalAmountMinor ||
+              current.totalAmountMinor !== current.netDistributableAmountMinor
+            ) {
+              throw new UnprocessableEntityException({
+                statusCode: 422,
+                error: 'LIQUIDATION_PUBLICATION_SOURCE_DRIFT',
+                message:
+                  'El desglose FIN-06 de la liquidación no reconcilia (preIncome/offsets/net); no se publica',
+              });
+            }
+          } else if (valuedSourceTotal !== current.totalAmountMinor) {
             throw new UnprocessableEntityException({
               statusCode: 422,
               error: 'LIQUIDATION_PUBLICATION_SOURCE_DRIFT',
@@ -563,25 +748,62 @@ export class LiquidationPublicationUseCase {
             current.buildingId,
           );
 
-          const publicationSnapshot = buildLiquidationPublicationSnapshot({
-            liquidationId: current.id,
-            tenantId,
-            buildingId: current.buildingId,
-            period: current.period,
-            valuationMode,
-            baseCurrency: current.baseCurrency,
-            totalAmountMinor: current.totalAmountMinor,
-            totalsByCurrency: parseTotalsByCurrency(current.totalsByCurrency),
-            expenses: publicationExpenses,
-            allocations: distribution.map((item) => ({
-              unitId: item.unitId,
-              unitCode: item.unitCode,
-              unitLabel: item.unitLabel,
-              amountMinor: item.amountMinor,
-            })),
-            dueDate,
-            publishedAt: now,
-          });
+          let publicationSnapshot: Prisma.InputJsonObject;
+          let snapshotVersion: number;
+
+          if (isIncomeOffsetLiquidation) {
+            const incomeOffsets = parseIncomeOffsetSnapshotItems(
+              current.incomeOffsetSnapshot,
+            );
+            publicationSnapshot = buildLiquidationPublicationSnapshotV3({
+              liquidationId: current.id,
+              tenantId,
+              buildingId: current.buildingId,
+              period: current.period,
+              valuationMode,
+              baseCurrency: current.baseCurrency,
+              totalAmountMinor: current.totalAmountMinor,
+              totalsByCurrency: parseTotalsByCurrency(current.totalsByCurrency),
+              grossExpenseAmountMinor: current.grossExpenseAmountMinor as number,
+              adjustmentAmountMinor: current.adjustmentAmountMinor as number,
+              preIncomeAmountMinor: current.preIncomeAmountMinor as number,
+              incomeOffsetAmountMinor: current.incomeOffsetAmountMinor as number,
+              netDistributableAmountMinor: current.netDistributableAmountMinor as number,
+              incomeOffsetsByCurrency: parseTotalsByCurrency(current.incomeOffsetsByCurrency),
+              expenses: publicationExpenses,
+              incomeOffsets,
+              allocations: distribution.map((item) => ({
+                unitId: item.unitId,
+                unitCode: item.unitCode,
+                unitLabel: item.unitLabel,
+                amountMinor: item.amountMinor,
+              })),
+              dueDate,
+              publishedAt: now,
+            });
+            snapshotVersion = 3;
+          } else {
+            publicationSnapshot = buildLiquidationPublicationSnapshot({
+              liquidationId: current.id,
+              tenantId,
+              buildingId: current.buildingId,
+              period: current.period,
+              valuationMode,
+              baseCurrency: current.baseCurrency,
+              totalAmountMinor: current.totalAmountMinor,
+              totalsByCurrency: parseTotalsByCurrency(current.totalsByCurrency),
+              expenses: publicationExpenses,
+              allocations: distribution.map((item) => ({
+                unitId: item.unitId,
+                unitCode: item.unitCode,
+                unitLabel: item.unitLabel,
+                amountMinor: item.amountMinor,
+              })),
+              dueDate,
+              publishedAt: now,
+            });
+            snapshotVersion = 2;
+          }
 
           const duplicatePublished = await tx.liquidation.findFirst({
             where: {
@@ -601,18 +823,21 @@ export class LiquidationPublicationUseCase {
           }
 
           const concept = `Expensas comunes ${current.period}`;
-          const expectedCharges = distribution.map((distributionItem) => ({
-            tenantId,
-            buildingId: current.buildingId,
-            unitId: distributionItem.unitId,
-            period: current.period,
-            type: 'COMMON_EXPENSE' as const,
-            concept,
-            amount: distributionItem.amountMinor,
-            currency: current.baseCurrency,
-            dueDate,
-            liquidationId,
-          }));
+          const expectedCharges =
+            current.totalAmountMinor === 0
+              ? []
+              : distribution.map((distributionItem) => ({
+                  tenantId,
+                  buildingId: current.buildingId,
+                  unitId: distributionItem.unitId,
+                  period: current.period,
+                  type: 'COMMON_EXPENSE' as const,
+                  concept,
+                  amount: distributionItem.amountMinor,
+                  currency: current.baseCurrency,
+                  dueDate,
+                  liquidationId,
+                }));
 
           const existingCharges = await tx.charge.findMany({
             where: {
@@ -663,7 +888,7 @@ export class LiquidationPublicationUseCase {
                 );
               }
             }
-          } else {
+          } else if (expectedCharges.length > 0) {
             await tx.charge.createMany({
               data: expectedCharges.map((charge) => ({
                 ...charge,
@@ -723,9 +948,19 @@ export class LiquidationPublicationUseCase {
                 chargesCount: distribution.length,
                 totalAmountMinor: current.totalAmountMinor,
                 baseCurrency: current.baseCurrency,
-                snapshotVersion: 1,
+                snapshotVersion,
                 dueDate: dueDate.toISOString().slice(0, 10),
                 publishedAt: now.toISOString(),
+                ...(isIncomeOffsetLiquidation
+                  ? {
+                      grossExpenseAmountMinor: current.grossExpenseAmountMinor,
+                      adjustmentAmountMinor: current.adjustmentAmountMinor,
+                      preIncomeAmountMinor: current.preIncomeAmountMinor,
+                      incomeOffsetAmountMinor: current.incomeOffsetAmountMinor,
+                      netDistributableAmountMinor: current.netDistributableAmountMinor,
+                      incomeOffsetCount: incomeOffsetReferences.length,
+                    }
+                  : {}),
               },
             },
             tx,
@@ -987,6 +1222,114 @@ function parseExpenseSnapshot(value: unknown): ParsedLiquidationExpenseItem[] {
       exchangeRateDirection: parsedExchangeRateDirection,
       exchangeRateEffectiveAt: parsedExchangeRateEffectiveAt,
       conversionDate: parsedConversionDate,
+    };
+  });
+}
+
+function parseIncomeOffsetSnapshotItems(value: unknown): PublishedIncomeOffsetSnapshot[] {
+  if (!Array.isArray(value)) {
+    throw new UnprocessableEntityException({
+      statusCode: 422,
+      error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+      message: 'El snapshot de income offsets de la liquidación es inválido; no se publica',
+    });
+  }
+
+  return value.map((item, index) => {
+    if (item === null || typeof item !== 'object' || Array.isArray(item)) {
+      throw new UnprocessableEntityException({
+        statusCode: 422,
+        error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+        message: `Income offset snapshot item ${index} es inválido`,
+      });
+    }
+
+    const snapshot = item as Record<string, unknown>;
+    const incomeId = snapshot.incomeId;
+    const incomeApplicationId = snapshot.incomeApplicationId;
+    const categoryId = snapshot.categoryId;
+    const categoryName = snapshot.categoryName;
+    const policyVersionId = snapshot.policyVersionId;
+    const scopeType = snapshot.scopeType;
+    const currencyCode = snapshot.currencyCode;
+    const applicationAmountMinor = snapshot.applicationAmountMinor;
+    const buildingAmountMinor = snapshot.buildingAmountMinor;
+    const valuedAmountMinor = snapshot.valuedAmountMinor;
+    const functionalCurrencyCode = snapshot.functionalCurrencyCode;
+    const exchangeRateId = snapshot.exchangeRateId;
+    const exchangeRateValue = snapshot.exchangeRateValue;
+    const exchangeRateDirection = snapshot.exchangeRateDirection;
+    const exchangeRateEffectiveAt = snapshot.exchangeRateEffectiveAt;
+    const conversionDate = snapshot.conversionDate;
+    const receivedDate = snapshot.receivedDate;
+    const period = snapshot.period;
+
+    const requiredString = (fieldName: string): string => {
+      if (typeof snapshot[fieldName] !== 'string' || (snapshot[fieldName] as string).length === 0) {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+          message: `Income offset snapshot item ${index} tiene ${fieldName} inválido`,
+        });
+      }
+      return snapshot[fieldName] as string;
+    };
+
+    const requiredInt = (fieldName: string): number => {
+      const value = snapshot[fieldName];
+      if (typeof value !== 'number' || !Number.isSafeInteger(value) || value <= 0) {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+          message: `Income offset snapshot item ${index} tiene ${fieldName} inválido`,
+        });
+      }
+      return value;
+    };
+
+    const nullableString = (fieldName: string): string | null => {
+      const value = snapshot[fieldName];
+      if (value === null || value === undefined) {
+        return null;
+      }
+      return requiredString(fieldName);
+    };
+
+    const nullableIsoDate = (fieldName: string): string | null => {
+      const value = snapshot[fieldName];
+      if (value === null || value === undefined) {
+        return null;
+      }
+      const parsed = new Date(String(value));
+      if (Number.isNaN(parsed.getTime())) {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+          message: `Income offset snapshot item ${index} tiene ${fieldName} inválido`,
+        });
+      }
+      return parsed.toISOString();
+    };
+
+    return {
+      incomeId: requiredString('incomeId'),
+      incomeApplicationId: requiredString('incomeApplicationId'),
+      categoryId: nullableString('categoryId') ?? '',
+      categoryName: nullableString('categoryName'),
+      policyVersionId: nullableString('policyVersionId'),
+      scopeType: requiredString('scopeType'),
+      currencyCode: requiredString('currencyCode'),
+      applicationAmountMinor: requiredInt('applicationAmountMinor'),
+      buildingAmountMinor: requiredInt('buildingAmountMinor'),
+      valuedAmountMinor: requiredInt('valuedAmountMinor'),
+      functionalCurrencyCode: nullableString('functionalCurrencyCode'),
+      exchangeRateId: nullableString('exchangeRateId'),
+      exchangeRateValue: nullableString('exchangeRateValue'),
+      exchangeRateDirection: nullableString('exchangeRateDirection'),
+      exchangeRateEffectiveAt: nullableIsoDate('exchangeRateEffectiveAt'),
+      conversionDate: nullableIsoDate('conversionDate'),
+      receivedDate: requiredString('receivedDate'),
+      period: requiredString('period'),
     };
   });
 }

--- a/apps/api/src/finanzas/liquidations.multicurrency.spec.ts
+++ b/apps/api/src/finanzas/liquidations.multicurrency.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UnprocessableEntityException } from '@nestjs/common';
 import { LiquidationsService } from './liquidations.service';
+import { LiquidationIncomeOffsetsService } from './liquidation-income-offsets.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { FinanzasValidators } from './finanzas.validators';
@@ -203,6 +204,17 @@ describe('LiquidationsService multicurrency valuation', () => {
                 jest.fn(),
               ),
             ),
+        },
+        {
+          provide: LiquidationIncomeOffsetsService,
+          useValue: {
+            collectEligibleOffsets: jest.fn().mockResolvedValue({
+              items: [],
+              references: [],
+              incomeOffsetAmountMinor: 0,
+              incomeOffsetsByCurrency: {},
+            }),
+          },
         },
       ],
     }).compile();

--- a/apps/api/src/finanzas/liquidations.service.spec.ts
+++ b/apps/api/src/finanzas/liquidations.service.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
 import { LiquidationsService } from './liquidations.service';
+import { LiquidationIncomeOffsetsService } from './liquidation-income-offsets.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { FinanzasValidators } from './finanzas.validators';
@@ -111,6 +112,17 @@ describe('LiquidationsService', () => {
       adjustment: {
         findMany: jest.fn().mockResolvedValue([]),
       },
+      income: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      incomeApplication: {
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      liquidationIncomeOffset: {
+        findMany: jest.fn().mockResolvedValue([]),
+        createMany: jest.fn().mockResolvedValue({ count: 0 }),
+      },
+      $executeRaw: jest.fn().mockResolvedValue(undefined),
       unit: {
         findMany: jest.fn().mockResolvedValue([
           { id: 'unit-1', code: '1A', label: '1A', unitCategory: null },
@@ -149,6 +161,7 @@ describe('LiquidationsService', () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         LiquidationsService,
+        LiquidationIncomeOffsetsService,
         {
           provide: LiquidationPublicationUseCase,
           inject: [PrismaService, AuditService, FinanzasValidators, NotificationsService],
@@ -929,7 +942,7 @@ describe('LiquidationsService', () => {
         entityType: 'Liquidation',
         entityId: 'liq-1',
         metadata: expect.objectContaining({
-          snapshotVersion: 1,
+          snapshotVersion: 2,
           dueDate: '2026-06-10',
         }),
       }),
@@ -1043,5 +1056,228 @@ describe('LiquidationsService', () => {
         'disabled',
       ),
     ).rejects.toThrow('No se encontró una membresía válida para el tenant');
+  });
+
+  describe('FIN-06 createDraft with income offsets', () => {
+    const offsetIncome = {
+      id: 'income-1',
+      buildingId: 'building-1',
+      period: '2026-05',
+      scopeType: 'BUILDING',
+      status: 'RECORDED',
+      functionalAmountMinor: null,
+      functionalCurrencyCode: null,
+      exchangeRateId: null,
+      exchangeRateValue: null,
+      exchangeRateDirection: null,
+      exchangeRateEffectiveAt: null,
+      conversionDate: null,
+      receivedDate: new Date('2026-05-10T00:00:00.000Z'),
+      categoryId: 'cat-1',
+      category: { name: 'Parrillera' },
+      allocations: [],
+      applications: [
+        {
+          id: 'app-offset-1',
+          destinationType: 'OFFSET_EXPENSES',
+          amountMinor: 7000,
+          currencyCode: 'ARS',
+          policyVersionId: 'pv-1',
+        },
+      ],
+    };
+
+    function mockExpenses(totalAmountMinor: number) {
+      tx.liquidation.findFirst.mockResolvedValueOnce(null);
+      tx.expense.findMany
+        .mockResolvedValueOnce([
+          {
+            id: 'exp-1',
+            amountMinor: totalAmountMinor,
+            currencyCode: 'ARS',
+            invoiceDate: new Date('2026-05-01T00:00:00.000Z'),
+            description: null,
+            category: { name: 'Water' },
+            vendor: { name: 'Vendor' },
+          },
+        ])
+        .mockResolvedValueOnce([]);
+      tx.adjustment.findMany.mockResolvedValueOnce([]);
+      tx.unit.findMany.mockResolvedValueOnce([
+        { id: 'unit-1', code: '1A', label: '1A', unitCategory: null },
+        { id: 'unit-2', code: '1B', label: '1B', unitCategory: null },
+      ]);
+    }
+
+    function mockOffsetIncome(income: unknown) {
+      const record = income as { id: string; status?: string; period?: string };
+      // collectEligibleOffsets hace dos findMany sobre income:
+      // 1. selección inicial (with applications include)
+      // 2. revalidación post-lock (solo id/status/period)
+      tx.income.findMany
+        .mockResolvedValueOnce([income])
+        .mockResolvedValueOnce([
+          {
+            id: record.id,
+            status: record.status ?? 'RECORDED',
+            period: record.period ?? '2026-05',
+          },
+        ]);
+    }
+
+    it('reduces the net distributable by eligible OFFSET applications', async () => {
+      mockExpenses(10000);
+      mockOffsetIncome(offsetIncome);
+      tx.incomeApplication.findMany.mockResolvedValueOnce([]);
+      (tx.liquidation.create as jest.Mock).mockResolvedValue({
+        ...baseLiquidation,
+        status: 'DRAFT',
+        totalAmountMinor: 3000,
+        grossExpenseAmountMinor: 10000,
+        adjustmentAmountMinor: 0,
+        preIncomeAmountMinor: 10000,
+        incomeOffsetAmountMinor: 7000,
+        netDistributableAmountMinor: 3000,
+        publicationSnapshot: null,
+      });
+
+      await service.createDraft('tenant-1', 'member-1', {
+        buildingId: 'building-1', period: '2026-05', baseCurrency: 'ARS',
+      });
+
+      expect(tx.liquidation.create).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({
+          totalAmountMinor: 3000,
+          grossExpenseAmountMinor: 10000,
+          adjustmentAmountMinor: 0,
+          preIncomeAmountMinor: 10000,
+          incomeOffsetAmountMinor: 7000,
+          netDistributableAmountMinor: 3000,
+        }),
+      }));
+      expect(tx.liquidationIncomeOffset.createMany).toHaveBeenCalledWith({
+        data: [
+          expect.objectContaining({
+            incomeApplicationId: 'app-offset-1',
+            buildingId: 'building-1',
+            originalAmountMinor: 7000,
+            valuedAmountMinor: 7000,
+            baseCurrency: 'ARS',
+          }),
+        ],
+        skipDuplicates: true,
+      });
+    });
+
+    it('rejects the draft when offsets exceed the pre-income total', async () => {
+      mockExpenses(5000);
+      mockOffsetIncome(offsetIncome);
+
+      await expect(service.createDraft('tenant-1', 'member-1', {
+        buildingId: 'building-1', period: '2026-05', baseCurrency: 'ARS',
+      })).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_INCOME_OFFSETS_EXCEED_GROSS',
+        },
+      });
+
+      expect(tx.liquidation.create).not.toHaveBeenCalled();
+      expect(tx.liquidationIncomeOffset.createMany).not.toHaveBeenCalled();
+    });
+
+    it('ignores FUND and CARRY_FORWARD applications (no net reduction)', async () => {
+      mockExpenses(10000);
+      mockOffsetIncome({
+        ...offsetIncome,
+        applications: [
+          { id: 'app-fund', destinationType: 'FUND', amountMinor: 10000, currencyCode: 'ARS', policyVersionId: null },
+        ],
+      });
+
+      await service.createDraft('tenant-1', 'member-1', {
+        buildingId: 'building-1', period: '2026-05', baseCurrency: 'ARS',
+      });
+
+      expect(tx.liquidation.create).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({
+          totalAmountMinor: 10000,
+          incomeOffsetAmountMinor: 0,
+        }),
+      }));
+    });
+
+    it('rejects cross-currency nominal offsets', async () => {
+      mockExpenses(10000);
+      mockOffsetIncome({
+        ...offsetIncome,
+        applications: [
+          { id: 'app-usd', destinationType: 'OFFSET_EXPENSES', amountMinor: 1000, currencyCode: 'USD', policyVersionId: null },
+        ],
+      });
+
+      await expect(service.createDraft('tenant-1', 'member-1', {
+        buildingId: 'building-1', period: '2026-05', baseCurrency: 'ARS',
+      })).rejects.toMatchObject({
+        response: {
+          statusCode: 422,
+          error: 'LIQUIDATION_INCOME_OFFSET_CURRENCY_MISMATCH',
+        },
+      });
+    });
+
+    it('ignores OFFSET from a VOID income (not eligible)', async () => {
+      mockExpenses(10000);
+      mockOffsetIncome({ ...offsetIncome, status: 'VOID' });
+
+      await service.createDraft('tenant-1', 'member-1', {
+        buildingId: 'building-1', period: '2026-05', baseCurrency: 'ARS',
+      });
+
+      expect(tx.liquidation.create).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({
+          totalAmountMinor: 10000,
+          incomeOffsetAmountMinor: 0,
+        }),
+      }));
+    });
+
+    it('ignores OFFSET from another period', async () => {
+      mockExpenses(10000);
+      mockOffsetIncome({ ...offsetIncome, period: '2026-04' });
+
+      await service.createDraft('tenant-1', 'member-1', {
+        buildingId: 'building-1', period: '2026-05', baseCurrency: 'ARS',
+      });
+
+      expect(tx.liquidation.create).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({
+          totalAmountMinor: 10000,
+          incomeOffsetAmountMinor: 0,
+        }),
+      }));
+    });
+
+    it('supports exact zero net (offset == pre-income)', async () => {
+      mockExpenses(10000);
+      mockOffsetIncome({
+        ...offsetIncome,
+        applications: [
+          { id: 'app-offset-1', destinationType: 'OFFSET_EXPENSES', amountMinor: 10000, currencyCode: 'ARS', policyVersionId: null },
+        ],
+      });
+
+      await service.createDraft('tenant-1', 'member-1', {
+        buildingId: 'building-1', period: '2026-05', baseCurrency: 'ARS',
+      });
+
+      expect(tx.liquidation.create).toHaveBeenCalledWith(expect.objectContaining({
+        data: expect.objectContaining({
+          totalAmountMinor: 0,
+          incomeOffsetAmountMinor: 10000,
+          netDistributableAmountMinor: 0,
+        }),
+      }));
+    });
   });
 });

--- a/apps/api/src/finanzas/liquidations.service.spec.ts
+++ b/apps/api/src/finanzas/liquidations.service.spec.ts
@@ -1165,7 +1165,6 @@ describe('LiquidationsService', () => {
             baseCurrency: 'ARS',
           }),
         ],
-        skipDuplicates: true,
       });
     });
 

--- a/apps/api/src/finanzas/liquidations.service.spec.ts
+++ b/apps/api/src/finanzas/liquidations.service.spec.ts
@@ -1111,18 +1111,17 @@ describe('LiquidationsService', () => {
 
     function mockOffsetIncome(income: unknown) {
       const record = income as { id: string; status?: string; period?: string };
-      // collectEligibleOffsets hace dos findMany sobre income:
-      // 1. selección inicial (with applications include)
-      // 2. revalidación post-lock (solo id/status/period)
+      // collectEligibleOffsets (FIN-06R2):
+      // 1. query inicial SOLO de IDs candidatos
+      // 2. reload COMPLETO post-lock (income + applications + allocations)
       tx.income.findMany
-        .mockResolvedValueOnce([income])
-        .mockResolvedValueOnce([
-          {
-            id: record.id,
-            status: record.status ?? 'RECORDED',
-            period: record.period ?? '2026-05',
-          },
-        ]);
+        .mockResolvedValueOnce([{ id: record.id }])
+        .mockResolvedValueOnce(
+          (record.status ?? 'RECORDED') === 'RECORDED' &&
+            (record.period ?? '2026-05') === '2026-05'
+            ? [income]
+            : [],
+        );
     }
 
     it('reduces the net distributable by eligible OFFSET applications', async () => {

--- a/apps/api/src/finanzas/liquidations.service.spec.ts
+++ b/apps/api/src/finanzas/liquidations.service.spec.ts
@@ -121,6 +121,7 @@ describe('LiquidationsService', () => {
       liquidationIncomeOffset: {
         findMany: jest.fn().mockResolvedValue([]),
         createMany: jest.fn().mockResolvedValue({ count: 0 }),
+        count: jest.fn().mockResolvedValue(0),
       },
       $executeRaw: jest.fn().mockResolvedValue(undefined),
       unit: {

--- a/apps/api/src/finanzas/liquidations.service.ts
+++ b/apps/api/src/finanzas/liquidations.service.ts
@@ -33,6 +33,13 @@ import {
   requireFinanceMembership,
   reviewLiquidationRecord,
 } from './liquidation-publication.use-case';
+import {
+  buildIncomeOffsetExceedsGrossError,
+} from './income-offset-allocation';
+import {
+  LiquidationIncomeOffsetsService,
+  type IncomeOffsetSnapshotItem,
+} from './liquidation-income-offsets.service';
 
 interface LiquidationExpenseSnapshotItem extends Prisma.InputJsonObject {
   expenseId: string;
@@ -84,6 +91,7 @@ export class LiquidationsService {
     private readonly auditService: AuditService,
     private readonly validators: FinanzasValidators,
     private readonly publicationUseCase: LiquidationPublicationUseCase,
+    private readonly incomeOffsetsService: LiquidationIncomeOffsetsService,
   ) {}
 
   private expenseAccountingPeriodWhere(period: string): {
@@ -424,13 +432,43 @@ export class LiquidationsService {
         valuationMode,
       );
 
+      // ── FIN-06: Income offsets (IncomeApplication OFFSET_EXPENSES) ──────
+      // Valuación: LEGACY_NOMINAL exige moneda == baseCurrency; FUNCTIONAL usa
+      // el snapshot funcional congelado del Income (nunca FX live).
+      const incomeOffsets = await this.incomeOffsetsService.collectEligibleOffsets(tx, {
+        tenantId,
+        buildingId: dto.buildingId,
+        period: dto.period,
+        valuationMode,
+        baseCurrency: dto.baseCurrency,
+      });
+
       const billableUnits = await tx.unit.findMany({
         where: { tenantId, buildingId: dto.buildingId, isBillable: true },
         include: { unitCategory: { select: { coefficient: true, id: true } } },
         orderBy: { code: 'asc' },
       });
 
-      const totalAmountMinor = sumValuationAmounts(valuationSources, valuationMode);
+      // Desglose financiero (mismo criterio de valuación que el total actual).
+      const grossExpenseAmountMinor = sumValuationAmounts(
+        valuationSources.filter((source) => source.type === 'EXPENSE'),
+        valuationMode,
+      );
+      const adjustmentAmountMinor = sumValuationAmounts(
+        valuationSources.filter((source) => source.type === 'ADJUSTMENT'),
+        valuationMode,
+      );
+      const preIncomeAmountMinor = grossExpenseAmountMinor + adjustmentAmountMinor;
+      const incomeOffsetAmountMinor = incomeOffsets.incomeOffsetAmountMinor;
+
+      if (incomeOffsetAmountMinor > preIncomeAmountMinor) {
+        throw buildIncomeOffsetExceedsGrossError({
+          incomeOffsetAmountMinor,
+          preIncomeAmountMinor,
+        });
+      }
+
+      const totalAmountMinor = preIncomeAmountMinor - incomeOffsetAmountMinor;
       const chargesPreview = this.calculateDistribution(
         billableUnits,
         totalAmountMinor,
@@ -450,6 +488,14 @@ export class LiquidationsService {
         expenseSnapshot: expenseSnapshotItems,
         unitCount: billableUnits.length,
         generatedByMembershipId: membership.id,
+        grossExpenseAmountMinor,
+        adjustmentAmountMinor,
+        preIncomeAmountMinor,
+        incomeOffsetAmountMinor,
+        netDistributableAmountMinor: totalAmountMinor,
+        incomeOffsetSnapshot: incomeOffsets.items as IncomeOffsetSnapshotItem[],
+        incomeOffsetsByCurrency: incomeOffsets.incomeOffsetsByCurrency,
+        createIncomeOffsetReferences: incomeOffsets.references,
       });
 
       return this.toDetailDto(created, {
@@ -727,6 +773,11 @@ export class LiquidationsService {
     publishedAt: Date | null;
     canceledAt: Date | null;
     createdAt: Date;
+    grossExpenseAmountMinor?: number | null;
+    adjustmentAmountMinor?: number | null;
+    preIncomeAmountMinor?: number | null;
+    incomeOffsetAmountMinor?: number | null;
+    netDistributableAmountMinor?: number | null;
   }): LiquidationResponseDto {
     const totalsByCurrency = parseTotalsByCurrency(liq.totalsByCurrency);
 
@@ -747,6 +798,11 @@ export class LiquidationsService {
       publishedAt: liq.publishedAt,
       canceledAt: liq.canceledAt,
       createdAt: liq.createdAt,
+      grossExpenseAmountMinor: liq.grossExpenseAmountMinor ?? null,
+      adjustmentAmountMinor: liq.adjustmentAmountMinor ?? null,
+      preIncomeAmountMinor: liq.preIncomeAmountMinor ?? null,
+      incomeOffsetAmountMinor: liq.incomeOffsetAmountMinor ?? null,
+      netDistributableAmountMinor: liq.netDistributableAmountMinor ?? null,
     };
   }
 

--- a/apps/api/src/finanzas/liquidations.wiring.spec.ts
+++ b/apps/api/src/finanzas/liquidations.wiring.spec.ts
@@ -10,6 +10,7 @@ import {
   LiquidationPublicationUseCase,
 } from './liquidation-publication.use-case';
 import { LiquidationsService } from './liquidations.service';
+import { LiquidationIncomeOffsetsService } from './liquidation-income-offsets.service';
 
 describe('FinanzasModule wiring', () => {
   it('registers LiquidationPublicationUseCase in module metadata and resolves the same Nest-managed instance inside LiquidationsService', async () => {
@@ -76,6 +77,17 @@ describe('FinanzasModule wiring', () => {
             ),
         },
         LiquidationsService,
+        {
+          provide: LiquidationIncomeOffsetsService,
+          useValue: {
+            collectEligibleOffsets: jest.fn().mockResolvedValue({
+              items: [],
+              references: [],
+              incomeOffsetAmountMinor: 0,
+              incomeOffsetsByCurrency: {},
+            }),
+          },
+        },
       ],
     }).compile();
 


### PR DESCRIPTION
## Descripción

FIN-06: las IncomeApplications `OFFSET_EXPENSES` ahora reducen el neto distributable de la Liquidation (motor activo `LiquidationsService` + `LiquidationPublicationUseCase`). El resultado financiero es:

```
gross expenses + adjustments − income offsets = net distributable
```

La Liquidation distribuye a las unidades SOLAMENTE el neto distributable; los Expenses originales nunca se modifican ni se convierten en income negativo.

### Arquitectura

- **Motor activo**: se trabajó sobre `LiquidationsService` + `LiquidationPublicationUseCase` (rutas `/tenants/:tenantId/finance/liquidations`). El legacy `LiquidationEngineService` NO fue modificado.
- **MovementAllocation vs IncomeApplication**: MovementAllocation decide a qué building pertenece el movimiento; IncomeApplication decide qué se hace con el dinero. Para BUILDING scope el offset completo pertenece al building del Income; para TENANT_SHARED/UNIT_GROUP se usa la distribución por `MovementAllocation.amountMinor` persistida (integer largest remainder determinístico, tie-break por buildingId).
- **Shared 60/40**: Income 10000 con allocations A=6000/B=4000 y aplicación 7000 OFFSET + 3000 FUND → Liquidación A offset = 4200, Liquidación B offset = 2800, SUM = 7000 (nunca doble deducción).
- **Valuación LEGACY_NOMINAL**: la aplicación debe estar en `baseCurrency`; si hay OFFSET elegible en otra moneda se rechaza el draft con `LIQUIDATION_INCOME_OFFSET_CURRENCY_MISMATCH` (no se ignora ni convierte).
- **Valuación FUNCTIONAL**: se usa exclusivamente el snapshot funcional congelado del Income al RECORD (`functionalAmountMinor`, `functionalCurrencyCode`, `exchangeRateId/Value/Direction/EffectiveAt`, `conversionDate`). Prohibido FX live: cambiar un ExchangeRate después del record NO altera el draft (test I).
- **Functional application valuation**: `Income.functionalAmountMinor` pertenece al income completo; cada aplicación recibe su parte proporcional (integer largest remainder: 70 OFFSET → 1750, 30 FUND → 750 de 2500), y luego se distribuye por building con los mismos weights.
- **V3 publication snapshot**: los drafts FIN-06 publican `LiquidationPublicationSnapshotV3` con `version: 3`, `valuationMode`, desglose completo (gross/adjustments/preIncome/incomeOffset/net), `incomeOffsets[]` con provenance por fuente (incomeId, incomeApplicationId, categoryId, policyVersionId, scopeType, currencyCode, montos, snapshot funcional, receivedDate, period) y `incomeOffsetsByCurrency`. V1/V2 existentes se parsean sin cambios.
- **Referencia relacional `LiquidationIncomeOffset`**: una fila por (liquidationId, incomeApplicationId) con unique DB, montos originales/valorados, monedas y building. Void-safety: un Income con OFFSET referenciado por liquidación DRAFT/REVIEWED/PUBLISHED NO puede anularse; CANCELED libera el void. Mezcla OFFSET+FUND publicada bloquea el void completo (all-or-nothing, sin reversa parcial del FUND).
- **Draft snapshot inmutable**: el publish NO recalcula offsets desde income live; valida integridad de las fuentes referenciadas (aplicación sigue OFFSET, montos/moneda coinciden, income RECORDED) → `LIQUIDATION_INCOME_SOURCE_DRIFT` si hay corrupción.
- **Offset > gross**: rechazo con `LIQUIDATION_INCOME_OFFSETS_EXCEED_GROSS` (nunca liquidación negativa, nunca clamp).
- **Zero-net**: `offset == preIncome` → total 0, publicación exitosa SIN cargos positivos (ni negativos), snapshot reconciliado a 0.
- **Concurrencia draft vs void**: se reutiliza `buildingos_income_lock_v1` por income (orden determinístico por incomeId) + revalidación post-lock (Income RECORDED).
- **Audit**: `LIQUIDATION_DRAFT` incluye gross/adjustments/preIncome/incomeOffset/net/incomeOffsetCount; `LIQUIDATION_PUBLISH` incluye snapshotVersion (3 para FIN-06) y el desglose; metadata sin nulls.
- **Backward compatibility**: columnas nuevas nullable; liquidaciones históricas V1/V2 siguen con GET/review/publish y parseo previo; `totalAmountMinor` de legacy no se reinterpreta.

### Migración

`20260816000002_income_offsets_to_liquidations` — aditiva: 7 columnas nullable en `Liquidation` (desglose + snapshots JSONB), tabla `LiquidationIncomeOffset` con CHECK `originalAmountMinor > 0` y `valuedAmountMinor > 0`, unique `(liquidationId, incomeApplicationId)`, FKs Cascade (tenant delete lifecycle intacto). Sin DROP de datos ni rewrites. Validada: zero-DB (95 migraciones) y upgrade desde origin/main (94 + 1).

### Fix baseline incluido (commit separado)

`fix(finance): stabilize liquidation publication baseline` — el test PG `publishes through the real PostgreSQL transaction, writes snapshot V1, audit, and charges` fallaba en origin/main porque esperaba `version: 1` pero el builder escribe `version: 2` (refactor V2 previo). Se actualizó la aserción a V2 (implementación autoritativa); la suite `liquidation-publication.postgres.spec.ts` quedó GREEN (7/7) antes de FIN-06.

### Validación local (counts reales)

| Suite | Resultado |
|---|---|
| Unit finanzas (63 suites) | 1254 passed, 0 failed |
| PostgreSQL FIN-06 (23 tests × 4 runs) | 23/23 determinista |
| PostgreSQL liquidation-publication | 7/7 |
| PostgreSQL FIN-02 regression | 15/15 |
| PostgreSQL FIN-03 regression | 25/25 |
| PostgreSQL FIN-05 regression | 15/15 |
| PostgreSQL payment-allocation | 10/10 |
| Full API (182 suites) | 2761 passed, 0 failed |
| Prisma validate / tsc / eslint / build / diff --check | todos OK |

### Exclusiones explícitas

- Sin impacto en Liquidations legacy engine, Payments, MovementAllocation (fuera de lectura), IncomePolicy semantics, legacy backfill (Income.destination = APPLY_TO_EXPENSES sin IncomeApplications NO descuenta — eso es FIN-04).
- Sin frontend (`apps/web` intocado).
- Sin cambios en staging ni producción.

## Tipo de cambio

- [x] Nueva funcionalidad

## Checklist de validación local obligatoria

- [x] Tests unitarios pasan
- [x] Tests de integración pasan
- [x] Tests E2E pasan (si aplica)
- [x] Typecheck (`tsc --noEmit`) sin errores
- [x] Lint sin errores nuevos
- [x] Build exitoso
- [x] `git diff --check` limpio
- [x] Confirmé que todos los cambios fueron implementados y probados localmente
- [x] Confirmé que el merge a main activará automáticamente el deploy a staging
- [x] El despliegue automático a staging está autorizado para este PR
- [x] Las migraciones incluidas fueron validadas localmente
- [x] No se requiere preservar ningún archivo temporal dentro del checkout de staging
- [x] La validación funcional en staging está definida para después del merge

## PM review hardening (FIN-06R)

Commit `a1464ae` — 6 hallazgos de la auditoría resueltos:

1. **FUNCTIONAL fail-closed**: un OFFSET elegible en modo FUNCTIONAL ahora EXIGE snapshot funcional válido (`functionalAmountMinor != null && > 0`, `functionalCurrencyCode == baseCurrency`); cualquier falla → 422 `LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED` con rollback (0 liquidaciones, 0 referencias). No hay skip/fallback silencioso.
2. **Aritmética exacta**: `distributeMinorByWeights` y `deriveApplicationFunctionalValues` usan `Prisma.Decimal` (`mul/div` + `toDecimalPlaces(ROUND_DOWN)` + remainder), alineado con `allocateFunctionalByLargestRemainder`. Eliminada toda multiplicación Number sobre productos que pueden exceder `MAX_SAFE_INTEGER`. Tests large-value (2e9 × 2e9) con expecteds exactos y 10 repeticiones estables.
3. **Reconciliación de fuentes en publish**: cardinalidad exacta snapshot == relations == unique IDs; igualdad estricta contra el snapshot (application amount/currency/policyVersionId, income id/status/period, reference amounts/currency/baseCurrency/buildingId, snapshot amounts/currency/period) + reconciliación de totales relacional y de snapshot. Matrix de 13 corrupciones controladas → todas 422 `LIQUIDATION_INCOME_SOURCE_DRIFT`, liquidation queda REVIEWED.
4. **Zero-net audit**: `chargesCount` ahora refleja los cargos reales (`expectedCharges.length`); se agregó `allocationCount` separado para las unidades. Zero-net → chargesCount 0, allocationCount N.
5. **DB invariants**: nueva migración `20260816000003_liquidation_income_offset_invariants` con CHECK nullable-safe: legacy rows (todo null) permitidas; rows FIN-06 exigen set completo no-negativo con `gross + adjustment = preIncome`, `preIncome - offset = net`, `net = total`. 9 tests DB reales (A2.1–A2.9).
6. **incomeOffsetsByCurrency**: reconciliación exacta a `{ baseCurrency: incomeOffsetAmountMinor }` cuando offset > 0 (vacío en offset cero) validada en builder V3, parser V3 y publish; tamper tests agregados.

También: `skipDuplicates` eliminado del createMany de referencias (duplicado = bug financiero → rollback; el unique de la DB es la última barrera).

### Nuevos counts de validación (FIN-06R)

| Suite | Resultado |
|---|---|
| Unit finanzas | 1265 passed, 0 failed |
| PostgreSQL FIN-06R (48 tests × 6 runs) | 48/48 determinista |
| Drift matrix (13 casos) | 13/13 422 |
| DB summary invariants (9 casos) | 9/9 |
| FUNCTIONAL fail-closed PG (3 casos) | 3/3 |
| Liquidation publication PG | 7/7 |
| FIN-02/03/05 PG regression | 15/15, 25/25, 15/15 |
| Full API | 2772 passed, 0 failed |
| Migración: zero-DB y upgrade-from-main | 96 migraciones ambas, sin drops/rewrites |


## PM review hardening — round 2 (FIN-06R2)

Commit `1266cbfd` — 2 gaps de clasificación cerrados:

1. **Building eligibility antes de la validación FUNCTIONAL**: la validez del snapshot funcional se exige SOLO cuando una IncomeApplication OFFSET realmente participa en el building de la liquidación (share > 0). Un Income defectuoso de otro building (BUILDING scope ajeno o TENANT_SHARED sin share en este building) ya no puede bloquear esta liquidación. Tests: CASE A–D (unit + PostgreSQL R2.A/R2.B/R2.C).
2. **Post-lock full reload**: `collectEligibleOffsets` ahora (a) descubre solo incomeIds candidatos, (b) adquiere income locks en orden determinístico, (c) RE-CARGA el estado completo post-lock (status/period/scope/building/snapshot funcional/category/allocations/applications) y calcula solo sobre esa lectura — sin estado stale pre-lock.
3. **Clasificación FIN-06 por presencia, nunca por offset > 0**: `isFin06Liquidation = hasFin06Summary || hasFin06Artifacts` (con `!= null` para tratar undefined como ausencia). Una row FIN-06 con offset 0 es FIN-06; una corrompida a offset 0 (ecuaciones DB válidas) o con summary todo NULL (rama legacy-null del CHECK) se detecta por artifacts y se rechaza con 422 — nunca degrada a legacy/V2.
4. **V3 para toda liquidación FIN-06 nueva, incluso offset 0**: los drafts FIN-06 persisten SIEMPRE `incomeOffsetSnapshot: []` e `incomeOffsetsByCurrency: {}` (no se omiten las columnas vacías); el publish de una FIN-06 sin offsets produce snapshot V3 con `incomeOffsets: []`, `incomeOffsetsByCurrency: {}`, summary completo y audit `snapshotVersion: 3`, `incomeOffsetCount: 0`. Solo liquidaciones históricas pre-FIN-06 mantienen null y publican V1/V2.
5. **Tamper bypass tests** (PostgreSQL real, corrupción en DRAFT antes de review — la DB bloquea UPDATE en REVIEWED por trigger de inmutabilidad):
   - R2.E: offset→0 consistente (equations válidas) → 422, queda REVIEWED, sin cargos.
   - R2.F: todos los summary a NULL con artifacts intactos → 422, nunca legacy.
   - R2.G: `incomeOffsetSnapshot = NULL` → 422.
   - R2.H: `incomeOffsetsByCurrency = NULL` → 422.
   - R2.I: offset 0 con snapshot items + reference → 422.
6. **Contracto completo exigido**: si hay evidencia FIN-06 y falta algún summary field → 422 `LIQUIDATION_INCOME_SOURCE_DRIFT` (sin fallback legacy).

### Nuevos counts (FIN-06R2)

| Suite | Resultado |
|---|---|
| Unit finanzas | 1269 passed, 0 failed |
| PostgreSQL FIN-06R2 (57 tests × 6 runs) | 57/57 determinista |
| Building isolation PG (R2.A/B/C) | 3/3 |
| Tamper bypass PG (R2.E–I) | 5/5 |
| Liquidation publication PG | 7/7 |
| FIN-02/03/05 PG regression | 15/15, 25/25, 15/15 |
| Full API | 2776 passed, 0 failed |
| Migraciones | sin cambios (fix a nivel servicio; 96 migraciones validadas) |

Sin migración nueva: ambos gaps se resolvieron en servicio y persistencia JSON. V1/V2 históricos intactos (marker: ausencia de summary y artifacts).


## PM review hardening — round 3 (FIN-06R3)

Commit `9f509d69` — cierre final del bypass relacional:

1. **Las referencias relacionales clasifican FIN-06**: `isFin06Liquidation` ahora es `hasFin06Summary || hasFin06JsonArtifacts || hasFin06RelationalArtifacts`, donde `hasFin06RelationalArtifacts = LiquidationIncomeOffset.count({tenantId, liquidationId}) > 0` (tenant-scoped). Una FIN-06 liquidation corrompida a summary NULL + JSON NULL pero conservando `LiquidationIncomeOffset` rows ya no puede clasificarse como legacy.
2. **Fail-closed**: con refs > 0 + resumen incompleto → 422 `LIQUIDATION_INCOME_SOURCE_DRIFT`; nunca V1/V2/legacy fallback.
3. **Test crítico R3.A** (PostgreSQL real): FIN-06 real (gross 10000, offset 3000, net 7000, snapshot + byCurrency + ref real) → corrupción total a summary NULL + JSON NULL conservando refs → publish rechaza 422, row queda REVIEWED, `publicationSnapshot` null, 0 charges. V2 demostradamente imposible.
4. **Legacy control R3.B**: verdadera liquidación legacy (summary null, JSON null, refs 0) conserva comportamiento histórico → publicación V2, cargos correctos. No se convierte a V3.
5. **Zero-offset control**: FIN-06 nuevo sin offsets (summary presente, JSON `[]`/`{}`, refs 0) sigue clasificando FIN-06 → V3 (test R2.D preservado).

Sin migración nueva (fix a nivel de clasificación en `LiquidationPublicationUseCase`).

### Counts (FIN-06R3)

| Suite | Resultado |
|---|---|
| Unit finanzas | 1269 passed, 0 failed |
| PostgreSQL FIN-06R3 (59 tests × 6 runs) | 59/59 determinista |
| Bypass relacional (R3.A) + legacy control (R3.B) | 2/2 |
| Liquidation publication PG | 7/7 |
| FIN-02/03/05 PG regression | 15/15, 25/25, 15/15 |
| Full API | 2776 passed, 0 failed |
| Prisma validate / tsc / eslint / build / diff check | todos OK |
| Migraciones | sin cambios (96 validadas previamente) |
