### PR TITLE
feat(finance): build liquidation v3 and legacy backfill ux

### DIFF
--- a/apps/api/src/finanzas/expense-ledger.dto.ts
+++ b/apps/api/src/finanzas/expense-ledger.dto.ts
@@ -300,6 +300,37 @@ export interface LiquidationResponseDto {
   preIncomeAmountMinor?: number | null;
   incomeOffsetAmountMinor?: number | null;
   netDistributableAmountMinor?: number | null;
+  // FIN-07C: detalle read-only de offsets de ingresos congelados (solo V3).
+  // null/undefined = liquidación histórica (pre-FIN-06) sin offsets.
+  incomeOffsetsByCurrency?: Record<string, number> | null;
+  incomeOffsetSnapshot?: LiquidationIncomeOffsetSnapshotItemDto[] | null;
+}
+
+/**
+ * FIN-07C: snapshot congelado de un offset de ingreso (espejo del JSON
+ * persistido en `Liquidation.incomeOffsetSnapshot`). No se deriva de datos
+ * live; es dato financiero histórico.
+ */
+export interface LiquidationIncomeOffsetSnapshotItemDto {
+  incomeId: string;
+  incomeApplicationId: string;
+  categoryId: string;
+  categoryName: string | null;
+  policyVersionId: string | null;
+  legacyDestination: string | null;
+  scopeType: string;
+  currencyCode: string;
+  applicationAmountMinor: number;
+  buildingAmountMinor: number;
+  valuedAmountMinor: number;
+  functionalCurrencyCode: string | null;
+  exchangeRateId: string | null;
+  exchangeRateValue: string | null;
+  exchangeRateDirection: string | null;
+  exchangeRateEffectiveAt: string | null;
+  conversionDate: string | null;
+  receivedDate: string;
+  period: string;
 }
 
 export interface LiquidationDetailDto extends LiquidationResponseDto {

--- a/apps/api/src/finanzas/liquidation-income-offset-snapshot.ts
+++ b/apps/api/src/finanzas/liquidation-income-offset-snapshot.ts
@@ -1,0 +1,276 @@
+import { BadRequestException } from '@nestjs/common';
+import type { IncomeOffsetSnapshotItem } from './liquidation-income-offsets.service';
+
+/**
+ * FIN-07CR4: parser/normalizador ÚNICO y autoritativo para el item de snapshot
+ * de ingresos aplicados de una Liquidación (`IncomeOffsetSnapshotItem`).
+ *
+ * - Construye y devuelve un objeto normalizado que SATISFACE el contrato en
+ *   tiempo de ejecución (nunca `undefined` a través de un cast).
+ * - Fail-closed: datos NO nulos corruptos -> BadRequestException (nunca se
+ *   degradan a null/[]/{} ni se descartan silenciosamente).
+ * - Compatibilidad histórica: los campos nullables históricamente ausentes se
+ *   normalizan a null (o `''` para categoryId) según el parser histórico de
+ *   publicación; NO se inventa un valor que la autoridad no defina.
+ *
+ * Reutilizado por la LECTURA (`liquidations.service`), el WRITE de publicación
+ * (`normalizeIncomeOffsetSnapshot`) y el READ de publicación (parseo del JSON
+ * `publicationSnapshot`), evitando definiciones divergentes del contrato.
+ */
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function throwBadRequest(message: string): never {
+  throw new BadRequestException(message);
+}
+
+/** String no vacío (trim) o lanza. */
+export function assertNonEmptyString(
+  value: unknown,
+  message: string,
+): asserts value is string {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throwBadRequest(message);
+  }
+}
+
+/** Entero seguro >= 0 o lanza. */
+export function assertSafeIntegerNonNegative(value: unknown, message: string): void {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throwBadRequest(message);
+  }
+}
+
+/** Entero seguro > 0 (montos de un item OFFSET: share real > 0). */
+function assertSafeIntegerPositive(value: unknown, message: string): void {
+  if (!Number.isSafeInteger(value) || (value as number) <= 0) {
+    throwBadRequest(message);
+  }
+}
+
+/** Cadena ISO-8601 parseable o lanza. */
+export function assertIsoDateString(value: unknown, message: string): void {
+  if (typeof value !== 'string' || Number.isNaN(new Date(value).getTime())) {
+    throwBadRequest(message);
+  }
+}
+
+/** Período YYYY-MM con mes 01-12 (misma semántica del backend de finanzas). */
+const PERIOD_PATTERN = /^\d{4}-(0[1-9]|1[0-2])$/;
+
+const INCOME_OFFSET_SCOPE_TYPES = ['BUILDING', 'TENANT_SHARED', 'UNIT_GROUP'];
+
+/** FIN-04/FIN-06: destino legacy válido del `IncomeDestination` persistido. */
+const LEGACY_DESTINATIONS = ['APPLY_TO_EXPENSES', 'RESERVE_FUND', 'SPECIAL_FUND'];
+
+/** Campo requerido no vacío. */
+function requiredString(value: unknown, label: string, field: string): string {
+  assertNonEmptyString(value, `Liquidation incomeOffsetSnapshot ${label}.${field} is invalid`);
+  return value;
+}
+
+/** Campo nullable: ausente -> null; presente -> string no vacío. */
+function nullableString(value: unknown, label: string, field: string): string | null {
+  if (value === null || value === undefined) return null;
+  assertNonEmptyString(value, `Liquidation incomeOffsetSnapshot ${label}.${field} is invalid`);
+  return value;
+}
+
+/** Campo nullable ISO: ausente -> null; presente -> cadena ISO parseable. */
+function nullableIsoDate(value: unknown, label: string, field: string): string | null {
+  if (value === null || value === undefined) return null;
+  assertIsoDateString(value, `Liquidation incomeOffsetSnapshot ${label}.${field} is invalid`);
+  return value as string;
+}
+
+/**
+ * Parsea y normaliza UN item del snapshot de ingresos. Devuelve el objeto
+ * normalizado (todos los campos presentes y con el tipo correcto).
+ */
+export function parseIncomeOffsetSnapshotItem(
+  value: unknown,
+  label: string,
+): IncomeOffsetSnapshotItem {
+  if (!isPlainObject(value)) {
+    throwBadRequest(`Liquidation incomeOffsetSnapshot ${label} is invalid`);
+  }
+  const item = value as Record<string, unknown>;
+
+  const incomeId = requiredString(item.incomeId, label, 'incomeId');
+  const incomeApplicationId = requiredString(item.incomeApplicationId, label, 'incomeApplicationId');
+  // categoryId es requerido; la compatibilidad histórica normaliza ausencia -> ''.
+  const categoryId =
+    item.categoryId === null || item.categoryId === undefined
+      ? ''
+      : requiredString(item.categoryId, label, 'categoryId');
+  const categoryName = nullableString(item.categoryName, label, 'categoryName');
+  const policyVersionId = nullableString(item.policyVersionId, label, 'policyVersionId');
+
+  const legacyDestination =
+    item.legacyDestination === null || item.legacyDestination === undefined
+      ? null
+      : parseLegacyDestination(item.legacyDestination, label);
+
+  const scopeType = requiredString(item.scopeType, label, 'scopeType');
+  if (!INCOME_OFFSET_SCOPE_TYPES.includes(scopeType)) {
+    throwBadRequest(`Liquidation incomeOffsetSnapshot ${label}.scopeType is invalid`);
+  }
+
+  const currencyCode = requiredString(item.currencyCode, label, 'currencyCode');
+
+  // FIN-06: un item OFFSET representa una aplicación/share real elegible > 0.
+  // Una liquidación con cero offsets se representa como `[]`, nunca con ítems 0.
+  assertSafeIntegerPositive(item.applicationAmountMinor, `Liquidation incomeOffsetSnapshot ${label}.applicationAmountMinor is invalid`);
+  assertSafeIntegerPositive(item.buildingAmountMinor, `Liquidation incomeOffsetSnapshot ${label}.buildingAmountMinor is invalid`);
+  assertSafeIntegerPositive(item.valuedAmountMinor, `Liquidation incomeOffsetSnapshot ${label}.valuedAmountMinor is invalid`);
+
+  const functionalCurrencyCode = nullableString(item.functionalCurrencyCode, label, 'functionalCurrencyCode');
+  const exchangeRateId = nullableString(item.exchangeRateId, label, 'exchangeRateId');
+  // exchangeRateValue: histórico puede venir numérico -> String() (misma
+  // compatibilidad del parser de publicación), pero nunca ausente/vacío.
+  const exchangeRateValue =
+    item.exchangeRateValue === null || item.exchangeRateValue === undefined
+      ? null
+      : parseNonEmptyStringified(item.exchangeRateValue, label, 'exchangeRateValue');
+  const exchangeRateDirection = nullableString(item.exchangeRateDirection, label, 'exchangeRateDirection');
+  const exchangeRateEffectiveAt = nullableIsoDate(item.exchangeRateEffectiveAt, label, 'exchangeRateEffectiveAt');
+  const conversionDate = nullableIsoDate(item.conversionDate, label, 'conversionDate');
+
+  assertIsoDateString(item.receivedDate, `Liquidation incomeOffsetSnapshot ${label}.receivedDate is invalid`);
+  const receivedDate = item.receivedDate as string;
+
+  const period = requiredString(item.period, label, 'period');
+  if (!PERIOD_PATTERN.test(period)) {
+    throwBadRequest(`Liquidation incomeOffsetSnapshot ${label}.period is invalid`);
+  }
+
+  // Campos que NO forman parte del contrato del item pero, si aparecen en datos
+  // persistidos, deben tener tipo coherente (no basta con que los IDs sean strings).
+  if ('baseCurrency' in item && item.baseCurrency !== null && item.baseCurrency !== undefined) {
+    assertNonEmptyString(
+      item.baseCurrency,
+      `Liquidation incomeOffsetSnapshot ${label}.baseCurrency is invalid`,
+    );
+  }
+  if ('buildingId' in item && item.buildingId !== null && item.buildingId !== undefined) {
+    assertNonEmptyString(
+      item.buildingId,
+      `Liquidation incomeOffsetSnapshot ${label}.buildingId is invalid`,
+    );
+  }
+
+  return {
+    incomeId,
+    incomeApplicationId,
+    categoryId,
+    categoryName,
+    policyVersionId,
+    legacyDestination,
+    scopeType,
+    currencyCode,
+    applicationAmountMinor: item.applicationAmountMinor as number,
+    buildingAmountMinor: item.buildingAmountMinor as number,
+    valuedAmountMinor: item.valuedAmountMinor as number,
+    functionalCurrencyCode,
+    exchangeRateId,
+    exchangeRateValue,
+    exchangeRateDirection,
+    exchangeRateEffectiveAt,
+    conversionDate,
+    receivedDate,
+    period,
+  };
+}
+
+function parseLegacyDestination(value: unknown, label: string): string {
+  assertNonEmptyString(value, `Liquidation incomeOffsetSnapshot ${label}.legacyDestination is invalid`);
+  if (!LEGACY_DESTINATIONS.includes(value)) {
+    throwBadRequest(`Liquidation incomeOffsetSnapshot ${label}.legacyDestination is invalid`);
+  }
+  return value;
+}
+
+function parseNonEmptyStringified(value: unknown, label: string, field: string): string {
+  const str = String(value);
+  if (str.trim().length === 0) {
+    throwBadRequest(`Liquidation incomeOffsetSnapshot ${label}.${field} is invalid`);
+  }
+  return str;
+}
+
+/**
+ * `Liquidation.incomeOffsetSnapshot`:
+ * null/undefined -> histórico (null)
+ * []             -> V3 cero offsets
+ * array          -> items parseados/normalizados uno a uno (fail-closed)
+ */
+export function parseIncomeOffsetSnapshot(
+  value: unknown,
+): IncomeOffsetSnapshotItem[] | null {
+  if (value === null || value === undefined) return null;
+  if (!Array.isArray(value)) {
+    throwBadRequest('Liquidation incomeOffsetSnapshot is invalid');
+  }
+  return value.map((item, index) => parseIncomeOffsetSnapshotItem(item, `item ${index}`));
+}
+
+/**
+ * `Liquidation.incomeOffsetsByCurrency`:
+ * null/undefined -> histórico (null)
+ * {}             -> V3 cero offsets
+ * object         -> { currencyNoVacio: safeInt >= 0 } (fail-closed)
+ * Los montos de este mapa mantienen semántica NON-NEGATIVE: `{}` es válido.
+ */
+export function parseIncomeOffsetsByCurrency(
+  value: unknown,
+): Record<string, number> | null {
+  if (value === null || value === undefined) return null;
+  if (!isPlainObject(value)) {
+    throwBadRequest('Liquidation incomeOffsetsByCurrency is invalid');
+  }
+  const source = value as Record<string, unknown>;
+  const result: Record<string, number> = {};
+  for (const [currency, amount] of Object.entries(source)) {
+    if (!currency || currency.trim().length === 0) {
+      throwBadRequest('Liquidation incomeOffsetsByCurrency currency code is invalid');
+    }
+    if (typeof amount !== 'number' || !Number.isSafeInteger(amount) || amount < 0) {
+      throwBadRequest(`Liquidation incomeOffsetsByCurrency amount for ${currency} is invalid`);
+    }
+    result[currency] = amount;
+  }
+  return result;
+}
+
+/** Resultado de la clasificación de consistencia V3/histórica de una fila. */
+export type LiquidationV3ReadKind = 'V3' | 'HISTORICAL';
+
+/**
+ * Clasificación de consistencia de los campos de resumen FIN-06 persistidos:
+ *
+ * - los 5 campos presentes  -> V3 moderna
+ * - los 5 ausentes/null     -> histórico V1/V2
+ * - presencia PARCIAL       -> corrupto (fail-closed)
+ */
+export function classifyLiquidationV3Summary(values: {
+  grossExpenseAmountMinor?: number | null;
+  adjustmentAmountMinor?: number | null;
+  preIncomeAmountMinor?: number | null;
+  incomeOffsetAmountMinor?: number | null;
+  netDistributableAmountMinor?: number | null;
+}): LiquidationV3ReadKind {
+  const present = [
+    values.grossExpenseAmountMinor,
+    values.adjustmentAmountMinor,
+    values.preIncomeAmountMinor,
+    values.incomeOffsetAmountMinor,
+    values.netDistributableAmountMinor,
+  ].filter((value) => value !== null && value !== undefined).length;
+
+  if (present === 5) return 'V3';
+  if (present === 0) return 'HISTORICAL';
+
+  throwBadRequest('Liquidation V3 summary fields are partially populated');
+}

