### PR TITLE
feat(finance): migrate legacy income destinations safely

### DIFF
--- a/apps/api/prisma/migrations/20260816000004_legacy_income_application_provenance/migration.sql
+++ b/apps/api/prisma/migrations/20260816000004_legacy_income_application_provenance/migration.sql
@@ -1,0 +1,30 @@
+-- FIN-04: provenance de materialización legacy en IncomeApplication.
+-- ADITIVA: columna nullable + AuditAction + CHECKs. Sin data rewrite financiero.
+
+-- AlterEnum AuditAction
+ALTER TYPE "AuditAction" ADD VALUE IF NOT EXISTS 'INCOME_LEGACY_BACKFILL';
+
+-- AlterTable IncomeApplication (provenance legacy)
+ALTER TABLE "IncomeApplication" ADD COLUMN     "legacyDestination" "IncomeDestination";
+
+-- CHECK: provenance mutuamente exclusiva (policy vs legacy)
+ALTER TABLE "IncomeApplication" ADD CONSTRAINT "IncomeApplication_provenance_exclusive"
+CHECK (
+  NOT ("policyVersionId" IS NOT NULL AND "legacyDestination" IS NOT NULL)
+);
+
+-- CHECK: mapping legacy -> destinationType/fundId coherente
+ALTER TABLE "IncomeApplication" ADD CONSTRAINT "IncomeApplication_legacy_destination_mapping"
+CHECK (
+  "legacyDestination" IS NULL
+  OR (
+    "legacyDestination" = 'APPLY_TO_EXPENSES'
+    AND "destinationType" = 'OFFSET_EXPENSES'
+    AND "fundId" IS NULL
+  )
+  OR (
+    "legacyDestination" IN ('RESERVE_FUND', 'SPECIAL_FUND')
+    AND "destinationType" = 'FUND'
+    AND "fundId" IS NOT NULL
+  )
+);

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -833,6 +833,7 @@ enum AuditAction {
   INCOME_POLICY_CREATE
   INCOME_POLICY_VERSION_CREATE
   INCOME_POLICY_DEACTIVATE
+  INCOME_LEGACY_BACKFILL // FIN-04: materialización explícita o automática de destino legacy
   // FUNDS (FIN-02)
   FUND_CREATE
   FUND_UPDATE
@@ -2074,6 +2075,7 @@ model IncomeApplication {
   @@index([tenantId, policyVersionId])
 
   policyVersionId String? // FIN-05: provenance — versión de política que generó esta aplicación (null = manual)
+  legacyDestination IncomeDestination? // FIN-04: provenance — destino legacy que materializó esta aplicación (null = manual/policy)
 }
 
 // ============================================================================

--- a/apps/api/src/finanzas/finanzas.module.ts
+++ b/apps/api/src/finanzas/finanzas.module.ts
@@ -24,6 +24,7 @@ import { ExpensesService } from './expenses.service';
 import { IncomesService } from './incomes.service';
 import { LiquidationsService } from './liquidations.service';
 import { LiquidationIncomeOffsetsService } from './liquidation-income-offsets.service';
+import { LegacyIncomeBackfillService } from './legacy-income-backfill.service';
 import { LiquidationEngineService } from './liquidation-engine.service';
 import { LiquidationEngineController } from './liquidation-engine.controller';
 import { MovementAllocationService } from './movement-allocation.service';
@@ -127,6 +128,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     },
     LiquidationsService,
     LiquidationIncomeOffsetsService,
+    LegacyIncomeBackfillService,
     MovementAllocationService,
     UnitGroupService,
     LiquidationEngineService,
@@ -154,6 +156,7 @@ const { provider: paymentProvider, options: paymentOptions } = resolvePaymentGat
     IncomesService,
     LiquidationsService,
     LiquidationIncomeOffsetsService,
+    LegacyIncomeBackfillService,
     MovementAllocationService,
     UnitGroupService,
     LiquidationEngineService,

--- a/apps/api/src/finanzas/income-applications.service.spec.ts
+++ b/apps/api/src/finanzas/income-applications.service.spec.ts
@@ -9,6 +9,7 @@ import {
   FundStatus,
   FundTransactionDirection,
   IncomeApplicationDestination,
+  IncomeDestination,
   IncomeStatus,
   Prisma,
 } from '@prisma/client';
@@ -711,6 +712,170 @@ describe('IncomeApplicationsService', () => {
       );
       expect(txAuditCalls).toHaveLength(1);
       expect(txAuditCalls[0]![0].metadata.policyVersionId).toBe('policy-version-1');
+    });
+  });
+
+  describe('FIN-04 publishLegacyBackfillPlan', () => {
+    const legacyIncome = {
+      id: 'income-legacy',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      period: '2026-08',
+      scopeType: 'BUILDING',
+      status: 'RECORDED',
+      destination: 'APPLY_TO_EXPENSES',
+      amountMinor: 5000,
+      currencyCode: 'USD',
+      receivedDate: new Date('2026-08-10T00:00:00.000Z'),
+      categoryId: 'cat-1',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+
+    it('APPLY legacy creates an OFFSET application with legacyDestination provenance', async () => {
+      (prismaValue.income.findFirst as jest.Mock).mockResolvedValue(legacyIncome);
+      (prismaValue.incomeApplication.findMany as jest.Mock).mockResolvedValue([]);
+      (prismaValue.incomeApplication.create as jest.Mock).mockImplementation(
+        ({ data }: { data: Record<string, unknown> }) =>
+          Promise.resolve({ id: 'app-legacy', ...data }),
+      );
+
+      await service.publishLegacyBackfillPlan(
+        prismaValue as unknown as Parameters<typeof service.publishLegacyBackfillPlan>[0],
+        {
+          tenantId: 'tenant-1',
+          incomeId: 'income-legacy',
+          membershipId: 'member-1',
+          legacyDestination: IncomeDestination.APPLY_TO_EXPENSES,
+          plan: [
+            {
+              destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+              fundId: null,
+              amountMinor: 5000,
+            },
+          ],
+        },
+      );
+
+      expect(prismaValue.incomeApplication.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+            fundId: null,
+            amountMinor: 5000,
+            currencyCode: 'USD',
+            policyVersionId: null,
+            legacyDestination: IncomeDestination.APPLY_TO_EXPENSES,
+          }),
+        }),
+      );
+    });
+
+    it('RESERVE legacy creates a FUND application with fundTransactionOccurredAt = receivedDate', async () => {
+      (prismaValue.income.findFirst as jest.Mock).mockResolvedValue(legacyIncome);
+      (prismaValue.incomeApplication.findMany as jest.Mock).mockResolvedValue([]);
+      (prismaValue.incomeApplication.create as jest.Mock).mockImplementation(
+        ({ data }: { data: Record<string, unknown> }) =>
+          Promise.resolve({ id: 'app-fund', ...data }),
+      );
+      (prismaValue.fundTransaction.create as jest.Mock).mockResolvedValue({
+        id: 'ft-1',
+        fundId: 'fund-1',
+        direction: FundTransactionDirection.CREDIT,
+        amountMinor: 5000,
+        currencyCode: 'USD',
+        occurredAt: legacyIncome.receivedDate,
+      });
+
+      await service.publishLegacyBackfillPlan(
+        prismaValue as unknown as Parameters<typeof service.publishLegacyBackfillPlan>[0],
+        {
+          tenantId: 'tenant-1',
+          incomeId: 'income-legacy',
+          membershipId: 'member-1',
+          legacyDestination: IncomeDestination.RESERVE_FUND,
+          plan: [
+            {
+              destinationType: IncomeApplicationDestination.FUND,
+              fundId: 'fund-1',
+              amountMinor: 5000,
+            },
+          ],
+        },
+      );
+
+      expect(prismaValue.incomeApplication.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            destinationType: IncomeApplicationDestination.FUND,
+            fundId: 'fund-1',
+            legacyDestination: IncomeDestination.RESERVE_FUND,
+          }),
+        }),
+      );
+      expect(prismaValue.fundTransaction.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            occurredAt: legacyIncome.receivedDate, // recibido, no hoy
+            incomeApplicationId: 'app-fund',
+          }),
+        }),
+      );
+    });
+
+    it('rejects a plan whose sum does not match the income amount', async () => {
+      (prismaValue.income.findFirst as jest.Mock).mockResolvedValue(legacyIncome);
+
+      await expect(
+        service.publishLegacyBackfillPlan(
+          prismaValue as unknown as Parameters<typeof service.publishLegacyBackfillPlan>[0],
+          {
+            tenantId: 'tenant-1',
+            incomeId: 'income-legacy',
+            membershipId: 'member-1',
+            legacyDestination: IncomeDestination.APPLY_TO_EXPENSES,
+            plan: [
+              {
+                destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+                fundId: null,
+                amountMinor: 4000,
+              },
+            ],
+          },
+        ),
+      ).rejects.toThrow(BadRequestException);
+      expect(prismaValue.incomeApplication.create).not.toHaveBeenCalled();
+    });
+
+    it('is idempotent when the same legacy plan already exists', async () => {
+      (prismaValue.income.findFirst as jest.Mock).mockResolvedValue(legacyIncome);
+      (prismaValue.incomeApplication.findMany as jest.Mock).mockResolvedValue([
+        makeApplication({
+          destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+          amountMinor: 5000,
+          currencyCode: 'USD',
+        }),
+      ]);
+
+      const result = await service.publishLegacyBackfillPlan(
+        prismaValue as unknown as Parameters<typeof service.publishLegacyBackfillPlan>[0],
+        {
+          tenantId: 'tenant-1',
+          incomeId: 'income-legacy',
+          membershipId: 'member-1',
+          legacyDestination: IncomeDestination.APPLY_TO_EXPENSES,
+          plan: [
+            {
+              destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+              fundId: null,
+              amountMinor: 5000,
+            },
+          ],
+        },
+      );
+
+      expect(result.applications).toHaveLength(1);
+      expect(prismaValue.incomeApplication.create).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/finanzas/income-applications.service.ts
+++ b/apps/api/src/finanzas/income-applications.service.ts
@@ -9,6 +9,7 @@ import {
   FundStatus,
   FundTransactionDirection,
   IncomeApplicationDestination,
+  IncomeDestination,
   IncomeStatus,
   Prisma,
 } from '@prisma/client';
@@ -204,6 +205,54 @@ export class IncomeApplicationsService {
     });
   }
 
+  /**
+   * FIN-04: publica un plan de materialización legacy reutilizando el publisher
+   * compartido (mismas invariantes: income lock, fund locks, CREDITs, audits,
+   * idempotencia). legacyDestination marca la provenance; el CREDIT de Fund usa
+   * fundTransactionOccurredAt (= Income.receivedDate para backfill histórico).
+   */
+  async publishLegacyBackfillPlan(
+    tx: Prisma.TransactionClient,
+    params: {
+      tenantId: string;
+      incomeId: string;
+      membershipId: string;
+      legacyDestination: IncomeDestination;
+      plan: Array<{ destinationType: IncomeApplicationDestination; fundId: string | null; amountMinor: number }>;
+      fundTransactionOccurredAt?: Date;
+    },
+  ): Promise<IncomeApplicationPlanResponseDto> {
+    const income = await tx.income.findFirst({
+      where: { id: params.incomeId, tenantId: params.tenantId },
+    });
+    if (!income) {
+      throw new NotFoundException(`Ingreso no encontrado: ${params.incomeId}`);
+    }
+    const totalAmountMinor = params.plan.reduce((sum, app) => sum + app.amountMinor, 0);
+    if (totalAmountMinor !== income.amountMinor) {
+      throw new BadRequestException(
+        `La suma de aplicaciones (${totalAmountMinor}) debe ser exactamente ${income.amountMinor}`,
+      );
+    }
+
+    return this.publishPlanTx(tx, {
+      tenantId: params.tenantId,
+      income: {
+        id: income.id,
+        amountMinor: income.amountMinor,
+        currencyCode: income.currencyCode,
+        receivedDate: income.receivedDate,
+        categoryId: income.categoryId,
+      },
+      membershipId: params.membershipId,
+      plan: params.plan,
+      totalAmountMinor,
+      policyVersionId: null,
+      legacyDestination: params.legacyDestination,
+      fundTransactionOccurredAt: params.fundTransactionOccurredAt ?? income.receivedDate,
+    });
+  }
+
   // ── Internos ─────────────────────────────────────────────────────────────
 
   /**
@@ -220,9 +269,13 @@ export class IncomeApplicationsService {
       plan: Array<{ destinationType: IncomeApplicationDestination; fundId: string | null; amountMinor: number }>;
       totalAmountMinor: number;
       policyVersionId: string | null;
+      legacyDestination?: IncomeDestination | null; // FIN-04
+      fundTransactionOccurredAt?: Date; // FIN-04: por defecto income.receivedDate
     },
   ): Promise<IncomeApplicationPlanResponseDto> {
     const { tenantId, income, membershipId, plan, totalAmountMinor, policyVersionId } = params;
+    const legacyDestination = params.legacyDestination ?? null;
+    const fundTransactionOccurredAt = params.fundTransactionOccurredAt ?? income.receivedDate;
     const incomeId = income.id;
 
     // Plan existente → idempotencia (mismo canonical → retorna existente)
@@ -305,6 +358,7 @@ export class IncomeApplicationsService {
           currencyCode: income.currencyCode,
           createdByMembershipId: membershipId,
           policyVersionId,
+          legacyDestination,
         },
       });
 
@@ -316,7 +370,7 @@ export class IncomeApplicationsService {
             direction: FundTransactionDirection.CREDIT,
             amountMinor: app.amountMinor,
             currencyCode: income.currencyCode,
-            occurredAt: income.receivedDate,
+            occurredAt: fundTransactionOccurredAt,
             description: `Aplicación de ingreso ${incomeId}`,
             createdByMembershipId: membershipId,
             idempotencyKey: incomeApplicationFundTransactionKey(application.id),
@@ -336,7 +390,7 @@ export class IncomeApplicationsService {
               direction: FundTransactionDirection.CREDIT,
               amountMinor: app.amountMinor,
               currencyCode: income.currencyCode,
-              occurredAt: income.receivedDate.toISOString(),
+              occurredAt: fundTransactionOccurredAt.toISOString(),
               idempotencyKey: incomeApplicationFundTransactionKey(application.id),
               incomeApplicationId: application.id,
               ...(policyVersionId !== null ? { policyVersionId } : {}),
@@ -367,6 +421,7 @@ export class IncomeApplicationsService {
           currencyCode: income.currencyCode,
           totalAmountMinor: totalAmountMinor,
           ...(policyVersionId !== null ? { policyVersionId } : {}),
+          ...(legacyDestination !== null ? { legacyDestination } : {}),
           applications: plan.map((app) => ({
             destinationType: app.destinationType,
             ...(app.fundId !== undefined && app.fundId !== null

--- a/apps/api/src/finanzas/incomes.controller.spec.ts
+++ b/apps/api/src/finanzas/incomes.controller.spec.ts
@@ -1,0 +1,76 @@
+import { Test } from '@nestjs/testing';
+import { IncomeDestination } from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { IncomesController } from './incomes.controller';
+import { IncomesService } from './incomes.service';
+import { IncomeApplicationsService } from './income-applications.service';
+import { LegacyIncomeBackfillService } from './legacy-income-backfill.service';
+
+describe('IncomesController legacy-backfill routes (FIN-04)', () => {
+  let controller: IncomesController;
+  let backfill: { preview: jest.Mock; apply: jest.Mock };
+
+  beforeEach(async () => {
+    backfill = { preview: jest.fn().mockResolvedValue([]), apply: jest.fn().mockResolvedValue([]) };
+
+    const module = await Test.createTestingModule({
+      controllers: [IncomesController],
+      providers: [
+        { provide: PrismaService, useValue: { membership: { findUnique: jest.fn() } } },
+        { provide: IncomesService, useValue: { getIncome: jest.fn() } },
+        { provide: IncomeApplicationsService, useValue: {} },
+        { provide: LegacyIncomeBackfillService, useValue: backfill },
+      ],
+    }).compile();
+
+    controller = module.get(IncomesController);
+  });
+
+  it('routes GET legacy-backfill/preview to the backfill service, not :incomeId', async () => {
+    const result = await controller.previewLegacyBackfill(
+      '2026-08',
+      'cat-1',
+      IncomeDestination.APPLY_TO_EXPENSES,
+      {
+        tenantId: 'tenant-1',
+        user: { membershipId: 'member-1', roles: ['TENANT_ADMIN'] },
+      } as never,
+    );
+
+    expect(backfill.preview).toHaveBeenCalledWith('tenant-1', 'member-1', ['TENANT_ADMIN'], {
+      period: '2026-08',
+      categoryId: 'cat-1',
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+    });
+    expect(result).toEqual([]);
+  });
+
+  it('routes POST legacy-backfill/apply to the backfill service', async () => {
+    backfill.apply.mockResolvedValue([{ incomeId: 'income-1', status: 'MIGRATED' }]);
+    const result = await controller.applyLegacyBackfill(
+      { items: [{ incomeId: 'income-1' }] },
+      {
+        tenantId: 'tenant-1',
+        user: { membershipId: 'member-1', roles: ['TENANT_ADMIN'] },
+      } as never,
+    );
+
+    expect(backfill.apply).toHaveBeenCalledWith('tenant-1', 'member-1', ['TENANT_ADMIN'], [
+      { incomeId: 'income-1' },
+    ]);
+    expect(result).toEqual([{ incomeId: 'income-1', status: 'MIGRATED' }]);
+  });
+
+  it('passes undefined filters when not provided', async () => {
+    await controller.previewLegacyBackfill(undefined, undefined, undefined, {
+      tenantId: 'tenant-1',
+      user: { membershipId: 'member-1', roles: ['TENANT_ADMIN'] },
+    } as never);
+
+    expect(backfill.preview).toHaveBeenCalledWith('tenant-1', 'member-1', ['TENANT_ADMIN'], {
+      period: undefined,
+      categoryId: undefined,
+      destination: undefined,
+    });
+  });
+});

--- a/apps/api/src/finanzas/incomes.controller.spec.ts
+++ b/apps/api/src/finanzas/incomes.controller.spec.ts
@@ -28,16 +28,14 @@ describe('IncomesController legacy-backfill routes (FIN-04)', () => {
 
   it('routes GET legacy-backfill/preview to the backfill service, not :incomeId', async () => {
     const result = await controller.previewLegacyBackfill(
-      '2026-08',
-      'cat-1',
-      IncomeDestination.APPLY_TO_EXPENSES,
+      { period: '2026-08', categoryId: 'cat-1', destination: IncomeDestination.APPLY_TO_EXPENSES },
       {
         tenantId: 'tenant-1',
         user: { membershipId: 'member-1', roles: ['TENANT_ADMIN'] },
       } as never,
     );
 
-    expect(backfill.preview).toHaveBeenCalledWith('tenant-1', 'member-1', ['TENANT_ADMIN'], {
+    expect(backfill.preview).toHaveBeenCalledWith('tenant-1', 'member-1', {
       period: '2026-08',
       categoryId: 'cat-1',
       destination: IncomeDestination.APPLY_TO_EXPENSES,
@@ -55,19 +53,22 @@ describe('IncomesController legacy-backfill routes (FIN-04)', () => {
       } as never,
     );
 
-    expect(backfill.apply).toHaveBeenCalledWith('tenant-1', 'member-1', ['TENANT_ADMIN'], [
+    expect(backfill.apply).toHaveBeenCalledWith('tenant-1', 'member-1', [
       { incomeId: 'income-1' },
     ]);
     expect(result).toEqual([{ incomeId: 'income-1', status: 'MIGRATED' }]);
   });
 
   it('passes undefined filters when not provided', async () => {
-    await controller.previewLegacyBackfill(undefined, undefined, undefined, {
-      tenantId: 'tenant-1',
-      user: { membershipId: 'member-1', roles: ['TENANT_ADMIN'] },
-    } as never);
+    await controller.previewLegacyBackfill(
+      { period: undefined, categoryId: undefined, destination: undefined },
+      {
+        tenantId: 'tenant-1',
+        user: { membershipId: 'member-1', roles: ['TENANT_ADMIN'] },
+      } as never,
+    );
 
-    expect(backfill.preview).toHaveBeenCalledWith('tenant-1', 'member-1', ['TENANT_ADMIN'], {
+    expect(backfill.preview).toHaveBeenCalledWith('tenant-1', 'member-1', {
       period: undefined,
       categoryId: undefined,
       destination: undefined,

--- a/apps/api/src/finanzas/incomes.controller.ts
+++ b/apps/api/src/finanzas/incomes.controller.ts
@@ -11,11 +11,13 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
+import { IncomeDestination } from '@prisma/client';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
 import { AuthenticatedRequest } from '../common/types/request.types';
 import { IncomesService } from './incomes.service';
 import { IncomeApplicationsService } from './income-applications.service';
+import { LegacyIncomeBackfillService } from './legacy-income-backfill.service';
 import { IncomeApplicationPlanResponseDto } from './income-applications.dto';
 import {
   CreateIncomeDto,
@@ -33,7 +35,43 @@ export class IncomesController {
   constructor(
     private readonly incomesService: IncomesService,
     private readonly incomeApplicationsService: IncomeApplicationsService,
+    private readonly legacyBackfillService: LegacyIncomeBackfillService,
   ) {}
+
+  /**
+   * FIN-04: rutas estáticas ANTES de :incomeId para evitar shadowing.
+   */
+  @Get('legacy-backfill/preview')
+  async previewLegacyBackfill(
+    @Query('period') period?: string,
+    @Query('categoryId') categoryId?: string,
+    @Query('destination') destination?: IncomeDestination,
+    @Request() req?: AuthenticatedRequest,
+  ) {
+    return this.legacyBackfillService.preview(
+      req!.tenantId!,
+      req!.user.membershipId ?? '',
+      req!.user.roles ?? [],
+      {
+        period,
+        categoryId,
+        destination,
+      },
+    );
+  }
+
+  @Post('legacy-backfill/apply')
+  async applyLegacyBackfill(
+    @Body() dto: { items: Array<{ incomeId: string; fundId?: string | null }> },
+    @Request() req?: AuthenticatedRequest,
+  ) {
+    return this.legacyBackfillService.apply(
+      req!.tenantId!,
+      req!.user.membershipId ?? '',
+      req!.user.roles ?? [],
+      dto.items,
+    );
+  }
 
   @Get()
   async listIncomes(

--- a/apps/api/src/finanzas/incomes.controller.ts
+++ b/apps/api/src/finanzas/incomes.controller.ts
@@ -11,13 +11,16 @@ import {
   HttpCode,
   HttpStatus,
 } from '@nestjs/common';
-import { IncomeDestination } from '@prisma/client';
-import { JwtAuthGuard } from '../auth/jwt-auth.guard';
-import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
-import { AuthenticatedRequest } from '../common/types/request.types';
 import { IncomesService } from './incomes.service';
 import { IncomeApplicationsService } from './income-applications.service';
 import { LegacyIncomeBackfillService } from './legacy-income-backfill.service';
+import {
+  LegacyBackfillApplyDto,
+  LegacyBackfillPreviewQueryDto,
+} from './legacy-income-backfill.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
+import { AuthenticatedRequest } from '../common/types/request.types';
 import { IncomeApplicationPlanResponseDto } from './income-applications.dto';
 import {
   CreateIncomeDto,
@@ -43,32 +46,28 @@ export class IncomesController {
    */
   @Get('legacy-backfill/preview')
   async previewLegacyBackfill(
-    @Query('period') period?: string,
-    @Query('categoryId') categoryId?: string,
-    @Query('destination') destination?: IncomeDestination,
+    @Query() query: LegacyBackfillPreviewQueryDto,
     @Request() req?: AuthenticatedRequest,
   ) {
     return this.legacyBackfillService.preview(
       req!.tenantId!,
       req!.user.membershipId ?? '',
-      req!.user.roles ?? [],
       {
-        period,
-        categoryId,
-        destination,
+        period: query.period,
+        categoryId: query.categoryId,
+        destination: query.destination,
       },
     );
   }
 
   @Post('legacy-backfill/apply')
   async applyLegacyBackfill(
-    @Body() dto: { items: Array<{ incomeId: string; fundId?: string | null }> },
+    @Body() dto: LegacyBackfillApplyDto,
     @Request() req?: AuthenticatedRequest,
   ) {
     return this.legacyBackfillService.apply(
       req!.tenantId!,
       req!.user.membershipId ?? '',
-      req!.user.roles ?? [],
       dto.items,
     );
   }

--- a/apps/api/src/finanzas/legacy-income-backfill.dto.ts
+++ b/apps/api/src/finanzas/legacy-income-backfill.dto.ts
@@ -1,0 +1,53 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  ArrayNotEmpty,
+  IsArray,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  Matches,
+  ValidateNested,
+} from 'class-validator';
+import { IncomeDestination } from '@prisma/client';
+
+/**
+ * FIN-04R: validación runtime de los endpoints de backfill legacy.
+ */
+
+export class LegacyBackfillPreviewQueryDto {
+  @IsOptional()
+  @IsString()
+  @Matches(/^\d{4}-\d{2}$/, { message: 'period must be in YYYY-MM format' })
+  period?: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  categoryId?: string;
+
+  @IsOptional()
+  @IsEnum(IncomeDestination)
+  destination?: IncomeDestination;
+}
+
+export class LegacyBackfillApplyItemDto {
+  @IsString()
+  @IsNotEmpty()
+  incomeId!: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  fundId?: string | null;
+}
+
+export class LegacyBackfillApplyDto {
+  @IsArray()
+  @ArrayNotEmpty()
+  @ArrayMaxSize(100)
+  @ValidateNested({ each: true })
+  @Type(() => LegacyBackfillApplyItemDto)
+  items!: LegacyBackfillApplyItemDto[];
+}

--- a/apps/api/src/finanzas/legacy-income-backfill.http.spec.ts
+++ b/apps/api/src/finanzas/legacy-income-backfill.http.spec.ts
@@ -1,0 +1,128 @@
+import { CanActivate, INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import request = require('supertest');
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { TenantAccessGuard } from '../tenancy/tenant-access.guard';
+import { IncomesController } from './incomes.controller';
+import { IncomesService } from './incomes.service';
+import { IncomeApplicationsService } from './income-applications.service';
+import { LegacyIncomeBackfillService } from './legacy-income-backfill.service';
+
+const alwaysPass: CanActivate = { canActivate: () => true };
+
+describe('Legacy backfill HTTP validation (FIN-04R)', () => {
+  let app: INestApplication;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      controllers: [IncomesController],
+      providers: [
+        { provide: IncomesService, useValue: { getIncome: jest.fn() } },
+        { provide: IncomeApplicationsService, useValue: {} },
+        {
+          provide: LegacyIncomeBackfillService,
+          useValue: {
+            preview: jest.fn().mockResolvedValue([]),
+            apply: jest.fn().mockResolvedValue([]),
+          },
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(alwaysPass)
+      .overrideGuard(TenantAccessGuard)
+      .useValue(alwaysPass)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.use((req: any, _res: any, next: any) => {
+      req.tenantId = 't-1';
+      req.user = { id: 'user-1', roles: ['TENANT_ADMIN'], membershipId: 'member-1' };
+      next();
+    });
+    app.useGlobalPipes(
+      new ValidationPipe({
+        whitelist: true,
+        forbidNonWhitelisted: false,
+        transform: true,
+        transformOptions: { enableImplicitConversion: true },
+      }),
+    );
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  const applyUrl = '/tenants/t-1/finance/incomes/legacy-backfill/apply';
+  const previewUrl = '/tenants/t-1/finance/incomes/legacy-backfill/preview';
+
+  it('POST {} → 400', async () => {
+    const res = await request(app.getHttpServer()).post(applyUrl).send({});
+    expect(res.status).toBe(400);
+  });
+
+  it('POST {"items":null} → 400', async () => {
+    const res = await request(app.getHttpServer()).post(applyUrl).send({ items: null });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST {"items":[]} → 400', async () => {
+    const res = await request(app.getHttpServer()).post(applyUrl).send({ items: [] });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST 101 items → 400', async () => {
+    const items = Array.from({ length: 101 }, (_, i) => ({ incomeId: `income-${i}` }));
+    const res = await request(app.getHttpServer()).post(applyUrl).send({ items });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST item without incomeId → 400', async () => {
+    const res = await request(app.getHttpServer())
+      .post(applyUrl)
+      .send({ items: [{ fundId: 'fund-1' }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST empty incomeId → 400', async () => {
+    const res = await request(app.getHttpServer())
+      .post(applyUrl)
+      .send({ items: [{ incomeId: '' }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST numeric fundId → 400', async () => {
+    const res = await request(app.getHttpServer())
+      .post(applyUrl)
+      .send({ items: [{ incomeId: 'income-1', fundId: 123 }] });
+    expect(res.status).toBe(400);
+  });
+
+  it('GET preview?destination=INVALID → 400', async () => {
+    const res = await request(app.getHttpServer())
+      .get(previewUrl)
+      .query({ destination: 'INVALID' });
+    expect(res.status).toBe(400);
+  });
+
+  it('GET preview?period=2026/05 → 400', async () => {
+    const res = await request(app.getHttpServer()).get(previewUrl).query({ period: '2026/05' });
+    expect(res.status).toBe(400);
+  });
+
+  it('GET preview valid → 200', async () => {
+    const res = await request(app.getHttpServer())
+      .get(previewUrl)
+      .query({ period: '2026-08', destination: 'APPLY_TO_EXPENSES' });
+    expect(res.status).toBe(200);
+  });
+
+  it('POST valid single item → 201', async () => {
+    const res = await request(app.getHttpServer())
+      .post(applyUrl)
+      .send({ items: [{ incomeId: 'income-1' }] });
+    expect(res.status).toBe(201);
+  });
+});

--- a/apps/api/src/finanzas/legacy-income-backfill.postgres.spec.ts
+++ b/apps/api/src/finanzas/legacy-income-backfill.postgres.spec.ts
@@ -59,14 +59,14 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
     );
     const appsSvc = new IncomeApplicationsService(prisma, audit, validators);
     return {
-      backfill: new LegacyIncomeBackfillService(prisma, audit, validators, appsSvc),
+      backfill: new LegacyIncomeBackfillService(prisma, audit, appsSvc),
       liquidations: new LiquidationsService(
         prisma,
         audit,
         validators,
         useCase,
         new LiquidationIncomeOffsetsService(prisma),
-        new LegacyIncomeBackfillService(prisma, audit, validators, appsSvc),
+        new LegacyIncomeBackfillService(prisma, audit, appsSvc),
       ),
       incomes: new IncomesService(prisma, audit, validators, new MovementAllocationService(prisma, audit, validators), new CurrencyConversionService(prisma)),
       apps: appsSvc,
@@ -312,7 +312,7 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
       amountMinor: 1000,
       destination: IncomeDestination.APPLY_TO_EXPENSES,
     });
-    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: income.id }]);
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, [{ incomeId: income.id }]);
     expect(result[0]!.status).toBe('MIGRATED');
 
     await observer.tenant.delete({ where: { id: ctx.tenant.id } });
@@ -502,13 +502,13 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
     });
 
     // Backfill explícito → conflicto (draft A activo del mismo período).
-    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: legacy.id }]);
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, [{ incomeId: legacy.id }]);
     expect(result[0]!.status).toBe('LIQUIDATION_CONFLICT');
     expect(await observer.incomeApplication.count({ where: { incomeId: legacy.id } })).toBe(0);
 
     // Cancelar el draft → ahora sí puede materializarse.
     await liquidations.cancelLiquidation(ctx.tenant.id, draftA.id, ctx.membership.id);
