### PR TITLE
feat(web): add finance domain contracts and hooks

### DIFF
--- a/apps/api/src/finanzas/income-applications.dto.ts
+++ b/apps/api/src/finanzas/income-applications.dto.ts
@@ -10,7 +10,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import { IncomeApplicationDestination } from '@prisma/client';
+import { IncomeApplicationDestination, IncomeDestination } from '@prisma/client';
 
 export const MAX_APPLICATIONS_PER_PLAN = 20;
 
@@ -45,6 +45,10 @@ export interface IncomeApplicationResponseDto {
   amountMinor: number;
   currencyCode: string;
   fundTransactionId: string | null;
+  /** Immutable provenance for policy-created applications. */
+  policyVersionId: string | null;
+  /** Immutable provenance for FIN-04 legacy backfill applications. */
+  legacyDestination: IncomeDestination | null;
   createdAt: Date;
 }
 

--- a/apps/api/src/finanzas/income-applications.service.spec.ts
+++ b/apps/api/src/finanzas/income-applications.service.spec.ts
@@ -141,6 +141,27 @@ describe('IncomeApplicationsService', () => {
     });
   });
 
+  describe('response provenance', () => {
+    it('returns immutable policy and legacy provenance with an application plan', async () => {
+      (prisma.income.findFirst as jest.Mock).mockResolvedValue(makeIncome());
+      (prisma.incomeApplication.findMany as jest.Mock).mockResolvedValue([
+        makeApplication({
+          policyVersionId: null,
+          legacyDestination: IncomeDestination.APPLY_TO_EXPENSES,
+        }),
+      ]);
+
+      await expect(service.getPlan('tenant-1', 'income-1', roles)).resolves.toMatchObject({
+        applications: [
+          expect.objectContaining({
+            policyVersionId: null,
+            legacyDestination: IncomeDestination.APPLY_TO_EXPENSES,
+          }),
+        ],
+      });
+    });
+  });
+
   // ── Lifecycle guards ────────────────────────────────────────────────────
 
   describe('lifecycle guards', () => {

--- a/apps/api/src/finanzas/income-applications.service.ts
+++ b/apps/api/src/finanzas/income-applications.service.ts
@@ -575,6 +575,8 @@ export class IncomeApplicationsService {
     amountMinor: number;
     currencyCode: string;
     fundTransactionId: string | null;
+    policyVersionId: string | null;
+    legacyDestination: IncomeDestination | null;
     createdAt: Date;
   } {
     return {
@@ -586,6 +588,8 @@ export class IncomeApplicationsService {
       amountMinor: app.amountMinor,
       currencyCode: app.currencyCode,
       fundTransactionId: app.fundTransaction?.id ?? null,
+      policyVersionId: app.policyVersionId,
+      legacyDestination: app.legacyDestination,
       createdAt: app.createdAt,
     };
   }

--- a/apps/web/features/finance/components/__tests__/LiquidationCard.test.tsx
+++ b/apps/web/features/finance/components/__tests__/LiquidationCard.test.tsx
@@ -87,6 +87,7 @@ function buildDetail(
 
   return {
     ...liquidation,
+    publicationSnapshotStatus: 'AVAILABLE',
     totalAmountMinor: overrides.totalAmountMinor ?? liquidation.totalAmountMinor,
     expenses:
       overrides.expenses ??

--- a/apps/web/features/finance/contracts/currencies.ts
+++ b/apps/web/features/finance/contracts/currencies.ts
@@ -1,0 +1,9 @@
+import { CANONICAL_CURRENCIES, type CanonicalCurrency } from '@buildingos/contracts';
+
+// Platform-accepted currencies, not a tenant-specific allowlist.
+export { CANONICAL_CURRENCIES } from '@buildingos/contracts';
+export type { CanonicalCurrency } from '@buildingos/contracts';
+
+export function isFinanceCurrency(value: unknown): value is CanonicalCurrency {
+  return typeof value === 'string' && CANONICAL_CURRENCIES.some((currency) => currency === value);
+}

--- a/apps/web/features/finance/contracts/finance-guards.test.ts
+++ b/apps/web/features/finance/contracts/finance-guards.test.ts
@@ -1,5 +1,6 @@
 import {
   isFundTransaction,
+  isFund,
   isIncomeApplication,
   isIncomeOffsetSnapshotItem,
   isIncomePolicy,
@@ -23,12 +24,23 @@ describe('FIN-07AR finance guards', () => {
     expect(isIncomeApplication({ ...application, destinationType: 'FUND', fundId: null })).toBe(false);
   });
 
+  it('requires complete Fund and FundTransaction response structures', () => {
+    const fund = { id: 'fund', tenantId: 'tenant', buildingId: null, scopeType: 'TENANT', type: 'RESERVE', name: 'Reserve', description: null, status: 'ACTIVE', balancesByCurrency: [], createdAt: '2026-08-01', archivedAt: null };
+    expect(isFund(fund)).toBe(true);
+    expect(isFund({ ...fund, scopeType: 'BUILDING' })).toBe(false);
+    expect(isFund({ ...fund, createdAt: undefined })).toBe(false);
+    expect(isFundTransaction({ id: 'tx', tenantId: 'tenant', fundId: 'fund', direction: 'CREDIT', amountMinor: 1, currencyCode: 'COP', occurredAt: '2026-08-01', description: null, idempotencyKey: null, reversalOfTransactionId: null, createdAt: '2026-08-01' })).toBe(true);
+    expect(isFundTransaction({ id: 'tx', tenantId: 'tenant', fundId: 'fund', direction: 'CREDIT', amountMinor: 1, currencyCode: 'COP' })).toBe(false);
+  });
+
   it('rejects malformed policy versions and basis points', () => {
-    const policy = { id: 'policy', tenantId: 'tenant', categoryId: 'category', currentVersion: null, versions: [{ id: 'version', version: 1, status: 'ACTIVE', createdAt: '2026-08-01', rules: [{ destinationType: 'FUND', fundId: 'fund', percentageBasisPoints: 10000 }] }] };
+    const policy = { id: 'policy', tenantId: 'tenant', categoryId: 'category', currentVersion: null, versions: [{ id: 'version', version: 1, status: 'ACTIVE', createdAt: '2026-08-01', rules: [{ id: 'rule', destinationType: 'FUND', fundId: 'fund', percentageBasisPoints: 10000 }] }] };
     expect(isIncomePolicy({ ...policy, currentVersion: { version: 0 } })).toBe(false);
     expect(isIncomePolicy({ ...policy, versions: [{ ...policy.versions[0], version: 0 }] })).toBe(false);
     expect(isIncomePolicy({ ...policy, versions: [{ ...policy.versions[0], status: 'UNKNOWN' }] })).toBe(false);
     expect(isIncomePolicy({ ...policy, versions: [{ ...policy.versions[0], rules: [{ destinationType: 'FUND', fundId: 'fund', percentageBasisPoints: '1' }] }] })).toBe(false);
+    expect(isIncomePolicy({ ...policy, versions: [{ ...policy.versions[0], rules: [{ ...policy.versions[0].rules[0], fundId: null }] }] })).toBe(false);
+    expect(isIncomePolicy({ ...policy, versions: [{ ...policy.versions[0], rules: [{ ...policy.versions[0].rules[0], destinationType: 'OFFSET_EXPENSES', fundId: 'fund' }] }] })).toBe(false);
   });
 
   it('rejects unknown legacy classifications and result statuses', () => {

--- a/apps/web/features/finance/contracts/finance-guards.test.ts
+++ b/apps/web/features/finance/contracts/finance-guards.test.ts
@@ -1,0 +1,60 @@
+import {
+  isFundTransaction,
+  isIncomeApplication,
+  isIncomeOffsetSnapshotItem,
+  isIncomePolicy,
+  isLiquidationV3Summary,
+  parseLegacyBackfillPreview,
+  parseLegacyBackfillResults,
+} from './finance-guards';
+import { CANONICAL_CURRENCIES, isFinanceCurrency } from './currencies';
+import { CANONICAL_CURRENCIES as SHARED_CANONICAL_CURRENCIES } from '@buildingos/contracts';
+
+const application = {
+  id: 'app-1', tenantId: 'tenant-1', incomeId: 'income-1', destinationType: 'OFFSET_EXPENSES',
+  fundId: null, amountMinor: 1, currencyCode: 'COP', fundTransactionId: null,
+  policyVersionId: null, legacyDestination: null, createdAt: '2026-08-01T00:00:00.000Z',
+};
+
+describe('FIN-07AR finance guards', () => {
+  it('rejects zero financial transaction and application amounts', () => {
+    expect(isFundTransaction({ id: 'tx', tenantId: 't', fundId: 'f', direction: 'CREDIT', amountMinor: 0, currencyCode: 'COP' })).toBe(false);
+    expect(isIncomeApplication({ ...application, amountMinor: 0 })).toBe(false);
+    expect(isIncomeApplication({ ...application, destinationType: 'FUND', fundId: null })).toBe(false);
+  });
+
+  it('rejects malformed policy versions and basis points', () => {
+    const policy = { id: 'policy', tenantId: 'tenant', categoryId: 'category', currentVersion: null, versions: [{ id: 'version', version: 1, status: 'ACTIVE', createdAt: '2026-08-01', rules: [{ destinationType: 'FUND', fundId: 'fund', percentageBasisPoints: 10000 }] }] };
+    expect(isIncomePolicy({ ...policy, currentVersion: { version: 0 } })).toBe(false);
+    expect(isIncomePolicy({ ...policy, versions: [{ ...policy.versions[0], version: 0 }] })).toBe(false);
+    expect(isIncomePolicy({ ...policy, versions: [{ ...policy.versions[0], status: 'UNKNOWN' }] })).toBe(false);
+    expect(isIncomePolicy({ ...policy, versions: [{ ...policy.versions[0], rules: [{ destinationType: 'FUND', fundId: 'fund', percentageBasisPoints: '1' }] }] })).toBe(false);
+  });
+
+  it('rejects unknown legacy classifications and result statuses', () => {
+    const preview = { incomeId: 'income', period: '2026-08', categoryId: 'cat', scopeType: 'BUILDING', buildingId: 'building', status: 'RECORDED', destination: 'APPLY_TO_EXPENSES', amountMinor: 1, currencyCode: 'USD', applicationsCount: 0, classification: 'UNKNOWN' };
+    expect(() => parseLegacyBackfillPreview([preview])).toThrow('Invalid legacy backfill preview response');
+    expect(() => parseLegacyBackfillResults([{ incomeId: 'income', status: 'UNKNOWN' }])).toThrow('Invalid legacy backfill results response');
+  });
+
+  it('requires all-or-none V3 summaries and exact safe equations', () => {
+    expect(isLiquidationV3Summary({})).toBe(true);
+    expect(isLiquidationV3Summary({ grossExpenseAmountMinor: null, adjustmentAmountMinor: null, preIncomeAmountMinor: null, incomeOffsetAmountMinor: null, netDistributableAmountMinor: null })).toBe(true);
+    expect(isLiquidationV3Summary({ grossExpenseAmountMinor: 10000, adjustmentAmountMinor: 0, preIncomeAmountMinor: 10000, incomeOffsetAmountMinor: 3000, netDistributableAmountMinor: 7000 })).toBe(true);
+    expect(isLiquidationV3Summary({ grossExpenseAmountMinor: 10000 })).toBe(false);
+    expect(isLiquidationV3Summary({ grossExpenseAmountMinor: 10000, adjustmentAmountMinor: 0, preIncomeAmountMinor: 10000, incomeOffsetAmountMinor: 3000, netDistributableAmountMinor: 6000 })).toBe(false);
+    expect(isLiquidationV3Summary({ grossExpenseAmountMinor: Number.MAX_SAFE_INTEGER, adjustmentAmountMinor: 1, preIncomeAmountMinor: Number.MAX_SAFE_INTEGER, incomeOffsetAmountMinor: 0, netDistributableAmountMinor: Number.MAX_SAFE_INTEGER })).toBe(false);
+  });
+
+  it('validates the FIN-07C offset snapshot foundation completely', () => {
+    expect(isIncomeOffsetSnapshotItem({ incomeId: 'income', incomeApplicationId: 'app', categoryId: 'cat', categoryName: null, policyVersionId: null, legacyDestination: 'APPLY_TO_EXPENSES', scopeType: 'BUILDING', currencyCode: 'USD', applicationAmountMinor: 1, buildingAmountMinor: 1, valuedAmountMinor: 1, functionalCurrencyCode: null, exchangeRateId: null, exchangeRateValue: null, exchangeRateDirection: null, exchangeRateEffectiveAt: null, conversionDate: null, receivedDate: '2026-08-01', period: '2026-08' })).toBe(true);
+  });
+
+  it('uses shared canonical currencies instead of a local list', () => {
+    expect(CANONICAL_CURRENCIES).toBe(SHARED_CANONICAL_CURRENCIES);
+    expect(isFinanceCurrency('COP')).toBe(true);
+    expect(isFinanceCurrency('USD')).toBe(true);
+    expect(isFinanceCurrency('VES')).toBe(true);
+    expect(isFinanceCurrency('ARS')).toBe(true);
+  });
+});

--- a/apps/web/features/finance/contracts/finance-guards.ts
+++ b/apps/web/features/finance/contracts/finance-guards.ts
@@ -77,11 +77,11 @@ export function isFund(value: unknown): value is Fund {
     return false;
   }
   const fund = value as Record<string, unknown>;
-  if (typeof fund.id !== 'string' || typeof fund.tenantId !== 'string') {
+  if (!isNonEmptyString(fund.id) || !isNonEmptyString(fund.tenantId)) {
     return false;
   }
   if (
-    typeof fund.name !== 'string' ||
+    !isNonEmptyString(fund.name) || !isNullableString(fund.buildingId) || !isNullableString(fund.description) ||
     !['TENANT', 'BUILDING'].includes(String(fund.scopeType)) ||
     !['RESERVE', 'SPECIAL', 'OTHER'].includes(String(fund.type)) ||
     !['ACTIVE', 'ARCHIVED'].includes(String(fund.status))
@@ -91,6 +91,9 @@ export function isFund(value: unknown): value is Fund {
   if (!Array.isArray(fund.balancesByCurrency)) {
     return false;
   }
+  if (!isNonEmptyString(fund.createdAt) || !isNullableString(fund.archivedAt)) return false;
+  if (fund.scopeType === 'TENANT' && fund.buildingId !== null) return false;
+  if (fund.scopeType === 'BUILDING' && !isNonEmptyString(fund.buildingId)) return false;
   // Fail-closed: cada balance debe ser válido; un balance inválido invalida el Fund.
   return fund.balancesByCurrency.every(isFundBalance);
 }
@@ -99,12 +102,17 @@ export function isFundTransaction(value: unknown): value is FundTransaction {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
   const transaction = value as Record<string, unknown>;
   return (
-    typeof transaction.id === 'string' &&
-    typeof transaction.tenantId === 'string' &&
-    typeof transaction.fundId === 'string' &&
+    isNonEmptyString(transaction.id) &&
+    isNonEmptyString(transaction.tenantId) &&
+    isNonEmptyString(transaction.fundId) &&
     ['CREDIT', 'DEBIT'].includes(String(transaction.direction)) &&
     isNonEmptyString(transaction.currencyCode) &&
-    isPositiveSafeInt(transaction.amountMinor)
+    isPositiveSafeInt(transaction.amountMinor) &&
+    isNonEmptyString(transaction.occurredAt) &&
+    isNullableString(transaction.description) &&
+    isNullableString(transaction.idempotencyKey) &&
+    isNullableString(transaction.reversalOfTransactionId) &&
+    isNonEmptyString(transaction.createdAt)
   );
 }
 
@@ -160,15 +168,26 @@ export function isIncomePolicyRule(value: unknown): value is IncomePolicyRule {
     return false;
   }
   const rule = value as Record<string, unknown>;
-  if (!isDestination(rule.destinationType)) {
+  if (!isNonEmptyString(rule.id) || !isDestination(rule.destinationType) || !isNullableString(rule.fundId)) {
     return false;
   }
   return (
     typeof rule.percentageBasisPoints === 'number' &&
     Number.isSafeInteger(rule.percentageBasisPoints) &&
     (rule.percentageBasisPoints as number) >= 1 &&
-    (rule.percentageBasisPoints as number) <= 10000
+    (rule.percentageBasisPoints as number) <= 10000 &&
+    (rule.destinationType === 'FUND' ? isNonEmptyString(rule.fundId) : rule.fundId === null)
   );
+}
+
+function hasFullPercentageAllocation(rules: unknown[]): boolean {
+  let total = 0;
+  for (const rule of rules) {
+    const amount = (rule as IncomePolicyRule).percentageBasisPoints;
+    if (!Number.isSafeInteger(total + amount)) return false;
+    total += amount;
+  }
+  return total === 10000;
 }
 
 export function isIncomeApplicationPlan(value: unknown): value is IncomeApplicationPlan {
@@ -190,7 +209,8 @@ export function isIncomePolicyVersion(value: unknown): boolean {
     isNonEmptyString(version.id) &&
     isPositiveSafeInt(version.version) &&
     typeof version.status === 'string' && POLICY_STATUSES.has(version.status) &&
-    Array.isArray(version.rules) && version.rules.every(isIncomePolicyRule) &&
+    Array.isArray(version.rules) && version.rules.length > 0 && version.rules.every(isIncomePolicyRule) &&
+    hasFullPercentageAllocation(version.rules) &&
     isNonEmptyString(version.createdAt)
   );
 }

--- a/apps/web/features/finance/contracts/finance-guards.ts
+++ b/apps/web/features/finance/contracts/finance-guards.ts
@@ -23,9 +23,32 @@ import type {
 
 const DESTINATIONS = new Set(['OFFSET_EXPENSES', 'FUND', 'CARRY_FORWARD']);
 const LEGACY_DESTINATIONS = new Set(['APPLY_TO_EXPENSES', 'RESERVE_FUND', 'SPECIAL_FUND']);
+const POLICY_STATUSES = new Set(['ACTIVE', 'INACTIVE']);
+const INCOME_SCOPES = new Set(['BUILDING', 'TENANT_SHARED', 'UNIT_GROUP']);
+const INCOME_STATUSES = new Set(['DRAFT', 'RECORDED', 'VOID']);
+const LEGACY_CLASSIFICATIONS = new Set([
+  'AUTO_MAPPABLE_OFFSET', 'REQUIRES_RESERVE_FUND', 'REQUIRES_SPECIAL_FUND',
+  'ALREADY_HAS_PLAN', 'NOT_RECORDED', 'LIQUIDATION_CONFLICT',
+]);
+const LEGACY_RESULT_STATUSES = new Set([
+  'MIGRATED', 'ALREADY_MIGRATED', 'ALREADY_HAS_PLAN', 'REQUIRES_FUND',
+  'INVALID_FUND', 'LIQUIDATION_CONFLICT', 'NOT_RECORDED', 'NOT_FOUND', 'INVALID_INCOME',
+]);
 
 export function isNonNegativeInt(value: unknown): value is number {
   return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+export function isPositiveSafeInt(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isNullableString(value: unknown): value is string | null {
+  return value === null || typeof value === 'string';
 }
 
 export function isDestination(value: unknown): value is IncomeApplicationDestination {
@@ -44,7 +67,7 @@ export function isFundBalance(value: unknown): value is FundBalance {
     typeof value === 'object' &&
     value !== null &&
     !Array.isArray(value) &&
-    typeof (value as FundBalance).currency === 'string' &&
+    isNonEmptyString((value as FundBalance).currency) &&
     isNonNegativeInt((value as FundBalance).amountMinor)
   );
 }
@@ -80,8 +103,8 @@ export function isFundTransaction(value: unknown): value is FundTransaction {
     typeof transaction.tenantId === 'string' &&
     typeof transaction.fundId === 'string' &&
     ['CREDIT', 'DEBIT'].includes(String(transaction.direction)) &&
-    typeof transaction.currencyCode === 'string' &&
-    isNonNegativeInt(transaction.amountMinor)
+    isNonEmptyString(transaction.currencyCode) &&
+    isPositiveSafeInt(transaction.amountMinor)
   );
 }
 
@@ -94,24 +117,28 @@ export function isIncomeApplication(value: unknown): value is IncomeApplication 
     return false;
   }
   const app = value as Record<string, unknown>;
-  if (typeof app.id !== 'string' || typeof app.incomeId !== 'string') {
+  if (
+    !isNonEmptyString(app.id) ||
+    !isNonEmptyString(app.tenantId) ||
+    !isNonEmptyString(app.incomeId) ||
+    !isNonEmptyString(app.currencyCode) ||
+    !isNonEmptyString(app.createdAt)
+  ) {
     return false;
   }
   if (!isDestination(app.destinationType)) {
     return false;
   }
-  if (!isNonNegativeInt(app.amountMinor) || typeof app.currencyCode !== 'string') {
+  if (!isPositiveSafeInt(app.amountMinor) || !isNullableString(app.fundId) || !isNullableString(app.fundTransactionId)) {
     return false;
   }
   const policyVersionId = app.policyVersionId;
   const legacyDestination = app.legacyDestination;
-  if (policyVersionId !== null && policyVersionId !== undefined && typeof policyVersionId !== 'string') {
+  if (!isNullableString(policyVersionId)) {
     return false;
   }
   if (
-    legacyDestination !== null &&
-    legacyDestination !== undefined &&
-    !isLegacyDestination(legacyDestination)
+    legacyDestination !== null && !isLegacyDestination(legacyDestination)
   ) {
     return false;
   }
@@ -119,6 +146,8 @@ export function isIncomeApplication(value: unknown): value is IncomeApplication 
   if (policyVersionId != null && legacyDestination != null) {
     return false;
   }
+  if (app.destinationType === 'FUND' && !isNonEmptyString(app.fundId)) return false;
+  if (app.destinationType !== 'FUND' && app.fundId !== null) return false;
   return true;
 }
 
@@ -146,52 +175,56 @@ export function isIncomeApplicationPlan(value: unknown): value is IncomeApplicat
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
   const plan = value as Record<string, unknown>;
   return (
-    typeof plan.incomeId === 'string' &&
-    typeof plan.currencyCode === 'string' &&
-    isNonNegativeInt(plan.totalAmountMinor) &&
+    isNonEmptyString(plan.incomeId) &&
+    isNonEmptyString(plan.currencyCode) &&
+    isPositiveSafeInt(plan.totalAmountMinor) &&
     Array.isArray(plan.applications) &&
     plan.applications.every(isIncomeApplication)
+  );
+}
+
+export function isIncomePolicyVersion(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const version = value as Record<string, unknown>;
+  return (
+    isNonEmptyString(version.id) &&
+    isPositiveSafeInt(version.version) &&
+    typeof version.status === 'string' && POLICY_STATUSES.has(version.status) &&
+    Array.isArray(version.rules) && version.rules.every(isIncomePolicyRule) &&
+    isNonEmptyString(version.createdAt)
   );
 }
 
 export function isIncomePolicy(value: unknown): value is IncomePolicy {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
   const policy = value as Record<string, unknown>;
-  if (typeof policy.id !== 'string' || typeof policy.tenantId !== 'string' || typeof policy.categoryId !== 'string') {
+  if (!isNonEmptyString(policy.id) || !isNonEmptyString(policy.tenantId) || !isNonEmptyString(policy.categoryId)) {
     return false;
   }
   const versions = policy.versions;
   if (!Array.isArray(versions)) return false;
-  return versions.every((version) => {
-    if (typeof version !== 'object' || version === null || Array.isArray(version)) return false;
-    const record = version as Record<string, unknown>;
-    return (
-      typeof record.id === 'string' &&
-      isNonNegativeInt(record.version) &&
-      ['ACTIVE', 'INACTIVE'].includes(String(record.status)) &&
-      Array.isArray(record.rules) &&
-      record.rules.every(isIncomePolicyRule)
-    );
-  });
+  return (policy.currentVersion === null || isIncomePolicyVersion(policy.currentVersion)) && versions.every(isIncomePolicyVersion);
 }
 
 export function isLegacyBackfillPreviewItem(value: unknown): value is LegacyBackfillPreviewItem {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
   const item = value as Record<string, unknown>;
   return (
-    typeof item.incomeId === 'string' &&
-    typeof item.period === 'string' &&
-    typeof item.categoryId === 'string' &&
-    typeof item.currencyCode === 'string' &&
-    isNonNegativeInt(item.amountMinor) &&
-    isLegacyDestination(item.destination)
+    isNonEmptyString(item.incomeId) && isNonEmptyString(item.period) &&
+    isNonEmptyString(item.categoryId) && INCOME_SCOPES.has(String(item.scopeType)) &&
+    isNullableString(item.buildingId) && INCOME_STATUSES.has(String(item.status)) &&
+    isLegacyDestination(item.destination) && isPositiveSafeInt(item.amountMinor) &&
+    isNonEmptyString(item.currencyCode) && isNonNegativeInt(item.applicationsCount) &&
+    LEGACY_CLASSIFICATIONS.has(String(item.classification)) &&
+    (item.relevantBuildings === undefined || (Array.isArray(item.relevantBuildings) && item.relevantBuildings.every(isNonEmptyString)))
   );
 }
 
 export function isLegacyBackfillApplyResultItem(value: unknown): value is LegacyBackfillApplyResultItem {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
   const item = value as Record<string, unknown>;
-  return typeof item.incomeId === 'string' && typeof item.status === 'string';
+  return isNonEmptyString(item.incomeId) && LEGACY_RESULT_STATUSES.has(String(item.status)) &&
+    (item.fundId === undefined || isNullableString(item.fundId));
 }
 
 function assertFinancialResponse(condition: boolean, responseName: string): asserts condition {
@@ -254,24 +287,30 @@ export function isIncomeOffsetSnapshotItem(value: unknown): value is IncomeOffse
     return false;
   }
   const item = value as Record<string, unknown>;
-  if (typeof item.incomeId !== 'string' || typeof item.incomeApplicationId !== 'string') {
+  if (!isNonEmptyString(item.incomeId) || !isNonEmptyString(item.incomeApplicationId) || !isNonEmptyString(item.categoryId)) {
     return false;
   }
-  if (!isNonNegativeInt(item.applicationAmountMinor) || !isNonNegativeInt(item.valuedAmountMinor)) {
+  if (
+    !isNullableString(item.categoryName) || !INCOME_SCOPES.has(String(item.scopeType)) ||
+    !isNonEmptyString(item.currencyCode) || !isPositiveSafeInt(item.applicationAmountMinor) ||
+    !isPositiveSafeInt(item.buildingAmountMinor) || !isPositiveSafeInt(item.valuedAmountMinor) ||
+    !isNullableString(item.functionalCurrencyCode) || !isNullableString(item.exchangeRateId) ||
+    !isNullableString(item.exchangeRateValue) || !isNullableString(item.exchangeRateDirection) ||
+    !isNullableString(item.exchangeRateEffectiveAt) || !isNullableString(item.conversionDate) ||
+    !isNonEmptyString(item.receivedDate)
+  ) {
     return false;
   }
-  if (typeof item.period !== 'string') {
+  if (typeof item.period !== 'string' || !/^\d{4}-(0[1-9]|1[0-2])$/.test(item.period)) {
     return false;
   }
   const policyVersionId = item.policyVersionId;
-  if (policyVersionId !== null && policyVersionId !== undefined && typeof policyVersionId !== 'string') {
+  if (!isNullableString(policyVersionId)) {
     return false;
   }
   const legacyDestination = item.legacyDestination;
   if (
-    legacyDestination !== null &&
-    legacyDestination !== undefined &&
-    !isLegacyDestination(legacyDestination)
+    legacyDestination !== null && !isLegacyDestination(legacyDestination)
   ) {
     return false;
   }
@@ -294,33 +333,13 @@ export function isLiquidationV3Summary(value: unknown): value is LiquidationV3Su
     'incomeOffsetAmountMinor',
     'netDistributableAmountMinor',
   ] as const;
-  for (const field of fields) {
-    const fieldValue = summary[field];
-    if (fieldValue === null || fieldValue === undefined) {
-      continue; // legacy V1/V2: null aceptado
-    }
-    if (!isNonNegativeInt(fieldValue)) {
-      return false;
-    }
-  }
-  const snapshot = summary.incomeOffsetSnapshot;
-  if (snapshot !== null && snapshot !== undefined) {
-    if (!Array.isArray(snapshot) || !snapshot.every(isIncomeOffsetSnapshotItem)) {
-      return false;
-    }
-  }
-  const byCurrency = summary.incomeOffsetsByCurrency;
-  if (byCurrency !== null && byCurrency !== undefined) {
-    if (typeof byCurrency !== 'object' || Array.isArray(byCurrency)) {
-      return false;
-    }
-    for (const amount of Object.values(byCurrency as Record<string, unknown>)) {
-      if (!isNonNegativeInt(amount)) {
-        return false;
-      }
-    }
-  }
-  return true;
+  const values = fields.map((field) => summary[field]);
+  const isLegacy = values.every((entry) => entry === null || entry === undefined);
+  if (isLegacy) return true;
+  if (!values.every(isNonNegativeInt)) return false;
+  const [gross, adjustment, preIncome, offset, net] = values as number[];
+  if (!Number.isSafeInteger(gross + adjustment) || gross + adjustment !== preIncome) return false;
+  return Number.isSafeInteger(preIncome - offset) && preIncome - offset === net;
 }
 
 /** Reject malformed FIN-06 fields while accepting historical V1/V2 nulls. */

--- a/apps/web/features/finance/contracts/finance-guards.ts
+++ b/apps/web/features/finance/contracts/finance-guards.ts
@@ -1,0 +1,329 @@
+/**
+ * FIN-07A: parsers/type guards runtime para respuestas financieras.
+ *
+ * Estrategia: fail-closed en contratos críticos (balances, provenance,
+ * basis points, V3). No instalar librería de validación: guards simples.
+ */
+
+import type {
+  Fund,
+  FundBalance,
+  IncomeApplication,
+  IncomeApplicationDestination,
+  IncomeDestination,
+  IncomeOffsetSnapshotItem,
+  IncomePolicyRule,
+  IncomePolicy,
+  IncomeApplicationPlan,
+  FundTransaction,
+  LegacyBackfillApplyResultItem,
+  LegacyBackfillPreviewItem,
+  LiquidationV3Summary,
+} from './finance-types';
+
+const DESTINATIONS = new Set(['OFFSET_EXPENSES', 'FUND', 'CARRY_FORWARD']);
+const LEGACY_DESTINATIONS = new Set(['APPLY_TO_EXPENSES', 'RESERVE_FUND', 'SPECIAL_FUND']);
+
+export function isNonNegativeInt(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+export function isDestination(value: unknown): value is IncomeApplicationDestination {
+  return typeof value === 'string' && DESTINATIONS.has(value);
+}
+
+export function isLegacyDestination(value: unknown): value is IncomeDestination {
+  return typeof value === 'string' && LEGACY_DESTINATIONS.has(value);
+}
+
+/**
+ * Fund balances: multi-moneda, fail-closed. Nunca colapsar a un número.
+ */
+export function isFundBalance(value: unknown): value is FundBalance {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as FundBalance).currency === 'string' &&
+    isNonNegativeInt((value as FundBalance).amountMinor)
+  );
+}
+
+export function isFund(value: unknown): value is Fund {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const fund = value as Record<string, unknown>;
+  if (typeof fund.id !== 'string' || typeof fund.tenantId !== 'string') {
+    return false;
+  }
+  if (
+    typeof fund.name !== 'string' ||
+    !['TENANT', 'BUILDING'].includes(String(fund.scopeType)) ||
+    !['RESERVE', 'SPECIAL', 'OTHER'].includes(String(fund.type)) ||
+    !['ACTIVE', 'ARCHIVED'].includes(String(fund.status))
+  ) {
+    return false;
+  }
+  if (!Array.isArray(fund.balancesByCurrency)) {
+    return false;
+  }
+  // Fail-closed: cada balance debe ser válido; un balance inválido invalida el Fund.
+  return fund.balancesByCurrency.every(isFundBalance);
+}
+
+export function isFundTransaction(value: unknown): value is FundTransaction {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const transaction = value as Record<string, unknown>;
+  return (
+    typeof transaction.id === 'string' &&
+    typeof transaction.tenantId === 'string' &&
+    typeof transaction.fundId === 'string' &&
+    ['CREDIT', 'DEBIT'].includes(String(transaction.direction)) &&
+    typeof transaction.currencyCode === 'string' &&
+    isNonNegativeInt(transaction.amountMinor)
+  );
+}
+
+/**
+ * IncomeApplication: destination válido; provenance coherente
+ * (policy y legacy mutuamente excluyentes).
+ */
+export function isIncomeApplication(value: unknown): value is IncomeApplication {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const app = value as Record<string, unknown>;
+  if (typeof app.id !== 'string' || typeof app.incomeId !== 'string') {
+    return false;
+  }
+  if (!isDestination(app.destinationType)) {
+    return false;
+  }
+  if (!isNonNegativeInt(app.amountMinor) || typeof app.currencyCode !== 'string') {
+    return false;
+  }
+  const policyVersionId = app.policyVersionId;
+  const legacyDestination = app.legacyDestination;
+  if (policyVersionId !== null && policyVersionId !== undefined && typeof policyVersionId !== 'string') {
+    return false;
+  }
+  if (
+    legacyDestination !== null &&
+    legacyDestination !== undefined &&
+    !isLegacyDestination(legacyDestination)
+  ) {
+    return false;
+  }
+  // Mutuamente excluyentes (espejo del CHECK DB).
+  if (policyVersionId != null && legacyDestination != null) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Policy rule: percentageBasisPoints entero (10000 = 100%).
+ * Rechaza floats o strings.
+ */
+export function isIncomePolicyRule(value: unknown): value is IncomePolicyRule {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const rule = value as Record<string, unknown>;
+  if (!isDestination(rule.destinationType)) {
+    return false;
+  }
+  return (
+    typeof rule.percentageBasisPoints === 'number' &&
+    Number.isSafeInteger(rule.percentageBasisPoints) &&
+    (rule.percentageBasisPoints as number) >= 1 &&
+    (rule.percentageBasisPoints as number) <= 10000
+  );
+}
+
+export function isIncomeApplicationPlan(value: unknown): value is IncomeApplicationPlan {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const plan = value as Record<string, unknown>;
+  return (
+    typeof plan.incomeId === 'string' &&
+    typeof plan.currencyCode === 'string' &&
+    isNonNegativeInt(plan.totalAmountMinor) &&
+    Array.isArray(plan.applications) &&
+    plan.applications.every(isIncomeApplication)
+  );
+}
+
+export function isIncomePolicy(value: unknown): value is IncomePolicy {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const policy = value as Record<string, unknown>;
+  if (typeof policy.id !== 'string' || typeof policy.tenantId !== 'string' || typeof policy.categoryId !== 'string') {
+    return false;
+  }
+  const versions = policy.versions;
+  if (!Array.isArray(versions)) return false;
+  return versions.every((version) => {
+    if (typeof version !== 'object' || version === null || Array.isArray(version)) return false;
+    const record = version as Record<string, unknown>;
+    return (
+      typeof record.id === 'string' &&
+      isNonNegativeInt(record.version) &&
+      ['ACTIVE', 'INACTIVE'].includes(String(record.status)) &&
+      Array.isArray(record.rules) &&
+      record.rules.every(isIncomePolicyRule)
+    );
+  });
+}
+
+export function isLegacyBackfillPreviewItem(value: unknown): value is LegacyBackfillPreviewItem {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const item = value as Record<string, unknown>;
+  return (
+    typeof item.incomeId === 'string' &&
+    typeof item.period === 'string' &&
+    typeof item.categoryId === 'string' &&
+    typeof item.currencyCode === 'string' &&
+    isNonNegativeInt(item.amountMinor) &&
+    isLegacyDestination(item.destination)
+  );
+}
+
+export function isLegacyBackfillApplyResultItem(value: unknown): value is LegacyBackfillApplyResultItem {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const item = value as Record<string, unknown>;
+  return typeof item.incomeId === 'string' && typeof item.status === 'string';
+}
+
+function assertFinancialResponse(condition: boolean, responseName: string): asserts condition {
+  if (!condition) {
+    throw new TypeError(`Invalid ${responseName} response`);
+  }
+}
+
+export function parseFund(value: unknown): Fund {
+  assertFinancialResponse(isFund(value), 'fund');
+  return value;
+}
+
+export function parseFunds(value: unknown): Fund[] {
+  assertFinancialResponse(Array.isArray(value) && value.every(isFund), 'fund list');
+  return value;
+}
+
+export function parseFundTransaction(value: unknown): FundTransaction {
+  assertFinancialResponse(isFundTransaction(value), 'fund transaction');
+  return value;
+}
+
+export function parseFundTransactions(value: unknown): FundTransaction[] {
+  assertFinancialResponse(Array.isArray(value) && value.every(isFundTransaction), 'fund transaction list');
+  return value;
+}
+
+export function parseIncomeApplicationPlan(value: unknown): IncomeApplicationPlan {
+  assertFinancialResponse(isIncomeApplicationPlan(value), 'income application plan');
+  return value;
+}
+
+export function parseIncomePolicies(value: unknown): IncomePolicy[] {
+  assertFinancialResponse(Array.isArray(value) && value.every(isIncomePolicy), 'income policy list');
+  return value;
+}
+
+export function parseIncomePolicy(value: unknown): IncomePolicy {
+  assertFinancialResponse(isIncomePolicy(value), 'income policy');
+  return value;
+}
+
+export function parseLegacyBackfillPreview(value: unknown): LegacyBackfillPreviewItem[] {
+  assertFinancialResponse(Array.isArray(value) && value.every(isLegacyBackfillPreviewItem), 'legacy backfill preview');
+  return value;
+}
+
+export function parseLegacyBackfillResults(value: unknown): LegacyBackfillApplyResultItem[] {
+  assertFinancialResponse(Array.isArray(value) && value.every(isLegacyBackfillApplyResultItem), 'legacy backfill results');
+  return value;
+}
+
+/**
+ * V3 income offset snapshot item. Campos V3 opcionales/nullables aceptados
+ * para compatibilidad V1/V2 histórica.
+ */
+export function isIncomeOffsetSnapshotItem(value: unknown): value is IncomeOffsetSnapshotItem {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const item = value as Record<string, unknown>;
+  if (typeof item.incomeId !== 'string' || typeof item.incomeApplicationId !== 'string') {
+    return false;
+  }
+  if (!isNonNegativeInt(item.applicationAmountMinor) || !isNonNegativeInt(item.valuedAmountMinor)) {
+    return false;
+  }
+  if (typeof item.period !== 'string') {
+    return false;
+  }
+  const policyVersionId = item.policyVersionId;
+  if (policyVersionId !== null && policyVersionId !== undefined && typeof policyVersionId !== 'string') {
+    return false;
+  }
+  const legacyDestination = item.legacyDestination;
+  if (
+    legacyDestination !== null &&
+    legacyDestination !== undefined &&
+    !isLegacyDestination(legacyDestination)
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Liquidación con summary FIN-06: campos V3 opcionales/nullables.
+ * V1/V2 históricas → campos null/ausentes aceptados.
+ */
+export function isLiquidationV3Summary(value: unknown): value is LiquidationV3Summary {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const summary = value as Record<string, unknown>;
+  const fields = [
+    'grossExpenseAmountMinor',
+    'adjustmentAmountMinor',
+    'preIncomeAmountMinor',
+    'incomeOffsetAmountMinor',
+    'netDistributableAmountMinor',
+  ] as const;
+  for (const field of fields) {
+    const fieldValue = summary[field];
+    if (fieldValue === null || fieldValue === undefined) {
+      continue; // legacy V1/V2: null aceptado
+    }
+    if (!isNonNegativeInt(fieldValue)) {
+      return false;
+    }
+  }
+  const snapshot = summary.incomeOffsetSnapshot;
+  if (snapshot !== null && snapshot !== undefined) {
+    if (!Array.isArray(snapshot) || !snapshot.every(isIncomeOffsetSnapshotItem)) {
+      return false;
+    }
+  }
+  const byCurrency = summary.incomeOffsetsByCurrency;
+  if (byCurrency !== null && byCurrency !== undefined) {
+    if (typeof byCurrency !== 'object' || Array.isArray(byCurrency)) {
+      return false;
+    }
+    for (const amount of Object.values(byCurrency as Record<string, unknown>)) {
+      if (!isNonNegativeInt(amount)) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+/** Reject malformed FIN-06 fields while accepting historical V1/V2 nulls. */
+export function assertLiquidationV3Summary(value: unknown): void {
+  assertFinancialResponse(isLiquidationV3Summary(value), 'liquidation V3 summary');
+}

--- a/apps/web/features/finance/contracts/finance-types.ts
+++ b/apps/web/features/finance/contracts/finance-types.ts
@@ -1,0 +1,311 @@
+/**
+ * FIN-07A: contratos de dominio finance (frontend).
+ *
+ * Fuente de verdad: apps/api (controllers/DTOs). No inferir shapes.
+ * Todo monto permanece en amountMinor (entero); sin floats financieros.
+ */
+
+// ── Enums (espejo exacto del backend) ──────────────────────────────────────
+
+export type FundScopeType = 'TENANT' | 'BUILDING';
+export type FundType = 'RESERVE' | 'SPECIAL' | 'OTHER';
+export type FundStatus = 'ACTIVE' | 'ARCHIVED';
+export type FundTransactionDirection = 'CREDIT' | 'DEBIT';
+export type IncomeApplicationDestination = 'OFFSET_EXPENSES' | 'FUND' | 'CARRY_FORWARD';
+export type IncomeDestination = 'APPLY_TO_EXPENSES' | 'RESERVE_FUND' | 'SPECIAL_FUND';
+export type IncomeStatus = 'DRAFT' | 'RECORDED' | 'VOID';
+export type IncomeScopeType = 'BUILDING' | 'TENANT_SHARED' | 'UNIT_GROUP';
+export type IncomePolicyVersionStatus = 'ACTIVE' | 'INACTIVE';
+export type LiquidationStatus = 'DRAFT' | 'REVIEWED' | 'PUBLISHED' | 'CANCELED';
+export type LiquidationValuationMode = 'FUNCTIONAL' | 'LEGACY_NOMINAL';
+
+// ── Fund (FIN-02) ──────────────────────────────────────────────────────────
+
+export interface FundBalance {
+  currency: string;
+  amountMinor: number;
+}
+
+export interface Fund {
+  id: string;
+  tenantId: string;
+  buildingId: string | null;
+  scopeType: FundScopeType;
+  type: FundType;
+  name: string;
+  description: string | null;
+  status: FundStatus;
+  balancesByCurrency: FundBalance[]; // multi-moneda: nunca colapsar a 1 número
+  createdAt: string;
+  archivedAt: string | null;
+}
+
+export interface CreateFundData {
+  scopeType: FundScopeType;
+  buildingId?: string;
+  type: FundType;
+  name: string;
+  description?: string;
+}
+
+export interface UpdateFundData {
+  name?: string;
+  description?: string;
+}
+
+export interface FundQuery {
+  buildingId?: string;
+  scopeType?: FundScopeType;
+  status?: FundStatus;
+}
+
+// ── FundTransaction (FIN-02) ───────────────────────────────────────────────
+
+export interface FundTransaction {
+  id: string;
+  tenantId: string;
+  fundId: string;
+  direction: FundTransactionDirection;
+  amountMinor: number;
+  currencyCode: string;
+  occurredAt: string;
+  description: string | null;
+  idempotencyKey: string | null;
+  reversalOfTransactionId: string | null;
+  createdAt: string;
+}
+
+export interface CreateFundTransactionData {
+  direction: FundTransactionDirection;
+  amountMinor: number;
+  currencyCode: string;
+  occurredAt: string;
+  description?: string;
+  idempotencyKey?: string;
+}
+
+export interface ReverseFundTransactionData {
+  reason?: string;
+}
+
+export interface FundTransactionQuery {
+  currencyCode?: string;
+  limit?: number;
+  offset?: number;
+}
+
+// ── Income (FIN-03/04) ─────────────────────────────────────────────────────
+
+export interface Income {
+  id: string;
+  tenantId: string;
+  buildingId: string | null;
+  period: string;
+  categoryId: string;
+  categoryName: string;
+  scopeType: IncomeScopeType;
+  unitGroupId: string | null;
+  destination: IncomeDestination; // legacy metadata; applications son autoritativas
+  amountMinor: number;
+  currencyCode: string;
+  receivedDate: string;
+  description: string | null;
+  attachmentFileKey: string | null;
+  status: IncomeStatus;
+  functionalAmountMinor: number | null;
+  functionalCurrencyCode: string | null;
+  exchangeRateId: string | null;
+  exchangeRateValue: string | null;
+  exchangeRateDirection: string | null;
+  exchangeRateEffectiveAt: string | null;
+  conversionDate: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MovementAllocationInput {
+  buildingId: string;
+  amountMinor?: number;
+  percentage?: number;
+}
+
+export interface CreateIncomeData {
+  period: string;
+  categoryId: string;
+  amountMinor: number;
+  currencyCode: string;
+  receivedDate: string;
+  description?: string;
+  attachmentFileKey?: string;
+  scopeType?: IncomeScopeType;
+  buildingId?: string;
+  unitGroupId?: string;
+  allocations?: MovementAllocationInput[];
+  destination?: IncomeDestination;
+}
+
+export interface UpdateIncomeData {
+  amountMinor?: number;
+  currencyCode?: string;
+  description?: string;
+}
+
+// ── IncomeApplication (FIN-03/05/04) ───────────────────────────────────────
+
+export interface IncomeApplication {
+  id: string;
+  tenantId: string;
+  incomeId: string;
+  destinationType: IncomeApplicationDestination;
+  fundId: string | null;
+  amountMinor: number;
+  currencyCode: string;
+  fundTransactionId: string | null;
+  policyVersionId: string | null; // FIN-05 provenance
+  legacyDestination: IncomeDestination | null; // FIN-04 provenance
+  createdAt: string;
+}
+
+export interface IncomeApplicationPlan {
+  incomeId: string;
+  currencyCode: string;
+  totalAmountMinor: number;
+  applications: IncomeApplication[];
+}
+
+export interface CreateIncomeApplicationInput {
+  destinationType: IncomeApplicationDestination;
+  fundId?: string | null;
+  amountMinor: number;
+}
+
+export interface CreateIncomeApplicationPlanData {
+  applications: CreateIncomeApplicationInput[];
+}
+
+// ── IncomePolicy (FIN-05) ──────────────────────────────────────────────────
+
+export interface IncomePolicyRule {
+  id: string;
+  destinationType: IncomeApplicationDestination;
+  fundId: string | null;
+  percentageBasisPoints: number; // entero: 10000 = 100%
+}
+
+export interface IncomePolicyVersion {
+  id: string;
+  version: number;
+  status: IncomePolicyVersionStatus;
+  rules: IncomePolicyRule[];
+  createdAt: string;
+}
+
+export interface IncomePolicy {
+  id: string;
+  tenantId: string;
+  categoryId: string;
+  currentVersion: IncomePolicyVersion | null;
+  versions: IncomePolicyVersion[];
+}
+
+export interface CreateIncomePolicyRuleData {
+  destinationType: IncomeApplicationDestination;
+  fundId?: string;
+  percentageBasisPoints: number; // entero, nunca float
+}
+
+export interface CreateIncomePolicyData {
+  categoryId: string;
+  rules: CreateIncomePolicyRuleData[];
+}
+
+export interface CreateIncomePolicyVersionData {
+  rules: CreateIncomePolicyRuleData[];
+}
+
+// ── Legacy income backfill (FIN-04) ────────────────────────────────────────
+
+export type LegacyBackfillClassification =
+  | 'AUTO_MAPPABLE_OFFSET'
+  | 'REQUIRES_RESERVE_FUND'
+  | 'REQUIRES_SPECIAL_FUND'
+  | 'ALREADY_HAS_PLAN'
+  | 'NOT_RECORDED'
+  | 'LIQUIDATION_CONFLICT';
+
+export type LegacyBackfillItemStatus =
+  | 'MIGRATED'
+  | 'ALREADY_MIGRATED'
+  | 'ALREADY_HAS_PLAN'
+  | 'REQUIRES_FUND'
+  | 'INVALID_FUND'
+  | 'LIQUIDATION_CONFLICT'
+  | 'NOT_RECORDED'
+  | 'NOT_FOUND'
+  | 'INVALID_INCOME';
+
+export interface LegacyBackfillPreviewItem {
+  incomeId: string;
+  period: string;
+  categoryId: string;
+  scopeType: string;
+  buildingId: string | null;
+  status: string;
+  destination: IncomeDestination;
+  amountMinor: number;
+  currencyCode: string;
+  applicationsCount: number;
+  classification: LegacyBackfillClassification;
+  relevantBuildings?: string[];
+}
+
+export interface LegacyBackfillPreviewQuery {
+  period?: string;
+  categoryId?: string;
+  destination?: IncomeDestination;
+}
+
+export interface LegacyBackfillApplyItem {
+  incomeId: string;
+  fundId?: string | null;
+}
+
+export interface LegacyBackfillApplyResultItem {
+  incomeId: string;
+  status: LegacyBackfillItemStatus;
+  fundId?: string | null;
+}
+
+// ── Liquidation FIN-06 V3 ──────────────────────────────────────────────────
+
+export interface IncomeOffsetSnapshotItem {
+  incomeId: string;
+  incomeApplicationId: string;
+  categoryId: string;
+  categoryName: string | null;
+  policyVersionId: string | null;
+  legacyDestination: IncomeDestination | null; // FIN-04 provenance
+  scopeType: string;
+  currencyCode: string;
+  applicationAmountMinor: number;
+  buildingAmountMinor: number;
+  valuedAmountMinor: number;
+  functionalCurrencyCode: string | null;
+  exchangeRateId: string | null;
+  exchangeRateValue: string | null;
+  exchangeRateDirection: string | null;
+  exchangeRateEffectiveAt: string | null;
+  conversionDate: string | null;
+  receivedDate: string;
+  period: string;
+}
+
+export interface LiquidationV3Summary {
+  grossExpenseAmountMinor: number | null;
+  adjustmentAmountMinor: number | null;
+  preIncomeAmountMinor: number | null;
+  incomeOffsetAmountMinor: number | null;
+  netDistributableAmountMinor: number | null;
+  incomeOffsetSnapshot?: IncomeOffsetSnapshotItem[] | null;
+  incomeOffsetsByCurrency?: Record<string, number> | null;
+}

--- a/apps/web/features/finance/contracts/finance-types.ts
+++ b/apps/web/features/finance/contracts/finance-types.ts
@@ -127,6 +127,7 @@ export interface MovementAllocationInput {
   buildingId: string;
   amountMinor?: number;
   percentage?: number;
+  currencyCode?: string;
 }
 
 export interface CreateIncomeData {
@@ -147,7 +148,10 @@ export interface CreateIncomeData {
 export interface UpdateIncomeData {
   amountMinor?: number;
   currencyCode?: string;
+  receivedDate?: string;
+  categoryId?: string;
   description?: string;
+  attachmentFileKey?: string;
 }
 
 // ── IncomeApplication (FIN-03/05/04) ───────────────────────────────────────
@@ -248,9 +252,9 @@ export interface LegacyBackfillPreviewItem {
   incomeId: string;
   period: string;
   categoryId: string;
-  scopeType: string;
+  scopeType: IncomeScopeType;
   buildingId: string | null;
-  status: string;
+  status: IncomeStatus;
   destination: IncomeDestination;
   amountMinor: number;
   currencyCode: string;
@@ -285,7 +289,7 @@ export interface IncomeOffsetSnapshotItem {
   categoryName: string | null;
   policyVersionId: string | null;
   legacyDestination: IncomeDestination | null; // FIN-04 provenance
-  scopeType: string;
+  scopeType: IncomeScopeType;
   currencyCode: string;
   applicationAmountMinor: number;
   buildingAmountMinor: number;
@@ -301,11 +305,54 @@ export interface IncomeOffsetSnapshotItem {
 }
 
 export interface LiquidationV3Summary {
-  grossExpenseAmountMinor: number | null;
-  adjustmentAmountMinor: number | null;
-  preIncomeAmountMinor: number | null;
-  incomeOffsetAmountMinor: number | null;
-  netDistributableAmountMinor: number | null;
-  incomeOffsetSnapshot?: IncomeOffsetSnapshotItem[] | null;
-  incomeOffsetsByCurrency?: Record<string, number> | null;
+  grossExpenseAmountMinor?: number | null;
+  adjustmentAmountMinor?: number | null;
+  preIncomeAmountMinor?: number | null;
+  incomeOffsetAmountMinor?: number | null;
+  netDistributableAmountMinor?: number | null;
+}
+
+// Income offset snapshots are FIN-07C foundation only. The current
+// liquidation read contract does not expose them.
+
+export interface LiquidationExpenseItem {
+  id: string;
+  categoryName: string;
+  vendorName: string | null;
+  amountMinor: number;
+  currencyCode: string;
+  invoiceDate: string;
+  description: string | null;
+}
+
+export interface LiquidationChargePreview {
+  unitId: string;
+  unitCode: string;
+  unitLabel: string | null;
+  amountMinor: number;
+}
+
+export interface Liquidation extends LiquidationV3Summary {
+  id: string;
+  tenantId: string;
+  buildingId: string;
+  period: string;
+  chargePeriod?: string | null;
+  status: LiquidationStatus;
+  valuationMode?: LiquidationValuationMode | null;
+  baseCurrency: string;
+  totalAmountMinor: number;
+  totalsByCurrency: Record<string, number>;
+  unitCount: number;
+  generatedAt: string;
+  reviewedAt: string | null;
+  publishedAt: string | null;
+  canceledAt: string | null;
+  createdAt: string;
+}
+
+export interface LiquidationDetail extends Liquidation {
+  publicationSnapshotStatus: 'AVAILABLE' | 'LEGACY';
+  expenses: LiquidationExpenseItem[];
+  chargesPreview: LiquidationChargePreview[];
 }

--- a/apps/web/features/finance/contracts/index.ts
+++ b/apps/web/features/finance/contracts/index.ts
@@ -1,2 +1,3 @@
 export * from './finance-types';
 export * from './finance-guards';
+export * from './currencies';

--- a/apps/web/features/finance/contracts/index.ts
+++ b/apps/web/features/finance/contracts/index.ts
@@ -1,0 +1,2 @@
+export * from './finance-types';
+export * from './finance-guards';

--- a/apps/web/features/finance/hooks/finance-query-keys.ts
+++ b/apps/web/features/finance/hooks/finance-query-keys.ts
@@ -1,0 +1,50 @@
+/**
+ * FIN-07A: factory de query keys para React Query (módulo finance).
+ *
+ * Convención: [scope, tenantId, ...entityId/filters].
+ * Todas las keys son tenant-scoped (nunca cross-tenant).
+ */
+
+export const financeKeys = {
+  funds: (tenantId: string, query?: { buildingId?: string; scopeType?: string; status?: string }) =>
+    ['finance', tenantId, 'funds', query ?? {}] as const,
+  fund: (tenantId: string, fundId: string) =>
+    ['finance', tenantId, 'funds', fundId] as const,
+  fundTransactions: (
+    tenantId: string,
+    fundId: string,
+    query?: { currencyCode?: string; limit?: number; offset?: number },
+  ) => ['finance', tenantId, 'funds', fundId, 'transactions', query ?? {}] as const,
+
+  incomes: (tenantId: string, query?: { buildingId?: string; period?: string; categoryId?: string }) =>
+    ['finance', tenantId, 'incomes', query ?? {}] as const,
+  income: (tenantId: string, incomeId: string) =>
+    ['finance', tenantId, 'incomes', incomeId] as const,
+  incomeApplications: (tenantId: string, incomeId: string) =>
+    ['finance', tenantId, 'incomes', incomeId, 'applications'] as const,
+
+  incomePolicies: (tenantId: string) => ['finance', tenantId, 'income-policies'] as const,
+  incomePolicy: (tenantId: string, categoryId: string) =>
+    ['finance', tenantId, 'income-policies', categoryId] as const,
+
+  legacyBackfillPreview: (
+    tenantId: string,
+    query?: { period?: string; categoryId?: string; destination?: string },
+  ) =>
+    ['finance', tenantId, 'legacy-backfill', 'preview', query ?? {}] as const,
+
+  liquidations: (tenantId: string, query?: { buildingId?: string; period?: string }) =>
+    ['finance', tenantId, 'liquidations', query ?? {}] as const,
+  liquidation: (tenantId: string, liquidationId: string) =>
+    ['finance', tenantId, 'liquidations', liquidationId] as const,
+};
+
+/**
+ * Familias de keys usadas para invalidación (exactas, sin prefix mágicos).
+ */
+export const financeKeyFamilies = {
+  funds: (tenantId: string) => ['finance', tenantId, 'funds'] as const,
+  incomes: (tenantId: string) => ['finance', tenantId, 'incomes'] as const,
+  incomePolicies: (tenantId: string) => ['finance', tenantId, 'income-policies'] as const,
+  liquidations: (tenantId: string) => ['finance', tenantId, 'liquidations'] as const,
+};

--- a/apps/web/features/finance/hooks/finance-query-keys.ts
+++ b/apps/web/features/finance/hooks/finance-query-keys.ts
@@ -32,6 +32,7 @@ export const financeKeys = {
     query?: { period?: string; categoryId?: string; destination?: string },
   ) =>
     ['finance', tenantId, 'legacy-backfill', 'preview', query ?? {}] as const,
+  financeSettings: (tenantId: string) => ['finance', tenantId, 'settings'] as const,
 
   liquidations: (tenantId: string, query?: { buildingId?: string; period?: string }) =>
     ['finance', tenantId, 'liquidations', query ?? {}] as const,
@@ -46,5 +47,6 @@ export const financeKeyFamilies = {
   funds: (tenantId: string) => ['finance', tenantId, 'funds'] as const,
   incomes: (tenantId: string) => ['finance', tenantId, 'incomes'] as const,
   incomePolicies: (tenantId: string) => ['finance', tenantId, 'income-policies'] as const,
+  legacyBackfill: (tenantId: string) => ['finance', tenantId, 'legacy-backfill'] as const,
   liquidations: (tenantId: string) => ['finance', tenantId, 'liquidations'] as const,
 };

--- a/apps/web/features/finance/hooks/useExpenseLedger.cache.test.tsx
+++ b/apps/web/features/finance/hooks/useExpenseLedger.cache.test.tsx
@@ -1,0 +1,61 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import { recordIncome, voidIncome } from '../services/expense-ledger.api';
+import { financeKeys } from './finance-query-keys';
+import { useRecordIncome, useVoidIncome } from './useExpenseLedger';
+
+jest.mock('../services/expense-ledger.api', () => ({
+  recordIncome: jest.fn(),
+  voidIncome: jest.fn(),
+}));
+
+const mockedRecordIncome = jest.mocked(recordIncome);
+const mockedVoidIncome = jest.mocked(voidIncome);
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useExpenseLedger finance cache convergence', () => {
+  beforeEach(() => {
+    mockedRecordIncome.mockReset();
+    mockedVoidIncome.mockReset();
+  });
+
+  it('records income against finance keys and invalidates only that tenant legacy preview', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const legacyA = financeKeys.legacyBackfillPreview('tenant-a', {});
+    const legacyB = financeKeys.legacyBackfillPreview('tenant-b', {});
+    queryClient.setQueryData(legacyA, []);
+    queryClient.setQueryData(legacyB, []);
+    mockedRecordIncome.mockResolvedValue({} as never);
+    const { result } = renderHook(() => useRecordIncome('tenant-a'), { wrapper: createWrapper(queryClient) });
+
+    await act(async () => {
+      await result.current.mutateAsync('income-1');
+    });
+
+    expect(queryClient.getQueryState(legacyA)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(legacyB)?.isInvalidated).toBe(false);
+  });
+
+  it('invalidates the tenant fund family after voiding an income', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const fundA = financeKeys.funds('tenant-a');
+    const fundB = financeKeys.funds('tenant-b');
+    queryClient.setQueryData(fundA, []);
+    queryClient.setQueryData(fundB, []);
+    mockedVoidIncome.mockResolvedValue({} as never);
+    const { result } = renderHook(() => useVoidIncome('tenant-a'), { wrapper: createWrapper(queryClient) });
+
+    await act(async () => {
+      await result.current.mutateAsync('income-1');
+    });
+
+    expect(queryClient.getQueryState(fundA)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(fundB)?.isInvalidated).toBe(false);
+  });
+});

--- a/apps/web/features/finance/hooks/useExpenseLedger.ts
+++ b/apps/web/features/finance/hooks/useExpenseLedger.ts
@@ -42,6 +42,7 @@ import {
   listAdjustments,
   ListAdjustmentsParams,
 } from '../services/expense-ledger.api';
+import { financeKeyFamilies, financeKeys } from './finance-query-keys';
 
 // ── ExpenseLedgerCategories hooks ──────────────────────────────────────────
 
@@ -273,7 +274,7 @@ export function useLiquidations(
   params: { buildingId?: string; period?: string } = {},
 ) {
   return useQuery({
-    queryKey: ['liquidations', tenantId, params],
+    queryKey: financeKeys.liquidations(tenantId, params),
     queryFn: () => listLiquidations(tenantId, params),
     staleTime: 2 * 60 * 1000,
     enabled: !!tenantId,
@@ -287,7 +288,7 @@ export function useLiquidationDetail(
   enabled = true,
 ) {
   return useQuery({
-    queryKey: ['liquidation', tenantId, liquidationId],
+    queryKey: financeKeys.liquidation(tenantId, liquidationId),
     queryFn: () => getLiquidation(tenantId, liquidationId),
     staleTime: 2 * 60 * 1000,
     enabled: !!tenantId && !!liquidationId && enabled,
@@ -299,8 +300,9 @@ export function useCreateLiquidationDraft(tenantId: string) {
   return useMutation({
     mutationFn: (data: { buildingId: string; period: string; baseCurrency: string }) =>
       createLiquidationDraft(tenantId, data),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['liquidations', tenantId] });
+    onSuccess: (liquidation) => {
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.liquidations(tenantId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeys.liquidation(tenantId, liquidation.id) });
     },
   });
 }
@@ -310,9 +312,9 @@ export function useReviewLiquidation(tenantId: string) {
   return useMutation({
     mutationFn: (liquidationId: string) => reviewLiquidation(tenantId, liquidationId),
     onSuccess: (_, liquidationId) => {
-      void queryClient.invalidateQueries({ queryKey: ['liquidations', tenantId] });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.liquidations(tenantId) });
       void queryClient.invalidateQueries({
-        queryKey: ['liquidation', tenantId, liquidationId],
+        queryKey: financeKeys.liquidation(tenantId, liquidationId),
       });
     },
   });
@@ -328,8 +330,9 @@ export function usePublishLiquidation(tenantId: string) {
       liquidationId: string;
       dueDate: string;
     }) => publishLiquidation(tenantId, liquidationId, { dueDate }),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['liquidations', tenantId] });
+    onSuccess: (_, { liquidationId }) => {
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.liquidations(tenantId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeys.liquidation(tenantId, liquidationId) });
       // También invalidar charges ya que se crearon nuevos
       void queryClient.invalidateQueries({ queryKey: ['charges'] });
     },
@@ -340,8 +343,9 @@ export function useCancelLiquidation(tenantId: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (liquidationId: string) => cancelLiquidation(tenantId, liquidationId),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['liquidations', tenantId] });
+    onSuccess: (_, liquidationId) => {
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.liquidations(tenantId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeys.liquidation(tenantId, liquidationId) });
       void queryClient.invalidateQueries({ queryKey: ['charges'] });
     },
   });
@@ -351,7 +355,7 @@ export function useCancelLiquidation(tenantId: string) {
 
 export function useIncomes(tenantId: string, params: ListIncomesParams = {}) {
   return useQuery({
-    queryKey: ['incomes', tenantId, params],
+    queryKey: financeKeys.incomes(tenantId, params),
     queryFn: () => listIncomes(tenantId, params),
     staleTime: 2 * 60 * 1000,
     enabled: !!tenantId,
@@ -364,7 +368,8 @@ export function useCreateIncome(tenantId: string) {
   return useMutation({
     mutationFn: (data: CreateIncomeData) => createIncome(tenantId, data),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['incomes', tenantId] });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.incomes(tenantId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.legacyBackfill(tenantId) });
     },
   });
 }
@@ -380,7 +385,8 @@ export function useUpdateIncome(tenantId: string) {
       data: UpdateIncomeData;
     }) => updateIncome(tenantId, incomeId, data),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['incomes', tenantId] });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.incomes(tenantId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.legacyBackfill(tenantId) });
     },
   });
 }
@@ -390,7 +396,8 @@ export function useRecordIncome(tenantId: string) {
   return useMutation({
     mutationFn: (incomeId: string) => recordIncome(tenantId, incomeId),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['incomes', tenantId] });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.incomes(tenantId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.legacyBackfill(tenantId) });
     },
   });
 }
@@ -400,7 +407,9 @@ export function useVoidIncome(tenantId: string) {
   return useMutation({
     mutationFn: (incomeId: string) => voidIncome(tenantId, incomeId),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ['incomes', tenantId] });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.incomes(tenantId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.legacyBackfill(tenantId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.funds(tenantId) });
     },
   });
 }