--- a/apps/api/src/finanzas/liquidation-publication-snapshot.ts
+++ b/apps/api/src/finanzas/liquidation-publication-snapshot.ts
@@ -1,5 +1,12 @@
 import { BadRequestException, UnprocessableEntityException } from '@nestjs/common';
 import { Prisma } from '@prisma/client';
+import {
+  assertIsoDateString,
+  assertNonEmptyString,
+  assertSafeIntegerNonNegative as assertSafeNonNegativeValue,
+  isPlainObject,
+  parseIncomeOffsetSnapshotItem,
+} from './liquidation-income-offset-snapshot';
 
 export interface PublishedExpenseSnapshot {
   expenseId: string;
@@ -817,26 +824,9 @@ function normalizeExpenseSnapshot(value: PublishedExpenseSnapshot): PublishedExp
 function normalizeIncomeOffsetSnapshot(
   value: PublishedIncomeOffsetSnapshot,
 ): PublishedIncomeOffsetSnapshot {
-  assertNonEmpty(value.incomeId, 'incomeId');
-  assertNonEmpty(value.incomeApplicationId, 'incomeApplicationId');
-  assertNonEmpty(value.currencyCode, 'currencyCode');
-  assertNonEmpty(value.scopeType, 'scopeType');
-  assertSafeIntegerNonNegative(value.applicationAmountMinor, 'applicationAmountMinor');
-  assertSafeIntegerNonNegative(value.buildingAmountMinor, 'buildingAmountMinor');
-  assertSafeIntegerNonNegative(value.valuedAmountMinor, 'valuedAmountMinor');
-  parseIsoDateString(value.receivedDate, 'receivedDate');
-  assertNonEmpty(value.period, 'period');
-  if (value.policyVersionId !== null) {
-    assertNonEmpty(value.policyVersionId, 'policyVersionId');
-  }
-  if (value.categoryId) {
-    assertNonEmpty(value.categoryId, 'categoryId');
-  }
-
-  return {
-    ...value,
-    legacyDestination: value.legacyDestination ?? null,
-  };
+  // FIN-07CR4: único normalizador autoritativo (mismo primitivo que la lectura).
+  // El builder de publicación siempre escribe items que satisfacen el contrato.
+  return parseIncomeOffsetSnapshotItem(value, 'incomeOffset') as PublishedIncomeOffsetSnapshot;
 }
 
 function toIncomeOffsetJsonObject(value: PublishedIncomeOffsetSnapshot): Prisma.InputJsonObject {
@@ -864,90 +854,9 @@ function toIncomeOffsetJsonObject(value: PublishedIncomeOffsetSnapshot): Prisma.
 }
 
 function parseIncomeOffsetSnapshot(value: unknown): PublishedIncomeOffsetSnapshot {
-  if (!isPlainObject(value)) {
-    throw new BadRequestException('Liquidation publication snapshot income offset is invalid');
-  }
-
-  const incomeId = parseNonEmptyString(value.incomeId, 'incomeId');
-  const incomeApplicationId = parseNonEmptyString(value.incomeApplicationId, 'incomeApplicationId');
-  const categoryId = value.categoryId === null || value.categoryId === undefined
-    ? ''
-    : parseNonEmptyString(value.categoryId, 'categoryId');
-  const categoryName =
-    value.categoryName === null || value.categoryName === undefined
-      ? null
-      : parseNullableString(value.categoryName, 'categoryName');
-  const policyVersionId =
-    value.policyVersionId === null || value.policyVersionId === undefined
-      ? null
-      : parseNullableString(value.policyVersionId, 'policyVersionId');
-  const scopeType = parseNonEmptyString(value.scopeType, 'scopeType');
-  const currencyCode = parseNonEmptyString(value.currencyCode, 'currencyCode');
-  const applicationAmountMinor = parseSafeIntegerNonNegative(
-    value.applicationAmountMinor,
-    'applicationAmountMinor',
-  );
-  const buildingAmountMinor = parseSafeIntegerNonNegative(
-    value.buildingAmountMinor,
-    'buildingAmountMinor',
-  );
-  const valuedAmountMinor = parseSafeIntegerNonNegative(
-    value.valuedAmountMinor,
-    'valuedAmountMinor',
-  );
-  const functionalCurrencyCode =
-    value.functionalCurrencyCode === null || value.functionalCurrencyCode === undefined
-      ? null
-      : parseNullableString(value.functionalCurrencyCode, 'functionalCurrencyCode');
-  const exchangeRateId =
-    value.exchangeRateId === null || value.exchangeRateId === undefined
-      ? null
-      : parseNullableString(value.exchangeRateId, 'exchangeRateId');
-  const exchangeRateValue =
-    value.exchangeRateValue === null || value.exchangeRateValue === undefined
-      ? null
-      : parseNullableString(String(value.exchangeRateValue), 'exchangeRateValue');
-  const exchangeRateDirection =
-    value.exchangeRateDirection === null || value.exchangeRateDirection === undefined
-      ? null
-      : parseNullableString(value.exchangeRateDirection, 'exchangeRateDirection');
-  const exchangeRateEffectiveAt =
-    value.exchangeRateEffectiveAt === null || value.exchangeRateEffectiveAt === undefined
-      ? null
-      : parseIsoDateString(value.exchangeRateEffectiveAt, 'exchangeRateEffectiveAt');
-  const conversionDate =
-    value.conversionDate === null || value.conversionDate === undefined
-      ? null
-      : parseIsoDateString(value.conversionDate, 'conversionDate');
-  const receivedDate = parseIsoDateString(value.receivedDate, 'receivedDate');
-  const period = parseNonEmptyString(value.period, 'period');
-  // FIN-04R: V3 histórico sin field → null (backward compatible).
-  const legacyDestination =
-    value.legacyDestination === null || value.legacyDestination === undefined
-      ? null
-      : parseNullableString(value.legacyDestination, 'legacyDestination');
-
-  return {
-    incomeId,
-    incomeApplicationId,
-    categoryId,
-    categoryName,
-    policyVersionId,
-    legacyDestination,
-    scopeType,
-    currencyCode,
-    applicationAmountMinor,
-    buildingAmountMinor,
-    valuedAmountMinor,
-    functionalCurrencyCode,
-    exchangeRateId,
-    exchangeRateValue,
-    exchangeRateDirection,
-    exchangeRateEffectiveAt,
-    conversionDate,
-    receivedDate,
-    period,
-  };
+  // FIN-07CR4: mismo parseo/normalización autoritativo que el camino de lectura
+  // y que el write del builder (sin definición divergente campo a campo).
+  return parseIncomeOffsetSnapshotItem(value, 'incomeOffset') as PublishedIncomeOffsetSnapshot;
 }
 
 function normalizeAllocationSnapshot(value: PublishedAllocationSnapshot): PublishedAllocationSnapshot {
@@ -1219,11 +1128,8 @@ function assertCurrencyTotalsMatch(
 }
 
 function parseNonEmptyString(value: unknown, field: string): string {
-  if (typeof value !== 'string' || value.trim().length === 0) {
-    throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
-  }
-
-  return value;
+  assertNonEmptyString(value, `Liquidation publication snapshot ${field} is invalid`);
+  return value as string;
 }
 
 function parseNullableString(value: unknown, field: string): string | null {
@@ -1235,24 +1141,13 @@ function parseNullableString(value: unknown, field: string): string | null {
 }
 
 function parseSafeIntegerNonNegative(value: unknown, field: string): number {
-  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
-    throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
-  }
-
-  return value;
+  assertSafeNonNegativeValue(value, `Liquidation publication snapshot ${field} is invalid`);
+  return value as number;
 }
 
 function parseIsoDateString(value: unknown, field: string): string {
-  if (typeof value !== 'string') {
-    throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
-  }
-
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
-  }
-
-  return parsed.toISOString();
+  assertIsoDateString(value, `Liquidation publication snapshot ${field} is invalid`);
+  return new Date(value as string).toISOString();
 }
 
 function assertIsoDate(value: Date, field: string): void {
@@ -1262,19 +1157,11 @@ function assertIsoDate(value: Date, field: string): void {
 }
 
 function assertNonEmpty(value: string | null | undefined, field: string): void {
-  if (typeof value !== 'string' || value.trim().length === 0) {
-    throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
-  }
+  assertNonEmptyString(value, `Liquidation publication snapshot ${field} is invalid`);
 }
 
 function assertSafeIntegerNonNegative(value: number, field: string): void {
-  if (!Number.isSafeInteger(value) || value < 0) {
-    throw new BadRequestException(`Liquidation publication snapshot ${field} is invalid`);
-  }
-}
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+  assertSafeNonNegativeValue(value, `Liquidation publication snapshot ${field} is invalid`);
 }
 
 function createJsonObject<T extends Prisma.InputJsonObject>(value: T): T {

--- a/apps/api/src/finanzas/liquidations.service.spec.ts
+++ b/apps/api/src/finanzas/liquidations.service.spec.ts
@@ -282,6 +282,355 @@ describe('LiquidationsService', () => {
     ]);
   });
 
