### PR TITLE
feat(finance): build income funds and policy UI

### DIFF
--- a/apps/api/src/finanzas/funds.dto.ts
+++ b/apps/api/src/finanzas/funds.dto.ts
@@ -149,5 +149,6 @@ export interface FundTransactionResponseDto {
   description: string | null;
   idempotencyKey: string | null;
   reversalOfTransactionId: string | null;
+  incomeApplicationId: string | null;
   createdAt: Date;
 }

--- a/apps/api/src/finanzas/funds.service.spec.ts
+++ b/apps/api/src/finanzas/funds.service.spec.ts
@@ -797,6 +797,28 @@ describe('FundsService', () => {
 
   // ── Tenant isolation ────────────────────────────────────────────────────
 
+  describe('transaction DTO provenance', () => {
+    it('exposes incomeApplicationId=null for a manual transaction', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      (prisma.fundTransaction.findMany as jest.Mock).mockResolvedValue([
+        makeTransaction({ incomeApplicationId: null }),
+      ]);
+
+      const result = await service.listTransactions('tenant-1', 'fund-1', roles);
+      expect(result[0]!.incomeApplicationId).toBeNull();
+    });
+
+    it('exposes incomeApplicationId for an IncomeApplication-owned transaction', async () => {
+      (prisma.fund.findFirst as jest.Mock).mockResolvedValue(makeFund());
+      (prisma.fundTransaction.findMany as jest.Mock).mockResolvedValue([
+        makeTransaction({ incomeApplicationId: 'app-1' }),
+      ]);
+
+      const result = await service.listTransactions('tenant-1', 'fund-1', roles);
+      expect(result[0]!.incomeApplicationId).toBe('app-1');
+    });
+  });
+
   describe('tenant isolation', () => {
     it('never queries without tenantId scope', async () => {
       (prisma.fund.findMany as jest.Mock).mockResolvedValue([]);

--- a/apps/api/src/finanzas/funds.service.ts
+++ b/apps/api/src/finanzas/funds.service.ts
@@ -770,6 +770,7 @@ export class FundsService {
       description: transaction.description,
       idempotencyKey: transaction.idempotencyKey,
       reversalOfTransactionId: transaction.reversalOfTransactionId,
+      incomeApplicationId: transaction.incomeApplicationId,
       createdAt: transaction.createdAt,
     };
   }

--- a/apps/web/features/finance/components/FinanceDialog.tsx
+++ b/apps/web/features/finance/components/FinanceDialog.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { X } from 'lucide-react';
+
+interface FinanceDialogProps {
+  readonly title: string;
+  readonly children: ReactNode;
+  readonly onClose: () => void;
+  readonly labelledBy: string;
+}
+
+export function FinanceDialog({ title, children, onClose, labelledBy }: FinanceDialogProps) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={labelledBy}
+    >
+      <div className="max-h-[95vh] w-full max-w-2xl overflow-y-auto rounded-xl bg-background p-6 shadow-xl">
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <h2 id={labelledBy} className="text-lg font-semibold">{title}</h2>
+          <button type="button" onClick={onClose} aria-label={`Cerrar diálogo: ${title}`} className="rounded p-1 hover:bg-muted">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/features/finance/components/FundsTab.tsx
+++ b/apps/web/features/finance/components/FundsTab.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2, Plus } from 'lucide-react';
+import Button from '@/shared/components/ui/Button';
+import Card from '@/shared/components/ui/Card';
+import { formatCurrency } from '@/shared/lib/format/money';
+import { useBuildings } from '@/features/buildings/hooks';
+import { CANONICAL_CURRENCIES } from '../contracts';
+import { useArchiveFund, useCreateFund, useCreateFundTransaction, useFund, useFunds, useFundTransactions, useReverseFundTransaction, useUpdateFund } from '../hooks/useFunds';
+import { useFinanceSettings } from '../hooks/useFinanceSettings';
+import { decimalToAmountMinor } from '../utils/money-input';
+import { isFundTransactionReversible } from '../utils/fund-transaction';
+import { resolveDefaultCurrency } from '../utils/currency-default';
+import { todayLocalDate } from '../utils/date-input';
+import type { Fund, FundTransaction, FundTransactionDirection } from '../contracts';
+import { FinanceDialog } from './FinanceDialog';
+
+interface FundsTabProps { readonly tenantId: string; }
+
+function message(error: unknown, fallback: string) { return error instanceof Error ? error.message : fallback; }
+
+export function FundsTab({ tenantId }: FundsTabProps) {
+  const [status, setStatus] = useState<'ACTIVE' | 'ARCHIVED'>('ACTIVE');
+  const [showCreate, setShowCreate] = useState(false);
+  const [selectedFundId, setSelectedFundId] = useState<string | null>(null);
+  const { data: funds = [], isPending, error } = useFunds(tenantId, { status });
+  return <div className="space-y-4">
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between"><div><h3 className="text-lg font-semibold">Fondos</h3><p className="text-sm text-muted-foreground">Los saldos se muestran separados por moneda, sin conversiones implícitas.</p></div><Button type="button" className="gap-2" onClick={() => setShowCreate(true)}><Plus className="h-4 w-4" />Crear fondo</Button></div>
+    <label className="block max-w-xs text-sm font-medium">Estado<select value={status} onChange={(event) => setStatus(event.target.value as typeof status)} className="mt-1 w-full rounded border p-2"><option value="ACTIVE">Activos</option><option value="ARCHIVED">Archivados</option></select></label>
+    {isPending ? <Card className="p-6 text-sm text-muted-foreground">Cargando fondos...</Card> : error ? <Card className="p-6 text-sm text-red-700">{message(error, 'No pudimos cargar los fondos.')}</Card> : funds.length === 0 ? <Card className="p-6 text-center text-sm text-muted-foreground">No hay fondos {status === 'ACTIVE' ? 'activos' : 'archivados'}.</Card> : <div className="grid gap-3 lg:grid-cols-2">{funds.map((fund) => <Card key={fund.id} className="p-4"><div className="flex items-start justify-between gap-3"><div><p className="font-medium">{fund.name}</p><p className="text-sm text-muted-foreground">{fund.type} · {fund.scopeType === 'TENANT' ? 'Conjunto' : 'Edificio'}</p>{fund.description && <p className="mt-1 text-sm text-muted-foreground">{fund.description}</p>}<div className="mt-3 space-y-1">{fund.balancesByCurrency.length ? fund.balancesByCurrency.map((balance) => <p key={balance.currency} className="text-sm font-medium">{balance.currency}: {formatCurrency(balance.amountMinor, balance.currency)}</p>) : <p className="text-sm text-muted-foreground">Sin movimientos.</p>}</div></div><Button type="button" size="sm" variant="secondary" onClick={() => setSelectedFundId(fund.id)}>Ver detalle</Button></div></Card>)}</div>}
+    {showCreate && <FundFormDialog tenantId={tenantId} onClose={() => setShowCreate(false)} />}
+    {selectedFundId && <FundDetailDialog tenantId={tenantId} fundId={selectedFundId} onClose={() => setSelectedFundId(null)} />}
+  </div>;
+}
+
+function FundFormDialog({ tenantId, fund, onClose }: { readonly tenantId: string; readonly fund?: Fund; readonly onClose: () => void }) {
+  const [scopeType, setScopeType] = useState(fund?.scopeType ?? 'TENANT');
+  const [buildingId, setBuildingId] = useState(fund?.buildingId ?? '');
+  const [type, setType] = useState(fund?.type ?? 'RESERVE');
+  const [name, setName] = useState(fund?.name ?? '');
+  const [description, setDescription] = useState(fund?.description ?? '');
+  const [error, setError] = useState<string | null>(null);
+  const create = useCreateFund(tenantId);
+  const update = useUpdateFund(tenantId, fund?.id ?? '');
+  const { buildings } = useBuildings(tenantId);
+  const submit = async () => {
+    if (!name.trim()) return setError('El nombre del fondo es obligatorio.');
+    if (!fund && scopeType === 'BUILDING' && !buildingId) return setError('Seleccioná el edificio del fondo.');
+    setError(null);
+    try {
+      if (fund) await update.mutateAsync({ name: name.trim(), description: description.trim() });
+      else await create.mutateAsync({ scopeType, buildingId: scopeType === 'BUILDING' ? buildingId : undefined, type, name: name.trim(), description: description.trim() || undefined });
+      onClose();
+    } catch { /* Mutation error is rendered below. */ }
+  };
+  const mutation = fund ? update : create;
+  return <FinanceDialog title={fund ? 'Editar fondo' : 'Crear fondo'} labelledBy="fund-form-title" onClose={onClose}><div className="space-y-3">{!fund && <div className="grid gap-3 sm:grid-cols-2"><label className="text-sm font-medium">Alcance<select value={scopeType} onChange={(event) => setScopeType(event.target.value as typeof scopeType)} className="mt-1 w-full rounded border p-2"><option value="TENANT">Conjunto</option><option value="BUILDING">Edificio</option></select></label><label className="text-sm font-medium">Tipo<select value={type} onChange={(event) => setType(event.target.value as typeof type)} className="mt-1 w-full rounded border p-2"><option value="RESERVE">Reserva</option><option value="SPECIAL">Especial</option><option value="OTHER">Otro</option></select></label>{scopeType === 'BUILDING' && <label className="text-sm font-medium sm:col-span-2">Edificio<select value={buildingId} onChange={(event) => setBuildingId(event.target.value)} className="mt-1 w-full rounded border p-2"><option value="">Seleccioná un edificio</option>{buildings.map((building) => <option key={building.id} value={building.id}>{building.name}</option>)}</select></label>}</div>}<label className="block text-sm font-medium">Nombre<input value={name} onChange={(event) => setName(event.target.value)} className="mt-1 w-full rounded border p-2" /></label><label className="block text-sm font-medium">Descripción<textarea value={description} onChange={(event) => setDescription(event.target.value)} rows={3} className="mt-1 w-full rounded border p-2" /></label>{(error || mutation.error) && <p role="alert" className="text-sm text-red-700">{error ?? message(mutation.error, 'No pudimos guardar el fondo.')}</p>}<div className="flex justify-end gap-2"><Button type="button" variant="secondary" onClick={onClose}>Cancelar</Button><Button type="button" disabled={mutation.isPending} onClick={() => void submit()}>{mutation.isPending && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}Guardar</Button></div></div></FinanceDialog>;
+}
+
+function FundDetailDialog({ tenantId, fundId, onClose }: { readonly tenantId: string; readonly fundId: string; readonly onClose: () => void }) {
+  const { data: fund, isPending, error } = useFund(tenantId, fundId);
+  const { data: transactions = [], isPending: transactionsPending, error: transactionsError } = useFundTransactions(tenantId, fundId, { limit: 100 });
+  const [editing, setEditing] = useState(false);
+  const [manualTransaction, setManualTransaction] = useState(false);
+  const [reversing, setReversing] = useState<string | null>(null);
+  const archive = useArchiveFund(tenantId, fundId);
+  const [archiveConfirm, setArchiveConfirm] = useState(false);
+  if (isPending) return <FinanceDialog title="Detalle de fondo" labelledBy="fund-detail-title" onClose={onClose}><p className="text-sm text-muted-foreground">Cargando fondo...</p></FinanceDialog>;
+  if (error || !fund) return <FinanceDialog title="Detalle de fondo" labelledBy="fund-detail-title" onClose={onClose}><p role="alert" className="text-sm text-red-700">{message(error, 'No pudimos cargar el fondo.')}</p></FinanceDialog>;
+  return <FinanceDialog title={fund.name} labelledBy="fund-detail-title" onClose={onClose}><div className="space-y-4"><div className="flex flex-wrap gap-2"><Button type="button" variant="secondary" size="sm" onClick={() => setEditing(true)}>Editar</Button>{fund.status === 'ACTIVE' && <><Button type="button" size="sm" onClick={() => setManualTransaction(true)}>Movimiento manual</Button><Button type="button" variant="secondary" size="sm" onClick={() => setArchiveConfirm(true)}>Archivar</Button></>}</div><div className="rounded border p-3"><p className="text-sm font-medium">Saldos por moneda</p>{fund.balancesByCurrency.map((balance) => <p key={balance.currency} className="mt-1 text-sm">{balance.currency}: {formatCurrency(balance.amountMinor, balance.currency)}</p>)}</div>      <div><h3 className="mb-2 text-sm font-medium">Libro de movimientos</h3>{transactionsPending ? <p className="text-sm text-muted-foreground">Cargando movimientos...</p> : transactionsError ? <p role="alert" className="text-sm text-red-700">{message(transactionsError, 'No pudimos cargar los movimientos.')}</p> : transactions.length === 0 ? <p className="text-sm text-muted-foreground">Sin movimientos.</p> : <div className="space-y-2">{transactions.map((transaction) => <TransactionRow key={transaction.id} fundStatus={fund.status} transaction={transaction} transactions={transactions} onReverse={(transactionId) => setReversing(transactionId)} />)}</div>}</div></div>
+    {editing && <FundFormDialog tenantId={tenantId} fund={fund} onClose={() => setEditing(false)} />}
+    {manualTransaction && <FundTransactionDialog tenantId={tenantId} fundId={fund.id} onClose={() => setManualTransaction(false)} />}
+    {archiveConfirm && <FinanceDialog title="Archivar fondo" labelledBy="archive-fund-title" onClose={() => setArchiveConfirm(false)}><p className="text-sm text-muted-foreground">El fondo dejará de estar disponible para nuevas aplicaciones. Esta acción no borra el libro.</p>{archive.error && <p role="alert" className="mt-3 text-sm text-red-700">{message(archive.error, 'No pudimos archivar el fondo.')}</p>}<div className="mt-5 flex justify-end gap-2"><Button type="button" variant="secondary" onClick={() => setArchiveConfirm(false)}>Cancelar</Button><Button type="button" disabled={archive.isPending} onClick={() => void archive.mutateAsync().then(() => setArchiveConfirm(false)).catch(() => undefined)}>Confirmar archivo</Button></div></FinanceDialog>}
+    {reversing && <ReverseTransactionDialog tenantId={tenantId} fundId={fund.id} transactionId={reversing} onClose={() => setReversing(null)} />}
+  </FinanceDialog>;
+}
+
+function FundTransactionDialog({ tenantId, fundId, onClose }: { readonly tenantId: string; readonly fundId: string; readonly onClose: () => void }) {
+  const { data: financeSettings } = useFinanceSettings(tenantId);
+  const [direction, setDirection] = useState<FundTransactionDirection>('CREDIT'); const [amount, setAmount] = useState('');
+  const [explicitCurrency, setExplicitCurrency] = useState<string | null>(null);
+  const currencyCode = explicitCurrency ?? resolveDefaultCurrency(financeSettings?.functionalCurrency, CANONICAL_CURRENCIES);
+  const [occurredAt, setOccurredAt] = useState(() => todayLocalDate()); const [description, setDescription] = useState(''); const [formError, setFormError] = useState<string | null>(null); const create = useCreateFundTransaction(tenantId, fundId);
+  const submit = async () => { const amountMinor = decimalToAmountMinor(amount); if (!amountMinor) return setFormError('Ingresá un monto positivo con hasta dos decimales.'); setFormError(null); try { await create.mutateAsync({ direction, amountMinor, currencyCode, occurredAt, description: description.trim() || undefined }); onClose(); } catch { /* Mutation error is rendered below. */ } };
+  return <FinanceDialog title="Movimiento manual" labelledBy="fund-transaction-title" onClose={onClose}><div className="space-y-3"><div className="grid gap-3 sm:grid-cols-2"><label className="text-sm font-medium">Dirección<select value={direction} onChange={(event) => setDirection(event.target.value as FundTransactionDirection)} className="mt-1 w-full rounded border p-2"><option value="CREDIT">Crédito</option><option value="DEBIT">Débito</option></select></label><label className="text-sm font-medium">Moneda<select value={currencyCode} onChange={(event) => setExplicitCurrency(event.target.value)} className="mt-1 w-full rounded border p-2">{CANONICAL_CURRENCIES.map((currency) => <option key={currency} value={currency}>{currency}</option>)}</select></label><label className="text-sm font-medium">Monto<input inputMode="decimal" value={amount} onChange={(event) => setAmount(event.target.value)} className="mt-1 w-full rounded border p-2" /></label><label className="text-sm font-medium">Fecha<input type="date" value={occurredAt} onChange={(event) => setOccurredAt(event.target.value)} className="mt-1 w-full rounded border p-2" /></label></div><label className="block text-sm font-medium">Descripción<input value={description} onChange={(event) => setDescription(event.target.value)} className="mt-1 w-full rounded border p-2" /></label>{(formError || create.error) && <p role="alert" className="text-sm text-red-700">{formError ?? message(create.error, 'No pudimos crear el movimiento.')}</p>}<div className="flex justify-end gap-2"><Button type="button" variant="secondary" onClick={onClose}>Cancelar</Button><Button type="button" disabled={create.isPending} onClick={() => void submit()}>Registrar movimiento</Button></div></div></FinanceDialog>;
+}
+
+function ReverseTransactionDialog({ tenantId, fundId, transactionId, onClose }: { readonly tenantId: string; readonly fundId: string; readonly transactionId: string; readonly onClose: () => void }) { const [reason, setReason] = useState(''); const reverse = useReverseFundTransaction(tenantId, fundId); return <FinanceDialog title="Revertir movimiento" labelledBy="reverse-fund-transaction-title" onClose={onClose}><p className="text-sm text-muted-foreground">La reversión crea un contramovimiento; no elimina el registro original.</p><label className="mt-3 block text-sm font-medium">Motivo (opcional)<input value={reason} onChange={(event) => setReason(event.target.value)} className="mt-1 w-full rounded border p-2" /></label>{reverse.error && <p role="alert" className="mt-3 text-sm text-red-700">{message(reverse.error, 'No pudimos revertir el movimiento.')}</p>}<div className="mt-5 flex justify-end gap-2"><Button type="button" variant="secondary" onClick={onClose}>Cancelar</Button><Button type="button" disabled={reverse.isPending} onClick={() => void reverse.mutateAsync({ transactionId, data: { reason: reason.trim() || undefined } }).then(onClose).catch(() => undefined)}>Confirmar reversión</Button></div></FinanceDialog>; }
+
+function TransactionRow({ fundStatus, transaction, transactions, onReverse }: {
+  readonly fundStatus: Fund['status'];
+  readonly transaction: FundTransaction;
+  readonly transactions: readonly FundTransaction[];
+  readonly onReverse: (transactionId: string) => void;
+}) {
+  const reversible = fundStatus === 'ACTIVE' && isFundTransactionReversible(transaction, transactions);
+  const ownedByApplication = transaction.incomeApplicationId !== null;
+  return <div className="flex flex-col gap-2 rounded border p-3 sm:flex-row sm:items-center sm:justify-between">
+    <div className="text-sm">
+      <span className="font-medium">{transaction.direction}</span> · {formatCurrency(transaction.amountMinor, transaction.currencyCode)}
+      <p className="text-muted-foreground">{transaction.occurredAt.slice(0, 10)} · {transaction.description || 'Sin descripción'}{transaction.reversalOfTransactionId ? ' · Reversión' : ''}</p>
+      {ownedByApplication && <p className="text-xs text-muted-foreground">Generado por una aplicación de ingreso; se revierte solo mediante la anulación del ingreso.</p>}
+    </div>
+    {reversible && <Button type="button" size="sm" variant="secondary" onClick={() => onReverse(transaction.id)}>Revertir</Button>}
+  </div>;
+}

--- a/apps/web/features/finance/components/IncomeCreateModal.test.tsx
+++ b/apps/web/features/finance/components/IncomeCreateModal.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncomeCreateModal } from './IncomeCreateModal';
+import * as useFinanceSettingsModule from '../hooks/useFinanceSettings';
+
+jest.mock('@/shared/components/ui/Toast', () => ({
+  useToast: () => ({ toast: jest.fn() }),
+}));
+
+jest.mock('@/features/buildings/hooks', () => ({
+  useBuildings: () => ({ buildings: [], loading: false }),
+}));
+
+jest.mock('../hooks/useExpenseLedger', () => ({
+  useCreateIncome: () => ({ mutateAsync: jest.fn(), isPending: false }),
+  useExpenseLedgerCategories: () => ({ data: [], isLoading: false }),
+}));
+
+jest.mock('../hooks/useFinanceSettings', () => ({
+  useFinanceSettings: jest.fn(),
+}));
+
+jest.mock('@buildingos/contracts', () => ({
+  CANONICAL_CURRENCIES: ['COP', 'USD', 'ARS', 'VES'],
+}));
+
+jest.mock('lucide-react', () => ({
+  Loader2: () => <span>Loader2</span>,
+  X: () => <span>X</span>,
+}));
+
+const mockedUseFinanceSettings = jest.mocked(useFinanceSettingsModule.useFinanceSettings);
+
+function renderModal() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <IncomeCreateModal tenantId="tenant-1" period="2026-08" onClose={() => undefined} onCreated={() => undefined} />
+    </QueryClientProvider>,
+  );
+}
+
+describe('IncomeCreateModal currency default (FIN-07BR3)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each(['USD', 'VES', 'COP'] as const)('starts with configured functional currency %s', (currency) => {
+    mockedUseFinanceSettings.mockReturnValue({ data: { functionalCurrency: currency } } as never);
+    renderModal();
+    expect((screen.getByLabelText('Moneda') as HTMLSelectElement).value).toBe(currency);
+  });
+
+  it('falls back to the first canonical currency when settings are absent', () => {
+    mockedUseFinanceSettings.mockReturnValue({ data: undefined } as never);
+    renderModal();
+    expect((screen.getByLabelText('Moneda') as HTMLSelectElement).value).toBe('COP');
+  });
+
+  it('defaults to a non-ARS canonical currency instead of a hardcoded ARS default', () => {
+    mockedUseFinanceSettings.mockReturnValue({ data: undefined } as never);
+    renderModal();
+    expect((screen.getByLabelText('Moneda') as HTMLSelectElement).value).not.toBe('ARS');
+  });
+
+  it('does not overwrite a user-selected currency when settings arrive later', () => {
+    mockedUseFinanceSettings.mockReturnValue({ data: undefined } as never);
+    const { rerender } = renderModal();
+    fireEvent.change(screen.getByLabelText('Moneda'), { target: { value: 'USD' } });
+    expect((screen.getByLabelText('Moneda') as HTMLSelectElement).value).toBe('USD');
+
+    // Settings arrive later with a different functional currency.
+    mockedUseFinanceSettings.mockReturnValue({ data: { functionalCurrency: 'VES' } } as never);
+    rerender(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <IncomeCreateModal tenantId="tenant-1" period="2026-08" onClose={() => undefined} onCreated={() => undefined} />
+      </QueryClientProvider>,
+    );
+    expect((screen.getByLabelText('Moneda') as HTMLSelectElement).value).toBe('USD');
+  });
+});