--- a/apps/web/features/finance/hooks/useExpenseLedger.ts
+++ b/apps/web/features/finance/hooks/useExpenseLedger.ts
@@ -36,6 +36,7 @@ import {
   CreateTenantRecurringExpenseData,
   ListIncomesParams,
   CreateIncomeData,
+  UpdateIncomeData,
   createAdjustment,
   validateAdjustment,
   listAdjustments,
@@ -376,7 +377,7 @@ export function useUpdateIncome(tenantId: string) {
       data,
     }: {
       incomeId: string;
-      data: Partial<CreateIncomeData>;
+      data: UpdateIncomeData;
     }) => updateIncome(tenantId, incomeId, data),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ['incomes', tenantId] });

--- a/apps/web/features/finance/hooks/useFinanceContracts.test.tsx
+++ b/apps/web/features/finance/hooks/useFinanceContracts.test.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createFundTransaction } from '../services/funds.api';
+import { applyLegacyIncomeBackfill } from '../services/legacy-backfill.api';
+import { useCreateFundTransaction } from './useFunds';
+import { useApplyLegacyIncomeBackfill } from './useLegacyIncomeBackfill';
+
+jest.mock('../services/funds.api', () => ({ createFundTransaction: jest.fn() }));
+jest.mock('../services/legacy-backfill.api', () => ({ applyLegacyIncomeBackfill: jest.fn() }));
+
+const mockedCreateFundTransaction = jest.mocked(createFundTransaction);
+const mockedApplyLegacyIncomeBackfill = jest.mocked(applyLegacyIncomeBackfill);
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('FIN-07A finance hooks', () => {
+  beforeEach(() => {
+    mockedCreateFundTransaction.mockReset();
+    mockedApplyLegacyIncomeBackfill.mockReset();
+  });
+
+  it('refreshes the fund and every transaction page after a transaction', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries');
+    mockedCreateFundTransaction.mockResolvedValue({} as never);
+    const { result } = renderHook(() => useCreateFundTransaction('tenant-1', 'fund-1'), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        direction: 'CREDIT', amountMinor: 500, currencyCode: 'COP', occurredAt: '2026-08-16',
+      });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-1', 'funds', 'fund-1'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['finance', 'tenant-1', 'funds', 'fund-1', 'transactions', {}],
+    });
+  });
+
+  it('invalidates related tenant-scoped finance data after legacy backfill', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries');
+    mockedApplyLegacyIncomeBackfill.mockResolvedValue([]);
+    const { result } = renderHook(() => useApplyLegacyIncomeBackfill('tenant-1'), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    act(() => result.current.mutate([{ incomeId: 'income-1' }]));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-1', 'incomes'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-1', 'funds'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-1', 'liquidations'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-1', 'legacy-backfill'] });
+  });
+});