+  it('maps FIN-07C income offset snapshot and per-currency totals', async () => {
+    prisma.liquidation.findMany.mockResolvedValueOnce([
+      {
+        ...baseLiquidation,
+        incomeOffsetsByCurrency: { ARS: 1500 },
+        incomeOffsetSnapshot: [
+          {
+            incomeId: 'income-1',
+            incomeApplicationId: 'app-1',
+            categoryId: 'cat-1',
+            categoryName: 'Alquiler',
+            policyVersionId: null,
+            legacyDestination: null,
+            scopeType: 'BUILDING',
+            currencyCode: 'ARS',
+            applicationAmountMinor: 1500,
+            buildingAmountMinor: 1500,
+            valuedAmountMinor: 1500,
+            functionalCurrencyCode: null,
+            exchangeRateId: null,
+            exchangeRateValue: null,
+            exchangeRateDirection: null,
+            exchangeRateEffectiveAt: null,
+            conversionDate: null,
+            receivedDate: '2026-05-01',
+            period: '2026-05',
+          },
+        ],
+      },
+    ]);
+
+    const [liquidation] = await service.listLiquidations('tenant-1', 'member-1', {});
+
+    expect(liquidation.incomeOffsetsByCurrency).toEqual({ ARS: 1500 });
+    expect(liquidation.incomeOffsetSnapshot).toHaveLength(1);
+    expect(liquidation.incomeOffsetSnapshot?.[0]?.categoryName).toBe('Alquiler');
+  });
+
+  it('maps null income offset fields for historical liquidations', async () => {
+    prisma.liquidation.findMany.mockResolvedValueOnce([baseLiquidation]);
+
+    const [liquidation] = await service.listLiquidations('tenant-1', 'member-1', {});
+
+    expect(liquidation.incomeOffsetsByCurrency).toBeNull();
+    expect(liquidation.incomeOffsetSnapshot).toBeNull();
+  });
+
+  it('accepts a valid zero-offset V3 liquidation (empty maps, non-null)', async () => {
+    prisma.liquidation.findMany.mockResolvedValueOnce([
+      {
+        ...baseLiquidation,
+        grossExpenseAmountMinor: 10000,
+        adjustmentAmountMinor: 0,
+        preIncomeAmountMinor: 10000,
+        incomeOffsetAmountMinor: 0,
+        netDistributableAmountMinor: 10000,
+        incomeOffsetSnapshot: [],
+        incomeOffsetsByCurrency: {},
+      },
+    ]);
+
+    const [liquidation] = await service.listLiquidations('tenant-1', 'member-1', {});
+
+    expect(liquidation.incomeOffsetsByCurrency).toEqual({});
+    expect(liquidation.incomeOffsetSnapshot).toEqual([]);
+  });
+
+  it('fails closed on malformed incomeOffsetsByCurrency instead of downgrading to null', async () => {
+    prisma.liquidation.findMany.mockResolvedValueOnce([
+      { ...baseLiquidation, incomeOffsetsByCurrency: ['ARS', 1500] },
+    ]);
+
+    await expect(
+      service.listLiquidations('tenant-1', 'member-1', {}),
+    ).rejects.toThrow('Liquidation incomeOffsetsByCurrency is invalid');
+  });
+
+  it('fails closed on malformed incomeOffsetSnapshot instead of downgrading to null', async () => {
+    prisma.liquidation.findMany.mockResolvedValueOnce([
+      {
+        ...baseLiquidation,
+        incomeOffsetSnapshot: [{ incomeId: 'income-1' }],
+      },
+    ]);
+
+    await expect(
+      service.listLiquidations('tenant-1', 'member-1', {}),
+    ).rejects.toThrow('Liquidation incomeOffsetSnapshot');
+  });
+
+  // ==========================================================================
+  // FIN-07CR3: read-contract hardening del snapshot de ingresos (maq. A–V)
+  // ==========================================================================
+
+  const V3_OFFSET_ITEM = {
+    incomeId: 'income-1',
+    incomeApplicationId: 'app-1',
+    categoryId: 'cat-1',
+    categoryName: 'Alquiler',
+    policyVersionId: null,
+    legacyDestination: null,
+    scopeType: 'BUILDING',
+    currencyCode: 'ARS',
+    applicationAmountMinor: 1500,
+    buildingAmountMinor: 1500,
+    valuedAmountMinor: 1500,
+    functionalCurrencyCode: null,
+    exchangeRateId: null,
+    exchangeRateValue: null,
+    exchangeRateDirection: null,
+    exchangeRateEffectiveAt: null,
+    conversionDate: null,
+    receivedDate: '2026-05-01',
+    period: '2026-05',
+  };
+
+  const V3_LIQUIDATION = {
+    ...baseLiquidation,
+    grossExpenseAmountMinor: 10000,
+    adjustmentAmountMinor: 0,
+    preIncomeAmountMinor: 10000,
+    incomeOffsetAmountMinor: 1500,
+    netDistributableAmountMinor: 8500,
+    incomeOffsetsByCurrency: { ARS: 1500 },
+    incomeOffsetSnapshot: [V3_OFFSET_ITEM],
+  };
+
+  async function listWith(liquidation: Record<string, unknown>) {
+    prisma.liquidation.findMany.mockResolvedValueOnce([liquidation as never]);
+    return service.listLiquidations('tenant-1', 'member-1', {});
+  }
+
+  it('A. accepts a historical record (summary null, artifacts null)', async () => {
+    const [liquidation] = await listWith(baseLiquidation);
+    expect(liquidation.grossExpenseAmountMinor).toBeNull();
+    expect(liquidation.incomeOffsetSnapshot).toBeNull();
+    expect(liquidation.incomeOffsetsByCurrency).toBeNull();
+  });
+
+  it('B. accepts a zero-offset V3 (summary present, [] and {})', async () => {
+    const [liquidation] = await listWith({
+      ...V3_LIQUIDATION,
+      incomeOffsetAmountMinor: 0,
+      netDistributableAmountMinor: 10000,
+      incomeOffsetSnapshot: [],
+      incomeOffsetsByCurrency: {},
+    });
+    expect(liquidation.incomeOffsetSnapshot).toEqual([]);
+    expect(liquidation.incomeOffsetsByCurrency).toEqual({});
+  });
+
+  it('C. accepts a valid full V3 snapshot unchanged', async () => {
+    const [liquidation] = await listWith(V3_LIQUIDATION);
+    expect(liquidation.incomeOffsetSnapshot?.[0]).toMatchObject({
+      incomeId: 'income-1',
+      applicationAmountMinor: 1500,
+      buildingAmountMinor: 1500,
+      valuedAmountMinor: 1500,
+    });
+  });
+
+  it.each([
+    ['D. buildingAmountMinor = "bad"', { ...V3_LIQUIDATION, incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, buildingAmountMinor: 'bad' }] }],
+    ['E. valuedAmountMinor = "bad"', { ...V3_LIQUIDATION, incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, valuedAmountMinor: 'bad' }] }],
+    ['F. negative application amount', { ...V3_LIQUIDATION, incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, applicationAmountMinor: -500 }] }],
+    ['G. currencyCode numeric', { ...V3_LIQUIDATION, incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, currencyCode: 123 }] }],
+    ['G2. currencyCode empty', { ...V3_LIQUIDATION, incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, currencyCode: '' }] }],
+    ['H. baseCurrency numeric', { ...V3_LIQUIDATION, incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, baseCurrency: 123 }] }],
+    ['H2. baseCurrency empty', { ...V3_LIQUIDATION, incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, baseCurrency: '' }] }],
+    ['I. scopeType INVALID', { ...V3_LIQUIDATION, incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, scopeType: 'INVALID' }] }],
+    ['J. buildingId numeric (invalid relation)', { ...V3_LIQUIDATION, incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, buildingId: 7 }] }],
+    ['K. period malformed (numeric)', { ...V3_LIQUIDATION, incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, period: 123 }] }],
+    ['L. receivedDate malformed', { ...V3_LIQUIDATION, incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, receivedDate: 'not-a-date' }] }],
+    ['M. provenance shape invalid', { ...V3_LIQUIDATION, incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, legacyDestination: 42 }] }],
+    ['N. functional FX conversionDate malformed', { ...V3_LIQUIDATION, incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, exchangeRateEffectiveAt: 'garbage', functionalCurrencyCode: 'ARS' }] }],
+  ])('%s => fails closed', async (_name, liquidation) => {
+    await expect(listWith(liquidation)).rejects.toThrow('Liquidation incomeOffsetSnapshot');
+  });
+
+  it.each([
+    ['O. empty currency key ""', { '': 100 }],
+    ['P. whitespace-only key', { ' ': 100 }],
+  ])('%s => fails closed', async (_name, byCurrency) => {
+    await expect(
+      listWith({ ...V3_LIQUIDATION, incomeOffsetsByCurrency: byCurrency }),
+    ).rejects.toThrow('Liquidation incomeOffsetsByCurrency');
+  });
+
+  it.each([
+    ['Q. string amount', { ARS: '1500' }],
+    ['R. unsafe integer', { ARS: Number.MAX_SAFE_INTEGER + 2 }],
+    ['S. negative amount', { ARS: -1 }],
+  ])('%s => fails closed', async (_name, byCurrency) => {
+    await expect(
+      listWith({ ...V3_LIQUIDATION, incomeOffsetsByCurrency: byCurrency }),
+    ).rejects.toThrow('Liquidation incomeOffsetsByCurrency');
+  });
+
+  it('T. modern summary present + snapshot null => fails', async () => {
+    await expect(
+      listWith({ ...V3_LIQUIDATION, incomeOffsetSnapshot: null }),
+    ).rejects.toThrow('Liquidation V3 is missing incomeOffset snapshot artifacts');
+  });
+
+  it('U. modern summary present + byCurrency null => fails', async () => {
+    await expect(
+      listWith({ ...V3_LIQUIDATION, incomeOffsetsByCurrency: null }),
+    ).rejects.toThrow('Liquidation V3 is missing incomeOffset snapshot artifacts');
+  });
+
+  it('V. control: summary all null + artifacts null => still accepted', async () => {
+    const [liquidation] = await listWith(baseLiquidation);
+    expect(liquidation.incomeOffsetSnapshot).toBeNull();
+    expect(liquidation.incomeOffsetsByCurrency).toBeNull();
+  });
+
+  it('W. partially populated summary => rejected (no silent historical downgrade)', async () => {
+    await expect(
+      listWith({
+        ...baseLiquidation,
+        grossExpenseAmountMinor: 10000,
+        incomeOffsetAmountMinor: null,
+      }),
+    ).rejects.toThrow('Liquidation V3 summary fields are partially populated');
+  });
+
+  // ==========================================================================
+  // FIN-07CR4: cierre del contrato del item (categoryId, legacyDestination,
+  // period, montos estrictamente positivos, nullables normalizados)
+  // ==========================================================================
+
+  it('rejects categoryId empty string', async () => {
+    await expect(
+      listWith({
+        ...V3_LIQUIDATION,
+        incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, categoryId: '' }],
+      }),
+    ).rejects.toThrow('Liquidation incomeOffsetSnapshot');
+  });
+
+  it('normalizes missing categoryId to empty string (historical contract)', async () => {
+    const { categoryId: _omit, ...withoutCategoryId } = V3_OFFSET_ITEM;
+    const [liquidation] = await listWith({
+      ...V3_LIQUIDATION,
+      incomeOffsetSnapshot: [withoutCategoryId],
+    });
+    expect(liquidation.incomeOffsetSnapshot?.[0]?.categoryId).toBe('');
+  });
+
+  it.each([
+    ['APPLY_TO_EXPENSES', 'APPLY_TO_EXPENSES'],
+    ['RESERVE_FUND', 'RESERVE_FUND'],
+    ['SPECIAL_FUND', 'SPECIAL_FUND'],
+  ])('accepts valid legacyDestination %s', async (_name, legacyDestination) => {
+    const [liquidation] = await listWith({
+      ...V3_LIQUIDATION,
+      incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, legacyDestination }],
+    });
+    expect(liquidation.incomeOffsetSnapshot?.[0]?.legacyDestination).toBe(legacyDestination);
+  });
+
+  it('rejects arbitrary legacyDestination string', async () => {
+    await expect(
+      listWith({
+        ...V3_LIQUIDATION,
+        incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, legacyDestination: 'NONSENSE' }],
+      }),
+    ).rejects.toThrow('Liquidation incomeOffsetSnapshot');
+  });
+
+  it('normalizes missing legacyDestination to null', async () => {
+    const { legacyDestination: _omit, ...withoutLegacy } = V3_OFFSET_ITEM;
+    const [liquidation] = await listWith({
+      ...V3_LIQUIDATION,
+      incomeOffsetSnapshot: [withoutLegacy],
+    });
+    expect(liquidation.incomeOffsetSnapshot?.[0]?.legacyDestination).toBeNull();
+  });
+
+  it.each([
+    ['period "abc"', 'abc'],
+    ['period "2026-13"', '2026-13'],
+    ['period "26-05"', '26-05'],
+  ])('rejects malformed %s', async (_name, period) => {
+    await expect(
+      listWith({
+        ...V3_LIQUIDATION,
+        incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, period }],
+      }),
+    ).rejects.toThrow('Liquidation incomeOffsetSnapshot');
+  });
+
+  it('accepts valid period "2026-05"', async () => {
+    const [liquidation] = await listWith({
+      ...V3_LIQUIDATION,
+      incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, period: '2026-05' }],
+    });
+    expect(liquidation.incomeOffsetSnapshot?.[0]?.period).toBe('2026-05');
+  });
+
+  it.each([
+    ['applicationAmountMinor = 0', 'applicationAmountMinor'],
+    ['buildingAmountMinor = 0', 'buildingAmountMinor'],
+    ['valuedAmountMinor = 0', 'valuedAmountMinor'],
+  ])('rejects zero item amount %s', async (_name, field) => {
+    await expect(
+      listWith({
+        ...V3_LIQUIDATION,
+        incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, [field]: 0 }],
+      }),
+    ).rejects.toThrow('Liquidation incomeOffsetSnapshot');
+  });
+
+  it('normalizes missing historical nullable fields to null', async () => {
+    const {
+      categoryName: _a,
+      policyVersionId: _b,
+      functionalCurrencyCode: _c,
+      exchangeRateId: _d,
+      exchangeRateValue: _e,
+      exchangeRateDirection: _f,
+      exchangeRateEffectiveAt: _g,
+      conversionDate: _h,
+      ...onlyRequired
+    } = V3_OFFSET_ITEM;
+    const [liquidation] = await listWith({
+      ...V3_LIQUIDATION,
+      incomeOffsetSnapshot: [onlyRequired],
+    });
+    const item = liquidation.incomeOffsetSnapshot?.[0];
+    expect(item?.categoryName).toBeNull();
+    expect(item?.policyVersionId).toBeNull();
+    expect(item?.functionalCurrencyCode).toBeNull();
+    expect(item?.exchangeRateId).toBeNull();
+    expect(item?.exchangeRateValue).toBeNull();
+    expect(item?.exchangeRateDirection).toBeNull();
+    expect(item?.exchangeRateEffectiveAt).toBeNull();
+    expect(item?.conversionDate).toBeNull();
+  });
+
+  it('rejects wrong-type nullable field (categoryName numeric)', async () => {
+    await expect(
+      listWith({
+        ...V3_LIQUIDATION,
+        incomeOffsetSnapshot: [{ ...V3_OFFSET_ITEM, categoryName: 42 }],
+      }),
+    ).rejects.toThrow('Liquidation incomeOffsetSnapshot');
+  });
+
   it('creates one charge per billable unit when publishing', async () => {
     tx.liquidation.findFirst
       .mockResolvedValueOnce({ ...baseLiquidation, status: 'REVIEWED' })

--- a/apps/api/src/finanzas/liquidations.service.ts
+++ b/apps/api/src/finanzas/liquidations.service.ts
@@ -40,6 +40,11 @@ import {
   LiquidationIncomeOffsetsService,
   type IncomeOffsetSnapshotItem,
 } from './liquidation-income-offsets.service';
+import {
+  classifyLiquidationV3Summary,
+  parseIncomeOffsetsByCurrency,
+  parseIncomeOffsetSnapshot,
+} from './liquidation-income-offset-snapshot';
 import { LegacyIncomeBackfillService } from './legacy-income-backfill.service';
 
 interface LiquidationExpenseSnapshotItem extends Prisma.InputJsonObject {
@@ -791,8 +796,38 @@ export class LiquidationsService {
     preIncomeAmountMinor?: number | null;
     incomeOffsetAmountMinor?: number | null;
     netDistributableAmountMinor?: number | null;
+    incomeOffsetsByCurrency?: unknown;
+    incomeOffsetSnapshot?: unknown;
   }): LiquidationResponseDto {
     const totalsByCurrency = parseTotalsByCurrency(liq.totalsByCurrency);
+
+    const grossExpenseAmountMinor = liq.grossExpenseAmountMinor ?? null;
+    const adjustmentAmountMinor = liq.adjustmentAmountMinor ?? null;
+    const preIncomeAmountMinor = liq.preIncomeAmountMinor ?? null;
+    const incomeOffsetAmountMinor = liq.incomeOffsetAmountMinor ?? null;
+    const netDistributableAmountMinor = liq.netDistributableAmountMinor ?? null;
+    const incomeOffsetsByCurrency = parseIncomeOffsetsByCurrency(liq.incomeOffsetsByCurrency);
+    const incomeOffsetSnapshot = parseIncomeOffsetSnapshot(liq.incomeOffsetSnapshot);
+
+    // FIN-07CR3: consistencia de artefactos. Una fila V3 (resumen FIN-06 presente
+    // completo) NO puede degradarse a representación histórica: exige snapshot y
+    // byCurrency NO nulos. Histórico (los 5 campos ausentes) sigue aceptado.
+    // Presencia parcial del resumen = corrupción (fail-closed).
+    const summaryKind = classifyLiquidationV3Summary({
+      grossExpenseAmountMinor,
+      adjustmentAmountMinor,
+      preIncomeAmountMinor,
+      incomeOffsetAmountMinor,
+      netDistributableAmountMinor,
+    });
+    if (
+      summaryKind === 'V3' &&
+      (incomeOffsetsByCurrency === null || incomeOffsetSnapshot === null)
+    ) {
+      throw new BadRequestException(
+        'Liquidation V3 is missing incomeOffset snapshot artifacts',
+      );
+    }
 
     return {
       id: liq.id,
@@ -811,11 +846,13 @@ export class LiquidationsService {
       publishedAt: liq.publishedAt,
       canceledAt: liq.canceledAt,
       createdAt: liq.createdAt,
-      grossExpenseAmountMinor: liq.grossExpenseAmountMinor ?? null,
-      adjustmentAmountMinor: liq.adjustmentAmountMinor ?? null,
-      preIncomeAmountMinor: liq.preIncomeAmountMinor ?? null,
-      incomeOffsetAmountMinor: liq.incomeOffsetAmountMinor ?? null,
-      netDistributableAmountMinor: liq.netDistributableAmountMinor ?? null,
+      grossExpenseAmountMinor,
+      adjustmentAmountMinor,
+      preIncomeAmountMinor,
+      incomeOffsetAmountMinor,
+      netDistributableAmountMinor,
+      incomeOffsetsByCurrency,
+      incomeOffsetSnapshot,
     };
   }
 
@@ -833,6 +870,8 @@ export class LiquidationsService {
       totalsByCurrency: unknown;
       expenseSnapshot: unknown;
       publicationSnapshot: unknown;
+      incomeOffsetsByCurrency?: unknown;
+      incomeOffsetSnapshot?: unknown;
       unitCount: number;
       generatedAt: Date;
       reviewedAt: Date | null;

--- a/apps/web/features/finance/components/CreateLiquidationModal.tsx
+++ b/apps/web/features/finance/components/CreateLiquidationModal.tsx
@@ -5,6 +5,7 @@ import Button from '@/shared/components/ui/Button';
 import Card from '@/shared/components/ui/Card';
 import { X, Loader2, Plus } from 'lucide-react';
 import { useCreateLiquidationDraft } from '../hooks/useExpenseLedger';
+import { liquidationDomainErrorMessage } from '../utils/liquidation-domain-error';
 
 interface Building {
   readonly id: string;
@@ -95,7 +96,7 @@ export function CreateLiquidationModal({
       setError('');
       onSuccess?.();
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : 'Error al crear la liquidación');
+      setError(liquidationDomainErrorMessage(err, 'Error al crear la liquidación'));
     }
   };
 

--- a/apps/web/features/finance/components/IncomesTab.test.tsx
+++ b/apps/web/features/finance/components/IncomesTab.test.tsx
@@ -8,6 +8,8 @@ import { IncomesTab } from './IncomesTab';
 import * as useExpenseLedger from '../hooks/useExpenseLedger';
 import * as useFundsModule from '../hooks/useFunds';
 import * as useIncomeApplicationsModule from '../hooks/useIncomeApplications';
+import * as useEffectiveRoleModule from '@/features/tenancy/hooks/useEffectiveRole';
+import * as useLegacyIncomeBackfillModule from '../hooks/useLegacyIncomeBackfill';
 
 jest.mock('../hooks/useExpenseLedger', () => ({
   useIncomes: jest.fn(),
@@ -25,6 +27,15 @@ jest.mock('../hooks/useIncomeApplications', () => ({
   useIncomeApplicationPlan: jest.fn(),
   useApplyIncomePolicy: jest.fn(),
   useCreateIncomeApplicationPlan: jest.fn(),
+}));
+
+jest.mock('../hooks/useLegacyIncomeBackfill', () => ({
+  useLegacyIncomeBackfillPreview: jest.fn(),
+  useApplyLegacyIncomeBackfill: jest.fn(),
+}));
+
+jest.mock('@/features/tenancy/hooks/useEffectiveRole', () => ({
+  useHasAnyRoleInTenant: jest.fn(),
 }));
 
 jest.mock('@/shared/lib/format/money', () => ({
@@ -47,6 +58,9 @@ const mockedUseFunds = jest.mocked(useFundsModule.useFunds);
 const mockedUseIncomeApplicationPlan = jest.mocked(useIncomeApplicationsModule.useIncomeApplicationPlan);
 const mockedUseApplyIncomePolicy = jest.mocked(useIncomeApplicationsModule.useApplyIncomePolicy);
 const mockedUseCreateIncomeApplicationPlan = jest.mocked(useIncomeApplicationsModule.useCreateIncomeApplicationPlan);
+const mockedUseHasAnyRoleInTenant = jest.mocked(useEffectiveRoleModule.useHasAnyRoleInTenant);
+const mockedUseLegacyIncomeBackfillPreview = jest.mocked(useLegacyIncomeBackfillModule.useLegacyIncomeBackfillPreview);
+const mockedUseApplyLegacyIncomeBackfill = jest.mocked(useLegacyIncomeBackfillModule.useApplyLegacyIncomeBackfill);
 
 const makeIncome = (overrides: Record<string, unknown> = {}) => ({
   id: 'income-1',
@@ -104,6 +118,8 @@ function renderIncomesTab(incomes: ReturnType<typeof makeIncome>[], plan?: unkno
   } as never);
   mockedUseApplyIncomePolicy.mockReturnValue({ mutateAsync: jest.fn(), isPending: false } as never);
   mockedUseCreateIncomeApplicationPlan.mockReturnValue({ mutateAsync: jest.fn(), isPending: false } as never);
+  mockedUseLegacyIncomeBackfillPreview.mockReturnValue({ data: [], isPending: false, error: null } as never);
+  mockedUseApplyLegacyIncomeBackfill.mockReturnValue({ mutateAsync: jest.fn(), isPending: false, error: null } as never);
 
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const utils = render(
@@ -314,5 +330,42 @@ describe('IncomesTab plan state machine (FIN-07BR3)', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Plan' }));
     expect(screen.getByText(/Registrá este ingreso antes de definir su plan/)).toBeTruthy();
     expect(screen.queryByRole('button', { name: /Guardar plan manual/ })).toBeNull();
+  });
+});
+
+describe('IncomesTab legacy backfill RBAC (FIN-07CR2)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    ['TENANT_OWNER', true],
+    ['TENANT_ADMIN', true],
+    ['OPERATOR', false],
+    ['RESIDENT', false],
+  ])('shows the migration control only for tenant-level OWNER/ADMIN (%s)', (_role, visible) => {
+    mockedUseHasAnyRoleInTenant.mockReturnValue(visible as never);
+    renderIncomesTab([makeIncome({ status: 'RECORDED' })]);
+    const control = screen.queryByRole('button', { name: 'Migración histórica' });
+    expect(control !== null).toBe(visible);
+  });
+
+  it('hides the migration control when the membership cannot prove tenant scope (scoped admin)', () => {
+    mockedUseHasAnyRoleInTenant.mockReturnValue(false as never);
+    renderIncomesTab([makeIncome({ status: 'RECORDED' })]);
+    expect(screen.queryByRole('button', { name: 'Migración histórica' })).toBeNull();
+  });
+
+  it('keeps the panel closed for denied memberships even if toggle state was set', () => {
+    mockedUseHasAnyRoleInTenant.mockReturnValue(false as never);
+    renderIncomesTab([makeIncome({ status: 'RECORDED' })]);
+    expect(screen.queryByText(/Migración de ingresos legacy/)).toBeNull();
+  });
+
+  it('opens the panel for a tenant-level admin', () => {
+    mockedUseHasAnyRoleInTenant.mockReturnValue(true as never);
+    renderIncomesTab([makeIncome({ status: 'RECORDED' })]);
+    fireEvent.click(screen.getByRole('button', { name: 'Migración histórica' }));
+    expect(screen.getByText(/No hay ingresos históricos pendientes de migración/)).toBeTruthy();
   });
 });

--- a/apps/web/features/finance/components/IncomesTab.tsx
+++ b/apps/web/features/finance/components/IncomesTab.tsx
@@ -9,9 +9,11 @@ import { formatCurrency } from '@/shared/lib/format/money';
 import { useExpenseLedgerCategories, useIncomes, useRecordIncome, useUpdateIncome, useVoidIncome } from '../hooks/useExpenseLedger';
 import { useApplyIncomePolicy, useCreateIncomeApplicationPlan, useIncomeApplicationPlan } from '../hooks/useIncomeApplications';
 import { useFunds } from '../hooks/useFunds';
+import { useHasAnyRoleInTenant } from '@/features/tenancy/hooks/useEffectiveRole';
 import type { CreateIncomeApplicationInput, Income, IncomeApplication, IncomeApplicationDestination, UpdateIncomeData } from '../contracts';
 import { FinanceDialog } from './FinanceDialog';
 import { IncomeCreateModal } from './IncomeCreateModal';
+import { LegacyBackfillPanel } from './LegacyBackfillPanel';
 import { decimalToAmountMinor, minorToDecimalString, sumAmountMinor } from '../utils/money-input';
 import { incomeApplicationProvenance, type IncomeApplicationProvenanceOrigin } from '../utils/income-application-provenance';
 import { sameDateInput, toDateInputValue } from '../utils/date-input';
@@ -36,7 +38,13 @@ export function IncomesTab({ tenantId, period }: IncomesTabProps) {
   const [categoryId, setCategoryId] = useState('');
   const [status, setStatus] = useState<'ALL' | Income['status']>('ALL');
   const [showCreate, setShowCreate] = useState(false);
+  const [showBackfill, setShowBackfill] = useState(false);
   const [planIncome, setPlanIncome] = useState<Income | null>(null);
+  // FIN-07CR2: el backfill legacy exige TENANT_OWNER/TENANT_ADMIN con alcance
+  // de inquilino. `useHasAnyRoleInTenant` consulta `membership.roles`, que el
+  // backend construye SOLO con roles scopeType=TENANT: un OPERATOR o un admin
+  // con alcance BUILDING/UNIT no califican. Fail-closed: sin sesión/rol -> oculto.
+  const canUseLegacyBackfill = useHasAnyRoleInTenant(tenantId, ['TENANT_OWNER', 'TENANT_ADMIN']);
   const [editingIncome, setEditingIncome] = useState<Income | null>(null);
   const [confirmAction, setConfirmAction] = useState<{ income: Income; action: 'record' | 'void' } | null>(null);
   const { data: incomes = [], isPending, error } = useIncomes(tenantId, { period, categoryId: categoryId || undefined });
@@ -66,8 +74,16 @@ export function IncomesTab({ tenantId, period }: IncomesTabProps) {
           <h3 className="text-lg font-semibold">Ingresos</h3>
           <p className="text-sm text-muted-foreground">Los borradores se registran antes de definir un plan de aplicaciones inmutable.</p>
         </div>
-        <Button type="button" onClick={() => setShowCreate(true)} className="gap-2"><Plus className="h-4 w-4" />Registrar ingreso</Button>
+        <div className="flex gap-2">
+          {canUseLegacyBackfill && (
+            <Button type="button" variant="secondary" onClick={() => setShowBackfill((v) => !v)} className="gap-2" aria-expanded={showBackfill}>
+              {showBackfill ? 'Ocultar migración histórica' : 'Migración histórica'}
+            </Button>
+          )}
+          <Button type="button" onClick={() => setShowCreate(true)} className="gap-2"><Plus className="h-4 w-4" />Registrar ingreso</Button>
+        </div>
       </div>
+      {canUseLegacyBackfill && showBackfill && <LegacyBackfillPanel tenantId={tenantId} />}
       <div className="grid gap-3 sm:grid-cols-2">
         <label className="text-sm font-medium">Rubro
           <select value={categoryId} onChange={(event) => setCategoryId(event.target.value)} className="mt-1 w-full rounded border p-2">

--- a/apps/web/features/finance/components/LegacyBackfillPanel.tsx
+++ b/apps/web/features/finance/components/LegacyBackfillPanel.tsx
@@ -1,0 +1,310 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { Loader2, AlertTriangle, ArrowRightLeft } from 'lucide-react';
+import Button from '@/shared/components/ui/Button';
+import Card from '@/shared/components/ui/Card';
+import { formatCurrency } from '@/shared/lib/format/money';
+import { useFunds } from '../hooks/useFunds';
+import {
+  useApplyLegacyIncomeBackfill,
+  useLegacyIncomeBackfillPreview,
+} from '../hooks/useLegacyIncomeBackfill';
+import type {
+  Fund,
+  LegacyBackfillApplyItem,
+  LegacyBackfillApplyResultItem,
+  LegacyBackfillClassification,
+  LegacyBackfillPreviewItem,
+} from '../contracts';
+
+interface LegacyBackfillPanelProps {
+  tenantId: string;
+}
+
+const MAX_BATCH = 100;
+
+const CLASSIFICATION_LABELS: Record<LegacyBackfillClassification, string> = {
+  AUTO_MAPPABLE_OFFSET: 'Puede migrarse a Aplicar a gastos',
+  REQUIRES_RESERVE_FUND: 'Seleccione un Fondo de Reserva',
+  REQUIRES_SPECIAL_FUND: 'Seleccione un Fondo Especial',
+  ALREADY_HAS_PLAN: 'Ya usa el modelo moderno; no se modificará',
+  NOT_RECORDED: 'Ingreso no registrado; no se puede migrar',
+  LIQUIDATION_CONFLICT:
+    'Existe una liquidación histórica que impide migrarlo automáticamente',
+};
+
+const RESULT_STATUS_LABELS: Record<string, string> = {
+  MIGRATED: 'Migrados',
+  ALREADY_MIGRATED: 'Ya estaban migrados',
+  ALREADY_HAS_PLAN: 'Ya usan el modelo moderno',
+  REQUIRES_FUND: 'Requieren fondo',
+  INVALID_FUND: 'Fondo no válido',
+  LIQUIDATION_CONFLICT: 'Bloqueados por liquidación histórica',
+  NOT_RECORDED: 'No registrados',
+  NOT_FOUND: 'No encontrados',
+  INVALID_INCOME: 'Ingresos no válidos',
+};
+
+function isActionable(classification: LegacyBackfillClassification): boolean {
+  return (
+    classification === 'AUTO_MAPPABLE_OFFSET' ||
+    classification === 'REQUIRES_RESERVE_FUND' ||
+    classification === 'REQUIRES_SPECIAL_FUND'
+  );
+}
+
+function requiredFundType(
+  classification: LegacyBackfillClassification,
+): 'RESERVE' | 'SPECIAL' | null {
+  if (classification === 'REQUIRES_RESERVE_FUND') return 'RESERVE';
+  if (classification === 'REQUIRES_SPECIAL_FUND') return 'SPECIAL';
+  return null;
+}
+
+function fundLabel(fund: Fund): string {
+  return `${fund.name} (${fund.type})`;
+}
+
+function summarizeResults(results: LegacyBackfillApplyResultItem[]): string {
+  const counts = new Map<string, number>();
+  for (const result of results) {
+    counts.set(result.status, (counts.get(result.status) ?? 0) + 1);
+  }
+  const parts = Array.from(counts.entries()).map(
+    ([status, count]) => `${count} ${RESULT_STATUS_LABELS[status] ?? status.toLowerCase()}`,
+  );
+  return parts.join(', ');
+}
+
+/**
+ * FIN-07C: herramienta de migración (administración) de ingresos legacy al
+ * modelo moderno de IncomeApplication. No es el flujo diario de asignación;
+ * es una sección de mantenimiento.
+ *
+ * El backend sigue siendo la autoridad (RBAC TENANT_OWNER/TENANT_ADMIN,
+ * tope de lote, validación de fondos). Acá solo se controla la selección.
+ */
+export function LegacyBackfillPanel({ tenantId }: LegacyBackfillPanelProps) {
+  const [fundByIncome, setFundByIncome] = useState<Record<string, string>>({});
+  const [lastResult, setLastResult] = useState<LegacyBackfillApplyResultItem[] | null>(null);
+
+  const previewQuery = useLegacyIncomeBackfillPreview(tenantId, {});
+  const { data: funds = [] } = useFunds(tenantId, { status: 'ACTIVE' });
+  const applyMutation = useApplyLegacyIncomeBackfill(tenantId);
+
+  const reserveFunds = useMemo(
+    () => funds.filter((fund) => fund.type === 'RESERVE' && fund.status === 'ACTIVE'),
+    [funds],
+  );
+  const specialFunds = useMemo(
+    () => funds.filter((fund) => fund.type === 'SPECIAL' && fund.status === 'ACTIVE'),
+    [funds],
+  );
+
+  const items: LegacyBackfillPreviewItem[] = previewQuery.data ?? [];
+
+  const selectableItems = items.filter((item) => isActionable(item.classification));
+  const selectedIds = Object.keys(fundByIncome);
+
+  const applyItems: LegacyBackfillApplyItem[] = selectableItems
+    .filter((item) => selectedIds.includes(item.incomeId))
+    .map((item) => {
+      const fundId =
+        requiredFundType(item.classification) !== null
+          ? fundByIncome[item.incomeId]
+          : null;
+      return { incomeId: item.incomeId, fundId: fundId ?? null };
+    });
+
+  const missingFund = selectableItems.some(
+    (item) =>
+      selectedIds.includes(item.incomeId) &&
+      requiredFundType(item.classification) !== null &&
+      !fundByIncome[item.incomeId],
+  );
+
+  const canApply =
+    applyItems.length > 0 &&
+    applyItems.length <= MAX_BATCH &&
+    !missingFund &&
+    !applyMutation.isPending;
+
+  const toggle = (item: LegacyBackfillPreviewItem) => {
+    const alreadySelected = item.incomeId in fundByIncome;
+    setFundByIncome((prev) => {
+      const next = { ...prev };
+      if (alreadySelected) {
+        delete next[item.incomeId];
+      } else {
+        next[item.incomeId] = '';
+      }
+      return next;
+    });
+    setLastResult(null);
+  };
+
+  const handleApply = async () => {
+    setLastResult(null);
+    try {
+      const results = await applyMutation.mutateAsync(applyItems);
+      setLastResult(results);
+      setFundByIncome({});
+    } catch {
+      // Mutation error is surfaced via applyMutation.error below.
+    }
+  };
+
+  if (previewQuery.isPending) {
+    return (
+      <Card className="flex items-center justify-center gap-2 p-6 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Analizando ingresos históricos…
+      </Card>
+    );
+  }
+
+  if (previewQuery.isError) {
+    return (
+      <Card className="p-6 text-sm text-red-700" role="alert">
+        No pudimos analizar los ingresos históricos. Intentá nuevamente.
+      </Card>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <Card className="p-6 text-center text-sm text-muted-foreground">
+        No hay ingresos históricos pendientes de migración.
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="space-y-4 p-4">
+      <div className="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+        <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+        <p>
+          Herramienta de migración de ingresos históricos al modelo moderno de
+          aplicaciones. Solo administradores con alcance de inquilino pueden
+          ejecutarla.
+        </p>
+      </div>
+
+      <ul className="space-y-2">
+        {items.map((item) => {
+          const actionable = isActionable(item.classification);
+          const fundType = requiredFundType(item.classification);
+          const compatibleFunds = fundType === 'RESERVE' ? reserveFunds : specialFunds;
+          const selected = item.incomeId in fundByIncome;
+          const noCompatibleFund = fundType !== null && compatibleFunds.length === 0;
+
+          return (
+            <li
+              key={item.incomeId}
+              className="flex flex-col gap-2 rounded-md border bg-muted/20 p-3 sm:flex-row sm:items-center sm:justify-between"
+            >
+              <div className="min-w-0">
+                <p className="text-sm font-medium">
+                  {formatCurrency(item.amountMinor, item.currencyCode)} · {item.period}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  {CLASSIFICATION_LABELS[item.classification]}
+                </p>
+              </div>
+
+              <div className="flex items-center gap-2">
+                {fundType !== null && selected ? (
+                  noCompatibleFund ? (
+                    <p className="text-xs text-amber-700">
+                      {fundType === 'RESERVE'
+                        ? 'No hay un Fondo de Reserva activo. Cree uno antes de migrar este ingreso.'
+                        : 'No hay un Fondo Especial activo. Cree uno antes de migrar este ingreso.'}
+                    </p>
+                  ) : (
+                    <select
+                      aria-label={
+                        fundType === 'RESERVE'
+                          ? 'Fondo de Reserva'
+                          : 'Fondo Especial'
+                      }
+                      value={fundByIncome[item.incomeId] ?? ''}
+                      onChange={(event) =>
+                        setFundByIncome((prev) => ({
+                          ...prev,
+                          [item.incomeId]: event.target.value,
+                        }))
+                      }
+                      className="rounded border p-1 text-sm"
+                    >
+                      <option value="">
+                        {fundType === 'RESERVE'
+                          ? 'Seleccionar fondo de reserva'
+                          : 'Seleccionar fondo especial'}
+                      </option>
+                      {compatibleFunds.map((fund) => (
+                        <option key={fund.id} value={fund.id}>
+                          {fundLabel(fund)}
+                        </option>
+                      ))}
+                    </select>
+                  )
+                ) : null}
+
+                {actionable ? (
+                  <label className="flex items-center gap-1 text-xs">
+                    <input
+                      type="checkbox"
+                      checked={selected}
+                      onChange={() => toggle(item)}
+                      disabled={applyMutation.isPending}
+                      aria-label={`Seleccionar ingreso ${item.period} ${formatCurrency(item.amountMinor, item.currencyCode)}`}
+                    />
+                    Migrar
+                  </label>
+                ) : null}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      {applyMutation.error ? (
+        <p className="text-sm text-red-700" role="alert">
+          No pudimos completar la migración. Revisá la selección e intentá de nuevo.
+        </p>
+      ) : null}
+
+      {lastResult ? (
+        <div
+          className="rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800"
+          role="status"
+        >
+          <p className="font-medium">
+            {lastResult.length} ingresos procesados
+          </p>
+          <p className="mt-1">{summarizeResults(lastResult)}</p>
+        </div>
+      ) : null}
+
+      <div className="flex items-center justify-between gap-2 border-t pt-3">
+        <p className="text-xs text-muted-foreground">
+          {applyItems.length} seleccionados · máx. {MAX_BATCH} por lote
+        </p>
+        <Button
+          type="button"
+          onClick={handleApply}
+          disabled={!canApply}
+          className="gap-2"
+        >
+          {applyMutation.isPending ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <ArrowRightLeft className="h-4 w-4" />
+          )}
+          {applyMutation.isPending ? 'Migrando…' : 'Aplicar migración'}
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/apps/web/features/finance/components/LiquidationCard.tsx
+++ b/apps/web/features/finance/components/LiquidationCard.tsx
@@ -13,6 +13,8 @@ import {
   useCancelLiquidation,
 } from '../hooks/useExpenseLedger';
 import { LiquidationPublishModal } from './LiquidationPublishModal';
+import { LiquidationV3Breakdown } from './LiquidationV3Breakdown';
+import { liquidationDomainErrorMessage } from '../utils/liquidation-domain-error';
 
 interface LiquidationCardProps {
   tenantId: string;
@@ -83,8 +85,8 @@ export function LiquidationCard({
       await reviewMutation.mutateAsync(liquidation.id);
       toast('Liquidación marcada como revisada', 'success');
       onRefresh();
-    } catch {
-      toast('Error al revisar la liquidación', 'error');
+    } catch (err: unknown) {
+      toast(liquidationDomainErrorMessage(err, 'Error al revisar la liquidación'), 'error');
     }
   };
 
@@ -94,8 +96,7 @@ export function LiquidationCard({
       toast('Liquidación cancelada', 'success');
       onRefresh();
     } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : 'Error al cancelar';
-      toast(msg, 'error');
+      toast(liquidationDomainErrorMessage(err, 'Error al cancelar'), 'error');
     }
   };
 
@@ -243,6 +244,8 @@ export function LiquidationCard({
             </div>
           ) : resolvedDetail ? (
             <>
+              <LiquidationV3Breakdown liquidation={resolvedDetail} />
+
               <div className="space-y-2">
                 <h4 className="text-xs font-semibold uppercase text-muted-foreground">
                   Gastos incluidos

--- a/apps/web/features/finance/components/LiquidationV3Breakdown.tsx
+++ b/apps/web/features/finance/components/LiquidationV3Breakdown.tsx
@@ -1,0 +1,182 @@
+'use client';
+
+import { formatCurrency } from '@/shared/lib/format/money';
+import { incomeApplicationProvenance } from '../utils/income-application-provenance';
+import {
+  liquidationHasV3Summary,
+  liquidationIsZeroNet,
+} from '../utils/liquidation-v3';
+import type {
+  IncomeOffsetSnapshotItem,
+  Liquidation,
+  LiquidationDetail,
+} from '../contracts';
+
+interface LiquidationV3BreakdownProps {
+  liquidation: Liquidation | LiquidationDetail;
+}
+
+const PROVENANCE_LABELS = {
+  MANUAL: 'Manual',
+  POLICY: 'Política',
+  LEGACY: 'Legacy',
+  INVALID: 'Desconocido',
+} as const;
+
+function offsetProvenanceLabel(item: IncomeOffsetSnapshotItem): string {
+  const provenance = incomeApplicationProvenance({
+    policyVersionId: item.policyVersionId,
+    legacyDestination: item.legacyDestination,
+  });
+  return PROVENANCE_LABELS[provenance.origin];
+}
+
+/**
+ * FIN-07C: desglose V3 de una liquidación usando los campos persistidos
+ * (gross / adjustments / pre-income / offset / net). No recalcula contra
+ * datos live: es información financiera histórica congelada.
+ */
+export function LiquidationV3Breakdown({
+  liquidation,
+}: LiquidationV3BreakdownProps) {
+  if (!liquidationHasV3Summary(liquidation)) {
+    return (
+      <div
+        className="rounded-md border bg-muted/30 p-3 text-sm text-muted-foreground"
+        data-testid="liquidation-historical"
+      >
+        Liquidación histórica — formato anterior. No se muestran desgloses V3 de
+        ingresos aplicados.
+      </div>
+    );
+  }
+
+  const gross = liquidation.grossExpenseAmountMinor ?? 0;
+  const adjustment = liquidation.adjustmentAmountMinor ?? 0;
+  const preIncome = liquidation.preIncomeAmountMinor ?? 0;
+  const offset = liquidation.incomeOffsetAmountMinor ?? 0;
+  const net = liquidation.netDistributableAmountMinor ?? 0;
+  const baseCurrency = liquidation.baseCurrency;
+  const offsets = liquidation.incomeOffsetSnapshot ?? [];
+  const offsetsByCurrency = liquidation.incomeOffsetsByCurrency ?? null;
+  const zeroNet = liquidationIsZeroNet(liquidation);
+
+  return (
+    <div
+      className="space-y-3 rounded-md border bg-muted/20 p-3"
+      data-testid="liquidation-v3-breakdown"
+    >
+      <h4 className="text-xs font-semibold uppercase text-muted-foreground">
+        Desglose de la liquidación
+      </h4>
+
+      <dl className="space-y-1 text-sm">
+        <div className="flex justify-between">
+          <dt className="text-muted-foreground">Gastos brutos</dt>
+          <dd className="font-mono font-medium">
+            {formatCurrency(gross, baseCurrency)}
+          </dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-muted-foreground">Ajustes</dt>
+          <dd className="font-mono font-medium">
+            {formatCurrency(adjustment, baseCurrency)}
+          </dd>
+        </div>
+        <div className="flex justify-between border-t pt-1">
+          <dt className="font-medium">Subtotal</dt>
+          <dd className="font-mono font-medium">
+            {formatCurrency(preIncome, baseCurrency)}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="space-y-1">
+        <p className="text-sm font-medium text-muted-foreground">
+          Ingresos aplicados
+        </p>
+        {offsets.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Sin desglose de ingresos disponible.
+          </p>
+        ) : (
+          <ul className="space-y-1">
+            {offsets.map((item) => {
+              const hasSharedScope = item.applicationAmountMinor !== item.buildingAmountMinor;
+              return (
+                <li
+                  key={item.incomeApplicationId}
+                  data-testid="liquidation-offset-row"
+                  className="flex items-center justify-between gap-2 text-sm"
+                >
+                  <div className="min-w-0">
+                    <span className="font-medium">
+                      {item.categoryName ?? 'Ingreso'}
+                    </span>
+                    <span className="ml-2 inline-block rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+                      {offsetProvenanceLabel(item)}
+                    </span>
+                    {hasSharedScope ? (
+                      <span className="block text-xs text-muted-foreground">
+                        Aplicación total:{' '}
+                        {formatCurrency(item.applicationAmountMinor, item.currencyCode)}
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="text-right font-mono">
+                    {formatCurrency(item.buildingAmountMinor, item.currencyCode)}
+                    {item.currencyCode !== baseCurrency ? (
+                      <span className="text-muted-foreground">
+                        {' '}
+                        → {formatCurrency(item.valuedAmountMinor, baseCurrency)}
+                      </span>
+                    ) : null}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+
+        {offsetsByCurrency !== null && Object.keys(offsetsByCurrency).length > 0 ? (
+          <div className="mt-2 space-y-0.5 border-t pt-2 text-xs text-muted-foreground">
+            <p className="font-medium">Por moneda</p>
+            {Object.entries(offsetsByCurrency).map(([currency, amount]) => (
+              <div key={currency} className="flex justify-between">
+                <span>{currency}</span>
+                <span className="font-mono">
+                  {formatCurrency(amount, currency)}
+                </span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      <dl className="space-y-1 border-t pt-2 text-sm">
+        <div className="flex justify-between">
+          <dt className="text-muted-foreground">Ingresos aplicados</dt>
+          <dd className="font-mono font-medium">
+            −{formatCurrency(offset, baseCurrency)}
+          </dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="font-semibold">Neto a distribuir</dt>
+          <dd className="font-mono font-semibold">
+            {formatCurrency(net, baseCurrency)}
+          </dd>
+        </div>
+      </dl>
+
+      {zeroNet ? (
+        <p
+          className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs text-emerald-800"
+          data-testid="liquidation-zero-net"
+        >
+          El ingreso del edificio cubrió por completo el monto distribuible del
+          período. No quedan gastos a distribuir entre las unidades.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/features/finance/components/LiquidationsTab.tsx
+++ b/apps/web/features/finance/components/LiquidationsTab.tsx
@@ -9,6 +9,7 @@ import {
   useCreateLiquidationDraft,
 } from '../hooks/useExpenseLedger';
 import { LiquidationCard } from './LiquidationCard';
+import { liquidationDomainErrorMessage } from '../utils/liquidation-domain-error';
 
 interface LiquidationsTabProps {
   tenantId: string;
@@ -49,9 +50,7 @@ export function LiquidationsTab({
       toast('Borrador de liquidación creado', 'success');
       void refetch();
     } catch (err: unknown) {
-      const msg =
-        err instanceof Error ? err.message : 'Error al crear la liquidación';
-      toast(msg, 'error');
+      toast(liquidationDomainErrorMessage(err, 'Error al crear la liquidación'), 'error');
     } finally {
       setCreating(false);
     }

--- a/apps/web/features/finance/components/__tests__/LegacyBackfillPanel.test.tsx
+++ b/apps/web/features/finance/components/__tests__/LegacyBackfillPanel.test.tsx
@@ -1,0 +1,191 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { LegacyBackfillPanel } from '../LegacyBackfillPanel';
+import type {
+  Fund,
+  LegacyBackfillPreviewItem,
+} from '../../contracts';
+
+const applyMutateAsync = jest.fn();
+
+jest.mock('../../hooks/useLegacyIncomeBackfill', () => ({
+  useLegacyIncomeBackfillPreview: jest.fn(),
+  useApplyLegacyIncomeBackfill: jest.fn(() => ({
+    mutateAsync: applyMutateAsync,
+    isPending: false,
+    error: null,
+  })),
+}));
+
+jest.mock('../../hooks/useFunds', () => ({
+  useFunds: jest.fn(),
+}));
+
+const { useLegacyIncomeBackfillPreview } = jest.requireMock(
+  '../../hooks/useLegacyIncomeBackfill',
+);
+const { useFunds } = jest.requireMock('../../hooks/useFunds');
+
+function previewItem(
+  overrides: Partial<LegacyBackfillPreviewItem>,
+): LegacyBackfillPreviewItem {
+  return {
+    incomeId: 'income-1',
+    period: '2026-04',
+    categoryId: 'cat-1',
+    scopeType: 'BUILDING',
+    buildingId: 'building-1',
+    status: 'RECORDED',
+    destination: 'APPLY_TO_EXPENSES',
+    amountMinor: 10000,
+    currencyCode: 'ARS',
+    applicationsCount: 0,
+    classification: 'AUTO_MAPPABLE_OFFSET',
+    ...overrides,
+  };
+}
+
+const reserveFund: Fund = {
+  id: 'fund-reserve',
+  tenantId: 'tenant-1',
+  buildingId: null,
+  scopeType: 'TENANT',
+  type: 'RESERVE',
+  name: 'Fondo Reserva',
+  description: null,
+  status: 'ACTIVE',
+  balancesByCurrency: [],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  archivedAt: null,
+};
+
+const specialFund: Fund = {
+  ...reserveFund,
+  id: 'fund-special',
+  type: 'SPECIAL',
+  name: 'Fondo Especial',
+};
+
+function setup(items: LegacyBackfillPreviewItem[], funds: Fund[] = []) {
+  useLegacyIncomeBackfillPreview.mockReturnValue({
+    data: items,
+    isPending: false,
+    isError: false,
+  });
+  useFunds.mockReturnValue({ data: funds });
+  return render(<LegacyBackfillPanel tenantId="tenant-1" />);
+}
+
+describe('LegacyBackfillPanel', () => {
+  beforeEach(() => {
+    applyMutateAsync.mockReset();
+  });
+
+  it('renders classification labels for each preview item', () => {
+    setup([
+      previewItem({ incomeId: 'i1', classification: 'AUTO_MAPPABLE_OFFSET' }),
+      previewItem({ incomeId: 'i2', classification: 'REQUIRES_RESERVE_FUND', destination: 'RESERVE_FUND' }),
+      previewItem({ incomeId: 'i3', classification: 'REQUIRES_SPECIAL_FUND', destination: 'SPECIAL_FUND' }),
+      previewItem({ incomeId: 'i4', classification: 'ALREADY_HAS_PLAN' }),
+      previewItem({ incomeId: 'i5', classification: 'LIQUIDATION_CONFLICT' }),
+    ]);
+
+    expect(screen.getByText('Puede migrarse a Aplicar a gastos')).toBeTruthy();
+    expect(screen.getByText('Seleccione un Fondo de Reserva')).toBeTruthy();
+    expect(screen.getByText('Seleccione un Fondo Especial')).toBeTruthy();
+    expect(screen.getByText('Ya usa el modelo moderno; no se modificará')).toBeTruthy();
+    expect(
+      screen.getByText(
+        'Existe una liquidación histórica que impide migrarlo automáticamente',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('renders no migration checkbox for non-actionable classifications', () => {
+    setup([
+      previewItem({ incomeId: 'i4', classification: 'ALREADY_HAS_PLAN' }),
+      previewItem({ incomeId: 'i5', classification: 'LIQUIDATION_CONFLICT' }),
+      previewItem({ incomeId: 'i6', classification: 'NOT_RECORDED' }),
+    ]);
+
+    expect(screen.queryByRole('checkbox')).toBeNull();
+  });
+
+  it('requires an explicit RESERVE fund before applying a REQUIRES_RESERVE_FUND income', () => {
+    setup(
+      [
+        previewItem({
+          incomeId: 'i2',
+          classification: 'REQUIRES_RESERVE_FUND',
+          destination: 'RESERVE_FUND',
+        }),
+      ],
+      [reserveFund, specialFund],
+    );
+
+    const checkbox = screen.getByRole('checkbox');
+    fireEvent.click(checkbox);
+
+    const select = screen.getByLabelText('Fondo de Reserva');
+    expect(select).toBeTruthy();
+
+    // Only RESERVE funds are offered (never SPECIAL, never fallback by name).
+    const options = Array.from(
+      select.querySelectorAll('option'),
+    ).map((option) => option.getAttribute('value'));
+    expect(options).toContain('fund-reserve');
+    expect(options).not.toContain('fund-special');
+
+    // Apply is disabled until a fund is selected.
+    expect(screen.getByRole('button', { name: /Aplicar migración/ }).getAttribute('disabled')).not.toBeNull();
+
+    fireEvent.change(select, { target: { value: 'fund-reserve' } });
+    expect(screen.getByRole('button', { name: /Aplicar migración/ }).getAttribute('disabled')).toBeNull();
+  });
+
+  it('shows an actionable empty state when no compatible RESERVE fund exists', () => {
+    setup(
+      [
+        previewItem({
+          incomeId: 'i2',
+          classification: 'REQUIRES_RESERVE_FUND',
+          destination: 'RESERVE_FUND',
+        }),
+      ],
+      [specialFund],
+    );
+
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    expect(
+      screen.getByText(
+        'No hay un Fondo de Reserva activo. Cree uno antes de migrar este ingreso.',
+      ),
+    ).toBeTruthy();
+  });
+
+  it('summarizes a mixed batch result without collapsing into success/failure', async () => {
+    applyMutateAsync.mockResolvedValue([
+      { incomeId: 'i1', status: 'MIGRATED' },
+      { incomeId: 'i2', status: 'MIGRATED' },
+      { incomeId: 'i3', status: 'ALREADY_MIGRATED' },
+      { incomeId: 'i4', status: 'LIQUIDATION_CONFLICT' },
+    ]);
+
+    setup([
+      previewItem({ incomeId: 'i1', classification: 'AUTO_MAPPABLE_OFFSET' }),
+      previewItem({ incomeId: 'i2', classification: 'AUTO_MAPPABLE_OFFSET' }),
+      previewItem({ incomeId: 'i3', classification: 'AUTO_MAPPABLE_OFFSET' }),
+      previewItem({ incomeId: 'i4', classification: 'AUTO_MAPPABLE_OFFSET' }),
+    ]);
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    checkboxes.forEach((checkbox) => fireEvent.click(checkbox));
+
+    fireEvent.click(screen.getByRole('button', { name: /Aplicar migración/ }));
+
+    expect(await screen.findByText('4 ingresos procesados')).toBeTruthy();
+    expect(screen.getByText(/2 Migrados/)).toBeTruthy();
+    expect(screen.getByText(/1 Ya estaban migrados/)).toBeTruthy();
+    expect(screen.getByText(/1 Bloqueados por liquidación histórica/)).toBeTruthy();
+  });
+});

--- a/apps/web/features/finance/components/__tests__/LiquidationV3Breakdown.test.tsx
+++ b/apps/web/features/finance/components/__tests__/LiquidationV3Breakdown.test.tsx
@@ -1,0 +1,287 @@
+import { render, screen } from '@testing-library/react';
+import { LiquidationV3Breakdown } from '../LiquidationV3Breakdown';
+import { formatCurrency } from '@/shared/lib/format/money';
+import type { IncomeOffsetSnapshotItem, Liquidation } from '../../contracts';
+
+function buildLiquidation(overrides: Partial<Liquidation> = {}): Liquidation {
+  return {
+    id: 'liq-1',
+    tenantId: 'tenant-1',
+    buildingId: 'building-1',
+    period: '2026-05',
+    status: 'REVIEWED',
+    baseCurrency: 'ARS',
+    totalAmountMinor: 8500,
+    totalsByCurrency: { ARS: 8500 },
+    unitCount: 2,
+    generatedAt: '2026-05-01T00:00:00.000Z',
+    reviewedAt: null,
+    publishedAt: null,
+    canceledAt: null,
+    createdAt: '2026-05-01T00:00:00.000Z',
+    grossExpenseAmountMinor: 10000,
+    adjustmentAmountMinor: 0,
+    preIncomeAmountMinor: 10000,
+    incomeOffsetAmountMinor: 1500,
+    netDistributableAmountMinor: 8500,
+    ...overrides,
+  };
+}
+
+function snapshotItem(overrides: Partial<IncomeOffsetSnapshotItem>): IncomeOffsetSnapshotItem {
+  return {
+    incomeId: 'income-1',
+    incomeApplicationId: 'app-1',
+    categoryId: 'cat-1',
+    categoryName: 'Alquiler parrillera',
+    policyVersionId: null,
+    legacyDestination: null,
+    scopeType: 'BUILDING',
+    currencyCode: 'ARS',
+    applicationAmountMinor: 1050,
+    buildingAmountMinor: 1050,
+    valuedAmountMinor: 1050,
+    functionalCurrencyCode: null,
+    exchangeRateId: null,
+    exchangeRateValue: null,
+    exchangeRateDirection: null,
+    exchangeRateEffectiveAt: null,
+    conversionDate: null,
+    receivedDate: '2026-05-10',
+    period: '2026-05',
+    ...overrides,
+  };
+}
+
+describe('LiquidationV3Breakdown', () => {
+  it('renders the persisted V3 breakdown with gross/adjustment/subtotal/offset/net', () => {
+    render(<LiquidationV3Breakdown liquidation={buildLiquidation()} />);
+
+    expect(screen.getByText('Gastos brutos')).toBeTruthy();
+    expect(screen.getByText('Ajustes')).toBeTruthy();
+    expect(screen.getByText('Subtotal')).toBeTruthy();
+    expect(screen.getByText('Neto a distribuir')).toBeTruthy();
+
+    expect(
+      screen.getAllByText((_, el) => el?.textContent === formatCurrency(10000, 'ARS'))
+        .length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByText((_, el) => el?.textContent === formatCurrency(8500, 'ARS')),
+    ).toBeTruthy();
+    expect(
+      screen.getByText((_, el) => el?.textContent === `−${formatCurrency(1500, 'ARS')}`),
+    ).toBeTruthy();
+  });
+
+  it('renders offset rows with manual, policy and legacy provenance', () => {
+    const liquidation = buildLiquidation({
+      incomeOffsetSnapshot: [
+        snapshotItem({
+          incomeApplicationId: 'app-1',
+          categoryName: 'Manual cat',
+          policyVersionId: null,
+          legacyDestination: null,
+        }),
+        snapshotItem({
+          incomeApplicationId: 'app-2',
+          categoryName: 'Policy cat',
+          policyVersionId: 'policy-1',
+          legacyDestination: null,
+        }),
+        snapshotItem({
+          incomeApplicationId: 'app-3',
+          categoryName: 'Legacy cat',
+          policyVersionId: null,
+          legacyDestination: 'APPLY_TO_EXPENSES',
+        }),
+      ],
+    });
+
+    render(<LiquidationV3Breakdown liquidation={liquidation} />);
+
+    expect(screen.getByText('Manual cat')).toBeTruthy();
+    expect(screen.getByText('Policy cat')).toBeTruthy();
+    expect(screen.getByText('Legacy cat')).toBeTruthy();
+    expect(screen.getByText('Manual')).toBeTruthy();
+    expect(screen.getByText('Política')).toBeTruthy();
+    expect(screen.getByText('Legacy')).toBeTruthy();
+  });
+
+  it('presents incomeOffsetsByCurrency as separate lines without a fake total', () => {
+    const liquidation = buildLiquidation({
+      incomeOffsetsByCurrency: { USD: 5000, COP: 8000000 },
+    });
+
+    render(<LiquidationV3Breakdown liquidation={liquidation} />);
+
+    expect(screen.getByText('USD')).toBeTruthy();
+    expect(screen.getByText('COP')).toBeTruthy();
+    expect(
+      screen.getByText((_, el) => el?.textContent === formatCurrency(5000, 'USD')),
+    ).toBeTruthy();
+    expect(
+      screen.getByText((_, el) => el?.textContent === formatCurrency(8000000, 'COP')),
+    ).toBeTruthy();
+  });
+
+  it('renders the historical label for V1/V2 (no V3 summary fields)', () => {
+    const liquidation = buildLiquidation({
+      grossExpenseAmountMinor: null,
+      adjustmentAmountMinor: null,
+      preIncomeAmountMinor: null,
+      incomeOffsetAmountMinor: null,
+      netDistributableAmountMinor: null,
+    });
+
+    render(<LiquidationV3Breakdown liquidation={liquidation} />);
+
+    expect(screen.getByTestId('liquidation-historical')).toBeTruthy();
+    expect(screen.queryByText('Gastos brutos')).toBeNull();
+  });
+
+  it('renders a valid zero-net liquidation with an explanation', () => {
+    const liquidation = buildLiquidation({
+      grossExpenseAmountMinor: 5000,
+      adjustmentAmountMinor: 0,
+      preIncomeAmountMinor: 5000,
+      incomeOffsetAmountMinor: 5000,
+      netDistributableAmountMinor: 0,
+      totalAmountMinor: 0,
+      totalsByCurrency: { ARS: 0 },
+    });
+
+    render(<LiquidationV3Breakdown liquidation={liquidation} />);
+
+    expect(screen.getByTestId('liquidation-zero-net')).toBeTruthy();
+    expect(
+      screen.getAllByText((_, el) => el?.textContent === formatCurrency(0, 'ARS'))
+        .length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('renders a valid zero-offset V3 liquidation (empty snapshot + empty currency map)', () => {
+    const liquidation = buildLiquidation({
+      grossExpenseAmountMinor: 10000,
+      adjustmentAmountMinor: 0,
+      preIncomeAmountMinor: 10000,
+      incomeOffsetAmountMinor: 0,
+      netDistributableAmountMinor: 10000,
+      totalAmountMinor: 10000,
+      totalsByCurrency: { ARS: 10000 },
+      incomeOffsetSnapshot: [],
+      incomeOffsetsByCurrency: {},
+    });
+
+    render(<LiquidationV3Breakdown liquidation={liquidation} />);
+
+    expect(screen.getByTestId('liquidation-v3-breakdown')).toBeTruthy();
+    expect(screen.queryByTestId('liquidation-offset-row')).toBeNull();
+    expect(screen.queryByText('Por moneda')).toBeNull();
+    expect(
+      screen.getAllByText((_, el) => el?.textContent === formatCurrency(10000, 'ARS'))
+        .length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('shows the building share (not the whole application) for TENANT_SHARED offsets', () => {
+    const liquidation = buildLiquidation({
+      incomeOffsetAmountMinor: 4200,
+      netDistributableAmountMinor: 5800,
+      totalAmountMinor: 5800,
+      totalsByCurrency: { ARS: 5800 },
+      incomeOffsetSnapshot: [
+        snapshotItem({
+          incomeApplicationId: 'app-shared',
+          categoryName: 'Alquiler parrillera',
+          scopeType: 'TENANT_SHARED',
+          currencyCode: 'ARS',
+          applicationAmountMinor: 7000,
+          buildingAmountMinor: 4200,
+          valuedAmountMinor: 4200,
+        }),
+      ],
+    });
+
+    render(<LiquidationV3Breakdown liquidation={liquidation} />);
+
+    const row = screen.getByTestId('liquidation-offset-row');
+    const primaryAmount = row.querySelector('div.text-right')?.textContent ?? '';
+    expect(primaryAmount).toContain('42,00');
+    expect(primaryAmount).not.toContain('70,00');
+    // El total de la aplicación queda expuesto secundariamente, etiquetado.
+    expect(row.textContent).toContain('Aplicación total:');
+    expect(row.textContent).toContain('70,00');
+  });
+
+  it('shows building original amount converted to base for cross-currency shared offsets', () => {
+    const liquidation = buildLiquidation({
+      baseCurrency: 'COP',
+      incomeOffsetAmountMinor: 2400000,
+      netDistributableAmountMinor: 1600000,
+      totalAmountMinor: 1600000,
+      totalsByCurrency: { COP: 1600000 },
+      incomeOffsetSnapshot: [
+        snapshotItem({
+          incomeApplicationId: 'app-xcur',
+          categoryName: 'Publicidad',
+          scopeType: 'UNIT_GROUP',
+          currencyCode: 'USD',
+          applicationAmountMinor: 10000,
+          buildingAmountMinor: 6000,
+          valuedAmountMinor: 2400000,
+          functionalCurrencyCode: 'COP',
+        }),
+      ],
+    });
+
+    render(<LiquidationV3Breakdown liquidation={liquidation} />);
+
+    const row = screen.getByTestId('liquidation-offset-row');
+    const primaryAmount = row.querySelector('div.text-right')?.textContent ?? '';
+    expect(primaryAmount).toContain('60,00');
+    expect(primaryAmount).toContain('24.000,00');
+    expect(primaryAmount).not.toContain('100,00');
+    // El total de la aplicación queda expuesto secundariamente, etiquetado.
+    expect(row.textContent).toContain('Aplicación total:');
+    expect(row.textContent).toContain('100,00');
+  });
+
+  it('reconciles displayed building shares with the persisted offset total', () => {
+    const liquidation = buildLiquidation({
+      incomeOffsetAmountMinor: 6000,
+      netDistributableAmountMinor: 4000,
+      totalAmountMinor: 4000,
+      totalsByCurrency: { ARS: 4000 },
+      incomeOffsetSnapshot: [
+        snapshotItem({
+          incomeApplicationId: 'app-shared-1',
+          categoryName: 'Alquiler parrillera',
+          scopeType: 'TENANT_SHARED',
+          currencyCode: 'ARS',
+          applicationAmountMinor: 10000,
+          buildingAmountMinor: 4200,
+          valuedAmountMinor: 4200,
+        }),
+        snapshotItem({
+          incomeApplicationId: 'app-shared-2',
+          categoryName: 'Publicidad',
+          scopeType: 'TENANT_SHARED',
+          currencyCode: 'ARS',
+          applicationAmountMinor: 10000,
+          buildingAmountMinor: 1800,
+          valuedAmountMinor: 1800,
+        }),
+      ],
+    });
+
+    render(<LiquidationV3Breakdown liquidation={liquidation} />);
+
+    const rows = screen.getAllByTestId('liquidation-offset-row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].textContent).toContain('42,00');
+    expect(rows[1].textContent).toContain('18,00');
+    // La suma de los shares mostrados reconcilia con el offset persistido.
+    expect(4200 + 1800).toBe(liquidation.incomeOffsetAmountMinor);
+  });
+});

--- a/apps/web/features/finance/contracts/finance-guards.test.ts
+++ b/apps/web/features/finance/contracts/finance-guards.test.ts
@@ -5,6 +5,8 @@ import {
   isIncomeOffsetSnapshotItem,
   isIncomePolicy,
   isLiquidationV3Summary,
+  parseIncomeOffsetsByCurrency,
+  parseIncomeOffsetSnapshot,
   parseLegacyBackfillPreview,
   parseLegacyBackfillResults,
 } from './finance-guards';
@@ -76,5 +78,36 @@ describe('FIN-07AR finance guards', () => {
     expect(isFinanceCurrency('USD')).toBe(true);
     expect(isFinanceCurrency('VES')).toBe(true);
     expect(isFinanceCurrency('ARS')).toBe(true);
+  });
+
+  it('parses income offsets by currency as separate entries (never a nominal total)', () => {
+    expect(parseIncomeOffsetsByCurrency(null)).toBeNull();
+    expect(parseIncomeOffsetsByCurrency(undefined)).toBeNull();
+    expect(parseIncomeOffsetsByCurrency({ USD: 5000, COP: 8000000 })).toEqual({
+      USD: 5000,
+      COP: 8000000,
+    });
+    // {} es válido: V3 moderna con cero offsets.
+    expect(parseIncomeOffsetsByCurrency({})).toEqual({});
+    expect(() => parseIncomeOffsetsByCurrency({ USD: -1 })).toThrow();
+    expect(() => parseIncomeOffsetsByCurrency({ USD: '5000' })).toThrow();
+    expect(() => parseIncomeOffsetsByCurrency([{ USD: 5000 }])).toThrow();
+  });
+
+  it('parses the frozen income offset snapshot array (or null for V1/V2)', () => {
+    const item = {
+      incomeId: 'income', incomeApplicationId: 'app', categoryId: 'cat', categoryName: null,
+      policyVersionId: null, legacyDestination: 'APPLY_TO_EXPENSES', scopeType: 'BUILDING',
+      currencyCode: 'USD', applicationAmountMinor: 1, buildingAmountMinor: 1, valuedAmountMinor: 1,
+      functionalCurrencyCode: null, exchangeRateId: null, exchangeRateValue: null,
+      exchangeRateDirection: null, exchangeRateEffectiveAt: null, conversionDate: null,
+      receivedDate: '2026-08-01', period: '2026-08',
+    };
+    expect(parseIncomeOffsetSnapshot(null)).toBeNull();
+    expect(parseIncomeOffsetSnapshot([item])).toHaveLength(1);
+    expect(() => parseIncomeOffsetSnapshot('nope')).toThrow();
+    expect(() =>
+      parseIncomeOffsetSnapshot([{ ...item, incomeApplicationId: undefined }]),
+    ).toThrow();
   });
 });

--- a/apps/web/features/finance/contracts/finance-guards.ts
+++ b/apps/web/features/finance/contracts/finance-guards.ts
@@ -367,3 +367,36 @@ export function isLiquidationV3Summary(value: unknown): value is LiquidationV3Su
 export function assertLiquidationV3Summary(value: unknown): void {
   assertFinancialResponse(isLiquidationV3Summary(value), 'liquidation V3 summary');
 }
+
+/**
+ * FIN-07C: mapa { currency: valuedMinor } de offsets congelados.
+ * Nunca colapsar a un nominal único entre monedas distintas.
+ *
+ * `{}` es válido: una liquidación V3 moderna puede tener CERO offsets
+ * (gross > 0, incomeOffset = 0, snapshot = [], byCurrency = {}).
+ * null/undefined solo representan registros históricos pre-FIN-06.
+ */
+export function isIncomeOffsetsByCurrency(value: unknown): value is Record<string, number> {
+  if (value === null || value === undefined) return true;
+  if (typeof value !== 'object' || Array.isArray(value)) return false;
+  const entries = Object.entries(value as Record<string, unknown>);
+  return entries.every(
+    ([currency, amount]) =>
+      currency.length > 0 && isNonNegativeInt(amount),
+  );
+}
+
+export function parseIncomeOffsetsByCurrency(value: unknown): Record<string, number> | null {
+  if (value === null || value === undefined) return null;
+  assertFinancialResponse(isIncomeOffsetsByCurrency(value), 'income offsets by currency');
+  return value as Record<string, number>;
+}
+
+export function parseIncomeOffsetSnapshot(value: unknown): IncomeOffsetSnapshotItem[] | null {
+  if (value === null || value === undefined) return null;
+  assertFinancialResponse(
+    Array.isArray(value) && value.every(isIncomeOffsetSnapshotItem),
+    'liquidation income offset snapshot',
+  );
+  return value;
+}

--- a/apps/web/features/finance/contracts/finance-types.ts
+++ b/apps/web/features/finance/contracts/finance-types.ts
@@ -358,6 +358,10 @@ export interface Liquidation extends LiquidationV3Summary {
   publishedAt: string | null;
   canceledAt: string | null;
   createdAt: string;
+  // FIN-07C: offsets de ingresos congelados (solo V3).
+  // null/undefined = liquidación histórica (pre-FIN-06) sin offsets.
+  incomeOffsetsByCurrency?: Record<string, number> | null;
+  incomeOffsetSnapshot?: IncomeOffsetSnapshotItem[] | null;
 }
 
 export interface LiquidationDetail extends Liquidation {

--- a/apps/web/features/finance/services/expense-ledger.api.ts
+++ b/apps/web/features/finance/services/expense-ledger.api.ts
@@ -1,5 +1,9 @@
 import { apiClient } from '@/shared/lib/http/client';
-import { assertLiquidationV3Summary } from '../contracts/finance-guards';
+import {
+  assertLiquidationV3Summary,
+  parseIncomeOffsetSnapshot,
+  parseIncomeOffsetsByCurrency,
+} from '../contracts/finance-guards';
 import type {
   CreateIncomeData,
   Income,
@@ -439,7 +443,7 @@ export async function listLiquidations(
     method: 'GET',
   });
   liquidations.forEach(assertLiquidationV3Summary);
-  return liquidations;
+  return liquidations.map(normalizeLiquidationIncomeOffsets);
 }
 
 export async function getLiquidation(
@@ -451,7 +455,24 @@ export async function getLiquidation(
     method: 'GET',
   });
   assertLiquidationV3Summary(liquidation);
-  return liquidation;
+  return normalizeLiquidationIncomeOffsets(liquidation);
+}
+
+/**
+ * FIN-07C: valida y normaliza los campos read-only de offsets congelados.
+ * null/undefined (histórico V1/V2) se aceptan; valores malformados se rechazan
+ * (fail-closed) en lugar de silenciarse.
+ */
+function normalizeLiquidationIncomeOffsets<T extends Liquidation>(liquidation: T): T {
+  return {
+    ...liquidation,
+    incomeOffsetsByCurrency: parseIncomeOffsetsByCurrency(
+      (liquidation as { incomeOffsetsByCurrency?: unknown }).incomeOffsetsByCurrency,
+    ),
+    incomeOffsetSnapshot: parseIncomeOffsetSnapshot(
+      (liquidation as { incomeOffsetSnapshot?: unknown }).incomeOffsetSnapshot,
+    ),
+  };
 }
 
 export async function createLiquidationDraft(

--- a/apps/web/features/finance/utils/liquidation-domain-error.test.ts
+++ b/apps/web/features/finance/utils/liquidation-domain-error.test.ts
@@ -1,0 +1,43 @@
+import { HttpError } from '@/shared/lib/http/client';
+import { liquidationDomainErrorMessage } from './liquidation-domain-error';
+
+describe('liquidationDomainErrorMessage', () => {
+  it('maps LIQUIDATION_INCOME_OFFSETS_EXCEED_GROSS', () => {
+    const err = new HttpError(422, 'Unprocessable', 'boom', {
+      error: 'LIQUIDATION_INCOME_OFFSETS_EXCEED_GROSS',
+      message: 'boom',
+    });
+    expect(liquidationDomainErrorMessage(err, 'fallback')).toContain(
+      'superan el subtotal distribuible',
+    );
+  });
+
+  it('maps LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED', () => {
+    const err = new HttpError(422, 'Unprocessable', 'boom', {
+      error: 'LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED',
+    });
+    expect(liquidationDomainErrorMessage(err, 'fallback')).toContain(
+      'valuación funcional congelada',
+    );
+  });
+
+  it('maps LIQUIDATION_INCOME_SOURCE_DRIFT', () => {
+    const err = new HttpError(422, 'Unprocessable', 'boom', {
+      error: 'LIQUIDATION_INCOME_SOURCE_DRIFT',
+    });
+    expect(liquidationDomainErrorMessage(err, 'fallback')).toContain(
+      'Cancelá y regenerá',
+    );
+  });
+
+  it('keeps the original message for non-domain errors', () => {
+    const err = new HttpError(400, 'Bad Request', 'mensaje original', {
+      error: 'SOMETHING_ELSE',
+    });
+    expect(liquidationDomainErrorMessage(err, 'fallback')).toBe('mensaje original');
+  });
+
+  it('returns the fallback for a plain unknown error', () => {
+    expect(liquidationDomainErrorMessage({}, 'fallback')).toBe('fallback');
+  });
+});

--- a/apps/web/features/finance/utils/liquidation-domain-error.ts
+++ b/apps/web/features/finance/utils/liquidation-domain-error.ts
@@ -1,0 +1,44 @@
+import { HttpError } from '@/shared/lib/http/client';
+
+/**
+ * FIN-07C: traduce códigos de dominio de liquidación (campo `error` de la
+ * respuesta 422) a mensajes accionables. No exponer stack traces ni texto
+ * interno del backend.
+ */
+
+const LIQUIDATION_DOMAIN_MESSAGES: Record<string, string> = {
+  LIQUIDATION_INCOME_OFFSETS_EXCEED_GROSS:
+    'Los ingresos aplicados superan el subtotal distribuible. Verificá los ingresos del período.',
+  LIQUIDATION_INCOME_OFFSET_CURRENCY_MISMATCH:
+    'No se puede aplicar un ingreso en otra moneda en una liquidación nominal. Ajustá la moneda o la valuación funcional.',
+  LIQUIDATION_FUNCTIONAL_SNAPSHOT_REQUIRED:
+    'Falta la valuación funcional congelada para completar la liquidación. Verificá la configuración multicurrency.',
+  LIQUIDATION_INCOME_SOURCE_DRIFT:
+    'Las fuentes financieras congeladas ya no coinciden con el borrador. Cancelá y regenerá la liquidación para mayor seguridad.',
+  LIQUIDATION_BASE_CURRENCY_MISMATCH:
+    'La moneda base de la liquidación no coincide con la esperada.',
+  MIXED_CURRENCY_LIQUIDATION_NOT_SUPPORTED:
+    'No se soportan liquidaciones con gastos en múltiples monedas sin valuación funcional.',
+  LIQUIDATION_PUBLICATION_SOURCE_DRIFT:
+    'Las fuentes de publicación ya no coinciden con el borrador. Cancelá y regenerá la liquidación.',
+};
+
+/**
+ * Devuelve un mensaje de error amigable para errores de dominio de liquidación.
+ * Si el error no es de dominio, conserva el mensaje original del error.
+ */
+export function liquidationDomainErrorMessage(
+  err: unknown,
+  fallback: string,
+): string {
+  if (err instanceof HttpError && err.data) {
+    const code = err.data.error ?? err.data.code;
+    if (typeof code === 'string' && code in LIQUIDATION_DOMAIN_MESSAGES) {
+      return LIQUIDATION_DOMAIN_MESSAGES[code];
+    }
+  }
+  if (err instanceof Error && err.message) {
+    return err.message;
+  }
+  return fallback;
+}

--- a/apps/web/features/finance/utils/liquidation-v3.test.ts
+++ b/apps/web/features/finance/utils/liquidation-v3.test.ts
@@ -1,0 +1,65 @@
+import { liquidationHasV3Summary, liquidationIsZeroNet } from './liquidation-v3';
+
+function base() {
+  return {
+    grossExpenseAmountMinor: 10000,
+    adjustmentAmountMinor: 0,
+    preIncomeAmountMinor: 10000,
+    incomeOffsetAmountMinor: 1500,
+    netDistributableAmountMinor: 8500,
+  };
+}
+
+describe('liquidationHasV3Summary', () => {
+  it('is true when all five FIN-06 fields are present', () => {
+    expect(liquidationHasV3Summary(base())).toBe(true);
+  });
+
+  it('is false for historical V1/V2 (null summary fields)', () => {
+    expect(
+      liquidationHasV3Summary({
+        grossExpenseAmountMinor: null,
+        adjustmentAmountMinor: null,
+        preIncomeAmountMinor: null,
+        incomeOffsetAmountMinor: null,
+        netDistributableAmountMinor: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('is false when any field is missing', () => {
+    expect(
+      liquidationHasV3Summary({ ...base(), netDistributableAmountMinor: null }),
+    ).toBe(false);
+  });
+});
+
+describe('liquidationIsZeroNet', () => {
+  it('detects zero net when pre-income equals the offset', () => {
+    expect(
+      liquidationIsZeroNet({
+        grossExpenseAmountMinor: 5000,
+        adjustmentAmountMinor: 0,
+        preIncomeAmountMinor: 5000,
+        incomeOffsetAmountMinor: 5000,
+        netDistributableAmountMinor: 0,
+      }),
+    ).toBe(true);
+  });
+
+  it('is false for a normal non-zero net', () => {
+    expect(liquidationIsZeroNet(base())).toBe(false);
+  });
+
+  it('is false for historical null fields', () => {
+    expect(
+      liquidationIsZeroNet({
+        grossExpenseAmountMinor: null,
+        adjustmentAmountMinor: null,
+        preIncomeAmountMinor: null,
+        incomeOffsetAmountMinor: null,
+        netDistributableAmountMinor: null,
+      }),
+    ).toBe(false);
+  });
+});

--- a/apps/web/features/finance/utils/liquidation-v3.ts
+++ b/apps/web/features/finance/utils/liquidation-v3.ts
@@ -1,0 +1,41 @@
+import type { Liquidation } from '../contracts';
+
+/**
+ * FIN-07C: helpers para distinguir liquidaciones V3 de históricas V1/V2 y
+ * detectar el caso zero-net. No recalcula nada: usa los campos persistidos.
+ */
+
+type V3SummaryFields = Pick<
+  Liquidation,
+  | 'grossExpenseAmountMinor'
+  | 'adjustmentAmountMinor'
+  | 'preIncomeAmountMinor'
+  | 'incomeOffsetAmountMinor'
+  | 'netDistributableAmountMinor'
+>;
+
+/**
+ * V3 real: los cinco campos FIN-06 están presentes (no null/undefined).
+ * Una liquidación histórica V1/V2 tiene estos campos null.
+ */
+export function liquidationHasV3Summary(liquidation: V3SummaryFields): boolean {
+  return (
+    liquidation.grossExpenseAmountMinor != null &&
+    liquidation.adjustmentAmountMinor != null &&
+    liquidation.preIncomeAmountMinor != null &&
+    liquidation.incomeOffsetAmountMinor != null &&
+    liquidation.netDistributableAmountMinor != null
+  );
+}
+
+/**
+ * Zero-net: el ingreso elegible cubrió por completo el distribuible del período.
+ * No es un estado roto; se muestra como liquidación válida con neto 0.
+ */
+export function liquidationIsZeroNet(liquidation: V3SummaryFields): boolean {
+  return (
+    liquidation.preIncomeAmountMinor != null &&
+    liquidation.incomeOffsetAmountMinor != null &&
+    liquidation.preIncomeAmountMinor === liquidation.incomeOffsetAmountMinor
+  );
+}

--- a/apps/web/features/tenancy/hooks/useEffectiveRole.test.ts
+++ b/apps/web/features/tenancy/hooks/useEffectiveRole.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment jsdom
+ *
+ * FIN-07CR2: prueba el hook de autoridad de tenant usado para gatear el
+ * backfill legacy. `useHasAnyRoleInTenant` lee `membership.roles`, que el
+ * backend construye SOLO con roles scopeType=TENANT (tenancy.service.ts).
+ * Por lo tanto un admin con alcance BUILDING/UNIT no califica, y el control
+ * permanece oculto (fail-closed).
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useHasAnyRoleInTenant } from './useEffectiveRole';
+import { useAuthSession } from '@/features/auth/useAuthSession';
+
+jest.mock('@/features/auth/useAuthSession', () => ({
+  useAuthSession: jest.fn(),
+}));
+
+const mockedUseAuthSession = jest.mocked(useAuthSession);
+
+function sessionWith(
+  roles: string[],
+  scopedRoles: unknown[],
+  membershipTenantId = 'tenant-1',
+) {
+  return {
+    user: { id: 'u1', email: 'a@b.c', name: 'A' },
+    activeTenantId: 'tenant-1',
+    memberships: [{ tenantId: membershipTenantId, roles, scopedRoles }],
+  };
+}
+
+describe('useHasAnyRoleInTenant (FIN-07CR2 legacy backfill gate)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each([
+    ['TENANT_OWNER', ['TENANT_OWNER'], true],
+    ['TENANT_ADMIN', ['TENANT_ADMIN'], true],
+    ['OPERATOR', ['OPERATOR'], false],
+    ['RESIDENT', ['RESIDENT'], false],
+  ])('proves tenant-level OWNER/ADMIN authority (%s)', (_label, roles, expected) => {
+    mockedUseAuthSession.mockReturnValue(sessionWith(roles, []) as never);
+
+    const { result } = renderHook(() =>
+      useHasAnyRoleInTenant('tenant-1', ['TENANT_OWNER', 'TENANT_ADMIN']),
+    );
+
+    expect(result.current).toBe(expected);
+  });
+
+  it('hides for a BUILDING-scoped admin (no tenant-scoped roles)', () => {
+    mockedUseAuthSession.mockReturnValue(
+      sessionWith([], [
+        {
+          id: 'r1',
+          role: 'TENANT_ADMIN',
+          scopeType: 'BUILDING',
+          scopeBuildingId: 'b1',
+          scopeUnitId: null,
+        },
+      ]) as never,
+    );
+
+    const { result } = renderHook(() =>
+      useHasAnyRoleInTenant('tenant-1', ['TENANT_OWNER', 'TENANT_ADMIN']),
+    );
+
+    expect(result.current).toBe(false);
+  });
+
+  it('hides for a UNIT-scoped admin (no tenant-scoped roles)', () => {
+    mockedUseAuthSession.mockReturnValue(
+      sessionWith([], [
+        {
+          id: 'r1',
+          role: 'TENANT_ADMIN',
+          scopeType: 'UNIT',
+          scopeBuildingId: null,
+          scopeUnitId: 'u1',
+        },
+      ]) as never,
+    );
+
+    const { result } = renderHook(() =>
+      useHasAnyRoleInTenant('tenant-1', ['TENANT_OWNER', 'TENANT_ADMIN']),
+    );
+
+    expect(result.current).toBe(false);
+  });
+
+  it('hides for a cross-tenant membership', () => {
+    mockedUseAuthSession.mockReturnValue(
+      sessionWith(['TENANT_ADMIN'], [], 'tenant-2') as never,
+    );
+
+    const { result } = renderHook(() =>
+      useHasAnyRoleInTenant('tenant-1', ['TENANT_OWNER', 'TENANT_ADMIN']),
+    );
+
+    expect(result.current).toBe(false);
+  });
+
+  it('fails closed without a session or tenant', () => {
+    mockedUseAuthSession.mockReturnValue(null as never);
+    const { result } = renderHook(() =>
+      useHasAnyRoleInTenant('tenant-1', ['TENANT_OWNER', 'TENANT_ADMIN']),
+    );
+    expect(result.current).toBe(false);
+
+    mockedUseAuthSession.mockReturnValue(sessionWith(['TENANT_ADMIN'], []) as never);
+    const { result: noTenant } = renderHook(() =>
+      useHasAnyRoleInTenant(undefined, ['TENANT_OWNER', 'TENANT_ADMIN']),
+    );
+    expect(noTenant.current).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Completes FIN-07C over the previously merged FIN-07A/FIN-07B finance foundation.

### Liquidation V3
- renders persisted gross expenses, adjustments, pre-income subtotal, income offsets and net distributable
- exposes frozen Income offset provenance and per-currency information
- displays building-specific shared Income amounts correctly
- preserves historical V1/V2 presentation
- handles valid zero-net liquidations
- translates known liquidation domain errors
- keeps mutation/cache flows without hard reload

### Legacy income backfill
- adds controlled preview/apply UX
- maps APPLY_TO_EXPENSES to OFFSET_EXPENSES
- requires explicit compatible RESERVE/SPECIAL funds
- keeps modern IncomeApplications authoritative
- exposes historical liquidation conflicts
- shows per-Income batch outcomes
- gates maintenance UX to TENANT_OWNER/TENANT_ADMIN while backend remains authoritative

### Read-contract hardening
- exposes persisted FIN-06 offset snapshot data read-only
- uses a shared fail-closed Income offset snapshot parser
- preserves historical compatibility
- accepts V3 zero-offset [] / {}
- rejects malformed modern V3 financial artifacts

## Validation

- focused FIN-07C tests green
- finance suites green
- full web suite green
- web build green
- API finance suite green
- API build green
- targeted lint green
- git diff --check clean
- real browser smoke completed on disposable PostgreSQL DB
- normal local database unchanged
- no schema changes
- no migrations
- no staging
- no production

Closes #182
