### PR TITLE
fix(release): close final production preflight blockers

### DIFF
--- a/docs/release/PRODUCTION_DEPLOY_RUNBOOK.md
+++ b/docs/release/PRODUCTION_DEPLOY_RUNBOOK.md
@@ -106,7 +106,7 @@ For incident recovery, use the separately gated candidate-restore, swap, and rev
 
 ## Exact migration transition
 
-`scripts/manifests/production-migrations-81-to-97.tsv` binds the only approved transition: 81 successful migrations, zero failed migrations, the exact next 16 migration names and SHA-256 values, and a final state of 97 successful migrations with zero failed or rolled-back rows.
+`scripts/manifests/production-migrations-81-to-97.tsv` binds the only approved transition: 81 successful migrations, zero failed migrations, the exact next 16 migration names and SHA-256 values, and a final state of 97 successful migrations with zero failed or rolled-back rows. `scripts/manifests/production-migration-metadata-exceptions.tsv` contains the only approved historical metadata exception: `20260719000000_add_receipt_sequence` may be finished and active with `applied_steps_count=0` only when its audited checksum matches and the ReceiptSequence DDL baseline passes exactly.
 
 The deploy sequence is fail-closed:
 
@@ -115,31 +115,31 @@ The deploy sequence is fail-closed:
 3. Immediately before `prisma migrate deploy`, the database must match the exact 81-row baseline and contain none of the 16 pending rows.
 4. Immediately after migration, the database must contain exactly the 97 expected active, finished rows; all 16 new database checksums must match the manifest.
 
-Any missing, extra, duplicate, failed, rolled-back, partial, reordered, renamed, or checksum-mismatched migration stops deployment. Do not edit migration history or bypass the verifier.
+Any missing, extra, duplicate, failed, rolled-back, partial, reordered, renamed, or checksum-mismatched migration stops deployment. No zero-step row is accepted outside the immutable historical exception manifest. Do not edit migration history or bypass the verifier.
 
 ## Application rollback
 
-`scripts/rollback-production.sh` uses captured image digests and never changes the database. It requires a protected compatibility receipt created only after an isolated rehearsal against the migrated schema.
+`scripts/rollback-production.sh` uses captured image digests and never changes the database. The deploy script creates the protected compatibility receipt only after migration, post-verification, and the shared compatibility guard pass, and before API/Web recreation. If generation or immediate validation fails, deployment stops before application recreation.
 
 Receipt format:
 
 ```text
-version=rollback-compatibility-receipt.v1
+receipt_version=rollback-compatibility-receipt.v2
 receipt_id=<unique-safe-id>
 timestamp_utc=<YYYY-MM-DDTHH:MM:SSZ>
-status=SAFE
+compatibility=SAFE
 target_sha=<deployed-40-character-sha>
 previous_sha=<previous-40-character-sha>
 previous_api_digest=sha256:<64-hex>
 previous_web_digest=sha256:<64-hex>
-migration_count=<verified-count>
+migration_count=97
 ```
 
-The filename must be `<receipt_id>.receipt`. Store receipts as direct children of `/opt/pawtech/apps/buildingos/compatibility/`, owned by `yoryi:yoryi`, with mode exactly `0600`; the directory path and every component must be canonical and contain no symlinks. Fields must appear exactly once in the order shown, use LF endings, and end with one LF. Never commit environment-specific receipts. If compatibility is `CONDITIONAL`, `UNKNOWN`, or `UNSAFE`, do not create a SAFE receipt and do not run rollback.
+The filename must be `<receipt_id>.receipt`. Store receipts as direct children of `/opt/pawtech/apps/buildingos/compatibility/`, owned by `yoryi:yoryi`, with directory mode exactly `0700` and receipt mode exactly `0600`; the directory path and every component must be canonical and contain no symlinks. Fields must appear exactly once in the order shown, use LF endings, and end with one LF. Never commit environment-specific receipts. If compatibility is `CONDITIONAL`, `UNKNOWN`, or `UNSAFE`, do not create a SAFE receipt and do not run rollback.
 
 Rollback does not check out old source or rebuild old images. It tags the captured digests locally, recreates only API/Web, verifies the unchanged migration count, then runs health smoke.
 
-Immediately before rollback, the script also requires zero rows using target-only Finance structures: cross-currency snapshots/rates, shared recurring expenses, funds, income applications/policies, valued liquidations and income offsets. If users have created any such data, the previous application is no longer considered compatible and rollback stops without changing runtime or database.
+Immediately before rollback, the script reuses the same read-only compatibility guard used by deploy and requires zero rows using target-only Finance structures: cross-currency snapshots/rates, shared recurring expenses, funds, income applications/policies, valued liquidations and income offsets. If users have created any such data, the previous application is no longer considered compatible and rollback stops without changing runtime or database.
 
 ## Post-deploy smoke
 

--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -54,6 +54,7 @@ NEW_API_DIGEST='unknown'
 NEW_WEB_DIGEST='unknown'
 BACKUP_ID='unknown'
 MIGRATION_COUNT='unknown'