--- a/apps/web/features/finance/hooks/useFinanceContracts.test.tsx
+++ b/apps/web/features/finance/hooks/useFinanceContracts.test.tsx
@@ -7,6 +7,7 @@ import { applyIncomePolicy, createIncomeApplicationPlan } from '../services/inco
 import { useCreateFundTransaction } from './useFunds';
 import { useApplyLegacyIncomeBackfill } from './useLegacyIncomeBackfill';
 import { useApplyIncomePolicy, useCreateIncomeApplicationPlan } from './useIncomeApplications';
+import { financeKeys } from './finance-query-keys';
 
 jest.mock('../services/funds.api', () => ({ createFundTransaction: jest.fn() }));
 jest.mock('../services/legacy-backfill.api', () => ({ applyLegacyIncomeBackfill: jest.fn() }));
@@ -80,6 +81,10 @@ describe('FIN-07A finance hooks', () => {
   it('invalidates tenant funds for a manual plan that creates a FUND credit', async () => {
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries');
+    const incomeKey = financeKeys.incomes('tenant-a', { period: '2026-08' });
+    const liquidationKey = financeKeys.liquidations('tenant-a', { period: '2026-08' });
+    queryClient.setQueryData(incomeKey, []);
+    queryClient.setQueryData(liquidationKey, []);
     mockedCreateIncomeApplicationPlan.mockResolvedValue(fundPlan as never);
     const { result } = renderHook(() => useCreateIncomeApplicationPlan('tenant-a', 'income-1'), {
       wrapper: createWrapper(queryClient),
@@ -90,6 +95,9 @@ describe('FIN-07A finance hooks', () => {
     });
 
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-a', 'funds'] });
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-a', 'legacy-backfill'] });
+    expect(queryClient.getQueryState(incomeKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(liquidationKey)?.isInvalidated).toBe(true);
     expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-b', 'funds'] });
   });
 

--- a/apps/web/features/finance/hooks/useFinanceContracts.test.tsx
+++ b/apps/web/features/finance/hooks/useFinanceContracts.test.tsx
@@ -3,14 +3,28 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { createFundTransaction } from '../services/funds.api';
 import { applyLegacyIncomeBackfill } from '../services/legacy-backfill.api';
+import { applyIncomePolicy, createIncomeApplicationPlan } from '../services/income-applications.api';
 import { useCreateFundTransaction } from './useFunds';
 import { useApplyLegacyIncomeBackfill } from './useLegacyIncomeBackfill';
+import { useApplyIncomePolicy, useCreateIncomeApplicationPlan } from './useIncomeApplications';
 
 jest.mock('../services/funds.api', () => ({ createFundTransaction: jest.fn() }));
 jest.mock('../services/legacy-backfill.api', () => ({ applyLegacyIncomeBackfill: jest.fn() }));
+jest.mock('../services/income-applications.api', () => ({
+  applyIncomePolicy: jest.fn(),
+  createIncomeApplicationPlan: jest.fn(),
+  getIncomeApplicationPlan: jest.fn(),
+}));
 
 const mockedCreateFundTransaction = jest.mocked(createFundTransaction);
 const mockedApplyLegacyIncomeBackfill = jest.mocked(applyLegacyIncomeBackfill);
+const mockedApplyIncomePolicy = jest.mocked(applyIncomePolicy);
+const mockedCreateIncomeApplicationPlan = jest.mocked(createIncomeApplicationPlan);
+
+const fundPlan = {
+  incomeId: 'income-1', currencyCode: 'COP', totalAmountMinor: 500,
+  applications: [{ destinationType: 'FUND' }],
+};
 
 function createWrapper(queryClient: QueryClient) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -22,6 +36,8 @@ describe('FIN-07A finance hooks', () => {
   beforeEach(() => {
     mockedCreateFundTransaction.mockReset();
     mockedApplyLegacyIncomeBackfill.mockReset();
+    mockedApplyIncomePolicy.mockReset();
+    mockedCreateIncomeApplicationPlan.mockReset();
   });
 
   it('refreshes the fund and every transaction page after a transaction', async () => {
@@ -59,5 +75,52 @@ describe('FIN-07A finance hooks', () => {
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-1', 'funds'] });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-1', 'liquidations'] });
     expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-1', 'legacy-backfill'] });
+  });
+
+  it('invalidates tenant funds for a manual plan that creates a FUND credit', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries');
+    mockedCreateIncomeApplicationPlan.mockResolvedValue(fundPlan as never);
+    const { result } = renderHook(() => useCreateIncomeApplicationPlan('tenant-a', 'income-1'), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ applications: [{ destinationType: 'FUND', fundId: 'fund-1', amountMinor: 500 }] });
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-a', 'funds'] });
+    expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-b', 'funds'] });
+  });
+
+  it('does not invalidate funds for an OFFSET-only manual plan', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries');
+    mockedCreateIncomeApplicationPlan.mockResolvedValue({ ...fundPlan, applications: [{ destinationType: 'OFFSET_EXPENSES' }] } as never);
+    const { result } = renderHook(() => useCreateIncomeApplicationPlan('tenant-a', 'income-1'), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ applications: [{ destinationType: 'OFFSET_EXPENSES', amountMinor: 500 }] });
+    });
+
+    expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-a', 'funds'] });
+  });
+
+  it('invalidates tenant funds when a policy returns a FUND application', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const invalidateQueries = jest.spyOn(queryClient, 'invalidateQueries');
+    mockedApplyIncomePolicy.mockResolvedValue(fundPlan as never);
+    const { result } = renderHook(() => useApplyIncomePolicy('tenant-a', 'income-1'), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(invalidateQueries).toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-a', 'funds'] });
+    expect(invalidateQueries).not.toHaveBeenCalledWith({ queryKey: ['finance', 'tenant-b', 'funds'] });
   });
 });

