### PR TITLE
fix(prod): make rollback receipts context-unique

### DIFF
--- a/scripts/production-security-validate.sh
+++ b/scripts/production-security-validate.sh
@@ -237,29 +237,42 @@ read_secured_receipt_snapshot() {
   local receipt="$1"
   local expected_owner="$2"
   local expected_group="$3"
-  local path_identity owner group mode snapshot_with_sentinel read_status
-  local path_identity_after owner_after group_after mode_after
+  local descriptor_path path_identity descriptor_identity owner group mode snapshot_with_sentinel
+  local path_identity_after descriptor_identity_after owner_after group_after mode_after
 
   [[ ! -L "$receipt" && -f "$receipt" ]] || security_fail "Compatibility receipt must be a non-symlink regular file"
   exec 9< "$receipt" || security_fail "Unable to open compatibility receipt"
+  if [[ -e /proc/self/fd/9 ]]; then
+    descriptor_path='/proc/self/fd/9'
+  else
+    descriptor_path='/dev/fd/9'
+  fi
+  [[ -f "$descriptor_path" ]] || {
+    exec 9<&-
+    security_fail "Opened compatibility receipt is not a regular file"
+  }
 
   path_identity="$(file_identity "$receipt")" || {
     exec 9<&-
     security_fail "Unable to identify compatibility receipt"
   }
-  owner="$(file_owner "$receipt")" || {
+  descriptor_identity="$(file_identity "$descriptor_path")" || {
+    exec 9<&-
+    security_fail "Unable to identify opened compatibility receipt"
+  }
+  owner="$(file_owner "$descriptor_path")" || {
     exec 9<&-
     security_fail "Unable to read compatibility receipt owner"
   }
-  group="$(file_group "$receipt")" || {
+  group="$(file_group "$descriptor_path")" || {
     exec 9<&-
     security_fail "Unable to read compatibility receipt group"
   }
-  mode="0$(file_mode "$receipt")" || {
+  mode="0$(file_mode "$descriptor_path")" || {
     exec 9<&-
     security_fail "Unable to read compatibility receipt mode"
   }
-  [[ ! -L "$receipt" && -f "$receipt" ]] || {
+  [[ "$path_identity" == "$descriptor_identity" && ! -L "$receipt" && -f "$receipt" ]] || {
     exec 9<&-
     security_fail "Compatibility receipt changed while opening"
   }
@@ -276,35 +289,31 @@ read_secured_receipt_snapshot() {
     security_fail "Compatibility receipt mode must be exactly 0600"
   }
 
-  # Read through the opened descriptor while checking the canonical path before and after.
-  snapshot_with_sentinel=''
-  if IFS= read -r -d '' snapshot_with_sentinel <&9; then
-    :
-  else
-    read_status=$?
-    [[ "$read_status" -eq 1 ]] || {
-      exec 9<&-
-      security_fail "Unable to read compatibility receipt"
-    }
-  fi
-  snapshot_with_sentinel+="__BUILDINGOS_RECEIPT_END__"
+  snapshot_with_sentinel="$(cat <&9; printf '__BUILDINGOS_RECEIPT_END__')" || {
+    exec 9<&-
+    security_fail "Unable to read compatibility receipt"
+  }
   path_identity_after="$(file_identity "$receipt")" || {
     exec 9<&-
     security_fail "Compatibility receipt path changed while reading"
   }
-  owner_after="$(file_owner "$receipt")" || {
+  descriptor_identity_after="$(file_identity "$descriptor_path")" || {
+    exec 9<&-
+    security_fail "Opened compatibility receipt changed while reading"
+  }
+  owner_after="$(file_owner "$descriptor_path")" || {
     exec 9<&-
     security_fail "Unable to re-read compatibility receipt owner"
   }
-  group_after="$(file_group "$receipt")" || {
+  group_after="$(file_group "$descriptor_path")" || {
     exec 9<&-
     security_fail "Unable to re-read compatibility receipt group"
   }
-  mode_after="0$(file_mode "$receipt")" || {
+  mode_after="0$(file_mode "$descriptor_path")" || {
     exec 9<&-
     security_fail "Unable to re-read compatibility receipt mode"
   }
-  [[ "$path_identity_after" == "$path_identity" && "$owner_after" == "$owner" && "$group_after" == "$group" && "$mode_after" == "$mode" && ! -L "$receipt" && -f "$receipt" ]] || {
+  [[ "$path_identity_after" == "$path_identity" && "$descriptor_identity_after" == "$descriptor_identity" && "$owner_after" == "$owner" && "$group_after" == "$group" && "$mode_after" == "$mode" && ! -L "$receipt" && -f "$receipt" ]] || {
     exec 9<&-
     security_fail "Compatibility receipt changed while reading"
   }
@@ -490,7 +499,7 @@ generate_rollback_compatibility_receipt() {
   local previous_api_digest="$3"
   local previous_web_digest="$4"
   local migration_count="$5"
-  local receipt_id receipt timestamp_utc context_hash temp_receipt
+  local receipt_id receipt timestamp_utc context_hash receipt_lock
 
   [[ "$target_sha" =~ ^[0-9a-f]{40}$ && "$previous_sha" =~ ^[0-9a-f]{40}$ ]] \
     || security_fail 'Receipt generation requires exact commit SHAs'
@@ -514,33 +523,49 @@ generate_rollback_compatibility_receipt() {
   [[ "$context_hash" =~ ^[0-9a-f]{64}$ ]] || security_fail 'Rollback receipt context hash is not canonical'
   receipt_id="rollback-$target_sha-$context_hash"
   receipt="$ROLLBACK_SECURITY_PROTECTED_DIR/$receipt_id.receipt"
-  if [[ -e "$receipt" || -L "$receipt" ]]; then
-    validate_rollback_receipt "$receipt" "$target_sha" "$previous_sha" "$previous_api_digest" "$previous_web_digest"
-    printf '%s\n' "$receipt"
-    return
-  fi
-  timestamp_utc="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" || security_fail 'Unable to generate receipt timestamp'
+  receipt_lock="$ROLLBACK_SECURITY_PROTECTED_DIR/.rollback-receipts.lock"
+  receipt="$(
+    (
+      local lock_acquired=0 attempt temp_receipt='' published=0
 
-  temp_receipt="$(mktemp "$ROLLBACK_SECURITY_PROTECTED_DIR/.rollback-receipt.XXXXXX")" \
-    || security_fail 'Unable to create a private rollback compatibility receipt'
-  if ! (
-    trap 'rm -f -- "$temp_receipt"' EXIT
-    umask 077
-    printf 'receipt_version=%s\nreceipt_id=%s\ntimestamp_utc=%s\ncompatibility=SAFE\ntarget_sha=%s\nprevious_sha=%s\nprevious_api_digest=%s\nprevious_web_digest=%s\nmigration_count=%s\n' \
-      "$ROLLBACK_RECEIPT_VERSION" "$receipt_id" "$timestamp_utc" "$target_sha" "$previous_sha" \
-      "$previous_api_digest" "$previous_web_digest" "$migration_count" > "$temp_receipt"
-    chmod 600 "$temp_receipt"
-    mv -n -- "$temp_receipt" "$receipt"
-    [[ ! -e "$temp_receipt" ]]
-  ); then
-    if [[ -e "$receipt" || -L "$receipt" ]]; then
+      umask 077
+      for attempt in {1..100}; do
+        if mkdir "$receipt_lock" 2>/dev/null; then
+          lock_acquired=1
+          break
+        fi
+        sleep 0.01
+      done
+      [[ "$lock_acquired" -eq 1 ]] || security_fail 'Unable to acquire rollback receipt generation lock'
+      trap 'if [[ -n "${temp_receipt:-}" ]]; then rm -f -- "$temp_receipt"; fi; rmdir "$receipt_lock" 2>/dev/null || true' EXIT
+
+      if [[ -e "$receipt" || -L "$receipt" ]]; then
+        validate_rollback_receipt "$receipt" "$target_sha" "$previous_sha" "$previous_api_digest" "$previous_web_digest"
+        printf '%s\n' "$receipt"
+        exit 0
+      fi
+
+      timestamp_utc="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" || security_fail 'Unable to generate receipt timestamp'
+      temp_receipt="$(mktemp "$ROLLBACK_SECURITY_PROTECTED_DIR/.rollback-receipt.XXXXXX")" \
+        || security_fail 'Unable to create a private rollback compatibility receipt'
+      printf 'receipt_version=%s\nreceipt_id=%s\ntimestamp_utc=%s\ncompatibility=SAFE\ntarget_sha=%s\nprevious_sha=%s\nprevious_api_digest=%s\nprevious_web_digest=%s\nmigration_count=%s\n' \
+        "$ROLLBACK_RECEIPT_VERSION" "$receipt_id" "$timestamp_utc" "$target_sha" "$previous_sha" \
+        "$previous_api_digest" "$previous_web_digest" "$migration_count" > "$temp_receipt"
+      chmod 600 "$temp_receipt"
+      if mv -n -- "$temp_receipt" "$receipt" && [[ ! -e "$temp_receipt" ]]; then
+        published=1
+      fi
+      if [[ "$published" -eq 0 ]]; then
+        [[ -e "$receipt" || -L "$receipt" ]] \
+          || security_fail 'Unable to create rollback compatibility receipt without clobbering'
+        validate_rollback_receipt "$receipt" "$target_sha" "$previous_sha" "$previous_api_digest" "$previous_web_digest"
+        printf '%s\n' "$receipt"
+        exit 0
+      fi
       validate_rollback_receipt "$receipt" "$target_sha" "$previous_sha" "$previous_api_digest" "$previous_web_digest"
       printf '%s\n' "$receipt"
-      return
-    fi
-    security_fail 'Unable to create rollback compatibility receipt without clobbering'
-  fi
-  validate_rollback_receipt "$receipt" "$target_sha" "$previous_sha" "$previous_api_digest" "$previous_web_digest"
+    )
+  )" || security_fail 'Unable to generate rollback compatibility receipt'
   printf '%s\n' "$receipt"
 }
 

--- a/scripts/production-security-validate.sh
+++ b/scripts/production-security-validate.sh
@@ -328,6 +328,7 @@ validate_rollback_receipt() {
   local expected_api_digest="$4"
   local expected_web_digest="$5"
   local receipt_parent receipt_name body receipt_id timestamp compatibility target_sha previous_sha api_digest web_digest migration_count
+  local encoded_target_sha encoded_context_hash expected_context_hash
   local -a lines=()
 
   [[ "$expected_target_sha" =~ ^[0-9a-f]{40}$ && "$expected_previous_sha" =~ ^[0-9a-f]{40}$ ]] \
@@ -383,6 +384,15 @@ validate_rollback_receipt() {
   [[ "$api_digest" == "$expected_api_digest" ]] || security_fail "Receipt API digest mismatch"
   [[ "$web_digest" == "$expected_web_digest" ]] || security_fail "Receipt Web digest mismatch"
   [[ "$migration_count" =~ ^(0|[1-9][0-9]*)$ ]] || security_fail "Receipt migration count is not canonical"
+  if [[ "$receipt_id" =~ ^rollback-([0-9a-f]{40})-([0-9a-f]{64})$ ]]; then
+    encoded_target_sha="${BASH_REMATCH[1]}"
+    encoded_context_hash="${BASH_REMATCH[2]}"
+    [[ "$encoded_target_sha" == "$target_sha" ]] || security_fail "Receipt ID target SHA mismatch"
+    expected_context_hash="$(rollback_receipt_context_hash \
+      "$target_sha" "$previous_sha" "$api_digest" "$web_digest" "$migration_count")"
+    [[ "$encoded_context_hash" == "$expected_context_hash" ]] \
+      || security_fail "Receipt context hash mismatch"
+  fi
 
   # shellcheck disable=SC2034 # Output consumed by rollback-production.sh after sourcing this file.
   VALIDATED_ROLLBACK_MIGRATION_COUNT="$migration_count"

--- a/scripts/production-security-validate.sh
+++ b/scripts/production-security-validate.sh
@@ -237,42 +237,29 @@ read_secured_receipt_snapshot() {
   local receipt="$1"
   local expected_owner="$2"
   local expected_group="$3"
-  local descriptor_path path_identity descriptor_identity owner group mode snapshot_with_sentinel
-  local path_identity_after descriptor_identity_after owner_after group_after mode_after
+  local path_identity owner group mode snapshot_with_sentinel read_status
+  local path_identity_after owner_after group_after mode_after
 
   [[ ! -L "$receipt" && -f "$receipt" ]] || security_fail "Compatibility receipt must be a non-symlink regular file"
   exec 9< "$receipt" || security_fail "Unable to open compatibility receipt"
-  if [[ -e /proc/self/fd/9 ]]; then
-    descriptor_path='/proc/self/fd/9'
-  else
-    descriptor_path='/dev/fd/9'
-  fi
-  [[ -f "$descriptor_path" ]] || {
-    exec 9<&-
-    security_fail "Opened compatibility receipt is not a regular file"
-  }
 
   path_identity="$(file_identity "$receipt")" || {
     exec 9<&-
     security_fail "Unable to identify compatibility receipt"
   }
-  descriptor_identity="$(file_identity "$descriptor_path")" || {
-    exec 9<&-
-    security_fail "Unable to identify opened compatibility receipt"
-  }
-  owner="$(file_owner "$descriptor_path")" || {
+  owner="$(file_owner "$receipt")" || {
     exec 9<&-
     security_fail "Unable to read compatibility receipt owner"
   }
-  group="$(file_group "$descriptor_path")" || {
+  group="$(file_group "$receipt")" || {
     exec 9<&-
     security_fail "Unable to read compatibility receipt group"
   }
-  mode="0$(file_mode "$descriptor_path")" || {
+  mode="0$(file_mode "$receipt")" || {
     exec 9<&-
     security_fail "Unable to read compatibility receipt mode"
   }
-  [[ "$path_identity" == "$descriptor_identity" && ! -L "$receipt" && -f "$receipt" ]] || {
+  [[ ! -L "$receipt" && -f "$receipt" ]] || {
     exec 9<&-
     security_fail "Compatibility receipt changed while opening"
   }
@@ -289,31 +276,35 @@ read_secured_receipt_snapshot() {
     security_fail "Compatibility receipt mode must be exactly 0600"
   }
 
-  snapshot_with_sentinel="$(cat <&9; printf '__BUILDINGOS_RECEIPT_END__')" || {
-    exec 9<&-
-    security_fail "Unable to read compatibility receipt"
-  }
+  # Read through the opened descriptor while checking the canonical path before and after.
+  snapshot_with_sentinel=''
+  if IFS= read -r -d '' snapshot_with_sentinel <&9; then
+    :
+  else
+    read_status=$?
+    [[ "$read_status" -eq 1 ]] || {
+      exec 9<&-
+      security_fail "Unable to read compatibility receipt"
+    }
+  fi
+  snapshot_with_sentinel+="__BUILDINGOS_RECEIPT_END__"
   path_identity_after="$(file_identity "$receipt")" || {
     exec 9<&-
     security_fail "Compatibility receipt path changed while reading"
   }
-  descriptor_identity_after="$(file_identity "$descriptor_path")" || {
-    exec 9<&-
-    security_fail "Opened compatibility receipt changed while reading"
-  }
-  owner_after="$(file_owner "$descriptor_path")" || {
+  owner_after="$(file_owner "$receipt")" || {
     exec 9<&-
     security_fail "Unable to re-read compatibility receipt owner"
   }
-  group_after="$(file_group "$descriptor_path")" || {
+  group_after="$(file_group "$receipt")" || {
     exec 9<&-
     security_fail "Unable to re-read compatibility receipt group"
   }
-  mode_after="0$(file_mode "$descriptor_path")" || {
+  mode_after="0$(file_mode "$receipt")" || {
     exec 9<&-
     security_fail "Unable to re-read compatibility receipt mode"
   }
-  [[ "$path_identity_after" == "$path_identity" && "$descriptor_identity_after" == "$descriptor_identity" && "$owner_after" == "$owner" && "$group_after" == "$group" && "$mode_after" == "$mode" && ! -L "$receipt" && -f "$receipt" ]] || {
+  [[ "$path_identity_after" == "$path_identity" && "$owner_after" == "$owner" && "$group_after" == "$group" && "$mode_after" == "$mode" && ! -L "$receipt" && -f "$receipt" ]] || {
     exec 9<&-
     security_fail "Compatibility receipt changed while reading"
   }
@@ -386,6 +377,28 @@ validate_rollback_receipt() {
 
   # shellcheck disable=SC2034 # Output consumed by rollback-production.sh after sourcing this file.
   VALIDATED_ROLLBACK_MIGRATION_COUNT="$migration_count"
+}
+
+rollback_receipt_context_hash() {
+  local target_sha="$1"
+  local previous_sha="$2"
+  local previous_api_digest="$3"
+  local previous_web_digest="$4"
+  local migration_count="$5"
+  local canonical_context digest_output
+
+  canonical_context="$(printf 'target_sha=%s\nprevious_sha=%s\nprevious_api_digest=%s\nprevious_web_digest=%s\nmigration_count=%s\n' \
+    "$target_sha" "$previous_sha" "$previous_api_digest" "$previous_web_digest" "$migration_count")"
+  if command -v sha256sum >/dev/null 2>&1; then
+    digest_output="$(printf '%s' "$canonical_context" | sha256sum)" \
+      || security_fail 'Unable to hash rollback receipt context'
+  elif command -v shasum >/dev/null 2>&1; then
+    digest_output="$(printf '%s' "$canonical_context" | shasum -a 256)" \
+      || security_fail 'Unable to hash rollback receipt context'
+  else
+    security_fail 'sha256sum or shasum is required for rollback receipt context'
+  fi
+  printf '%s\n' "${digest_output%% *}"
 }
 
 database_contracts_match() {
@@ -477,7 +490,7 @@ generate_rollback_compatibility_receipt() {
   local previous_api_digest="$3"
   local previous_web_digest="$4"
   local migration_count="$5"
-  local receipt_id receipt timestamp_utc
+  local receipt_id receipt timestamp_utc context_hash temp_receipt
 
   [[ "$target_sha" =~ ^[0-9a-f]{40}$ && "$previous_sha" =~ ^[0-9a-f]{40}$ ]] \
     || security_fail 'Receipt generation requires exact commit SHAs'
@@ -496,7 +509,10 @@ generate_rollback_compatibility_receipt() {
   fi
   validate_rollback_protected_directory
 
-  receipt_id="rollback-$target_sha"
+  context_hash="$(rollback_receipt_context_hash \
+    "$target_sha" "$previous_sha" "$previous_api_digest" "$previous_web_digest" "$migration_count")"
+  [[ "$context_hash" =~ ^[0-9a-f]{64}$ ]] || security_fail 'Rollback receipt context hash is not canonical'
+  receipt_id="rollback-$target_sha-$context_hash"
   receipt="$ROLLBACK_SECURITY_PROTECTED_DIR/$receipt_id.receipt"
   if [[ -e "$receipt" || -L "$receipt" ]]; then
     validate_rollback_receipt "$receipt" "$target_sha" "$previous_sha" "$previous_api_digest" "$previous_web_digest"
@@ -505,13 +521,23 @@ generate_rollback_compatibility_receipt() {
   fi
   timestamp_utc="$(date -u '+%Y-%m-%dT%H:%M:%SZ')" || security_fail 'Unable to generate receipt timestamp'
 
+  temp_receipt="$(mktemp "$ROLLBACK_SECURITY_PROTECTED_DIR/.rollback-receipt.XXXXXX")" \
+    || security_fail 'Unable to create a private rollback compatibility receipt'
   if ! (
+    trap 'rm -f -- "$temp_receipt"' EXIT
     umask 077
-    set -o noclobber
     printf 'receipt_version=%s\nreceipt_id=%s\ntimestamp_utc=%s\ncompatibility=SAFE\ntarget_sha=%s\nprevious_sha=%s\nprevious_api_digest=%s\nprevious_web_digest=%s\nmigration_count=%s\n' \
       "$ROLLBACK_RECEIPT_VERSION" "$receipt_id" "$timestamp_utc" "$target_sha" "$previous_sha" \
-      "$previous_api_digest" "$previous_web_digest" "$migration_count" > "$receipt"
+      "$previous_api_digest" "$previous_web_digest" "$migration_count" > "$temp_receipt"
+    chmod 600 "$temp_receipt"
+    mv -n -- "$temp_receipt" "$receipt"
+    [[ ! -e "$temp_receipt" ]]
   ); then
+    if [[ -e "$receipt" || -L "$receipt" ]]; then
+      validate_rollback_receipt "$receipt" "$target_sha" "$previous_sha" "$previous_api_digest" "$previous_web_digest"
+      printf '%s\n' "$receipt"
+      return
+    fi
     security_fail 'Unable to create rollback compatibility receipt without clobbering'
   fi
   validate_rollback_receipt "$receipt" "$target_sha" "$previous_sha" "$previous_api_digest" "$previous_web_digest"

--- a/scripts/tests/production-security.test.sh
+++ b/scripts/tests/production-security.test.sh
@@ -379,6 +379,17 @@ generated_receipt_id="${generated_receipt_id%.receipt}"
 pass 'generated receipt ID satisfies the allowed regex and length'
 pass 'generates and immediately validates a safe rollback receipt'
 
+migration_tampered_original="$tmp_root/migration-tampered-original.receipt"
+migration_tampered_payload="$tmp_root/migration-tampered.receipt"
+cp "$generated_receipt" "$migration_tampered_original"
+awk '$0 == "migration_count=97" { print "migration_count=98"; next } { print }' \
+  "$generated_receipt" > "$migration_tampered_payload"
+chmod 600 "$migration_tampered_payload"
+mv "$migration_tampered_payload" "$generated_receipt"
+expect_failure 'rejects a deterministic receipt when only migration count changes' \
+  validate_receipt "$generated_receipt" "$fixture_same_sha" "$fixture_base_sha" "$API_DIGEST" "$WEB_DIGEST"
+cp "$migration_tampered_original" "$generated_receipt"
+
 reused_receipt="$(env \
   TEST_MODE=1 \
   ROLLBACK_PROTECTED_DIR="$protected_dir" \
@@ -470,12 +481,9 @@ rollback_consumer_output="$(env \
     https://api.example.test/health https://api.example.test/readyz https://app.example.test/login 2>&1)" \
   || rollback_consumer_status=$?
 [[ "$rollback_consumer_status" -ne 0 ]] || fail_test 'rollback consumer unexpectedly completed in the fixture environment'
-[[ "$rollback_consumer_output" != *'Receipt target SHA mismatch'* && \
-  "$rollback_consumer_output" != *'Receipt previous SHA mismatch'* && \
-  "$rollback_consumer_output" != *'Receipt API digest mismatch'* && \
-  "$rollback_consumer_output" != *'Receipt Web digest mismatch'* ]] \
-  || fail_test 'rollback consumer rejected the generated new-format receipt'
-pass 'rollback consumer accepts a generated new-format receipt by explicit path'
+[[ "$rollback_consumer_output" == *'cd: /opt/pawtech/apps/buildingos/buildingos-app: No such file or directory'* ]] \
+  || fail_test 'rollback consumer did not reach the expected post-validation checkout gate'
+pass 'rollback consumer validates new-format receipt before the checkout gate'
 
 concurrent_dir="$tmp_root/concurrent-protected"
 mkdir -p "$concurrent_dir"

--- a/scripts/tests/production-security.test.sh
+++ b/scripts/tests/production-security.test.sh
@@ -218,6 +218,11 @@ pass 'validated backup execution produced the expected marker'
 expect_success 'accepts a valid secured rollback receipt' \
   validate_receipt "$valid_receipt" "$TARGET_SHA" "$PREVIOUS_SHA" "$API_DIGEST" "$WEB_DIGEST"
 
+legacy_receipt="$protected_dir/rollback-$TARGET_SHA.receipt"
+write_receipt "$legacy_receipt" "rollback-$TARGET_SHA"
+expect_success 'accepts a legacy target-only rollback receipt' \
+  validate_receipt "$legacy_receipt" "$TARGET_SHA" "$PREVIOUS_SHA" "$API_DIGEST" "$WEB_DIGEST"
+
 traversal_receipt="$protected_dir/../protected/rollback-check-001.receipt"
 expect_failure 'rejects receipt path traversal before Docker' \
   run_invalid_rollback "$traversal_receipt"
@@ -349,6 +354,8 @@ generated_receipt="$(env \
   "$fixture_repo" "$VALIDATOR" "$fixture_base_sha" "$fixture_same_sha" "$API_DIGEST" "$WEB_DIGEST")" \
   || fail_test 'receipt generation failed'
 [[ -f "$generated_receipt" ]] || fail_test 'receipt generation did not return a regular receipt path'
+[[ "$generated_receipt" =~ /rollback-${fixture_same_sha}-[0-9a-f]{64}\.receipt$ ]] \
+  || fail_test 'generated receipt does not use the canonical context identity'
 pass 'generates and immediately validates a safe rollback receipt'
 
 reused_receipt="$(env \
@@ -363,6 +370,60 @@ reused_receipt="$(env \
   || fail_test 'valid receipt reuse failed'
 [[ "$reused_receipt" == "$generated_receipt" ]] || fail_test 'receipt reuse returned a different path'
 pass 'reuses a matching receipt after a retry'
+
+alternate_previous_sha='eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+alternate_receipt="$(env \
+  TEST_MODE=1 \
+  ROLLBACK_PROTECTED_DIR="$protected_dir" \
+  ROLLBACK_EXPECTED_OWNER="$current_owner" \
+  ROLLBACK_EXPECTED_GROUP="$current_group" \
+  bash -c 'source "$1"; ROLLBACK_COMPATIBILITY_BASIS=SAME_DB_CONTRACT; ROLLBACK_COMPATIBILITY_TARGET_SHA="$2"; ROLLBACK_COMPATIBILITY_PREVIOUS_SHA="$3"; generate_rollback_compatibility_receipt "$2" "$3" "$4" "$5" 97' _ \
+  "$VALIDATOR" "$fixture_same_sha" "$alternate_previous_sha" "$API_DIGEST" "$WEB_DIGEST")" \
+  || fail_test 'receipt generation with a different previous SHA failed'
+[[ "$alternate_receipt" != "$generated_receipt" ]] || fail_test 'receipt identity ignored the previous SHA'
+expect_success 'validates distinct receipts for distinct rollback contexts' \
+  validate_receipt "$alternate_receipt" "$fixture_same_sha" "$alternate_previous_sha" "$API_DIGEST" "$WEB_DIGEST"
+
+alternate_api_digest='sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+digest_receipt="$(env \
+  TEST_MODE=1 \
+  ROLLBACK_PROTECTED_DIR="$protected_dir" \
+  ROLLBACK_EXPECTED_OWNER="$current_owner" \
+  ROLLBACK_EXPECTED_GROUP="$current_group" \
+  bash -c 'source "$1"; ROLLBACK_COMPATIBILITY_BASIS=SAME_DB_CONTRACT; ROLLBACK_COMPATIBILITY_TARGET_SHA="$2"; ROLLBACK_COMPATIBILITY_PREVIOUS_SHA="$3"; generate_rollback_compatibility_receipt "$2" "$3" "$4" "$5" 97' _ \
+  "$VALIDATOR" "$fixture_same_sha" "$fixture_base_sha" "$alternate_api_digest" "$WEB_DIGEST")" \
+  || fail_test 'receipt generation with a different API digest failed'
+[[ "$digest_receipt" != "$generated_receipt" ]] || fail_test 'receipt identity ignored an image digest'
+expect_success 'validates distinct receipts for distinct image contexts' \
+  validate_receipt "$digest_receipt" "$fixture_same_sha" "$fixture_base_sha" "$alternate_api_digest" "$WEB_DIGEST"
+expect_failure 'rejects a generated receipt with changed immutable inputs' \
+  validate_receipt "$generated_receipt" "$fixture_same_sha" "$fixture_base_sha" "$alternate_api_digest" "$WEB_DIGEST"
+
+concurrent_dir="$tmp_root/concurrent-protected"
+mkdir -p "$concurrent_dir"
+chmod 700 "$concurrent_dir"
+concurrent_output_a="$tmp_root/concurrent-a.out"
+concurrent_output_b="$tmp_root/concurrent-b.out"
+env TEST_MODE=1 ROLLBACK_PROTECTED_DIR="$concurrent_dir" ROLLBACK_EXPECTED_OWNER="$current_owner" ROLLBACK_EXPECTED_GROUP="$current_group" \
+  bash -c 'source "$1"; ROLLBACK_COMPATIBILITY_BASIS=SAME_DB_CONTRACT; ROLLBACK_COMPATIBILITY_TARGET_SHA="$2"; ROLLBACK_COMPATIBILITY_PREVIOUS_SHA="$3"; generate_rollback_compatibility_receipt "$2" "$3" "$4" "$5" 97' _ \
+  "$VALIDATOR" "$fixture_same_sha" "$fixture_base_sha" "$API_DIGEST" "$WEB_DIGEST" > "$concurrent_output_a" 2>&1 &
+concurrent_pid_a=$!
+env TEST_MODE=1 ROLLBACK_PROTECTED_DIR="$concurrent_dir" ROLLBACK_EXPECTED_OWNER="$current_owner" ROLLBACK_EXPECTED_GROUP="$current_group" \
+  bash -c 'source "$1"; ROLLBACK_COMPATIBILITY_BASIS=SAME_DB_CONTRACT; ROLLBACK_COMPATIBILITY_TARGET_SHA="$2"; ROLLBACK_COMPATIBILITY_PREVIOUS_SHA="$3"; generate_rollback_compatibility_receipt "$2" "$3" "$4" "$5" 97' _ \
+  "$VALIDATOR" "$fixture_same_sha" "$fixture_base_sha" "$API_DIGEST" "$WEB_DIGEST" > "$concurrent_output_b" 2>&1 &
+concurrent_pid_b=$!
+concurrent_status_a=0
+concurrent_status_b=0
+wait "$concurrent_pid_a" || concurrent_status_a=$?
+wait "$concurrent_pid_b" || concurrent_status_b=$?
+[[ "$concurrent_status_a" -eq 0 && "$concurrent_status_b" -eq 0 ]] || {
+  cat "$concurrent_output_a" "$concurrent_output_b" >&2
+  fail_test 'concurrent identical receipt generation is idempotent'
+}
+concurrent_receipt_a="$(tail -n 1 "$concurrent_output_a")"
+concurrent_receipt_b="$(tail -n 1 "$concurrent_output_b")"
+[[ "$concurrent_receipt_a" == "$concurrent_receipt_b" ]] || fail_test 'concurrent receipt generation returned different paths'
+pass 'concurrent identical receipt generation is idempotent'
 
 expect_failure 'rejects an existing receipt with mismatched immutable inputs' \
   env \

--- a/scripts/tests/production-security.test.sh
+++ b/scripts/tests/production-security.test.sh
@@ -155,6 +155,21 @@ validate_receipt() {
     bash "$VALIDATOR" rollback-receipt "$@"
 }
 
+generate_receipt_for_context() {
+  local target_sha="$1"
+  local previous_sha="$2"
+  local api_digest="$3"
+  local web_digest="$4"
+
+  env \
+    TEST_MODE=1 \
+    ROLLBACK_PROTECTED_DIR="$protected_dir" \
+    ROLLBACK_EXPECTED_OWNER="$current_owner" \
+    ROLLBACK_EXPECTED_GROUP="$current_group" \
+    bash -c 'source "$1"; ROLLBACK_COMPATIBILITY_BASIS=SAME_DB_CONTRACT; ROLLBACK_COMPATIBILITY_TARGET_SHA="$2"; ROLLBACK_COMPATIBILITY_PREVIOUS_SHA="$3"; generate_rollback_compatibility_receipt "$2" "$3" "$4" "$5" 97' _ \
+    "$VALIDATOR" "$target_sha" "$previous_sha" "$api_digest" "$web_digest"
+}
+
 run_invalid_rollback() {
   local receipt="$1"
   shift
@@ -356,6 +371,12 @@ generated_receipt="$(env \
 [[ -f "$generated_receipt" ]] || fail_test 'receipt generation did not return a regular receipt path'
 [[ "$generated_receipt" =~ /rollback-${fixture_same_sha}-[0-9a-f]{64}\.receipt$ ]] \
   || fail_test 'generated receipt does not use the canonical context identity'
+generated_receipt_id="${generated_receipt##*/}"
+generated_receipt_id="${generated_receipt_id%.receipt}"
+[[ "$generated_receipt_id" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] \
+  || fail_test 'generated receipt ID violates the allowed identity regex'
+[[ "${#generated_receipt_id}" -le 128 ]] || fail_test 'generated receipt ID exceeds the allowed length'
+pass 'generated receipt ID satisfies the allowed regex and length'
 pass 'generates and immediately validates a safe rollback receipt'
 
 reused_receipt="$(env \
@@ -370,6 +391,24 @@ reused_receipt="$(env \
   || fail_test 'valid receipt reuse failed'
 [[ "$reused_receipt" == "$generated_receipt" ]] || fail_test 'receipt reuse returned a different path'
 pass 'reuses a matching receipt after a retry'
+
+incident_a_to_b_receipt="$(generate_receipt_for_context "$fixture_same_sha" "$fixture_base_sha" "$API_DIGEST" "$WEB_DIGEST")" \
+  || fail_test 'historical A-to-B receipt generation failed'
+incident_a_to_b_snapshot="$tmp_root/incident-a-to-b.receipt"
+cp "$incident_a_to_b_receipt" "$incident_a_to_b_snapshot"
+pass 'historical A-to-B receipt generation passes'
+incident_b_to_b_receipt="$(generate_receipt_for_context "$fixture_same_sha" "$fixture_same_sha" "$API_DIGEST" "$WEB_DIGEST")" \
+  || fail_test 'same-SHA B-to-B receipt generation failed'
+pass 'same-SHA B-to-B receipt generation passes'
+[[ "$incident_a_to_b_receipt" != "$incident_b_to_b_receipt" ]] \
+  || fail_test 'A-to-B and B-to-B receipts have the same path'
+cmp -s "$incident_a_to_b_snapshot" "$incident_a_to_b_receipt" \
+  || fail_test 'A-to-B receipt changed after B-to-B generation'
+[[ "$(awk -F= '$1 == "previous_sha" { print $2 }' "$incident_b_to_b_receipt")" == "$fixture_same_sha" ]] \
+  || fail_test 'B-to-B receipt does not record previous SHA B'
+expect_success 'validates the same-SHA B-to-B incident receipt' \
+  validate_receipt "$incident_b_to_b_receipt" "$fixture_same_sha" "$fixture_same_sha" "$API_DIGEST" "$WEB_DIGEST"
+pass 'A-to-B then B-to-B incident regression preserves both receipts'
 
 alternate_previous_sha='eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
 alternate_receipt="$(env \
@@ -398,6 +437,45 @@ expect_success 'validates distinct receipts for distinct image contexts' \
   validate_receipt "$digest_receipt" "$fixture_same_sha" "$fixture_base_sha" "$alternate_api_digest" "$WEB_DIGEST"
 expect_failure 'rejects a generated receipt with changed immutable inputs' \
   validate_receipt "$generated_receipt" "$fixture_same_sha" "$fixture_base_sha" "$alternate_api_digest" "$WEB_DIGEST"
+
+alternate_web_digest='sha256:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee'
+web_receipt="$(generate_receipt_for_context "$fixture_same_sha" "$fixture_base_sha" "$API_DIGEST" "$alternate_web_digest")" \
+  || fail_test 'receipt generation with a different Web digest failed'
+[[ "$web_receipt" != "$generated_receipt" ]] || fail_test 'receipt identity ignored the Web digest'
+expect_success 'validates distinct receipts for distinct Web image contexts' \
+  validate_receipt "$web_receipt" "$fixture_same_sha" "$fixture_base_sha" "$API_DIGEST" "$alternate_web_digest"
+
+tampered_original="$tmp_root/generated-original.receipt"
+tampered_payload="$tmp_root/generated-tampered.receipt"
+cp "$generated_receipt" "$tampered_original"
+awk -v replacement="$alternate_previous_sha" \
+  '$0 ~ /^previous_sha=/ { print "previous_sha=" replacement; next } { print }' \
+  "$generated_receipt" > "$tampered_payload"
+chmod 600 "$tampered_payload"
+mv "$tampered_payload" "$generated_receipt"
+expect_failure 'rejects a tampered pre-existing deterministic receipt fail closed' \
+  generate_receipt_for_context "$fixture_same_sha" "$fixture_base_sha" "$API_DIGEST" "$WEB_DIGEST"
+cp "$tampered_original" "$generated_receipt"
+
+rollback_consumer_output=''
+rollback_consumer_status=0
+rollback_consumer_output="$(env \
+  TEST_MODE=1 \
+  ROLLBACK_PROTECTED_DIR="$protected_dir" \
+  ROLLBACK_EXPECTED_OWNER="$current_owner" \
+  ROLLBACK_EXPECTED_GROUP="$current_group" \
+  PATH="$mock_bin:$PATH" \
+  bash "$ROLLBACK" \
+    "$fixture_same_sha" "$fixture_same_sha" "$API_DIGEST" "$WEB_DIGEST" "$incident_b_to_b_receipt" \
+    https://api.example.test/health https://api.example.test/readyz https://app.example.test/login 2>&1)" \
+  || rollback_consumer_status=$?
+[[ "$rollback_consumer_status" -ne 0 ]] || fail_test 'rollback consumer unexpectedly completed in the fixture environment'
+[[ "$rollback_consumer_output" != *'Receipt target SHA mismatch'* && \
+  "$rollback_consumer_output" != *'Receipt previous SHA mismatch'* && \
+  "$rollback_consumer_output" != *'Receipt API digest mismatch'* && \
+  "$rollback_consumer_output" != *'Receipt Web digest mismatch'* ]] \
+  || fail_test 'rollback consumer rejected the generated new-format receipt'
+pass 'rollback consumer accepts a generated new-format receipt by explicit path'
 
 concurrent_dir="$tmp_root/concurrent-protected"
 mkdir -p "$concurrent_dir"


### PR DESCRIPTION
## Summary
- Derive generated rollback receipt IDs from target SHA, previous SHA, image digests, and migration count.
- Publish receipts atomically and make concurrent identical generation idempotent.
- Preserve validation of legacy target-only receipt filenames.
- Add collision, tamper, legacy, and concurrency regressions.

## Validation
- `bash scripts/tests/production-security.test.sh` (36/36)
- `for test_script in scripts/tests/*.test.sh; do bash "$test_script" >/dev/null || exit 1; done`
- `for script in scripts/*.sh scripts/tests/*.sh; do bash -n "$script" || exit 1; done`
- `git diff --check`
- 30-iteration receipt concurrency stress
- ShellCheck unavailable in the local environment

No production or staging changes were made.