### PR TITLE
fix(release): preserve readonly migration env

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -211,14 +211,14 @@ for image in buildingos-api buildingos-web; do
 done
 
 PHASE='migration-baseline'
-POSTGRES_CONTAINER="$POSTGRES_CONTAINER" DATABASE_NAME=buildingos_db ./scripts/verify-production-migration-baseline.sh
-POSTGRES_CONTAINER="$POSTGRES_CONTAINER" DATABASE_NAME=buildingos_db \
+env POSTGRES_CONTAINER="$POSTGRES_CONTAINER" DATABASE_NAME=buildingos_db ./scripts/verify-production-migration-baseline.sh
+env POSTGRES_CONTAINER="$POSTGRES_CONTAINER" DATABASE_NAME=buildingos_db \
   bash ./scripts/verify-production-migration-manifest.sh verify-db pre
 
 PHASE='migrations'
 "${compose[@]}" --profile migrate run --rm --no-deps -T buildingos-migrate < /dev/null
 "${compose[@]}" --profile migrate run --rm --no-deps -T buildingos-migrate migrate status --schema apps/api/prisma/schema.prisma < /dev/null
-POSTGRES_CONTAINER="$POSTGRES_CONTAINER" DATABASE_NAME=buildingos_db \
+env POSTGRES_CONTAINER="$POSTGRES_CONTAINER" DATABASE_NAME=buildingos_db \
   bash ./scripts/verify-production-migration-manifest.sh verify-db post
 MIGRATION_COUNT="$(docker exec "$POSTGRES_CONTAINER" sh -lc 'exec psql -qAt -U "$POSTGRES_USER" -d buildingos_db -c '\''SELECT count(*) FROM "_prisma_migrations" WHERE finished_at IS NOT NULL AND rolled_back_at IS NULL'\''')"
 [[ "$MIGRATION_COUNT" == '97' ]] || fail "Final migration count is not exactly 97"

--- a/scripts/tests/production-deploy-order.test.sh
+++ b/scripts/tests/production-deploy-order.test.sh
@@ -7,12 +7,54 @@ readonly DEPLOY_SCRIPT="$ROOT_DIR/scripts/deploy-production.sh"
 readonly ROLLBACK_SCRIPT="$ROOT_DIR/scripts/rollback-production.sh"
 
 line_number() { awk -v pattern="$1" 'index($0, pattern) { print NR; exit }' "$2"; }
+backup_phase_line="$(line_number "PHASE='backup'" "$DEPLOY_SCRIPT")"
+checkout_phase_line="$(line_number "PHASE='checkout'" "$DEPLOY_SCRIPT")"
+build_phase_line="$(line_number "PHASE='build'" "$DEPLOY_SCRIPT")"
+baseline_phase_line="$(line_number "PHASE='migration-baseline'" "$DEPLOY_SCRIPT")"
+migrations_phase_line="$(line_number "PHASE='migrations'" "$DEPLOY_SCRIPT")"
+baseline_line="$(line_number 'verify-production-migration-baseline.sh' "$DEPLOY_SCRIPT")"
+pre_line="$(line_number 'verify-production-migration-manifest.sh verify-db pre' "$DEPLOY_SCRIPT")"
+migrate_line="$(line_number '--profile migrate run --rm --no-deps -T buildingos-migrate' "$DEPLOY_SCRIPT")"
 post_line="$(line_number 'verify-production-migration-manifest.sh verify-db post' "$DEPLOY_SCRIPT")"
 compatibility_line="$(line_number 'validate_application_rollback_compatibility "$POSTGRES_CONTAINER" buildingos_db' "$DEPLOY_SCRIPT")"
 receipt_line="$(line_number 'generate_rollback_compatibility_receipt' "$DEPLOY_SCRIPT")"
 recreate_line="$(line_number 'up --detach --no-deps --force-recreate buildingos-api buildingos-web' "$DEPLOY_SCRIPT")"