--- a/apps/web/features/finance/components/IncomeCreateModal.tsx
+++ b/apps/web/features/finance/components/IncomeCreateModal.tsx
@@ -1,13 +1,20 @@
 'use client';
 
 import { useState } from 'react';
-import { X, Loader2 } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { CANONICAL_CURRENCIES } from '@buildingos/contracts';
+import { Loader2, X } from 'lucide-react';
 import Button from '@/shared/components/ui/Button';
+import { useBuildings } from '@/features/buildings/hooks';
 import { useToast } from '@/shared/components/ui/Toast';
-import {
-  useCreateIncome,
-  useExpenseLedgerCategories,
-} from '../hooks/useExpenseLedger';
+import { useCreateIncome, useExpenseLedgerCategories } from '../hooks/useExpenseLedger';
+import { useFinanceSettings } from '../hooks/useFinanceSettings';
+import { financeKeys } from '../hooks/finance-query-keys';
+import { unitGroupApi } from '../services/liquidation.api';
+import type { IncomeScopeType, MovementAllocationInput } from '../contracts';
+import { decimalToAmountMinor, sumAmountMinor } from '../utils/money-input';
+import { resolveDefaultCurrency } from '../utils/currency-default';
+import { todayLocalDate } from '../utils/date-input';
 
 interface IncomeCreateModalProps {
   tenantId: string;
@@ -17,195 +24,106 @@ interface IncomeCreateModalProps {
   onCreated: () => void;
 }
 
-const CURRENCIES = ['ARS', 'VES', 'USD'];
+interface AllocationDraft {
+  buildingId: string;
+  amount: string;
+}
 
-export function IncomeCreateModal({
-  tenantId,
-  buildingId,
-  period,
-  onClose,
-  onCreated,
-}: IncomeCreateModalProps) {
+export function IncomeCreateModal({ tenantId, buildingId, period, onClose, onCreated }: IncomeCreateModalProps) {
   const { toast } = useToast();
-  const { data: allCategories = [] } = useExpenseLedgerCategories(tenantId);
+  const { buildings, loading: buildingsLoading } = useBuildings(tenantId);
+  const { data: categories = [], isLoading: categoriesLoading } = useExpenseLedgerCategories(tenantId);
+  const { data: financeSettings } = useFinanceSettings(tenantId);
   const createMutation = useCreateIncome(tenantId);
-  const categoryFieldId = 'income-create-category';
-  const amountFieldId = 'income-create-amount';
-  const currencyFieldId = 'income-create-currency';
-  const receivedDateFieldId = 'income-create-received-date';
-  const descriptionFieldId = 'income-create-description';
+  const [scopeType, setScopeType] = useState<IncomeScopeType>('BUILDING');
+  const [selectedBuildingId, setSelectedBuildingId] = useState(buildingId ?? '');
+  const [unitGroupId, setUnitGroupId] = useState('');
+  const [categoryId, setCategoryId] = useState('');
+  const [amount, setAmount] = useState('');
+  const [explicitCurrency, setExplicitCurrency] = useState<string | null>(null);
+  const currencyCode = explicitCurrency ?? resolveDefaultCurrency(financeSettings?.functionalCurrency, CANONICAL_CURRENCIES);
+  const [receivedDate, setReceivedDate] = useState(() => todayLocalDate());
+  const [description, setDescription] = useState('');
+  const [allocationDrafts, setAllocationDrafts] = useState<AllocationDraft[]>([]);
 
-  // Filtrar solo categorías de INGRESOS
-  const categories = allCategories.filter((c) => c.movementType === 'INCOME');
-
-  const [form, setForm] = useState({
-    categoryId: '',
-    amountMinor: '',
-    currencyCode: 'ARS',
-    receivedDate: new Date().toISOString().split('T')[0] ?? '',
-    description: '',
+  const groupsQuery = useQuery({
+    queryKey: financeKeys.unitGroups(tenantId, selectedBuildingId),
+    queryFn: () => unitGroupApi.list(tenantId, selectedBuildingId),
+    enabled: scopeType === 'UNIT_GROUP' && Boolean(selectedBuildingId),
   });
+  const incomeCategories = categories.filter((category) => category.movementType === 'INCOME' && category.isActive);
+  const amountMinor = decimalToAmountMinor(amount);
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const syncAllocations = () => {
+    setAllocationDrafts(buildings.map((building) => ({ buildingId: building.id, amount: '' })));
+  };
 
-    const amountMinor = Math.round(parseFloat(form.amountMinor) * 100);
-    if (isNaN(amountMinor) || amountMinor <= 0) {
-      toast('El monto debe ser un número positivo', 'error');
-      return;
-    }
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!amountMinor) return toast('Ingresá un monto positivo con hasta dos decimales.', 'error');
+    if (!categoryId) return toast('Seleccioná un rubro de ingreso.', 'error');
+    if (scopeType === 'BUILDING' && !selectedBuildingId) return toast('Seleccioná un edificio.', 'error');
+    if (scopeType === 'UNIT_GROUP' && (!selectedBuildingId || !unitGroupId)) return toast('Seleccioná el edificio y grupo de unidades.', 'error');
 
-    if (!form.categoryId) {
-      toast('Debes seleccionar un rubro de ingreso', 'error');
-      return;
+    let allocations: MovementAllocationInput[] | undefined;
+    if (scopeType !== 'BUILDING') {
+      const parsed = allocationDrafts.map((allocation) => ({
+        buildingId: allocation.buildingId,
+        amountMinor: decimalToAmountMinor(allocation.amount),
+      }));
+      if (parsed.length === 0 || parsed.some((allocation) => !allocation.amountMinor)) {
+        return toast('Asigná un importe positivo a cada edificio incluido.', 'error');
+      }
+      const total = sumAmountMinor(parsed.map((allocation) => allocation.amountMinor!));
+      if (total !== amountMinor) return toast('La suma de asignaciones debe coincidir exactamente con el ingreso.', 'error');
+      allocations = parsed.map((allocation) => ({ ...allocation, amountMinor: allocation.amountMinor!, currencyCode }));
     }
 
     try {
       await createMutation.mutateAsync({
-        buildingId: buildingId || undefined,
         period,
-        categoryId: form.categoryId,
+        categoryId,
         amountMinor,
-        currencyCode: form.currencyCode,
-        receivedDate: form.receivedDate,
-        description: form.description || undefined,
+        currencyCode,
+        receivedDate,
+        description: description.trim() || undefined,
+        scopeType,
+        buildingId: scopeType === 'BUILDING' ? selectedBuildingId : undefined,
+        unitGroupId: scopeType === 'UNIT_GROUP' ? unitGroupId : undefined,
+        allocations,
       });
-
-      toast('Ingreso registrado', 'success');
+      toast('Ingreso creado como borrador.', 'success');
       onCreated();
       onClose();
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : 'Error al registrar el ingreso';
-      toast(msg, 'error');
+    } catch (error) {
+      toast(error instanceof Error ? error.message : 'No pudimos crear el ingreso.', 'error');
     }
   };
 
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-      <div className="bg-background rounded-xl shadow-xl w-full max-w-md p-6">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-semibold">Registrar Ingreso</h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Cerrar diálogo de registrar ingreso"
-            className="p-1 hover:bg-muted rounded text-muted-foreground hover:text-foreground"
-          >
-            <X className="h-5 w-5" />
-          </button>
-        </div>
-
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label htmlFor={categoryFieldId} className="block text-sm font-medium mb-1">
-              Rubro <span className="text-red-500">*</span>
-            </label>
-            <select
-              id={categoryFieldId}
-              required
-              value={form.categoryId}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, categoryId: e.target.value }))
-              }
-              className="w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-            >
-              <option value="">Seleccioná un rubro de ingreso</option>
-              {categories
-                .filter((c) => c.isActive)
-                .map((c) => (
-                  <option key={c.id} value={c.id}>
-                    {c.name}
-                  </option>
-                ))}
-            </select>
-          </div>
-
-          <div className="grid grid-cols-2 gap-3">
-            <div>
-              <label htmlFor={amountFieldId} className="block text-sm font-medium mb-1">
-                Monto <span className="text-red-500">*</span>
-              </label>
-              <input
-                id={amountFieldId}
-                type="number"
-                required
-                step="0.01"
-                min="0.01"
-                placeholder="0.00"
-                value={form.amountMinor}
-                onChange={(e) =>
-                  setForm((f) => ({ ...f, amountMinor: e.target.value }))
-                }
-                className="w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-              />
-            </div>
-            <div>
-              <label htmlFor={currencyFieldId} className="block text-sm font-medium mb-1">Moneda</label>
-              <select
-                id={currencyFieldId}
-                value={form.currencyCode}
-                onChange={(e) =>
-                  setForm((f) => ({ ...f, currencyCode: e.target.value }))
-                }
-                className="w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-              >
-                {CURRENCIES.map((c) => (
-                  <option key={c} value={c}>
-                    {c}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-
-          <div>
-            <label htmlFor={receivedDateFieldId} className="block text-sm font-medium mb-1">
-              Fecha de Recepción <span className="text-red-500">*</span>
-            </label>
-            <input
-              id={receivedDateFieldId}
-              type="date"
-              required
-              value={form.receivedDate}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, receivedDate: e.target.value }))
-              }
-              className="w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-            />
-          </div>
-
-          <div>
-            <label htmlFor={descriptionFieldId} className="block text-sm font-medium mb-1">
-              Descripción (opcional)
-            </label>
-            <textarea
-              id={descriptionFieldId}
-              placeholder="Ej: Cuota extraordinaria pagada por..."
-              value={form.description}
-              onChange={(e) =>
-                setForm((f) => ({ ...f, description: e.target.value }))
-              }
-              rows={3}
-              className="w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary"
-            />
-          </div>
-
-          <div className="flex justify-end gap-2 pt-2">
-            <Button type="button" variant="secondary" onClick={onClose}>
-              Cancelar
-            </Button>
-            <Button
-              type="submit"
-              disabled={createMutation.isPending}
-            >
-              {createMutation.isPending ? (
-                <Loader2 className="h-4 w-4 animate-spin mr-1" />
-              ) : null}
-              Registrar
-            </Button>
-          </div>
-        </form>
+  return <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4" role="dialog" aria-modal="true" aria-labelledby="income-create-title">
+    <div className="max-h-[95vh] w-full max-w-2xl overflow-y-auto rounded-xl bg-background p-6 shadow-xl">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div><h2 id="income-create-title" className="text-lg font-semibold">Registrar ingreso</h2><p className="text-sm text-muted-foreground">El plan de aplicaciones define el uso financiero final.</p></div>
+        <button type="button" onClick={onClose} aria-label="Cerrar diálogo de ingreso" className="rounded p-1 hover:bg-muted"><X className="h-5 w-5" /></button>
       </div>