--- a/apps/web/features/finance/hooks/useFinanceSettings.ts
+++ b/apps/web/features/finance/hooks/useFinanceSettings.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query';
+import { getFinanceSettings } from '../services/multicurrency.api';
+
+export function useFinanceSettings(tenantId: string) {
+  return useQuery({
+    queryKey: ['finance-settings', tenantId],
+    queryFn: () => getFinanceSettings(tenantId),
+    enabled: Boolean(tenantId),
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/apps/web/features/finance/hooks/useFinanceSettings.ts
+++ b/apps/web/features/finance/hooks/useFinanceSettings.ts
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { getFinanceSettings } from '../services/multicurrency.api';
+import { financeKeys } from './finance-query-keys';
 
 export function useFinanceSettings(tenantId: string) {
   return useQuery({
-    queryKey: ['finance-settings', tenantId],
+    queryKey: financeKeys.financeSettings(tenantId),
     queryFn: () => getFinanceSettings(tenantId),
     enabled: Boolean(tenantId),
     staleTime: 5 * 60 * 1000,

--- a/apps/web/features/finance/hooks/useFunds.ts
+++ b/apps/web/features/finance/hooks/useFunds.ts
@@ -1,0 +1,111 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  archiveFund,
+  createFund,
+  createFundTransaction,
+  getFund,
+  listFunds,
+  listFundTransactions,
+  reverseFundTransaction,
+  updateFund,
+} from '../services/funds.api';
+import type {
+  CreateFundData,
+  CreateFundTransactionData,
+  FundQuery,
+  FundTransactionQuery,
+  ReverseFundTransactionData,
+  UpdateFundData,
+} from '../contracts/finance-types';
+import { financeKeyFamilies, financeKeys } from './finance-query-keys';
+
+export function useFunds(tenantId: string, query: FundQuery = {}) {
+  return useQuery({
+    queryKey: financeKeys.funds(tenantId, query),
+    queryFn: () => listFunds(tenantId, query),
+    enabled: !!tenantId,
+    staleTime: 30 * 1000,
+  });
+}
+
+export function useFund(tenantId: string, fundId: string) {
+  return useQuery({
+    queryKey: financeKeys.fund(tenantId, fundId),
+    queryFn: () => getFund(tenantId, fundId),
+    enabled: !!tenantId && !!fundId,
+    staleTime: 30 * 1000,
+  });
+}
+
+export function useFundTransactions(
+  tenantId: string,
+  fundId: string,
+  query: FundTransactionQuery = {},
+) {
+  return useQuery({
+    queryKey: financeKeys.fundTransactions(tenantId, fundId, query),
+    queryFn: () => listFundTransactions(tenantId, fundId, query),
+    enabled: !!tenantId && !!fundId,
+    staleTime: 30 * 1000,
+  });
+}
+
+export function useCreateFund(tenantId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateFundData) => createFund(tenantId, data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.funds(tenantId) });
+    },
+  });
+}
+
+export function useUpdateFund(tenantId: string, fundId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: UpdateFundData) => updateFund(tenantId, fundId, data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.funds(tenantId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeys.fund(tenantId, fundId) });
+    },
+  });
+}
+
+export function useArchiveFund(tenantId: string, fundId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => archiveFund(tenantId, fundId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.funds(tenantId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeys.fund(tenantId, fundId) });
+    },
+  });
+}
+
+export function useCreateFundTransaction(tenantId: string, fundId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateFundTransactionData) =>
+      createFundTransaction(tenantId, fundId, data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: financeKeys.fund(tenantId, fundId) });
+      void queryClient.invalidateQueries({
+        queryKey: financeKeys.fundTransactions(tenantId, fundId),
+      });
+    },
+  });
+}
+
+export function useReverseFundTransaction(tenantId: string, fundId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ transactionId, data }: { transactionId: string; data?: ReverseFundTransactionData }) =>
+      reverseFundTransaction(tenantId, fundId, transactionId, data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: financeKeys.fund(tenantId, fundId) });
+      void queryClient.invalidateQueries({
+        queryKey: financeKeys.fundTransactions(tenantId, fundId),
+      });
+    },
+  });
+}

