### PR TITLE
chore(ops): add minio backup and recovery safeguards

### DIFF
--- a/docs/runbooks/MINIO_BACKUP_RECOVERY.md
+++ b/docs/runbooks/MINIO_BACKUP_RECOVERY.md
@@ -45,6 +45,12 @@ prefix is reused. The backup prefix is
 `buildingos/<source-environment>/<backup-set-id>/`. Each set contains objects,
 `meta/minio-manifest.json`, its SHA-256 file, and `backup-receipt.json`.
 
+`BACKUP_PREFIX` is optional. When supplied, it must be a safe relative
+slash-separated prefix using only letters, numbers, `.`, `_`, and `-`; empty
+segments and `.`/`..` segments are rejected. Verify and restore compare the
+requested `BACKUP_SET_ID` exactly with `backup-receipt.json.backup_set_id` and
+fail closed on mismatch.
+
 The destination must be a different endpoint or bucket and should provide
 server-side encryption, object lock/retention, and a separate restricted
 backup credential. If the selected destination cannot provide those controls,

--- a/docs/runbooks/MINIO_BACKUP_RECOVERY.md
+++ b/docs/runbooks/MINIO_BACKUP_RECOVERY.md
@@ -62,8 +62,11 @@ The non-destructive copy is intentional: source deletion never propagates to
 existing backup sets. A new uniquely identified set is created for every run,
 and a reused `BACKUP_SET_ID` fails closed. True immutability requires
 destination versioning, Object Lock, and retention controls. The scripts
-compare object keys, sizes, ETags where supplied by the client, counts, byte
-totals, and manifest SHA-256.
+calculate and compare per-object SHA-256 content digests, object keys, byte
+sizes, counts, byte totals, and the manifest SHA-256. Verify and restore also
+bind the verified manifest SHA-256, count, and byte total to the backup receipt.
+ETags are not used as the portable cryptographic integrity control because
+their semantics vary by provider, multipart upload, and encryption mode.
 
 ### Required paired evidence
 
@@ -116,12 +119,28 @@ by the target-environment allowlist; there is no production override flag.
 
 ```bash
 export TARGET_ENVIRONMENT=rehearsal
-export TARGET_ENDPOINT='http://127.0.0.1:9000'
+export TARGET_ENDPOINT='http://127.0.0.1:19000'
 export TARGET_ACCESS_KEY='<rehearsal-key>'
 export TARGET_SECRET_KEY='<rehearsal-secret>'
-export TARGET_BUCKET='buildingos-restore-<unique-id>'
+export TARGET_BUCKET='buildingos-restore-rehearsal'
 export RESTORE_CONFIRMATION='RESTORE TO NON-PRODUCTION'
+export RESTORE_TARGET_POLICY_FILE='/etc/buildingos/minio-restore-target-policy.json'
 scripts/restore-minio.sh
+```
+
+`RESTORE_TARGET_POLICY_FILE` is required non-secret operational configuration.
+It must be supplied from trusted protected configuration and must not be
+created dynamically by the same restore invocation. It binds each allowed
+non-production environment to the canonical endpoint identity and exact
+restore bucket. Production must not be present in the policy. For example:
+
+```json
+{
+  "rehearsal": {
+    "endpoint_identity": "127.0.0.1:19000",
+    "bucket": "buildingos-restore-rehearsal"
+  }
+}
 ```
 
 ## Read-only production audit

--- a/docs/runbooks/MINIO_BACKUP_RECOVERY.md
+++ b/docs/runbooks/MINIO_BACKUP_RECOVERY.md
@@ -124,15 +124,20 @@ export TARGET_ACCESS_KEY='<rehearsal-key>'
 export TARGET_SECRET_KEY='<rehearsal-secret>'
 export TARGET_BUCKET='buildingos-restore-rehearsal'
 export RESTORE_CONFIRMATION='RESTORE TO NON-PRODUCTION'