+      <form onSubmit={submit} className="space-y-4">
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="text-sm font-medium">Rubro<select required value={categoryId} onChange={(event) => setCategoryId(event.target.value)} className="mt-1 w-full rounded border p-2"><option value="">Seleccioná un rubro</option>{incomeCategories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}</select></label>
+          <label className="text-sm font-medium">Período<input required type="month" value={period} readOnly className="mt-1 w-full rounded border bg-muted p-2" /></label>
+          <label className="text-sm font-medium">Monto<input required inputMode="decimal" placeholder="0.00" value={amount} onChange={(event) => setAmount(event.target.value)} className="mt-1 w-full rounded border p-2" /></label>
+          <label className="text-sm font-medium">Moneda<select value={currencyCode} onChange={(event) => setExplicitCurrency(event.target.value)} className="mt-1 w-full rounded border p-2">{CANONICAL_CURRENCIES.map((currency) => <option key={currency} value={currency}>{currency}</option>)}</select></label>
+          <label className="text-sm font-medium">Fecha recibida<input required type="date" value={receivedDate} onChange={(event) => setReceivedDate(event.target.value)} className="mt-1 w-full rounded border p-2" /></label>
+          <label className="text-sm font-medium">Alcance<select value={scopeType} onChange={(event) => { const next = event.target.value as IncomeScopeType; setScopeType(next); setUnitGroupId(''); if (next !== 'BUILDING') syncAllocations(); }} className="mt-1 w-full rounded border p-2"><option value="BUILDING">Edificio</option><option value="TENANT_SHARED">Compartido del conjunto</option><option value="UNIT_GROUP">Grupo de unidades</option></select></label>
+        </div>
+        <p className="text-xs text-muted-foreground">Moneda funcional: {financeSettings?.functionalCurrency ?? 'cargando'}. Es contexto contable, no una lista de monedas permitidas.</p>
+        <label className="block text-sm font-medium">Edificio<select required={scopeType !== 'TENANT_SHARED'} value={selectedBuildingId} onChange={(event) => { setSelectedBuildingId(event.target.value); setUnitGroupId(''); }} className="mt-1 w-full rounded border p-2"><option value="">{scopeType === 'TENANT_SHARED' ? 'No aplica al ingreso compartido' : 'Seleccioná un edificio'}</option>{buildings.map((building) => <option key={building.id} value={building.id}>{building.name}</option>)}</select></label>
+        {scopeType === 'UNIT_GROUP' && <label className="block text-sm font-medium">Grupo de unidades<select required value={unitGroupId} onChange={(event) => setUnitGroupId(event.target.value)} className="mt-1 w-full rounded border p-2" disabled={groupsQuery.isLoading || !selectedBuildingId}><option value="">{groupsQuery.isLoading ? 'Cargando grupos...' : 'Seleccioná un grupo'}</option>{groupsQuery.data?.map((group) => <option key={group.id} value={group.id}>{group.name} ({group.memberCount} unidades)</option>)}</select>{groupsQuery.error && <span className="text-xs text-red-700">No pudimos cargar grupos: {groupsQuery.error instanceof Error ? groupsQuery.error.message : 'Error desconocido'}</span>}</label>}
+        {scopeType !== 'BUILDING' && <div className="rounded border p-3"><div className="mb-2 flex items-center justify-between"><p className="text-sm font-medium">Asignaciones por edificio</p><Button type="button" variant="secondary" size="sm" onClick={syncAllocations}>Cargar edificios</Button></div>{allocationDrafts.length === 0 ? <p className="text-sm text-muted-foreground">Cargá los edificios para asignar importes exactos.</p> : <div className="space-y-2">{allocationDrafts.map((allocation, index) => <label key={allocation.buildingId} className="flex items-center gap-2 text-sm"><span className="min-w-0 flex-1 truncate">{buildings.find((building) => building.id === allocation.buildingId)?.name ?? allocation.buildingId}</span><input inputMode="decimal" placeholder="0.00" value={allocation.amount} onChange={(event) => setAllocationDrafts((current) => current.map((item, itemIndex) => itemIndex === index ? { ...item, amount: event.target.value } : item))} className="w-28 rounded border p-2" /></label>)}</div>}</div>}
+        <label className="block text-sm font-medium">Descripción<textarea value={description} onChange={(event) => setDescription(event.target.value)} rows={3} className="mt-1 w-full rounded border p-2" /></label>
+        {(categoriesLoading || buildingsLoading) && <p className="text-sm text-muted-foreground">Cargando datos del formulario...</p>}
+        {createMutation.error && <p className="text-sm text-red-700">{createMutation.error.message}</p>}
+        <div className="flex justify-end gap-2"><Button type="button" variant="secondary" onClick={onClose}>Cancelar</Button><Button type="submit" disabled={createMutation.isPending}>{createMutation.isPending && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}Crear borrador</Button></div>
+      </form>
     </div>
-  );
+  </div>;
 }

--- a/apps/web/features/finance/components/IncomePoliciesTab.tsx
+++ b/apps/web/features/finance/components/IncomePoliciesTab.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2, Plus } from 'lucide-react';
+import Button from '@/shared/components/ui/Button';
+import Card from '@/shared/components/ui/Card';
+import { useExpenseLedgerCategories } from '../hooks/useExpenseLedger';
+import { useFunds } from '../hooks/useFunds';
+import { useCreateIncomePolicy, useCreateIncomePolicyVersion, useDeactivateIncomePolicy, useIncomePolicies } from '../hooks/useIncomePolicies';
+import { percentageToBasisPoints } from '../utils/money-input';
+import type { CreateIncomePolicyRuleData, IncomeApplicationDestination, IncomePolicy } from '../contracts';
+import { FinanceDialog } from './FinanceDialog';
+
+interface IncomePoliciesTabProps { readonly tenantId: string; }
+
+interface RuleDraft { readonly id: string; destinationType: IncomeApplicationDestination; fundId: string; percentage: string; }
+
+function message(error: unknown, fallback: string) { return error instanceof Error ? error.message : fallback; }
+
+export function IncomePoliciesTab({ tenantId }: IncomePoliciesTabProps) {
+  const [creating, setCreating] = useState(false);
+  const [versioning, setVersioning] = useState<IncomePolicy | null>(null);
+  const [deactivating, setDeactivating] = useState<IncomePolicy | null>(null);
+  const { data: policies = [], isPending, error } = useIncomePolicies(tenantId);
+  const { data: categories = [] } = useExpenseLedgerCategories(tenantId, 'INCOME');
+  const categoryNames = new Map(categories.map((category) => [category.id, category.name]));
+  const deactivate = useDeactivateIncomePolicy(tenantId, deactivating?.categoryId ?? '');
+  return <div className="space-y-4"><div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between"><div><h3 className="text-lg font-semibold">Políticas de ingreso</h3><p className="text-sm text-muted-foreground">Cada versión distribuye exactamente 10.000 puntos básicos y queda como procedencia del plan aplicado.</p></div><Button type="button" className="gap-2" onClick={() => setCreating(true)}><Plus className="h-4 w-4" />Crear política</Button></div>{isPending ? <Card className="p-6 text-sm text-muted-foreground">Cargando políticas...</Card> : error ? <Card className="p-6 text-sm text-red-700">{message(error, 'No pudimos cargar las políticas.')}</Card> : policies.length === 0 ? <Card className="p-6 text-center text-sm text-muted-foreground">No hay políticas de ingreso configuradas.</Card> : <div className="space-y-3">{policies.map((policy) => <Card key={policy.id} className="p-4"><div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between"><div><p className="font-medium">{categoryNames.get(policy.categoryId) ?? policy.categoryId}</p>{policy.currentVersion ? <><p className="text-sm text-muted-foreground">Versión {policy.currentVersion.version} · {policy.currentVersion.status}</p><PolicyRules tenantId={tenantId} rules={policy.currentVersion.rules} /></> : <p className="text-sm text-muted-foreground">Sin versión activa.</p>}</div><div className="flex flex-wrap gap-2"><Button type="button" size="sm" variant="secondary" onClick={() => setVersioning(policy)}>Nueva versión</Button>{policy.currentVersion?.status === 'ACTIVE' && <Button type="button" size="sm" variant="secondary" onClick={() => setDeactivating(policy)}>Desactivar</Button>}</div></div></Card>)}</div>}{creating && <PolicyFormDialog tenantId={tenantId} usedCategoryIds={new Set(policies.map((policy) => policy.categoryId))} onClose={() => setCreating(false)} />}{versioning && <PolicyFormDialog tenantId={tenantId} policy={versioning} usedCategoryIds={new Set()} onClose={() => setVersioning(null)} />}{deactivating && <FinanceDialog title="Desactivar política" labelledBy="deactivate-policy-title" onClose={() => setDeactivating(null)}><p className="text-sm text-muted-foreground">Las nuevas aplicaciones no usarán esta política. Los planes ya aplicados no cambian.</p>{deactivate.error && <p role="alert" className="mt-3 text-sm text-red-700">{message(deactivate.error, 'No pudimos desactivar la política.')}</p>}<div className="mt-5 flex justify-end gap-2"><Button type="button" variant="secondary" onClick={() => setDeactivating(null)}>Cancelar</Button><Button type="button" disabled={deactivate.isPending} onClick={() => void deactivate.mutateAsync().then(() => setDeactivating(null)).catch(() => undefined)}>{deactivate.isPending && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}Confirmar desactivación</Button></div></FinanceDialog>}</div>;
+}
+
+function PolicyRules({ tenantId, rules }: { readonly tenantId: string; readonly rules: readonly { id: string; destinationType: string; fundId: string | null; percentageBasisPoints: number }[] }) { const { data: funds = [] } = useFunds(tenantId, {}); return <div className="mt-2 space-y-1">{rules.map((rule) => <p key={rule.id} className="text-sm text-muted-foreground">{rule.destinationType}{rule.fundId ? ` · ${funds.find((fund) => fund.id === rule.fundId)?.name ?? rule.fundId}` : ''}: {rule.percentageBasisPoints} bps</p>)}</div>; }
+
+function PolicyFormDialog({ tenantId, policy, usedCategoryIds, onClose }: { readonly tenantId: string; readonly policy?: IncomePolicy; readonly usedCategoryIds: ReadonlySet<string>; readonly onClose: () => void }) {
+  const { data: categories = [] } = useExpenseLedgerCategories(tenantId, 'INCOME');
+  const { data: funds = [] } = useFunds(tenantId, { status: 'ACTIVE' });
+  const [categoryId, setCategoryId] = useState(policy?.categoryId ?? '');
+  const [rules, setRules] = useState<RuleDraft[]>([{ id: 'first', destinationType: 'OFFSET_EXPENSES', fundId: '', percentage: '100' }]);
+  const [formError, setFormError] = useState<string | null>(null);
+  const create = useCreateIncomePolicy(tenantId);
+  const version = useCreateIncomePolicyVersion(tenantId, policy?.categoryId ?? '');
+  const mutation = policy ? version : create;
+  const updateRule = (id: string, field: keyof Omit<RuleDraft, 'id'>, value: string) => setRules((current) => current.map((rule) => rule.id === id ? { ...rule, [field]: value } : rule));
+  const submit = async () => {
+    if (!policy && !categoryId) return setFormError('Seleccioná un rubro de ingreso.');
+    const parsed: CreateIncomePolicyRuleData[] = [];
+    for (const rule of rules) { const percentageBasisPoints = percentageToBasisPoints(rule.percentage); if (!percentageBasisPoints) return setFormError('Cada porcentaje debe estar entre 0,01% y 100%, con hasta dos decimales.'); if (rule.destinationType === 'FUND' && !rule.fundId) return setFormError('Las reglas de fondo requieren seleccionar un fondo activo.'); parsed.push({ destinationType: rule.destinationType, fundId: rule.destinationType === 'FUND' ? rule.fundId : undefined, percentageBasisPoints }); }
+    if (parsed.reduce((total, rule) => total + rule.percentageBasisPoints, 0) !== 10000) return setFormError('La suma de reglas debe ser exactamente 10.000 bps (100%).');
+    setFormError(null); try { if (policy) await version.mutateAsync({ rules: parsed }); else await create.mutateAsync({ categoryId, rules: parsed }); onClose(); } catch { /* Mutation error is rendered below. */ }
+  };
+  return <FinanceDialog title={policy ? 'Crear nueva versión' : 'Crear política de ingreso'} labelledBy="income-policy-form-title" onClose={onClose}><div className="space-y-4">{!policy && <label className="block text-sm font-medium">Rubro de ingreso<select value={categoryId} onChange={(event) => setCategoryId(event.target.value)} className="mt-1 w-full rounded border p-2"><option value="">Seleccioná un rubro</option>{categories.filter((category) => !usedCategoryIds.has(category.id)).map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}</select></label>}<div className="space-y-2 rounded border p-3"><p className="text-sm font-medium">Reglas</p>{rules.map((rule) => <div key={rule.id} className="grid gap-2 sm:grid-cols-[1fr_1fr_130px_auto]"><select aria-label="Destino de política" value={rule.destinationType} onChange={(event) => updateRule(rule.id, 'destinationType', event.target.value)} className="rounded border p-2"><option value="OFFSET_EXPENSES">Compensar gastos</option><option value="FUND">Fondo</option><option value="CARRY_FORWARD">Arrastre</option></select>{rule.destinationType === 'FUND' ? <select aria-label="Fondo de política" value={rule.fundId} onChange={(event) => updateRule(rule.id, 'fundId', event.target.value)} className="rounded border p-2"><option value="">Seleccioná un fondo</option>{funds.map((fund) => <option key={fund.id} value={fund.id}>{fund.name}</option>)}</select> : <span className="hidden sm:block" />}<input aria-label="Porcentaje" inputMode="decimal" value={rule.percentage} onChange={(event) => updateRule(rule.id, 'percentage', event.target.value)} placeholder="Porcentaje" className="rounded border p-2" /><Button type="button" size="sm" variant="secondary" disabled={rules.length === 1} onClick={() => setRules((current) => current.filter((item) => item.id !== rule.id))}>Quitar</Button></div>)}<Button type="button" size="sm" variant="secondary" className="mt-2" onClick={() => setRules((current) => [...current, { id: String(Date.now()), destinationType: 'OFFSET_EXPENSES', fundId: '', percentage: '' }])}>Agregar regla</Button></div>{(formError || mutation.error) && <p role="alert" className="text-sm text-red-700">{formError ?? message(mutation.error, 'No pudimos guardar la política.')}</p>}<div className="flex justify-end gap-2"><Button type="button" variant="secondary" onClick={onClose}>Cancelar</Button><Button type="button" disabled={mutation.isPending} onClick={() => void submit()}>{mutation.isPending && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}Guardar versión</Button></div></div></FinanceDialog>;
+}

