### PR TITLE
fix(release): support rollback across identical db contracts

### DIFF
--- a/scripts/deploy-production.sh
+++ b/scripts/deploy-production.sh
@@ -73,6 +73,7 @@ write_record() {
     printf 'backup_id=%s\n' "$BACKUP_ID"
     printf 'migration_count=%s\n' "$MIGRATION_COUNT"
     printf 'rollback_receipt=%s\n' "$ROLLBACK_RECEIPT"
+    printf 'rollback_compatibility_basis=%s\n' "$ROLLBACK_COMPATIBILITY_BASIS"
     printf 'database_rollback=never-automatic\n'
     printf 'services_recreated=buildingos-api buildingos-web\n'
     printf 'seeds=no\n'
@@ -224,7 +225,7 @@ MIGRATION_COUNT="$(docker exec "$POSTGRES_CONTAINER" sh -lc 'exec psql -qAt -U "
 [[ "$MIGRATION_COUNT" == '97' ]] || fail "Final migration count is not exactly 97"
 
 PHASE='rollback-compatibility'
-validate_application_rollback_compatibility "$POSTGRES_CONTAINER" buildingos_db
+validate_application_rollback_compatibility "$POSTGRES_CONTAINER" buildingos_db "$PREVIOUS_SHA" "$TARGET_SHA"
 ROLLBACK_RECEIPT="$(generate_rollback_compatibility_receipt \
   "$TARGET_SHA" "$PREVIOUS_SHA" "$PREVIOUS_API_DIGEST" "$PREVIOUS_WEB_DIGEST" "$MIGRATION_COUNT")"
 

--- a/scripts/production-security-validate.sh
+++ b/scripts/production-security-validate.sh
@@ -12,6 +12,10 @@ readonly PRODUCTION_ROLLBACK_PROTECTED_DIR='/opt/pawtech/apps/buildingos/compati
 readonly PRODUCTION_ROLLBACK_EXPECTED_OWNER='yoryi'
 readonly PRODUCTION_ROLLBACK_EXPECTED_GROUP='yoryi'
 
+ROLLBACK_COMPATIBILITY_BASIS=''
+ROLLBACK_COMPATIBILITY_PREVIOUS_SHA=''
+ROLLBACK_COMPATIBILITY_TARGET_SHA=''
+
 security_fail() {
   printf 'ERROR: %s\n' "$1" >&2
   exit 1
@@ -384,10 +388,51 @@ validate_rollback_receipt() {
   VALIDATED_ROLLBACK_MIGRATION_COUNT="$migration_count"
 }
 
+database_contracts_match() {
+  local previous_sha="$1"
+  local target_sha="$2"
+  local comparison_status
+
+  [[ "$previous_sha" =~ ^[0-9a-f]{40}$ ]] || security_fail 'Previous SHA is required for database contract comparison'
+  [[ "$target_sha" =~ ^[0-9a-f]{40}$ ]] || security_fail 'Target SHA is required for database contract comparison'
+  command -v git >/dev/null 2>&1 || security_fail 'git is required for database contract comparison'
+  git cat-file -e "${previous_sha}^{commit}" >/dev/null 2>&1 \
+    || security_fail 'Previous SHA cannot be resolved for database contract comparison'
+  git cat-file -e "${target_sha}^{commit}" >/dev/null 2>&1 \
+    || security_fail 'Target SHA cannot be resolved for database contract comparison'
+
+  if git diff --no-ext-diff --no-textconv --quiet \
+    "$previous_sha" "$target_sha" -- \
+    apps/api/prisma/schema.prisma apps/api/prisma/migrations; then
+    return 0
+  else
+    comparison_status=$?
+  fi
+
+  [[ "$comparison_status" -eq 1 ]] \
+    || security_fail 'Unable to compare database contract between SHAs'
+  return 1
+}
+
 validate_application_rollback_compatibility() {
   local postgres_container="${1:-pawtech-postgres}"
   local database_name="${2:-buildingos_db}"
+  local previous_sha="${3:-}"
+  local target_sha="${4:-}"
   local result
+
+  [[ "$#" -eq 4 ]] || security_fail 'Application rollback compatibility requires previous and target SHAs'
+  ROLLBACK_COMPATIBILITY_BASIS=''
+  ROLLBACK_COMPATIBILITY_PREVIOUS_SHA=''
+  ROLLBACK_COMPATIBILITY_TARGET_SHA=''
+
+  if database_contracts_match "$previous_sha" "$target_sha"; then
+    ROLLBACK_COMPATIBILITY_BASIS='SAME_DB_CONTRACT'
+    ROLLBACK_COMPATIBILITY_PREVIOUS_SHA="$previous_sha"
+    ROLLBACK_COMPATIBILITY_TARGET_SHA="$target_sha"
+    printf 'Application rollback compatibility verified: SAFE (basis=SAME_DB_CONTRACT)\n'
+    return 0
+  fi
 
   [[ "$postgres_container" =~ ^[A-Za-z0-9_.-]+$ ]] || security_fail 'Unsafe PostgreSQL container name'
   [[ "$database_name" =~ ^[a-z0-9_]+$ ]] || security_fail 'Unsafe database name'
@@ -420,7 +465,10 @@ SQL
   } 2>/dev/null)" || security_fail 'Unable to validate application rollback compatibility'
 
   [[ "$result" == 'SAFE' ]] || security_fail 'New-schema data makes application rollback unsafe'
-  printf 'Application rollback compatibility verified: SAFE\n'
+  ROLLBACK_COMPATIBILITY_BASIS='DATA_COMPATIBILITY'
+  ROLLBACK_COMPATIBILITY_PREVIOUS_SHA="$previous_sha"
+  ROLLBACK_COMPATIBILITY_TARGET_SHA="$target_sha"
+  printf 'Application rollback compatibility verified: SAFE (basis=DATA_COMPATIBILITY)\n'
 }
 
 generate_rollback_compatibility_receipt() {
@@ -436,6 +484,10 @@ generate_rollback_compatibility_receipt() {
   [[ "$previous_api_digest" =~ ^sha256:[0-9a-f]{64}$ && "$previous_web_digest" =~ ^sha256:[0-9a-f]{64}$ ]] \
     || security_fail 'Receipt generation requires immutable image digests'
   [[ "$migration_count" == '97' ]] || security_fail 'Receipt generation requires exactly 97 applied migrations'
+  [[ "$ROLLBACK_COMPATIBILITY_BASIS" == 'SAME_DB_CONTRACT' || "$ROLLBACK_COMPATIBILITY_BASIS" == 'DATA_COMPATIBILITY' ]] \
+    || security_fail 'Receipt generation requires validated rollback compatibility'
+  [[ "$ROLLBACK_COMPATIBILITY_TARGET_SHA" == "$target_sha" && "$ROLLBACK_COMPATIBILITY_PREVIOUS_SHA" == "$previous_sha" ]] \
+    || security_fail 'Receipt generation inputs differ from validated rollback compatibility'
 
   resolve_rollback_security_context
   if [[ ! -e "$ROLLBACK_SECURITY_PROTECTED_DIR" ]]; then

--- a/scripts/rollback-production.sh
+++ b/scripts/rollback-production.sh
@@ -52,7 +52,7 @@ cd "$APP_DIR"
 [[ "$(git rev-parse HEAD)" == "$EXPECTED_CURRENT_SHA" ]] || fail "Production checkout changed since compatibility review"
 current_migration_count="$(docker exec "$POSTGRES_CONTAINER" sh -lc 'exec psql -qAt -U "$POSTGRES_USER" -d buildingos_db -c '\''SELECT count(*) FROM "_prisma_migrations" WHERE finished_at IS NOT NULL AND rolled_back_at IS NULL'\''')"
 [[ "$current_migration_count" == "$migration_count" ]] || fail "Database migration count changed after compatibility review"
-validate_application_rollback_compatibility "$POSTGRES_CONTAINER" buildingos_db
+validate_application_rollback_compatibility "$POSTGRES_CONTAINER" buildingos_db "$PREVIOUS_SHA" "$EXPECTED_CURRENT_SHA"
 
 docker image inspect "$PREVIOUS_API_DIGEST" >/dev/null
 docker image inspect "$PREVIOUS_WEB_DIGEST" >/dev/null
@@ -87,6 +87,7 @@ umask 077
   printf 'api_digest=%s\n' "$PREVIOUS_API_DIGEST"
   printf 'web_digest=%s\n' "$PREVIOUS_WEB_DIGEST"
   printf 'migration_count=%s\n' "$migration_count"
+  printf 'rollback_compatibility_basis=%s\n' "$ROLLBACK_COMPATIBILITY_BASIS"
   printf 'database_changed=no\n'
   printf 'database_restore=never-automatic\n'
 } > "$RECORD"

--- a/scripts/tests/production-security.test.sh
+++ b/scripts/tests/production-security.test.sh
@@ -71,6 +71,64 @@ exit 99
 EOF
 chmod 700 "$mock_bin/docker"
 
+fixture_repo="$tmp_root/database-contract-repo"
+mkdir -p "$fixture_repo"
+(
+  cd "$fixture_repo"
+  git init -q
+  git config core.hooksPath /dev/null
+  git config user.name 'BuildingOS Tests'
+  git config user.email 'tests@buildingos.invalid'
+  mkdir -p apps/api/prisma/migrations
+  printf 'schema-v1\n' > apps/api/prisma/schema.prisma
+  printf 'migration-v1\n' > apps/api/prisma/migrations/001_contract.sql
+  git add apps/api/prisma
+  git commit -qm 'fixture: initial database contract'
+)
+fixture_base_sha="$(git -C "$fixture_repo" rev-parse HEAD)"
+
+printf 'application-v2\n' > "$fixture_repo/application.txt"
+git -C "$fixture_repo" add application.txt
+git -C "$fixture_repo" commit -qm 'fixture: application-only release'
+fixture_same_sha="$(git -C "$fixture_repo" rev-parse HEAD)"
+
+git -C "$fixture_repo" switch --quiet --detach "$fixture_base_sha"
+printf 'schema-v2\n' > "$fixture_repo/apps/api/prisma/schema.prisma"
+git -C "$fixture_repo" add apps/api/prisma/schema.prisma
+git -C "$fixture_repo" commit -qm 'fixture: schema contract change'
+fixture_schema_changed_sha="$(git -C "$fixture_repo" rev-parse HEAD)"
+
+git -C "$fixture_repo" switch --quiet --detach "$fixture_base_sha"
+printf 'migration-v2\n' > "$fixture_repo/apps/api/prisma/migrations/001_contract.sql"
+git -C "$fixture_repo" add apps/api/prisma/migrations/001_contract.sql
+git -C "$fixture_repo" commit -qm 'fixture: migration contract change'
+fixture_migration_changed_sha="$(git -C "$fixture_repo" rev-parse HEAD)"
+
+run_contract_validation() {
+  local previous_sha="$1"
+  local target_sha="$2"
+  local mock_compatibility="$3"
+
+  env \
+    PATH="$mock_bin:$PATH" \
+    MOCK_COMPATIBILITY="$mock_compatibility" \
+    bash -c 'cd "$1"; source "$2"; validate_application_rollback_compatibility mock-postgres buildingos_db "$3" "$4"' \
+    _ "$fixture_repo" "$VALIDATOR" "$previous_sha" "$target_sha"
+}
+
+expect_output_contains() {
+  local name="$1"
+  local expected="$2"
+  local output
+  shift 2
+  if ! output="$("$@" 2>&1)"; then
+    printf '%s\n' "$output" >&2
+    fail_test "$name"
+  fi
+  [[ "$output" == *"$expected"* ]] || fail_test "$name"
+  pass "$name"
+}
+
 write_receipt() {
   local path="$1"
   local receipt_id="$2"
@@ -217,20 +275,78 @@ expect_success 'shared compatibility guard accepts safe data' \
   env \
     PATH="$mock_bin:$PATH" \
     MOCK_COMPATIBILITY=SAFE \
-    bash -c 'source "$1"; validate_application_rollback_compatibility mock-postgres buildingos_db' _ "$VALIDATOR"
+    bash -c 'cd "$1"; source "$2"; validate_application_rollback_compatibility mock-postgres buildingos_db "$3" "$4"' _ \
+    "$fixture_repo" "$VALIDATOR" "$fixture_base_sha" "$fixture_schema_changed_sha"
 
 expect_failure 'shared compatibility guard rejects unsafe data' \
+  run_contract_validation "$fixture_base_sha" "$fixture_schema_changed_sha" UNSAFE
+
+expect_output_contains 'same schema and migrations with new data use SAME_DB_CONTRACT' \
+  'basis=SAME_DB_CONTRACT' \
+  run_contract_validation "$fixture_base_sha" "$fixture_same_sha" UNSAFE
+
+expect_failure 'schema changes with new data remain unsafe' \
+  run_contract_validation "$fixture_base_sha" "$fixture_schema_changed_sha" UNSAFE
+
+expect_failure 'migration changes with new data remain unsafe' \
+  run_contract_validation "$fixture_base_sha" "$fixture_migration_changed_sha" UNSAFE
+
+expect_failure 'same migration count with different migration content is not SAME_DB_CONTRACT' \
+  run_contract_validation "$fixture_base_sha" "$fixture_migration_changed_sha" UNSAFE
+
+expect_failure 'same schema with different migration content is not SAME_DB_CONTRACT' \
+  run_contract_validation "$fixture_base_sha" "$fixture_migration_changed_sha" UNSAFE
+
+expect_output_contains 'schema changes with zero new data use DATA_COMPATIBILITY' \
+  'basis=DATA_COMPATIBILITY' \
+  run_contract_validation "$fixture_base_sha" "$fixture_schema_changed_sha" SAFE
+
+expect_output_contains 'migration changes with zero new data use DATA_COMPATIBILITY' \
+  'basis=DATA_COMPATIBILITY' \
+  run_contract_validation "$fixture_base_sha" "$fixture_migration_changed_sha" SAFE
+
+expect_failure 'missing previous SHA fails closed' \
+  run_contract_validation aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "$fixture_same_sha" UNSAFE
+
+expect_failure 'missing target SHA fails closed' \
+  run_contract_validation "$fixture_base_sha" bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb UNSAFE
+
+git_error_bin="$tmp_root/git-error-bin"
+mkdir -p "$git_error_bin"
+real_git="$(command -v git)"
+cat > "$git_error_bin/git" <<EOF
+#!/usr/bin/env bash
+case "\${1:-}" in
+  cat-file) exit 0 ;;
+  diff) exit 2 ;;
+  *) exec "$real_git" "\$@" ;;
+EOF
+chmod 700 "$git_error_bin/git"
+
+expect_failure 'git comparison errors fail closed' \
   env \