-[[ -n "$post_line" && -n "$compatibility_line" && -n "$receipt_line" && -n "$recreate_line" ]]
+[[ -n "$backup_phase_line" && -n "$checkout_phase_line" && -n "$build_phase_line" ]]
+[[ -n "$baseline_phase_line" && -n "$migrations_phase_line" && -n "$baseline_line" ]]
+[[ -n "$pre_line" && -n "$migrate_line" && -n "$post_line" ]]
+[[ -n "$compatibility_line" && -n "$receipt_line" && -n "$recreate_line" ]]
+(( backup_phase_line < checkout_phase_line ))
+(( checkout_phase_line < build_phase_line ))
+(( build_phase_line < baseline_phase_line && baseline_phase_line < migrations_phase_line ))
+(( baseline_line < pre_line && pre_line < migrate_line && migrate_line < post_line ))
 (( post_line < compatibility_line && compatibility_line < receipt_line && receipt_line < recreate_line ))
+
+env_invocation_count="$(grep -F -c 'env POSTGRES_CONTAINER="$POSTGRES_CONTAINER" DATABASE_NAME=buildingos_db' "$DEPLOY_SCRIPT")"
+[[ "$env_invocation_count" -eq 3 ]]
+if awk '/POSTGRES_CONTAINER="\$POSTGRES_CONTAINER" DATABASE_NAME=buildingos_db/ && $0 !~ /^[[:space:]]*env / { bad = 1 } END { exit bad }' "$DEPLOY_SCRIPT"; then
+  :
+else
+  printf 'FAIL: readonly environment was reassigned in the parent shell\n' >&2
+  exit 1
+fi
+
+assert_child_environment() {
+  local -r POSTGRES_CONTAINER='pawtech-postgres'
+  local -r DATABASE_NAME='buildingos_db'
+  local phase
+  local received
+
+  for phase in baseline pre post; do
+    received="$(env POSTGRES_CONTAINER="$POSTGRES_CONTAINER" DATABASE_NAME="$DATABASE_NAME" \
+      bash -c 'printf "%s|%s" "$POSTGRES_CONTAINER" "$DATABASE_NAME"')"
+    [[ "$received" == 'pawtech-postgres|buildingos_db' ]] || {
+      printf 'FAIL: %s did not receive the expected environment\n' "$phase" >&2
+      exit 1
+    }
+  done
+}
+
+assert_child_environment
 grep -F 'validate_application_rollback_compatibility "$POSTGRES_CONTAINER" buildingos_db' "$ROLLBACK_SCRIPT" >/dev/null
 if grep -F 'incompatible_rows=' "$ROLLBACK_SCRIPT" >/dev/null; then exit 1; fi
-printf 'PASS: migration -> post verification -> compatibility -> receipt -> application recreation\n'
+printf 'PASS: readonly env propagation and backup -> checkout -> build -> baseline -> pre -> migrate -> post -> compatibility -> receipt -> application recreation\n'


### PR DESCRIPTION
Closes #188

## Descripción

- El workflow productivo falló antes de ejecutar migraciones por una reasignación de la variable readonly POSTGRES_CONTAINER.
- Producción quedó en 81 migraciones aplicadas, 0 fallidas y 16 pendientes; API/Web no fueron recreados.
- El fix usa env para pasar el entorno al child process sin reasignar la variable del shell padre.

## Tipo de cambio

- [x] Bug fix
- [ ] Nueva funcionalidad
- [ ] Refactor

## Cambios

| Archivo | Cambio |
|--------|--------|
| scripts/deploy-production.sh | Usa env en baseline, verify-db pre y verify-db post. |
| scripts/tests/production-deploy-order.test.sh | Verifica readonly env propagation y el orden completo de gates. |

## Validación

- [x] bash -n del script productivo
- [x] Harness de deploy order y readonly environment
- [x] Tests de migration baseline
- [x] Tests de migration manifest
- [x] git diff --check
- [x] E2E/typecheck/build: no aplican a este cambio shell-only; CI ejecutará la suite del repositorio.
- [ ] ShellCheck: no disponible localmente; no se instalaron herramientas globales.

## Seguridad productiva

- No se modificó producción desde esta corrección.
- No se lanzaron workflows, migraciones, Storage Init, SSH de escritura ni cambios de checkout productivo.
- No se modificaron gates ni el orden backup → checkout → build → baseline → verify-db pre → migrate → verify-db post → compatibility → receipt → recreate.

## Revisión

- Revisión estática P0/P1: sin hallazgos en el diff.
- El advisory del hook señaló un riesgo preexistente de receipts fuera del alcance de este PR; no se modificó.

## Checklist

- [x] Issue aprobado enlazado
- [x] Label type:bug
- [x] Commit convencional
- [x] Sin secretos ni Co-Authored-By
- [x] No mergear todavía.