--- a/apps/web/features/finance/components/IncomesTab.test.tsx
+++ b/apps/web/features/finance/components/IncomesTab.test.tsx
@@ -1,0 +1,318 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IncomesTab } from './IncomesTab';
+import * as useExpenseLedger from '../hooks/useExpenseLedger';
+import * as useFundsModule from '../hooks/useFunds';
+import * as useIncomeApplicationsModule from '../hooks/useIncomeApplications';
+
+jest.mock('../hooks/useExpenseLedger', () => ({
+  useIncomes: jest.fn(),
+  useExpenseLedgerCategories: jest.fn(),
+  useRecordIncome: jest.fn(),
+  useVoidIncome: jest.fn(),
+  useUpdateIncome: jest.fn(),
+}));
+
+jest.mock('../hooks/useFunds', () => ({
+  useFunds: jest.fn(),
+}));
+
+jest.mock('../hooks/useIncomeApplications', () => ({
+  useIncomeApplicationPlan: jest.fn(),
+  useApplyIncomePolicy: jest.fn(),
+  useCreateIncomeApplicationPlan: jest.fn(),
+}));
+
+jest.mock('@/shared/lib/format/money', () => ({
+  formatCurrency: (value: number, currency: string) => `${currency} ${value}`,
+}));
+
+jest.mock('lucide-react', () => ({
+  Loader2: () => <span>Loader2</span>,
+  Plus: () => <span>Plus</span>,
+  Save: () => <span>Save</span>,
+  X: () => <span>X</span>,
+}));
+
+const mockedUseIncomes = jest.mocked(useExpenseLedger.useIncomes);
+const mockedUseCategories = jest.mocked(useExpenseLedger.useExpenseLedgerCategories);
+const mockedUseRecord = jest.mocked(useExpenseLedger.useRecordIncome);
+const mockedUseVoid = jest.mocked(useExpenseLedger.useVoidIncome);
+const mockedUseUpdate = jest.mocked(useExpenseLedger.useUpdateIncome);
+const mockedUseFunds = jest.mocked(useFundsModule.useFunds);
+const mockedUseIncomeApplicationPlan = jest.mocked(useIncomeApplicationsModule.useIncomeApplicationPlan);
+const mockedUseApplyIncomePolicy = jest.mocked(useIncomeApplicationsModule.useApplyIncomePolicy);
+const mockedUseCreateIncomeApplicationPlan = jest.mocked(useIncomeApplicationsModule.useCreateIncomeApplicationPlan);
+
+const makeIncome = (overrides: Record<string, unknown> = {}) => ({
+  id: 'income-1',
+  tenantId: 'tenant-1',
+  buildingId: 'building-1',
+  period: '2026-08',
+  categoryId: 'category-1',
+  categoryName: 'Alquiler',
+  scopeType: 'BUILDING',
+  unitGroupId: null,
+  destination: 'APPLY_TO_EXPENSES',
+  amountMinor: 10000,
+  currencyCode: 'ARS',
+  receivedDate: '2026-08-10T00:00:00.000Z',
+  description: null,
+  attachmentFileKey: null,
+  status: 'DRAFT',
+  functionalAmountMinor: null,
+  functionalCurrencyCode: null,
+  exchangeRateId: null,
+  exchangeRateValue: null,
+  exchangeRateDirection: null,
+  exchangeRateEffectiveAt: null,
+  conversionDate: null,
+  createdAt: '2026-08-01T00:00:00.000Z',
+  updatedAt: '2026-08-01T00:00:00.000Z',
+  ...overrides,
+});
+
+const makePlan = (applications: unknown[] = []) => ({
+  incomeId: 'income-1',
+  currencyCode: 'ARS',
+  totalAmountMinor: applications.reduce((sum, app) => sum + ((app as { amountMinor?: number }).amountMinor ?? 0), 0),
+  applications,
+});
+
+const makeApplication = () => ({
+  id: 'app-1', tenantId: 'tenant-1', incomeId: 'income-1', destinationType: 'OFFSET_EXPENSES',
+  fundId: null, amountMinor: 10000, currencyCode: 'ARS', fundTransactionId: null,
+  policyVersionId: null, legacyDestination: null, createdAt: '2026-08-01T00:00:00.000Z',
+});
+
+function renderIncomesTab(incomes: ReturnType<typeof makeIncome>[], plan?: unknown) {
+  mockedUseIncomes.mockReturnValue({ data: incomes, isPending: false, error: null } as never);
+  mockedUseCategories.mockReturnValue({ data: [{ id: 'category-1', name: 'Alquiler' }] } as never);
+  mockedUseFunds.mockReturnValue({ data: [] } as never);
+  mockedUseRecord.mockReturnValue({ mutateAsync: jest.fn(), isPending: false } as never);
+  mockedUseVoid.mockReturnValue({ mutateAsync: jest.fn(), isPending: false } as never);
+  const updateMutate = jest.fn().mockResolvedValue({});
+  mockedUseUpdate.mockReturnValue({ mutateAsync: updateMutate, isPending: false } as never);
+  mockedUseIncomeApplicationPlan.mockReturnValue({
+    data: plan,
+    isPending: plan === undefined ? true : false,
+    error: null,
+  } as never);
+  mockedUseApplyIncomePolicy.mockReturnValue({ mutateAsync: jest.fn(), isPending: false } as never);
+  mockedUseCreateIncomeApplicationPlan.mockReturnValue({ mutateAsync: jest.fn(), isPending: false } as never);
+
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <IncomesTab tenantId="tenant-1" period="2026-08" />
+    </QueryClientProvider>,
+  );
+  return { ...utils, updateMutate };
+}
+
+describe('IncomesTab income edit (FIN-07BR)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('exposes Edit for a DRAFT income', () => {
+    renderIncomesTab([makeIncome()]);
+    expect(screen.getByRole('button', { name: 'Editar' })).toBeTruthy();
+  });
+
+  it('does not expose Edit for a RECORDED income', () => {
+    renderIncomesTab([makeIncome({ status: 'RECORDED' })]);
+    expect(screen.queryByRole('button', { name: 'Editar' })).toBeNull();
+  });
+
+  it('does not expose Edit for a VOID income', () => {
+    renderIncomesTab([makeIncome({ status: 'VOID' })]);
+    expect(screen.queryByRole('button', { name: 'Editar' })).toBeNull();
+  });
+
+  it('submits an exact amountMinor conversion on edit', async () => {
+    const { updateMutate } = renderIncomesTab([makeIncome()]);
+    fireEvent.click(screen.getByRole('button', { name: 'Editar' }));
+
+    const amountInput = screen.getByPlaceholderText('Dejarlo vacío conserva el actual');
+    fireEvent.change(amountInput, { target: { value: '123.45' } });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar/ }));
+
+    await waitFor(() => {
+      expect(updateMutate).toHaveBeenCalledWith({
+        incomeId: 'income-1',
+        data: expect.objectContaining({ amountMinor: 12345 }),
+      });
+    });
+  });
+
+  it('closes the dialog when nothing changed', async () => {
+    const { updateMutate } = renderIncomesTab([makeIncome()]);
+    fireEvent.click(screen.getByRole('button', { name: 'Editar' }));
+    fireEvent.click(screen.getByRole('button', { name: /Guardar/ }));
+
+    await waitFor(() => {
+      expect(updateMutate).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('IncomesTab allocated-income edit safety (FIN-07BR3)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each(['TENANT_SHARED', 'UNIT_GROUP'] as const)('locks amount and currency for %s', (scopeType) => {
+    renderIncomesTab([makeIncome({ scopeType })]);
+    fireEvent.click(screen.getByRole('button', { name: 'Editar' }));
+    const amount = screen.getByPlaceholderText('No editable con asignaciones') as HTMLInputElement;
+    const currency = screen.getByLabelText('Moneda') as HTMLSelectElement;
+    expect(amount.disabled).toBe(true);
+    expect(currency.disabled).toBe(true);
+    expect(screen.getByText(/asignaciones por edificio/)).toBeTruthy();
+  });
+
+  it.each([['TENANT_SHARED', 10000, '100.00'], ['UNIT_GROUP', 5000, '50.00']] as const)(
+    '%s disabled amount displays the decimal user value (not minor units)',
+    (scopeType, amountMinor, expected) => {
+      renderIncomesTab([makeIncome({ scopeType, amountMinor })]);
+      fireEvent.click(screen.getByRole('button', { name: 'Editar' }));
+      const amount = screen.getByPlaceholderText('No editable con asignaciones') as HTMLInputElement;
+      expect(amount.value).toBe(expected);
+    },
+  );
+
+  it.each(['TENANT_SHARED', 'UNIT_GROUP'] as const)('%s PATCH never includes amountMinor or currencyCode', async (scopeType) => {
+    const { updateMutate } = renderIncomesTab([makeIncome({ scopeType, description: 'vieja' })]);
+    fireEvent.click(screen.getByRole('button', { name: 'Editar' }));
+    fireEvent.change(screen.getByLabelText('Descripción'), { target: { value: 'nueva' } });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar/ }));
+
+    await waitFor(() => {
+      expect(updateMutate).toHaveBeenCalledTimes(1);
+    });
+    const data = updateMutate.mock.calls[0][0].data as Record<string, unknown>;
+    expect(data.amountMinor).toBeUndefined();
+    expect(data.currencyCode).toBeUndefined();
+    expect(data.description).toBe('nueva');
+  });
+
+  it('keeps category/date/description editable for shared scopes', async () => {
+    const { updateMutate } = renderIncomesTab([makeIncome({ scopeType: 'TENANT_SHARED' })]);
+    fireEvent.click(screen.getByRole('button', { name: 'Editar' }));
+    fireEvent.change(screen.getByLabelText('Fecha recibida'), { target: { value: '2026-08-12' } });
+    fireEvent.change(screen.getByLabelText('Descripción'), { target: { value: 'x' } });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar/ }));
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    const data = updateMutate.mock.calls[0][0].data as Record<string, unknown>;
+    expect(data.receivedDate).toBe('2026-08-12');
+    expect(data.description).toBe('x');
+    expect(data.categoryId).toBe('category-1');
+  });
+
+  it('allows BUILDING to PATCH currencyCode', async () => {
+    const { updateMutate } = renderIncomesTab([makeIncome()]);
+    fireEvent.click(screen.getByRole('button', { name: 'Editar' }));
+    fireEvent.change(screen.getByLabelText('Moneda'), { target: { value: 'USD' } });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar/ }));
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    expect((updateMutate.mock.calls[0][0].data as Record<string, unknown>).currencyCode).toBe('USD');
+  });
+});
+
+describe('IncomesTab description clear and date normalization (FIN-07BR3)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('clears an existing Income description intentionally', async () => {
+    const { updateMutate } = renderIncomesTab([makeIncome({ description: 'texto viejo' })]);
+    fireEvent.click(screen.getByRole('button', { name: 'Editar' }));
+    fireEvent.change(screen.getByLabelText('Descripción'), { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar/ }));
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    expect((updateMutate.mock.calls[0][0].data as Record<string, unknown>).description).toBe('');
+  });
+
+  it('does not manufacture a change for an unchanged null/empty description', async () => {
+    const { updateMutate } = renderIncomesTab([makeIncome({ description: null })]);
+    fireEvent.click(screen.getByRole('button', { name: 'Editar' }));
+    fireEvent.change(screen.getByLabelText('Fecha recibida'), { target: { value: '2026-08-12' } });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar/ }));
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    const data = updateMutate.mock.calls[0][0].data as Record<string, unknown>;
+    expect(data.description).toBeUndefined();
+    expect(data.receivedDate).toBe('2026-08-12');
+  });
+
+  it('renders the list date as YYYY-MM-DD, not raw ISO', () => {
+    renderIncomesTab([makeIncome()]);
+    expect(screen.getByText(/2026-08-10/)).toBeTruthy();
+    expect(screen.queryByText(/2026-08-10T00:00:00/)).toBeNull();
+  });
+
+  it('initializes the edit date input to YYYY-MM-DD', () => {
+    renderIncomesTab([makeIncome()]);
+    fireEvent.click(screen.getByRole('button', { name: 'Editar' }));
+    expect((screen.getByLabelText('Fecha recibida') as HTMLInputElement).value).toBe('2026-08-10');
+  });
+
+  it('sends a changed date as YYYY-MM-DD', async () => {
+    const { updateMutate } = renderIncomesTab([makeIncome()]);
+    fireEvent.click(screen.getByRole('button', { name: 'Editar' }));
+    fireEvent.change(screen.getByLabelText('Fecha recibida'), { target: { value: '2026-08-11' } });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar/ }));
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    const data = updateMutate.mock.calls[0][0].data as Record<string, unknown>;
+    expect(data.receivedDate).toBe('2026-08-11');
+  });
+
+  it('does not send receivedDate when unchanged', async () => {
+    const { updateMutate } = renderIncomesTab([makeIncome()]);
+    fireEvent.click(screen.getByRole('button', { name: 'Editar' }));
+    fireEvent.change(screen.getByLabelText('Descripción'), { target: { value: 'nuevo' } });
+    fireEvent.click(screen.getByRole('button', { name: /Guardar/ }));
+    await waitFor(() => expect(updateMutate).toHaveBeenCalledTimes(1));
+    const data = updateMutate.mock.calls[0][0].data as Record<string, unknown>;
+    expect(data.receivedDate).toBeUndefined();
+  });
+});
+
+describe('IncomesTab plan state machine (FIN-07BR3)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('VOID with empty plan does not say "Plan aplicado" nor expose creation', () => {
+    renderIncomesTab([makeIncome({ status: 'VOID' })], makePlan([]));
+    fireEvent.click(screen.getByRole('button', { name: 'Plan' }));
+    expect(screen.queryByText(/Plan aplicado\. Solo lectura/)).toBeNull();
+    expect(screen.queryByRole('button', { name: /Guardar plan manual/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Aplicar política/ })).toBeNull();
+    expect(screen.getByText(/anulado y no tiene plan de aplicaciones/)).toBeTruthy();
+  });
+
+  it('VOID with existing applications shows the historical read-only plan', () => {
+    renderIncomesTab([makeIncome({ status: 'VOID' })], makePlan([makeApplication()]));
+    fireEvent.click(screen.getByRole('button', { name: 'Plan' }));
+    expect(screen.getByText(/Plan aplicado\. Solo lectura/)).toBeTruthy();
+  });
+
+  it('RECORDED with empty plan exposes the application builder', () => {
+    renderIncomesTab([makeIncome({ status: 'RECORDED' })], makePlan([]));
+    fireEvent.click(screen.getByRole('button', { name: 'Plan' }));
+    expect(screen.getByRole('button', { name: /Aplicar política/ })).toBeTruthy();
+    expect(screen.getByRole('button', { name: /Guardar plan manual/ })).toBeTruthy();
+  });
+
+  it('DRAFT requires record first', () => {
+    renderIncomesTab([makeIncome()], makePlan([]));
+    fireEvent.click(screen.getByRole('button', { name: 'Plan' }));
+    expect(screen.getByText(/Registrá este ingreso antes de definir su plan/)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Guardar plan manual/ })).toBeNull();
+  });
+});