-    PATH="$mock_bin:$PATH" \
-    MOCK_COMPATIBILITY=UNSAFE \
-    bash -c 'source "$1"; validate_application_rollback_compatibility mock-postgres buildingos_db' _ "$VALIDATOR"
+    PATH="$git_error_bin:$PATH" \
+    bash -c 'cd "$1"; source "$2"; validate_application_rollback_compatibility mock-postgres buildingos_db "$3" "$4"' _ \
+    "$fixture_repo" "$VALIDATOR" "$fixture_base_sha" "$fixture_same_sha"
+
+expect_failure 'receipt generation rejects unvalidated compatibility' \
+  env \
+    TEST_MODE=1 \
+    ROLLBACK_PROTECTED_DIR="$protected_dir" \
+    ROLLBACK_EXPECTED_OWNER="$current_owner" \
+    ROLLBACK_EXPECTED_GROUP="$current_group" \
+    bash -c 'source "$1"; generate_rollback_compatibility_receipt "$2" "$3" "$4" "$5" 97' _ \
+    "$VALIDATOR" "$TARGET_SHA" "$PREVIOUS_SHA" "$API_DIGEST" "$WEB_DIGEST"
 
 generated_receipt="$(env \
   TEST_MODE=1 \
   ROLLBACK_PROTECTED_DIR="$protected_dir" \
   ROLLBACK_EXPECTED_OWNER="$current_owner" \
   ROLLBACK_EXPECTED_GROUP="$current_group" \
-  bash -c 'source "$1"; generate_rollback_compatibility_receipt "$2" "$3" "$4" "$5" 97' _ "$VALIDATOR" "$TARGET_SHA" "$PREVIOUS_SHA" "$API_DIGEST" "$WEB_DIGEST")" \
+  PATH="$mock_bin:$PATH" \
+  MOCK_COMPATIBILITY=UNSAFE \
+  bash -c 'cd "$1"; source "$2"; validate_application_rollback_compatibility mock-postgres buildingos_db "$3" "$4" >&2; generate_rollback_compatibility_receipt "$4" "$3" "$5" "$6" 97' _ \
+  "$fixture_repo" "$VALIDATOR" "$fixture_base_sha" "$fixture_same_sha" "$API_DIGEST" "$WEB_DIGEST")" \
   || fail_test 'receipt generation failed'
 [[ -f "$generated_receipt" ]] || fail_test 'receipt generation did not return a regular receipt path'
 pass 'generates and immediately validates a safe rollback receipt'