--- a/apps/web/features/finance/hooks/useIncomeApplications.ts
+++ b/apps/web/features/finance/hooks/useIncomeApplications.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { CreateIncomeApplicationPlanData } from '../contracts';
+import {
+  applyIncomePolicy,
+  createIncomeApplicationPlan,
+  getIncomeApplicationPlan,
+} from '../services/income-applications.api';
+import { financeKeyFamilies, financeKeys } from './finance-query-keys';
+
+export function useIncomeApplicationPlan(tenantId: string, incomeId: string) {
+  return useQuery({
+    queryKey: financeKeys.incomeApplications(tenantId, incomeId),
+    queryFn: () => getIncomeApplicationPlan(tenantId, incomeId),
+    enabled: Boolean(tenantId && incomeId),
+    staleTime: 30 * 1000,
+  });
+}
+
+export function useCreateIncomeApplicationPlan(tenantId: string, incomeId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateIncomeApplicationPlanData) =>
+      createIncomeApplicationPlan(tenantId, incomeId, data),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: financeKeys.incomeApplications(tenantId, incomeId),
+      });
+      void queryClient.invalidateQueries({ queryKey: financeKeys.income(tenantId, incomeId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.liquidations(tenantId) });
+    },
+  });
+}
+
+export function useApplyIncomePolicy(tenantId: string, incomeId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => applyIncomePolicy(tenantId, incomeId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: financeKeys.incomeApplications(tenantId, incomeId),
+      });
+      void queryClient.invalidateQueries({ queryKey: financeKeys.income(tenantId, incomeId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.liquidations(tenantId) });
+    },
+  });
+}