--- a/apps/web/features/finance/components/IncomesTab.tsx
+++ b/apps/web/features/finance/components/IncomesTab.tsx
@@ -1,0 +1,234 @@
+'use client';
+
+import { useState } from 'react';
+import { Loader2, Plus, Save, X } from 'lucide-react';
+import { CANONICAL_CURRENCIES } from '@buildingos/contracts';
+import Button from '@/shared/components/ui/Button';
+import Card from '@/shared/components/ui/Card';
+import { formatCurrency } from '@/shared/lib/format/money';
+import { useExpenseLedgerCategories, useIncomes, useRecordIncome, useUpdateIncome, useVoidIncome } from '../hooks/useExpenseLedger';
+import { useApplyIncomePolicy, useCreateIncomeApplicationPlan, useIncomeApplicationPlan } from '../hooks/useIncomeApplications';
+import { useFunds } from '../hooks/useFunds';
+import type { CreateIncomeApplicationInput, Income, IncomeApplication, IncomeApplicationDestination, UpdateIncomeData } from '../contracts';
+import { FinanceDialog } from './FinanceDialog';
+import { IncomeCreateModal } from './IncomeCreateModal';
+import { decimalToAmountMinor, minorToDecimalString, sumAmountMinor } from '../utils/money-input';
+import { incomeApplicationProvenance, type IncomeApplicationProvenanceOrigin } from '../utils/income-application-provenance';
+import { sameDateInput, toDateInputValue } from '../utils/date-input';
+
+interface IncomesTabProps {
+  readonly tenantId: string;
+  readonly period: string;
+}
+
+interface ApplicationDraft {
+  readonly id: string;
+  destinationType: IncomeApplicationDestination;
+  fundId: string;
+  amount: string;
+}
+
+function errorMessage(error: unknown, fallback: string) {
+  return error instanceof Error ? error.message : fallback;
+}
+
+export function IncomesTab({ tenantId, period }: IncomesTabProps) {
+  const [categoryId, setCategoryId] = useState('');
+  const [status, setStatus] = useState<'ALL' | Income['status']>('ALL');
+  const [showCreate, setShowCreate] = useState(false);
+  const [planIncome, setPlanIncome] = useState<Income | null>(null);
+  const [editingIncome, setEditingIncome] = useState<Income | null>(null);
+  const [confirmAction, setConfirmAction] = useState<{ income: Income; action: 'record' | 'void' } | null>(null);
+  const { data: incomes = [], isPending, error } = useIncomes(tenantId, { period, categoryId: categoryId || undefined });
+  const { data: categories = [] } = useExpenseLedgerCategories(tenantId, 'INCOME');
+  const { data: funds = [] } = useFunds(tenantId, { status: 'ACTIVE' });
+  const recordIncome = useRecordIncome(tenantId);
+  const voidIncome = useVoidIncome(tenantId);
+  const updateIncome = useUpdateIncome(tenantId);
+
+  const visibleIncomes = incomes.filter((income) => status === 'ALL' || income.status === status);
+  const runConfirmation = async () => {
+    if (!confirmAction) return;
+    try {
+      if (confirmAction.action === 'record') await recordIncome.mutateAsync(confirmAction.income.id);
+      else await voidIncome.mutateAsync(confirmAction.income.id);
+      setConfirmAction(null);
+    } catch {
+      // Mutation error stays visible in the confirmation dialog.
+    }
+  };
+  const confirmationMutation = confirmAction?.action === 'record' ? recordIncome : voidIncome;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">Ingresos</h3>
+          <p className="text-sm text-muted-foreground">Los borradores se registran antes de definir un plan de aplicaciones inmutable.</p>
+        </div>
+        <Button type="button" onClick={() => setShowCreate(true)} className="gap-2"><Plus className="h-4 w-4" />Registrar ingreso</Button>
+      </div>
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="text-sm font-medium">Rubro
+          <select value={categoryId} onChange={(event) => setCategoryId(event.target.value)} className="mt-1 w-full rounded border p-2">
+            <option value="">Todos los rubros</option>
+            {categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
+          </select>
+        </label>
+        <label className="text-sm font-medium">Estado
+          <select value={status} onChange={(event) => setStatus(event.target.value as typeof status)} className="mt-1 w-full rounded border p-2">
+            <option value="ALL">Todos</option><option value="DRAFT">Borrador</option><option value="RECORDED">Registrado</option><option value="VOID">Anulado</option>
+          </select>
+        </label>
+      </div>
+      {isPending ? <Card className="p-6 text-sm text-muted-foreground">Cargando ingresos...</Card> : error ? <Card className="p-6 text-sm text-red-700">{errorMessage(error, 'No pudimos cargar los ingresos.')}</Card> : visibleIncomes.length === 0 ? <Card className="p-6 text-center text-sm text-muted-foreground">No hay ingresos para los filtros seleccionados.</Card> : (
+        <div className="space-y-3">
+          {visibleIncomes.map((income) => <Card key={income.id} className="p-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-1">
+                <p className="font-medium">{income.categoryName}</p>
+                <p className="text-sm text-muted-foreground">{formatCurrency(income.amountMinor, income.currencyCode)} · {toDateInputValue(income.receivedDate)} · {income.scopeType}</p>
+                {income.description && <p className="text-sm text-muted-foreground">{income.description}</p>}
+                <span className="inline-flex rounded bg-muted px-2 py-0.5 text-xs font-medium">{income.status}</span>
+              </div>
+              <div className="flex flex-wrap gap-2">
+                <Button type="button" size="sm" variant="secondary" onClick={() => setPlanIncome(income)}>Plan</Button>
+                {income.status === 'DRAFT' && <Button type="button" size="sm" variant="secondary" onClick={() => setEditingIncome(income)}>Editar</Button>}
+                {income.status === 'DRAFT' && <Button type="button" size="sm" onClick={() => setConfirmAction({ income, action: 'record' })}>Registrar</Button>}
+                {income.status === 'RECORDED' && <Button type="button" size="sm" variant="secondary" onClick={() => setConfirmAction({ income, action: 'void' })}>Anular</Button>}
+              </div>
+            </div>
+          </Card>)}
+        </div>
+      )}
+      {showCreate && <IncomeCreateModal tenantId={tenantId} period={period} onClose={() => setShowCreate(false)} onCreated={() => setShowCreate(false)} />}
+      {planIncome && <IncomePlanDialog tenantId={tenantId} income={planIncome} funds={funds} onClose={() => setPlanIncome(null)} />}
+      {editingIncome && <IncomeEditDialog income={editingIncome} categories={categories} updateIncome={updateIncome} onClose={() => setEditingIncome(null)} />}
+      {confirmAction && <FinanceDialog title={confirmAction.action === 'record' ? 'Registrar ingreso' : 'Anular ingreso'} labelledBy="income-confirm-title" onClose={() => setConfirmAction(null)}>
+        <p className="text-sm text-muted-foreground">{confirmAction.action === 'record' ? 'Esta acción confirma el ingreso y no permitirá editarlo.' : 'Esta acción anula el ingreso registrado. Confirmá que querés continuar.'}</p>
+        {confirmationMutation.error && <p role="alert" className="mt-3 text-sm text-red-700">{errorMessage(confirmationMutation.error, 'No pudimos completar la acción.')}</p>}
+        <div className="mt-5 flex justify-end gap-2"><Button type="button" variant="secondary" onClick={() => setConfirmAction(null)}>Cancelar</Button><Button type="button" disabled={confirmationMutation.isPending} onClick={() => void runConfirmation()}>{confirmationMutation.isPending && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}Confirmar</Button></div>
+      </FinanceDialog>}
+    </div>
+  );
+}
+
+function IncomePlanDialog({ tenantId, income, funds, onClose }: { readonly tenantId: string; readonly income: Income; readonly funds: readonly { id: string; name: string }[]; readonly onClose: () => void }) {
+  const { data: plan, isPending, error } = useIncomeApplicationPlan(tenantId, income.id);
+  const applyPolicy = useApplyIncomePolicy(tenantId, income.id);
+  const createPlan = useCreateIncomeApplicationPlan(tenantId, income.id);
+  const [drafts, setDrafts] = useState<ApplicationDraft[]>([{ id: 'first', destinationType: 'OFFSET_EXPENSES', fundId: '', amount: '' }]);
+  const [formError, setFormError] = useState<string | null>(null);
+  const applications = plan?.applications ?? [];
+  const hasApplications = applications.length > 0;
+  const planNotApplicable = income.status === 'VOID' && !hasApplications;
+  const readonly = hasApplications;
+  const cannotCreatePlan = income.status !== 'RECORDED';
+  const updateDraft = (id: string, field: keyof Omit<ApplicationDraft, 'id'>, value: string) => setDrafts((current) => current.map((draft) => draft.id === id ? { ...draft, [field]: value } : draft));
+  const submitManualPlan = async () => {
+    const applications: CreateIncomeApplicationInput[] = [];
+    for (const draft of drafts) {
+      const amountMinor = decimalToAmountMinor(draft.amount);
+      if (!amountMinor) return setFormError('Cada aplicación debe tener un importe positivo con hasta dos decimales.');
+      if (draft.destinationType === 'FUND' && !draft.fundId) return setFormError('Las aplicaciones a fondo requieren seleccionar un fondo activo.');
+      applications.push({ destinationType: draft.destinationType, fundId: draft.destinationType === 'FUND' ? draft.fundId : null, amountMinor });
+    }
+    if (sumAmountMinor(applications.map((application) => application.amountMinor)) !== income.amountMinor) return setFormError('La suma debe coincidir exactamente con el importe del ingreso, sin redondeos.');
+    setFormError(null);
+    try { await createPlan.mutateAsync({ applications }); } catch { /* mutation error is rendered below */ }
+  };
+
+  return <FinanceDialog title={`Plan de aplicaciones: ${income.categoryName}`} labelledBy="income-plan-title" onClose={onClose}>
+    <p className="mb-4 text-sm text-muted-foreground">Total: {formatCurrency(income.amountMinor, income.currencyCode)} ({income.amountMinor} unidades menores).</p>
+    {isPending ? <p className="text-sm text-muted-foreground">Cargando plan...</p> : error ? <p role="alert" className="text-sm text-red-700">{errorMessage(error, 'No pudimos cargar el plan.')}</p> : readonly ? <div className="space-y-2"><p className="text-sm font-medium">Plan aplicado. Solo lectura.</p>{applications.map((application) => <ApplicationRow key={application.id} application={application} funds={funds} />)}</div> : planNotApplicable ? <p className="text-sm text-muted-foreground">Este ingreso está anulado y no tiene plan de aplicaciones.</p> : cannotCreatePlan ? <p className="text-sm text-muted-foreground">Registrá este ingreso antes de definir su plan de aplicaciones.</p> : (
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">Aplicá una política vigente o definí un plan manual. Los importes se convierten a unidades menores de forma exacta.</p>
+        <Button type="button" variant="secondary" disabled={applyPolicy.isPending} onClick={() => void applyPolicy.mutateAsync().catch(() => undefined)}>{applyPolicy.isPending && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}Aplicar política</Button>
+        {applyPolicy.error && <p role="alert" className="text-sm text-red-700">{errorMessage(applyPolicy.error, 'No pudimos aplicar la política.')}</p>}
+        <div className="space-y-2 rounded border p-3">{drafts.map((draft) => <div key={draft.id} className="grid gap-2 sm:grid-cols-[1fr_1fr_140px_auto]"><select aria-label="Destino" value={draft.destinationType} onChange={(event) => updateDraft(draft.id, 'destinationType', event.target.value)} className="rounded border p-2"><option value="OFFSET_EXPENSES">Compensar gastos</option><option value="FUND">Fondo</option><option value="CARRY_FORWARD">Arrastre</option></select>{draft.destinationType === 'FUND' ? <select aria-label="Fondo" value={draft.fundId} onChange={(event) => updateDraft(draft.id, 'fundId', event.target.value)} className="rounded border p-2"><option value="">Seleccioná un fondo</option>{funds.map((fund) => <option key={fund.id} value={fund.id}>{fund.name}</option>)}</select> : <span className="hidden sm:block" />}<input aria-label="Importe" inputMode="decimal" value={draft.amount} onChange={(event) => updateDraft(draft.id, 'amount', event.target.value)} placeholder="0.00" className="rounded border p-2" /><Button type="button" variant="secondary" size="sm" disabled={drafts.length === 1} onClick={() => setDrafts((current) => current.filter((item) => item.id !== draft.id))}>Quitar</Button></div>)}<div className="mt-2 flex flex-wrap gap-2"><Button type="button" variant="secondary" size="sm" onClick={() => setDrafts((current) => [...current, { id: String(Date.now()), destinationType: 'OFFSET_EXPENSES', fundId: '', amount: '' }])}>Agregar destino</Button><Button type="button" disabled={createPlan.isPending} onClick={() => void submitManualPlan()}>{createPlan.isPending && <Loader2 className="mr-1 h-4 w-4 animate-spin" />}Guardar plan manual</Button></div></div>
+        {(formError || createPlan.error) && <p role="alert" className="text-sm text-red-700">{formError ?? errorMessage(createPlan.error, 'No pudimos guardar el plan.')}</p>}
+      </div>
+    )}
+  </FinanceDialog>;
+}
+
+function provenanceOriginLabel(origin: IncomeApplicationProvenanceOrigin | null): string {
+  switch (origin) {
+    case 'MANUAL': return 'Origen: Manual';
+    case 'POLICY': return 'Origen: Política';
+    case 'LEGACY': return 'Origen: Legacy';
+    default: return 'Origen: Desconocido';
+  }
+}
+
+function ApplicationRow({ application, funds }: { readonly application: IncomeApplication; readonly funds: readonly { id: string; name: string }[] }) {
+  const provenance = incomeApplicationProvenance(application);
+  return <div className="rounded border p-3 text-sm space-y-1">
+    <div className="flex flex-wrap items-center gap-x-2"><span className="font-medium">{application.destinationType}</span> · {formatCurrency(application.amountMinor, application.currencyCode)}{application.fundId ? ` · Fondo ${funds.find((fund) => fund.id === application.fundId)?.name ?? application.fundId}` : ''}</div>
+    <p className={provenance.origin === 'INVALID' ? 'text-red-700' : 'text-muted-foreground'}>
+      {provenanceOriginLabel(provenance.origin)}
+      {provenance.origin === 'POLICY' && provenance.policyVersionId ? ` · Versión ${provenance.policyVersionId}` : ''}
+      {provenance.origin === 'LEGACY' && provenance.legacyDestination ? ` · Destino legado ${provenance.legacyDestination}` : ''}
+    </p>
+  </div>;
+}
+
+function IncomeEditDialog({ income, categories, updateIncome, onClose }: {
+  readonly income: Income;
+  readonly categories: readonly { id: string; name: string }[];
+  readonly updateIncome: ReturnType<typeof useUpdateIncome>;
+  readonly onClose: () => void;
+}) {
+  const scopeAllocates = income.scopeType === 'TENANT_SHARED' || income.scopeType === 'UNIT_GROUP';
+  const originalDescription = (income.description ?? '').trim();
+  const [categoryId, setCategoryId] = useState(income.categoryId);
+  const [amount, setAmount] = useState('');
+  const [currencyCode, setCurrencyCode] = useState(income.currencyCode);
+  const [receivedDate, setReceivedDate] = useState(toDateInputValue(income.receivedDate));
+  const [description, setDescription] = useState(income.description ?? '');
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const submit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    const amountChanged = amount.trim() !== '';
+    const amountMinor = amountChanged ? decimalToAmountMinor(amount) : income.amountMinor;
+    if (amountChanged && !amountMinor) return setFormError('Ingresá un monto positivo con hasta dos decimales.');
+    // Los ingresos con asignaciones por edificio no pueden cambiar monto/moneda.
+    const descriptionChanged = description.trim() !== originalDescription;
+    const dateChanged = !sameDateInput(receivedDate, income.receivedDate);
+    const unchanged = !amountChanged && !dateChanged && !descriptionChanged && categoryId === income.categoryId && (scopeAllocates || currencyCode === income.currencyCode);
+    if (unchanged) {
+      onClose();
+      return;
+    }
+    const data: UpdateIncomeData = { categoryId };
+    if (descriptionChanged) data.description = description.trim();
+    if (!scopeAllocates) {
+      data.currencyCode = currencyCode;
+      if (amountChanged && amountMinor != null) data.amountMinor = amountMinor;
+    }
+    if (dateChanged) data.receivedDate = toDateInputValue(receivedDate);
+    setFormError(null);
+    try {
+      await updateIncome.mutateAsync({ incomeId: income.id, data });
+      onClose();
+    } catch {
+      // Mutation error is rendered below.
+    }
+  };
+
+  return <FinanceDialog title="Editar ingreso" labelledBy="income-edit-title" onClose={onClose}>
+    <form onSubmit={submit} className="space-y-4">
+      <div className="grid gap-3 sm:grid-cols-2">
+        <label className="text-sm font-medium">Rubro<select required value={categoryId} onChange={(event) => setCategoryId(event.target.value)} className="mt-1 w-full rounded border p-2"><option value="">Seleccioná un rubro</option>{categories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}</select></label>
+        <label className="text-sm font-medium">Moneda<select value={currencyCode} disabled={scopeAllocates} onChange={(event) => setCurrencyCode(event.target.value)} className="mt-1 w-full rounded border p-2">{CANONICAL_CURRENCIES.map((currency) => <option key={currency} value={currency}>{currency}</option>)}</select></label>
+        <label className={`text-sm font-medium ${scopeAllocates ? 'opacity-60' : ''}`}>Monto<input inputMode="decimal" disabled={scopeAllocates} placeholder={scopeAllocates ? 'No editable con asignaciones' : 'Dejarlo vacío conserva el actual'} value={scopeAllocates ? minorToDecimalString(income.amountMinor) : amount} onChange={(event) => setAmount(event.target.value)} className="mt-1 w-full rounded border p-2 disabled:cursor-not-allowed" /></label>
+        <label className="text-sm font-medium">Fecha recibida<input required type="date" value={receivedDate} onChange={(event) => setReceivedDate(event.target.value)} className="mt-1 w-full rounded border p-2" /></label>
+      </div>
+      <label className="block text-sm font-medium">Descripción<textarea value={description} onChange={(event) => setDescription(event.target.value)} rows={3} className="mt-1 w-full rounded border p-2" /></label>
+      {scopeAllocates ? <p className="text-xs text-muted-foreground">El monto y la moneda no pueden cambiarse porque este ingreso tiene asignaciones por edificio.</p> : <p className="text-xs text-muted-foreground">El alcance y las unidades asignadas no se modifican aquí; solo se pueden editar los campos que el contrato de actualización permite.</p>}
+      {(formError || updateIncome.error) && <p role="alert" className="text-sm text-red-700">{formError ?? errorMessage(updateIncome.error, 'No pudimos guardar los cambios.')}</p>}
+      <div className="flex justify-end gap-2"><Button type="button" variant="secondary" onClick={onClose}><X className="mr-1 h-4 w-4" />Cancelar</Button><Button type="submit" disabled={updateIncome.isPending}>{updateIncome.isPending ? <Loader2 className="mr-1 h-4 w-4 animate-spin" /> : <Save className="mr-1 h-4 w-4" />}Guardar</Button></div>
+    </form>
+  </FinanceDialog>;
+}

