### PR TITLE
fix(deps): harden production runtime dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10103,9 +10103,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-      "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.1.tgz",
+      "integrity": "sha512-pIM/1n3ntFXKYrUZwW7QCK0gAW7XY+wzj1YMIV3tLDvPj/V+zTGJK5e3/4WJfwj0qWw2ElNXiTixda/R+3YSug==",
       "funding": [
         {
           "type": "github",
@@ -10114,7 +10114,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -14403,9 +14404,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -15193,9 +15194,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-      "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
       "funding": [
         {
           "type": "github",
@@ -19596,6 +19597,21 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xml2js": {


### PR DESCRIPTION
## Summary

- Applies a narrow lockfile-only production dependency hardening.
- Updates safe transitive resolutions without changing application source, package manifests, Prisma schema, migrations, or business logic.
- Reduces the production `npm audit --omit=dev` result from:
  - 1 critical / 16 high / 10 moderate
  to:
  - 1 critical / 14 high / 10 moderate.
- Eliminates 2 high-severity findings.
- No additional non-major remediation was identified as safely applicable in this slice.

## Dependency changes

- fast-xml-builder 1.1.4 -> 1.3.1
- path-expression-matcher -> 1.6.2
- xml-naming -> 0.3.0
- nanoid 3.3.11 -> 3.3.18

Only `package-lock.json` changes.

## Validation

Passed:

- API typecheck/build/lint/tests
- focused dependency-sensitive tests
- Web tests: 113 suites / 995 tests
- Web production build
- API config E2E: 2/2
- Prisma validation
- git diff --check

## Existing baseline debt

The following failures were reproduced identically against the clean base and are NOT regressions from this dependency change:

- Web typecheck: existing `IncomesTab.test.tsx` failure.
- Web lint: 68 existing errors and 112 warnings.

These are intentionally outside this security slice.

## Remaining security debt

The post-fix production dependency audit still reports:

- Critical: 1
- High: 14
- Moderate: 10

The remaining critical/high findings require separate risk-specific work, major/breaking dependency changes, or explicit risk acceptance.

## Safety

- No source changes.
- No schema or migration changes.
- No staging mutation.
- No production mutation.
- No deploy performed.

DO NOT MERGE.