--- a/apps/web/features/finance/hooks/useIncomeApplications.ts
+++ b/apps/web/features/finance/hooks/useIncomeApplications.ts
@@ -21,12 +21,15 @@ export function useCreateIncomeApplicationPlan(tenantId: string, incomeId: strin
   return useMutation({
     mutationFn: (data: CreateIncomeApplicationPlanData) =>
       createIncomeApplicationPlan(tenantId, incomeId, data),
-    onSuccess: () => {
+    onSuccess: (plan) => {
       void queryClient.invalidateQueries({
         queryKey: financeKeys.incomeApplications(tenantId, incomeId),
       });
       void queryClient.invalidateQueries({ queryKey: financeKeys.income(tenantId, incomeId) });
       void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.liquidations(tenantId) });
+      if (plan.applications.some((application) => application.destinationType === 'FUND')) {
+        void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.funds(tenantId) });
+      }
     },
   });
 }
@@ -35,12 +38,15 @@ export function useApplyIncomePolicy(tenantId: string, incomeId: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: () => applyIncomePolicy(tenantId, incomeId),
-    onSuccess: () => {
+    onSuccess: (plan) => {
       void queryClient.invalidateQueries({
         queryKey: financeKeys.incomeApplications(tenantId, incomeId),
       });
       void queryClient.invalidateQueries({ queryKey: financeKeys.income(tenantId, incomeId) });
       void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.liquidations(tenantId) });
+      if (plan.applications.some((application) => application.destinationType === 'FUND')) {
+        void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.funds(tenantId) });
+      }
     },
   });
 }

--- a/apps/web/features/finance/hooks/useIncomeApplications.ts
+++ b/apps/web/features/finance/hooks/useIncomeApplications.ts
@@ -25,8 +25,9 @@ export function useCreateIncomeApplicationPlan(tenantId: string, incomeId: strin
       void queryClient.invalidateQueries({
         queryKey: financeKeys.incomeApplications(tenantId, incomeId),
       });
-      void queryClient.invalidateQueries({ queryKey: financeKeys.income(tenantId, incomeId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.incomes(tenantId) });
       void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.liquidations(tenantId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.legacyBackfill(tenantId) });
       if (plan.applications.some((application) => application.destinationType === 'FUND')) {
         void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.funds(tenantId) });
       }
@@ -42,8 +43,9 @@ export function useApplyIncomePolicy(tenantId: string, incomeId: string) {
       void queryClient.invalidateQueries({
         queryKey: financeKeys.incomeApplications(tenantId, incomeId),
       });
-      void queryClient.invalidateQueries({ queryKey: financeKeys.income(tenantId, incomeId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.incomes(tenantId) });
       void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.liquidations(tenantId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.legacyBackfill(tenantId) });
       if (plan.applications.some((application) => application.destinationType === 'FUND')) {
         void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.funds(tenantId) });
       }

--- a/apps/web/features/finance/hooks/useIncomePolicies.ts
+++ b/apps/web/features/finance/hooks/useIncomePolicies.ts
@@ -1,0 +1,58 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { CreateIncomePolicyData, CreateIncomePolicyVersionData } from '../contracts';
+import {
+  createIncomePolicy,
+  createIncomePolicyVersion,
+  deactivateIncomePolicy,
+  getIncomePolicy,
+  listIncomePolicies,
+} from '../services/income-policies.api';
+import { financeKeyFamilies, financeKeys } from './finance-query-keys';
+
+export function useIncomePolicies(tenantId: string) {
+  return useQuery({
+    queryKey: financeKeys.incomePolicies(tenantId),
+    queryFn: () => listIncomePolicies(tenantId),
+    enabled: Boolean(tenantId),
+    staleTime: 30 * 1000,
+  });
+}
+
+export function useIncomePolicy(tenantId: string, categoryId: string) {
+  return useQuery({
+    queryKey: financeKeys.incomePolicy(tenantId, categoryId),
+    queryFn: () => getIncomePolicy(tenantId, categoryId),
+    enabled: Boolean(tenantId && categoryId),
+    staleTime: 30 * 1000,
+  });
+}
+
+function invalidatePolicies(queryClient: ReturnType<typeof useQueryClient>, tenantId: string, categoryId: string) {
+  void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.incomePolicies(tenantId) });
+  void queryClient.invalidateQueries({ queryKey: financeKeys.incomePolicy(tenantId, categoryId) });
+}
+
+export function useCreateIncomePolicy(tenantId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateIncomePolicyData) => createIncomePolicy(tenantId, data),
+    onSuccess: (policy) => invalidatePolicies(queryClient, tenantId, policy.categoryId),
+  });
+}
+
+export function useCreateIncomePolicyVersion(tenantId: string, categoryId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateIncomePolicyVersionData) =>
+      createIncomePolicyVersion(tenantId, categoryId, data),
+    onSuccess: () => invalidatePolicies(queryClient, tenantId, categoryId),
+  });
+}
+
+export function useDeactivateIncomePolicy(tenantId: string, categoryId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => deactivateIncomePolicy(tenantId, categoryId),
+    onSuccess: () => invalidatePolicies(queryClient, tenantId, categoryId),
+  });
+}

--- a/apps/web/features/finance/hooks/useLegacyIncomeBackfill.ts
+++ b/apps/web/features/finance/hooks/useLegacyIncomeBackfill.ts
@@ -26,9 +26,7 @@ export function useApplyLegacyIncomeBackfill(tenantId: string) {
       void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.incomes(tenantId) });
       void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.funds(tenantId) });
       void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.liquidations(tenantId) });
-      void queryClient.invalidateQueries({
-        queryKey: ['finance', tenantId, 'legacy-backfill'] as const,
-      });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.legacyBackfill(tenantId) });
     },
   });
 }

--- a/apps/web/features/finance/hooks/useLegacyIncomeBackfill.ts
+++ b/apps/web/features/finance/hooks/useLegacyIncomeBackfill.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { LegacyBackfillApplyItem, LegacyBackfillPreviewQuery } from '../contracts';
+import {
+  applyLegacyIncomeBackfill,
+  previewLegacyIncomeBackfill,
+} from '../services/legacy-backfill.api';
+import { financeKeyFamilies, financeKeys } from './finance-query-keys';
+
+export function useLegacyIncomeBackfillPreview(
+  tenantId: string,
+  query: LegacyBackfillPreviewQuery = {},
+) {
+  return useQuery({
+    queryKey: financeKeys.legacyBackfillPreview(tenantId, query),
+    queryFn: () => previewLegacyIncomeBackfill(tenantId, query),
+    enabled: Boolean(tenantId),
+    staleTime: 30 * 1000,
+  });
+}
+
+export function useApplyLegacyIncomeBackfill(tenantId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (items: LegacyBackfillApplyItem[]) => applyLegacyIncomeBackfill(tenantId, items),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.incomes(tenantId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.funds(tenantId) });
+      void queryClient.invalidateQueries({ queryKey: financeKeyFamilies.liquidations(tenantId) });
+      void queryClient.invalidateQueries({
+        queryKey: ['finance', tenantId, 'legacy-backfill'] as const,
+      });
+    },
+  });
+}

--- a/apps/web/features/finance/index.ts
+++ b/apps/web/features/finance/index.ts
@@ -26,6 +26,7 @@ export * from './hooks/useFunds';
 export * from './hooks/useIncomeApplications';
 export * from './hooks/useIncomePolicies';
 export * from './hooks/useLegacyIncomeBackfill';
+export * from './hooks/useFinanceSettings';
 export { financeKeyFamilies, financeKeys } from './hooks/finance-query-keys';
 
 // Export service types and API

--- a/apps/web/features/finance/index.ts
+++ b/apps/web/features/finance/index.ts
@@ -22,6 +22,16 @@ export { usePaymentsReview } from './hooks/usePaymentsReview';
 export { useAllocation } from './hooks/useAllocation';
 export { useUnitLedger } from './hooks/useUnitLedger';
 export { useTenantFinanceSummary } from './hooks/useTenantFinanceSummary';
+export * from './hooks/useFunds';
+export * from './hooks/useIncomeApplications';
+export * from './hooks/useIncomePolicies';
+export * from './hooks/useLegacyIncomeBackfill';
+export { financeKeyFamilies, financeKeys } from './hooks/finance-query-keys';
 
 // Export service types and API
 export * from './services/finance.api';
+export * from './contracts';
+export * from './services/funds.api';
+export * from './services/income-applications.api';
+export * from './services/income-policies.api';
+export * from './services/legacy-backfill.api';

--- a/apps/web/features/finance/services/expense-ledger.api.test.ts
+++ b/apps/web/features/finance/services/expense-ledger.api.test.ts
@@ -7,6 +7,8 @@ import {
   listTenantRecurringExpenses,
   createTenantRecurringExpense,
   updateTenantRecurringExpense,
+  createIncome,
+  updateIncome,
 } from './expense-ledger.api';
 
 jest.mock('@/shared/lib/http/client', () => ({
@@ -67,6 +69,21 @@ describe('expense ledger liquidation API', () => {
         baseCurrency: 'ARS',
       }),
     ).rejects.toThrow('network down');
+  });
+
+  it('guards every liquidation mutation response', async () => {
+    const invalidPartialSummary = { grossExpenseAmountMinor: 10000 };
+    mockedApiClient.mockResolvedValueOnce(invalidPartialSummary);
+    await expect(createLiquidationDraft('tenant-1', {
+      buildingId: 'building-1', period: '2026-07', baseCurrency: 'ARS',
+    })).rejects.toThrow('Invalid liquidation V3 summary response');
+
+    mockedApiClient.mockResolvedValueOnce(invalidPartialSummary);
+    await expect(reviewLiquidation('tenant-1', 'liq-1')).rejects.toThrow('Invalid liquidation V3 summary response');
+    mockedApiClient.mockResolvedValueOnce(invalidPartialSummary);
+    await expect(publishLiquidation('tenant-1', 'liq-1', { dueDate: '2026-08-10' })).rejects.toThrow('Invalid liquidation V3 summary response');
+    mockedApiClient.mockResolvedValueOnce(invalidPartialSummary);
+    await expect(cancelLiquidation('tenant-1', 'liq-1')).rejects.toThrow('Invalid liquidation V3 summary response');
   });
 });
 
@@ -142,5 +159,32 @@ describe('tenant recurring expenses API', () => {
 
     const calls = mockedApiClient.mock.calls.map((call) => call[0]);
     expect(calls.every((call) => !String(call.path).startsWith('/buildings/'))).toBe(true);
+  });
+});
+
+describe('income write contracts', () => {
+  beforeEach(() => {
+    mockedApiClient.mockReset();
+    mockedApiClient.mockResolvedValue({});
+  });
+
+  it('transports allocation currencyCode with the exact create contract', async () => {
+    const payload = {
+      period: '2026-08', categoryId: 'category-1', amountMinor: 1000, currencyCode: 'COP',
+      receivedDate: '2026-08-16', scopeType: 'TENANT_SHARED' as const,
+      allocations: [{ buildingId: 'building-1', amountMinor: 1000, currencyCode: 'COP' }],
+    };
+    await createIncome('tenant-1', payload);
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/tenants/tenant-1/finance/incomes', method: 'POST', body: payload,
+    });
+  });
+
+  it('sends only UpdateIncomeDto fields through PATCH', async () => {
+    const payload = { amountMinor: 1000, currencyCode: 'VES', receivedDate: '2026-08-16', categoryId: 'category-2', description: 'Adjusted', attachmentFileKey: 'file-1' };
+    await updateIncome('tenant-1', 'income-1', payload);
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/tenants/tenant-1/finance/incomes/income-1', method: 'PATCH', body: payload,
+    });
   });
 });