+ROLLBACK_RECEIPT='unknown'
 
 write_record() {
   local status="$1"
@@ -71,6 +72,7 @@ write_record() {
     printf 'new_web_digest=%s\n' "$NEW_WEB_DIGEST"
     printf 'backup_id=%s\n' "$BACKUP_ID"
     printf 'migration_count=%s\n' "$MIGRATION_COUNT"
+    printf 'rollback_receipt=%s\n' "$ROLLBACK_RECEIPT"
     printf 'database_rollback=never-automatic\n'
     printf 'services_recreated=buildingos-api buildingos-web\n'
     printf 'seeds=no\n'
@@ -220,6 +222,11 @@ POSTGRES_CONTAINER="$POSTGRES_CONTAINER" DATABASE_NAME=buildingos_db \
   bash ./scripts/verify-production-migration-manifest.sh verify-db post
 MIGRATION_COUNT="$(docker exec "$POSTGRES_CONTAINER" sh -lc 'exec psql -qAt -U "$POSTGRES_USER" -d buildingos_db -c '\''SELECT count(*) FROM "_prisma_migrations" WHERE finished_at IS NOT NULL AND rolled_back_at IS NULL'\''')"
 [[ "$MIGRATION_COUNT" == '97' ]] || fail "Final migration count is not exactly 97"
+
+PHASE='rollback-compatibility'
+validate_application_rollback_compatibility "$POSTGRES_CONTAINER" buildingos_db
+ROLLBACK_RECEIPT="$(generate_rollback_compatibility_receipt \
+  "$TARGET_SHA" "$PREVIOUS_SHA" "$PREVIOUS_API_DIGEST" "$PREVIOUS_WEB_DIGEST" "$MIGRATION_COUNT")"
 
 PHASE='application-recreate'
 "${compose[@]}" up --detach --no-deps --force-recreate buildingos-api buildingos-web

--- a/scripts/manifests/production-migration-metadata-exceptions.tsv
+++ b/scripts/manifests/production-migration-metadata-exceptions.tsv
@@ -1,0 +1,2 @@
+manifest_version	1
+exception	20260719000000_add_receipt_sequence	93c6d2c0b8c4468fea26489cfb4875bfdc6763ec0056487c21094eae0dbcb257

--- a/scripts/production-security-validate.sh
+++ b/scripts/production-security-validate.sh
@@ -7,7 +7,7 @@ readonly BACKUP_SCRIPT_SHA256='3cbf2bf191bd9a06e7bbf831848cfa2816cd80fca980593f8
 readonly BACKUP_SCRIPT_OWNER='yoryi'
 readonly BACKUP_SCRIPT_GROUP='yoryi'
 readonly BACKUP_SCRIPT_MODE='0775'
-readonly ROLLBACK_RECEIPT_VERSION='rollback-compatibility-receipt.v1'
+readonly ROLLBACK_RECEIPT_VERSION='rollback-compatibility-receipt.v2'
 readonly PRODUCTION_ROLLBACK_PROTECTED_DIR='/opt/pawtech/apps/buildingos/compatibility'
 readonly PRODUCTION_ROLLBACK_EXPECTED_OWNER='yoryi'
 readonly PRODUCTION_ROLLBACK_EXPECTED_GROUP='yoryi'
@@ -201,6 +201,18 @@ resolve_rollback_security_context() {
   fi
 }
 
+validate_rollback_protected_directory() {
+  local owner group mode
+
+  require_canonical_directory_without_symlinks "$ROLLBACK_SECURITY_PROTECTED_DIR" 'Rollback protected directory'
+  owner="$(file_owner "$ROLLBACK_SECURITY_PROTECTED_DIR")" || security_fail 'Unable to read rollback protected directory owner'
+  group="$(file_group "$ROLLBACK_SECURITY_PROTECTED_DIR")" || security_fail 'Unable to read rollback protected directory group'
+  mode="0$(file_mode "$ROLLBACK_SECURITY_PROTECTED_DIR")" || security_fail 'Unable to read rollback protected directory mode'
+  [[ "$owner" == "$ROLLBACK_SECURITY_EXPECTED_OWNER" ]] || security_fail 'Rollback protected directory owner mismatch'
+  [[ "$group" == "$ROLLBACK_SECURITY_EXPECTED_GROUP" ]] || security_fail 'Rollback protected directory group mismatch'
+  [[ "$mode" == '0700' ]] || security_fail 'Rollback protected directory mode must be exactly 0700'
+}
+
 validate_canonical_timestamp() {
   local timestamp="$1"
   local parsed
@@ -311,7 +323,7 @@ validate_rollback_receipt() {
   local expected_previous_sha="$3"
   local expected_api_digest="$4"
   local expected_web_digest="$5"
-  local receipt_parent receipt_name body receipt_id timestamp status target_sha previous_sha api_digest web_digest migration_count
+  local receipt_parent receipt_name body receipt_id timestamp compatibility target_sha previous_sha api_digest web_digest migration_count
   local -a lines=()
 
   [[ "$expected_target_sha" =~ ^[0-9a-f]{40}$ && "$expected_previous_sha" =~ ^[0-9a-f]{40}$ ]] \
@@ -320,7 +332,7 @@ validate_rollback_receipt() {
     || security_fail "Receipt digest arguments must be immutable SHA-256 digests"
 
   resolve_rollback_security_context
-  require_canonical_directory_without_symlinks "$ROLLBACK_SECURITY_PROTECTED_DIR" 'Rollback protected directory'
+  validate_rollback_protected_directory
   [[ "$receipt" == /* && "$receipt" != *'//'* && "$receipt" != *'/./'* && "$receipt" != *'/../'* && "$receipt" != */. && "$receipt" != */.. ]] \
     || security_fail "Compatibility receipt path is not lexically canonical"
   receipt_parent="${receipt%/*}"
@@ -338,11 +350,11 @@ validate_rollback_receipt() {
   while IFS= read -r line; do
     lines+=("$line")
   done <<< "$body"
-  [[ "${#lines[@]}" -eq 9 ]] || security_fail "Compatibility receipt must contain exactly nine ordered v1 fields"
-  [[ "${lines[0]}" == "version=$ROLLBACK_RECEIPT_VERSION" ]] || security_fail "Compatibility receipt version mismatch"
+  [[ "${#lines[@]}" -eq 9 ]] || security_fail "Compatibility receipt must contain exactly nine ordered v2 fields"
+  [[ "${lines[0]}" == "receipt_version=$ROLLBACK_RECEIPT_VERSION" ]] || security_fail "Compatibility receipt version mismatch"
   [[ "${lines[1]}" == receipt_id=* ]] || security_fail "Compatibility receipt field 2 must be receipt_id"
   [[ "${lines[2]}" == timestamp_utc=* ]] || security_fail "Compatibility receipt field 3 must be timestamp_utc"
-  [[ "${lines[3]}" == status=* ]] || security_fail "Compatibility receipt field 4 must be status"
+  [[ "${lines[3]}" == compatibility=* ]] || security_fail "Compatibility receipt field 4 must be compatibility"
   [[ "${lines[4]}" == target_sha=* ]] || security_fail "Compatibility receipt field 5 must be target_sha"
   [[ "${lines[5]}" == previous_sha=* ]] || security_fail "Compatibility receipt field 6 must be previous_sha"
   [[ "${lines[6]}" == previous_api_digest=* ]] || security_fail "Compatibility receipt field 7 must be previous_api_digest"
@@ -351,7 +363,7 @@ validate_rollback_receipt() {
 
   receipt_id="${lines[1]#receipt_id=}"
   timestamp="${lines[2]#timestamp_utc=}"
-  status="${lines[3]#status=}"
+  compatibility="${lines[3]#compatibility=}"
   target_sha="${lines[4]#target_sha=}"
   previous_sha="${lines[5]#previous_sha=}"
   api_digest="${lines[6]#previous_api_digest=}"
@@ -361,7 +373,7 @@ validate_rollback_receipt() {
   [[ "$receipt_id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || security_fail "Receipt ID is invalid"
   [[ "$receipt_name" == "$receipt_id.receipt" ]] || security_fail "Receipt filename does not match receipt_id"
   validate_canonical_timestamp "$timestamp"
-  [[ "$status" == 'SAFE' ]] || security_fail "Rollback compatibility is not SAFE"
+  [[ "$compatibility" == 'SAFE' ]] || security_fail "Rollback compatibility is not SAFE"
   [[ "$target_sha" == "$expected_target_sha" ]] || security_fail "Receipt target SHA mismatch"
   [[ "$previous_sha" == "$expected_previous_sha" ]] || security_fail "Receipt previous SHA mismatch"
   [[ "$api_digest" == "$expected_api_digest" ]] || security_fail "Receipt API digest mismatch"
@@ -370,6 +382,88 @@ validate_rollback_receipt() {
 
   # shellcheck disable=SC2034 # Output consumed by rollback-production.sh after sourcing this file.
   VALIDATED_ROLLBACK_MIGRATION_COUNT="$migration_count"
+}
+
+validate_application_rollback_compatibility() {
+  local postgres_container="${1:-pawtech-postgres}"
+  local database_name="${2:-buildingos_db}"
+  local result
+
+  [[ "$postgres_container" =~ ^[A-Za-z0-9_.-]+$ ]] || security_fail 'Unsafe PostgreSQL container name'
+  [[ "$database_name" =~ ^[a-z0-9_]+$ ]] || security_fail 'Unsafe database name'
+  command -v docker >/dev/null 2>&1 || security_fail 'docker is required for compatibility validation'
+  docker inspect "$postgres_container" >/dev/null 2>&1 || security_fail 'PostgreSQL container is unavailable for compatibility validation'
+
+  result="$({
+    docker exec -i "$postgres_container" sh -lc \
+      'exec psql -v ON_ERROR_STOP=1 -qAt -U "$POSTGRES_USER" -d "$1"' sh "$database_name" <<'SQL'
+BEGIN READ ONLY;
+SELECT CASE WHEN
+  (
+    SELECT count(*) FROM "RecurringExpense" WHERE "buildingId" IS NULL
+  )
+  + (SELECT count(*) FROM "ExchangeRate")
+  + (SELECT count(*) FROM "Expense" WHERE "functionalAmountMinor" IS NOT NULL)
+  + (SELECT count(*) FROM "Income" WHERE "functionalAmountMinor" IS NOT NULL)
+  + (SELECT count(*) FROM "Adjustment" WHERE "functionalAmountMinor" IS NOT NULL)
+  + (SELECT count(*) FROM "Payment" WHERE "functionalAmountMinor" IS NOT NULL)
+  + (SELECT count(*) FROM "PaymentAllocation" WHERE "paymentOriginalAmountMinor" IS NOT NULL)
+  + (SELECT count(*) FROM "Liquidation" WHERE "valuationMode" IS NOT NULL)
+  + (SELECT count(*) FROM "Fund")
+  + (SELECT count(*) FROM "FundTransaction")
+  + (SELECT count(*) FROM "IncomeApplication")
+  + (SELECT count(*) FROM "IncomePolicy")
+  + (SELECT count(*) FROM "LiquidationIncomeOffset") = 0
+THEN 'SAFE' ELSE 'UNSAFE' END;
+COMMIT;
+SQL
+  } 2>/dev/null)" || security_fail 'Unable to validate application rollback compatibility'
+
+  [[ "$result" == 'SAFE' ]] || security_fail 'New-schema data makes application rollback unsafe'
+  printf 'Application rollback compatibility verified: SAFE\n'
+}
+
+generate_rollback_compatibility_receipt() {
+  local target_sha="$1"
+  local previous_sha="$2"
+  local previous_api_digest="$3"
+  local previous_web_digest="$4"
+  local migration_count="$5"
+  local receipt_id receipt timestamp_utc
+
+  [[ "$target_sha" =~ ^[0-9a-f]{40}$ && "$previous_sha" =~ ^[0-9a-f]{40}$ ]] \
+    || security_fail 'Receipt generation requires exact commit SHAs'
+  [[ "$previous_api_digest" =~ ^sha256:[0-9a-f]{64}$ && "$previous_web_digest" =~ ^sha256:[0-9a-f]{64}$ ]] \
+    || security_fail 'Receipt generation requires immutable image digests'
+  [[ "$migration_count" == '97' ]] || security_fail 'Receipt generation requires exactly 97 applied migrations'
+
+  resolve_rollback_security_context
+  if [[ ! -e "$ROLLBACK_SECURITY_PROTECTED_DIR" ]]; then
+    (umask 077 && mkdir "$ROLLBACK_SECURITY_PROTECTED_DIR") \
+      || security_fail 'Unable to create rollback protected directory'
+  fi
+  validate_rollback_protected_directory
+
+  receipt_id="rollback-$target_sha"
+  receipt="$ROLLBACK_SECURITY_PROTECTED_DIR/$receipt_id.receipt"
+  if [[ -e "$receipt" || -L "$receipt" ]]; then
+    validate_rollback_receipt "$receipt" "$target_sha" "$previous_sha" "$previous_api_digest" "$previous_web_digest"
+    printf '%s\n' "$receipt"
+    return
+  fi
+  timestamp_utc="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" || security_fail 'Unable to generate receipt timestamp'
+
+  if ! (
+    umask 077
+    set -o noclobber
+    printf 'receipt_version=%s\nreceipt_id=%s\ntimestamp_utc=%s\ncompatibility=SAFE\ntarget_sha=%s\nprevious_sha=%s\nprevious_api_digest=%s\nprevious_web_digest=%s\nmigration_count=%s\n' \
+      "$ROLLBACK_RECEIPT_VERSION" "$receipt_id" "$timestamp_utc" "$target_sha" "$previous_sha" \
+      "$previous_api_digest" "$previous_web_digest" "$migration_count" > "$receipt"
+  ); then
+    security_fail 'Unable to create rollback compatibility receipt without clobbering'
+  fi
+  validate_rollback_receipt "$receipt" "$target_sha" "$previous_sha" "$previous_api_digest" "$previous_web_digest"
+  printf '%s\n' "$receipt"
 }
 
 production_security_usage() {

--- a/scripts/rollback-production.sh
+++ b/scripts/rollback-production.sh
@@ -52,23 +52,7 @@ cd "$APP_DIR"
 [[ "$(git rev-parse HEAD)" == "$EXPECTED_CURRENT_SHA" ]] || fail "Production checkout changed since compatibility review"
 current_migration_count="$(docker exec "$POSTGRES_CONTAINER" sh -lc 'exec psql -qAt -U "$POSTGRES_USER" -d buildingos_db -c '\''SELECT count(*) FROM "_prisma_migrations" WHERE finished_at IS NOT NULL AND rolled_back_at IS NULL'\''')"
 [[ "$current_migration_count" == "$migration_count" ]] || fail "Database migration count changed after compatibility review"
-incompatible_rows="$(docker exec "$POSTGRES_CONTAINER" sh -lc 'exec psql -qAt -U "$POSTGRES_USER" -d buildingos_db -c '\''
-  SELECT
-    (SELECT count(*) FROM "RecurringExpense" WHERE "buildingId" IS NULL)
-    + (SELECT count(*) FROM "ExchangeRate")
-    + (SELECT count(*) FROM "Expense" WHERE "functionalAmountMinor" IS NOT NULL)
-    + (SELECT count(*) FROM "Income" WHERE "functionalAmountMinor" IS NOT NULL)
-    + (SELECT count(*) FROM "Adjustment" WHERE "functionalAmountMinor" IS NOT NULL)
-    + (SELECT count(*) FROM "Payment" WHERE "functionalAmountMinor" IS NOT NULL)
-    + (SELECT count(*) FROM "PaymentAllocation" WHERE "paymentOriginalAmountMinor" IS NOT NULL)
-    + (SELECT count(*) FROM "Liquidation" WHERE "valuationMode" IS NOT NULL)
-    + (SELECT count(*) FROM "Fund")
-    + (SELECT count(*) FROM "FundTransaction")
-    + (SELECT count(*) FROM "IncomeApplication")
-    + (SELECT count(*) FROM "IncomePolicy")
-    + (SELECT count(*) FROM "LiquidationIncomeOffset")
-'\''')"
-[[ "$incompatible_rows" == '0' ]] || fail "New-schema Finance data makes application rollback unsafe"
+validate_application_rollback_compatibility "$POSTGRES_CONTAINER" buildingos_db
 
 docker image inspect "$PREVIOUS_API_DIGEST" >/dev/null
 docker image inspect "$PREVIOUS_WEB_DIGEST" >/dev/null

--- a/scripts/tests/production-deploy-order.test.sh
+++ b/scripts/tests/production-deploy-order.test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly DEPLOY_SCRIPT="$ROOT_DIR/scripts/deploy-production.sh"
+readonly ROLLBACK_SCRIPT="$ROOT_DIR/scripts/rollback-production.sh"
+
+line_number() { awk -v pattern="$1" 'index($0, pattern) { print NR; exit }' "$2"; }
+post_line="$(line_number 'verify-production-migration-manifest.sh verify-db post' "$DEPLOY_SCRIPT")"
+compatibility_line="$(line_number 'validate_application_rollback_compatibility "$POSTGRES_CONTAINER" buildingos_db' "$DEPLOY_SCRIPT")"
+receipt_line="$(line_number 'generate_rollback_compatibility_receipt' "$DEPLOY_SCRIPT")"
+recreate_line="$(line_number 'up --detach --no-deps --force-recreate buildingos-api buildingos-web' "$DEPLOY_SCRIPT")"
+[[ -n "$post_line" && -n "$compatibility_line" && -n "$receipt_line" && -n "$recreate_line" ]]
+(( post_line < compatibility_line && compatibility_line < receipt_line && receipt_line < recreate_line ))
+grep -F 'validate_application_rollback_compatibility "$POSTGRES_CONTAINER" buildingos_db' "$ROLLBACK_SCRIPT" >/dev/null
+if grep -F 'incompatible_rows=' "$ROLLBACK_SCRIPT" >/dev/null; then exit 1; fi
+printf 'PASS: migration -> post verification -> compatibility -> receipt -> application recreation\n'

--- a/scripts/tests/production-security.test.sh
+++ b/scripts/tests/production-security.test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2016
 set -Eeuo pipefail
 
 ROOT_DIR="$(cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd -P)"
@@ -50,6 +51,7 @@ protected_dir="$tmp_root/protected"
 mock_bin="$tmp_root/mock-bin"
 docker_marker="$tmp_root/docker-called"
 mkdir -p "$protected_dir" "$mock_bin"
+chmod 700 "$protected_dir"
 
 current_owner="$(id -un)"
 current_group="$(id -gn)"
@@ -57,6 +59,14 @@ current_group="$(id -gn)"
 cat > "$mock_bin/docker" <<EOF
 #!/usr/bin/env bash
 touch '$docker_marker'
+if [[ "\$1" == 'inspect' ]]; then
+  exit 0
+fi
+if [[ "\$1" == 'exec' ]]; then
+  cat >/dev/null
+  printf '%s\n' "\${MOCK_COMPATIBILITY:-SAFE}"
+  exit 0
+fi
 exit 99
 EOF
 chmod 700 "$mock_bin/docker"
@@ -65,10 +75,10 @@ write_receipt() {
   local path="$1"
   local receipt_id="$2"
   cat > "$path" <<EOF
-version=rollback-compatibility-receipt.v1
+receipt_version=rollback-compatibility-receipt.v2
 receipt_id=$receipt_id
 timestamp_utc=2026-08-23T12:34:56Z
-status=SAFE
+compatibility=SAFE
 target_sha=$TARGET_SHA
 previous_sha=$PREVIOUS_SHA
 previous_api_digest=$API_DIGEST
@@ -172,7 +182,7 @@ expect_failure 'rejects a receipt not using exact 0600 before Docker' \
   run_invalid_rollback "$wrong_mode_receipt"
 
 malformed_receipt="$protected_dir/rollback-malformed.receipt"
-printf 'version=rollback-compatibility-receipt.v1\r\nreceipt_id=rollback-malformed\r\n' > "$malformed_receipt"
+printf 'receipt_version=rollback-compatibility-receipt.v2\r\nreceipt_id=rollback-malformed\r\n' > "$malformed_receipt"
 chmod 600 "$malformed_receipt"
 expect_failure 'rejects a malformed CRLF receipt before Docker' \
   run_invalid_rollback "$malformed_receipt"
@@ -202,5 +212,45 @@ expect_failure 'rejects a backup manifest with a mismatched SHA-256' \
 
 [[ ! -e "$docker_marker" ]] || fail_test 'failed validation must not invoke Docker'
 pass 'all failed rollback validations avoid Docker side effects'
+
+expect_success 'shared compatibility guard accepts safe data' \
+  env \
+    PATH="$mock_bin:$PATH" \
+    MOCK_COMPATIBILITY=SAFE \
+    bash -c 'source "$1"; validate_application_rollback_compatibility mock-postgres buildingos_db' _ "$VALIDATOR"
+
+expect_failure 'shared compatibility guard rejects unsafe data' \
+  env \
+    PATH="$mock_bin:$PATH" \
+    MOCK_COMPATIBILITY=UNSAFE \
+    bash -c 'source "$1"; validate_application_rollback_compatibility mock-postgres buildingos_db' _ "$VALIDATOR"
+
+generated_receipt="$(env \
+  TEST_MODE=1 \
+  ROLLBACK_PROTECTED_DIR="$protected_dir" \
+  ROLLBACK_EXPECTED_OWNER="$current_owner" \
+  ROLLBACK_EXPECTED_GROUP="$current_group" \
+  bash -c 'source "$1"; generate_rollback_compatibility_receipt "$2" "$3" "$4" "$5" 97' _ "$VALIDATOR" "$TARGET_SHA" "$PREVIOUS_SHA" "$API_DIGEST" "$WEB_DIGEST")" \
+  || fail_test 'receipt generation failed'
+[[ -f "$generated_receipt" ]] || fail_test 'receipt generation did not return a regular receipt path'
+pass 'generates and immediately validates a safe rollback receipt'
+
+reused_receipt="$(env \
+  TEST_MODE=1 \
+  ROLLBACK_PROTECTED_DIR="$protected_dir" \
+  ROLLBACK_EXPECTED_OWNER="$current_owner" \
+  ROLLBACK_EXPECTED_GROUP="$current_group" \
+  bash -c 'source "$1"; generate_rollback_compatibility_receipt "$2" "$3" "$4" "$5" 97' _ "$VALIDATOR" "$TARGET_SHA" "$PREVIOUS_SHA" "$API_DIGEST" "$WEB_DIGEST")" \
+  || fail_test 'valid receipt reuse failed'
+[[ "$reused_receipt" == "$generated_receipt" ]] || fail_test 'receipt reuse returned a different path'
+pass 'reuses a matching receipt after a retry'
+
+expect_failure 'rejects an existing receipt with mismatched immutable inputs' \
+  env \
+    TEST_MODE=1 \
+    ROLLBACK_PROTECTED_DIR="$protected_dir" \
+    ROLLBACK_EXPECTED_OWNER="$current_owner" \
+    ROLLBACK_EXPECTED_GROUP="$current_group" \
+    bash -c 'source "$1"; generate_rollback_compatibility_receipt "$2" "$3" "$4" "$5" 97' _ "$VALIDATOR" "$TARGET_SHA" "$TARGET_SHA" "$API_DIGEST" "$WEB_DIGEST"
 
 printf '1..%d\n' "$tests_run"

--- a/scripts/tests/verify-production-migration-baseline.test.sh
+++ b/scripts/tests/verify-production-migration-baseline.test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly VERIFIER="$ROOT_DIR/scripts/verify-production-migration-baseline.sh"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/migration-baseline-test.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+mkdir -p "$TMP_DIR/bin"
+
+cat > "$TMP_DIR/bin/docker" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "$1" == inspect ]]; then exit 0; fi
+if [[ "$1" == exec ]]; then
+  query="$(cat)"
+  [[ "$query" == *ReceiptSequence* ]] || exit 1
+  printf '%s\n' "${BASELINE_RESULT:-OK}"
+  exit 0
+fi
+exit 1
+MOCK
+chmod 700 "$TMP_DIR/bin/docker"
+
+PATH="$TMP_DIR/bin:$PATH" BASELINE_RESULT=OK bash "$VERIFIER"
+printf 'ok 1 - ReceiptSequence baseline invariants pass\n'
+if PATH="$TMP_DIR/bin:$PATH" BASELINE_RESULT=FAIL bash "$VERIFIER" >/dev/null 2>&1; then
+  printf 'not ok - ReceiptSequence DDL mismatch unexpectedly passed\n' >&2
+  exit 1
+fi
+printf 'ok 2 - ReceiptSequence DDL mismatch fails closed\n1..2\n'

--- a/scripts/tests/verify-production-migration-manifest.test.sh
+++ b/scripts/tests/verify-production-migration-manifest.test.sh
@@ -76,6 +76,14 @@ write_fixture() {
   done
 }
 
+write_historical_exception_fixture() {
+  local destination="$1"
+
+  write_fixture "$TMP_DIR/historical-base.tsv" 81
+  awk -F "$TAB" -v OFS="$TAB" '$1 == "20260719000000_add_receipt_sequence" { $5 = 0 } { print }' \
+    "$TMP_DIR/historical-base.tsv" > "$destination"
+}
+
 run_fixture() {
   local fixture="$1"
   local phase="$2"
@@ -112,6 +120,32 @@ grep -F $'status=ok\tmode=verify-db\tphase=pre\tmanifest_version=1\tapplied=81\t
   "$TMP_DIR/output.tsv" >/dev/null || fail_test "exact pre state output mismatch: $(tr '\n' ' ' < "$TMP_DIR/output.tsv")"
 pass_test 'exact pre state passes'
 
+write_historical_exception_fixture "$TMP_DIR/historical-exception.tsv"
+if ! run_fixture "$TMP_DIR/historical-exception.tsv" pre "$TMP_DIR/output.tsv"; then
+  fail_test "approved historical metadata exception failed: $(tr '\n' ' ' < "$TMP_DIR/output.tsv")"
+fi
+pass_test 'approved historical zero-step exception passes'
+
+awk -F "$TAB" -v OFS="$TAB" 'NR == 1 { $5 = 0 } { print }' \
+  "$TMP_DIR/pre.tsv" > "$TMP_DIR/non-approved-zero-step.tsv"
+assert_failure_code 'non-approved zero-step migration is rejected' \
+  "$TMP_DIR/non-approved-zero-step.tsv" pre 'database_incomplete_row'
+
+awk -F "$TAB" -v OFS="$TAB" '$1 == "20260719000000_add_receipt_sequence" { $2 = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" } { print }' \
+  "$TMP_DIR/historical-exception.tsv" > "$TMP_DIR/historical-wrong-checksum.tsv"
+assert_failure_code 'historical exception checksum mismatch is rejected' \
+  "$TMP_DIR/historical-wrong-checksum.tsv" pre 'database_metadata_exception_checksum_mismatch'
+
+awk -F "$TAB" -v OFS="$TAB" '$1 == "20260719000000_add_receipt_sequence" { $3 = "failed" } { print }' \
+  "$TMP_DIR/historical-exception.tsv" > "$TMP_DIR/historical-unfinished.tsv"
+assert_failure_code 'historical exception unfinished state is rejected' \
+  "$TMP_DIR/historical-unfinished.tsv" pre 'database_failed_row'
+
+awk -F "$TAB" -v OFS="$TAB" '$1 == "20260719000000_add_receipt_sequence" { $4 = "rolled_back" } { print }' \
+  "$TMP_DIR/historical-exception.tsv" > "$TMP_DIR/historical-rolled-back.tsv"
+assert_failure_code 'historical exception rolled-back state is rejected' \
+  "$TMP_DIR/historical-rolled-back.tsv" pre 'database_rolled_back_row'
+
 write_fixture "$TMP_DIR/post.tsv" 97
 if ! run_fixture "$TMP_DIR/post.tsv" post "$TMP_DIR/output.tsv"; then
   fail_test "exact post state failed: $(tr '\n' ' ' < "$TMP_DIR/output.tsv")"
@@ -119,6 +153,14 @@ fi
 grep -F $'status=ok\tmode=verify-db\tphase=post\tmanifest_version=1\tapplied=97\tfailed=0\tpending=0\ttarget=97' \
   "$TMP_DIR/output.tsv" >/dev/null || fail_test "exact post state output mismatch: $(tr '\n' ' ' < "$TMP_DIR/output.tsv")"
 pass_test 'exact post state passes'
+
+write_fixture "$TMP_DIR/historical-post-base.tsv" 97
+awk -F "$TAB" -v OFS="$TAB" '$1 == "20260719000000_add_receipt_sequence" { $5 = 0 } { print }' \
+  "$TMP_DIR/historical-post-base.tsv" > "$TMP_DIR/historical-post-exception.tsv"
+if ! run_fixture "$TMP_DIR/historical-post-exception.tsv" post "$TMP_DIR/output.tsv"; then
+  fail_test "approved historical post metadata exception failed: $(tr '\n' ' ' < "$TMP_DIR/output.tsv")"
+fi
+pass_test 'approved historical zero-step exception persists through post state'
 
 cp "$TMP_DIR/post.tsv" "$TMP_DIR/missing.tsv"
 missing_name="$(tail -n 1 "$TMP_DIR/missing.tsv" | cut -f 1)"

--- a/scripts/verify-production-migration-baseline.sh
+++ b/scripts/verify-production-migration-baseline.sh
@@ -99,6 +99,59 @@ SELECT CASE WHEN
       AND data_type = 'text'
       AND is_nullable = 'NO'
   )
+  AND (
+    SELECT count(*) = 6
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'ReceiptSequence'
+      AND (
+        (column_name = 'id' AND data_type = 'text' AND is_nullable = 'NO' AND column_default IS NULL)
+        OR (column_name = 'tenantId' AND data_type = 'text' AND is_nullable = 'NO' AND column_default IS NULL)
+        OR (column_name = 'year' AND data_type = 'integer' AND is_nullable = 'NO' AND column_default IS NULL)
+        OR (column_name = 'lastNumber' AND data_type = 'integer' AND is_nullable = 'NO' AND column_default = '0')
+        OR (column_name = 'createdAt' AND data_type = 'timestamp without time zone' AND datetime_precision = 3 AND is_nullable = 'NO' AND column_default = 'CURRENT_TIMESTAMP')
+        OR (column_name = 'updatedAt' AND data_type = 'timestamp without time zone' AND datetime_precision = 3 AND is_nullable = 'NO' AND column_default IS NULL)
+      )
+  )
+  AND (
+    SELECT count(*) = 6
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'ReceiptSequence'
+  )
+  AND (
+    SELECT count(*) = 1 AND bool_and(
+      conname = 'ReceiptSequence_pkey'
+      AND convalidated
+      AND conkey = ARRAY[(SELECT attnum FROM pg_attribute WHERE attrelid = 'public."ReceiptSequence"'::regclass AND attname = 'id' AND NOT attisdropped)]::smallint[]
+    )
+    FROM pg_constraint
+    WHERE conrelid = 'public."ReceiptSequence"'::regclass
+      AND contype = 'p'
+  )
+  AND (
+    SELECT count(*) = 1 AND bool_and(
+      conname = 'ReceiptSequence_tenantId_fkey'
+      AND convalidated
+      AND conkey = ARRAY[(SELECT attnum FROM pg_attribute WHERE attrelid = 'public."ReceiptSequence"'::regclass AND attname = 'tenantId' AND NOT attisdropped)]::smallint[]
+      AND confrelid = 'public."Tenant"'::regclass
+      AND confkey = ARRAY[(SELECT attnum FROM pg_attribute WHERE attrelid = 'public."Tenant"'::regclass AND attname = 'id' AND NOT attisdropped)]::smallint[]
+      AND confdeltype = 'c'
+      AND confupdtype = 'c'
+    )
+    FROM pg_constraint
+    WHERE conrelid = 'public."ReceiptSequence"'::regclass
+      AND contype = 'f'
+  )
+  AND (
+    SELECT count(*) = 3
+      AND count(*) FILTER (WHERE c.relname = 'ReceiptSequence_pkey' AND i.indisunique AND i.indkey::text = '1') = 1
+      AND count(*) FILTER (WHERE c.relname = 'ReceiptSequence_tenantId_year_key' AND i.indisunique AND i.indkey::text = '2 3') = 1
+      AND count(*) FILTER (WHERE c.relname = 'ReceiptSequence_tenantId_idx' AND NOT i.indisunique AND i.indkey::text = '2') = 1
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indexrelid
+    WHERE i.indrelid = 'public."ReceiptSequence"'::regclass
+  )
 THEN 'OK' ELSE 'FAIL' END;
 SQL
 } 2>/dev/null)" || fail "Unable to verify the production migration baseline"

--- a/scripts/verify-production-migration-manifest.sh
+++ b/scripts/verify-production-migration-manifest.sh
@@ -8,6 +8,7 @@ readonly SCRIPT_DIR
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 readonly REPO_ROOT
 readonly MANIFEST_FILE="${MANIFEST_FILE:-$SCRIPT_DIR/manifests/production-migrations-81-to-97.tsv}"
+readonly METADATA_EXCEPTION_FILE="${METADATA_EXCEPTION_FILE:-$SCRIPT_DIR/manifests/production-migration-metadata-exceptions.tsv}"
 readonly MIGRATIONS_DIR="${MIGRATIONS_DIR:-$REPO_ROOT/apps/api/prisma/migrations}"
 readonly POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-pawtech-postgres}"
 readonly DATABASE_NAME="${DATABASE_NAME:-buildingos_db}"
@@ -20,6 +21,7 @@ readonly TARGET_APPLIED=97
 readonly TARGET_FAILED=0
 readonly EXPECTED_PENDING=16
 readonly TAB=$'\t'
+readonly METADATA_EXCEPTION_VERSION=1
 
 MODE="${1:-}"
 PHASE="${2:-none}"
@@ -27,6 +29,8 @@ TMP_DIR=''
 LOCAL_NAMES=()
 STATE_NAMES=()
 STATE_CHECKSUMS=()
+HISTORICAL_EXCEPTION_NAME=''
+HISTORICAL_EXCEPTION_CHECKSUM=''
 
 EXPECTED_NAMES=(
   '20260805000000_add_receipt_generated_to_payment_audit_action'
@@ -137,6 +141,41 @@ validate_manifest() {
   done < "$MANIFEST_FILE"
 
   [[ "$line_number" -eq $((EXPECTED_PENDING + 3)) ]] || fail 'manifest_row_count_mismatch'
+}
+
+validate_metadata_exception_manifest() {
+  local line
+  local line_number=0
+  local exception_kind
+  local exception_name
+  local exception_checksum
+
+  [[ -f "$METADATA_EXCEPTION_FILE" && ! -L "$METADATA_EXCEPTION_FILE" ]] || fail 'metadata_exception_manifest_not_regular_file'
+  [[ -s "$METADATA_EXCEPTION_FILE" ]] || fail 'metadata_exception_manifest_empty'
+  [[ -z "$(tail -c 1 "$METADATA_EXCEPTION_FILE")" ]] || fail 'metadata_exception_manifest_missing_final_newline'
+
+  while IFS= read -r line; do
+    line_number=$((line_number + 1))
+    case "$line_number" in
+      1)
+        [[ "$line" == "manifest_version${TAB}${METADATA_EXCEPTION_VERSION}" ]] || fail 'metadata_exception_manifest_version_mismatch'
+        ;;
+      2)
+        IFS="$TAB" read -r exception_kind exception_name exception_checksum <<< "$line"
+        [[ "$exception_kind" == 'exception' ]] || fail 'metadata_exception_manifest_kind_mismatch'
+        [[ "$exception_name" == '20260719000000_add_receipt_sequence' ]] || fail 'metadata_exception_manifest_name_mismatch'
+        [[ "$exception_checksum" == '93c6d2c0b8c4468fea26489cfb4875bfdc6763ec0056487c21094eae0dbcb257' ]] || fail 'metadata_exception_manifest_checksum_mismatch'
+        HISTORICAL_EXCEPTION_NAME="$exception_name"
+        HISTORICAL_EXCEPTION_CHECKSUM="$exception_checksum"
+        ;;
+      *)
+        fail 'metadata_exception_manifest_extra_row'
+        ;;
+    esac
+  done < "$METADATA_EXCEPTION_FILE"
+
+  [[ "$line_number" -eq 2 && -n "$HISTORICAL_EXCEPTION_NAME" && -n "$HISTORICAL_EXCEPTION_CHECKSUM" ]] \
+    || fail 'metadata_exception_manifest_row_count_mismatch'
 }
 
 validate_local_migrations() {
@@ -253,6 +292,7 @@ validate_database_state() {
   local duplicate_name
 
   [[ -s "$state_file" ]] || fail 'database_state_empty'
+  validate_metadata_exception_manifest
   [[ -z "$(tail -c 1 "$state_file")" ]] || fail 'database_state_missing_final_newline'
   state_row_pattern="^([^[:space:]]+)${TAB}([0-9a-f]{64}|manual_insert)${TAB}(finished|failed)${TAB}(active|rolled_back)${TAB}([0-9]+)$"
 
@@ -272,7 +312,11 @@ validate_database_state() {
 
     [[ "$finish_state" == 'finished' ]] || fail 'database_failed_row'
     [[ "$rollback_state" == 'active' ]] || fail 'database_rolled_back_row'
-    [[ "$applied_steps" == '1' ]] || fail 'database_incomplete_row'
+    if [[ "$applied_steps" != '1' ]]; then
+      [[ "$name" == "$HISTORICAL_EXCEPTION_NAME" ]] || fail 'database_incomplete_row'
+      [[ "$checksum" == "$HISTORICAL_EXCEPTION_CHECKSUM" ]] || fail 'database_metadata_exception_checksum_mismatch'
+      [[ "$applied_steps" == '0' ]] || fail 'database_incomplete_row'
+    fi
 
     STATE_NAMES[${#STATE_NAMES[@]}]="$name"
     STATE_CHECKSUMS[${#STATE_CHECKSUMS[@]}]="$checksum"
@@ -308,6 +352,7 @@ case "$MODE" in
   verify-files)
     [[ "$#" -eq 1 ]] || fail 'usage'
     validate_manifest
+    validate_metadata_exception_manifest
     validate_local_migrations
     printf 'status=ok\tmode=verify-files\tmanifest_version=%s\tlocal=%s\tbaseline=%s\ttarget=%s\tpending=%s\n' \
       "$MANIFEST_VERSION" "${#LOCAL_NAMES[@]}" "$BASELINE_APPLIED" "$TARGET_APPLIED" "$EXPECTED_PENDING"


### PR DESCRIPTION
Closes #188

## Descripción

Resuelve únicamente los dos blockers finales del PROD-00: la excepción histórica exacta de metadata de ReceiptSequence y la generación/validación del rollback compatibility receipt durante deploy.

## Tipo de cambio

- [x] Bug fix
- [ ] Nueva funcionalidad
- [ ] Refactor
- [ ] Cambio de documentación
- [ ] Otro

## Cambios

- Agrega `scripts/manifests/production-migration-metadata-exceptions.tsv` con nombre y checksum inmutables.
- Mantiene `applied_steps_count=1` para todas las migraciones salvo esa excepción exacta, con estado finished/active y checksum obligatorio.
- Extiende el baseline read-only con invariants exactos de ReceiptSequence: columnas, PK, índices y FK cascade.
- Extrae el compatibility guard read-only para que deploy y rollback usen la misma consulta.
- Genera el receipt v2 después de migrate/post/compatibility y antes de recrear API/Web; valida path, owner, group, mode, contenido y permite reintentos solo con inputs idénticos.

## Checklist de validación local obligatoria

- [ ] Tests unitarios pasan
- [ ] Tests de integración pasan
- [ ] Tests E2E pasan (no aplica a estos scripts; no ejecutados)
- [x] Typecheck (`npm run lint:ci`, incluye validación TypeScript) sin errores
- [x] Lint sin errores nuevos: `npm run lint:ci`
- [ ] Build exitoso (no ejecutado; no fue necesario para este cambio de scripts)
- [x] `git diff --check` limpio
- [x] Confirmé que todos los cambios fueron implementados y probados localmente
- [ ] Confirmé que el merge a main activará automáticamente el deploy a staging (intencionalmente no se autoriza merge/staging en esta etapa)
- [ ] El despliegue automático a staging está autorizado para este PR
- [x] Las migraciones incluidas fueron validadas localmente mediante rehearsal aislada 81→97
- [x] No se requiere preservar ningún archivo temporal dentro del checkout de staging
- [x] ShellCheck, `bash -n`, harnesses focalizados y `docker compose config` pasan

## Notas

- Rehearsal local real: pre PASS, Prisma `97 applied / 0 failed / 0 pending`, post PASS.
- Negativos DDL: índice ausente y FK ausente fallan cerrado; restauración devuelve PASS.
- Codex focalizado: P0=0, P1=0; P2 informativo sobre naming transition-specific del receipt.
- Producción, staging y `_prisma_migrations` productivo no fueron modificados. No se ejecutó deploy.
