### PR TITLE
fix: prevent golden seed secret from blocking staging deploy

### DIFF
--- a/apps/api/prisma/seed-staging-golden.ts
+++ b/apps/api/prisma/seed-staging-golden.ts
@@ -12,8 +12,8 @@ import {
   ConnectionIdentity,
 } from './lib/staging-seed/staging-golden-seed';
 
-function requiredPassword(): string {
-  const password = process.env[STAGING_GOLDEN_PASSWORD_ENV];
+export function requiredPassword(environment: Readonly<Record<string, string | undefined>> = process.env): string {
+  const password = environment[STAGING_GOLDEN_PASSWORD_ENV];
   if (!password || password.length < 12) {
     throw new Error(`${STAGING_GOLDEN_PASSWORD_ENV} is required and must contain at least 12 characters`);
   }

--- a/apps/api/src/staging-seed/staging-golden-seed.spec.ts
+++ b/apps/api/src/staging-seed/staging-golden-seed.spec.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'fs';
 import { join } from 'path';
 
+import { requiredPassword } from '../../prisma/seed-staging-golden';
 import {
   applyStagingGoldenSeed,
   assertConnectedStagingGoldenTarget,
@@ -83,6 +84,21 @@ describe('STG-DATA-01 Golden Dataset safety', () => {
   it('requires explicit opt-in and confirmation', () => {
     expect(() => assertSafeStagingGoldenEnvironment({ ...baseEnvironment, STAGING_GOLDEN_SEED: undefined })).toThrow('STAGING_GOLDEN_SEED');
     expect(() => assertSafeStagingGoldenEnvironment({ ...baseEnvironment, STAGING_GOLDEN_CONFIRMATION: 'wrong' })).toThrow('STAGING_GOLDEN_CONFIRMATION');
+  });
+
+  it('requires the QA password at the application execution boundary', () => {
+    const validPassword = 'x'.repeat(12);
+    expect(() => requiredPassword({})).toThrow('STAGING_GOLDEN_QA_PASSWORD');
+    expect(() => requiredPassword({ STAGING_GOLDEN_QA_PASSWORD: 'too-short' })).toThrow('STAGING_GOLDEN_QA_PASSWORD');
+    expect(requiredPassword({ STAGING_GOLDEN_QA_PASSWORD: validPassword })).toBe(validPassword);
+  });
+
+  it('keeps the Golden service profile-gated without requiring its password during Compose interpolation', () => {
+    const compose = readFileSync(join(__dirname, '../../../../infra/docker/docker-compose.staging.yml'), 'utf8');
+    const service = compose.match(/  api-seed-staging-golden:\n([\s\S]*?)(?=\n  [a-z])/i)?.[1] ?? '';
+    expect(service).toContain('profiles: ["seed-staging-golden"]');
+    expect(service).toContain('STAGING_GOLDEN_QA_PASSWORD: ${STAGING_GOLDEN_QA_PASSWORD:-}');
+    expect(service).not.toContain('STAGING_GOLDEN_QA_PASSWORD:?');
   });
 
   it('requires the verified PostgreSQL identity to be private staging infrastructure', async () => {

--- a/infra/docker/docker-compose.staging.yml
+++ b/infra/docker/docker-compose.staging.yml
@@ -135,7 +135,7 @@ services:
       NODE_ENV: staging
       STAGING_GOLDEN_SEED: "1"
       STAGING_GOLDEN_CONFIRMATION: STG-DATA-01
-      STAGING_GOLDEN_QA_PASSWORD: ${STAGING_GOLDEN_QA_PASSWORD:?STAGING_GOLDEN_QA_PASSWORD is required}
+      STAGING_GOLDEN_QA_PASSWORD: ${STAGING_GOLDEN_QA_PASSWORD:-}
       DATABASE_URL: postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB is required}
     command: ["npm", "run", "seed:staging:golden", "-w", "apps/api"]
     restart: "no"


### PR DESCRIPTION
## Root cause
Docker Compose interpolates variables before profile filtering. The `api-seed-staging-golden` service used `${STAGING_GOLDEN_QA_PASSWORD:?STAGING_GOLDEN_QA_PASSWORD is required}`, so normal staging `docker compose config` failed even though the Golden profile was inactive.

## Fix
- Use an empty interpolation default for `STAGING_GOLDEN_QA_PASSWORD`.
- Keep the application-level required/12-character password guard before `PrismaClient` construction and seed writes.
- Add focused regression coverage for the password boundary, Compose fallback, and profile gating.

## Validation
- Secret-free normal Compose config: PASS.
- Secret-free `seed-staging-golden` profile Compose config: PASS.
- Focused Golden tests: 19 passed.
- `npm run build:packages`: PASS.
- `npx tsc --noEmit -p apps/api/tsconfig.json`: PASS.
- `npm run build -w apps/api`: PASS.
- `npm run lint:ci -w apps/api`: PASS.
- Prisma validate with local placeholder URL: PASS.
- `npm run test:forbid-only -w apps/api`: PASS.
- `git diff --check`: PASS.

No Golden seed was run. No staging data or production configuration was changed. No migrations, Prisma schema, or business logic were modified.