-    const after = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: legacy.id }]);
+    const after = await backfill.apply(ctx.tenant.id, ctx.membership.id, [{ incomeId: legacy.id }]);
     expect(after[0]!.status).toBe('MIGRATED');
   }, 30000);
 
@@ -529,7 +529,7 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
       buildingId: buildingA.id,
     });
 
-    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: legacy.id }]);
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, [{ incomeId: legacy.id }]);
     expect(result[0]!.status).toBe('LIQUIDATION_CONFLICT');
     expect(await observer.incomeApplication.count({ where: { incomeId: legacy.id } })).toBe(0);
   }, 30000);
@@ -572,7 +572,7 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
       data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `R ${Date.now()}`, createdByMembershipId: ctx.membership.id },
     });
 
-    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, [
       { incomeId: income.id, fundId: fund.id },
     ]);
     expect(result[0]!.status).toBe('MIGRATED');
@@ -607,7 +607,7 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
     expect(actionSet.has('INCOME_LEGACY_BACKFILL')).toBe(true);
 
     // Retry idempotente.
-    const retry = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [
+    const retry = await backfill.apply(ctx.tenant.id, ctx.membership.id, [
       { incomeId: income.id, fundId: fund.id },
     ]);
     expect(retry[0]!.status).toBe('ALREADY_MIGRATED');
@@ -626,7 +626,7 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
       data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'SPECIAL', name: `S ${Date.now()}`, createdByMembershipId: ctx.membership.id },
     });
 
-    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, [
       { incomeId: income.id, fundId: fund.id },
     ]);
     expect(result[0]!.status).toBe('MIGRATED');
@@ -646,7 +646,7 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
       data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'SPECIAL', name: `W ${Date.now()}`, createdByMembershipId: ctx.membership.id },
     });
 
-    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, [
       { incomeId: income.id, fundId: fund.id },
     ]);
     expect(result[0]!.status).toBe('INVALID_FUND');
@@ -672,7 +672,7 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
       },
     });
 
-    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, [
       { incomeId: income.id, fundId: fund.id },
     ]);
     expect(result[0]!.status).toBe('INVALID_FUND');
@@ -690,7 +690,7 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
       data: { tenantId: ctxB.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `X ${Date.now()}`, createdByMembershipId: ctxB.membership.id },
     });
 
-    const result = await backfill.apply(ctxA.tenant.id, ctxA.membership.id, roles, [
+    const result = await backfill.apply(ctxA.tenant.id, ctxA.membership.id, [
       { incomeId: income.id, fundId: fundB.id },
     ]);
     expect(result[0]!.status).toBe('INVALID_FUND');
@@ -704,8 +704,8 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
       destination: IncomeDestination.APPLY_TO_EXPENSES,
     });
 
-    const first = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: income.id }]);
-    const second = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: income.id }]);
+    const first = await backfill.apply(ctx.tenant.id, ctx.membership.id, [{ incomeId: income.id }]);
+    const second = await backfill.apply(ctx.tenant.id, ctx.membership.id, [{ incomeId: income.id }]);
 
     expect(first[0]!.status).toBe('MIGRATED');
     expect(second[0]!.status).toBe('ALREADY_MIGRATED');
@@ -721,8 +721,8 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
     });
 
     const [a, b] = await Promise.all([
-      backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: income.id }]),
-      backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: income.id }]),
+      backfill.apply(ctx.tenant.id, ctx.membership.id, [{ incomeId: income.id }]),
+      backfill.apply(ctx.tenant.id, ctx.membership.id, [{ incomeId: income.id }]),
     ]);
 
     expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(1);
@@ -742,7 +742,7 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
       applications: [{ destinationType: IncomeApplicationDestination.CARRY_FORWARD, amountMinor: 3000 }],
     });
 
-    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: income.id }]);
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, [{ incomeId: income.id }]);
     expect(result[0]!.status).toBe('ALREADY_HAS_PLAN');
     expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(1);
     const app = await observer.incomeApplication.findFirstOrThrow({ where: { incomeId: income.id } });
@@ -784,7 +784,7 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
 
     await incomes.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles);
 
-    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: income.id }]);
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, [{ incomeId: income.id }]);
     expect(result[0]!.status).toBe('NOT_RECORDED');
     expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(0);
   }, 30000);
@@ -893,8 +893,8 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
       destination: IncomeDestination.APPLY_TO_EXPENSES,
       buildingId: buildingA.id,
     });
-    await backfill.preview(ctx.tenant.id, ctx.membership.id, roles, {});
-    const applyResult = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: legacy.id }]);
+    await backfill.preview(ctx.tenant.id, ctx.membership.id, {});
+    const applyResult = await backfill.apply(ctx.tenant.id, ctx.membership.id, [{ incomeId: legacy.id }]);
     expect(applyResult[0]!.status).toBe('LIQUIDATION_CONFLICT');
 
     // Nada mutó: snapshot, total, charges intactos.
@@ -917,7 +917,7 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
     const previewA = await backfill.preview(ctxA.tenant.id, ctxA.membership.id, roles, {});
     expect(previewA).toHaveLength(0);
 
-    const applyB = await backfill.apply(ctxB.tenant.id, ctxB.membership.id, roles, [{ incomeId: incomeB.id }]);
+    const applyB = await backfill.apply(ctxB.tenant.id, ctxB.membership.id, [{ incomeId: incomeB.id }]);
     expect(applyB[0]!.status).toBe('MIGRATED');
     expect(await observer.incomeApplication.count({ where: { tenantId: ctxA.tenant.id } })).toBe(0);
   }, 30000);
@@ -926,4 +926,248 @@ describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
     const leftover = await observer.tenant.count({ where: { name: { startsWith: `${fixturePhase}-` } } });
     expect(leftover).toBe(0);
   }, 10000);
+
+  // ── FIN-04R: building isolation for lazy materialization ────────────────
+
+  it('R1.A. legacy BUILDING income B is not materialized by draft A', async () => {
+    const ctx = await fixture('r1-a');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const buildingB = await building(ctx.tenant.id, 'B');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const incomeB = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 3000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      buildingId: buildingB.id,
+    });
+
+    const draft = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    expect(draft.incomeOffsetAmountMinor).toBe(0);
+    expect(await observer.incomeApplication.count({ where: { incomeId: incomeB.id } })).toBe(0);
+    expect(
+      await observer.auditLog.count({
+        where: { tenantId: ctx.tenant.id, action: 'INCOME_LEGACY_BACKFILL' },
+      }),
+    ).toBe(0);
+  }, 30000);
+
+  it('R1.B. historical conflict of unrelated building B does not block draft A', async () => {
+    const ctx = await fixture('r1-b');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const buildingB = await building(ctx.tenant.id, 'B');
+    await units(ctx.tenant.id, buildingA.id);
+    await units(ctx.tenant.id, buildingB.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    await validatedExpense(ctx.tenant.id, buildingB.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+
+    // Building B ya tiene liquidation PUBLISHED.
+    const draftB = await createDraftFor(ctx.tenant.id, buildingB.id, ctx.membership.id);
+    const reviewedB = await liquidations.reviewLiquidation(ctx.tenant.id, draftB.id, ctx.membership.id);
+    await liquidations.publishLiquidation(ctx.tenant.id, reviewedB.id, ctx.membership.id, { dueDate: '2026-09-10' });
+
+    // Income legacy de B (después de publicar B).
+    const incomeB = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 3000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      buildingId: buildingB.id,
+    });
+
+    // Draft A debe funcionar sin conflicto histórico de B.
+    const draftA = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    expect(draftA.incomeOffsetAmountMinor).toBe(0);
+    expect(await observer.incomeApplication.count({ where: { incomeId: incomeB.id } })).toBe(0);
+  }, 30000);
+
+  it('R1.C. shared income allocated only to B is not materialized by draft A', async () => {
+    const ctx = await fixture('r1-c');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const buildingB = await building(ctx.tenant.id, 'B');
+    await units(ctx.tenant.id, buildingA.id);
+    await units(ctx.tenant.id, buildingB.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    await validatedExpense(ctx.tenant.id, buildingB.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+
+    // B publicada antes del shared.
+    const draftB = await createDraftFor(ctx.tenant.id, buildingB.id, ctx.membership.id);
+    const reviewedB = await liquidations.reviewLiquidation(ctx.tenant.id, draftB.id, ctx.membership.id);
+    await liquidations.publishLiquidation(ctx.tenant.id, reviewedB.id, ctx.membership.id, { dueDate: '2026-09-10' });
+
+    const shared = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      scopeType: MovementScope.TENANT_SHARED,
+    });
+    await allocateIncome(ctx.tenant.id, shared.id, [
+      { buildingId: buildingB.id, amountMinor: 10000 },
+    ]);
+
+    // Draft A: el shared no participa en A → no materializa, sin conflicto.
+    const draftA = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    expect(draftA.incomeOffsetAmountMinor).toBe(0);
+    expect(await observer.incomeApplication.count({ where: { incomeId: shared.id } })).toBe(0);
+  }, 30000);
+
+  it('R1.D. shared income with positive A share + B published → 422 conflict for A', async () => {
+    const ctx = await fixture('r1-d');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const buildingB = await building(ctx.tenant.id, 'B');
+    await units(ctx.tenant.id, buildingA.id);
+    await units(ctx.tenant.id, buildingB.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    await validatedExpense(ctx.tenant.id, buildingB.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+
+    const draftB = await createDraftFor(ctx.tenant.id, buildingB.id, ctx.membership.id);
+    const reviewedB = await liquidations.reviewLiquidation(ctx.tenant.id, draftB.id, ctx.membership.id);
+    await liquidations.publishLiquidation(ctx.tenant.id, reviewedB.id, ctx.membership.id, { dueDate: '2026-09-10' });
+
+    const shared = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      scopeType: MovementScope.TENANT_SHARED,
+    });
+    await allocateIncome(ctx.tenant.id, shared.id, [
+      { buildingId: buildingA.id, amountMinor: 6000 },
+      { buildingId: buildingB.id, amountMinor: 4000 },
+    ]);
+
+    await expect(createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id)).rejects.toMatchObject({
+      response: { statusCode: 422, error: LEGACY_BACKFILL_LIQUIDATION_CONFLICT },
+    });
+    expect(await observer.incomeApplication.count({ where: { incomeId: shared.id } })).toBe(0);
+  }, 30000);
+
+  it('R1.E. allocation amountMinor = 0 does not make the building relevant', async () => {
+    const ctx = await fixture('r1-e');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+
+    // A ya publicada.
+    const draftA = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    const reviewedA = await liquidations.reviewLiquidation(ctx.tenant.id, draftA.id, ctx.membership.id);
+    await liquidations.publishLiquidation(ctx.tenant.id, reviewedA.id, ctx.membership.id, { dueDate: '2026-09-10' });
+
+    const shared = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      scopeType: MovementScope.TENANT_SHARED,
+    });
+    // Allocation A = 0 (no relevante), B > 0.
+    await observer.movementAllocation.createMany({
+      data: [
+        { tenantId: ctx.tenant.id, incomeId: shared.id, buildingId: buildingA.id, amountMinor: 0 },
+      ],
+    });
+
+    // Explicit backfill: A no cuenta como relevante (allocation 0) → sin conflicto.
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, [
+      { incomeId: shared.id },
+    ]);
+    expect(result[0]!.status).toBe('MIGRATED');
+    expect(await observer.incomeApplication.count({ where: { incomeId: shared.id } })).toBe(1);
+  }, 30000);
+
+  it('R1.F. lazy provenance: legacyDestination frozen in snapshot; tamper → drift', async () => {
+    const ctx = await fixture('r1-f');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 3000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      buildingId: buildingA.id,
+    });
+
+    const draft = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    expect(draft.incomeOffsetAmountMinor).toBe(3000);
+
+    // Snapshot congelado con legacyDestination = APPLY_TO_EXPENSES.
+    const row = await observer.liquidation.findUniqueOrThrow({ where: { id: draft.id } });
+    const snapshot = row.incomeOffsetSnapshot as unknown as Array<{ legacyDestination: string | null; policyVersionId: string | null }>;
+    expect(snapshot[0]!.legacyDestination).toBe('APPLY_TO_EXPENSES');
+    expect(snapshot[0]!.policyVersionId).toBeNull();
+
+    // Review + tamper de provenance en DB disposable → publish drift.
+    await liquidations.reviewLiquidation(ctx.tenant.id, draft.id, ctx.membership.id);
+    await observer.incomeApplication.updateMany({
+      where: { incomeId: income.id },
+      data: { legacyDestination: null },
+    });
+
+    await expect(
+      liquidations.publishLiquidation(ctx.tenant.id, draft.id, ctx.membership.id, {
+        dueDate: '2026-09-10',
+      }),
+    ).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_INCOME_SOURCE_DRIFT' },
+    });
+
+    expect(
+      await observer.liquidation.findUniqueOrThrow({ where: { id: draft.id } }),
+    ).toMatchObject({ status: 'REVIEWED' });
+    expect(await observer.charge.count({ where: { liquidationId: draft.id } })).toBe(0);
+  }, 30000);
+
+  it('R1.G. multi-income concurrent drafts: deterministic locks, no deadlock, one app per income', async () => {
+    const ctx = await fixture('r1-g');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const buildingB = await building(ctx.tenant.id, 'B');
+    await units(ctx.tenant.id, buildingA.id);
+    await units(ctx.tenant.id, buildingB.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 20000);
+    await validatedExpense(ctx.tenant.id, buildingB.id, expCat.id, 20000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+
+    // Dos shared incomes legacy relevantes para A y B.
+    const shared1 = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      scopeType: MovementScope.TENANT_SHARED,
+    });
+    await allocateIncome(ctx.tenant.id, shared1.id, [
+      { buildingId: buildingA.id, amountMinor: 6000 },
+      { buildingId: buildingB.id, amountMinor: 4000 },
+    ]);
+    const shared2 = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 5000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      scopeType: MovementScope.TENANT_SHARED,
+    });
+    await allocateIncome(ctx.tenant.id, shared2.id, [
+      { buildingId: buildingA.id, amountMinor: 3000 },
+      { buildingId: buildingB.id, amountMinor: 2000 },
+    ]);
+
+    // 10 repeticiones concurrentes de drafts A y B.
+    for (let iteration = 0; iteration < 10; iteration += 1) {
+      const [draftA, draftB] = await Promise.all([
+        createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id),
+        createDraftFor(ctx.tenant.id, buildingB.id, ctx.membership.id),
+      ]);
+
+      expect(draftA.incomeOffsetAmountMinor).toBe(9000); // 6000 + 3000
+      expect(draftB.incomeOffsetAmountMinor).toBe(6000); // 4000 + 2000
+
+      await liquidations.cancelLiquidation(ctx.tenant.id, draftA.id, ctx.membership.id);
+      await liquidations.cancelLiquidation(ctx.tenant.id, draftB.id, ctx.membership.id);
+    }
+
+    // Cada income tiene exactamente UNA aplicación legacy.
+    expect(await observer.incomeApplication.count({ where: { incomeId: shared1.id } })).toBe(1);
+    expect(await observer.incomeApplication.count({ where: { incomeId: shared2.id } })).toBe(1);
+  }, 60000);
 });