--- a/apps/web/features/finance/components/TenantFinanceDashboard.test.tsx
+++ b/apps/web/features/finance/components/TenantFinanceDashboard.test.tsx
@@ -111,6 +111,18 @@ jest.mock('./TenantRecurringExpensesTab', () => ({
   ),
 }));
 
+jest.mock('./IncomesTab', () => ({
+  IncomesTab: () => <div>Incomes tab</div>,
+}));
+
+jest.mock('./FundsTab', () => ({
+  FundsTab: () => <div>Funds tab</div>,
+}));
+
+jest.mock('./IncomePoliciesTab', () => ({
+  IncomePoliciesTab: () => <div>Income policies tab</div>,
+}));
+
 jest.mock('@/shared/lib/format/money', () => ({
   formatCurrency: (value: number) => `$${value.toLocaleString('es-AR')}`,
 }));
@@ -221,5 +233,16 @@ describe('TenantFinanceDashboard', () => {
     render(<TenantFinanceDashboard />);
 
     expect(screen.queryByTestId('tenant-recurring-tab')).toBeNull();
+  });
+
+  it.each([
+    ['incomes', 'Incomes tab'],
+    ['funds', 'Funds tab'],
+    ['policies', 'Income policies tab'],
+  ])('selects the %s finance tab from the query string', (tab, expectedContent) => {
+    searchParams = new URLSearchParams(`tab=${tab}`);
+    render(<TenantFinanceDashboard />);
+
+    expect(screen.getByText(expectedContent)).toBeTruthy();
   });
 });

--- a/apps/web/features/finance/components/TenantFinanceDashboard.tsx
+++ b/apps/web/features/finance/components/TenantFinanceDashboard.tsx
@@ -26,8 +26,11 @@ import { getDownloadUrl } from '@/features/buildings/services/documents.api';
 import { FileText, Loader2 } from 'lucide-react';
 import { useToast } from '@/shared/components/ui/Toast';
 import { MulticurrencySettings } from './MulticurrencySettings';
+import { IncomesTab } from './IncomesTab';
+import { FundsTab } from './FundsTab';
+import { IncomePoliciesTab } from './IncomePoliciesTab';
 