-export RESTORE_TARGET_POLICY_FILE='/etc/buildingos/minio-restore-target-policy.json'
 scripts/restore-minio.sh
 ```
 
-`RESTORE_TARGET_POLICY_FILE` is required non-secret operational configuration.
-It must be supplied from trusted protected configuration and must not be
-created dynamically by the same restore invocation. It binds each allowed
-non-production environment to the canonical endpoint identity and exact
-restore bucket. Production must not be present in the policy. For example:
+Normal operational restores always load the non-secret allowlist from the
+fixed path `/etc/buildingos/minio-restore-target-policy.json`; the restore
+caller cannot select another operational policy. The file must be a regular,
+non-symlink, root-owned file that is not group or world writable. It must be
+provisioned separately through protected operational configuration, not
+created dynamically by the restore invocation. This slice does not provision
+that file.
+
+The policy binds each allowed non-production environment to a canonical
+endpoint identity and exact restore bucket. Only `development`, `rehearsal`,
+and `test` keys are accepted, and production must never appear. For example:
 
 ```json
 {
@@ -142,6 +147,16 @@ restore bucket. Production must not be present in the policy. For example:
   }
 }
 ```
+
+For isolated local rehearsal only, tests may set
+`MINIO_RESTORE_TEST_MODE=LOCAL_ISOLATED_ONLY` and
+`MINIO_RESTORE_TEST_POLICY_FILE` to a caller-owned, non-writable test policy.
+That mode accepts only `rehearsal` or `test` targets and loopback/local Docker
+host identities (`localhost`, `127.0.0.1`, `::1`, or
+`host.docker.internal`) over plain HTTP, plus a dedicated
+`buildingos-test-restore-*` bucket. It cannot authorize a remote endpoint or
+production-shaped bucket. `RESTORE_TARGET_POLICY_FILE` is not supported in any
+mode.
 
 ## Read-only production audit
 

--- a/docs/runbooks/MINIO_BACKUP_RECOVERY.md
+++ b/docs/runbooks/MINIO_BACKUP_RECOVERY.md
@@ -1,0 +1,187 @@
+# MinIO Backup and Recovery
+
+## Scope and current state
+
+This runbook is an executable, fail-closed procedure for later adoption. It
+does not create production backups, change bucket policy, restart containers,
+or restore production data. Credentials are supplied outside Git through
+protected environment injection, Docker secrets, or a mode-0600 server file.
+Never put credentials, signed URLs, or complete environment files in evidence.
+
+Production currently runs a pinned `minio/minio` image with the named Docker
+volume `buildingos_buildingos_miniodata`, bucket identity supplied by
+`S3_BUCKET`, and anonymous access disabled by the production init service. The
+repository contains no completed off-host MinIO backup or restore rehearsal.
+The public health endpoint responds, while an anonymous root request is
+denied. Exact object counts, bytes, versioning, object lock, encryption, and
+replication remain production audit values to collect with read-only `mc`.
+
+## Database and object consistency
+
+| Database model/field | Bucket/key source | Tenant scope | Delete behavior | Recovery requirement |
+| --- | --- | --- | --- | --- |
+| `File.bucket`, `File.objectKey` | `tenant-{tenantId}/documents/{cuid...}` or `tenant-{tenantId}/payment-proofs/{cuid...}` | `File.tenantId`; key prefix | DB cascade/SetNull relations; MinIO delete is asynchronous | Restore every referenced object and verify the `File` mapping |
+| `Document.fileId` | `File` row | `Document.tenantId` | Document delete cascades to File | Required for document metadata |
+| `Quote.fileId` | `File` row | `Quote.tenantId` | SetNull when File is deleted | Required when quote attachment is retained |
+| `Payment.proofFileId` | `File` row | `Payment.tenantId` | SetNull when File is deleted | Required for payment proof |
+| `Payment.receiptDocumentId` | `Document` then `File` | `Payment.tenantId` | Payment-linked documents are protected from mutation | Required for approved receipt history |
+| `ImportJob.originalObjectKey`, `normalizedObjectKey` | deterministic `onboarding-imports/{tenantId}/{importId}/...` | `ImportJob.tenantId` | Job lifecycle cleanup is separate | Required if import audit/replay is in scope |
+
+The model is `DB_MINIO_CONSISTENCY_MODEL=PARTIAL`. The database transaction
+does not include the object upload; an upload can remain orphaned when DB
+creation fails, and a DB row can outlive an object after asynchronous cleanup,
+manual deletion, or storage loss. Keys are tenant-prefixed, normalized, and
+not directly user-controlled, but are generated and stored in PostgreSQL, so
+they are not derivable from all other metadata. No MinIO versioning or object
+lock is configured by the repository compose files.
+
+## Recommended backup design
+
+Use `mc mirror --overwrite` from the source bucket to a separate off-host S3
+`buildingos/<source-environment>/<backup-set-id>/`. Each set contains objects,
+`meta/minio-manifest.json`, its SHA-256 file, and `backup-receipt.json`.
+
+The destination must be a different endpoint or bucket and should provide
+server-side encryption, object lock/retention, and a separate restricted
+backup credential. If the selected destination cannot provide those controls,
+put client-side encryption (for example an externally managed `rclone crypt`)
+in front of it in a later operations change. This slice does not introduce a
+new secret-management platform.
+
+The non-destructive copy is intentional: source deletion never propagates to
+existing backup sets. A new immutable set is created for every run, and a
+reused `BACKUP_SET_ID` fails closed. The scripts compare object keys, sizes,
+ETags where supplied by the client, counts, byte totals, and manifest SHA-256.
+
+### Required paired evidence
+
+The backup receipt binds:
+
+`BACKUP_SET_ID`, start/completion timestamps, source environment/host/bucket,
+`APP_SHA`, PostgreSQL backup ID, PostgreSQL SHA-256, PostgreSQL completion
+timestamp, MinIO manifest name/SHA-256, object count, byte total, and the
+explicit `deletion_propagation=false` guard.
+
+The current PostgreSQL script can upload a dump and metadata to S3, but it
+does not yet emit this shared backup-set contract. A later production change
+must make the PostgreSQL job create or accept the same `BACKUP_SET_ID` and
+publish its receipt before the MinIO receipt is finalized. Until then, the
+MinIO script requires PostgreSQL evidence as input and cannot invent it.
+
+## Usage
+
+All commands below use placeholders and must be supplied by a protected
+secret injector. Values are not printed by the scripts.
+
+```bash
+export SOURCE_ENVIRONMENT=production
+export EXPECTED_SOURCE_ENVIRONMENT=production
+export SOURCE_ENDPOINT='https://<internal-minio-endpoint>'
+export SOURCE_ACCESS_KEY='<read-only-backup-key>'
+export SOURCE_SECRET_KEY='<secret-from-secret-store>'
+export SOURCE_BUCKET='buildingos-prod'
+export BACKUP_ENDPOINT='https://<off-host-s3-endpoint>'
+export BACKUP_ACCESS_KEY='<backup-write-key>'
+export BACKUP_SECRET_KEY='<secret-from-secret-store>'
+export BACKUP_BUCKET='buildingos-backups'
+export BACKUP_SET_ID='20260827t120000z-prod-<short-id>'
+export APP_SHA='<40-character-deployed-sha>'
+export POSTGRES_BACKUP_ID='<postgres-backup-id>'
+export POSTGRES_BACKUP_SHA256='<64-character-sha256>'
+export POSTGRES_BACKUP_COMPLETED_AT='<postgres-completion-time>'
+scripts/backup-minio.sh
+```
+
+Verify a set independently:
+
+```bash
+export EXPECTED_SOURCE_ENVIRONMENT=production
+scripts/verify-minio-backup.sh
+```
+
+Restore only to a new, empty, non-production bucket. Production is rejected
+by the target-environment allowlist; there is no production override flag.
+
+```bash
+export TARGET_ENVIRONMENT=rehearsal
+export TARGET_ENDPOINT='http://127.0.0.1:9000'
+export TARGET_ACCESS_KEY='<rehearsal-key>'
+export TARGET_SECRET_KEY='<rehearsal-secret>'
+export TARGET_BUCKET='buildingos-restore-<unique-id>'
+export RESTORE_CONFIRMATION='RESTORE TO NON-PRODUCTION'
+scripts/restore-minio.sh
+```
+
+## Read-only production audit
+
+Use an ephemeral `MC_CONFIG_DIR` outside all checkouts. Configure an alias
+only in that temporary directory, then run read-only `mc admin info`, `mc stat`,
+`mc ls --recursive --summarize`, `mc version info`, `mc ilm rule list`, and
+`mc encrypt info` as permitted by the operator credential. Record aggregate
+counts and bytes, MinIO image digest, volume name, bucket identity, versioning,
+object lock, encryption, lifecycle, replication, and destination status. Do
+not list object names unnecessarily. The public health endpoint is not proof
+of backup coverage.
+
+## Failure modes and controls
+
+| Failure | Impact | Current protection/gap | Recommended control |
+| --- | --- | --- | --- |
+| VPS disk loss / volume corruption | All local objects unavailable | Persistent volume only | Daily off-host immutable sets and restore rehearsal |
+| Accidental deletion | Documents disappear | Async cleanup can leave ambiguity | Append-only sets, object lock, no delete propagation |
+| Ransomware/host compromise | Local and mounted credentials/backups exposed | Same-host persistence | Separate endpoint/account, encryption, isolated credentials |
+| Credential compromise | Unauthorized read/write/delete | Root credentials currently used by app/MinIO | Least-privilege read and write identities, rotation plan |
+| PostgreSQL restored without MinIO | Metadata points to missing objects | No paired set contract | Shared backup receipt and manifest |
+| Different DB/MinIO points in time | Missing/new object mismatch | No atomic cross-system snapshot | Bounded window, timestamps, reconciliation report |
+| Partial/interrupted/corrupt copy | Incomplete recovery | No existing evidence | Manifest, checksum, count/bytes, independent verification |
+| Destination unavailable | RPO breach | No off-host job | Alert on failed receipt and retention monitoring |
+| Wrong environment/bucket | Cross-environment contamination | Manual configuration risk | Endpoint, environment, bucket, and set identity guards |
+| Interrupted upload during backup | Orphan object or absent DB row | Upload and DB are separate | Reconciliation report; retain backup objects until policy expiry |
+
+## Recovery procedure
+
+1. Freeze application writes if the incident plan requires a point-in-time recovery.
+2. Select a PostgreSQL dump and MinIO set with matching receipt, SHA-256,
+   `APP_SHA`, and completion timestamps.
+3. Verify the MinIO set independently.
+4. Restore PostgreSQL into an isolated temporary database using the existing
+   PostgreSQL recovery procedure.
+5. Restore MinIO into a new empty non-production bucket using this runbook.
+6. Run a reconciliation query over `File` and import-key fields against the
+   restored manifest. Report missing rows, missing objects, and orphans; do
+   not delete automatically.
+7. Validate representative documents, payment proofs, receipts, and import
+   artifacts through the application.
+8. Only a separately approved production recovery plan may switch application
+   configuration to restored infrastructure.
+
+An atomic snapshot across PostgreSQL and MinIO is not possible with the
+current architecture. The practical target is a bounded consistency window:
+PostgreSQL backup completion must be recorded before MinIO copy begins, or
+the application must be quiesced for both operations. A future version could
+add a write fence and shared backup coordinator, but that is not implemented
+here.
+
+## RPO, RTO, and retention
+
+- Recommended MinIO RPO: 24 hours initially; reduce to 6 hours if document
+  volume and operational needs justify four daily runs.
+- Recommended MinIO RTO: 4 hours for a verified isolated restore and recovery
+  handoff, excluding provider provisioning.
+- Retention: 14 daily sets, 8 weekly sets, and 12 monthly sets; destination
+  object lock should outlive the deletion-recovery window.
+- Rehearsal: monthly isolated restore, plus an annual full disaster-recovery
+  exercise. Monitor receipt age and verification failures.
+
+## Production adoption still required
+
+- Provision a separate off-host S3-compatible bucket with encryption and
+  immutable retention.
+- Create separate least-privilege backup-read/source and backup-write/
+  restore-write credentials through the existing protected secret mechanism.
+- Integrate `BACKUP_SET_ID` and PostgreSQL receipt creation into the scheduled
+  backup job.
+- Add a scheduler/alert for `backup-minio.sh` and
+  `verify-minio-backup.sh`; no compose change is included in this slice.
+- Perform a separately approved read-only MinIO inventory and then a
+  non-production restore rehearsal using production-shaped metadata.

--- a/docs/runbooks/MINIO_BACKUP_RECOVERY.md
+++ b/docs/runbooks/MINIO_BACKUP_RECOVERY.md
@@ -37,7 +37,11 @@ lock is configured by the repository compose files.
 
 ## Recommended backup design
 
-Use `mc mirror --overwrite` from the source bucket to a separate off-host S3
+Use `mc mirror --overwrite` from the source bucket to a separate off-host
+S3-compatible backup bucket, with no `--remove`. This protects against source
+deletions propagating to the backup, but is not itself append-only or
+immutable: `--overwrite` can replace an existing destination key if a backup
+prefix is reused. The backup prefix is
 `buildingos/<source-environment>/<backup-set-id>/`. Each set contains objects,
 `meta/minio-manifest.json`, its SHA-256 file, and `backup-receipt.json`.
 
@@ -49,9 +53,11 @@ in front of it in a later operations change. This slice does not introduce a
 new secret-management platform.
 
 The non-destructive copy is intentional: source deletion never propagates to
-existing backup sets. A new immutable set is created for every run, and a
-reused `BACKUP_SET_ID` fails closed. The scripts compare object keys, sizes,
-ETags where supplied by the client, counts, byte totals, and manifest SHA-256.
+existing backup sets. A new uniquely identified set is created for every run,
+and a reused `BACKUP_SET_ID` fails closed. True immutability requires
+destination versioning, Object Lock, and retention controls. The scripts
+compare object keys, sizes, ETags where supplied by the client, counts, byte
+totals, and manifest SHA-256.
 
 ### Required paired evidence
 

--- a/scripts/backup-minio.sh
+++ b/scripts/backup-minio.sh
@@ -20,6 +20,44 @@ validate_prefix() {
     [[ "$segment" != "." && "$segment" != ".." ]] || fail "unsafe BACKUP_PREFIX"
   done
 }
+hash_object() {
+  local object_path="$1"
+  local sha256
+  if ! sha256="$(mc cat "$object_path" < /dev/null | sha256sum | cut -d ' ' -f1)"; then
+    fail "unable to hash object: $object_path"
+  fi
+  [[ "$sha256" =~ ^[0-9a-fA-F]{64}$ ]] || fail "invalid object SHA-256: $object_path"
+  printf '%s\n' "$sha256"
+}
+create_manifest() {
+  local listing_file="$1"
+  local object_root="$2"
+  local manifest_file="$3"
+  local strip_objects_prefix="$4"
+  local entries_file sorted_manifest_file
+  entries_file="$TEMP_DIR/$(basename "$manifest_file").entries"
+  sorted_manifest_file="$TEMP_DIR/$(basename "$manifest_file").sorted"
+  local key size sha256 record
+
+  if ! jq -s -e 'all(.[]; ((.type // "file") != "file") or (((.key // .name) | type) == "string" and ((.size // 0) | type) == "number" and ((.size // 0) >= 0) and (((.size // 0) | floor) == (.size // 0))))' "$listing_file" >/dev/null; then
+    fail "invalid MinIO listing"
+  fi
+  if [[ "$strip_objects_prefix" == true ]]; then
+    jq -r 'select((.type // "file") == "file") | [((.key // .name) | sub("^.*?/objects/"; "")), (.size // 0)] | @tsv' "$listing_file" > "$entries_file" || fail "unable to normalize MinIO listing"
+  else
+    jq -r 'select((.type // "file") == "file") | [(.key // .name), (.size // 0)] | @tsv' "$listing_file" > "$entries_file" || fail "unable to normalize MinIO listing"
+  fi
+
+  : > "$manifest_file"
+  while IFS=$'\t' read -r key size; do
+    [[ -n "$key" ]] || fail "MinIO listing contains an empty object key"
+    sha256="$(hash_object "$object_root/$key")"
+    record="$(jq -cn --arg key "$key" --argjson size "$size" --arg sha256 "$sha256" '{key:$key,size:$size,sha256:$sha256}')"
+    printf '%s\n' "$record" >> "$manifest_file"
+  done < "$entries_file"
+  jq -s 'sort_by(.key)' "$manifest_file" > "$sorted_manifest_file" || fail "unable to create MinIO manifest"
+  mv "$sorted_manifest_file" "$manifest_file"
+}
 
 for variable in SOURCE_ENVIRONMENT EXPECTED_SOURCE_ENVIRONMENT SOURCE_ENDPOINT SOURCE_ACCESS_KEY SOURCE_SECRET_KEY SOURCE_BUCKET BACKUP_ENDPOINT BACKUP_ACCESS_KEY BACKUP_SECRET_KEY BACKUP_BUCKET BACKUP_SET_ID APP_SHA POSTGRES_BACKUP_ID POSTGRES_BACKUP_SHA256 POSTGRES_BACKUP_COMPLETED_AT; do
   require "$variable"
@@ -53,13 +91,20 @@ mc alias set source "$SOURCE_ENDPOINT" "$SOURCE_ACCESS_KEY" "$SOURCE_SECRET_KEY"
 mc alias set backup "$BACKUP_ENDPOINT" "$BACKUP_ACCESS_KEY" "$BACKUP_SECRET_KEY" >/dev/null
 mc stat "source/$SOURCE_BUCKET" >/dev/null || fail "source bucket is unavailable"
 mc stat "backup/$BACKUP_BUCKET" >/dev/null || fail "backup bucket is unavailable"
-if mc ls --recursive --json "backup/$BACKUP_BUCKET/$PREFIX" | jq -e 'select((.type // "file") == "file")' >/dev/null 2>&1; then
+if ! mc ls --recursive --json "backup/$BACKUP_BUCKET/$PREFIX" > "$TEMP_DIR/backup-set-listing.json"; then
+  fail "backup set listing is unavailable"
+fi
+if ! backup_set_has_objects="$(jq -s 'any(.[]; ((.type // "file") == "file"))' "$TEMP_DIR/backup-set-listing.json")"; then
+  fail "backup set listing is invalid"
+fi
+if [[ "$backup_set_has_objects" == true ]]; then
   fail "backup set already exists; use a new BACKUP_SET_ID"
 fi
 
-mc ls --recursive --json "source/$SOURCE_BUCKET" \
-  | jq -c 'select((.type // "file") == "file") | {key:(.key // .name),size:(.size // 0),etag:(.etag // null),lastModified:(.lastModified // null)}' \
-  | jq -s 'sort_by(.key)' > "$TEMP_DIR/source-manifest.json"
+if ! mc ls --recursive --json "source/$SOURCE_BUCKET" > "$TEMP_DIR/source-listing.json"; then
+  fail "source listing is unavailable"
+fi
+create_manifest "$TEMP_DIR/source-listing.json" "source/$SOURCE_BUCKET" "$TEMP_DIR/source-manifest.json" false
 
 object_count="$(jq 'length' "$TEMP_DIR/source-manifest.json")"
 total_bytes="$(jq '[.[].size] | add // 0' "$TEMP_DIR/source-manifest.json")"
@@ -68,16 +113,17 @@ total_bytes="$(jq '[.[].size] | add // 0' "$TEMP_DIR/source-manifest.json")"
 # Deliberately omit --remove: source deletions must never propagate to backups.
 mc mirror --overwrite --json "source/$SOURCE_BUCKET" "backup/$BACKUP_BUCKET/$PREFIX/objects" >/dev/null
 
-mc ls --recursive --json "backup/$BACKUP_BUCKET/$PREFIX/objects" \
-  | jq -c 'select((.type // "file") == "file") | {key:(.key // .name | sub("^.*?/objects/"; "")),size:(.size // 0),etag:(.etag // null),lastModified:(.lastModified // null)}' \
-  | jq -s 'sort_by(.key)' > "$TEMP_DIR/backup-manifest.json"
+if ! mc ls --recursive --json "backup/$BACKUP_BUCKET/$PREFIX/objects" > "$TEMP_DIR/backup-listing.json"; then
+  fail "backup object listing is unavailable"
+fi
+create_manifest "$TEMP_DIR/backup-listing.json" "backup/$BACKUP_BUCKET/$PREFIX/objects" "$TEMP_DIR/backup-manifest.json" true
 
 backup_count="$(jq 'length' "$TEMP_DIR/backup-manifest.json")"
 backup_bytes="$(jq '[.[].size] | add // 0' "$TEMP_DIR/backup-manifest.json")"
 [[ "$object_count" == "$backup_count" && "$total_bytes" == "$backup_bytes" ]] || fail "copied object count or byte total does not match source"
 
-if ! jq -S 'map({key,size})' "$TEMP_DIR/source-manifest.json" | cmp -s - <(jq -S 'map({key,size})' "$TEMP_DIR/backup-manifest.json"); then
-  fail "copied object keys or sizes do not match source manifest"
+if ! jq -S 'map({key,size,sha256})' "$TEMP_DIR/source-manifest.json" | cmp -s - <(jq -S 'map({key,size,sha256})' "$TEMP_DIR/backup-manifest.json"); then
+  fail "copied object keys, sizes, or SHA-256 values do not match source manifest"
 fi
 cp "$TEMP_DIR/source-manifest.json" "$TEMP_DIR/minio-manifest.json"
 printf '%s  %s\n' "$(sha256sum "$TEMP_DIR/minio-manifest.json" | cut -d ' ' -f1)" "minio-manifest.json" > "$TEMP_DIR/minio-manifest.sha256"

--- a/scripts/backup-minio.sh
+++ b/scripts/backup-minio.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Create an append-only MinIO backup set. Credentials are supplied through the
+# environment and are kept in a temporary mc config outside the repository.
+
+fail() { printf 'ERROR: %s\n' "$1" >&2; exit 1; }
+require() { [[ -n "${!1:-}" ]] || fail "$1 is required"; }
+safe_id() { [[ "$1" =~ ^[a-z0-9][a-z0-9._-]{0,95}$ ]]; }
+endpoint_identity() { local value="${1#*://}"; printf '%s\n' "${value%%/*}"; }
+
+for variable in SOURCE_ENVIRONMENT EXPECTED_SOURCE_ENVIRONMENT SOURCE_ENDPOINT SOURCE_ACCESS_KEY SOURCE_SECRET_KEY SOURCE_BUCKET BACKUP_ENDPOINT BACKUP_ACCESS_KEY BACKUP_SECRET_KEY BACKUP_BUCKET BACKUP_SET_ID APP_SHA POSTGRES_BACKUP_ID POSTGRES_BACKUP_SHA256 POSTGRES_BACKUP_COMPLETED_AT; do
+  require "$variable"
+done
+
+[[ "$SOURCE_ENVIRONMENT" == "$EXPECTED_SOURCE_ENVIRONMENT" ]] || fail "source environment identity mismatch"
+[[ "$SOURCE_ENVIRONMENT" =~ ^(production|staging|development|rehearsal)$ ]] || fail "unsafe source environment"
+safe_id "$BACKUP_SET_ID" || fail "unsafe BACKUP_SET_ID"
+[[ "$POSTGRES_BACKUP_SHA256" =~ ^[0-9a-fA-F]{64}$ ]] || fail "POSTGRES_BACKUP_SHA256 must be SHA-256"
+[[ "$APP_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "APP_SHA must be a 40-character commit SHA"
+[[ "$SOURCE_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]] || fail "unsafe SOURCE_BUCKET"
+[[ "$BACKUP_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]] || fail "unsafe BACKUP_BUCKET"
+[[ "$(endpoint_identity "$SOURCE_ENDPOINT")" != "$(endpoint_identity "$BACKUP_ENDPOINT")" || "$SOURCE_BUCKET" != "$BACKUP_BUCKET" ]] || fail "backup destination must not be the source bucket"
+command -v mc >/dev/null 2>&1 || fail "mc is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v sha256sum >/dev/null 2>&1 || fail "sha256sum is required"
+
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/buildingos-minio-backup.XXXXXX")"
+readonly TEMP_DIR
+readonly MC_CONFIG_DIR="$TEMP_DIR/mc-config"
+readonly PREFIX="${BACKUP_PREFIX:-buildingos/$SOURCE_ENVIRONMENT}/$BACKUP_SET_ID"
+export MC_CONFIG_DIR
+trap 'rm -rf "$TEMP_DIR"' EXIT
+umask 077
+mkdir -p "$MC_CONFIG_DIR"
+STARTED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+readonly STARTED_AT
+
+mc alias set source "$SOURCE_ENDPOINT" "$SOURCE_ACCESS_KEY" "$SOURCE_SECRET_KEY" >/dev/null
+mc alias set backup "$BACKUP_ENDPOINT" "$BACKUP_ACCESS_KEY" "$BACKUP_SECRET_KEY" >/dev/null
+mc stat "source/$SOURCE_BUCKET" >/dev/null || fail "source bucket is unavailable"
+mc stat "backup/$BACKUP_BUCKET" >/dev/null || fail "backup bucket is unavailable"
+if mc ls --recursive --json "backup/$BACKUP_BUCKET/$PREFIX" | jq -e 'select((.type // "file") == "file")' >/dev/null 2>&1; then
+  fail "backup set already exists; use a new BACKUP_SET_ID"
+fi
+
+mc ls --recursive --json "source/$SOURCE_BUCKET" \
+  | jq -c 'select((.type // "file") == "file") | {key:(.key // .name),size:(.size // 0),etag:(.etag // null),lastModified:(.lastModified // null)}' \
+  | jq -s 'sort_by(.key)' > "$TEMP_DIR/source-manifest.json"
+
+object_count="$(jq 'length' "$TEMP_DIR/source-manifest.json")"
+total_bytes="$(jq '[.[].size] | add // 0' "$TEMP_DIR/source-manifest.json")"
+[[ "$object_count" =~ ^[0-9]+$ && "$total_bytes" =~ ^[0-9]+$ ]] || fail "source manifest totals are invalid"
+
+# Deliberately omit --remove: source deletions must never propagate to backups.
+mc mirror --overwrite --json "source/$SOURCE_BUCKET" "backup/$BACKUP_BUCKET/$PREFIX/objects" >/dev/null
+
+mc ls --recursive --json "backup/$BACKUP_BUCKET/$PREFIX/objects" \
+  | jq -c 'select((.type // "file") == "file") | {key:(.key // .name | sub("^.*?/objects/"; "")),size:(.size // 0),etag:(.etag // null),lastModified:(.lastModified // null)}' \
+  | jq -s 'sort_by(.key)' > "$TEMP_DIR/backup-manifest.json"
+
+backup_count="$(jq 'length' "$TEMP_DIR/backup-manifest.json")"
+backup_bytes="$(jq '[.[].size] | add // 0' "$TEMP_DIR/backup-manifest.json")"
+[[ "$object_count" == "$backup_count" && "$total_bytes" == "$backup_bytes" ]] || fail "copied object count or byte total does not match source"
+
+if ! jq -S 'map({key,size})' "$TEMP_DIR/source-manifest.json" | cmp -s - <(jq -S 'map({key,size})' "$TEMP_DIR/backup-manifest.json"); then
+  fail "copied object keys or sizes do not match source manifest"
+fi
+cp "$TEMP_DIR/source-manifest.json" "$TEMP_DIR/minio-manifest.json"
+printf '%s  %s\n' "$(sha256sum "$TEMP_DIR/minio-manifest.json" | cut -d ' ' -f1)" "minio-manifest.json" > "$TEMP_DIR/minio-manifest.sha256"
+
+jq -n \
+  --arg backupSetId "$BACKUP_SET_ID" \
+  --arg startedAt "$STARTED_AT" \
+  --arg completedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  --arg sourceEnv "$SOURCE_ENVIRONMENT" \
+  --arg sourceHost "$(endpoint_identity "$SOURCE_ENDPOINT")" \
+  --arg sourceBucket "$SOURCE_BUCKET" \
+  --arg appSha "$APP_SHA" \
+  --arg postgresBackupId "$POSTGRES_BACKUP_ID" \
+  --arg postgresSha256 "$POSTGRES_BACKUP_SHA256" \
+  --arg postgresCompletedAt "$POSTGRES_BACKUP_COMPLETED_AT" \
+  --arg minioManifestSha256 "$(cut -d ' ' -f1 "$TEMP_DIR/minio-manifest.sha256")" \
+  --argjson objectCount "$object_count" \
+  --argjson totalBytes "$total_bytes" \
+  '{backup_set_id:$backupSetId,started_at:$startedAt,completed_at:$completedAt,source_env:$sourceEnv,source_host:$sourceHost,source_bucket:$sourceBucket,app_sha:$appSha,postgres_backup_id:$postgresBackupId,postgres_sha256:$postgresSha256,postgres_completed_at:$postgresCompletedAt,minio_manifest:"minio-manifest.json",minio_manifest_sha256:$minioManifestSha256,object_count:$objectCount,total_bytes:$totalBytes,deletion_propagation:false}' \
+  > "$TEMP_DIR/backup-receipt.json"
+
+mc cp "$TEMP_DIR/minio-manifest.json" "backup/$BACKUP_BUCKET/$PREFIX/meta/minio-manifest.json" >/dev/null
+mc cp "$TEMP_DIR/minio-manifest.sha256" "backup/$BACKUP_BUCKET/$PREFIX/meta/minio-manifest.sha256" >/dev/null
+mc cp "$TEMP_DIR/backup-receipt.json" "backup/$BACKUP_BUCKET/$PREFIX/meta/backup-receipt.json" >/dev/null
+
+printf 'MinIO backup verified: set=%s environment=%s objects=%s bytes=%s destination=%s/%s\n' \
+  "$BACKUP_SET_ID" "$SOURCE_ENVIRONMENT" "$object_count" "$total_bytes" "$BACKUP_BUCKET" "$PREFIX"

--- a/scripts/backup-minio.sh
+++ b/scripts/backup-minio.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-# Create an append-only MinIO backup set. Credentials are supplied through the
-# environment and are kept in a temporary mc config outside the repository.
+# Create a deletion-propagation-protected MinIO backup set. Credentials are
+# supplied through the environment and kept in a temporary mc config outside
+# the repository.
 
 fail() { printf 'ERROR: %s\n' "$1" >&2; exit 1; }
 require() { [[ -n "${!1:-}" ]] || fail "$1 is required"; }

--- a/scripts/backup-minio.sh
+++ b/scripts/backup-minio.sh
@@ -9,6 +9,17 @@ fail() { printf 'ERROR: %s\n' "$1" >&2; exit 1; }
 require() { [[ -n "${!1:-}" ]] || fail "$1 is required"; }
 safe_id() { [[ "$1" =~ ^[a-z0-9][a-z0-9._-]{0,95}$ ]]; }
 endpoint_identity() { local value="${1#*://}"; printf '%s\n' "${value%%/*}"; }
+validate_prefix() {
+  local prefix="$1"
+  [[ -z "$prefix" ]] && return 0
+  [[ "$prefix" =~ ^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$ ]] || fail "unsafe BACKUP_PREFIX"
+  local segment
+  local -a segments
+  IFS='/' read -r -a segments <<< "$prefix"
+  for segment in "${segments[@]}"; do
+    [[ "$segment" != "." && "$segment" != ".." ]] || fail "unsafe BACKUP_PREFIX"
+  done
+}
 
 for variable in SOURCE_ENVIRONMENT EXPECTED_SOURCE_ENVIRONMENT SOURCE_ENDPOINT SOURCE_ACCESS_KEY SOURCE_SECRET_KEY SOURCE_BUCKET BACKUP_ENDPOINT BACKUP_ACCESS_KEY BACKUP_SECRET_KEY BACKUP_BUCKET BACKUP_SET_ID APP_SHA POSTGRES_BACKUP_ID POSTGRES_BACKUP_SHA256 POSTGRES_BACKUP_COMPLETED_AT; do
   require "$variable"
@@ -17,6 +28,7 @@ done
 [[ "$SOURCE_ENVIRONMENT" == "$EXPECTED_SOURCE_ENVIRONMENT" ]] || fail "source environment identity mismatch"
 [[ "$SOURCE_ENVIRONMENT" =~ ^(production|staging|development|rehearsal)$ ]] || fail "unsafe source environment"
 safe_id "$BACKUP_SET_ID" || fail "unsafe BACKUP_SET_ID"
+validate_prefix "${BACKUP_PREFIX:-}"
 [[ "$POSTGRES_BACKUP_SHA256" =~ ^[0-9a-fA-F]{64}$ ]] || fail "POSTGRES_BACKUP_SHA256 must be SHA-256"
 [[ "$APP_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "APP_SHA must be a 40-character commit SHA"
 [[ "$SOURCE_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]] || fail "unsafe SOURCE_BUCKET"

--- a/scripts/restore-minio.sh
+++ b/scripts/restore-minio.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+fail() { printf 'ERROR: %s\n' "$1" >&2; exit 1; }
+require() { [[ -n "${!1:-}" ]] || fail "$1 is required"; }
+safe_id() { [[ "$1" =~ ^[a-z0-9][a-z0-9._-]{0,95}$ ]]; }
+endpoint_identity() { local value="${1#*://}"; printf '%s\n' "${value%%/*}"; }
+
+for variable in BACKUP_ENDPOINT BACKUP_ACCESS_KEY BACKUP_SECRET_KEY BACKUP_BUCKET BACKUP_SET_ID EXPECTED_SOURCE_ENVIRONMENT TARGET_ENDPOINT TARGET_ACCESS_KEY TARGET_SECRET_KEY TARGET_BUCKET TARGET_ENVIRONMENT RESTORE_CONFIRMATION; do require "$variable"; done
+safe_id "$BACKUP_SET_ID" || fail "unsafe BACKUP_SET_ID"
+[[ "$EXPECTED_SOURCE_ENVIRONMENT" =~ ^(production|staging|development|rehearsal)$ ]] || fail "unsafe source environment"
+[[ "$TARGET_ENVIRONMENT" =~ ^(development|rehearsal|test)$ ]] || fail "restore target must be non-production"
+[[ "$RESTORE_CONFIRMATION" == "RESTORE TO NON-PRODUCTION" ]] || fail "exact non-production restore confirmation is required"
+[[ "$BACKUP_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ && "$TARGET_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]] || fail "unsafe bucket name"
+[[ "$(endpoint_identity "$BACKUP_ENDPOINT")" != "$(endpoint_identity "$TARGET_ENDPOINT")" || "$BACKUP_BUCKET" != "$TARGET_BUCKET" ]] || fail "restore target must not be the backup bucket"
+command -v mc >/dev/null 2>&1 || fail "mc is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v sha256sum >/dev/null 2>&1 || fail "sha256sum is required"
+
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/buildingos-minio-restore.XXXXXX")"
+readonly TEMP_DIR
+readonly MC_CONFIG_DIR="$TEMP_DIR/mc-config"
+readonly PREFIX="${BACKUP_PREFIX:-buildingos/$EXPECTED_SOURCE_ENVIRONMENT}/$BACKUP_SET_ID"
+export MC_CONFIG_DIR
+trap 'rm -rf "$TEMP_DIR"' EXIT
+umask 077
+mkdir -p "$MC_CONFIG_DIR"
+
+mc alias set backup "$BACKUP_ENDPOINT" "$BACKUP_ACCESS_KEY" "$BACKUP_SECRET_KEY" >/dev/null
+mc alias set target "$TARGET_ENDPOINT" "$TARGET_ACCESS_KEY" "$TARGET_SECRET_KEY" >/dev/null
+mc stat "backup/$BACKUP_BUCKET" >/dev/null || fail "backup bucket is unavailable"
+mc stat "target/$TARGET_BUCKET" >/dev/null || fail "target bucket is unavailable"
+if mc ls --recursive --json "target/$TARGET_BUCKET" | jq -e 'select((.type // "file") == "file")' >/dev/null 2>&1; then
+  fail "target bucket is not empty; restore will not overwrite or delete existing objects"
+fi
+
+mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/minio-manifest.json" "$TEMP_DIR/minio-manifest.json" >/dev/null || fail "manifest is unavailable"
+mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/minio-manifest.sha256" "$TEMP_DIR/minio-manifest.sha256" >/dev/null || fail "manifest checksum is unavailable"
+mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/backup-receipt.json" "$TEMP_DIR/backup-receipt.json" >/dev/null || fail "backup receipt is unavailable"
+grep -Eq '^[0-9a-fA-F]{64}[[:space:]]+[*]?minio-manifest\.json$' "$TEMP_DIR/minio-manifest.sha256" || fail "invalid manifest checksum file"
+(cd "$TEMP_DIR" && sha256sum -c minio-manifest.sha256 >/dev/null) || fail "manifest checksum verification failed"
+jq -e --arg environment "$EXPECTED_SOURCE_ENVIRONMENT" '.source_env == $environment and .deletion_propagation == false' "$TEMP_DIR/backup-receipt.json" >/dev/null || fail "backup receipt identity or deletion guard is invalid"
+
+# Restore is additive into a proven-empty bucket; no delete or mirror removal is used.
+mc cp --recursive "backup/$BACKUP_BUCKET/$PREFIX/objects/" "target/$TARGET_BUCKET/" >/dev/null
+mc ls --recursive --json "target/$TARGET_BUCKET" \
+  | jq -c 'select((.type // "file") == "file") | {key:(.key // .name),size:(.size // 0),etag:(.etag // null),lastModified:(.lastModified // null)}' \
+  | jq -s 'sort_by(.key)' > "$TEMP_DIR/actual-manifest.json"
+if ! jq -S 'map({key,size})' "$TEMP_DIR/minio-manifest.json" | cmp -s - <(jq -S 'map({key,size})' "$TEMP_DIR/actual-manifest.json"); then
+  fail "restored object keys or sizes do not match the approved manifest"
+fi

--- a/scripts/restore-minio.sh
+++ b/scripts/restore-minio.sh
@@ -16,8 +16,51 @@ validate_prefix() {
     [[ "$segment" != "." && "$segment" != ".." ]] || fail "unsafe BACKUP_PREFIX"
   done
 }
+hash_object() {
+  local object_path="$1"
+  local sha256
+  if ! sha256="$(mc cat "$object_path" < /dev/null | sha256sum | cut -d ' ' -f1)"; then
+    fail "unable to hash object: $object_path"
+  fi
+  [[ "$sha256" =~ ^[0-9a-fA-F]{64}$ ]] || fail "invalid object SHA-256: $object_path"
+  printf '%s\n' "$sha256"
+}
+create_manifest() {
+  local listing_file="$1"
+  local object_root="$2"
+  local manifest_file="$3"
+  local entries_file sorted_manifest_file
+  entries_file="$TEMP_DIR/$(basename "$manifest_file").entries"
+  sorted_manifest_file="$TEMP_DIR/$(basename "$manifest_file").sorted"
+  local key size sha256 record
 
-for variable in BACKUP_ENDPOINT BACKUP_ACCESS_KEY BACKUP_SECRET_KEY BACKUP_BUCKET BACKUP_SET_ID EXPECTED_SOURCE_ENVIRONMENT TARGET_ENDPOINT TARGET_ACCESS_KEY TARGET_SECRET_KEY TARGET_BUCKET TARGET_ENVIRONMENT RESTORE_CONFIRMATION; do require "$variable"; done
+  if ! jq -s -e 'all(.[]; ((.type // "file") != "file") or (((.key // .name) | type) == "string" and ((.size // 0) | type) == "number" and ((.size // 0) >= 0) and (((.size // 0) | floor) == (.size // 0))))' "$listing_file" >/dev/null; then
+    fail "invalid MinIO listing"
+  fi
+  jq -r 'select((.type // "file") == "file") | [((.key // .name) | sub("^.*?/objects/"; "")), (.size // 0)] | @tsv' "$listing_file" > "$entries_file" || fail "unable to normalize MinIO listing"
+
+  : > "$manifest_file"
+  while IFS=$'\t' read -r key size; do
+    [[ -n "$key" ]] || fail "MinIO listing contains an empty object key"
+    sha256="$(hash_object "$object_root/$key")"
+    record="$(jq -cn --arg key "$key" --argjson size "$size" --arg sha256 "$sha256" '{key:$key,size:$size,sha256:$sha256}')"
+    printf '%s\n' "$record" >> "$manifest_file"
+  done < "$entries_file"
+  jq -s 'sort_by(.key)' "$manifest_file" > "$sorted_manifest_file" || fail "unable to create MinIO manifest"
+  mv "$sorted_manifest_file" "$manifest_file"
+}
+validate_target_policy() {
+  [[ -f "$RESTORE_TARGET_POLICY_FILE" && -r "$RESTORE_TARGET_POLICY_FILE" ]] || fail "restore target policy is unavailable"
+  jq -e 'type == "object" and (has("production") | not) and all(to_entries[]; (.value | type == "object" and (.endpoint_identity | type == "string" and length > 0) and (.bucket | type == "string" and length > 0)))' "$RESTORE_TARGET_POLICY_FILE" >/dev/null || fail "restore target policy is invalid"
+  jq -e --arg environment "$TARGET_ENVIRONMENT" 'has($environment)' "$RESTORE_TARGET_POLICY_FILE" >/dev/null || fail "restore target environment is not allowed by policy"
+  local policy_endpoint policy_bucket
+  policy_endpoint="$(jq -er --arg environment "$TARGET_ENVIRONMENT" '.[$environment].endpoint_identity' "$RESTORE_TARGET_POLICY_FILE")" || fail "restore target endpoint policy is invalid"
+  policy_bucket="$(jq -er --arg environment "$TARGET_ENVIRONMENT" '.[$environment].bucket' "$RESTORE_TARGET_POLICY_FILE")" || fail "restore target bucket policy is invalid"
+  [[ "$(endpoint_identity "$TARGET_ENDPOINT")" == "$policy_endpoint" ]] || fail "target endpoint does not match restore target policy"
+  [[ "$TARGET_BUCKET" == "$policy_bucket" ]] || fail "target bucket does not match restore target policy"
+}
+
+for variable in BACKUP_ENDPOINT BACKUP_ACCESS_KEY BACKUP_SECRET_KEY BACKUP_BUCKET BACKUP_SET_ID EXPECTED_SOURCE_ENVIRONMENT TARGET_ENDPOINT TARGET_ACCESS_KEY TARGET_SECRET_KEY TARGET_BUCKET TARGET_ENVIRONMENT RESTORE_CONFIRMATION RESTORE_TARGET_POLICY_FILE; do require "$variable"; done
 safe_id "$BACKUP_SET_ID" || fail "unsafe BACKUP_SET_ID"
 validate_prefix "${BACKUP_PREFIX:-}"
 [[ "$EXPECTED_SOURCE_ENVIRONMENT" =~ ^(production|staging|development|rehearsal)$ ]] || fail "unsafe source environment"
@@ -43,29 +86,53 @@ mc stat "backup/$BACKUP_BUCKET" >/dev/null || fail "backup bucket is unavailable
 mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/backup-receipt.json" "$TEMP_DIR/backup-receipt.json" >/dev/null || fail "backup receipt is unavailable"
 jq -er 'select((.backup_set_id | type) == "string") | .backup_set_id' "$TEMP_DIR/backup-receipt.json" > "$TEMP_DIR/receipt-backup-set-id" || fail "backup receipt backup_set_id is missing or invalid"
 [[ "$(<"$TEMP_DIR/receipt-backup-set-id")" == "$BACKUP_SET_ID" ]] || fail "backup set identity mismatch"
+receipt_source_host="$(jq -er 'select((.source_host | type) == "string" and (.source_host | length > 0)) | .source_host' "$TEMP_DIR/backup-receipt.json")" || fail "backup receipt source host is missing or invalid"
+receipt_source_bucket="$(jq -er 'select((.source_bucket | type) == "string" and (.source_bucket | length > 0)) | .source_bucket' "$TEMP_DIR/backup-receipt.json")" || fail "backup receipt source bucket is missing or invalid"
 
 mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/minio-manifest.json" "$TEMP_DIR/minio-manifest.json" >/dev/null || fail "manifest is unavailable"
 mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/minio-manifest.sha256" "$TEMP_DIR/minio-manifest.sha256" >/dev/null || fail "manifest checksum is unavailable"
 grep -Eq '^[0-9a-fA-F]{64}[[:space:]]+[*]?minio-manifest\.json$' "$TEMP_DIR/minio-manifest.sha256" || fail "invalid manifest checksum file"
 (cd "$TEMP_DIR" && sha256sum -c minio-manifest.sha256 >/dev/null) || fail "manifest checksum verification failed"
 jq -e --arg environment "$EXPECTED_SOURCE_ENVIRONMENT" '.source_env == $environment and .deletion_propagation == false' "$TEMP_DIR/backup-receipt.json" >/dev/null || fail "backup receipt identity or deletion guard is invalid"
+receipt_manifest_sha256="$(jq -er 'select((.minio_manifest_sha256 | type) == "string") | .minio_manifest_sha256' "$TEMP_DIR/backup-receipt.json")" || fail "backup receipt manifest SHA-256 is missing or invalid"
+[[ "$receipt_manifest_sha256" =~ ^[0-9a-fA-F]{64}$ ]] || fail "backup receipt manifest SHA-256 is invalid"
+receipt_object_count="$(jq -er 'select((.object_count | type) == "number" and .object_count >= 0 and ((.object_count | floor) == .object_count)) | .object_count' "$TEMP_DIR/backup-receipt.json")" || fail "backup receipt object count is missing or invalid"
+receipt_total_bytes="$(jq -er 'select((.total_bytes | type) == "number" and .total_bytes >= 0 and ((.total_bytes | floor) == .total_bytes)) | .total_bytes' "$TEMP_DIR/backup-receipt.json")" || fail "backup receipt byte total is missing or invalid"
+if ! jq -e 'type == "array" and all(.[]; (.key | type == "string" and length > 0) and (.size | type == "number" and . >= 0 and floor == .) and (.sha256 | type == "string" and test("^[0-9a-fA-F]{64}$")))' "$TEMP_DIR/minio-manifest.json" >/dev/null; then
+  fail "manifest schema is invalid"
+fi
+actual_manifest_sha256="$(sha256sum "$TEMP_DIR/minio-manifest.json" | cut -d ' ' -f1)"
+actual_object_count="$(jq 'length' "$TEMP_DIR/minio-manifest.json")"
+actual_total_bytes="$(jq '[.[].size] | add // 0' "$TEMP_DIR/minio-manifest.json")"
+[[ "$actual_manifest_sha256" == "$receipt_manifest_sha256" ]] || fail "manifest SHA-256 does not match backup receipt"
+[[ "$actual_object_count" == "$receipt_object_count" ]] || fail "manifest object count does not match backup receipt"
+[[ "$actual_total_bytes" == "$receipt_total_bytes" ]] || fail "manifest byte total does not match backup receipt"
+[[ "$(endpoint_identity "$TARGET_ENDPOINT")" != "$receipt_source_host" || "$TARGET_BUCKET" != "$receipt_source_bucket" ]] || fail "restore target matches backup source identity"
+validate_target_policy
 
 mc alias set target "$TARGET_ENDPOINT" "$TARGET_ACCESS_KEY" "$TARGET_SECRET_KEY" >/dev/null
 mc stat "target/$TARGET_BUCKET" >/dev/null || fail "target bucket is unavailable"
-if mc ls --recursive --json "target/$TARGET_BUCKET" | jq -e 'select((.type // "file") == "file")' >/dev/null 2>&1; then
+if ! mc ls --recursive --json "target/$TARGET_BUCKET" > "$TEMP_DIR/target-listing.json"; then
+  fail "target listing is unavailable"
+fi
+if ! target_has_objects="$(jq -s 'any(.[]; ((.type // "file") == "file"))' "$TEMP_DIR/target-listing.json")"; then
+  fail "target listing is invalid"
+fi
+if [[ "$target_has_objects" == true ]]; then
   fail "target bucket is not empty; restore will not overwrite or delete existing objects"
 fi
 
 # Restore is additive into a proven-empty bucket; no delete or mirror removal is used.
 mc cp --recursive "backup/$BACKUP_BUCKET/$PREFIX/objects/" "target/$TARGET_BUCKET/" >/dev/null
-mc ls --recursive --json "target/$TARGET_BUCKET" \
-  | jq -c 'select((.type // "file") == "file") | {key:(.key // .name),size:(.size // 0),etag:(.etag // null),lastModified:(.lastModified // null)}' \
-  | jq -s 'sort_by(.key)' > "$TEMP_DIR/actual-manifest.json"
-if ! jq -S 'map({key,size})' "$TEMP_DIR/minio-manifest.json" | cmp -s - <(jq -S 'map({key,size})' "$TEMP_DIR/actual-manifest.json"); then
-  fail "restored object keys or sizes do not match the approved manifest"
+if ! mc ls --recursive --json "target/$TARGET_BUCKET" > "$TEMP_DIR/target-listing.json"; then
+  fail "restored object listing is unavailable"
+fi
+create_manifest "$TEMP_DIR/target-listing.json" "target/$TARGET_BUCKET" "$TEMP_DIR/actual-manifest.json" true
+if ! jq -S 'map({key,size,sha256})' "$TEMP_DIR/minio-manifest.json" | cmp -s - <(jq -S 'map({key,size,sha256})' "$TEMP_DIR/actual-manifest.json"); then
+  fail "restored object keys, sizes, or SHA-256 values do not match the approved manifest"
 fi
 
-restored_object_count="$(jq 'length' "$TEMP_DIR/minio-manifest.json")"
-restored_total_bytes="$(jq '[.[].size] | add // 0' "$TEMP_DIR/minio-manifest.json")"
+restored_object_count="$actual_object_count"
+restored_total_bytes="$actual_total_bytes"
 printf 'MINIO_RESTORE_COMPLETE\nSTATUS=PASS\nBACKUP_SET_ID=%s\nTARGET_ENV=%s\nTARGET_BUCKET=%s\nRESTORED_OBJECT_COUNT=%s\nRESTORED_TOTAL_BYTES=%s\n' \
   "$BACKUP_SET_ID" "$TARGET_ENVIRONMENT" "$TARGET_BUCKET" "$restored_object_count" "$restored_total_bytes"

--- a/scripts/restore-minio.sh
+++ b/scripts/restore-minio.sh
@@ -5,9 +5,21 @@ fail() { printf 'ERROR: %s\n' "$1" >&2; exit 1; }
 require() { [[ -n "${!1:-}" ]] || fail "$1 is required"; }
 safe_id() { [[ "$1" =~ ^[a-z0-9][a-z0-9._-]{0,95}$ ]]; }
 endpoint_identity() { local value="${1#*://}"; printf '%s\n' "${value%%/*}"; }
+validate_prefix() {
+  local prefix="$1"
+  [[ -z "$prefix" ]] && return 0
+  [[ "$prefix" =~ ^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$ ]] || fail "unsafe BACKUP_PREFIX"
+  local segment
+  local -a segments
+  IFS='/' read -r -a segments <<< "$prefix"
+  for segment in "${segments[@]}"; do
+    [[ "$segment" != "." && "$segment" != ".." ]] || fail "unsafe BACKUP_PREFIX"
+  done
+}
 
 for variable in BACKUP_ENDPOINT BACKUP_ACCESS_KEY BACKUP_SECRET_KEY BACKUP_BUCKET BACKUP_SET_ID EXPECTED_SOURCE_ENVIRONMENT TARGET_ENDPOINT TARGET_ACCESS_KEY TARGET_SECRET_KEY TARGET_BUCKET TARGET_ENVIRONMENT RESTORE_CONFIRMATION; do require "$variable"; done
 safe_id "$BACKUP_SET_ID" || fail "unsafe BACKUP_SET_ID"
+validate_prefix "${BACKUP_PREFIX:-}"
 [[ "$EXPECTED_SOURCE_ENVIRONMENT" =~ ^(production|staging|development|rehearsal)$ ]] || fail "unsafe source environment"
 [[ "$TARGET_ENVIRONMENT" =~ ^(development|rehearsal|test)$ ]] || fail "restore target must be non-production"
 [[ "$RESTORE_CONFIRMATION" == "RESTORE TO NON-PRODUCTION" ]] || fail "exact non-production restore confirmation is required"
@@ -27,19 +39,22 @@ umask 077
 mkdir -p "$MC_CONFIG_DIR"
 
 mc alias set backup "$BACKUP_ENDPOINT" "$BACKUP_ACCESS_KEY" "$BACKUP_SECRET_KEY" >/dev/null
-mc alias set target "$TARGET_ENDPOINT" "$TARGET_ACCESS_KEY" "$TARGET_SECRET_KEY" >/dev/null
 mc stat "backup/$BACKUP_BUCKET" >/dev/null || fail "backup bucket is unavailable"
+mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/backup-receipt.json" "$TEMP_DIR/backup-receipt.json" >/dev/null || fail "backup receipt is unavailable"
+jq -er 'select((.backup_set_id | type) == "string") | .backup_set_id' "$TEMP_DIR/backup-receipt.json" > "$TEMP_DIR/receipt-backup-set-id" || fail "backup receipt backup_set_id is missing or invalid"
+[[ "$(<"$TEMP_DIR/receipt-backup-set-id")" == "$BACKUP_SET_ID" ]] || fail "backup set identity mismatch"
+
+mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/minio-manifest.json" "$TEMP_DIR/minio-manifest.json" >/dev/null || fail "manifest is unavailable"
+mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/minio-manifest.sha256" "$TEMP_DIR/minio-manifest.sha256" >/dev/null || fail "manifest checksum is unavailable"
+grep -Eq '^[0-9a-fA-F]{64}[[:space:]]+[*]?minio-manifest\.json$' "$TEMP_DIR/minio-manifest.sha256" || fail "invalid manifest checksum file"
+(cd "$TEMP_DIR" && sha256sum -c minio-manifest.sha256 >/dev/null) || fail "manifest checksum verification failed"
+jq -e --arg environment "$EXPECTED_SOURCE_ENVIRONMENT" '.source_env == $environment and .deletion_propagation == false' "$TEMP_DIR/backup-receipt.json" >/dev/null || fail "backup receipt identity or deletion guard is invalid"
+
+mc alias set target "$TARGET_ENDPOINT" "$TARGET_ACCESS_KEY" "$TARGET_SECRET_KEY" >/dev/null
 mc stat "target/$TARGET_BUCKET" >/dev/null || fail "target bucket is unavailable"
 if mc ls --recursive --json "target/$TARGET_BUCKET" | jq -e 'select((.type // "file") == "file")' >/dev/null 2>&1; then
   fail "target bucket is not empty; restore will not overwrite or delete existing objects"
 fi
-
-mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/minio-manifest.json" "$TEMP_DIR/minio-manifest.json" >/dev/null || fail "manifest is unavailable"
-mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/minio-manifest.sha256" "$TEMP_DIR/minio-manifest.sha256" >/dev/null || fail "manifest checksum is unavailable"
-mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/backup-receipt.json" "$TEMP_DIR/backup-receipt.json" >/dev/null || fail "backup receipt is unavailable"
-grep -Eq '^[0-9a-fA-F]{64}[[:space:]]+[*]?minio-manifest\.json$' "$TEMP_DIR/minio-manifest.sha256" || fail "invalid manifest checksum file"
-(cd "$TEMP_DIR" && sha256sum -c minio-manifest.sha256 >/dev/null) || fail "manifest checksum verification failed"
-jq -e --arg environment "$EXPECTED_SOURCE_ENVIRONMENT" '.source_env == $environment and .deletion_propagation == false' "$TEMP_DIR/backup-receipt.json" >/dev/null || fail "backup receipt identity or deletion guard is invalid"
 
 # Restore is additive into a proven-empty bucket; no delete or mirror removal is used.
 mc cp --recursive "backup/$BACKUP_BUCKET/$PREFIX/objects/" "target/$TARGET_BUCKET/" >/dev/null

--- a/scripts/restore-minio.sh
+++ b/scripts/restore-minio.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+readonly OPERATIONAL_RESTORE_TARGET_POLICY_FILE='/etc/buildingos/minio-restore-target-policy.json'
+
 fail() { printf 'ERROR: %s\n' "$1" >&2; exit 1; }
 require() { [[ -n "${!1:-}" ]] || fail "$1 is required"; }
 safe_id() { [[ "$1" =~ ^[a-z0-9][a-z0-9._-]{0,95}$ ]]; }
@@ -50,17 +52,71 @@ create_manifest() {
   mv "$sorted_manifest_file" "$manifest_file"
 }
 validate_target_policy() {
-  [[ -f "$RESTORE_TARGET_POLICY_FILE" && -r "$RESTORE_TARGET_POLICY_FILE" ]] || fail "restore target policy is unavailable"
-  jq -e 'type == "object" and (has("production") | not) and all(to_entries[]; (.value | type == "object" and (.endpoint_identity | type == "string" and length > 0) and (.bucket | type == "string" and length > 0)))' "$RESTORE_TARGET_POLICY_FILE" >/dev/null || fail "restore target policy is invalid"
-  jq -e --arg environment "$TARGET_ENVIRONMENT" 'has($environment)' "$RESTORE_TARGET_POLICY_FILE" >/dev/null || fail "restore target environment is not allowed by policy"
+  local policy_file="$1"
+  local expected_owner_uid="$2"
+  local owner_uid mode mode_value
+
+  [[ "$policy_file" == /* ]] || fail "restore target policy path must be absolute"
+  [[ ! -L "$policy_file" ]] || fail "restore target policy must not be a symlink"
+  [[ -f "$policy_file" && -r "$policy_file" ]] || fail "restore target policy is unavailable"
+  if owner_uid="$(stat -c '%u' "$policy_file" 2>/dev/null)" && mode="$(stat -c '%a' "$policy_file" 2>/dev/null)"; then
+    :
+  elif owner_uid="$(stat -f '%u' "$policy_file" 2>/dev/null)" && mode="$(stat -f '%Lp' "$policy_file" 2>/dev/null)"; then
+    :
+  else
+    fail "unable to validate restore target policy ownership and permissions"
+  fi
+  [[ "$owner_uid" == "$expected_owner_uid" ]] || fail "restore target policy has an untrusted owner"
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || fail "restore target policy permissions are invalid"
+  mode_value=$((8#$mode))
+  (( (mode_value & 0022) == 0 )) || fail "restore target policy must not be group or world writable"
+  jq -e '
+    type == "object" and length > 0 and
+    all(keys[]; test("^(development|rehearsal|test)$")) and
+    all(to_entries[];
+      (.value | type) == "object" and
+      (.value.endpoint_identity | type) == "string" and
+      (.value.endpoint_identity | length) > 0 and
+      (.value.bucket | type) == "string" and
+      (.value.bucket | length) > 0
+    )
+  ' "$policy_file" >/dev/null || fail "restore target policy is invalid"
+  jq -e --arg environment "$TARGET_ENVIRONMENT" 'has($environment)' "$policy_file" >/dev/null || fail "restore target environment is not allowed by policy"
   local policy_endpoint policy_bucket
-  policy_endpoint="$(jq -er --arg environment "$TARGET_ENVIRONMENT" '.[$environment].endpoint_identity' "$RESTORE_TARGET_POLICY_FILE")" || fail "restore target endpoint policy is invalid"
-  policy_bucket="$(jq -er --arg environment "$TARGET_ENVIRONMENT" '.[$environment].bucket' "$RESTORE_TARGET_POLICY_FILE")" || fail "restore target bucket policy is invalid"
+  policy_endpoint="$(jq -er --arg environment "$TARGET_ENVIRONMENT" '.[$environment].endpoint_identity' "$policy_file")" || fail "restore target endpoint policy is invalid"
+  policy_bucket="$(jq -er --arg environment "$TARGET_ENVIRONMENT" '.[$environment].bucket' "$policy_file")" || fail "restore target bucket policy is invalid"
   [[ "$(endpoint_identity "$TARGET_ENDPOINT")" == "$policy_endpoint" ]] || fail "target endpoint does not match restore target policy"
   [[ "$TARGET_BUCKET" == "$policy_bucket" ]] || fail "target bucket does not match restore target policy"
 }
+is_local_test_endpoint() {
+  local identity
+  [[ "$1" == http://* ]] || return 1
+  identity="$(endpoint_identity "$1")"
+  [[ "$identity" =~ ^(localhost|127\.0\.0\.1|host\.docker\.internal)(:[0-9]{1,5})?$ || "$identity" =~ ^\[::1\](:[0-9]{1,5})?$ ]]
+}
+select_target_policy() {
+  [[ -z "${RESTORE_TARGET_POLICY_FILE:-}" ]] || fail "caller-selected RESTORE_TARGET_POLICY_FILE is not supported"
+  case "${MINIO_RESTORE_TEST_MODE:-}" in
+    '')
+      [[ -z "${MINIO_RESTORE_TEST_POLICY_FILE:-}" ]] || fail "test policy requires isolated test mode"
+      TARGET_POLICY_FILE="$OPERATIONAL_RESTORE_TARGET_POLICY_FILE"
+      TARGET_POLICY_OWNER_UID=0
+      ;;
+    LOCAL_ISOLATED_ONLY)
+      [[ "$TARGET_ENVIRONMENT" =~ ^(rehearsal|test)$ ]] || fail "isolated test policy requires rehearsal or test target"
+      is_local_test_endpoint "$TARGET_ENDPOINT" || fail "isolated test policy requires a local endpoint"
+      [[ "$TARGET_BUCKET" =~ ^buildingos-test-restore-[a-z0-9.-]+$ ]] || fail "isolated test policy requires a dedicated test restore bucket"
+      [[ -n "${MINIO_RESTORE_TEST_POLICY_FILE:-}" ]] || fail "MINIO_RESTORE_TEST_POLICY_FILE is required in isolated test mode"
+      TARGET_POLICY_FILE="$MINIO_RESTORE_TEST_POLICY_FILE"
+      TARGET_POLICY_OWNER_UID="$(id -u)"
+      ;;
+    *)
+      fail "invalid MINIO_RESTORE_TEST_MODE"
+      ;;
+  esac
+}
 
-for variable in BACKUP_ENDPOINT BACKUP_ACCESS_KEY BACKUP_SECRET_KEY BACKUP_BUCKET BACKUP_SET_ID EXPECTED_SOURCE_ENVIRONMENT TARGET_ENDPOINT TARGET_ACCESS_KEY TARGET_SECRET_KEY TARGET_BUCKET TARGET_ENVIRONMENT RESTORE_CONFIRMATION RESTORE_TARGET_POLICY_FILE; do require "$variable"; done
+for variable in BACKUP_ENDPOINT BACKUP_ACCESS_KEY BACKUP_SECRET_KEY BACKUP_BUCKET BACKUP_SET_ID EXPECTED_SOURCE_ENVIRONMENT TARGET_ENDPOINT TARGET_ACCESS_KEY TARGET_SECRET_KEY TARGET_BUCKET TARGET_ENVIRONMENT RESTORE_CONFIRMATION; do require "$variable"; done
 safe_id "$BACKUP_SET_ID" || fail "unsafe BACKUP_SET_ID"
 validate_prefix "${BACKUP_PREFIX:-}"
 [[ "$EXPECTED_SOURCE_ENVIRONMENT" =~ ^(production|staging|development|rehearsal)$ ]] || fail "unsafe source environment"
@@ -68,9 +124,11 @@ validate_prefix "${BACKUP_PREFIX:-}"
 [[ "$RESTORE_CONFIRMATION" == "RESTORE TO NON-PRODUCTION" ]] || fail "exact non-production restore confirmation is required"
 [[ "$BACKUP_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ && "$TARGET_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]] || fail "unsafe bucket name"
 [[ "$(endpoint_identity "$BACKUP_ENDPOINT")" != "$(endpoint_identity "$TARGET_ENDPOINT")" || "$BACKUP_BUCKET" != "$TARGET_BUCKET" ]] || fail "restore target must not be the backup bucket"
+select_target_policy
 command -v mc >/dev/null 2>&1 || fail "mc is required"
 command -v jq >/dev/null 2>&1 || fail "jq is required"
 command -v sha256sum >/dev/null 2>&1 || fail "sha256sum is required"
+validate_target_policy "$TARGET_POLICY_FILE" "$TARGET_POLICY_OWNER_UID"
 
 TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/buildingos-minio-restore.XXXXXX")"
 readonly TEMP_DIR
@@ -107,8 +165,14 @@ actual_total_bytes="$(jq '[.[].size] | add // 0' "$TEMP_DIR/minio-manifest.json"
 [[ "$actual_manifest_sha256" == "$receipt_manifest_sha256" ]] || fail "manifest SHA-256 does not match backup receipt"
 [[ "$actual_object_count" == "$receipt_object_count" ]] || fail "manifest object count does not match backup receipt"
 [[ "$actual_total_bytes" == "$receipt_total_bytes" ]] || fail "manifest byte total does not match backup receipt"
+if ! mc ls --recursive --json "backup/$BACKUP_BUCKET/$PREFIX/objects" > "$TEMP_DIR/backup-listing.json"; then
+  fail "backup object listing is unavailable"
+fi
+create_manifest "$TEMP_DIR/backup-listing.json" "backup/$BACKUP_BUCKET/$PREFIX/objects" "$TEMP_DIR/backup-actual-manifest.json" true
+if ! jq -S 'map({key,size,sha256})' "$TEMP_DIR/minio-manifest.json" | cmp -s - <(jq -S 'map({key,size,sha256})' "$TEMP_DIR/backup-actual-manifest.json"); then
+  fail "backup object keys, sizes, or SHA-256 values do not match the approved manifest"
+fi
 [[ "$(endpoint_identity "$TARGET_ENDPOINT")" != "$receipt_source_host" || "$TARGET_BUCKET" != "$receipt_source_bucket" ]] || fail "restore target matches backup source identity"
-validate_target_policy
 
 mc alias set target "$TARGET_ENDPOINT" "$TARGET_ACCESS_KEY" "$TARGET_SECRET_KEY" >/dev/null
 mc stat "target/$TARGET_BUCKET" >/dev/null || fail "target bucket is unavailable"

--- a/scripts/restore-minio.sh
+++ b/scripts/restore-minio.sh
@@ -49,3 +49,8 @@ mc ls --recursive --json "target/$TARGET_BUCKET" \
 if ! jq -S 'map({key,size})' "$TEMP_DIR/minio-manifest.json" | cmp -s - <(jq -S 'map({key,size})' "$TEMP_DIR/actual-manifest.json"); then
   fail "restored object keys or sizes do not match the approved manifest"
 fi
+
+restored_object_count="$(jq 'length' "$TEMP_DIR/minio-manifest.json")"
+restored_total_bytes="$(jq '[.[].size] | add // 0' "$TEMP_DIR/minio-manifest.json")"
+printf 'MINIO_RESTORE_COMPLETE\nSTATUS=PASS\nBACKUP_SET_ID=%s\nTARGET_ENV=%s\nTARGET_BUCKET=%s\nRESTORED_OBJECT_COUNT=%s\nRESTORED_TOTAL_BYTES=%s\n' \
+  "$BACKUP_SET_ID" "$TARGET_ENVIRONMENT" "$TARGET_BUCKET" "$restored_object_count" "$restored_total_bytes"

--- a/scripts/verify-minio-backup.sh
+++ b/scripts/verify-minio-backup.sh
@@ -4,9 +4,21 @@ set -Eeuo pipefail
 fail() { printf 'ERROR: %s\n' "$1" >&2; exit 1; }
 require() { [[ -n "${!1:-}" ]] || fail "$1 is required"; }
 safe_id() { [[ "$1" =~ ^[a-z0-9][a-z0-9._-]{0,95}$ ]]; }
+validate_prefix() {
+  local prefix="$1"
+  [[ -z "$prefix" ]] && return 0
+  [[ "$prefix" =~ ^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$ ]] || fail "unsafe BACKUP_PREFIX"
+  local segment
+  local -a segments
+  IFS='/' read -r -a segments <<< "$prefix"
+  for segment in "${segments[@]}"; do
+    [[ "$segment" != "." && "$segment" != ".." ]] || fail "unsafe BACKUP_PREFIX"
+  done
+}
 
 for variable in BACKUP_ENDPOINT BACKUP_ACCESS_KEY BACKUP_SECRET_KEY BACKUP_BUCKET BACKUP_SET_ID EXPECTED_SOURCE_ENVIRONMENT; do require "$variable"; done
 safe_id "$BACKUP_SET_ID" || fail "unsafe BACKUP_SET_ID"
+validate_prefix "${BACKUP_PREFIX:-}"
 [[ "$EXPECTED_SOURCE_ENVIRONMENT" =~ ^(production|staging|development|rehearsal)$ ]] || fail "unsafe expected source environment"
 [[ "$BACKUP_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]] || fail "unsafe BACKUP_BUCKET"
 command -v mc >/dev/null 2>&1 || fail "mc is required"
@@ -31,6 +43,8 @@ mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/backup-receipt.json" "$TEMP_DIR/backup
 grep -Eq '^[0-9a-fA-F]{64}[[:space:]]+[*]?minio-manifest\.json$' "$TEMP_DIR/minio-manifest.sha256" || fail "invalid manifest checksum file"
 (cd "$TEMP_DIR" && sha256sum -c minio-manifest.sha256 >/dev/null) || fail "manifest checksum verification failed"
 jq -e --arg environment "$EXPECTED_SOURCE_ENVIRONMENT" '.source_env == $environment and .deletion_propagation == false' "$TEMP_DIR/backup-receipt.json" >/dev/null || fail "backup receipt identity or deletion guard is invalid"
+jq -er 'select((.backup_set_id | type) == "string") | .backup_set_id' "$TEMP_DIR/backup-receipt.json" > "$TEMP_DIR/receipt-backup-set-id" || fail "backup receipt backup_set_id is missing or invalid"
+[[ "$(<"$TEMP_DIR/receipt-backup-set-id")" == "$BACKUP_SET_ID" ]] || fail "backup set identity mismatch"
 jq -e 'type == "array" and all(.[]; (.key | type == "string") and (.size | type == "number"))' "$TEMP_DIR/minio-manifest.json" >/dev/null || fail "manifest schema is invalid"
 
 mc ls --recursive --json "backup/$BACKUP_BUCKET/$PREFIX/objects" \

--- a/scripts/verify-minio-backup.sh
+++ b/scripts/verify-minio-backup.sh
@@ -39,3 +39,9 @@ mc ls --recursive --json "backup/$BACKUP_BUCKET/$PREFIX/objects" \
 if ! jq -S 'map({key,size})' "$TEMP_DIR/minio-manifest.json" | cmp -s - <(jq -S 'map({key,size})' "$TEMP_DIR/actual-manifest.json"); then
   fail "backup object keys or sizes do not match the approved manifest"
 fi
+
+object_count="$(jq 'length' "$TEMP_DIR/minio-manifest.json")"
+total_bytes="$(jq '[.[].size] | add // 0' "$TEMP_DIR/minio-manifest.json")"
+manifest_sha256="$(cut -d ' ' -f1 "$TEMP_DIR/minio-manifest.sha256")"
+printf 'MINIO_BACKUP_VERIFY_COMPLETE\nSTATUS=PASS\nBACKUP_SET_ID=%s\nSOURCE_ENV=%s\nBUCKET=%s\nOBJECT_COUNT=%s\nTOTAL_BYTES=%s\nMANIFEST_SHA256=%s\n' \
+  "$BACKUP_SET_ID" "$EXPECTED_SOURCE_ENVIRONMENT" "$BACKUP_BUCKET" "$object_count" "$total_bytes" "$manifest_sha256"

--- a/scripts/verify-minio-backup.sh
+++ b/scripts/verify-minio-backup.sh
@@ -15,6 +15,39 @@ validate_prefix() {
     [[ "$segment" != "." && "$segment" != ".." ]] || fail "unsafe BACKUP_PREFIX"
   done
 }
+hash_object() {
+  local object_path="$1"
+  local sha256
+  if ! sha256="$(mc cat "$object_path" < /dev/null | sha256sum | cut -d ' ' -f1)"; then
+    fail "unable to hash object: $object_path"
+  fi
+  [[ "$sha256" =~ ^[0-9a-fA-F]{64}$ ]] || fail "invalid object SHA-256: $object_path"
+  printf '%s\n' "$sha256"
+}
+create_manifest() {
+  local listing_file="$1"
+  local object_root="$2"
+  local manifest_file="$3"
+  local entries_file sorted_manifest_file
+  entries_file="$TEMP_DIR/$(basename "$manifest_file").entries"
+  sorted_manifest_file="$TEMP_DIR/$(basename "$manifest_file").sorted"
+  local key size sha256 record
+
+  if ! jq -s -e 'all(.[]; ((.type // "file") != "file") or (((.key // .name) | type) == "string" and ((.size // 0) | type) == "number" and ((.size // 0) >= 0) and (((.size // 0) | floor) == (.size // 0))))' "$listing_file" >/dev/null; then
+    fail "invalid MinIO listing"
+  fi
+  jq -r 'select((.type // "file") == "file") | [((.key // .name) | sub("^.*?/objects/"; "")), (.size // 0)] | @tsv' "$listing_file" > "$entries_file" || fail "unable to normalize MinIO listing"
+
+  : > "$manifest_file"
+  while IFS=$'\t' read -r key size; do
+    [[ -n "$key" ]] || fail "MinIO listing contains an empty object key"
+    sha256="$(hash_object "$object_root/$key")"
+    record="$(jq -cn --arg key "$key" --argjson size "$size" --arg sha256 "$sha256" '{key:$key,size:$size,sha256:$sha256}')"
+    printf '%s\n' "$record" >> "$manifest_file"
+  done < "$entries_file"
+  jq -s 'sort_by(.key)' "$manifest_file" > "$sorted_manifest_file" || fail "unable to create MinIO manifest"
+  mv "$sorted_manifest_file" "$manifest_file"
+}
 
 for variable in BACKUP_ENDPOINT BACKUP_ACCESS_KEY BACKUP_SECRET_KEY BACKUP_BUCKET BACKUP_SET_ID EXPECTED_SOURCE_ENVIRONMENT; do require "$variable"; done
 safe_id "$BACKUP_SET_ID" || fail "unsafe BACKUP_SET_ID"
@@ -45,17 +78,35 @@ grep -Eq '^[0-9a-fA-F]{64}[[:space:]]+[*]?minio-manifest\.json$' "$TEMP_DIR/mini
 jq -e --arg environment "$EXPECTED_SOURCE_ENVIRONMENT" '.source_env == $environment and .deletion_propagation == false' "$TEMP_DIR/backup-receipt.json" >/dev/null || fail "backup receipt identity or deletion guard is invalid"
 jq -er 'select((.backup_set_id | type) == "string") | .backup_set_id' "$TEMP_DIR/backup-receipt.json" > "$TEMP_DIR/receipt-backup-set-id" || fail "backup receipt backup_set_id is missing or invalid"
 [[ "$(<"$TEMP_DIR/receipt-backup-set-id")" == "$BACKUP_SET_ID" ]] || fail "backup set identity mismatch"
-jq -e 'type == "array" and all(.[]; (.key | type == "string") and (.size | type == "number"))' "$TEMP_DIR/minio-manifest.json" >/dev/null || fail "manifest schema is invalid"
-
-mc ls --recursive --json "backup/$BACKUP_BUCKET/$PREFIX/objects" \
-  | jq -c 'select((.type // "file") == "file") | {key:(.key // .name | sub("^.*?/objects/"; "")),size:(.size // 0),etag:(.etag // null),lastModified:(.lastModified // null)}' \
-  | jq -s 'sort_by(.key)' > "$TEMP_DIR/actual-manifest.json"
-if ! jq -S 'map({key,size})' "$TEMP_DIR/minio-manifest.json" | cmp -s - <(jq -S 'map({key,size})' "$TEMP_DIR/actual-manifest.json"); then
-  fail "backup object keys or sizes do not match the approved manifest"
+receipt_manifest_sha256="$(jq -er 'select((.minio_manifest_sha256 | type) == "string") | .minio_manifest_sha256' "$TEMP_DIR/backup-receipt.json")" || fail "backup receipt manifest SHA-256 is missing or invalid"
+[[ "$receipt_manifest_sha256" =~ ^[0-9a-fA-F]{64}$ ]] || fail "backup receipt manifest SHA-256 is invalid"
+receipt_object_count="$(jq -er 'select((.object_count | type) == "number" and .object_count >= 0 and ((.object_count | floor) == .object_count)) | .object_count' "$TEMP_DIR/backup-receipt.json")" || fail "backup receipt object count is missing or invalid"
+receipt_total_bytes="$(jq -er 'select((.total_bytes | type) == "number" and .total_bytes >= 0 and ((.total_bytes | floor) == .total_bytes)) | .total_bytes' "$TEMP_DIR/backup-receipt.json")" || fail "backup receipt byte total is missing or invalid"
+if ! jq -e 'type == "array" and all(.[]; (.key | type == "string" and length > 0) and (.size | type == "number" and . >= 0 and floor == .) and (.sha256 | type == "string" and test("^[0-9a-fA-F]{64}$")))' "$TEMP_DIR/minio-manifest.json" >/dev/null; then
+  fail "manifest schema is invalid"
 fi
 
-object_count="$(jq 'length' "$TEMP_DIR/minio-manifest.json")"
-total_bytes="$(jq '[.[].size] | add // 0' "$TEMP_DIR/minio-manifest.json")"
+if ! grep -Eq '^[0-9a-fA-F]{64}[[:space:]]+[*]?minio-manifest\.json$' "$TEMP_DIR/minio-manifest.sha256"; then
+  fail "invalid manifest checksum file"
+fi
+(cd "$TEMP_DIR" && sha256sum -c minio-manifest.sha256 >/dev/null) || fail "manifest checksum verification failed"
+actual_manifest_sha256="$(sha256sum "$TEMP_DIR/minio-manifest.json" | cut -d ' ' -f1)"
+actual_object_count="$(jq 'length' "$TEMP_DIR/minio-manifest.json")"
+actual_total_bytes="$(jq '[.[].size] | add // 0' "$TEMP_DIR/minio-manifest.json")"
+[[ "$actual_manifest_sha256" == "$receipt_manifest_sha256" ]] || fail "manifest SHA-256 does not match backup receipt"
+[[ "$actual_object_count" == "$receipt_object_count" ]] || fail "manifest object count does not match backup receipt"
+[[ "$actual_total_bytes" == "$receipt_total_bytes" ]] || fail "manifest byte total does not match backup receipt"
+
+if ! mc ls --recursive --json "backup/$BACKUP_BUCKET/$PREFIX/objects" > "$TEMP_DIR/backup-listing.json"; then
+  fail "backup object listing is unavailable"
+fi
+create_manifest "$TEMP_DIR/backup-listing.json" "backup/$BACKUP_BUCKET/$PREFIX/objects" "$TEMP_DIR/actual-manifest.json" true
+if ! jq -S 'map({key,size,sha256})' "$TEMP_DIR/minio-manifest.json" | cmp -s - <(jq -S 'map({key,size,sha256})' "$TEMP_DIR/actual-manifest.json"); then
+  fail "backup object keys, sizes, or SHA-256 values do not match the approved manifest"
+fi
+
+object_count="$actual_object_count"
+total_bytes="$actual_total_bytes"
 manifest_sha256="$(cut -d ' ' -f1 "$TEMP_DIR/minio-manifest.sha256")"
 printf 'MINIO_BACKUP_VERIFY_COMPLETE\nSTATUS=PASS\nBACKUP_SET_ID=%s\nSOURCE_ENV=%s\nBUCKET=%s\nOBJECT_COUNT=%s\nTOTAL_BYTES=%s\nMANIFEST_SHA256=%s\n' \
   "$BACKUP_SET_ID" "$EXPECTED_SOURCE_ENVIRONMENT" "$BACKUP_BUCKET" "$object_count" "$total_bytes" "$manifest_sha256"

--- a/scripts/verify-minio-backup.sh
+++ b/scripts/verify-minio-backup.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+fail() { printf 'ERROR: %s\n' "$1" >&2; exit 1; }
+require() { [[ -n "${!1:-}" ]] || fail "$1 is required"; }
+safe_id() { [[ "$1" =~ ^[a-z0-9][a-z0-9._-]{0,95}$ ]]; }
+
+for variable in BACKUP_ENDPOINT BACKUP_ACCESS_KEY BACKUP_SECRET_KEY BACKUP_BUCKET BACKUP_SET_ID EXPECTED_SOURCE_ENVIRONMENT; do require "$variable"; done
+safe_id "$BACKUP_SET_ID" || fail "unsafe BACKUP_SET_ID"
+[[ "$EXPECTED_SOURCE_ENVIRONMENT" =~ ^(production|staging|development|rehearsal)$ ]] || fail "unsafe expected source environment"
+[[ "$BACKUP_BUCKET" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]] || fail "unsafe BACKUP_BUCKET"
+command -v mc >/dev/null 2>&1 || fail "mc is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v sha256sum >/dev/null 2>&1 || fail "sha256sum is required"
+
+TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/buildingos-minio-verify.XXXXXX")"
+readonly TEMP_DIR
+readonly MC_CONFIG_DIR="$TEMP_DIR/mc-config"
+readonly PREFIX="${BACKUP_PREFIX:-buildingos/$EXPECTED_SOURCE_ENVIRONMENT}/$BACKUP_SET_ID"
+export MC_CONFIG_DIR
+trap 'rm -rf "$TEMP_DIR"' EXIT
+umask 077
+mkdir -p "$MC_CONFIG_DIR"
+
+mc alias set backup "$BACKUP_ENDPOINT" "$BACKUP_ACCESS_KEY" "$BACKUP_SECRET_KEY" >/dev/null
+mc stat "backup/$BACKUP_BUCKET" >/dev/null || fail "backup bucket is unavailable"
+mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/minio-manifest.json" "$TEMP_DIR/minio-manifest.json" >/dev/null || fail "manifest is unavailable"
+mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/minio-manifest.sha256" "$TEMP_DIR/minio-manifest.sha256" >/dev/null || fail "manifest checksum is unavailable"
+mc cp "backup/$BACKUP_BUCKET/$PREFIX/meta/backup-receipt.json" "$TEMP_DIR/backup-receipt.json" >/dev/null || fail "backup receipt is unavailable"
+
+grep -Eq '^[0-9a-fA-F]{64}[[:space:]]+[*]?minio-manifest\.json$' "$TEMP_DIR/minio-manifest.sha256" || fail "invalid manifest checksum file"
+(cd "$TEMP_DIR" && sha256sum -c minio-manifest.sha256 >/dev/null) || fail "manifest checksum verification failed"
+jq -e --arg environment "$EXPECTED_SOURCE_ENVIRONMENT" '.source_env == $environment and .deletion_propagation == false' "$TEMP_DIR/backup-receipt.json" >/dev/null || fail "backup receipt identity or deletion guard is invalid"
+jq -e 'type == "array" and all(.[]; (.key | type == "string") and (.size | type == "number"))' "$TEMP_DIR/minio-manifest.json" >/dev/null || fail "manifest schema is invalid"
+
+mc ls --recursive --json "backup/$BACKUP_BUCKET/$PREFIX/objects" \
+  | jq -c 'select((.type // "file") == "file") | {key:(.key // .name | sub("^.*?/objects/"; "")),size:(.size // 0),etag:(.etag // null),lastModified:(.lastModified // null)}' \
+  | jq -s 'sort_by(.key)' > "$TEMP_DIR/actual-manifest.json"
+if ! jq -S 'map({key,size})' "$TEMP_DIR/minio-manifest.json" | cmp -s - <(jq -S 'map({key,size})' "$TEMP_DIR/actual-manifest.json"); then
+  fail "backup object keys or sizes do not match the approved manifest"
+fi


### PR DESCRIPTION
## Summary

Adds a fail-closed, versioned MinIO backup, verification, and recovery toolkit
for BuildingOS.

This PR adds operational tooling and documentation only.

It does not mutate or configure production infrastructure.

## Added

- `scripts/backup-minio.sh`
- `scripts/verify-minio-backup.sh`
- `scripts/restore-minio.sh`
- `docs/runbooks/MINIO_BACKUP_RECOVERY.md`

## Safety model

- encrypted off-host S3-compatible backup target
- no source deletion propagation
- immutable retention delegated to destination Object Lock/versioning/retention
- strict environment and bucket identity checks
- strict `BACKUP_PREFIX` validation
- exact `BACKUP_SET_ID` binding against backup receipt
- corruption detection
- explicit completion evidence
- production restore denied by default
- non-empty restore target rejected by default
- no destructive delete synchronization

## Important recovery invariant

The requested `BACKUP_SET_ID` must exactly match the backup receipt identity.

A mismatch fails closed before restore target mutation.

This behavior was tested and the restore target remained empty.

## Local rehearsal

Passed:

- backup
- verification
- isolated restore
- 2 restored objects / 25 bytes
- corrupt backup rejection
- wrong environment rejection
- production restore rejection
- non-empty target protection
- deletion propagation protection
- unsafe prefix rejection matrix
- verify backup identity mismatch rejection
- restore backup identity mismatch rejection
- restore mismatch before mutation
- completion evidence
- bash syntax
- ShellCheck
- git diff --check

## Immutability note

`mc mirror --overwrite` without `--remove` prevents source deletion
propagation but is not by itself immutable.

True immutability requires destination-side versioning, Object Lock,
and/or retention controls.

## Production work still required

This PR does NOT provision production infrastructure.

A separately authorized production slice will be required to:

1. provision encrypted immutable off-host storage
2. provision least-privilege credentials
3. coordinate PostgreSQL and MinIO backup sets
4. install scheduler and alerting
5. perform a production-shaped restore rehearsal outside production

## Safety

- no application source changes
- no Prisma schema changes
- no migrations
- no staging mutation
- no production mutation
- no production backup executed
- no production restore executed

DO NOT MERGE automatically.