--- a/apps/web/features/finance/services/expense-ledger.api.ts
+++ b/apps/web/features/finance/services/expense-ledger.api.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/shared/lib/http/client';
+import { assertLiquidationV3Summary } from '../contracts/finance-guards';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -66,6 +67,17 @@ export interface Income {
   status: IncomeStatus;
   createdAt: string;
   updatedAt: string;
+  // FIN-07A: metadata multicurrency/scope (backend toDto)
+  scopeType?: 'BUILDING' | 'TENANT_SHARED' | 'UNIT_GROUP';
+  unitGroupId?: string | null;
+  destination?: 'APPLY_TO_EXPENSES' | 'RESERVE_FUND' | 'SPECIAL_FUND';
+  functionalAmountMinor?: number | null;
+  functionalCurrencyCode?: string | null;
+  exchangeRateId?: string | null;
+  exchangeRateValue?: string | null;
+  exchangeRateDirection?: string | null;
+  exchangeRateEffectiveAt?: string | null;
+  conversionDate?: string | null;
 }
 
 export interface LiquidationExpenseItem {
@@ -101,6 +113,12 @@ export interface Liquidation {
   publishedAt: string | null;
   canceledAt: string | null;
   createdAt: string;
+  // FIN-06 V3: resumen del neto distributable (nullable = histórico V1/V2)
+  grossExpenseAmountMinor?: number | null;
+  adjustmentAmountMinor?: number | null;
+  preIncomeAmountMinor?: number | null;
+  incomeOffsetAmountMinor?: number | null;
+  netDistributableAmountMinor?: number | null;
 }
 
 export interface LiquidationDetail extends Liquidation {
@@ -473,20 +491,24 @@ export async function listLiquidations(
   if (params.period) qs.append('period', params.period);
 
   const queryStr = qs.toString();
-  return apiClient<Liquidation[]>({
+  const liquidations = await apiClient<Liquidation[]>({
     path: `/tenants/${tenantId}/finance/liquidations${queryStr ? '?' + queryStr : ''}`,
     method: 'GET',
   });
+  liquidations.forEach(assertLiquidationV3Summary);
+  return liquidations;
 }
 
 export async function getLiquidation(
   tenantId: string,
   liquidationId: string,
 ): Promise<LiquidationDetail> {
-  return apiClient<LiquidationDetail>({
+  const liquidation = await apiClient<LiquidationDetail>({
     path: `/tenants/${tenantId}/finance/liquidations/${liquidationId}`,
     method: 'GET',
   });
+  assertLiquidationV3Summary(liquidation);
+  return liquidation;
 }
 
 export async function createLiquidationDraft(
@@ -572,6 +594,11 @@ export interface CreateIncomeData {
   receivedDate: string;
   description?: string;
   attachmentFileKey?: string;
+  // FIN-07A: scope/allocations según backend (FIN-04)
+  scopeType?: 'BUILDING' | 'TENANT_SHARED' | 'UNIT_GROUP';
+  destination?: 'APPLY_TO_EXPENSES' | 'RESERVE_FUND' | 'SPECIAL_FUND';
+  unitGroupId?: string;
+  allocations?: Array<{ buildingId: string; amountMinor?: number; percentage?: number }>;
 }
 
 export async function createIncome(

--- a/apps/web/features/finance/services/expense-ledger.api.ts
+++ b/apps/web/features/finance/services/expense-ledger.api.ts
@@ -1,12 +1,29 @@
 import { apiClient } from '@/shared/lib/http/client';
 import { assertLiquidationV3Summary } from '../contracts/finance-guards';
+import type {
+  CreateIncomeData,
+  Income,
+  Liquidation,
+  LiquidationDetail,
+  UpdateIncomeData,
+} from '../contracts/finance-types';
+
+export type {
+  CreateIncomeData,
+  Income,
+  Liquidation,
+  LiquidationChargePreview,
+  LiquidationDetail,
+  LiquidationExpenseItem,
+  LiquidationStatus,
+  LiquidationValuationMode,
+  MovementAllocationInput,
+  UpdateIncomeData,
+} from '../contracts/finance-types';
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
 export type ExpenseStatus = 'DRAFT' | 'VALIDATED' | 'VOID';
-export type IncomeStatus = 'DRAFT' | 'RECORDED' | 'VOID';
-export type LiquidationStatus = 'DRAFT' | 'REVIEWED' | 'PUBLISHED' | 'CANCELED';
-export type LiquidationValuationMode = 'FUNCTIONAL' | 'LEGACY_NOMINAL';
 export type CatalogScope = 'BUILDING' | 'CONDOMINIUM_COMMON';
 
 export interface ExpenseLedgerCategory {
@@ -50,80 +67,6 @@ export interface Expense {
   conversionDate?: string | null;
   createdAt: string;
   updatedAt: string;
-}
-
-export interface Income {
-  id: string;
-  tenantId: string;
-  buildingId: string | null;
-  period: string;
-  categoryId: string;
-  categoryName: string;
-  amountMinor: number;
-  currencyCode: string;
-  receivedDate: string;
-  description: string | null;
-  attachmentFileKey: string | null;
-  status: IncomeStatus;
-  createdAt: string;
-  updatedAt: string;
-  // FIN-07A: metadata multicurrency/scope (backend toDto)
-  scopeType?: 'BUILDING' | 'TENANT_SHARED' | 'UNIT_GROUP';
-  unitGroupId?: string | null;
-  destination?: 'APPLY_TO_EXPENSES' | 'RESERVE_FUND' | 'SPECIAL_FUND';
-  functionalAmountMinor?: number | null;
-  functionalCurrencyCode?: string | null;
-  exchangeRateId?: string | null;
-  exchangeRateValue?: string | null;
-  exchangeRateDirection?: string | null;
-  exchangeRateEffectiveAt?: string | null;
-  conversionDate?: string | null;
-}
-
-export interface LiquidationExpenseItem {
-  id: string;
-  categoryName: string;
-  vendorName: string | null;
-  amountMinor: number;
-  currencyCode: string;
-  invoiceDate: string;
-  description: string | null;
-}
-
-export interface LiquidationChargePreview {
-  unitId: string;
-  unitCode: string;
-  unitLabel: string | null;
-  amountMinor: number;
-}
-
-export interface Liquidation {
-  id: string;
-  tenantId: string;
-  buildingId: string;
-  period: string;
-  status: LiquidationStatus;
-  valuationMode?: LiquidationValuationMode | null;
-  baseCurrency: string;
-  totalAmountMinor: number;
-  totalsByCurrency: Record<string, number>;
-  unitCount: number;
-  generatedAt: string;
-  reviewedAt: string | null;
-  publishedAt: string | null;
-  canceledAt: string | null;
-  createdAt: string;
-  // FIN-06 V3: resumen del neto distributable (nullable = histórico V1/V2)
-  grossExpenseAmountMinor?: number | null;
-  adjustmentAmountMinor?: number | null;
-  preIncomeAmountMinor?: number | null;
-  incomeOffsetAmountMinor?: number | null;
-  netDistributableAmountMinor?: number | null;
-}
-
-export interface LiquidationDetail extends Liquidation {
-  expenses: LiquidationExpenseItem[];
-  chargesPreview: LiquidationChargePreview[];
 }
 
 export interface BulkValidateExpensesResult {
@@ -515,21 +458,25 @@ export async function createLiquidationDraft(
   tenantId: string,
   data: { buildingId: string; period: string; baseCurrency: string },
 ): Promise<LiquidationDetail> {
-  return apiClient<LiquidationDetail, typeof data>({
+  const liquidation = await apiClient<LiquidationDetail, typeof data>({
     path: `/tenants/${tenantId}/finance/liquidations/draft`,
     method: 'POST',
     body: data,
   });
+  assertLiquidationV3Summary(liquidation);
+  return liquidation;
 }
 
 export async function reviewLiquidation(
   tenantId: string,
   liquidationId: string,
 ): Promise<Liquidation> {
-  return apiClient<Liquidation>({
+  const liquidation = await apiClient<Liquidation>({
     path: `/tenants/${tenantId}/finance/liquidations/${liquidationId}/review`,
     method: 'POST',
   });
+  assertLiquidationV3Summary(liquidation);
+  return liquidation;
 }
 
 export async function publishLiquidation(
@@ -537,21 +484,25 @@ export async function publishLiquidation(
   liquidationId: string,
   data: { dueDate: string },
 ): Promise<Liquidation> {
-  return apiClient<Liquidation, typeof data>({
+  const liquidation = await apiClient<Liquidation, typeof data>({
     path: `/tenants/${tenantId}/finance/liquidations/${liquidationId}/publish`,
     method: 'POST',
     body: data,
   });
+  assertLiquidationV3Summary(liquidation);
+  return liquidation;
 }
 
 export async function cancelLiquidation(
   tenantId: string,
   liquidationId: string,
 ): Promise<Liquidation> {
-  return apiClient<Liquidation>({
+  const liquidation = await apiClient<Liquidation>({
     path: `/tenants/${tenantId}/finance/liquidations/${liquidationId}/cancel`,
     method: 'POST',
   });
+  assertLiquidationV3Summary(liquidation);
+  return liquidation;
 }
 
 // ── Incomes API ────────────────────────────────────────────────────────────
@@ -585,22 +536,6 @@ export async function getIncome(tenantId: string, incomeId: string): Promise<Inc
   });
 }
 
-export interface CreateIncomeData {
-  buildingId?: string;
-  period: string;
-  categoryId: string;
-  amountMinor: number;
-  currencyCode: string;
-  receivedDate: string;
-  description?: string;
-  attachmentFileKey?: string;
-  // FIN-07A: scope/allocations según backend (FIN-04)
-  scopeType?: 'BUILDING' | 'TENANT_SHARED' | 'UNIT_GROUP';
-  destination?: 'APPLY_TO_EXPENSES' | 'RESERVE_FUND' | 'SPECIAL_FUND';
-  unitGroupId?: string;
-  allocations?: Array<{ buildingId: string; amountMinor?: number; percentage?: number }>;
-}
-
 export async function createIncome(
   tenantId: string,
   data: CreateIncomeData,
@@ -615,9 +550,9 @@ export async function createIncome(
 export async function updateIncome(
   tenantId: string,
   incomeId: string,
-  data: Partial<CreateIncomeData>,
+  data: UpdateIncomeData,
 ): Promise<Income> {
-  return apiClient<Income, Partial<CreateIncomeData>>({
+  return apiClient<Income, UpdateIncomeData>({
     path: `/tenants/${tenantId}/finance/incomes/${incomeId}`,
     method: 'PATCH',
     body: data,

--- a/apps/web/features/finance/services/finance-contracts.api.test.ts
+++ b/apps/web/features/finance/services/finance-contracts.api.test.ts
@@ -1,0 +1,90 @@
+import { apiClient } from '@/shared/lib/http/client';
+import { createFundTransaction, listFunds, reverseFundTransaction } from './funds.api';
+import { getIncomeApplicationPlan } from './income-applications.api';
+import { previewLegacyIncomeBackfill } from './legacy-backfill.api';
+
+jest.mock('@/shared/lib/http/client', () => ({ apiClient: jest.fn() }));
+
+const mockedApiClient = jest.mocked(apiClient);
+
+describe('FIN-07A finance contract APIs', () => {
+  beforeEach(() => {
+    mockedApiClient.mockReset();
+  });
+
+  it('uses backend fund filters and preserves balances by currency', async () => {
+    mockedApiClient.mockResolvedValueOnce([
+      {
+        id: 'fund-1', tenantId: 'tenant-1', buildingId: null, scopeType: 'TENANT',
+        type: 'RESERVE', name: 'Reserve', description: null, status: 'ACTIVE',
+        balancesByCurrency: [{ currency: 'COP', amountMinor: 1000 }, { currency: 'ARS', amountMinor: 2000 }],
+      },
+    ]);
+
+    const funds = await listFunds('tenant-1', { buildingId: 'building-1', status: 'ACTIVE' });
+
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/tenants/tenant-1/finance/funds?buildingId=building-1&status=ACTIVE', method: 'GET',
+    });
+    expect(funds[0]?.balancesByCurrency).toEqual([
+      { currency: 'COP', amountMinor: 1000 }, { currency: 'ARS', amountMinor: 2000 },
+    ]);
+  });
+
+  it('sends the optional reversal reason and rejects malformed fund transactions', async () => {
+    mockedApiClient.mockResolvedValueOnce({
+      id: 'transaction-2', tenantId: 'tenant-1', fundId: 'fund-1', direction: 'DEBIT',
+      amountMinor: 100, currencyCode: 'USD',
+    });
+
+    await reverseFundTransaction('tenant-1', 'fund-1', 'transaction-1', { reason: 'Duplicate entry' });
+    expect(mockedApiClient).toHaveBeenCalledWith({
+      path: '/tenants/tenant-1/finance/funds/fund-1/transactions/transaction-1/reverse',
+      method: 'POST', body: { reason: 'Duplicate entry' },
+    });
+
+    mockedApiClient.mockResolvedValueOnce({
+      id: 'transaction-3', tenantId: 'tenant-1', fundId: 'fund-1', direction: 'CREDIT',
+      amountMinor: 1.5, currencyCode: 'USD',
+    });
+    await expect(createFundTransaction('tenant-1', 'fund-1', {
+      direction: 'CREDIT', amountMinor: 100, currencyCode: 'USD', occurredAt: '2026-08-16',
+    })).rejects.toThrow('Invalid fund transaction response');
+  });
+
+  it('exposes application provenance and rejects conflicting provenance', async () => {
+    const application = {
+      id: 'application-1', tenantId: 'tenant-1', incomeId: 'income-1',
+      destinationType: 'OFFSET_EXPENSES', fundId: null, amountMinor: 1200,
+      currencyCode: 'VES', fundTransactionId: null, policyVersionId: null,
+      legacyDestination: 'APPLY_TO_EXPENSES',
+    };
+    mockedApiClient.mockResolvedValueOnce({
+      incomeId: 'income-1', currencyCode: 'VES', totalAmountMinor: 1200, applications: [application],
+    });
+
+    await expect(getIncomeApplicationPlan('tenant-1', 'income-1')).resolves.toMatchObject({
+      applications: [expect.objectContaining({ legacyDestination: 'APPLY_TO_EXPENSES' })],
+    });
+
+    mockedApiClient.mockResolvedValueOnce({
+      incomeId: 'income-1', currencyCode: 'VES', totalAmountMinor: 1200,
+      applications: [{ ...application, policyVersionId: 'policy-1' }],
+    });
+    await expect(getIncomeApplicationPlan('tenant-1', 'income-1')).rejects.toThrow(
+      'Invalid income application plan response',
+    );
+  });
+
+  it('rejects malformed legacy preview monetary amounts', async () => {
+    mockedApiClient.mockResolvedValueOnce([{
+      incomeId: 'income-1', period: '2026-08', categoryId: 'category-1', scopeType: 'BUILDING',
+      buildingId: 'building-1', status: 'RECORDED', destination: 'APPLY_TO_EXPENSES',
+      amountMinor: 12.5, currencyCode: 'COP', applicationsCount: 0, classification: 'AUTO_MAPPABLE_OFFSET',
+    }]);
+
+    await expect(previewLegacyIncomeBackfill('tenant-1')).rejects.toThrow(
+      'Invalid legacy backfill preview response',
+    );
+  });
+});

--- a/apps/web/features/finance/services/finance-contracts.api.test.ts
+++ b/apps/web/features/finance/services/finance-contracts.api.test.ts
@@ -57,7 +57,7 @@ describe('FIN-07A finance contract APIs', () => {
       id: 'application-1', tenantId: 'tenant-1', incomeId: 'income-1',
       destinationType: 'OFFSET_EXPENSES', fundId: null, amountMinor: 1200,
       currencyCode: 'VES', fundTransactionId: null, policyVersionId: null,
-      legacyDestination: 'APPLY_TO_EXPENSES',
+      legacyDestination: 'APPLY_TO_EXPENSES', createdAt: '2026-08-01T00:00:00.000Z',
     };
     mockedApiClient.mockResolvedValueOnce({
       incomeId: 'income-1', currencyCode: 'VES', totalAmountMinor: 1200, applications: [application],

--- a/apps/web/features/finance/services/finance-contracts.api.test.ts
+++ b/apps/web/features/finance/services/finance-contracts.api.test.ts
@@ -18,6 +18,7 @@ describe('FIN-07A finance contract APIs', () => {
         id: 'fund-1', tenantId: 'tenant-1', buildingId: null, scopeType: 'TENANT',
         type: 'RESERVE', name: 'Reserve', description: null, status: 'ACTIVE',
         balancesByCurrency: [{ currency: 'COP', amountMinor: 1000 }, { currency: 'ARS', amountMinor: 2000 }],
+        createdAt: '2026-08-01T00:00:00.000Z', archivedAt: null,
       },
     ]);
 
@@ -34,7 +35,8 @@ describe('FIN-07A finance contract APIs', () => {
   it('sends the optional reversal reason and rejects malformed fund transactions', async () => {
     mockedApiClient.mockResolvedValueOnce({
       id: 'transaction-2', tenantId: 'tenant-1', fundId: 'fund-1', direction: 'DEBIT',
-      amountMinor: 100, currencyCode: 'USD',
+      amountMinor: 100, currencyCode: 'USD', occurredAt: '2026-08-01T00:00:00.000Z',
+      description: null, idempotencyKey: null, reversalOfTransactionId: null, createdAt: '2026-08-01T00:00:00.000Z',
     });
 
     await reverseFundTransaction('tenant-1', 'fund-1', 'transaction-1', { reason: 'Duplicate entry' });
@@ -45,7 +47,8 @@ describe('FIN-07A finance contract APIs', () => {
 
     mockedApiClient.mockResolvedValueOnce({
       id: 'transaction-3', tenantId: 'tenant-1', fundId: 'fund-1', direction: 'CREDIT',
-      amountMinor: 1.5, currencyCode: 'USD',
+      amountMinor: 1.5, currencyCode: 'USD', occurredAt: '2026-08-01T00:00:00.000Z',
+      description: null, idempotencyKey: null, reversalOfTransactionId: null, createdAt: '2026-08-01T00:00:00.000Z',
     });
     await expect(createFundTransaction('tenant-1', 'fund-1', {
       direction: 'CREDIT', amountMinor: 100, currencyCode: 'USD', occurredAt: '2026-08-16',

--- a/apps/web/features/finance/services/funds.api.ts
+++ b/apps/web/features/finance/services/funds.api.ts
@@ -1,0 +1,109 @@
+/**
+ * FIN-07A: API client para Funds / FundTransactions (FIN-02).
+ * Endpoints: /tenants/:tenantId/finance/funds
+ */
+
+import { apiClient } from '@/shared/lib/http/client';
+import {
+  parseFund,
+  parseFunds,
+  parseFundTransaction,
+  parseFundTransactions,
+} from '../contracts/finance-guards';
+import type {
+  CreateFundData,
+  CreateFundTransactionData,
+  Fund,
+  FundTransaction,
+  FundTransactionQuery,
+  FundQuery,
+  ReverseFundTransactionData,
+  UpdateFundData,
+} from '../contracts/finance-types';
+
+export function listFunds(tenantId: string, query: FundQuery = {}): Promise<Fund[]> {
+  const searchParams = new URLSearchParams();
+  if (query.buildingId) searchParams.set('buildingId', query.buildingId);
+  if (query.scopeType) searchParams.set('scopeType', query.scopeType);
+  if (query.status) searchParams.set('status', query.status);
+  const qs = searchParams.toString();
+  return apiClient<unknown>({
+    path: `/tenants/${tenantId}/finance/funds${qs ? `?${qs}` : ''}`,
+    method: 'GET',
+  }).then(parseFunds);
+}
+
+export function getFund(tenantId: string, fundId: string): Promise<Fund> {
+  return apiClient<unknown>({
+    path: `/tenants/${tenantId}/finance/funds/${fundId}`,
+    method: 'GET',
+  }).then(parseFund);
+}
+
+export function createFund(tenantId: string, data: CreateFundData): Promise<Fund> {
+  return apiClient<unknown, CreateFundData>({
+    path: `/tenants/${tenantId}/finance/funds`,
+    method: 'POST',
+    body: data,
+  }).then(parseFund);
+}
+
+export function updateFund(
+  tenantId: string,
+  fundId: string,
+  data: UpdateFundData,
+): Promise<Fund> {
+  return apiClient<unknown, UpdateFundData>({
+    path: `/tenants/${tenantId}/finance/funds/${fundId}`,
+    method: 'PATCH',
+    body: data,
+  }).then(parseFund);
+}
+
+export function archiveFund(tenantId: string, fundId: string): Promise<Fund> {
+  return apiClient<unknown>({
+    path: `/tenants/${tenantId}/finance/funds/${fundId}/archive`,
+    method: 'POST',
+  }).then(parseFund);
+}
+
+export function listFundTransactions(
+  tenantId: string,
+  fundId: string,
+  query: FundTransactionQuery = {},
+): Promise<FundTransaction[]> {
+  const searchParams = new URLSearchParams();
+  if (query.currencyCode) searchParams.set('currencyCode', query.currencyCode);
+  if (query.limit !== undefined) searchParams.set('limit', String(query.limit));
+  if (query.offset !== undefined) searchParams.set('offset', String(query.offset));
+  const qs = searchParams.toString();
+  return apiClient<unknown>({
+    path: `/tenants/${tenantId}/finance/funds/${fundId}/transactions${qs ? `?${qs}` : ''}`,
+    method: 'GET',
+  }).then(parseFundTransactions);
+}
+
+export function createFundTransaction(
+  tenantId: string,
+  fundId: string,
+  data: CreateFundTransactionData,
+): Promise<FundTransaction> {
+  return apiClient<unknown, CreateFundTransactionData>({
+    path: `/tenants/${tenantId}/finance/funds/${fundId}/transactions`,
+    method: 'POST',
+    body: data,
+  }).then(parseFundTransaction);
+}
+
+export function reverseFundTransaction(
+  tenantId: string,
+  fundId: string,
+  transactionId: string,
+  data: ReverseFundTransactionData = {},
+): Promise<FundTransaction> {
+  return apiClient<unknown, ReverseFundTransactionData>({
+    path: `/tenants/${tenantId}/finance/funds/${fundId}/transactions/${transactionId}/reverse`,
+    method: 'POST',
+    body: data,
+  }).then(parseFundTransaction);
+}

--- a/apps/web/features/finance/services/income-applications.api.ts
+++ b/apps/web/features/finance/services/income-applications.api.ts
@@ -1,0 +1,43 @@
+/**
+ * FIN-07A: API client para IncomeApplications (FIN-03/05/04).
+ * Endpoints: /tenants/:tenantId/finance/incomes/:incomeId/applications
+ */
+
+import { apiClient } from '@/shared/lib/http/client';
+import { parseIncomeApplicationPlan } from '../contracts/finance-guards';
+import type {
+  CreateIncomeApplicationPlanData,
+  IncomeApplicationPlan,
+} from '../contracts/finance-types';
+
+export function getIncomeApplicationPlan(
+  tenantId: string,
+  incomeId: string,
+): Promise<IncomeApplicationPlan> {
+  return apiClient<unknown>({
+    path: `/tenants/${tenantId}/finance/incomes/${incomeId}/applications`,
+    method: 'GET',
+  }).then(parseIncomeApplicationPlan);
+}
+
+export function createIncomeApplicationPlan(
+  tenantId: string,
+  incomeId: string,
+  data: CreateIncomeApplicationPlanData,
+): Promise<IncomeApplicationPlan> {
+  return apiClient<unknown, CreateIncomeApplicationPlanData>({
+    path: `/tenants/${tenantId}/finance/incomes/${incomeId}/applications`,
+    method: 'POST',
+    body: data,
+  }).then(parseIncomeApplicationPlan);
+}
+
+export function applyIncomePolicy(
+  tenantId: string,
+  incomeId: string,
+): Promise<IncomeApplicationPlan> {
+  return apiClient<unknown>({
+    path: `/tenants/${tenantId}/finance/incomes/${incomeId}/apply-policy`,
+    method: 'POST',
+  }).then(parseIncomeApplicationPlan);
+}

--- a/apps/web/features/finance/services/income-policies.api.ts
+++ b/apps/web/features/finance/services/income-policies.api.ts
@@ -1,0 +1,62 @@
+/**
+ * FIN-07A: API client para IncomePolicies (FIN-05).
+ * Endpoints: /tenants/:tenantId/finance/income-policies
+ */
+
+import { apiClient } from '@/shared/lib/http/client';
+import { parseIncomePolicies, parseIncomePolicy } from '../contracts/finance-guards';
+import type {
+  CreateIncomePolicyData,
+  CreateIncomePolicyVersionData,
+  IncomePolicy,
+} from '../contracts/finance-types';
+
+export function listIncomePolicies(tenantId: string): Promise<IncomePolicy[]> {
+  return apiClient<unknown>({
+    path: `/tenants/${tenantId}/finance/income-policies`,
+    method: 'GET',
+  }).then(parseIncomePolicies);
+}
+
+export function getIncomePolicy(
+  tenantId: string,
+  categoryId: string,
+): Promise<IncomePolicy> {
+  return apiClient<unknown>({
+    path: `/tenants/${tenantId}/finance/income-policies/${categoryId}`,
+    method: 'GET',
+  }).then(parseIncomePolicy);
+}
+
+export function createIncomePolicy(
+  tenantId: string,
+  data: CreateIncomePolicyData,
+): Promise<IncomePolicy> {
+  return apiClient<unknown, CreateIncomePolicyData>({
+    path: `/tenants/${tenantId}/finance/income-policies`,
+    method: 'POST',
+    body: data,
+  }).then(parseIncomePolicy);
+}
+
+export function createIncomePolicyVersion(
+  tenantId: string,
+  categoryId: string,
+  data: CreateIncomePolicyVersionData,
+): Promise<IncomePolicy> {
+  return apiClient<unknown, CreateIncomePolicyVersionData>({
+    path: `/tenants/${tenantId}/finance/income-policies/${categoryId}/versions`,
+    method: 'POST',
+    body: data,
+  }).then(parseIncomePolicy);
+}
+
+export function deactivateIncomePolicy(
+  tenantId: string,
+  categoryId: string,
+): Promise<IncomePolicy> {
+  return apiClient<unknown>({
+    path: `/tenants/${tenantId}/finance/income-policies/${categoryId}/deactivate`,
+    method: 'POST',
+  }).then(parseIncomePolicy);
+}

--- a/apps/web/features/finance/services/legacy-backfill.api.ts
+++ b/apps/web/features/finance/services/legacy-backfill.api.ts
@@ -1,0 +1,41 @@
+/**
+ * FIN-07A: API client para Legacy income backfill (FIN-04).
+ * Endpoints:
+ *   GET  /tenants/:tenantId/finance/incomes/legacy-backfill/preview
+ *   POST /tenants/:tenantId/finance/incomes/legacy-backfill/apply
+ */
+
+import { apiClient } from '@/shared/lib/http/client';
+import { parseLegacyBackfillPreview, parseLegacyBackfillResults } from '../contracts/finance-guards';
+import type {
+  LegacyBackfillApplyItem,
+  LegacyBackfillApplyResultItem,
+  LegacyBackfillPreviewItem,
+  LegacyBackfillPreviewQuery,
+} from '../contracts/finance-types';
+
+export function previewLegacyIncomeBackfill(
+  tenantId: string,
+  query: LegacyBackfillPreviewQuery = {},
+): Promise<LegacyBackfillPreviewItem[]> {
+  const searchParams = new URLSearchParams();
+  if (query.period) searchParams.set('period', query.period);
+  if (query.categoryId) searchParams.set('categoryId', query.categoryId);
+  if (query.destination) searchParams.set('destination', query.destination);
+  const qs = searchParams.toString();
+  return apiClient<unknown>({
+    path: `/tenants/${tenantId}/finance/incomes/legacy-backfill/preview${qs ? `?${qs}` : ''}`,
+    method: 'GET',
+  }).then(parseLegacyBackfillPreview);
+}
+
+export function applyLegacyIncomeBackfill(
+  tenantId: string,
+  items: LegacyBackfillApplyItem[],
+): Promise<LegacyBackfillApplyResultItem[]> {
+  return apiClient<unknown, { items: LegacyBackfillApplyItem[] }>({
+    path: `/tenants/${tenantId}/finance/incomes/legacy-backfill/apply`,
+    method: 'POST',
+    body: { items },
+  }).then(parseLegacyBackfillResults);
+}


### PR DESCRIPTION
Closes #178

## Descripcion

- Adds the typed, tenant-scoped finance frontend foundation without visual redesign.
- Includes the minimal backend response contract gap for immutable income-application provenance; no financial behavior changes.

## Tipo de cambio

- [x] Nueva funcionalidad
- [ ] Bug fix
- [ ] Refactor
- [ ] Cambio de documentación
- [ ] Otro

## Alcance

- Funds and FundTransactions contracts, API clients, guarded responses, and React Query hooks. Fund balances remain separated by currency and all monetary values use integer `amountMinor`.
- IncomeApplications expose `policyVersionId` and `legacyDestination` provenance.
- IncomePolicies and legacy income backfill API clients and hooks.
- Extended Income multicurrency/scope metadata plus FIN-06 Liquidation V3 nullable fields; historical V1/V2 records remain accepted.
- Tenant-scoped query-key factory and post-mutation cache invalidation. No direct page API integration or visual redesign.
- Currency strategy supports backend-configured currencies, including COP/USD/VES and ARS where configured; no tenant-wide currency list is hardcoded.

## Backend Contract Gap

`GET /tenants/:tenantId/finance/incomes/:incomeId/applications` persisted provenance but omitted it from the response. This PR exposes the existing `policyVersionId` and `legacyDestination` fields only; it changes no finance semantics.

## Validacion Local

- [x] Focused web services/hooks: 14 tests passed.
- [x] IncomeApplications API service: 45 tests passed.
- [x] Full web suite with `NEXT_PUBLIC_API_URL=http://localhost:3001`: 98 suites, 840 tests passed.
- [x] Web typecheck passed.
- [x] Targeted web/API lint passed. Global web lint remains blocked by 68 pre-existing errors across 107 unrelated files.
- [x] Web build passed.
- [x] `git diff --check` passed.

## Entornos

No staging, production, deployment, or merge was performed.

## PM review hardening

- Fund cache coherence: application-plan and policy mutations invalidate tenant funds only when their returned plan contains a FUND application.
- Fail-closed guards: positive financial amounts, complete application provenance and fund invariants, strict policy versions, and exact legacy enums.
- FIN-06 V3 integrity: summaries are all-or-none, integer-safe, and equation-checked; all liquidation mutation responses are guarded.
- Canonical contracts: Income and Liquidation types now have one authoritative frontend source, with legacy service re-exports for callers.
- Exact income writes: PATCH accepts only UpdateIncomeDto fields and allocations carry currencyCode.
- Currency foundation: reuses @buildingos/contracts CANONICAL_CURRENCIES; functionalCurrency remains the tenant accounting currency, not a tenant allowlist.

No staging, production, deployment, or merge was performed.

## PM review hardening round 2

- Converged production Income and Liquidation hooks on the shared finance query-key factory and family invalidations.
- Void Income now refreshes tenant Fund balances and transaction descendants.
- Legacy backfill preview invalidates after Income lifecycle changes, application plans, policies, and backfill application.
- FinanceSettings uses the finance key factory.
- Completed policy-rule, Fund, and FundTransaction fail-closed response guards.

No staging, production, deployment, or merge was performed.