@@ -240,7 +356,10 @@ reused_receipt="$(env \
   ROLLBACK_PROTECTED_DIR="$protected_dir" \
   ROLLBACK_EXPECTED_OWNER="$current_owner" \
   ROLLBACK_EXPECTED_GROUP="$current_group" \
-  bash -c 'source "$1"; generate_rollback_compatibility_receipt "$2" "$3" "$4" "$5" 97' _ "$VALIDATOR" "$TARGET_SHA" "$PREVIOUS_SHA" "$API_DIGEST" "$WEB_DIGEST")" \
+  PATH="$mock_bin:$PATH" \
+  MOCK_COMPATIBILITY=UNSAFE \
+  bash -c 'cd "$1"; source "$2"; validate_application_rollback_compatibility mock-postgres buildingos_db "$3" "$4" >&2; generate_rollback_compatibility_receipt "$4" "$3" "$5" "$6" 97' _ \
+  "$fixture_repo" "$VALIDATOR" "$fixture_base_sha" "$fixture_same_sha" "$API_DIGEST" "$WEB_DIGEST")" \
   || fail_test 'valid receipt reuse failed'
 [[ "$reused_receipt" == "$generated_receipt" ]] || fail_test 'receipt reuse returned a different path'
 pass 'reuses a matching receipt after a retry'