-type Tab = 'overview' | 'rubros' | 'expenses' | 'recurring' | 'payments' | 'charges' | 'delinquent' | 'reports' | 'notas' | 'settings';
+type Tab = 'overview' | 'rubros' | 'expenses' | 'recurring' | 'payments' | 'charges' | 'incomes' | 'funds' | 'policies' | 'delinquent' | 'reports' | 'notas' | 'settings';
 
 interface Params {
   tenantId: string;
@@ -45,7 +48,7 @@ export const TenantFinanceDashboard = () => {
   const searchParams = useSearchParams();
   const tenantId = params?.tenantId;
   const currentMonth = new Date().toISOString().slice(0, 7);
-  const allowedTabs: readonly Tab[] = ['overview', 'rubros', 'expenses', 'recurring', 'payments', 'charges', 'delinquent', 'reports', 'notas', 'settings'];
+  const allowedTabs: readonly Tab[] = ['overview', 'rubros', 'expenses', 'recurring', 'payments', 'charges', 'incomes', 'funds', 'policies', 'delinquent', 'reports', 'notas', 'settings'];
   const activeTab = (() => {
     const tabParam = searchParams.get('tab');
     if (tabParam && allowedTabs.includes(tabParam as Tab)) {
@@ -177,7 +180,10 @@ export const TenantFinanceDashboard = () => {
                 { id: 'rubros', label: 'Rubros' },
                 { id: 'recurring', label: 'Reglas recurrentes' },
                 { id: 'payments', label: `Pagos (${payments.length})` },
-                { id: 'charges', label: 'Cargos' },
+                 { id: 'charges', label: 'Cargos' },
+                 { id: 'incomes', label: 'Ingresos' },
+                 { id: 'funds', label: 'Fondos' },
+                 { id: 'policies', label: 'Políticas de ingreso' },
                 { id: 'delinquent', label: `Morosos (${summary?.delinquentUnitsCount || 0})` },
                 { id: 'reports', label: 'Historial de gastos' },
                  { id: 'notas', label: 'Notas Revelatorias' },
@@ -317,6 +323,9 @@ export const TenantFinanceDashboard = () => {
         {activeTab === 'charges' && (
           <TenantChargesTab tenantId={tenantId || ''} buildingNames={buildingNames} />
         )}
+        {activeTab === 'incomes' && <IncomesTab tenantId={tenantId || ''} period={period} />}
+        {activeTab === 'funds' && <FundsTab tenantId={tenantId || ''} />}
+        {activeTab === 'policies' && <IncomePoliciesTab tenantId={tenantId || ''} />}
         {activeTab === 'delinquent' && (
           <TenantDelinquentUnitsList 
             tenantId={tenantId || ''} 

--- a/apps/web/features/finance/components/index.ts
+++ b/apps/web/features/finance/components/index.ts
@@ -21,3 +21,6 @@ export { RecurringExpensesTab } from './RecurringExpensesTab';
 export { RecurringExpenseModal } from './RecurringExpenseModal';
 export { TenantRecurringExpensesTab } from './TenantRecurringExpensesTab';
 export { TenantRecurringExpenseModal } from './TenantRecurringExpenseModal';
+export { IncomesTab } from './IncomesTab';
+export { FundsTab } from './FundsTab';
+export { IncomePoliciesTab } from './IncomePoliciesTab';

--- a/apps/web/features/finance/contracts/finance-guards.test.ts
+++ b/apps/web/features/finance/contracts/finance-guards.test.ts
@@ -29,8 +29,16 @@ describe('FIN-07AR finance guards', () => {
     expect(isFund(fund)).toBe(true);
     expect(isFund({ ...fund, scopeType: 'BUILDING' })).toBe(false);
     expect(isFund({ ...fund, createdAt: undefined })).toBe(false);
-    expect(isFundTransaction({ id: 'tx', tenantId: 'tenant', fundId: 'fund', direction: 'CREDIT', amountMinor: 1, currencyCode: 'COP', occurredAt: '2026-08-01', description: null, idempotencyKey: null, reversalOfTransactionId: null, createdAt: '2026-08-01' })).toBe(true);
+    expect(isFundTransaction({ id: 'tx', tenantId: 'tenant', fundId: 'fund', direction: 'CREDIT', amountMinor: 1, currencyCode: 'COP', occurredAt: '2026-08-01', description: null, idempotencyKey: null, reversalOfTransactionId: null, incomeApplicationId: null, createdAt: '2026-08-01' })).toBe(true);
     expect(isFundTransaction({ id: 'tx', tenantId: 'tenant', fundId: 'fund', direction: 'CREDIT', amountMinor: 1, currencyCode: 'COP' })).toBe(false);
+  });
+
+  it('accepts incomeApplicationId string|null and rejects malformed provenance', () => {
+    const base = { id: 'tx', tenantId: 'tenant', fundId: 'fund', direction: 'CREDIT', amountMinor: 1, currencyCode: 'COP', occurredAt: '2026-08-01', description: null, idempotencyKey: null, reversalOfTransactionId: null, createdAt: '2026-08-01' };
+    expect(isFundTransaction({ ...base, incomeApplicationId: null })).toBe(true);
+    expect(isFundTransaction({ ...base, incomeApplicationId: 'app-1' })).toBe(true);
+    expect(isFundTransaction({ ...base, incomeApplicationId: undefined })).toBe(false);
+    expect(isFundTransaction({ ...base, incomeApplicationId: 123 })).toBe(false);
   });
 
   it('rejects malformed policy versions and basis points', () => {

--- a/apps/web/features/finance/contracts/finance-guards.ts
+++ b/apps/web/features/finance/contracts/finance-guards.ts
@@ -112,6 +112,7 @@ export function isFundTransaction(value: unknown): value is FundTransaction {
     isNullableString(transaction.description) &&
     isNullableString(transaction.idempotencyKey) &&
     isNullableString(transaction.reversalOfTransactionId) &&
+    isNullableString(transaction.incomeApplicationId) &&
     isNonEmptyString(transaction.createdAt)
   );
 }
@@ -196,7 +197,7 @@ export function isIncomeApplicationPlan(value: unknown): value is IncomeApplicat
   return (
     isNonEmptyString(plan.incomeId) &&
     isNonEmptyString(plan.currencyCode) &&
-    isPositiveSafeInt(plan.totalAmountMinor) &&
+    isNonNegativeInt(plan.totalAmountMinor) &&
     Array.isArray(plan.applications) &&
     plan.applications.every(isIncomeApplication)
   );

--- a/apps/web/features/finance/contracts/finance-types.ts
+++ b/apps/web/features/finance/contracts/finance-types.ts
@@ -72,6 +72,7 @@ export interface FundTransaction {
   description: string | null;
   idempotencyKey: string | null;
   reversalOfTransactionId: string | null;
+  incomeApplicationId: string | null;
   createdAt: string;
 }
 
@@ -128,6 +129,14 @@ export interface MovementAllocationInput {
   amountMinor?: number;
   percentage?: number;
   currencyCode?: string;
+}
+
+export interface UnitGroupOption {
+  id: string;
+  buildingId: string;
+  name: string;
+  description: string | null;
+  memberCount: number;
 }
 
 export interface CreateIncomeData {

--- a/apps/web/features/finance/hooks/finance-query-keys.ts
+++ b/apps/web/features/finance/hooks/finance-query-keys.ts
@@ -33,6 +33,8 @@ export const financeKeys = {
   ) =>
     ['finance', tenantId, 'legacy-backfill', 'preview', query ?? {}] as const,
   financeSettings: (tenantId: string) => ['finance', tenantId, 'settings'] as const,
+  unitGroups: (tenantId: string, buildingId: string) =>
+    ['finance', tenantId, 'unit-groups', buildingId] as const,
 
   liquidations: (tenantId: string, query?: { buildingId?: string; period?: string }) =>
     ['finance', tenantId, 'liquidations', query ?? {}] as const,

--- a/apps/web/features/finance/services/finance-contracts.api.test.ts
+++ b/apps/web/features/finance/services/finance-contracts.api.test.ts
@@ -36,7 +36,7 @@ describe('FIN-07A finance contract APIs', () => {
     mockedApiClient.mockResolvedValueOnce({
       id: 'transaction-2', tenantId: 'tenant-1', fundId: 'fund-1', direction: 'DEBIT',
       amountMinor: 100, currencyCode: 'USD', occurredAt: '2026-08-01T00:00:00.000Z',
-      description: null, idempotencyKey: null, reversalOfTransactionId: null, createdAt: '2026-08-01T00:00:00.000Z',
+      description: null, idempotencyKey: null, reversalOfTransactionId: null, incomeApplicationId: null, createdAt: '2026-08-01T00:00:00.000Z',
     });
 
     await reverseFundTransaction('tenant-1', 'fund-1', 'transaction-1', { reason: 'Duplicate entry' });
@@ -77,6 +77,16 @@ describe('FIN-07A finance contract APIs', () => {
     await expect(getIncomeApplicationPlan('tenant-1', 'income-1')).rejects.toThrow(
       'Invalid income application plan response',
     );
+  });
+
+  it('accepts an empty plan before its first application', async () => {
+    mockedApiClient.mockResolvedValueOnce({
+      incomeId: 'income-1', currencyCode: 'VES', totalAmountMinor: 0, applications: [],
+    });
+
+    await expect(getIncomeApplicationPlan('tenant-1', 'income-1')).resolves.toEqual({
+      incomeId: 'income-1', currencyCode: 'VES', totalAmountMinor: 0, applications: [],
+    });
   });
 
   it('rejects malformed legacy preview monetary amounts', async () => {

--- a/apps/web/features/finance/services/liquidation.api.test.ts
+++ b/apps/web/features/finance/services/liquidation.api.test.ts
@@ -29,7 +29,7 @@ function listSourceFiles(directory: string): string[] {
 
 describe('legacy liquidation cleanup', () => {
   beforeEach(() => {
-    mockedApiClient.mockResolvedValue({});
+    mockedApiClient.mockResolvedValue([]);
   });
 
   it('does not leave active code importing the legacy liquidation hook or API', () => {
@@ -54,8 +54,16 @@ describe('legacy liquidation cleanup', () => {
 
     expect(mockedApiClient).toHaveBeenCalledWith({
       path: '/tenants/tenant-1/unit-groups?buildingId=building-1',
-      headers: { 'tenant-id': 'tenant-1' },
+      headers: { 'x-tenant-id': 'tenant-1' },
     });
+  });
+
+  it('rejects an invalid unit group list response', async () => {
+    mockedApiClient.mockResolvedValueOnce({});
+
+    await expect(unitGroupApi.list('tenant-1', 'building-1')).rejects.toThrow(
+      'Invalid unit group list response',
+    );
   });
 
   it('keeps allocationApi available with unchanged request behavior', async () => {
@@ -84,7 +92,7 @@ describe('legacy liquidation cleanup', () => {
         description: 'Main block',
         unitIds: ['unit-1', 'unit-2'],
       },
-      headers: { 'tenant-id': 'tenant-1' },
+      headers: { 'x-tenant-id': 'tenant-1' },
     });
   });
 

--- a/apps/web/features/finance/services/liquidation.api.ts
+++ b/apps/web/features/finance/services/liquidation.api.ts
@@ -1,4 +1,15 @@
 import { apiClient } from '@/shared/lib/http/client';
+import type { UnitGroupOption } from '../contracts/finance-types';
+
+function isUnitGroupOption(value: unknown): value is UnitGroupOption {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const group = value as Record<string, unknown>;
+  return (
+    typeof group.id === 'string' && typeof group.buildingId === 'string' &&
+    typeof group.name === 'string' && (group.description === null || typeof group.description === 'string') &&
+    typeof group.memberCount === 'number' && Number.isSafeInteger(group.memberCount) && group.memberCount >= 0
+  );
+}
 
 interface CreateUnitGroupPayload {
   readonly buildingId: string;
@@ -44,7 +55,7 @@ export const unitGroupApi = {
         description: payload.description?.trim(),
         unitIds: payload.unitIds.map((unitId) => requirePathSegment('unitId', unitId)),
       },
-      headers: { 'tenant-id': tenantId.trim() },
+      headers: { 'x-tenant-id': tenantId.trim() },
     });
   },
 
@@ -56,23 +67,27 @@ export const unitGroupApi = {
     const groupSegment = requirePathSegment('groupId', groupId);
     return apiClient({
       path: `/tenants/${tenantSegment}/unit-groups/${groupSegment}`,
-      headers: { 'tenant-id': tenantId.trim() },
+      headers: { 'x-tenant-id': tenantId.trim() },
     });
   },
 
   /**
    * List unit groups for tenant (optionally filtered by building)
    */
-  async list(tenantId: string, buildingId?: string) {
+  async list(tenantId: string, buildingId?: string): Promise<UnitGroupOption[]> {
     const tenantSegment = requirePathSegment('tenantId', tenantId);
     const params = new URLSearchParams();
     const normalizedBuildingId = optionalQueryValue('buildingId', buildingId);
     if (normalizedBuildingId) params.append('buildingId', normalizedBuildingId);
     const query = params.toString();
-    return apiClient({
+    const groups = await apiClient<unknown>({
       path: `/tenants/${tenantSegment}/unit-groups${query ? `?${query}` : ''}`,
-      headers: { 'tenant-id': tenantId.trim() },
+      headers: { 'x-tenant-id': tenantId.trim() },
     });
+    if (!Array.isArray(groups) || !groups.every(isUnitGroupOption)) {
+      throw new TypeError('Invalid unit group list response');
+    }
+    return groups;
   },
 
   /**
@@ -86,7 +101,7 @@ export const unitGroupApi = {
       path: `/tenants/${tenantSegment}/unit-groups/${groupSegment}/members/${unitSegment}`,
       method: 'POST',
       body: { unitId: unitId.trim() },
-      headers: { 'tenant-id': tenantId.trim() },
+      headers: { 'x-tenant-id': tenantId.trim() },
     });
   },
 
@@ -100,7 +115,7 @@ export const unitGroupApi = {
     return apiClient({
       path: `/tenants/${tenantSegment}/unit-groups/${groupSegment}/members/${unitSegment}`,
       method: 'DELETE',
-      headers: { 'tenant-id': tenantId.trim() },
+      headers: { 'x-tenant-id': tenantId.trim() },
     });
   },
 
@@ -113,7 +128,7 @@ export const unitGroupApi = {
     return apiClient({
       path: `/tenants/${tenantSegment}/unit-groups/${groupSegment}`,
       method: 'DELETE',
-      headers: { 'tenant-id': tenantId.trim() },
+      headers: { 'x-tenant-id': tenantId.trim() },
     });
   },
 };

--- a/apps/web/features/finance/utils/currency-default.test.ts
+++ b/apps/web/features/finance/utils/currency-default.test.ts
@@ -1,0 +1,20 @@
+import { resolveDefaultCurrency } from './currency-default';
+
+const CANON = ['ARS', 'USD', 'VES', 'COP'] as const;
+
+describe('resolveDefaultCurrency', () => {
+  it('uses the configured functional currency', () => {
+    expect(resolveDefaultCurrency('USD', CANON)).toBe('USD');
+    expect(resolveDefaultCurrency('VES', CANON)).toBe('VES');
+    expect(resolveDefaultCurrency('COP', CANON)).toBe('COP');
+  });
+
+  it('falls back to the first canonical currency when settings are absent', () => {
+    expect(resolveDefaultCurrency(undefined, CANON)).toBe('ARS');
+    expect(resolveDefaultCurrency(null, CANON)).toBe('ARS');
+  });
+
+  it('ignores an unknown functional currency and falls back to canonical', () => {
+    expect(resolveDefaultCurrency('EUR' as string, CANON)).toBe('ARS');
+  });
+});

--- a/apps/web/features/finance/utils/currency-default.ts
+++ b/apps/web/features/finance/utils/currency-default.ts
@@ -1,0 +1,18 @@
+/**
+ * FIN-07BR3: resolución del default de moneda.
+ *
+ * Precedencia:
+ * 1. financeSettings.functionalCurrency (solo si pertenece al canon)
+ * 2. CANONICAL_CURRENCIES[0] como fallback técnico
+ *
+ * Nunca hardcodear ARS/USD/VES/COP como default de negocio.
+ */
+export function resolveDefaultCurrency(
+  functionalCurrency: string | null | undefined,
+  canonical: readonly string[],
+): string {
+  if (functionalCurrency && canonical.includes(functionalCurrency)) {
+    return functionalCurrency;
+  }
+  return canonical[0] ?? '';
+}

--- a/apps/web/features/finance/utils/date-input.test.ts
+++ b/apps/web/features/finance/utils/date-input.test.ts
@@ -1,0 +1,46 @@
+import { sameDateInput, toDateInputValue, todayLocalDate, toLocalDateString } from './date-input';
+
+// Zona explícita (UTC-04) para validar el borde UTC->calendario local.
+const previousTZ = process.env.TZ;
+process.env.TZ = 'Etc/GMT+4';
+afterAll(() => {
+  process.env.TZ = previousTZ;
+});
+
+describe('date input normalization (FIN-07BR3)', () => {
+  it('normalizes an ISO receivedDate to YYYY-MM-DD', () => {
+    expect(toDateInputValue('2026-08-10T00:00:00.000Z')).toBe('2026-08-10');
+  });
+
+  it('passes a plain date through as-is', () => {
+    expect(toDateInputValue('2026-08-10')).toBe('2026-08-10');
+  });
+
+  it('handles empty values', () => {
+    expect(toDateInputValue('')).toBe('');
+  });
+
+  it('treats ISO and plain date as the same day', () => {
+    expect(sameDateInput('2026-08-10', '2026-08-10T00:00:00.000Z')).toBe(true);
+    expect(sameDateInput('2026-08-11', '2026-08-10T00:00:00.000Z')).toBe(false);
+  });
+});
+
+describe('local calendar date default (FIN-07BR3F)', () => {
+  it('uses local calendar components, not UTC, for a late-evening instant at UTC-04', () => {
+    // 2026-08-18T02:30:00Z === 2026-08-17T22:30 local (Etc/GMT+4).
+    const instant = new Date('2026-08-18T02:30:00.000Z');
+    expect(instant.toISOString().slice(0, 10)).toBe('2026-08-18'); // UTC day
+    expect(toLocalDateString(instant)).toBe('2026-08-17'); // local calendar day
+  });
+
+  it('returns the local calendar date for "today" with fake timers', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-08-18T02:30:00.000Z'));
+    expect(todayLocalDate()).toBe('2026-08-17');
+    jest.useRealTimers();
+  });
+
+  it('zero-pads month and day', () => {
+    expect(toLocalDateString(new Date('2026-08-05T12:00:00.000Z'))).toBe('2026-08-05');
+  });
+});

--- a/apps/web/features/finance/utils/date-input.test.ts
+++ b/apps/web/features/finance/utils/date-input.test.ts
@@ -1,12 +1,5 @@
 import { sameDateInput, toDateInputValue, todayLocalDate, toLocalDateString } from './date-input';
 
-// Zona explícita (UTC-04) para validar el borde UTC->calendario local.
-const previousTZ = process.env.TZ;
-process.env.TZ = 'Etc/GMT+4';
-afterAll(() => {
-  process.env.TZ = previousTZ;
-});
-
 describe('date input normalization (FIN-07BR3)', () => {
   it('normalizes an ISO receivedDate to YYYY-MM-DD', () => {
     expect(toDateInputValue('2026-08-10T00:00:00.000Z')).toBe('2026-08-10');
@@ -27,20 +20,45 @@ describe('date input normalization (FIN-07BR3)', () => {
 });
 
 describe('local calendar date default (FIN-07BR3F)', () => {
-  it('uses local calendar components, not UTC, for a late-evening instant at UTC-04', () => {
-    // 2026-08-18T02:30:00Z === 2026-08-17T22:30 local (Etc/GMT+4).
+  it('reads local calendar components instead of the UTC serialization', () => {
+    // Instante UTC real. Sus getters de calendario local se simulan de forma
+    // determinista (2026-08-17) para no depender de la timezone de la máquina.
     const instant = new Date('2026-08-18T02:30:00.000Z');
-    expect(instant.toISOString().slice(0, 10)).toBe('2026-08-18'); // UTC day
-    expect(toLocalDateString(instant)).toBe('2026-08-17'); // local calendar day
+    const yearSpy = jest.spyOn(instant, 'getFullYear').mockReturnValue(2026);
+    const monthSpy = jest.spyOn(instant, 'getMonth').mockReturnValue(7);
+    const daySpy = jest.spyOn(instant, 'getDate').mockReturnValue(17);
+    try {
+      expect(instant.toISOString().slice(0, 10)).toBe('2026-08-18');
+      expect(toLocalDateString(instant)).toBe('2026-08-17');
+    } finally {
+      yearSpy.mockRestore();
+      monthSpy.mockRestore();
+      daySpy.mockRestore();
+    }
   });
 
-  it('returns the local calendar date for "today" with fake timers', () => {
-    jest.useFakeTimers().setSystemTime(new Date('2026-08-18T02:30:00.000Z'));
-    expect(todayLocalDate()).toBe('2026-08-17');
-    jest.useRealTimers();
+  it('returns the local calendar date for "today" with frozen timers', () => {
+    jest.useFakeTimers();
+    try {
+      const frozen = new Date('2026-08-18T02:30:00.000Z');
+      jest.setSystemTime(frozen);
+      expect(todayLocalDate()).toBe(toLocalDateString(new Date()));
+    } finally {
+      jest.useRealTimers();
+    }
   });
 
-  it('zero-pads month and day', () => {
-    expect(toLocalDateString(new Date('2026-08-05T12:00:00.000Z'))).toBe('2026-08-05');
+  it('zero-pads month and day with controlled calendar components', () => {
+    const date = new Date('2026-08-05T12:00:00.000Z');
+    const yearSpy = jest.spyOn(date, 'getFullYear').mockReturnValue(2026);
+    const monthSpy = jest.spyOn(date, 'getMonth').mockReturnValue(7);
+    const daySpy = jest.spyOn(date, 'getDate').mockReturnValue(5);
+    try {
+      expect(toLocalDateString(date)).toBe('2026-08-05');
+    } finally {
+      yearSpy.mockRestore();
+      monthSpy.mockRestore();
+      daySpy.mockRestore();
+    }
   });
 });

--- a/apps/web/features/finance/utils/date-input.ts
+++ b/apps/web/features/finance/utils/date-input.ts
@@ -1,0 +1,38 @@
+/**
+ * FIN-07BR3: normalización de fechas tipo date input (YYYY-MM-DD).
+ *
+ * El backend serializa Income.receivedDate como ISO (p.ej. 2026-08-10T00:00:00.000Z),
+ * pero un <input type="date"> requiere YYYY-MM-DD. Recortar prefix es seguro
+ * porque la plataforma trabaja con fechas calendario (sin semántica de instante).
+ */
+export function toDateInputValue(value: string): string {
+  const normalized = value.trim();
+  if (!normalized) return '';
+  return normalized.slice(0, 10);
+}
+
+/**
+ * True si el valor editado representa la misma fecha que el original
+ * (comparación normalizada; evita "changes" espurios por offsets ISO).
+ */
+export function sameDateInput(edited: string, original: string): boolean {
+  return toDateInputValue(edited) === toDateInputValue(original);
+}
+
+/**
+ * YYYY-MM-DD desde los componentes de calendario LOCAL del Date dado.
+ *
+ * NO usar toISOString() para "hoy": toISOString es UTC y puede devolver
+ * el día siguiente en timezones UTC-negativas durante la tarde/noche.
+ */
+export function toLocalDateString(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/** Fecha de calendario local de "hoy" (o del Date provisto) en YYYY-MM-DD. */
+export function todayLocalDate(now: Date = new Date()): string {
+  return toLocalDateString(now);
+}

--- a/apps/web/features/finance/utils/fund-transaction.test.ts
+++ b/apps/web/features/finance/utils/fund-transaction.test.ts
@@ -1,0 +1,35 @@
+import { isFundTransactionReversible } from './fund-transaction';
+
+describe('isFundTransactionReversible', () => {
+  const base = {
+    id: 'tx-manual',
+    incomeApplicationId: null,
+    reversalOfTransactionId: null,
+  };
+
+  it('allows an untouched manual transaction', () => {
+    expect(isFundTransactionReversible(base, [])).toBe(true);
+  });
+
+  it('blocks a transaction owned by an IncomeApplication', () => {
+    expect(isFundTransactionReversible(
+      { ...base, incomeApplicationId: 'app-1' },
+      [],
+    )).toBe(false);
+  });
+
+  it('blocks a transaction that is itself a reversal row', () => {
+    expect(isFundTransactionReversible(
+      { ...base, reversalOfTransactionId: 'tx-original' },
+      [],
+    )).toBe(false);
+  });
+
+  it('blocks an already-reversed original', () => {
+    const transactions = [
+      base,
+      { id: 'tx-reversal', incomeApplicationId: null, reversalOfTransactionId: 'tx-manual' },
+    ];
+    expect(isFundTransactionReversible(base, transactions)).toBe(false);
+  });
+});

--- a/apps/web/features/finance/utils/fund-transaction.ts
+++ b/apps/web/features/finance/utils/fund-transaction.ts
@@ -1,0 +1,31 @@
+/**
+ * FIN-07BR: reversibilidad de un FundTransaction en UI.
+ *
+ * Solo se ofrece "Revertir" cuando TODAS las invariantes cliente-conocidas
+ * lo permiten:
+ * - no es una reversión en sí misma (reversalOfTransactionId == null)
+ * - no pertenece a una IncomeApplication (incomeApplicationId == null):
+ *   esas transacciones solo se revierten vía voidIncome en backend.
+ * - el original NO fue ya revertido (existe otra tx con
+ *   reversalOfTransactionId === transaction.id).
+ *
+ * El caller debe exigir además fund.status === 'ACTIVE' (no lo derivo aquí
+ * para mantener la función independiente del tipo Fund).
+ */
+export function isFundTransactionReversible(
+  transaction: {
+    readonly id: string;
+    readonly incomeApplicationId: string | null;
+    readonly reversalOfTransactionId: string | null;
+  },
+  allTransactions: readonly {
+    readonly reversalOfTransactionId: string | null;
+  }[],
+): boolean {
+  if (transaction.reversalOfTransactionId !== null) return false;
+  if (transaction.incomeApplicationId !== null) return false;
+  const alreadyReversed = allTransactions.some(
+    (candidate) => candidate.reversalOfTransactionId === transaction.id,
+  );
+  return !alreadyReversed;
+}

--- a/apps/web/features/finance/utils/income-application-provenance.test.ts
+++ b/apps/web/features/finance/utils/income-application-provenance.test.ts
@@ -1,0 +1,35 @@
+import { incomeApplicationProvenance } from './income-application-provenance';
+
+describe('incomeApplicationProvenance', () => {
+  it('labels a manual application (no provenance fields)', () => {
+    expect(incomeApplicationProvenance({ policyVersionId: null, legacyDestination: null })).toEqual({
+      origin: 'MANUAL',
+      policyVersionId: null,
+      legacyDestination: null,
+    });
+  });
+
+  it('labels a policy application with its version', () => {
+    expect(incomeApplicationProvenance({ policyVersionId: 'version-1', legacyDestination: null })).toEqual({
+      origin: 'POLICY',
+      policyVersionId: 'version-1',
+      legacyDestination: null,
+    });
+  });
+
+  it('labels a legacy application with its destination', () => {
+    expect(incomeApplicationProvenance({ policyVersionId: null, legacyDestination: 'RESERVE_FUND' })).toEqual({
+      origin: 'LEGACY',
+      policyVersionId: null,
+      legacyDestination: 'RESERVE_FUND',
+    });
+  });
+
+  it('fails closed on malformed policy+legacy combination', () => {
+    expect(incomeApplicationProvenance({ policyVersionId: 'version-1', legacyDestination: 'RESERVE_FUND' })).toEqual({
+      origin: 'INVALID',
+      policyVersionId: 'version-1',
+      legacyDestination: 'RESERVE_FUND',
+    });
+  });
+});

--- a/apps/web/features/finance/utils/income-application-provenance.ts
+++ b/apps/web/features/finance/utils/income-application-provenance.ts
@@ -1,0 +1,41 @@
+import type { IncomeApplication } from '../contracts';
+
+/**
+ * FIN-07BR: provenance de una IncomeApplication.
+ *
+ * Reglas fail-closed (espejo del CHECK DB de mutua exclusión):
+ * - policyVersionId != null && legacyDestination == null => POLICY
+ * - policyVersionId == null && legacyDestination != null => LEGACY
+ * - policyVersionId == null && legacyDestination == null => MANUAL
+ * - ambos != null => INVALID (datos malformados; no etiquetar en silencio)
+ */
+export type IncomeApplicationProvenanceOrigin =
+  | 'MANUAL'
+  | 'POLICY'
+  | 'LEGACY'
+  | 'INVALID';
+
+export interface IncomeApplicationProvenance {
+  readonly origin: IncomeApplicationProvenanceOrigin;
+  readonly policyVersionId: string | null;
+  readonly legacyDestination: IncomeApplication['legacyDestination'];
+}
+
+export function incomeApplicationProvenance(
+  application: Pick<
+    IncomeApplication,
+    'policyVersionId' | 'legacyDestination'
+  >,
+): IncomeApplicationProvenance {
+  const { policyVersionId, legacyDestination } = application;
+  if (policyVersionId != null && legacyDestination != null) {
+    return { origin: 'INVALID', policyVersionId, legacyDestination };
+  }
+  if (policyVersionId != null) {
+    return { origin: 'POLICY', policyVersionId, legacyDestination: null };
+  }
+  if (legacyDestination != null) {
+    return { origin: 'LEGACY', policyVersionId: null, legacyDestination };
+  }
+  return { origin: 'MANUAL', policyVersionId: null, legacyDestination: null };
+}

--- a/apps/web/features/finance/utils/money-input.test.ts
+++ b/apps/web/features/finance/utils/money-input.test.ts
@@ -1,0 +1,65 @@
+import {
+  decimalToAmountMinor,
+  minorToDecimalString,
+  percentageToBasisPoints,
+  sumAmountMinor,
+} from './money-input';
+
+describe('money input helpers', () => {
+  describe('decimalToAmountMinor', () => {
+    it.each([
+      ['12', 1200],
+      ['12.3', 1230],
+      ['12.34', 1234],
+      [' 0.01 ', 1],
+    ])('converts %s to its exact minor-unit amount', (value, expected) => {
+      expect(decimalToAmountMinor(value)).toBe(expected);
+    });
+
+    it.each(['', '0', '12.345', '-1', '.50', '1,25', 'abc'])('rejects invalid monetary input %s', (value) => {
+      expect(decimalToAmountMinor(value)).toBeNull();
+    });
+  });
+
+  describe('percentageToBasisPoints', () => {
+    it.each([
+      ['100', 10000],
+      ['33.33', 3333],
+      ['0.01', 1],
+    ])('converts %s%% to basis points', (value, expected) => {
+      expect(percentageToBasisPoints(value)).toBe(expected);
+    });
+
+    it.each(['0', '100.01', '1.234', '-1', ''])('rejects invalid percentages %s', (value) => {
+      expect(percentageToBasisPoints(value)).toBeNull();
+    });
+  });
+
+  it('adds minor-unit values without floating-point arithmetic', () => {
+    expect(sumAmountMinor([3333, 3333, 3334])).toBe(10000);
+    expect(sumAmountMinor([1, -1])).toBeNull();
+  });
+});
+
+describe('minorToDecimalString (FIN-07BR3F)', () => {
+  it.each([
+    [10000, '100.00'],
+    [12345, '123.45'],
+    [1, '0.01'],
+    [5, '0.05'],
+    [0, '0.00'],
+    [100000, '1000.00'],
+  ])('formats %i minor units as %s', (minor, expected) => {
+    expect(minorToDecimalString(minor)).toBe(expected);
+  });
+
+  it('handles a safe-integer boundary without drift', () => {
+    const big = Number.MAX_SAFE_INTEGER - (Number.MAX_SAFE_INTEGER % 100);
+    expect(minorToDecimalString(big)).toBe(`${Math.floor(big / 100)}.00`);
+  });
+
+  it('rejects unsafe or negative input', () => {
+    expect(minorToDecimalString(-1)).toBe('');
+    expect(minorToDecimalString(1.5)).toBe('');
+  });
+});

--- a/apps/web/features/finance/utils/money-input.ts
+++ b/apps/web/features/finance/utils/money-input.ts
@@ -1,0 +1,51 @@
+/**
+ * The platform currently stores every supported currency in two minor units.
+ * Keep user-entered decimal text out of financial calculations until this
+ * conversion succeeds.
+ */
+export function decimalToAmountMinor(value: string): number | null {
+  const normalized = value.trim();
+  const match = /^(\d+)(?:\.(\d{1,2}))?$/.exec(normalized);
+  if (!match) return null;
+
+  const whole = Number(match[1]);
+  const fraction = Number((match[2] ?? '').padEnd(2, '0'));
+  if (!Number.isSafeInteger(whole) || !Number.isSafeInteger(fraction)) return null;
+  if (whole > Math.floor((Number.MAX_SAFE_INTEGER - fraction) / 100)) return null;
+
+  const amountMinor = whole * 100 + fraction;
+  return amountMinor > 0 && Number.isSafeInteger(amountMinor) ? amountMinor : null;
+}
+
+export function percentageToBasisPoints(value: string): number | null {
+  const normalized = value.trim();
+  const match = /^(\d{1,3})(?:\.(\d{1,2}))?$/.exec(normalized);
+  if (!match) return null;
+  const whole = Number(match[1]);
+  const fraction = Number((match[2] ?? '').padEnd(2, '0'));
+  const basisPoints = whole * 100 + fraction;
+  return basisPoints >= 1 && basisPoints <= 10000 ? basisPoints : null;
+}
+
+export function sumAmountMinor(values: readonly number[]): number | null {
+  let total = 0;
+  for (const value of values) {
+    if (!Number.isSafeInteger(value) || value < 0 || !Number.isSafeInteger(total + value)) return null;
+    total += value;
+  }
+  return total;
+}
+
+/**
+ * Convierte amountMinor (entero de la plataforma) a su representación
+ * decimal de entrada, p.ej. 10000 -> "100.00", 12345 -> "123.45", 1 -> "0.01".
+ *
+ * Operaciones enteras/string exactas: sin parseInt de floats, sin Math.round,
+ * sin aritmética float sobre dinero.
+ */
+export function minorToDecimalString(amountMinor: number): string {
+  if (!Number.isSafeInteger(amountMinor) || amountMinor < 0) return '';
+  const whole = Math.floor(amountMinor / 100);
+  const fraction = amountMinor - whole * 100;
+  return `${whole}.${String(fraction).padStart(2, '0')}`;
+}


### PR DESCRIPTION
## Summary

- adds administration UI for building-owned incomes
- adds exact IncomeApplication allocation UI
- adds Funds and immutable FundTransaction ledger UI
- adds IncomePolicy creation/application UI
- adds provenance for manual/policy/legacy applications
- supports BUILDING, TENANT_SHARED and UNIT_GROUP income scopes
- uses canonical tenant financial currency defaults
- preserves allocated-income amount/currency invariants
- exposes only existing FundTransaction ownership provenance required
  to safely control reversals

## Financial invariants

- Payment and Income remain separate domains
- amountMinor integer remains source of truth
- no mixed-currency nominal totals
- IncomeApplication remains authority for use of income
- FundTransaction ledger remains immutable
- allocated Income cannot mutate amount/currency without atomic allocation support
- no live FX used for historical financial effects

## Validation

- authenticated local disposable-DB finance UI smoke passed
- BUILDING, TENANT_SHARED and UNIT_GROUP passed
- manual and policy IncomeApplications passed
- Funds transactions/reversal eligibility passed
- 107 web suites / 936 tests passed
- typecheck passed
- lint passed
- web build passed
- API focused tests/build passed
- git diff --check passed

## Scope

No schema changes.
No migrations.
No FIN-07C Liquidation V3 UI.
No legacy-backfill UX.
No production changes.

Closes #180