--- a/apps/api/src/finanzas/legacy-income-backfill.postgres.spec.ts
+++ b/apps/api/src/finanzas/legacy-income-backfill.postgres.spec.ts
@@ -1,0 +1,929 @@
+import { UnprocessableEntityException } from '@nestjs/common';
+import {
+  FundStatus,
+  FundType,
+  IncomeApplicationDestination,
+  IncomeDestination,
+  IncomeStatus,
+  MovementScope,
+  PrismaClient,
+  TenantType,
+} from '@prisma/client';
+import { AuditService } from '../audit/audit.service';
+import { PrismaService } from '../prisma/prisma.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { ResidentAccessService } from '../resident-access/resident-access.service';
+import { NotificationsService } from '../notifications/notifications.service';
+import { LiquidationsService } from './liquidations.service';
+import { LiquidationIncomeOffsetsService } from './liquidation-income-offsets.service';
+import { LegacyIncomeBackfillService, LEGACY_BACKFILL_LIQUIDATION_CONFLICT } from './legacy-income-backfill.service';
+import { IncomesService } from './incomes.service';
+import { IncomeApplicationsService } from './income-applications.service';
+import { FundsService } from './funds.service';
+import { CurrencyConversionService } from './currency-conversion.service';
+import { MovementAllocationService } from './movement-allocation.service';
+import {
+  createLiquidationWorkflowDependencies,
+  LiquidationPublicationUseCase,
+} from './liquidation-publication.use-case';
+
+const ACCEPTANCE_DATABASES = new Set(['buildingos_fin04_acceptance']);
+const expectedDatabaseName = process.env.POSTGRES_TEST_DB_NAME;
+const fixturePhase = 'fin04';
+const enabled =
+  process.env.RUN_POSTGRES_INTEGRATION === '1' &&
+  expectedDatabaseName !== undefined &&
+  ACCEPTANCE_DATABASES.has(expectedDatabaseName);
+const describePostgres = enabled ? describe : describe.skip;
+
+describePostgres('FIN-04 legacy income backfill (PostgreSQL)', () => {
+  let observer: PrismaClient;
+  let backfill: LegacyIncomeBackfillService;
+  let liquidations: LiquidationsService;
+  let incomes: IncomesService;
+  let apps: IncomeApplicationsService;
+  let funds: FundsService;
+  const tenantIds: string[] = [];
+  const userIds: string[] = [];
+  const membershipIds: string[] = [];
+
+  const roles = ['TENANT_ADMIN'];
+
+  function buildServices(client: PrismaClient) {
+    const prisma = client as unknown as PrismaService;
+    const audit = new AuditService(prisma);
+    const validators = new FinanzasValidators(prisma, new ResidentAccessService(prisma));
+    const notifications = { createNotification: () => Promise.resolve({ id: 'n' }) } as unknown as NotificationsService;
+    const useCase = new LiquidationPublicationUseCase(
+      createLiquidationWorkflowDependencies({ prisma, auditService: audit, validators, notificationsService: notifications }),
+    );
+    const appsSvc = new IncomeApplicationsService(prisma, audit, validators);
+    return {
+      backfill: new LegacyIncomeBackfillService(prisma, audit, validators, appsSvc),
+      liquidations: new LiquidationsService(
+        prisma,
+        audit,
+        validators,
+        useCase,
+        new LiquidationIncomeOffsetsService(prisma),
+        new LegacyIncomeBackfillService(prisma, audit, validators, appsSvc),
+      ),
+      incomes: new IncomesService(prisma, audit, validators, new MovementAllocationService(prisma, audit, validators), new CurrencyConversionService(prisma)),
+      apps: appsSvc,
+      funds: new FundsService(prisma, audit, validators),
+    };
+  }
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required');
+    observer = new PrismaClient();
+    await observer.$connect();
+    const [database] = await observer.$queryRaw<Array<{ name: string }>>`SELECT current_database() AS name`;
+    if (database?.name !== expectedDatabaseName || !ACCEPTANCE_DATABASES.has(database.name)) {
+      throw new Error(`Refusing destructive test database ${database?.name ?? 'unknown'}`);
+    }
+    const svc = buildServices(observer);
+    backfill = svc.backfill;
+    liquidations = svc.liquidations;
+    incomes = svc.incomes;
+    apps = svc.apps;
+    funds = svc.funds;
+    await observer.tenant.deleteMany({ where: { name: { startsWith: `${fixturePhase}-` } } });
+  });
+
+  afterEach(async () => {
+    for (const membershipId of membershipIds.splice(0)) {
+      await observer.membership.delete({ where: { id: membershipId } }).catch(() => undefined);
+    }
+    for (const tenantId of tenantIds.splice(0)) {
+      await observer.tenant.delete({ where: { id: tenantId } }).catch(() => undefined);
+    }
+    for (const userId of userIds.splice(0)) {
+      await observer.user.delete({ where: { id: userId } }).catch(() => undefined);
+    }
+  });
+
+  afterAll(async () => observer?.$disconnect());
+
+  async function fixture(label: string) {
+    const suffix = `${Date.now()}-${Math.random()}`;
+    const tenant = await observer.tenant.create({
+      data: { name: `${fixturePhase}-${label}-${suffix}`, type: TenantType.ADMINISTRADORA, functionalCurrency: 'ARS' },
+    });
+    tenantIds.push(tenant.id);
+    const user = await observer.user.create({
+      data: { email: `${fixturePhase}-${suffix}@buildingos.local`, name: `${fixturePhase} ${label}`, passwordHash: 'test' },
+    });
+    userIds.push(user.id);
+    const membership = await observer.membership.create({ data: { tenantId: tenant.id, userId: user.id } });
+    membershipIds.push(membership.id);
+    await observer.membershipRole.create({
+      data: { tenantId: tenant.id, membershipId: membership.id, role: 'TENANT_ADMIN', scopeType: 'TENANT' },
+    });
+    return { tenant, membership };
+  }
+
+  async function building(tenantId: string, label: string) {
+    return observer.building.create({
+      data: { tenantId, name: `B ${label} ${Date.now()}`, alias: `B-${label}-${Date.now().toString(36)}` },
+    });
+  }
+
+  async function units(tenantId: string, buildingId: string, count = 2) {
+    return Promise.all(
+      Array.from({ length: count }, (_, i) =>
+        observer.unit.create({
+          data: {
+            tenantId,
+            buildingId,
+            code: `U-${i + 1}-${Date.now().toString(36)}`,
+            label: `Unit ${i + 1}`,
+            unitType: 'APARTAMENTO',
+            occupancyStatus: 'OCCUPIED',
+            isBillable: true,
+          },
+        }),
+      ),
+    );
+  }
+
+  async function incomeCategory(tenantId: string) {
+    return observer.expenseLedgerCategory.create({ data: { tenantId, name: `Inc ${Date.now()}`, movementType: 'INCOME' } });
+  }
+
+  async function expenseCategory(tenantId: string) {
+    return observer.expenseLedgerCategory.create({ data: { tenantId, name: `Exp ${Date.now()}`, movementType: 'EXPENSE' } });
+  }
+
+  async function validatedExpense(
+    tenantId: string,
+    buildingId: string,
+    categoryId: string,
+    amountMinor: number,
+    functional?: { functionalAmountMinor: number; functionalCurrencyCode: string },
+  ) {
+    return observer.expense.create({
+      data: {
+        tenantId,
+        buildingId,
+        period: '2026-08',
+        categoryId,
+        amountMinor,
+        currencyCode: 'ARS',
+        invoiceDate: new Date('2026-08-05T00:00:00.000Z'),
+        status: 'VALIDATED',
+        scopeType: 'BUILDING',
+        createdByMembershipId: membershipIds[membershipIds.length - 1]!,
+        ...(functional
+          ? {
+              functionalAmountMinor: functional.functionalAmountMinor,
+              functionalCurrencyCode: functional.functionalCurrencyCode,
+              exchangeRateValue: '1',
+              exchangeRateDirection: 'IDENTITY',
+              conversionDate: new Date('2026-08-05T00:00:00.000Z'),
+            }
+          : {}),
+      },
+    });
+  }
+
+  async function legacyIncome(
+    tenantId: string,
+    membershipId: string,
+    categoryId: string,
+    params: {
+      amountMinor: number;
+      destination: IncomeDestination;
+      period?: string;
+      buildingId?: string | null;
+      scopeType?: MovementScope;
+      currencyCode?: string;
+      receivedDate?: Date;
+      status?: IncomeStatus;
+      functionalAmountMinor?: number | null;
+      functionalCurrencyCode?: string | null;
+    },
+  ) {
+    return observer.income.create({
+      data: {
+        tenantId,
+        period: params.period ?? '2026-08',
+        categoryId,
+        amountMinor: params.amountMinor,
+        currencyCode: params.currencyCode ?? 'ARS',
+        receivedDate: params.receivedDate ?? new Date('2026-08-10T00:00:00.000Z'),
+        status: params.status ?? IncomeStatus.RECORDED,
+        scopeType: params.scopeType ?? MovementScope.BUILDING,
+        buildingId: params.buildingId ?? null,
+        destination: params.destination,
+        functionalAmountMinor: params.functionalAmountMinor ?? null,
+        functionalCurrencyCode: params.functionalCurrencyCode ?? null,
+        createdByMembershipId: membershipId,
+      },
+    });
+  }
+
+  async function allocateIncome(tenantId: string, incomeId: string, allocations: Array<{ buildingId: string; amountMinor: number }>) {
+    await observer.movementAllocation.createMany({
+      data: allocations.map((a) => ({ tenantId, incomeId, buildingId: a.buildingId, amountMinor: a.amountMinor })),
+    });
+  }
+
+  async function createDraftFor(tenantId: string, buildingId: string, membershipId: string, period = '2026-08') {
+    return liquidations.createDraft(tenantId, membershipId, { buildingId, period, baseCurrency: 'ARS' });
+  }
+
+  // ── A. DB provenance CHECK ───────────────────────────────────────────────
+
+  it('A. policy + legacy provenance are mutually exclusive at the DB level', async () => {
+    const ctx = await fixture('provenance-check');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, cat.id, {
+      amountMinor: 1000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+    });
+    const policy = await observer.incomePolicy.create({
+      data: { tenantId: ctx.tenant.id, categoryId: cat.id, createdByMembershipId: ctx.membership.id },
+    });
+    const version = await observer.incomePolicyVersion.create({
+      data: { policyId: policy.id, version: 1, createdByMembershipId: ctx.membership.id },
+    });
+
+    await expect(
+      observer.incomeApplication.create({
+        data: {
+          tenantId: ctx.tenant.id,
+          incomeId: income.id,
+          destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+          amountMinor: 1000,
+          currencyCode: 'ARS',
+          createdByMembershipId: ctx.membership.id,
+          policyVersionId: version.id,
+          legacyDestination: IncomeDestination.APPLY_TO_EXPENSES,
+        },
+      }),
+    ).rejects.toThrow(/check constraint|Check/);
+  }, 20000);
+
+  it('A2. legacy mapping CHECK rejects inconsistent destination/fund combinations', async () => {
+    const ctx = await fixture('mapping-check');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, cat.id, {
+      amountMinor: 1000,
+      destination: IncomeDestination.RESERVE_FUND,
+    });
+
+    // APPLY legacy con fundId → CHECK violado
+    await expect(
+      observer.incomeApplication.create({
+        data: {
+          tenantId: ctx.tenant.id,
+          incomeId: income.id,
+          destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+          fundId: 'fund-x',
+          amountMinor: 1000,
+          currencyCode: 'ARS',
+          createdByMembershipId: ctx.membership.id,
+          legacyDestination: IncomeDestination.APPLY_TO_EXPENSES,
+        },
+      }),
+    ).rejects.toThrow(/check constraint|Check/);
+
+    // RESERVE legacy sin fundId → CHECK violado
+    await expect(
+      observer.incomeApplication.create({
+        data: {
+          tenantId: ctx.tenant.id,
+          incomeId: income.id,
+          destinationType: IncomeApplicationDestination.FUND,
+          amountMinor: 1000,
+          currencyCode: 'ARS',
+          createdByMembershipId: ctx.membership.id,
+          legacyDestination: IncomeDestination.RESERVE_FUND,
+        },
+      }),
+    ).rejects.toThrow(/check constraint|Check/);
+  }, 20000);
+
+  it('B. tenant hard-delete lifecycle removes backfilled applications', async () => {
+    const ctx = await fixture('fk-lifecycle');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, cat.id, {
+      amountMinor: 1000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+    });
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: income.id }]);
+    expect(result[0]!.status).toBe('MIGRATED');
+
+    await observer.tenant.delete({ where: { id: ctx.tenant.id } });
+
+    expect(await observer.incomeApplication.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+    tenantIds.splice(tenantIds.indexOf(ctx.tenant.id), 1);
+    membershipIds.splice(membershipIds.indexOf(ctx.membership.id), 1);
+    userIds.splice(userIds.indexOf(ctx.userId), 1);
+  }, 30000);
+
+  // ── C. Lazy materialization ─────────────────────────────────────────────
+
+  it('C. lazy materializes APPLY legacy and FIN-06 consumes the real application', async () => {
+    const ctx = await fixture('lazy-apply');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 3000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      buildingId: buildingA.id,
+    });
+
+    const draft = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    expect(draft.incomeOffsetAmountMinor).toBe(3000);
+    expect(draft.netDistributableAmountMinor).toBe(7000);
+
+    // La aplicación legacy es REAL y persistida.
+    const app = await observer.incomeApplication.findFirstOrThrow({ where: { incomeId: income.id } });
+    expect(app.destinationType).toBe(IncomeApplicationDestination.OFFSET_EXPENSES);
+    expect(app.legacyDestination).toBe(IncomeDestination.APPLY_TO_EXPENSES);
+    expect(app.amountMinor).toBe(3000);
+
+    // Reference relacional FIN-06 creada.
+    expect(await observer.liquidationIncomeOffset.count({ where: { liquidationId: draft.id } })).toBe(1);
+
+    // Audit de backfill con mode LIQUIDATION_AUTO_MATERIALIZE.
+    const audit = await observer.auditLog.findFirst({
+      where: { tenantId: ctx.tenant.id, action: 'INCOME_LEGACY_BACKFILL' },
+    });
+    expect(audit).not.toBeNull();
+    expect((audit!.metadata as Record<string, unknown>).mode).toBe('LIQUIDATION_AUTO_MATERIALIZE');
+  }, 30000);
+
+  it('D. lazy application rolls back when the draft fails (offset > gross)', async () => {
+    const ctx = await fixture('lazy-rollback');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 5000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 6000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      buildingId: buildingA.id,
+    });
+
+    await expect(createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id)).rejects.toMatchObject({
+      response: { statusCode: 422, error: 'LIQUIDATION_INCOME_OFFSETS_EXCEED_GROSS' },
+    });
+
+    // Rollback completo: sin application legacy, sin audit, sin liquidation.
+    expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(0);
+    expect(await observer.auditLog.count({ where: { tenantId: ctx.tenant.id, action: 'INCOME_LEGACY_BACKFILL' } })).toBe(0);
+    expect(await observer.liquidation.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+  }, 30000);
+
+  it('E. existing modern plan wins over legacy destination', async () => {
+    const ctx = await fixture('modern-wins');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      buildingId: buildingA.id,
+    });
+
+    // Plan manual 100% FUND (aunque destination = APPLY).
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `F ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+    await apps.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [{ destinationType: IncomeApplicationDestination.FUND, fundId: fund.id, amountMinor: 10000 }],
+    });
+
+    const draft = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    // FUND no reduce liquidación; fallback OFFSET NO se ejecuta.
+    expect(draft.incomeOffsetAmountMinor).toBe(0);
+    const appCount = await observer.incomeApplication.count({ where: { incomeId: income.id } });
+    expect(appCount).toBe(1);
+  }, 30000);
+
+  it('F. shared legacy materializes ONE application; shares split across buildings', async () => {
+    const ctx = await fixture('shared-one-app');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const buildingB = await building(ctx.tenant.id, 'B');
+    await units(ctx.tenant.id, buildingA.id);
+    await units(ctx.tenant.id, buildingB.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    await validatedExpense(ctx.tenant.id, buildingB.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      scopeType: MovementScope.TENANT_SHARED,
+    });
+    await allocateIncome(ctx.tenant.id, income.id, [
+      { buildingId: buildingA.id, amountMinor: 6000 },
+      { buildingId: buildingB.id, amountMinor: 4000 },
+    ]);
+
+    const draftA = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    expect(draftA.incomeOffsetAmountMinor).toBe(6000);
+    await liquidations.cancelLiquidation(ctx.tenant.id, draftA.id, ctx.membership.id);
+
+    const draftB = await createDraftFor(ctx.tenant.id, buildingB.id, ctx.membership.id);
+    expect(draftB.incomeOffsetAmountMinor).toBe(4000);
+
+    // UNA sola aplicación, no dos.
+    const appCount = await observer.incomeApplication.count({ where: { incomeId: income.id } });
+    expect(appCount).toBe(1);
+    const refs = await observer.liquidationIncomeOffset.findMany({
+      where: { tenantId: ctx.tenant.id },
+    });
+    expect(refs.reduce((sum, r) => sum + r.valuedAmountMinor, 0)).toBe(10000);
+  }, 30000);
+
+  it('G. shared historical conflict blocks auto-materialization', async () => {
+    const ctx = await fixture('shared-conflict');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const buildingB = await building(ctx.tenant.id, 'B');
+    await units(ctx.tenant.id, buildingA.id);
+    await units(ctx.tenant.id, buildingB.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    await validatedExpense(ctx.tenant.id, buildingB.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+
+    // Publicar liquidation A ANTES de que exista el shared legacy.
+    const draftA = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    const reviewedA = await liquidations.reviewLiquidation(ctx.tenant.id, draftA.id, ctx.membership.id);
+    await liquidations.publishLiquidation(ctx.tenant.id, reviewedA.id, ctx.membership.id, { dueDate: '2026-09-10' });
+
+    // El shared legacy aparece después (históricamente ambiguo).
+    const shared = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      scopeType: MovementScope.TENANT_SHARED,
+    });
+    await allocateIncome(ctx.tenant.id, shared.id, [
+      { buildingId: buildingA.id, amountMinor: 6000 },
+      { buildingId: buildingB.id, amountMinor: 4000 },
+    ]);
+
+    // Intentar liquidation B → conflicto histórico del shared (A ya publicada).
+    await expect(createDraftFor(ctx.tenant.id, buildingB.id, ctx.membership.id)).rejects.toMatchObject({
+      response: { statusCode: 422, error: LEGACY_BACKFILL_LIQUIDATION_CONFLICT },
+    });
+
+    // No se creó application parcial para el shared.
+    expect(await observer.incomeApplication.count({ where: { incomeId: shared.id } })).toBe(0);
+  }, 30000);
+
+  it('H. DRAFT liquidation conflict blocks explicit backfill', async () => {
+    const ctx = await fixture('draft-conflict');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+
+    // Draft A activo creado ANTES del legacy income (snapshot congelado sin él).
+    const draftA = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+
+    const legacy = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 3000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      buildingId: buildingA.id,
+    });
+
+    // Backfill explícito → conflicto (draft A activo del mismo período).
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: legacy.id }]);
+    expect(result[0]!.status).toBe('LIQUIDATION_CONFLICT');
+    expect(await observer.incomeApplication.count({ where: { incomeId: legacy.id } })).toBe(0);
+
+    // Cancelar el draft → ahora sí puede materializarse.
+    await liquidations.cancelLiquidation(ctx.tenant.id, draftA.id, ctx.membership.id);
+    const after = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: legacy.id }]);
+    expect(after[0]!.status).toBe('MIGRATED');
+  }, 30000);
+
+  it('I. REVIEWED liquidation conflict blocks explicit backfill', async () => {
+    const ctx = await fixture('reviewed-conflict');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+
+    const draftA = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    await liquidations.reviewLiquidation(ctx.tenant.id, draftA.id, ctx.membership.id);
+
+    const legacy = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 3000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      buildingId: buildingA.id,
+    });
+
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: legacy.id }]);
+    expect(result[0]!.status).toBe('LIQUIDATION_CONFLICT');
+    expect(await observer.incomeApplication.count({ where: { incomeId: legacy.id } })).toBe(0);
+  }, 30000);
+
+  it('J. CANCELED liquidation does not block materialization', async () => {
+    const ctx = await fixture('canceled-ok');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+
+    const draftA = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    await liquidations.cancelLiquidation(ctx.tenant.id, draftA.id, ctx.membership.id);
+
+    const legacy = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 3000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      buildingId: buildingA.id,
+    });
+
+    const draft2 = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    expect(draft2.incomeOffsetAmountMinor).toBe(3000);
+    expect(await observer.incomeApplication.count({ where: { incomeId: legacy.id } })).toBe(1);
+  }, 30000);
+
+  // ── K. Explicit Fund backfill ────────────────────────────────────────────
+
+  it('K. RESERVE explicit backfill: application + real Fund CREDIT with occurredAt = receivedDate', async () => {
+    const ctx = await fixture('reserve-explicit');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const receivedDate = new Date('2026-03-15T00:00:00.000Z');
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, cat.id, {
+      amountMinor: 5000,
+      destination: IncomeDestination.RESERVE_FUND,
+      currencyCode: 'USD',
+      receivedDate,
+    });
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `R ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [
+      { incomeId: income.id, fundId: fund.id },
+    ]);
+    expect(result[0]!.status).toBe('MIGRATED');
+
+    const app = await observer.incomeApplication.findFirstOrThrow({ where: { incomeId: income.id } });
+    expect(app.destinationType).toBe(IncomeApplicationDestination.FUND);
+    expect(app.fundId).toBe(fund.id);
+    expect(app.legacyDestination).toBe(IncomeDestination.RESERVE_FUND);
+    expect(app.amountMinor).toBe(5000);
+    expect(app.currencyCode).toBe('USD');
+
+    const tx = await observer.fundTransaction.findFirstOrThrow({ where: { fundId: fund.id, direction: 'CREDIT' } });
+    expect(tx.amountMinor).toBe(5000);
+    expect(tx.currencyCode).toBe('USD');
+    expect(tx.occurredAt.toISOString()).toBe(receivedDate.toISOString()); // histórico, no hoy
+    expect(tx.incomeApplicationId).toBe(app.id);
+
+    const balance = await observer.fundTransaction.aggregate({
+      where: { fundId: fund.id, direction: 'CREDIT', reversalOfTransactionId: null },
+      _sum: { amountMinor: true },
+    });
+    expect(balance._sum.amountMinor).toBe(5000);
+
+    // Audits requeridos (tenant-scoped; FUND_TRANSACTION_CREATE usa entityId = tx.id).
+    const actions = await observer.auditLog.findMany({
+      where: { tenantId: ctx.tenant.id },
+      select: { action: true },
+    });
+    const actionSet = new Set(actions.map((a) => a.action));
+    expect(actionSet.has('INCOME_APPLICATIONS_CREATE')).toBe(true);
+    expect(actionSet.has('FUND_TRANSACTION_CREATE')).toBe(true);
+    expect(actionSet.has('INCOME_LEGACY_BACKFILL')).toBe(true);
+
+    // Retry idempotente.
+    const retry = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [
+      { incomeId: income.id, fundId: fund.id },
+    ]);
+    expect(retry[0]!.status).toBe('ALREADY_MIGRATED');
+    expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(1);
+    expect(await observer.fundTransaction.count({ where: { fundId: fund.id, direction: 'CREDIT' } })).toBe(1);
+  }, 30000);
+
+  it('L. SPECIAL explicit backfill works with a SPECIAL fund', async () => {
+    const ctx = await fixture('special-explicit');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, cat.id, {
+      amountMinor: 2000,
+      destination: IncomeDestination.SPECIAL_FUND,
+    });
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'SPECIAL', name: `S ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [
+      { incomeId: income.id, fundId: fund.id },
+    ]);
+    expect(result[0]!.status).toBe('MIGRATED');
+    const app = await observer.incomeApplication.findFirstOrThrow({ where: { incomeId: income.id } });
+    expect(app.legacyDestination).toBe(IncomeDestination.SPECIAL_FUND);
+    expect(await observer.fundTransaction.count({ where: { fundId: fund.id, direction: 'CREDIT' } })).toBe(1);
+  }, 30000);
+
+  it('M. wrong Fund type is rejected (RESERVE income + SPECIAL fund)', async () => {
+    const ctx = await fixture('wrong-type');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, cat.id, {
+      amountMinor: 2000,
+      destination: IncomeDestination.RESERVE_FUND,
+    });
+    const fund = await observer.fund.create({
+      data: { tenantId: ctx.tenant.id, scopeType: 'TENANT', type: 'SPECIAL', name: `W ${Date.now()}`, createdByMembershipId: ctx.membership.id },
+    });
+
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [
+      { incomeId: income.id, fundId: fund.id },
+    ]);
+    expect(result[0]!.status).toBe('INVALID_FUND');
+    expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(0);
+    expect(await observer.fundTransaction.count({ where: { fundId: fund.id } })).toBe(0);
+  }, 30000);
+
+  it('N. archived Fund is rejected', async () => {
+    const ctx = await fixture('archived-fund');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, cat.id, {
+      amountMinor: 2000,
+      destination: IncomeDestination.RESERVE_FUND,
+    });
+    const fund = await observer.fund.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        scopeType: 'TENANT',
+        type: 'RESERVE',
+        name: `A ${Date.now()}`,
+        createdByMembershipId: ctx.membership.id,
+        status: FundStatus.ARCHIVED,
+      },
+    });
+
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [
+      { incomeId: income.id, fundId: fund.id },
+    ]);
+    expect(result[0]!.status).toBe('INVALID_FUND');
+  }, 30000);
+
+  it('O. cross-tenant Fund is rejected', async () => {
+    const ctxA = await fixture('iso-a');
+    const ctxB = await fixture('iso-b');
+    const cat = await incomeCategory(ctxA.tenant.id);
+    const income = await legacyIncome(ctxA.tenant.id, ctxA.membership.id, cat.id, {
+      amountMinor: 2000,
+      destination: IncomeDestination.RESERVE_FUND,
+    });
+    const fundB = await observer.fund.create({
+      data: { tenantId: ctxB.tenant.id, scopeType: 'TENANT', type: 'RESERVE', name: `X ${Date.now()}`, createdByMembershipId: ctxB.membership.id },
+    });
+
+    const result = await backfill.apply(ctxA.tenant.id, ctxA.membership.id, roles, [
+      { incomeId: income.id, fundId: fundB.id },
+    ]);
+    expect(result[0]!.status).toBe('INVALID_FUND');
+  }, 30000);
+
+  it('P. retry same backfill does not duplicate applications nor FundTransaction', async () => {
+    const ctx = await fixture('retry');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, cat.id, {
+      amountMinor: 3000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+    });
+
+    const first = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: income.id }]);
+    const second = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: income.id }]);
+
+    expect(first[0]!.status).toBe('MIGRATED');
+    expect(second[0]!.status).toBe('ALREADY_MIGRATED');
+    expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(1);
+  }, 30000);
+
+  it('Q. concurrent duplicate backfill produces exactly one application', async () => {
+    const ctx = await fixture('dup-backfill');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, cat.id, {
+      amountMinor: 3000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+    });
+
+    const [a, b] = await Promise.all([
+      backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: income.id }]),
+      backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: income.id }]),
+    ]);
+
+    expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(1);
+    expect(a[0]!.status === 'MIGRATED' || b[0]!.status === 'MIGRATED').toBe(true);
+  }, 30000);
+
+  it('R. backfill vs manual plan: only one wins', async () => {
+    const ctx = await fixture('backfill-vs-manual');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, cat.id, {
+      amountMinor: 3000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+    });
+
+    // Manual plan gana primero.
+    await apps.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [{ destinationType: IncomeApplicationDestination.CARRY_FORWARD, amountMinor: 3000 }],
+    });
+
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: income.id }]);
+    expect(result[0]!.status).toBe('ALREADY_HAS_PLAN');
+    expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(1);
+    const app = await observer.incomeApplication.findFirstOrThrow({ where: { incomeId: income.id } });
+    expect(app.destinationType).toBe(IncomeApplicationDestination.CARRY_FORWARD);
+    expect(app.legacyDestination).toBeNull();
+  }, 30000);
+
+  it('S. lazy vs manual plan: manual plan is authoritative', async () => {
+    const ctx = await fixture('lazy-vs-manual');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      buildingId: buildingA.id,
+    });
+
+    // Plan manual CARRY 10000 antes del draft.
+    await apps.createPlan(ctx.tenant.id, income.id, ctx.membership.id, roles, {
+      applications: [{ destinationType: IncomeApplicationDestination.CARRY_FORWARD, amountMinor: 10000 }],
+    });
+
+    const draft = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    expect(draft.incomeOffsetAmountMinor).toBe(0); // CARRY no descuenta; sin fallback OFFSET
+    const app = await observer.incomeApplication.findFirstOrThrow({ where: { incomeId: income.id } });
+    expect(app.destinationType).toBe(IncomeApplicationDestination.CARRY_FORWARD);
+  }, 30000);
+
+  it('T. backfill vs void: no applications created on VOID income', async () => {
+    const ctx = await fixture('backfill-vs-void');
+    const cat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, cat.id, {
+      amountMinor: 3000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+    });
+
+    await incomes.voidIncome(ctx.tenant.id, income.id, ctx.membership.id, roles);
+
+    const result = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: income.id }]);
+    expect(result[0]!.status).toBe('NOT_RECORDED');
+    expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(0);
+  }, 30000);
+
+  it('U. two buildings lazy-materializing the same shared income produce one application', async () => {
+    const ctx = await fixture('shared-race');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    const buildingB = await building(ctx.tenant.id, 'B');
+    await units(ctx.tenant.id, buildingA.id);
+    await units(ctx.tenant.id, buildingB.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    await validatedExpense(ctx.tenant.id, buildingB.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      scopeType: MovementScope.TENANT_SHARED,
+    });
+    await allocateIncome(ctx.tenant.id, income.id, [
+      { buildingId: buildingA.id, amountMinor: 6000 },
+      { buildingId: buildingB.id, amountMinor: 4000 },
+    ]);
+
+    const [draftA, draftB] = await Promise.all([
+      createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id),
+      createDraftFor(ctx.tenant.id, buildingB.id, ctx.membership.id),
+    ]);
+
+    // UNA sola aplicación para el shared.
+    expect(await observer.incomeApplication.count({ where: { incomeId: income.id } })).toBe(1);
+    expect(draftA.incomeOffsetAmountMinor).toBe(6000);
+    expect(draftB.incomeOffsetAmountMinor).toBe(4000);
+  }, 30000);
+
+  it('V. legacy functional frozen FX: live rate change does not affect lazy liquidation', async () => {
+    const ctx = await fixture('legacy-fx');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 2500, {
+      functionalAmountMinor: 2500,
+      functionalCurrencyCode: 'ARS',
+    });
+    const incCat = await incomeCategory(ctx.tenant.id);
+    const fx = await observer.exchangeRate.create({
+      data: {
+        tenantId: ctx.tenant.id,
+        baseCurrency: 'USD',
+        quoteCurrency: 'ARS',
+        rate: '0.25',
+        effectiveAt: new Date('2026-08-10T00:00:00.000Z'),
+        source: 'fixture-fin04',
+      },
+    });
+    const income = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 10000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      buildingId: buildingA.id,
+      currencyCode: 'USD',
+      functionalAmountMinor: 2500,
+      functionalCurrencyCode: 'ARS',
+    });
+    await observer.income.update({
+      where: { id: income.id },
+      data: {
+        exchangeRateId: fx.id,
+        exchangeRateValue: '0.25',
+        exchangeRateDirection: 'INVERSE',
+        exchangeRateEffectiveAt: new Date('2026-08-10T00:00:00.000Z'),
+        conversionDate: new Date('2026-08-10T00:00:00.000Z'),
+      },
+    });
+
+    const draft1 = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    expect(draft1.incomeOffsetAmountMinor).toBe(2500);
+    await liquidations.cancelLiquidation(ctx.tenant.id, draft1.id, ctx.membership.id);
+
+    // Mutar FX live → el draft debe ser idéntico (snapshot congelado).
+    await observer.exchangeRate.update({ where: { id: fx.id }, data: { rate: '0.50' } });
+    const draft2 = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    expect(draft2.incomeOffsetAmountMinor).toBe(2500);
+  }, 30000);
+
+  it('W. published Liquidation snapshot is unchanged by preview/backfill attempts', async () => {
+    const ctx = await fixture('no-mutation');
+    const buildingA = await building(ctx.tenant.id, 'A');
+    await units(ctx.tenant.id, buildingA.id);
+    const expCat = await expenseCategory(ctx.tenant.id);
+    await validatedExpense(ctx.tenant.id, buildingA.id, expCat.id, 10000);
+    const incCat = await incomeCategory(ctx.tenant.id);
+
+    // Publicar liquidation A ANTES de que exista el legacy income.
+    const draft = await createDraftFor(ctx.tenant.id, buildingA.id, ctx.membership.id);
+    const reviewed = await liquidations.reviewLiquidation(ctx.tenant.id, draft.id, ctx.membership.id);
+    await liquidations.publishLiquidation(ctx.tenant.id, reviewed.id, ctx.membership.id, { dueDate: '2026-09-10' });
+
+    const before = await observer.liquidation.findUniqueOrThrow({ where: { id: draft.id } });
+    const snapshotBefore = JSON.stringify(before.publicationSnapshot);
+    const totalBefore = before.totalAmountMinor;
+    const chargesBefore = await observer.charge.count({ where: { liquidationId: draft.id } });
+
+    // El legacy aparece después → backfill debe bloquearse por conflicto.
+    const legacy = await legacyIncome(ctx.tenant.id, ctx.membership.id, incCat.id, {
+      amountMinor: 3000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      buildingId: buildingA.id,
+    });
+    await backfill.preview(ctx.tenant.id, ctx.membership.id, roles, {});
+    const applyResult = await backfill.apply(ctx.tenant.id, ctx.membership.id, roles, [{ incomeId: legacy.id }]);
+    expect(applyResult[0]!.status).toBe('LIQUIDATION_CONFLICT');
+
+    // Nada mutó: snapshot, total, charges intactos.
+    const after = await observer.liquidation.findUniqueOrThrow({ where: { id: draft.id } });
+    expect(JSON.stringify(after.publicationSnapshot)).toBe(snapshotBefore);
+    expect(after.totalAmountMinor).toBe(totalBefore);
+    expect(await observer.charge.count({ where: { liquidationId: draft.id } })).toBe(chargesBefore);
+    expect(await observer.incomeApplication.count({ where: { incomeId: legacy.id } })).toBe(0);
+  }, 30000);
+
+  it('X. tenant isolation: preview and apply are tenant-scoped', async () => {
+    const ctxA = await fixture('iso-preview-a');
+    const ctxB = await fixture('iso-preview-b');
+    const catB = await incomeCategory(ctxB.tenant.id);
+    const incomeB = await legacyIncome(ctxB.tenant.id, ctxB.membership.id, catB.id, {
+      amountMinor: 3000,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+    });
+
+    const previewA = await backfill.preview(ctxA.tenant.id, ctxA.membership.id, roles, {});
+    expect(previewA).toHaveLength(0);
+
+    const applyB = await backfill.apply(ctxB.tenant.id, ctxB.membership.id, roles, [{ incomeId: incomeB.id }]);
+    expect(applyB[0]!.status).toBe('MIGRATED');
+    expect(await observer.incomeApplication.count({ where: { tenantId: ctxA.tenant.id } })).toBe(0);
+  }, 30000);
+
+  it('Y. no fixture leftovers after the suite', async () => {
+    const leftover = await observer.tenant.count({ where: { name: { startsWith: `${fixturePhase}-` } } });
+    expect(leftover).toBe(0);
+  }, 10000);
+});

--- a/apps/api/src/finanzas/legacy-income-backfill.service.spec.ts
+++ b/apps/api/src/finanzas/legacy-income-backfill.service.spec.ts
@@ -1,0 +1,556 @@
+import {
+  BadRequestException,
+  ForbiddenException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import {
+  FundStatus,
+  FundType,
+  IncomeApplicationDestination,
+  IncomeDestination,
+  IncomeStatus,
+  Prisma,
+} from '@prisma/client';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { IncomeApplicationsService } from './income-applications.service';
+import { LegacyIncomeBackfillService, LEGACY_BACKFILL_LIQUIDATION_CONFLICT } from './legacy-income-backfill.service';
+
+describe('LegacyIncomeBackfillService (FIN-04)', () => {
+  let service: LegacyIncomeBackfillService;
+  let prisma: {
+    membership: { findFirst: jest.Mock };
+    income: { findMany: jest.Mock; findFirst: jest.Mock };
+    incomeApplication: { count: jest.Mock; findFirst: jest.Mock; groupBy: jest.Mock };
+    movementAllocation: { findMany: jest.Mock };
+    liquidation: { findMany: jest.Mock };
+    fund: { findFirst: jest.Mock };
+    $transaction: jest.Mock;
+  };
+  let applicationsService: { publishLegacyBackfillPlan: jest.Mock };
+  let audit: { createLogRequired: jest.Mock };
+  let validators: { isAdminOrOperator: jest.Mock };
+
+  const roles = ['TENANT_ADMIN'];
+  const membershipId = 'member-1';
+
+  function makeIncome(overrides: Record<string, unknown> = {}) {
+    return {
+      id: 'income-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      period: '2026-08',
+      scopeType: 'BUILDING',
+      status: IncomeStatus.RECORDED,
+      destination: IncomeDestination.APPLY_TO_EXPENSES,
+      amountMinor: 10000,
+      currencyCode: 'ARS',
+      receivedDate: new Date('2026-08-10T00:00:00.000Z'),
+      categoryId: 'cat-1',
+      ...overrides,
+    };
+  }
+
+  function setupTx(overrides: Record<string, unknown> = {}) {
+    const tx = {
+      income: {
+        findFirst: jest.fn().mockResolvedValue(makeIncome(overrides)),
+        findMany: jest.fn().mockResolvedValue([]),
+      },
+      incomeApplication: {
+        count: jest.fn().mockResolvedValue(0),
+        findFirst: jest.fn().mockResolvedValue(null),
+        groupBy: jest.fn().mockResolvedValue([]),
+      },
+      movementAllocation: { findMany: jest.fn().mockResolvedValue([]) },
+      liquidation: { findMany: jest.fn().mockResolvedValue([]) },
+      fund: { findFirst: jest.fn().mockResolvedValue(null) },
+      $executeRaw: jest.fn().mockResolvedValue(undefined),
+      ...overrides,
+    };
+    (prisma.$transaction as jest.Mock).mockImplementation(async (callback: (t: unknown) => unknown) =>
+      callback(tx),
+    );
+    return tx;
+  }
+
+  beforeEach(async () => {
+    prisma = {
+      membership: { findFirst: jest.fn().mockResolvedValue({ id: membershipId }) },
+      income: { findMany: jest.fn().mockResolvedValue([]), findFirst: jest.fn() },
+      incomeApplication: {
+        count: jest.fn().mockResolvedValue(0),
+        findFirst: jest.fn().mockResolvedValue(null),
+        groupBy: jest.fn().mockResolvedValue([]),
+      },
+      movementAllocation: { findMany: jest.fn().mockResolvedValue([]) },
+      liquidation: { findMany: jest.fn().mockResolvedValue([]) },
+      fund: { findFirst: jest.fn().mockResolvedValue(null) },
+      $transaction: jest.fn(),
+    };
+    applicationsService = { publishLegacyBackfillPlan: jest.fn() };
+    audit = { createLogRequired: jest.fn().mockResolvedValue(undefined) };
+    validators = { isAdminOrOperator: jest.fn().mockReturnValue(true) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LegacyIncomeBackfillService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: AuditService, useValue: audit },
+        { provide: FinanzasValidators, useValue: validators },
+        { provide: IncomeApplicationsService, useValue: applicationsService },
+      ],
+    }).compile();
+
+    service = module.get(LegacyIncomeBackfillService);
+  });
+
+  // ── Classification / preview ────────────────────────────────────────────
+
+  it('classifies APPLY_TO_EXPENSES without applications as AUTO_MAPPABLE_OFFSET', async () => {
+    prisma.income.findMany.mockResolvedValue([makeIncome()]);
+    const result = await service.preview('tenant-1', membershipId, roles, {});
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.classification).toBe('AUTO_MAPPABLE_OFFSET');
+  });
+
+  it('classifies RESERVE_FUND as REQUIRES_RESERVE_FUND', async () => {
+    prisma.income.findMany.mockResolvedValue([
+      makeIncome({ destination: IncomeDestination.RESERVE_FUND }),
+    ]);
+    const result = await service.preview('tenant-1', membershipId, roles, {});
+
+    expect(result[0]!.classification).toBe('REQUIRES_RESERVE_FUND');
+  });
+
+  it('classifies SPECIAL_FUND as REQUIRES_SPECIAL_FUND', async () => {
+    prisma.income.findMany.mockResolvedValue([
+      makeIncome({ destination: IncomeDestination.SPECIAL_FUND }),
+    ]);
+    const result = await service.preview('tenant-1', membershipId, roles, {});
+
+    expect(result[0]!.classification).toBe('REQUIRES_SPECIAL_FUND');
+  });
+
+  it('classifies income with existing applications as ALREADY_HAS_PLAN', async () => {
+    prisma.income.findMany.mockResolvedValue([makeIncome()]);
+    prisma.incomeApplication.groupBy.mockResolvedValue([
+      { incomeId: 'income-1', _count: { _all: 1 } },
+    ]);
+    const result = await service.preview('tenant-1', membershipId, roles, {});
+
+    expect(result[0]!.classification).toBe('ALREADY_HAS_PLAN');
+  });
+
+  it('classifies DRAFT/VOID as NOT_RECORDED', async () => {
+    prisma.income.findMany.mockResolvedValue([
+      makeIncome({ status: IncomeStatus.DRAFT }),
+      makeIncome({ id: 'income-2', status: IncomeStatus.VOID }),
+    ]);
+    const result = await service.preview('tenant-1', membershipId, roles, {});
+
+    expect(result.map((item) => item.classification)).toEqual(['NOT_RECORDED', 'NOT_RECORDED']);
+  });
+
+  it('classifies APPLY with relevant non-canceled liquidation as LIQUIDATION_CONFLICT', async () => {
+    prisma.income.findMany.mockResolvedValue([makeIncome()]);
+    prisma.liquidation.findMany.mockResolvedValue([
+      { buildingId: 'building-1', status: 'DRAFT' },
+    ]);
+    const result = await service.preview('tenant-1', membershipId, roles, {});
+
+    expect(result[0]!.classification).toBe('LIQUIDATION_CONFLICT');
+  });
+
+  it('preview performs zero writes', async () => {
+    prisma.income.findMany.mockResolvedValue([makeIncome()]);
+    await service.preview('tenant-1', membershipId, roles, {});
+
+    expect(applicationsService.publishLegacyBackfillPlan).not.toHaveBeenCalled();
+    expect(audit.createLogRequired).not.toHaveBeenCalled();
+  });
+
+  it('rejects non-admin roles', async () => {
+    validators.isAdminOrOperator.mockReturnValue(false);
+
+    await expect(service.preview('tenant-1', membershipId, ['RESIDENT'], {})).rejects.toThrow(
+      ForbiddenException,
+    );
+    await expect(service.apply('tenant-1', membershipId, ['RESIDENT'], [])).rejects.toThrow(
+      ForbiddenException,
+    );
+  });
+
+  // ── Apply ───────────────────────────────────────────────────────────────
+
+  it('APPLY materializes 100% OFFSET via shared publisher with legacy provenance', async () => {
+    setupTx();
+    (applicationsService.publishLegacyBackfillPlan as jest.Mock).mockResolvedValue({
+      incomeId: 'income-1',
+      totalAmountMinor: 10000,
+      applications: [{ id: 'app-1', destinationType: 'OFFSET_EXPENSES' }],
+    });
+
+    const result = await service.apply('tenant-1', membershipId, roles, [
+      { incomeId: 'income-1' },
+    ]);
+
+    expect(result).toEqual([{ incomeId: 'income-1', status: 'MIGRATED' }]);
+    expect(applicationsService.publishLegacyBackfillPlan).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        legacyDestination: IncomeDestination.APPLY_TO_EXPENSES,
+        plan: [
+          {
+            destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+            fundId: null,
+            amountMinor: 10000,
+          },
+        ],
+      }),
+    );
+    expect(audit.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'INCOME_LEGACY_BACKFILL',
+        metadata: expect.objectContaining({ mode: 'EXPLICIT_BACKFILL' }),
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('RESERVE_FUND requires an explicit fundId (REQUIRES_FUND)', async () => {
+    setupTx({ destination: IncomeDestination.RESERVE_FUND });
+    const result = await service.apply('tenant-1', membershipId, roles, [
+      { incomeId: 'income-1' },
+    ]);
+
+    expect(result[0]!.status).toBe('REQUIRES_FUND');
+    expect(applicationsService.publishLegacyBackfillPlan).not.toHaveBeenCalled();
+  });
+
+  it('SPECIAL_FUND requires an explicit fundId (REQUIRES_FUND)', async () => {
+    setupTx({ destination: IncomeDestination.SPECIAL_FUND });
+    const result = await service.apply('tenant-1', membershipId, roles, [
+      { incomeId: 'income-1' },
+    ]);
+
+    expect(result[0]!.status).toBe('REQUIRES_FUND');
+  });
+
+  it('RESERVE_FUND rejects a SPECIAL fund (INVALID_FUND)', async () => {
+    setupTx({ destination: IncomeDestination.RESERVE_FUND });
+    prisma.fund.findFirst.mockResolvedValue({
+      id: 'fund-1',
+      status: FundStatus.ACTIVE,
+      type: FundType.SPECIAL,
+    });
+
+    const result = await service.apply('tenant-1', membershipId, roles, [
+      { incomeId: 'income-1', fundId: 'fund-1' },
+    ]);
+
+    expect(result[0]!.status).toBe('INVALID_FUND');
+  });
+
+  it('SPECIAL_FUND rejects a RESERVE fund (INVALID_FUND)', async () => {
+    setupTx({ destination: IncomeDestination.SPECIAL_FUND });
+    prisma.fund.findFirst.mockResolvedValue({
+      id: 'fund-1',
+      status: FundStatus.ACTIVE,
+      type: FundType.RESERVE,
+    });
+
+    const result = await service.apply('tenant-1', membershipId, roles, [
+      { incomeId: 'income-1', fundId: 'fund-1' },
+    ]);
+
+    expect(result[0]!.status).toBe('INVALID_FUND');
+  });
+
+  it('rejects an archived Fund (INVALID_FUND)', async () => {
+    setupTx({ destination: IncomeDestination.RESERVE_FUND });
+    prisma.fund.findFirst.mockResolvedValue({
+      id: 'fund-1',
+      status: FundStatus.ARCHIVED,
+      type: FundType.RESERVE,
+    });
+
+    const result = await service.apply('tenant-1', membershipId, roles, [
+      { incomeId: 'income-1', fundId: 'fund-1' },
+    ]);
+
+    expect(result[0]!.status).toBe('INVALID_FUND');
+  });
+
+  it('rejects a cross-tenant Fund (INVALID_FUND)', async () => {
+    setupTx({ destination: IncomeDestination.RESERVE_FUND });
+    prisma.fund.findFirst.mockResolvedValue(null);
+
+    const result = await service.apply('tenant-1', membershipId, roles, [
+      { incomeId: 'income-1', fundId: 'fund-other-tenant' },
+    ]);
+
+    expect(result[0]!.status).toBe('INVALID_FUND');
+  });
+
+  it('RESERVE_FUND materializes with fund CREDIT occurredAt = receivedDate', async () => {
+    const tx = setupTx({ destination: IncomeDestination.RESERVE_FUND });
+    tx.fund.findFirst.mockResolvedValue({
+      id: 'fund-1',
+      status: FundStatus.ACTIVE,
+      type: FundType.RESERVE,
+    });
+    (applicationsService.publishLegacyBackfillPlan as jest.Mock).mockResolvedValue({
+      incomeId: 'income-1',
+      totalAmountMinor: 10000,
+      applications: [{ id: 'app-1', destinationType: 'FUND' }],
+    });
+
+    const result = await service.apply('tenant-1', membershipId, roles, [
+      { incomeId: 'income-1', fundId: 'fund-1' },
+    ]);
+
+    expect(result[0]!.status).toBe('MIGRATED');
+    expect(applicationsService.publishLegacyBackfillPlan).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        legacyDestination: IncomeDestination.RESERVE_FUND,
+        fundTransactionOccurredAt: new Date('2026-08-10T00:00:00.000Z'),
+        plan: [
+          {
+            destinationType: IncomeApplicationDestination.FUND,
+            fundId: 'fund-1',
+            amountMinor: 10000,
+          },
+        ],
+      }),
+    );
+  });
+
+  it('retry with existing legacy application is idempotent (ALREADY_MIGRATED)', async () => {
+    const tx = setupTx();
+    tx.incomeApplication.count.mockResolvedValue(1);
+    tx.incomeApplication.findFirst.mockResolvedValue({ id: 'app-1' });
+
+    const result = await service.apply('tenant-1', membershipId, roles, [
+      { incomeId: 'income-1' },
+    ]);
+
+    expect(result[0]!.status).toBe('ALREADY_MIGRATED');
+    expect(applicationsService.publishLegacyBackfillPlan).not.toHaveBeenCalled();
+  });
+
+  it('retry with existing non-legacy plan is ALREADY_HAS_PLAN', async () => {
+    const tx = setupTx();
+    tx.incomeApplication.count.mockResolvedValue(1);
+    tx.incomeApplication.findFirst.mockResolvedValue(null);
+
+    const result = await service.apply('tenant-1', membershipId, roles, [
+      { incomeId: 'income-1' },
+    ]);
+
+    expect(result[0]!.status).toBe('ALREADY_HAS_PLAN');
+  });
+
+  it('DRAFT income apply returns NOT_RECORDED', async () => {
+    setupTx({ status: IncomeStatus.DRAFT });
+    const result = await service.apply('tenant-1', membershipId, roles, [
+      { incomeId: 'income-1' },
+    ]);
+
+    expect(result[0]!.status).toBe('NOT_RECORDED');
+  });
+
+  it('VOID income apply returns NOT_RECORDED (never revived)', async () => {
+    setupTx({ status: IncomeStatus.VOID });
+    const result = await service.apply('tenant-1', membershipId, roles, [
+      { incomeId: 'income-1' },
+    ]);
+
+    expect(result[0]!.status).toBe('NOT_RECORDED');
+    expect(applicationsService.publishLegacyBackfillPlan).not.toHaveBeenCalled();
+  });
+
+  it('unknown income returns NOT_FOUND', async () => {
+    const tx = setupTx();
+    tx.income.findFirst.mockResolvedValue(null);
+    const result = await service.apply('tenant-1', membershipId, roles, [
+      { incomeId: 'income-x' },
+    ]);
+
+    expect(result[0]!.status).toBe('NOT_FOUND');
+  });
+
+  it('APPLY with liquidation conflict returns LIQUIDATION_CONFLICT', async () => {
+    const tx = setupTx();
+    tx.liquidation.findMany.mockResolvedValue([
+      { buildingId: 'building-1', status: 'PUBLISHED' },
+    ]);
+
+    const result = await service.apply('tenant-1', membershipId, roles, [
+      { incomeId: 'income-1' },
+    ]);
+
+    expect(result[0]!.status).toBe('LIQUIDATION_CONFLICT');
+    expect(applicationsService.publishLegacyBackfillPlan).not.toHaveBeenCalled();
+  });
+
+  it('CANCELED liquidation does not conflict', async () => {
+    setupTx();
+    prisma.liquidation.findMany.mockResolvedValue([
+      { buildingId: 'building-1', status: 'CANCELED' },
+    ]);
+    (applicationsService.publishLegacyBackfillPlan as jest.Mock).mockResolvedValue({
+      incomeId: 'income-1',
+      totalAmountMinor: 10000,
+      applications: [{ id: 'app-1', destinationType: 'OFFSET_EXPENSES' }],
+    });
+
+    const result = await service.apply('tenant-1', membershipId, roles, [
+      { incomeId: 'income-1' },
+    ]);
+
+    expect(result[0]!.status).toBe('MIGRATED');
+  });
+
+  it('rejects empty batch and batches over the limit', async () => {
+    await expect(service.apply('tenant-1', membershipId, roles, [])).rejects.toThrow(
+      BadRequestException,
+    );
+    const big = Array.from({ length: 101 }, (_, i) => ({ incomeId: `income-${i}` }));
+    await expect(service.apply('tenant-1', membershipId, roles, big)).rejects.toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('processes batch items in deterministic incomeId order', async () => {
+    setupTx();
+    (applicationsService.publishLegacyBackfillPlan as jest.Mock).mockResolvedValue({
+      incomeId: 'x',
+      totalAmountMinor: 10000,
+      applications: [{ id: 'app', destinationType: 'OFFSET_EXPENSES' }],
+    });
+    const items = [{ incomeId: 'b' }, { incomeId: 'a' }];
+
+    const result = await service.apply('tenant-1', membershipId, roles, items);
+
+    expect(result.map((r) => r.incomeId)).toEqual(['a', 'b']);
+  });
+
+  // ── Lazy materialization for liquidation ────────────────────────────────
+
+  it('lazy materializes APPLY legacy income inside the liquidation tx', async () => {
+    const tx = setupTx();
+    tx.income.findMany.mockResolvedValue([makeIncome()]);
+    (applicationsService.publishLegacyBackfillPlan as jest.Mock).mockResolvedValue({
+      incomeId: 'income-1',
+      totalAmountMinor: 10000,
+      applications: [{ id: 'app-1', destinationType: 'OFFSET_EXPENSES' }],
+    });
+
+    await service.materializeForLiquidation({
+      tx: tx as unknown as Prisma.TransactionClient,
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      period: '2026-08',
+      membershipId,
+    });
+
+    expect(applicationsService.publishLegacyBackfillPlan).toHaveBeenCalledWith(
+      tx,
+      expect.objectContaining({
+        legacyDestination: IncomeDestination.APPLY_TO_EXPENSES,
+        plan: [
+          {
+            destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+            fundId: null,
+            amountMinor: 10000,
+          },
+        ],
+      }),
+    );
+    expect(audit.createLogRequired).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'INCOME_LEGACY_BACKFILL',
+        metadata: expect.objectContaining({ mode: 'LIQUIDATION_AUTO_MATERIALIZE' }),
+      }),
+      tx,
+    );
+  });
+
+  it('lazy skips income that gained applications concurrently (plan authoritative)', async () => {
+    const tx = setupTx();
+    tx.income.findMany.mockResolvedValue([makeIncome()]);
+    tx.incomeApplication.count.mockResolvedValue(1);
+
+    await service.materializeForLiquidation({
+      tx: tx as unknown as Prisma.TransactionClient,
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      period: '2026-08',
+      membershipId,
+    });
+
+    expect(applicationsService.publishLegacyBackfillPlan).not.toHaveBeenCalled();
+  });
+
+  it('lazy skips VOID income', async () => {
+    const tx = setupTx();
+    tx.income.findMany.mockResolvedValue([makeIncome({ status: IncomeStatus.VOID })]);
+
+    await service.materializeForLiquidation({
+      tx: tx as unknown as Prisma.TransactionClient,
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      period: '2026-08',
+      membershipId,
+    });
+
+    expect(applicationsService.publishLegacyBackfillPlan).not.toHaveBeenCalled();
+  });
+
+  it('lazy throws LEGACY_INCOME_BACKFILL_LIQUIDATION_CONFLICT on historical conflict', async () => {
+    const tx = setupTx();
+    tx.income.findMany.mockResolvedValue([makeIncome()]);
+    tx.liquidation.findMany.mockResolvedValue([
+      { buildingId: 'building-1', status: 'PUBLISHED' },
+    ]);
+
+    await expect(
+      service.materializeForLiquidation({
+        tx: tx as unknown as Prisma.TransactionClient,
+        tenantId: 'tenant-1',
+        buildingId: 'building-1',
+        period: '2026-08',
+        membershipId,
+      }),
+    ).rejects.toMatchObject({
+      response: { statusCode: 422, error: LEGACY_BACKFILL_LIQUIDATION_CONFLICT },
+    });
+
+    expect(applicationsService.publishLegacyBackfillPlan).not.toHaveBeenCalled();
+  });
+
+  it('lazy skips RESERVE_FUND/SPECIAL_FUND (never auto-materialized)', async () => {
+    const tx = setupTx();
+    const reserve = makeIncome({ id: 'r', destination: IncomeDestination.RESERVE_FUND });
+    const special = makeIncome({ id: 's', destination: IncomeDestination.SPECIAL_FUND });
+    tx.income.findMany.mockResolvedValue([reserve, special]);
+    tx.income.findFirst.mockImplementation(({ where }: { where: { id: string } }) =>
+      Promise.resolve([reserve, special].find((income) => income.id === where.id) ?? null),
+    );
+
+    await service.materializeForLiquidation({
+      tx: tx as unknown as Prisma.TransactionClient,
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      period: '2026-08',
+      membershipId,
+    });
+
+    expect(applicationsService.publishLegacyBackfillPlan).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/finanzas/legacy-income-backfill.service.spec.ts
+++ b/apps/api/src/finanzas/legacy-income-backfill.service.spec.ts
@@ -78,7 +78,12 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
 
   beforeEach(async () => {
     prisma = {
-      membership: { findFirst: jest.fn().mockResolvedValue({ id: membershipId }) },
+      membership: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: membershipId,
+          roles: [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }],
+        }),
+      },
       income: { findMany: jest.fn().mockResolvedValue([]), findFirst: jest.fn() },
       incomeApplication: {
         count: jest.fn().mockResolvedValue(0),
@@ -99,7 +104,6 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
         LegacyIncomeBackfillService,
         { provide: PrismaService, useValue: prisma },
         { provide: AuditService, useValue: audit },
-        { provide: FinanzasValidators, useValue: validators },
         { provide: IncomeApplicationsService, useValue: applicationsService },
       ],
     }).compile();
@@ -107,11 +111,18 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
     service = module.get(LegacyIncomeBackfillService);
   });
 
+  function setMembershipRoles(rolesList: Array<{ role: string; scopeType: string }>) {
+    (prisma.membership.findFirst as jest.Mock).mockResolvedValue({
+      id: membershipId,
+      roles: rolesList,
+    });
+  }
+
   // ── Classification / preview ────────────────────────────────────────────
 
   it('classifies APPLY_TO_EXPENSES without applications as AUTO_MAPPABLE_OFFSET', async () => {
     prisma.income.findMany.mockResolvedValue([makeIncome()]);
-    const result = await service.preview('tenant-1', membershipId, roles, {});
+    const result = await service.preview('tenant-1', membershipId, {});
 
     expect(result).toHaveLength(1);
     expect(result[0]!.classification).toBe('AUTO_MAPPABLE_OFFSET');
@@ -121,7 +132,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
     prisma.income.findMany.mockResolvedValue([
       makeIncome({ destination: IncomeDestination.RESERVE_FUND }),
     ]);
-    const result = await service.preview('tenant-1', membershipId, roles, {});
+    const result = await service.preview('tenant-1', membershipId, {});
 
     expect(result[0]!.classification).toBe('REQUIRES_RESERVE_FUND');
   });
@@ -130,7 +141,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
     prisma.income.findMany.mockResolvedValue([
       makeIncome({ destination: IncomeDestination.SPECIAL_FUND }),
     ]);
-    const result = await service.preview('tenant-1', membershipId, roles, {});
+    const result = await service.preview('tenant-1', membershipId, {});
 
     expect(result[0]!.classification).toBe('REQUIRES_SPECIAL_FUND');
   });
@@ -140,7 +151,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
     prisma.incomeApplication.groupBy.mockResolvedValue([
       { incomeId: 'income-1', _count: { _all: 1 } },
     ]);
-    const result = await service.preview('tenant-1', membershipId, roles, {});
+    const result = await service.preview('tenant-1', membershipId, {});
 
     expect(result[0]!.classification).toBe('ALREADY_HAS_PLAN');
   });
@@ -150,7 +161,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
       makeIncome({ status: IncomeStatus.DRAFT }),
       makeIncome({ id: 'income-2', status: IncomeStatus.VOID }),
     ]);
-    const result = await service.preview('tenant-1', membershipId, roles, {});
+    const result = await service.preview('tenant-1', membershipId, {});
 
     expect(result.map((item) => item.classification)).toEqual(['NOT_RECORDED', 'NOT_RECORDED']);
   });
@@ -160,26 +171,48 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
     prisma.liquidation.findMany.mockResolvedValue([
       { buildingId: 'building-1', status: 'DRAFT' },
     ]);
-    const result = await service.preview('tenant-1', membershipId, roles, {});
+    const result = await service.preview('tenant-1', membershipId, {});
 
     expect(result[0]!.classification).toBe('LIQUIDATION_CONFLICT');
   });
 
   it('preview performs zero writes', async () => {
     prisma.income.findMany.mockResolvedValue([makeIncome()]);
-    await service.preview('tenant-1', membershipId, roles, {});
+    await service.preview('tenant-1', membershipId, {});
 
     expect(applicationsService.publishLegacyBackfillPlan).not.toHaveBeenCalled();
     expect(audit.createLogRequired).not.toHaveBeenCalled();
   });
 
-  it('rejects non-admin roles', async () => {
-    validators.isAdminOrOperator.mockReturnValue(false);
+  it.each([
+    ['TENANT_OWNER TENANT-scoped', [{ role: 'TENANT_OWNER', scopeType: 'TENANT' }], true],
+    ['TENANT_ADMIN TENANT-scoped', [{ role: 'TENANT_ADMIN', scopeType: 'TENANT' }], true],
+    ['OPERATOR TENANT-scoped', [{ role: 'OPERATOR', scopeType: 'TENANT' }], false],
+    ['RESIDENT TENANT-scoped', [{ role: 'RESIDENT', scopeType: 'TENANT' }], false],
+    ['BUILDING-scoped TENANT_ADMIN only', [{ role: 'TENANT_ADMIN', scopeType: 'BUILDING' }], false],
+    ['UNIT-scoped TENANT_ADMIN only', [{ role: 'TENANT_ADMIN', scopeType: 'UNIT' }], false],
+    ['cross-tenant membership', [], false],
+  ])(
+    'RBAC: %s → %s',
+    async (_label, rolesList, allowed) => {
+      prisma.income.findMany.mockResolvedValue([makeIncome()]);
+      setMembershipRoles(rolesList as Array<{ role: string; scopeType: string }>);
 
-    await expect(service.preview('tenant-1', membershipId, ['RESIDENT'], {})).rejects.toThrow(
-      ForbiddenException,
-    );
-    await expect(service.apply('tenant-1', membershipId, ['RESIDENT'], [])).rejects.toThrow(
+      if (allowed) {
+        const result = await service.preview('tenant-1', membershipId, {});
+        expect(result).toHaveLength(1);
+      } else {
+        await expect(service.preview('tenant-1', membershipId, {})).rejects.toThrow(
+          ForbiddenException,
+        );
+      }
+    },
+  );
+
+  it('rejects a membership from another tenant', async () => {
+    (prisma.membership.findFirst as jest.Mock).mockResolvedValue(null);
+
+    await expect(service.preview('tenant-1', membershipId, {})).rejects.toThrow(
       ForbiddenException,
     );
   });
@@ -194,7 +227,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
       applications: [{ id: 'app-1', destinationType: 'OFFSET_EXPENSES' }],
     });
 
-    const result = await service.apply('tenant-1', membershipId, roles, [
+    const result = await service.apply('tenant-1', membershipId, [
       { incomeId: 'income-1' },
     ]);
 
@@ -223,7 +256,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
 
   it('RESERVE_FUND requires an explicit fundId (REQUIRES_FUND)', async () => {
     setupTx({ destination: IncomeDestination.RESERVE_FUND });
-    const result = await service.apply('tenant-1', membershipId, roles, [
+    const result = await service.apply('tenant-1', membershipId, [
       { incomeId: 'income-1' },
     ]);
 
@@ -233,7 +266,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
 
   it('SPECIAL_FUND requires an explicit fundId (REQUIRES_FUND)', async () => {
     setupTx({ destination: IncomeDestination.SPECIAL_FUND });
-    const result = await service.apply('tenant-1', membershipId, roles, [
+    const result = await service.apply('tenant-1', membershipId, [
       { incomeId: 'income-1' },
     ]);
 
@@ -248,7 +281,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
       type: FundType.SPECIAL,
     });
 
-    const result = await service.apply('tenant-1', membershipId, roles, [
+    const result = await service.apply('tenant-1', membershipId, [
       { incomeId: 'income-1', fundId: 'fund-1' },
     ]);
 
@@ -263,7 +296,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
       type: FundType.RESERVE,
     });
 
-    const result = await service.apply('tenant-1', membershipId, roles, [
+    const result = await service.apply('tenant-1', membershipId, [
       { incomeId: 'income-1', fundId: 'fund-1' },
     ]);
 
@@ -278,7 +311,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
       type: FundType.RESERVE,
     });
 
-    const result = await service.apply('tenant-1', membershipId, roles, [
+    const result = await service.apply('tenant-1', membershipId, [
       { incomeId: 'income-1', fundId: 'fund-1' },
     ]);
 
@@ -289,7 +322,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
     setupTx({ destination: IncomeDestination.RESERVE_FUND });
     prisma.fund.findFirst.mockResolvedValue(null);
 
-    const result = await service.apply('tenant-1', membershipId, roles, [
+    const result = await service.apply('tenant-1', membershipId, [
       { incomeId: 'income-1', fundId: 'fund-other-tenant' },
     ]);
 
@@ -309,7 +342,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
       applications: [{ id: 'app-1', destinationType: 'FUND' }],
     });
 
-    const result = await service.apply('tenant-1', membershipId, roles, [
+    const result = await service.apply('tenant-1', membershipId, [
       { incomeId: 'income-1', fundId: 'fund-1' },
     ]);
 
@@ -335,7 +368,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
     tx.incomeApplication.count.mockResolvedValue(1);
     tx.incomeApplication.findFirst.mockResolvedValue({ id: 'app-1' });
 
-    const result = await service.apply('tenant-1', membershipId, roles, [
+    const result = await service.apply('tenant-1', membershipId, [
       { incomeId: 'income-1' },
     ]);
 
@@ -348,7 +381,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
     tx.incomeApplication.count.mockResolvedValue(1);
     tx.incomeApplication.findFirst.mockResolvedValue(null);
 
-    const result = await service.apply('tenant-1', membershipId, roles, [
+    const result = await service.apply('tenant-1', membershipId, [
       { incomeId: 'income-1' },
     ]);
 
@@ -357,7 +390,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
 
   it('DRAFT income apply returns NOT_RECORDED', async () => {
     setupTx({ status: IncomeStatus.DRAFT });
-    const result = await service.apply('tenant-1', membershipId, roles, [
+    const result = await service.apply('tenant-1', membershipId, [
       { incomeId: 'income-1' },
     ]);
 
@@ -366,7 +399,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
 
   it('VOID income apply returns NOT_RECORDED (never revived)', async () => {
     setupTx({ status: IncomeStatus.VOID });
-    const result = await service.apply('tenant-1', membershipId, roles, [
+    const result = await service.apply('tenant-1', membershipId, [
       { incomeId: 'income-1' },
     ]);
 
@@ -377,7 +410,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
   it('unknown income returns NOT_FOUND', async () => {
     const tx = setupTx();
     tx.income.findFirst.mockResolvedValue(null);
-    const result = await service.apply('tenant-1', membershipId, roles, [
+    const result = await service.apply('tenant-1', membershipId, [
       { incomeId: 'income-x' },
     ]);
 
@@ -390,7 +423,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
       { buildingId: 'building-1', status: 'PUBLISHED' },
     ]);
 
-    const result = await service.apply('tenant-1', membershipId, roles, [
+    const result = await service.apply('tenant-1', membershipId, [
       { incomeId: 'income-1' },
     ]);
 
@@ -409,7 +442,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
       applications: [{ id: 'app-1', destinationType: 'OFFSET_EXPENSES' }],
     });
 
-    const result = await service.apply('tenant-1', membershipId, roles, [
+    const result = await service.apply('tenant-1', membershipId, [
       { incomeId: 'income-1' },
     ]);
 
@@ -417,11 +450,11 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
   });
 
   it('rejects empty batch and batches over the limit', async () => {
-    await expect(service.apply('tenant-1', membershipId, roles, [])).rejects.toThrow(
+    await expect(service.apply('tenant-1', membershipId, [])).rejects.toThrow(
       BadRequestException,
     );
     const big = Array.from({ length: 101 }, (_, i) => ({ incomeId: `income-${i}` }));
-    await expect(service.apply('tenant-1', membershipId, roles, big)).rejects.toThrow(
+    await expect(service.apply('tenant-1', membershipId, big)).rejects.toThrow(
       BadRequestException,
     );
   });
@@ -435,7 +468,7 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
     });
     const items = [{ incomeId: 'b' }, { incomeId: 'a' }];
 
-    const result = await service.apply('tenant-1', membershipId, roles, items);
+    const result = await service.apply('tenant-1', membershipId, items);
 
     expect(result.map((r) => r.incomeId)).toEqual(['a', 'b']);
   });
@@ -484,7 +517,9 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
   it('lazy skips income that gained applications concurrently (plan authoritative)', async () => {
     const tx = setupTx();
     tx.income.findMany.mockResolvedValue([makeIncome()]);
-    tx.incomeApplication.count.mockResolvedValue(1);
+    tx.incomeApplication.groupBy.mockResolvedValue([
+      { incomeId: 'income-1', _count: { _all: 1 } },
+    ]);
 
     await service.materializeForLiquidation({
       tx: tx as unknown as Prisma.TransactionClient,
@@ -538,9 +573,14 @@ describe('LegacyIncomeBackfillService (FIN-04)', () => {
     const tx = setupTx();
     const reserve = makeIncome({ id: 'r', destination: IncomeDestination.RESERVE_FUND });
     const special = makeIncome({ id: 's', destination: IncomeDestination.SPECIAL_FUND });
-    tx.income.findMany.mockResolvedValue([reserve, special]);
-    tx.income.findFirst.mockImplementation(({ where }: { where: { id: string } }) =>
-      Promise.resolve([reserve, special].find((income) => income.id === where.id) ?? null),
+    // El discovery filtra por destination APPLY; el mock respeta el filtro.
+    tx.income.findMany.mockImplementation(
+      ({ where }: { where?: { destination?: IncomeDestination } }) =>
+        Promise.resolve(
+          [reserve, special].filter(
+            (income) => income.destination === where?.destination,
+          ),
+        ),
     );
 
     await service.materializeForLiquidation({

--- a/apps/api/src/finanzas/legacy-income-backfill.service.ts
+++ b/apps/api/src/finanzas/legacy-income-backfill.service.ts
@@ -1,6 +1,5 @@
 import {
   BadRequestException,
-  ConflictException,
   ForbiddenException,
   Injectable,
   NotFoundException,
@@ -13,10 +12,10 @@ import {
   IncomeDestination,
   IncomeStatus,
   Prisma,
+  ScopeType,
 } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
-import { FinanzasValidators } from './finanzas.validators';
 import { IncomeApplicationsService } from './income-applications.service';
 import { acquireIncomeLock } from './fund-locks';
 
@@ -30,6 +29,10 @@ import { acquireIncomeLock } from './fund-locks';
  * - Nunca un OFFSET sintético en memoria: la Liquidación consume rows reales.
  * - Historical safety: no materializar si una liquidation no-cancelada relevante
  *   del mismo período ya existe (el snapshot se habría congelado sin el income).
+ * - FIN-04R: la materialización lazy es building-targeted (nunca materializa
+ *   incomes de otros buildings ni shared con share 0); los income locks se
+ *   adquieren en orden determinístico global; el backfill explícito exige
+ *   membresía real TENANT-scoped TENANT_OWNER/TENANT_ADMIN.
  */
 
 export type LegacyBackfillClassification =
@@ -53,7 +56,7 @@ export type LegacyBackfillItemStatus =
 
 export const LEGACY_BACKFILL_LIQUIDATION_CONFLICT = 'LEGACY_INCOME_BACKFILL_LIQUIDATION_CONFLICT';
 
-const MAX_BACKFILL_BATCH = 100;
+export const MAX_BACKFILL_BATCH = 100;
 
 interface BackfillCandidate {
   income: {
@@ -92,13 +95,40 @@ export class LegacyIncomeBackfillService {
   constructor(
     private readonly prisma: PrismaService,
     private readonly auditService: AuditService,
-    private readonly validators: FinanzasValidators,
     private readonly applicationsService: IncomeApplicationsService,
   ) {}
 
-  private assertAdmin(roles: string[], action: string): void {
-    if (!this.validators.isAdminOrOperator(roles)) {
-      throw new ForbiddenException(`Solo administradores pueden ${action}`);
+  /**
+   * FIN-04R RBAC estricto: backfill explícito tenant-wide exige membresía REAL
+   * con rol TENANT-scoped TENANT_OWNER o TENANT_ADMIN.
+   * OPERATOR / RESIDENT / BUILDING-scoped admin / UNIT-scoped / otro tenant → 403.
+   */
+  private async assertExplicitBackfillAdminMembership(
+    tenantId: string,
+    membershipId: string,
+  ): Promise<void> {
+    const membership = await this.prisma.membership.findFirst({
+      where: { id: membershipId, tenantId },
+      select: {
+        id: true,
+        roles: { select: { role: true, scopeType: true } },
+      },
+    });
+
+    if (!membership) {
+      throw new ForbiddenException('No se encontró una membresía válida para el tenant');
+    }
+
+    const allowed = membership.roles.some(
+      (role) =>
+        role.scopeType === ScopeType.TENANT &&
+        (role.role === 'TENANT_OWNER' || role.role === 'TENANT_ADMIN'),
+    );
+
+    if (!allowed) {
+      throw new ForbiddenException(
+        'Solo administradores con rol de tenant pueden ejecutar el backfill de ingresos legacy',
+      );
     }
   }
 
@@ -106,11 +136,15 @@ export class LegacyIncomeBackfillService {
    * Detección de conflictos históricos: si existe una liquidation no-cancelada
    * (DRAFT/REVIEWED/PUBLISHED) para un building/period relevante del income,
    * la materialización se bloquea (el snapshot previo quedó sin el offset).
+   *
+   * FIN-04R: para shared, solo allocations con amountMinor > 0 cuentan como
+   * relevantes (una allocation 0/NULL no genera conflicto ni relevance).
    */
   private async hasRelevantLiquidationConflict(
     tx: Prisma.TransactionClient,
     tenantId: string,
     income: BackfillCandidate['income'],
+    allocations?: ReadonlyArray<{ buildingId: string; amountMinor: number | null }>,
   ): Promise<{ conflicted: boolean; buildingIds: string[] }> {
     const relevantBuildings: string[] = [];
 
@@ -119,15 +153,17 @@ export class LegacyIncomeBackfillService {
         relevantBuildings.push(income.buildingId);
       }
     } else {
-      // TENANT_SHARED / UNIT_GROUP: usar MovementAllocation persistida.
-      const allocations = await tx.movementAllocation.findMany({
-        where: { tenantId, incomeId: income.id },
-        select: { buildingId: true },
-      });
-      relevantBuildings.push(...allocations.map((allocation) => allocation.buildingId));
+      // TENANT_SHARED / UNIT_GROUP: solo allocations con amountMinor > 0.
+      const source = allocations ?? (await this.loadAllocations(tx, tenantId, income.id));
+      for (const allocation of source) {
+        if (allocation.amountMinor !== null && allocation.amountMinor > 0) {
+          relevantBuildings.push(allocation.buildingId);
+        }
+      }
     }
 
-    if (relevantBuildings.length === 0) {
+    const uniqueBuildings = [...new Set(relevantBuildings)].sort();
+    if (uniqueBuildings.length === 0) {
       return { conflicted: false, buildingIds: [] };
     }
 
@@ -135,7 +171,7 @@ export class LegacyIncomeBackfillService {
       where: {
         tenantId,
         period: income.period,
-        buildingId: { in: relevantBuildings },
+        buildingId: { in: uniqueBuildings },
         status: { in: ['DRAFT', 'REVIEWED', 'PUBLISHED'] },
       },
       select: { buildingId: true, status: true },
@@ -143,22 +179,36 @@ export class LegacyIncomeBackfillService {
 
     return {
       conflicted: conflictedLiquidations.length > 0,
-      buildingIds: relevantBuildings,
+      buildingIds: uniqueBuildings,
     };
+  }
+
+  private async loadAllocations(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    incomeId: string,
+  ): Promise<Array<{ buildingId: string; amountMinor: number | null }>> {
+    return tx.movementAllocation.findMany({
+      where: { tenantId, incomeId },
+      select: { buildingId: true, amountMinor: true },
+    });
   }
 
   private async loadCandidates(
     tx: Prisma.TransactionClient,
     tenantId: string,
     filters: { period?: string; categoryId?: string; destination?: IncomeDestination },
+    incomeIds?: string[],
   ): Promise<BackfillCandidate[]> {
     const incomes = await tx.income.findMany({
       where: {
         tenantId,
+        ...(incomeIds ? { id: { in: incomeIds } } : {}),
         ...(filters.period ? { period: filters.period } : {}),
         ...(filters.categoryId ? { categoryId: filters.categoryId } : {}),
         ...(filters.destination ? { destination: filters.destination } : {}),
       },
+      orderBy: { id: 'asc' }, // FIN-04R: orden determinístico en discovery
       select: {
         id: true,
         tenantId: true,
@@ -174,9 +224,14 @@ export class LegacyIncomeBackfillService {
       },
     });
 
+    if (incomes.length === 0) {
+      return [];
+    }
+
+    const ids = incomes.map((income) => income.id);
     const applicationCounts = await tx.incomeApplication.groupBy({
       by: ['incomeId'],
-      where: { tenantId },
+      where: { tenantId, incomeId: { in: ids } }, // FIN-04R: limitar a candidatos
       _count: { _all: true },
     });
     const countByIncome = new Map(
@@ -222,17 +277,9 @@ export class LegacyIncomeBackfillService {
   async preview(
     tenantId: string,
     membershipId: string,
-    roles: string[],
     filters: { period?: string; categoryId?: string; destination?: IncomeDestination },
   ): Promise<LegacyBackfillPreviewItem[]> {
-    this.assertAdmin(roles, 'previsualizar backfill de ingresos legacy');
-    const membership = await this.prisma.membership.findFirst({
-      where: { id: membershipId, tenantId },
-      select: { id: true },
-    });
-    if (!membership) {
-      throw new ForbiddenException('No se encontró una membresía válida para el tenant');
-    }
+    await this.assertExplicitBackfillAdminMembership(tenantId, membershipId);
 
     const candidates = await this.loadCandidates(this.prisma, tenantId, filters);
     const result: LegacyBackfillPreviewItem[] = [];
@@ -270,11 +317,14 @@ export class LegacyIncomeBackfillService {
   async apply(
     tenantId: string,
     membershipId: string,
-    roles: string[],
     items: Array<{ incomeId: string; fundId?: string | null }>,
   ): Promise<Array<{ incomeId: string; status: LegacyBackfillItemStatus; fundId?: string | null }>> {
-    this.assertAdmin(roles, 'ejecutar backfill de ingresos legacy');
+    await this.assertExplicitBackfillAdminMembership(tenantId, membershipId);
 
+    // Defense in depth: nunca items.length TypeError.
+    if (!Array.isArray(items) || items === null || items === undefined) {
+      throw new BadRequestException('El lote de backfill debe ser un array');
+    }
     if (items.length === 0) {
       throw new BadRequestException('El lote de backfill está vacío');
     }
@@ -282,6 +332,11 @@ export class LegacyIncomeBackfillService {
       throw new BadRequestException(
         `El lote máximo es ${MAX_BACKFILL_BATCH} items (recibido: ${items.length})`,
       );
+    }
+    for (const item of items) {
+      if (!item || typeof item.incomeId !== 'string' || item.incomeId.trim().length === 0) {
+        throw new BadRequestException('Cada item de backfill requiere incomeId no vacío');
+      }
     }
 
     // Orden determinístico por incomeId.
@@ -389,6 +444,14 @@ export class LegacyIncomeBackfillService {
         fundTransactionOccurredAt: income.receivedDate,
       });
 
+      // FIN-04R: el mapping legacy siempre produce exactamente UNA aplicación.
+      const [application] = published.applications;
+      if (!application) {
+        throw new Error(
+          `Legacy backfill invariant violation: se esperaba exactamente 1 aplicación para ${incomeId}`,
+        );
+      }
+
       await this.auditService.createLogRequired(
         {
           tenantId,
@@ -399,8 +462,8 @@ export class LegacyIncomeBackfillService {
           metadata: {
             incomeId,
             legacyDestination: destination,
-            applicationId: published.applications[0]?.id ?? null,
-            destinationType: published.applications[0]?.destinationType ?? null,
+            applicationId: application.id,
+            destinationType: application.destinationType,
             amountMinor: income.amountMinor,
             currencyCode: income.currencyCode,
             mode: 'EXPLICIT_BACKFILL',
@@ -419,8 +482,13 @@ export class LegacyIncomeBackfillService {
   /**
    * Auto-materialización para Liquidation (createDraft): materializa incomes
    * legacy APPLY_TO_EXPENSES sin applications dentro de la MISMA transacción.
-   * Los conflictos históricos bloquean; si createDraft falla después, todo
-   * (application + audits) hace rollback con la tx.
+   *
+   * FIN-04R:
+   * - Solo candidates RELEVANTES para el building objetivo (BUILDING con el
+   *   building exacto; shared con allocation > 0 hacia ese building).
+   * - Discovery determinístico (orderBy id) + locks en orden ASC global.
+   * - Reload completo post-lock; relevance recalculada post-lock.
+   * - Un candidate con share 0 en el building objetivo se SKIP (no materializa).
    */
   async materializeForLiquidation(params: {
     tx: Prisma.TransactionClient;
@@ -431,40 +499,59 @@ export class LegacyIncomeBackfillService {
   }): Promise<void> {
     const { tx, tenantId, buildingId, period, membershipId } = params;
 
-    const candidates = await this.loadCandidates(tx, tenantId, {
+    // 1. Discovery de candidate IDs relevantes para el building objetivo.
+    const relevantIncomeIds = await this.discoverRelevantCandidateIds(
+      tx,
+      tenantId,
+      buildingId,
       period,
-      destination: 'APPLY_TO_EXPENSES' as IncomeDestination,
-    });
+    );
+
+    if (relevantIncomeIds.length === 0) {
+      return;
+    }
+
+    // 2. Locks en orden determinístico ASC (evita deadlock por orden variable).
+    for (const incomeId of relevantIncomeIds) {
+      await acquireIncomeLock(tx, tenantId, incomeId);
+    }
+
+    // 3. Reload completo POST-LOCK.
+    const candidates = await this.loadCandidates(
+      tx,
+      tenantId,
+      { period, destination: IncomeDestination.APPLY_TO_EXPENSES },
+      relevantIncomeIds,
+    );
 
     for (const candidate of candidates) {
       const { income, applicationsCount } = candidate;
       if (income.status !== IncomeStatus.RECORDED || applicationsCount > 0) {
         continue; // applications existentes son autoritativas
       }
-
-      // Income lock en orden determinístico (race void/plan vs lazy).
-      await acquireIncomeLock(tx, tenantId, income.id);
-
-      // Reload post-lock: estado fresco.
-      const reloaded = await tx.income.findFirst({
-        where: { id: income.id, tenantId, status: IncomeStatus.RECORDED },
-      });
-      if (!reloaded) {
-        continue; // void ganó la carrera
-      }
-      // Defensivo: solo se auto-materializa APPLY_TO_EXPENSES (el filtro de la
-      // query ya lo restringe; esto protege contra cualquier desviación).
-      if (reloaded.destination !== IncomeDestination.APPLY_TO_EXPENSES) {
+      // Defensivo: solo APPLY_TO_EXPENSES se auto-materializa (el discovery ya
+      // filtra; esto protege contra cualquier desviación del filtro).
+      if (income.destination !== IncomeDestination.APPLY_TO_EXPENSES) {
         continue; // RESERVE/SPECIAL nunca se auto-materializan
       }
-      const reloadedCount = await tx.incomeApplication.count({
-        where: { tenantId, incomeId: income.id },
-      });
-      if (reloadedCount > 0) {
-        continue; // plan concurrente ganó → autoritativo
+
+      // 4. Relevancia post-lock (nunca stale pre-lock).
+      const allocations = await this.loadAllocations(tx, tenantId, income.id);
+      const hasPositiveShareInTrigger = this.hasPositiveShareInBuilding(
+        income,
+        allocations,
+        buildingId,
+      );
+      if (!hasPositiveShareInTrigger) {
+        continue; // share 0 en el building objetivo → no materializa
       }
 
-      const conflict = await this.hasRelevantLiquidationConflict(tx, tenantId, reloaded);
+      const conflict = await this.hasRelevantLiquidationConflict(
+        tx,
+        tenantId,
+        income,
+        allocations,
+      );
       if (conflict.conflicted) {
         throw new UnprocessableEntityException({
           statusCode: 422,
@@ -475,7 +562,7 @@ export class LegacyIncomeBackfillService {
         });
       }
 
-      await this.applicationsService.publishLegacyBackfillPlan(tx, {
+      const published = await this.applicationsService.publishLegacyBackfillPlan(tx, {
         tenantId,
         incomeId: income.id,
         membershipId,
@@ -484,10 +571,18 @@ export class LegacyIncomeBackfillService {
           {
             destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
             fundId: null,
-            amountMinor: reloaded.amountMinor,
+            amountMinor: income.amountMinor,
           },
         ],
       });
+
+      // FIN-04R: exactamente una aplicación; audit con applicationId exacto.
+      const [application] = published.applications;
+      if (!application) {
+        throw new Error(
+          `Legacy lazy materialization invariant violation: se esperaba 1 aplicación para ${income.id}`,
+        );
+      }
 
       await this.auditService.createLogRequired(
         {
@@ -498,12 +593,13 @@ export class LegacyIncomeBackfillService {
           entityId: income.id,
           metadata: {
             incomeId: income.id,
-            legacyDestination: 'APPLY_TO_EXPENSES',
-            destinationType: 'OFFSET_EXPENSES',
-            amountMinor: reloaded.amountMinor,
-            currencyCode: reloaded.currencyCode,
+            legacyDestination: IncomeDestination.APPLY_TO_EXPENSES,
+            applicationId: application.id,
+            destinationType: application.destinationType,
+            amountMinor: income.amountMinor,
+            currencyCode: income.currencyCode,
             mode: 'LIQUIDATION_AUTO_MATERIALIZE',
-            incomeReceivedDate: reloaded.receivedDate.toISOString(),
+            incomeReceivedDate: income.receivedDate.toISOString(),
             triggerBuildingId: buildingId,
             period: income.period,
           },
@@ -511,5 +607,72 @@ export class LegacyIncomeBackfillService {
         tx,
       );
     }
+  }
+
+  /**
+   * Descubre SOLO incomes legacy APPLY relevantes para el building objetivo:
+   * - BUILDING: income.buildingId == trigger building.
+   * - TENANT_SHARED / UNIT_GROUP: existe MovementAllocation con amountMinor > 0
+   *   hacia el trigger building.
+   * Retorna IDs ordenados ASC.
+   */
+  private async discoverRelevantCandidateIds(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    buildingId: string,
+    period: string,
+  ): Promise<string[]> {
+    const incomes = await tx.income.findMany({
+      where: {
+        tenantId,
+        period,
+        status: IncomeStatus.RECORDED,
+        destination: IncomeDestination.APPLY_TO_EXPENSES,
+      },
+      orderBy: { id: 'asc' },
+      select: { id: true, scopeType: true, buildingId: true },
+    });
+
+    const buildingIds = incomes
+      .filter((income) => income.scopeType === 'BUILDING' && income.buildingId === buildingId)
+      .map((income) => income.id);
+
+    const sharedIds = incomes
+      .filter((income) => income.scopeType !== 'BUILDING')
+      .map((income) => income.id);
+
+    const relevantSharedIds: string[] = [];
+    if (sharedIds.length > 0) {
+      const allocations = await tx.movementAllocation.findMany({
+        where: {
+          tenantId,
+          incomeId: { in: sharedIds },
+          buildingId,
+          amountMinor: { gt: 0 },
+        },
+        select: { incomeId: true },
+      });
+      relevantSharedIds.push(
+        ...allocations.map((allocation) => allocation.incomeId as string),
+      );
+    }
+
+    return [...new Set([...buildingIds, ...relevantSharedIds])].sort();
+  }
+
+  private hasPositiveShareInBuilding(
+    income: BackfillCandidate['income'],
+    allocations: ReadonlyArray<{ buildingId: string; amountMinor: number | null }>,
+    buildingId: string,
+  ): boolean {
+    if (income.scopeType === 'BUILDING') {
+      return income.buildingId === buildingId;
+    }
+    return allocations.some(
+      (allocation) =>
+        allocation.buildingId === buildingId &&
+        allocation.amountMinor !== null &&
+        allocation.amountMinor > 0,
+    );
   }
 }

--- a/apps/api/src/finanzas/legacy-income-backfill.service.ts
+++ b/apps/api/src/finanzas/legacy-income-backfill.service.ts
@@ -1,0 +1,515 @@
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+  UnprocessableEntityException,
+} from '@nestjs/common';
+import {
+  FundStatus,
+  FundType,
+  IncomeApplicationDestination,
+  IncomeDestination,
+  IncomeStatus,
+  Prisma,
+} from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { IncomeApplicationsService } from './income-applications.service';
+import { acquireIncomeLock } from './fund-locks';
+
+/**
+ * FIN-04: compatibilidad de Income.destination legacy → IncomeApplication.
+ *
+ * Principios:
+ * - IncomeApplications existentes son AUTORITATIVAS; destination queda como metadata.
+ * - APPLY_TO_EXPENSES puede materializarse como 100% OFFSET_EXPENSES real.
+ * - RESERVE_FUND / SPECIAL_FUND requieren fundId explícito (type validado).
+ * - Nunca un OFFSET sintético en memoria: la Liquidación consume rows reales.
+ * - Historical safety: no materializar si una liquidation no-cancelada relevante
+ *   del mismo período ya existe (el snapshot se habría congelado sin el income).
+ */
+
+export type LegacyBackfillClassification =
+  | 'AUTO_MAPPABLE_OFFSET'
+  | 'REQUIRES_RESERVE_FUND'
+  | 'REQUIRES_SPECIAL_FUND'
+  | 'ALREADY_HAS_PLAN'
+  | 'NOT_RECORDED'
+  | 'LIQUIDATION_CONFLICT';
+
+export type LegacyBackfillItemStatus =
+  | 'MIGRATED'
+  | 'ALREADY_MIGRATED'
+  | 'ALREADY_HAS_PLAN'
+  | 'REQUIRES_FUND'
+  | 'INVALID_FUND'
+  | 'LIQUIDATION_CONFLICT'
+  | 'NOT_RECORDED'
+  | 'NOT_FOUND'
+  | 'INVALID_INCOME';
+
+export const LEGACY_BACKFILL_LIQUIDATION_CONFLICT = 'LEGACY_INCOME_BACKFILL_LIQUIDATION_CONFLICT';
+
+const MAX_BACKFILL_BATCH = 100;
+
+interface BackfillCandidate {
+  income: {
+    id: string;
+    tenantId: string;
+    buildingId: string | null;
+    period: string;
+    scopeType: 'BUILDING' | 'TENANT_SHARED' | 'UNIT_GROUP';
+    status: 'DRAFT' | 'RECORDED' | 'VOID';
+    destination: IncomeDestination;
+    amountMinor: number;
+    currencyCode: string;
+    receivedDate: Date;
+    categoryId: string;
+  };
+  applicationsCount: number;
+}
+
+export interface LegacyBackfillPreviewItem {
+  incomeId: string;
+  period: string;
+  categoryId: string;
+  scopeType: string;
+  buildingId: string | null;
+  status: string;
+  destination: IncomeDestination;
+  amountMinor: number;
+  currencyCode: string;
+  applicationsCount: number;
+  classification: LegacyBackfillClassification;
+  relevantBuildings?: string[];
+}
+
+@Injectable()
+export class LegacyIncomeBackfillService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly auditService: AuditService,
+    private readonly validators: FinanzasValidators,
+    private readonly applicationsService: IncomeApplicationsService,
+  ) {}
+
+  private assertAdmin(roles: string[], action: string): void {
+    if (!this.validators.isAdminOrOperator(roles)) {
+      throw new ForbiddenException(`Solo administradores pueden ${action}`);
+    }
+  }
+
+  /**
+   * Detección de conflictos históricos: si existe una liquidation no-cancelada
+   * (DRAFT/REVIEWED/PUBLISHED) para un building/period relevante del income,
+   * la materialización se bloquea (el snapshot previo quedó sin el offset).
+   */
+  private async hasRelevantLiquidationConflict(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    income: BackfillCandidate['income'],
+  ): Promise<{ conflicted: boolean; buildingIds: string[] }> {
+    const relevantBuildings: string[] = [];
+
+    if (income.scopeType === 'BUILDING') {
+      if (income.buildingId) {
+        relevantBuildings.push(income.buildingId);
+      }
+    } else {
+      // TENANT_SHARED / UNIT_GROUP: usar MovementAllocation persistida.
+      const allocations = await tx.movementAllocation.findMany({
+        where: { tenantId, incomeId: income.id },
+        select: { buildingId: true },
+      });
+      relevantBuildings.push(...allocations.map((allocation) => allocation.buildingId));
+    }
+
+    if (relevantBuildings.length === 0) {
+      return { conflicted: false, buildingIds: [] };
+    }
+
+    const conflictedLiquidations = await tx.liquidation.findMany({
+      where: {
+        tenantId,
+        period: income.period,
+        buildingId: { in: relevantBuildings },
+        status: { in: ['DRAFT', 'REVIEWED', 'PUBLISHED'] },
+      },
+      select: { buildingId: true, status: true },
+    });
+
+    return {
+      conflicted: conflictedLiquidations.length > 0,
+      buildingIds: relevantBuildings,
+    };
+  }
+
+  private async loadCandidates(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    filters: { period?: string; categoryId?: string; destination?: IncomeDestination },
+  ): Promise<BackfillCandidate[]> {
+    const incomes = await tx.income.findMany({
+      where: {
+        tenantId,
+        ...(filters.period ? { period: filters.period } : {}),
+        ...(filters.categoryId ? { categoryId: filters.categoryId } : {}),
+        ...(filters.destination ? { destination: filters.destination } : {}),
+      },
+      select: {
+        id: true,
+        tenantId: true,
+        buildingId: true,
+        period: true,
+        scopeType: true,
+        status: true,
+        destination: true,
+        amountMinor: true,
+        currencyCode: true,
+        receivedDate: true,
+        categoryId: true,
+      },
+    });
+
+    const applicationCounts = await tx.incomeApplication.groupBy({
+      by: ['incomeId'],
+      where: { tenantId },
+      _count: { _all: true },
+    });
+    const countByIncome = new Map(
+      applicationCounts.map((row) => [row.incomeId, row._count._all]),
+    );
+
+    return incomes.map((income) => ({
+      income: income as BackfillCandidate['income'],
+      applicationsCount: countByIncome.get(income.id) ?? 0,
+    }));
+  }
+
+  private async classify(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    candidate: BackfillCandidate,
+  ): Promise<LegacyBackfillClassification> {
+    const { income, applicationsCount } = candidate;
+
+    if (income.status !== 'RECORDED') {
+      return 'NOT_RECORDED';
+    }
+    if (applicationsCount > 0) {
+      return 'ALREADY_HAS_PLAN';
+    }
+    if (income.destination === 'RESERVE_FUND') {
+      return 'REQUIRES_RESERVE_FUND';
+    }
+    if (income.destination === 'SPECIAL_FUND') {
+      return 'REQUIRES_SPECIAL_FUND';
+    }
+    // APPLY_TO_EXPENSES
+    const conflict = await this.hasRelevantLiquidationConflict(tx, tenantId, income);
+    if (conflict.conflicted) {
+      return 'LIQUIDATION_CONFLICT';
+    }
+    return 'AUTO_MAPPABLE_OFFSET';
+  }
+
+  /**
+   * Preview: no escribe. Devuelve candidatos legacy con clasificación.
+   */
+  async preview(
+    tenantId: string,
+    membershipId: string,
+    roles: string[],
+    filters: { period?: string; categoryId?: string; destination?: IncomeDestination },
+  ): Promise<LegacyBackfillPreviewItem[]> {
+    this.assertAdmin(roles, 'previsualizar backfill de ingresos legacy');
+    const membership = await this.prisma.membership.findFirst({
+      where: { id: membershipId, tenantId },
+      select: { id: true },
+    });
+    if (!membership) {
+      throw new ForbiddenException('No se encontró una membresía válida para el tenant');
+    }
+
+    const candidates = await this.loadCandidates(this.prisma, tenantId, filters);
+    const result: LegacyBackfillPreviewItem[] = [];
+
+    for (const candidate of candidates) {
+      const { income, applicationsCount } = candidate;
+      const classification = await this.classify(this.prisma, tenantId, candidate);
+      const conflict = await this.hasRelevantLiquidationConflict(this.prisma, tenantId, income);
+
+      result.push({
+        incomeId: income.id,
+        period: income.period,
+        categoryId: income.categoryId,
+        scopeType: income.scopeType,
+        buildingId: income.buildingId,
+        status: income.status,
+        destination: income.destination,
+        amountMinor: income.amountMinor,
+        currencyCode: income.currencyCode,
+        applicationsCount,
+        classification,
+        ...(conflict.buildingIds.length > 0
+          ? { relevantBuildings: conflict.buildingIds }
+          : {}),
+      });
+    }
+
+    return result;
+  }
+
+  /**
+   * Apply: transacción POR INCOME (idempotente, restartable). Cada item
+   * retorna un status; un error no pierde los ya migrados.
+   */
+  async apply(
+    tenantId: string,
+    membershipId: string,
+    roles: string[],
+    items: Array<{ incomeId: string; fundId?: string | null }>,
+  ): Promise<Array<{ incomeId: string; status: LegacyBackfillItemStatus; fundId?: string | null }>> {
+    this.assertAdmin(roles, 'ejecutar backfill de ingresos legacy');
+
+    if (items.length === 0) {
+      throw new BadRequestException('El lote de backfill está vacío');
+    }
+    if (items.length > MAX_BACKFILL_BATCH) {
+      throw new BadRequestException(
+        `El lote máximo es ${MAX_BACKFILL_BATCH} items (recibido: ${items.length})`,
+      );
+    }
+
+    // Orden determinístico por incomeId.
+    const sortedItems = [...items].sort((a, b) => a.incomeId.localeCompare(b.incomeId));
+    const results: Array<{ incomeId: string; status: LegacyBackfillItemStatus; fundId?: string | null }> = [];
+
+    for (const item of sortedItems) {
+      results.push(
+        await this.applySingle(tenantId, membershipId, item.incomeId, item.fundId ?? null),
+      );
+    }
+
+    return results;
+  }
+
+  private async applySingle(
+    tenantId: string,
+    membershipId: string,
+    incomeId: string,
+    fundId: string | null,
+  ): Promise<{ incomeId: string; status: LegacyBackfillItemStatus; fundId?: string | null }> {
+    return this.prisma.$transaction(async (tx) => {
+      await acquireIncomeLock(tx, tenantId, incomeId);
+
+      const income = await tx.income.findFirst({
+        where: { id: incomeId, tenantId },
+      });
+      if (!income) {
+        return { incomeId, status: 'NOT_FOUND' };
+      }
+      if (income.status !== IncomeStatus.RECORDED) {
+        return { incomeId, status: 'NOT_RECORDED' };
+      }
+
+      const existingApplications = await tx.incomeApplication.count({
+        where: { tenantId, incomeId },
+      });
+      if (existingApplications > 0) {
+        // Idempotencia: si el plan existente fue creado por legacy → ALREADY_MIGRATED.
+        const legacyApp = await tx.incomeApplication.findFirst({
+          where: { tenantId, incomeId, legacyDestination: { not: null } },
+          select: { id: true },
+        });
+        return {
+          incomeId,
+          status: legacyApp ? 'ALREADY_MIGRATED' : 'ALREADY_HAS_PLAN',
+        };
+      }
+
+      const destination = income.destination;
+      let plan: Array<{
+        destinationType: IncomeApplicationDestination;
+        fundId: string | null;
+        amountMinor: number;
+      }>;
+
+      if (destination === 'APPLY_TO_EXPENSES') {
+        const conflict = await this.hasRelevantLiquidationConflict(tx, tenantId, income);
+        if (conflict.conflicted) {
+          return { incomeId, status: 'LIQUIDATION_CONFLICT' };
+        }
+        plan = [
+          {
+            destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+            fundId: null,
+            amountMinor: income.amountMinor,
+          },
+        ];
+      } else if (destination === 'RESERVE_FUND' || destination === 'SPECIAL_FUND') {
+        if (!fundId) {
+          return { incomeId, status: 'REQUIRES_FUND' };
+        }
+        const expectedType = destination === 'RESERVE_FUND' ? FundType.RESERVE : FundType.SPECIAL;
+        const fund = await tx.fund.findFirst({
+          where: { id: fundId, tenantId },
+          select: { id: true, status: true, type: true },
+        });
+        if (!fund) {
+          return { incomeId, status: 'INVALID_FUND' };
+        }
+        if (fund.status !== FundStatus.ACTIVE) {
+          return { incomeId, status: 'INVALID_FUND' };
+        }
+        if (fund.type !== expectedType) {
+          return { incomeId, status: 'INVALID_FUND' };
+        }
+        plan = [
+          {
+            destinationType: IncomeApplicationDestination.FUND,
+            fundId: fund.id,
+            amountMinor: income.amountMinor,
+          },
+        ];
+      } else {
+        return { incomeId, status: 'INVALID_INCOME' };
+      }
+
+      // Publicar mediante el publisher FIN-03 compartido (aplicación real + CREDIT).
+      const published = await this.applicationsService.publishLegacyBackfillPlan(tx, {
+        tenantId,
+        incomeId,
+        membershipId,
+        legacyDestination: destination,
+        plan,
+        fundTransactionOccurredAt: income.receivedDate,
+      });
+
+      await this.auditService.createLogRequired(
+        {
+          tenantId,
+          actorMembershipId: membershipId,
+          action: 'INCOME_LEGACY_BACKFILL',
+          entityType: 'Income',
+          entityId: incomeId,
+          metadata: {
+            incomeId,
+            legacyDestination: destination,
+            applicationId: published.applications[0]?.id ?? null,
+            destinationType: published.applications[0]?.destinationType ?? null,
+            amountMinor: income.amountMinor,
+            currencyCode: income.currencyCode,
+            mode: 'EXPLICIT_BACKFILL',
+            ...(destination !== 'APPLY_TO_EXPENSES' && fundId ? { fundId } : {}),
+            incomeReceivedDate: income.receivedDate.toISOString(),
+            period: income.period,
+          },
+        },
+        tx,
+      );
+
+      return { incomeId, status: 'MIGRATED', fundId: fundId ?? undefined };
+    });
+  }
+
+  /**
+   * Auto-materialización para Liquidation (createDraft): materializa incomes
+   * legacy APPLY_TO_EXPENSES sin applications dentro de la MISMA transacción.
+   * Los conflictos históricos bloquean; si createDraft falla después, todo
+   * (application + audits) hace rollback con la tx.
+   */
+  async materializeForLiquidation(params: {
+    tx: Prisma.TransactionClient;
+    tenantId: string;
+    buildingId: string;
+    period: string;
+    membershipId: string;
+  }): Promise<void> {
+    const { tx, tenantId, buildingId, period, membershipId } = params;
+
+    const candidates = await this.loadCandidates(tx, tenantId, {
+      period,
+      destination: 'APPLY_TO_EXPENSES' as IncomeDestination,
+    });
+
+    for (const candidate of candidates) {
+      const { income, applicationsCount } = candidate;
+      if (income.status !== IncomeStatus.RECORDED || applicationsCount > 0) {
+        continue; // applications existentes son autoritativas
+      }
+
+      // Income lock en orden determinístico (race void/plan vs lazy).
+      await acquireIncomeLock(tx, tenantId, income.id);
+
+      // Reload post-lock: estado fresco.
+      const reloaded = await tx.income.findFirst({
+        where: { id: income.id, tenantId, status: IncomeStatus.RECORDED },
+      });
+      if (!reloaded) {
+        continue; // void ganó la carrera
+      }
+      // Defensivo: solo se auto-materializa APPLY_TO_EXPENSES (el filtro de la
+      // query ya lo restringe; esto protege contra cualquier desviación).
+      if (reloaded.destination !== IncomeDestination.APPLY_TO_EXPENSES) {
+        continue; // RESERVE/SPECIAL nunca se auto-materializan
+      }
+      const reloadedCount = await tx.incomeApplication.count({
+        where: { tenantId, incomeId: income.id },
+      });
+      if (reloadedCount > 0) {
+        continue; // plan concurrente ganó → autoritativo
+      }
+
+      const conflict = await this.hasRelevantLiquidationConflict(tx, tenantId, reloaded);
+      if (conflict.conflicted) {
+        throw new UnprocessableEntityException({
+          statusCode: 422,
+          error: LEGACY_BACKFILL_LIQUIDATION_CONFLICT,
+          message:
+            `El ingreso legacy ${income.id} tiene un conflicto histórico de liquidación ` +
+            `(${income.period}); no se materializa su OFFSET automáticamente`,
+        });
+      }
+
+      await this.applicationsService.publishLegacyBackfillPlan(tx, {
+        tenantId,
+        incomeId: income.id,
+        membershipId,
+        legacyDestination: IncomeDestination.APPLY_TO_EXPENSES,
+        plan: [
+          {
+            destinationType: IncomeApplicationDestination.OFFSET_EXPENSES,
+            fundId: null,
+            amountMinor: reloaded.amountMinor,
+          },
+        ],
+      });
+
+      await this.auditService.createLogRequired(
+        {
+          tenantId,
+          actorMembershipId: membershipId,
+          action: 'INCOME_LEGACY_BACKFILL',
+          entityType: 'Income',
+          entityId: income.id,
+          metadata: {
+            incomeId: income.id,
+            legacyDestination: 'APPLY_TO_EXPENSES',
+            destinationType: 'OFFSET_EXPENSES',
+            amountMinor: reloaded.amountMinor,
+            currencyCode: reloaded.currencyCode,
+            mode: 'LIQUIDATION_AUTO_MATERIALIZE',
+            incomeReceivedDate: reloaded.receivedDate.toISOString(),
+            triggerBuildingId: buildingId,
+            period: income.period,
+          },
+        },
+        tx,
+      );
+    }
+  }
+}

--- a/apps/api/src/finanzas/liquidation-income-offsets.postgres.spec.ts
+++ b/apps/api/src/finanzas/liquidation-income-offsets.postgres.spec.ts
@@ -19,6 +19,7 @@ import { LiquidationsService } from './liquidations.service';
 import { LiquidationIncomeOffsetsService } from './liquidation-income-offsets.service';
 import { IncomesService } from './incomes.service';
 import { IncomeApplicationsService } from './income-applications.service';
+import { LegacyIncomeBackfillService } from './legacy-income-backfill.service';
 import { FundsService } from './funds.service';
 import { CurrencyConversionService } from './currency-conversion.service';
 import { MovementAllocationService } from './movement-allocation.service';
@@ -73,6 +74,7 @@ describePostgres('FIN-06 income offsets → liquidation (PostgreSQL)', () => {
         validators,
         useCase,
         new LiquidationIncomeOffsetsService(prisma),
+        new LegacyIncomeBackfillService(prisma, audit, validators, new IncomeApplicationsService(prisma, audit, validators)),
       ),
       incomes: new IncomesService(
         prisma,

--- a/apps/api/src/finanzas/liquidation-income-offsets.service.ts
+++ b/apps/api/src/finanzas/liquidation-income-offsets.service.ts
@@ -29,6 +29,7 @@ export interface IncomeOffsetSnapshotItem extends Prisma.InputJsonObject {
   categoryId: string;
   categoryName: string | null;
   policyVersionId: string | null;
+  legacyDestination: string | null; // FIN-04: provenance legacy (null = manual/policy)
   scopeType: string;
   currencyCode: string;
   applicationAmountMinor: number;
@@ -84,6 +85,7 @@ interface IncomeWithApplications {
     amountMinor: number;
     currencyCode: string;
     policyVersionId: string | null;
+    legacyDestination: string | null; // FIN-04
   }>;
 }
 
@@ -225,6 +227,7 @@ export function computeIncomeOffsetsForLiquidation(
         categoryId: income.categoryId,
         categoryName: income.category?.name ?? null,
         policyVersionId: application.policyVersionId,
+        legacyDestination: application.legacyDestination ?? null,
         scopeType: income.scopeType,
         currencyCode: application.currencyCode,
         applicationAmountMinor: application.amountMinor,
@@ -335,6 +338,7 @@ export class LiquidationIncomeOffsetsService {
             amountMinor: true,
             currencyCode: true,
             policyVersionId: true,
+            legacyDestination: true,
           },
         },
       },

--- a/apps/api/src/finanzas/liquidation-publication-snapshot.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication-snapshot.spec.ts
@@ -651,5 +651,75 @@ describe('liquidation publication snapshot', () => {
       const snapshot = buildLiquidationPublicationSnapshotV3(zeroInput);
       expect(snapshot).toMatchObject({ version: 3, totalAmountMinor: 10000 });
     });
+
+    // ── FIN-04R: legacyDestination provenance en V3 ────────────────────────
+
+    it('persists legacyDestination in new V3 snapshots', () => {
+      const legacyInput = {
+        ...v3Input,
+        incomeOffsets: [
+          {
+            ...v3Input.incomeOffsets[0]!,
+            policyVersionId: null,
+            legacyDestination: 'APPLY_TO_EXPENSES',
+          },
+        ],
+      };
+
+      const snapshot = buildLiquidationPublicationSnapshotV3(legacyInput);
+      expect(snapshot.incomeOffsets[0]).toMatchObject({
+        policyVersionId: null,
+        legacyDestination: 'APPLY_TO_EXPENSES',
+      });
+
+      const parsed = parseLiquidationPublicationSnapshot(snapshot);
+      expect(parsed?.incomeOffsets[0]).toMatchObject({
+        policyVersionId: null,
+        legacyDestination: 'APPLY_TO_EXPENSES',
+      });
+    });
+
+    it('normalizes missing legacyDestination to null (manual/policy V3)', () => {
+      const snapshot = buildLiquidationPublicationSnapshotV3(v3Input);
+      expect(snapshot.incomeOffsets[0]).toMatchObject({
+        policyVersionId: 'pv-1',
+        legacyDestination: null,
+      });
+    });
+
+    it('parses an old V3 snapshot without legacyDestination field as null', () => {
+      // V3 histórico de pre-FIN-04: sin campo legacyDestination.
+      const oldStyle = {
+        ...v3Input,
+        incomeOffsets: [
+          {
+            incomeId: 'income-1',
+            incomeApplicationId: 'app-offset-1',
+            categoryId: 'cat-1',
+            categoryName: 'Parrillera',
+            policyVersionId: null,
+            scopeType: 'BUILDING',
+            currencyCode: 'ARS',
+            applicationAmountMinor: 7000,
+            buildingAmountMinor: 7000,
+            valuedAmountMinor: 7000,
+            functionalCurrencyCode: null,
+            exchangeRateId: null,
+            exchangeRateValue: null,
+            exchangeRateDirection: null,
+            exchangeRateEffectiveAt: null,
+            conversionDate: null,
+            receivedDate: '2026-08-10T00:00:00.000Z',
+            period: '2026-08',
+          },
+        ],
+      };
+
+      const snapshot = buildLiquidationPublicationSnapshotV3(oldStyle);
+      const parsed = parseLiquidationPublicationSnapshot(snapshot);
+      expect(parsed?.incomeOffsets[0]).toMatchObject({
+        legacyDestination: null,
+      });
+    });
   });
 });

--- a/apps/api/src/finanzas/liquidation-publication-snapshot.ts
+++ b/apps/api/src/finanzas/liquidation-publication-snapshot.ts
@@ -64,6 +64,7 @@ export interface PublishedIncomeOffsetSnapshot {
   categoryId: string;
   categoryName: string | null;
   policyVersionId: string | null;
+  legacyDestination: string | null; // FIN-04: provenance legacy (null = manual/policy)
   scopeType: string;
   currencyCode: string;
   applicationAmountMinor: number;
@@ -832,7 +833,10 @@ function normalizeIncomeOffsetSnapshot(
     assertNonEmpty(value.categoryId, 'categoryId');
   }
 
-  return value;
+  return {
+    ...value,
+    legacyDestination: value.legacyDestination ?? null,
+  };
 }
 
 function toIncomeOffsetJsonObject(value: PublishedIncomeOffsetSnapshot): Prisma.InputJsonObject {
@@ -842,6 +846,7 @@ function toIncomeOffsetJsonObject(value: PublishedIncomeOffsetSnapshot): Prisma.
     categoryId: value.categoryId,
     categoryName: value.categoryName,
     policyVersionId: value.policyVersionId,
+    legacyDestination: value.legacyDestination ?? null,
     scopeType: value.scopeType,
     currencyCode: value.currencyCode,
     applicationAmountMinor: value.applicationAmountMinor,
@@ -916,6 +921,11 @@ function parseIncomeOffsetSnapshot(value: unknown): PublishedIncomeOffsetSnapsho
       : parseIsoDateString(value.conversionDate, 'conversionDate');
   const receivedDate = parseIsoDateString(value.receivedDate, 'receivedDate');
   const period = parseNonEmptyString(value.period, 'period');
+  // FIN-04R: V3 histórico sin field → null (backward compatible).
+  const legacyDestination =
+    value.legacyDestination === null || value.legacyDestination === undefined
+      ? null
+      : parseNullableString(value.legacyDestination, 'legacyDestination');
 
   return {
     incomeId,
@@ -923,6 +933,7 @@ function parseIncomeOffsetSnapshot(value: unknown): PublishedIncomeOffsetSnapsho
     categoryId,
     categoryName,
     policyVersionId,
+    legacyDestination,
     scopeType,
     currencyCode,
     applicationAmountMinor,

--- a/apps/api/src/finanzas/liquidation-publication.postgres.spec.ts
+++ b/apps/api/src/finanzas/liquidation-publication.postgres.spec.ts
@@ -13,6 +13,8 @@ import { FinanzasValidators } from './finanzas.validators';
 import { ResidentAccessService } from '../resident-access/resident-access.service';
 import { LiquidationsService } from './liquidations.service';
 import { LiquidationIncomeOffsetsService } from './liquidation-income-offsets.service';
+import { LegacyIncomeBackfillService } from './legacy-income-backfill.service';
+import { IncomeApplicationsService } from './income-applications.service';
 import {
   createLiquidationWorkflowDependencies,
   createLiquidationDraftRecord,
@@ -254,6 +256,12 @@ describePostgresIntegration('Liquidation publication PostgreSQL integration', ()
         }),
       ),
       new LiquidationIncomeOffsetsService(prisma as unknown as PrismaService),
+      new LegacyIncomeBackfillService(
+        prisma as unknown as PrismaService,
+        auditService,
+        validators,
+        new IncomeApplicationsService(prisma as unknown as PrismaService, auditService, validators),
+      ),
     );
   }
 

--- a/apps/api/src/finanzas/liquidation-publication.use-case.ts
+++ b/apps/api/src/finanzas/liquidation-publication.use-case.ts
@@ -724,6 +724,7 @@ export class LiquidationPublicationUseCase {
                 amountMinor: true,
                 currencyCode: true,
                 policyVersionId: true,
+                legacyDestination: true,
                 income: { select: { id: true, status: true, period: true } },
               },
             });
@@ -756,6 +757,8 @@ export class LiquidationPublicationUseCase {
                 application.amountMinor !== snapshot.applicationAmountMinor ||
                 application.currencyCode !== snapshot.currencyCode ||
                 application.policyVersionId !== snapshot.policyVersionId ||
+                (application.legacyDestination ?? null) !==
+                  (snapshot.legacyDestination ?? null) ||
                 application.income === null ||
                 application.income.id !== snapshot.incomeId ||
                 application.income.status !== 'RECORDED' ||
@@ -1467,6 +1470,7 @@ function parseIncomeOffsetSnapshotItems(value: unknown): PublishedIncomeOffsetSn
       categoryId: nullableString('categoryId') ?? '',
       categoryName: nullableString('categoryName'),
       policyVersionId: nullableString('policyVersionId'),
+      legacyDestination: nullableString('legacyDestination'),
       scopeType: requiredString('scopeType'),
       currencyCode: requiredString('currencyCode'),
       applicationAmountMinor: requiredInt('applicationAmountMinor'),

--- a/apps/api/src/finanzas/liquidations.multicurrency.spec.ts
+++ b/apps/api/src/finanzas/liquidations.multicurrency.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UnprocessableEntityException } from '@nestjs/common';
 import { LiquidationsService } from './liquidations.service';
+import { LegacyIncomeBackfillService } from './legacy-income-backfill.service';
 import { LiquidationIncomeOffsetsService } from './liquidation-income-offsets.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
@@ -214,6 +215,12 @@ describe('LiquidationsService multicurrency valuation', () => {
               incomeOffsetAmountMinor: 0,
               incomeOffsetsByCurrency: {},
             }),
+          },
+        },
+        {
+          provide: LegacyIncomeBackfillService,
+          useValue: {
+            materializeForLiquidation: jest.fn().mockResolvedValue(undefined),
           },
         },
       ],

--- a/apps/api/src/finanzas/liquidations.service.spec.ts
+++ b/apps/api/src/finanzas/liquidations.service.spec.ts
@@ -9,6 +9,7 @@ import {
 import { Prisma } from '@prisma/client';
 import { LiquidationsService } from './liquidations.service';
 import { LiquidationIncomeOffsetsService } from './liquidation-income-offsets.service';
+import { LegacyIncomeBackfillService } from './legacy-income-backfill.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { FinanzasValidators } from './finanzas.validators';
@@ -163,6 +164,14 @@ describe('LiquidationsService', () => {
       providers: [
         LiquidationsService,
         LiquidationIncomeOffsetsService,
+        {
+          provide: LegacyIncomeBackfillService,
+          useValue: {
+            materializeForLiquidation: jest.fn().mockResolvedValue(undefined),
+            preview: jest.fn().mockResolvedValue([]),
+            apply: jest.fn().mockResolvedValue([]),
+          },
+        },
         {
           provide: LiquidationPublicationUseCase,
           inject: [PrismaService, AuditService, FinanzasValidators, NotificationsService],

--- a/apps/api/src/finanzas/liquidations.service.ts
+++ b/apps/api/src/finanzas/liquidations.service.ts
@@ -40,6 +40,7 @@ import {
   LiquidationIncomeOffsetsService,
   type IncomeOffsetSnapshotItem,
 } from './liquidation-income-offsets.service';
+import { LegacyIncomeBackfillService } from './legacy-income-backfill.service';
 
 interface LiquidationExpenseSnapshotItem extends Prisma.InputJsonObject {
   expenseId: string;
@@ -92,6 +93,7 @@ export class LiquidationsService {
     private readonly validators: FinanzasValidators,
     private readonly publicationUseCase: LiquidationPublicationUseCase,
     private readonly incomeOffsetsService: LiquidationIncomeOffsetsService,
+    private readonly legacyBackfillService: LegacyIncomeBackfillService,
   ) {}
 
   private expenseAccountingPeriodWhere(period: string): {
@@ -431,6 +433,17 @@ export class LiquidationsService {
         dto.baseCurrency,
         valuationMode,
       );
+
+      // ── FIN-04: materializar legacy APPLY_TO_EXPENSES antes de congelar ──
+      // Dentro de la MISMA transacción: si el draft falla después, la
+      // application legacy y sus audits hacen rollback con la tx.
+      await this.legacyBackfillService.materializeForLiquidation({
+        tx,
+        tenantId,
+        buildingId: dto.buildingId,
+        period: dto.period,
+        membershipId: membership.id,
+      });
 
       // ── FIN-06: Income offsets (IncomeApplication OFFSET_EXPENSES) ──────
       // Valuación: LEGACY_NOMINAL exige moneda == baseCurrency; FUNCTIONAL usa

--- a/apps/api/src/finanzas/liquidations.wiring.spec.ts
+++ b/apps/api/src/finanzas/liquidations.wiring.spec.ts
@@ -11,6 +11,7 @@ import {
 } from './liquidation-publication.use-case';
 import { LiquidationsService } from './liquidations.service';
 import { LiquidationIncomeOffsetsService } from './liquidation-income-offsets.service';
+import { LegacyIncomeBackfillService } from './legacy-income-backfill.service';
 
 describe('FinanzasModule wiring', () => {
   it('registers LiquidationPublicationUseCase in module metadata and resolves the same Nest-managed instance inside LiquidationsService', async () => {
@@ -86,6 +87,12 @@ describe('FinanzasModule wiring', () => {
               incomeOffsetAmountMinor: 0,
               incomeOffsetsByCurrency: {},
             }),
+          },
+        },
+        {
+          provide: LegacyIncomeBackfillService,
+          useValue: {
+            materializeForLiquidation: jest.fn().mockResolvedValue(undefined),
           },
         },
       ],


### PR DESCRIPTION
## Descripción

FIN-04: cierre de la transición desde `Income.destination` legacy hacia `IncomeApplication`, sin romper historia ni generar dobles efectos financieros.

### Contrato final

1. **IncomeApplications autoritativas**: si un Income tiene aplicaciones, `Income.destination` queda como metadata legacy y nunca las sobreescribe (ni manual ni policy).
2. **APPLY_TO_EXPENSES** → puede materializarse como 100% `OFFSET_EXPENSES` real y persistida (nunca un OFFSET sintético en memoria).
3. **RESERVE_FUND / SPECIAL_FUND** → requieren `fundId` explícito validado (tenant, ACTIVE, type RESERVE/SPECIAL respectivamente; nunca selección automática por nombre).
4. **Historial seguro**: no se materializa un legacy APPLY si existe una liquidation no-cancelada (DRAFT/REVIEWED/PUBLISHED) relevante del mismo período — el snapshot previo se habría congelado sin ese income. CANCELED no bloquea.

### Arquitectura

- **Provenance legacy**: `IncomeApplication.legacyDestination IncomeDestination?` — manual: `policyVersionId null + legacyDestination null`; policy: `policyVersionId != null + legacyDestination null`; legacy: `policyVersionId null + legacyDestination != null`. CHECK DB de exclusión mutua + CHECK de mapping (APPLY → OFFSET sin fund; RESERVE/SPECIAL → FUND con fund).
- **Reuso del publisher FIN-03**: el backfill usa `publishPlanTx` compartido (income lock, fund locks, Fund ACTIVE validation, CREDITs, idempotencia, audits requeridos) vía `publishLegacyBackfillPlan`. Sin segundo implementation path.
- **FundTransaction occurredAt**: para backfill histórico el CREDIT usa `Income.receivedDate` (no la fecha del backfill); `createdAt` puede ser hoy. Default manual/policy intacto.
- **Lazy materialization para Liquidation**: dentro de la MISMA transacción de `createDraft` se materializan incomes legacy APPLY sin applications (income lock + reload post-lock + conflict check). Si el draft falla después (offset>gross, constraints), la aplicación legacy y sus audits hacen rollback con la tx. RESERVE/SPECIAL nunca se auto-materializan.
- **API explícita** (rutas estáticas ANTES de `:incomeId` para evitar shadowing):
  - `GET /tenants/:tenantId/finance/incomes/legacy-backfill/preview` (sin escrituras; clasifica AUTO_MAPPABLE_OFFSET / REQUIRES_RESERVE_FUND / REQUIRES_SPECIAL_FUND / ALREADY_HAS_PLAN / NOT_RECORDED / LIQUIDATION_CONFLICT)
  - `POST /tenants/:tenantId/finance/incomes/legacy-backfill/apply` (batch ≤ 100, transacción POR INCOME idempotente y restartable; statuses MIGRATED / ALREADY_MIGRATED / ALREADY_HAS_PLAN / REQUIRES_FUND / INVALID_FUND / LIQUIDATION_CONFLICT / NOT_RECORDED / NOT_FOUND)
  - RBAC: preview/apply exigen membresía REAL TENANT-scoped TENANT_OWNER o TENANT_ADMIN (OPERATOR/RESIDENT/scoped admin → 403). Lazy liquidation: RBAC normal de Liquidation.
- **Audit**: nueva acción `INCOME_LEGACY_BACKFILL` con metadata completa (incomeId, legacyDestination, applicationId, destinationType, amountMinor, currencyCode, mode `EXPLICIT_BACKFILL` | `LIQUIDATION_AUTO_MATERIALIZE`, fundId cuando aplica, incomeReceivedDate, period, triggerBuildingId). Además del INCOME_APPLICATIONS_CREATE y FUND_TRANSACTION_CREATE del publisher. Sin nulls.

### Seguridad financiera

- Sin migración SQL masiva de aplicaciones; la migración 00004 es solo schema/provenance/audit (columna nullable + AuditAction + CHECKs). Sin UPDATE de `Income.destination`, sin reescribir aplicaciones ni snapshots publicados.
- Sin FX live: la materialización conserva `Income.currencyCode`; FIN-06 valora después con el snapshot funcional congelado (test V: mutar ExchangeRate live no cambia el resultado).
- Shared legacy: UNA aplicación para el income; los drafts de cada building usan sus shares (60/40 exacto). Sin double counting.
- Void: backfill nunca revive VOID; void tras backfill FUND usa las semantics FIN-03 existentes.

### Migración

`20260816000004_legacy_income_application_provenance` — aditiva: `IncomeApplication.legacyDestination`, `INCOME_LEGACY_BACKFILL` en AuditAction, CHECK `provenance_exclusive` y `legacy_destination_mapping`. Sin DROP de datos ni rewrites. Validada: zero-DB (97 migraciones) y upgrade desde origin/main (96 + 1).

### Validación local (counts reales)

| Suite | Resultado |
|---|---|
| Unit finanzas | 1306 passed, 0 failed |
| PostgreSQL FIN-04 (26 tests × 4 runs) | 26/26 determinista |
| FIN-02 PG regression | 15/15 |
| FIN-03 PG regression | 25/25 |
| FIN-05 PG regression | 15/15 |
| FIN-06 PG regression | 59/59 (baseline intacto) |
| Liquidation publication PG | 7/7 |
| Payment allocation PG | 10/10 |
| Full API (184 suites) | 2813 passed, 0 failed |
| Prisma validate / tsc / eslint / build / diff check | todos OK |

### Exclusiones explícitas

- Sin frontend (`apps/web` intocado), sin legacy LiquidationEngine, sin cambios de Payment ni IncomePolicy semantics, sin FIN-07.
- El P2002 preexistente de duplicate liquidation draft queda como follow-up separado (no tocado).

## Tipo de cambio

- [x] Nueva funcionalidad

## Checklist de validación local obligatoria

- [x] Tests unitarios pasan
- [x] Tests de integración pasan
- [x] Typecheck (`tsc --noEmit`) sin errores
- [x] Lint sin errores nuevos
- [x] Build exitoso
- [x] `git diff --check` limpio
- [x] Confirmé que todos los cambios fueron implementados y probados localmente
- [x] Confirmé que el merge a main activará automáticamente el deploy a staging
- [x] El despliegue automático a staging está autorizado para este PR
- [x] Las migraciones incluidas fueron validadas localmente
- [x] No se requiere preservar ningún archivo temporal dentro del checkout de staging
- [x] La validación funcional en staging está definida para después del merge

## PM review hardening (FIN-04R)

Commit `3680f9e` — 6 gaps de la auditoría PM cerrados:

1. **Lazy building isolation**: `materializeForLiquidation` descubre SOLO candidates relevantes al building objetivo (BUILDING con buildingId exacto; shared con MovementAllocation amountMinor > 0 hacia ese building). Un income de otro building nunca se materializa ni genera side effects ni conflictos (tests R1.A/B/C). Allocation 0/NULL no cuenta como relevante (R1.E). Un candidate con share 0 se SKIP.
2. **Lock order determinístico**: discovery con `orderBy id asc`, candidate IDs sorteados ASC y TODOS los income locks adquiridos en ese orden antes de materializar; reload completo post-lock (relevance recalculada post-lock). Test R1.G: 2 shared incomes × 2 drafts concurrentes × 10 iteraciones — sin deadlock, 1 aplicación por income, shares exactos.
3. **RBAC estricto**: preview/apply exigen membresía REAL con rol TENANT-scoped TENANT_OWNER o TENANT_ADMIN (consulta DB, no confía en req.user.roles). OPERATOR, RESIDENT, BUILDING/UNIT-scoped admin, cross-tenant → 403. Matrix unit de 7 casos. El lazy createDraft conserva el RBAC normal de Liquidation.
4. **DTOs runtime**: `LegacyBackfillPreviewQueryDto` (period YYYY-MM, destination enum, categoryId) + `LegacyBackfillApplyDto` (items array 1..100, item incomeId/fundId) + defense in depth en el servicio (items null/undefined/no-array → 400). Spec HTTP con ValidationPipe real: 10 casos malformed → 400, 0×500.
5. **Provenance legacy congelada en V3**: `IncomeOffsetSnapshotItem`/`PublishedIncomeOffsetSnapshot` incluyen `legacyDestination` (null = manual/policy, APPLY_TO_EXPENSES = legacy). El parser acepta V3 históricos sin el campo → null (backward compatible). Source-drift ahora compara `application.legacyDestination == snapshot.legacyDestination`; test R1.F: tamper DB a NULL → 422 LIQUIDATION_INCOME_SOURCE_DRIFT, queda REVIEWED, 0 charges.
6. **Audits con applicationId exacto**: el mapping legacy produce exactamente 1 aplicación (invariant violation si no); explicit y lazy audits usan applicationId/destinationType exactos — nunca `?? null`.

### Counts (FIN-04R)

| Suite | Resultado |
|---|---|
| Unit finanzas | 1327 passed, 0 failed |
| PostgreSQL FIN-04R (33 tests × 6 runs) | 33/33 determinista (incl. 10x concurrency R1.G) |
| FIN-06 PG regression | 59/59 (provenance new compatible) |
| FIN-02/03/05 PG | 15/15, 25/25, 15/15 |
| Liquidation publication PG | 7/7 |
| Payment allocation PG | 10/10 |
| Full API (185 suites) | 2834 passed, 0 failed |
| Prisma validate / tsc / eslint / build / diff check | todos OK |
| Migración 00004 | sin cambios |