@@ -251,6 +370,7 @@ expect_failure 'rejects an existing receipt with mismatched immutable inputs' \
     ROLLBACK_PROTECTED_DIR="$protected_dir" \
     ROLLBACK_EXPECTED_OWNER="$current_owner" \
     ROLLBACK_EXPECTED_GROUP="$current_group" \
-    bash -c 'source "$1"; generate_rollback_compatibility_receipt "$2" "$3" "$4" "$5" 97' _ "$VALIDATOR" "$TARGET_SHA" "$TARGET_SHA" "$API_DIGEST" "$WEB_DIGEST"
+    bash -c 'cd "$1"; source "$2"; validate_application_rollback_compatibility mock-postgres buildingos_db "$3" "$4" >&2; generate_rollback_compatibility_receipt "$4" "$4" "$5" "$6" 97' _ \
+    "$fixture_repo" "$VALIDATOR" "$fixture_base_sha" "$fixture_same_sha" "$API_DIGEST" "$WEB_DIGEST"
 
 printf '1..%d\n' "$tests_run"


### PR DESCRIPTION
Closes #196

## Root Cause
Production rollback compatibility rejected existing post-97 data even though previous and target applications had identical Prisma DB contracts.

## Behavior
- Exact identical schema and migration tree -> `SAME_DB_CONTRACT`
- Changed DB contract -> existing `DATA_COMPATIBILITY` guard
- Missing SHA or comparison error -> fail closed
- Receipt v2 preserved
- Deployment order preserved

## Validation
- Focused security suite: 31 assertions PASS
- Deploy order: PASS
- Migration manifest: PASS
- Migration baseline: PASS
- PostgreSQL recovery: PASS
- Bash syntax: PASS
- `git diff --check`: PASS
- Shellcheck: unavailable locally; CI validation required

## Scope
- No application Finance changes
- No schema
- No migrations
- No seeds
- No staging mutation
- No production mutation

## Changes
| File | Change |
|------|--------|
| `scripts/production-security-validate.sh` | Add exact fail-closed DB contract comparison and receipt basis validation |
| `scripts/deploy-production.sh` | Pass SHA pair and record compatibility basis |
| `scripts/rollback-production.sh` | Validate rollback against the current DB contract semantics |
| `scripts/tests/production-security.test.sh` | Add fixture coverage for identical/changed contracts and fail-closed cases |

## Checklist
- [x] Linked approved issue
- [x] Conventional commit
- [x] No schema, migration, seed, staging, or production changes
- [x] No merge or deploy performed
- [ ] Shellcheck run locally: unavailable; CI will run it