### PR TITLE
fix(finance): make movement lifecycle atomic

### DIFF
--- a/apps/api/src/finanzas/atomic-movement-lifecycle.postgres.spec.ts
+++ b/apps/api/src/finanzas/atomic-movement-lifecycle.postgres.spec.ts
@@ -1,5 +1,6 @@
-import { ConflictException } from '@nestjs/common';
+import { BadRequestException, ConflictException } from '@nestjs/common';
 import {
+  Prisma,
   PrismaClient,
   TenantType,
 } from '@prisma/client';
@@ -20,6 +21,7 @@ const enabled =
   expectedDatabaseName !== undefined &&
   ACCEPTANCE_DATABASES.has(expectedDatabaseName);
 const describePostgres = enabled ? describe : describe.skip;
+const TEST_BARRIER_KEY = 'buildingos:finance:fin02a:test-barrier:v1';
 
 describePostgres('Atomic movement lifecycle PostgreSQL', () => {
   let observer: PrismaClient;
@@ -163,6 +165,113 @@ describePostgres('Atomic movement lifecycle PostgreSQL', () => {
     };
   }
 
+  async function installRaceBarrier(): Promise<void> {
+    await observer.$executeRaw(Prisma.sql`
+      CREATE OR REPLACE FUNCTION "fin02a_block_update"()
+      RETURNS trigger
+      LANGUAGE plpgsql
+      AS $function$
+      BEGIN
+        PERFORM pg_advisory_xact_lock(
+          hashtextextended('buildingos:finance:fin02a:test-barrier:v1', 0)
+        );
+        RETURN NEW;
+      END;
+      $function$
+    `);
+    await observer.$executeRaw(Prisma.sql`
+      DROP TRIGGER IF EXISTS "fin02a_block_update" ON "Expense"
+    `);
+    await observer.$executeRaw(Prisma.sql`
+      DROP TRIGGER IF EXISTS "fin02a_block_update" ON "Income"
+    `);
+    await observer.$executeRaw(Prisma.sql`
+      CREATE TRIGGER "fin02a_block_update"
+      BEFORE UPDATE ON "Expense"
+      FOR EACH ROW EXECUTE FUNCTION "fin02a_block_update"()
+    `);
+    await observer.$executeRaw(Prisma.sql`
+      CREATE TRIGGER "fin02a_block_update"
+      BEFORE UPDATE ON "Income"
+      FOR EACH ROW EXECUTE FUNCTION "fin02a_block_update"()
+    `);
+  }
+
+  async function removeRaceBarrier(): Promise<void> {
+    await observer.$executeRaw(Prisma.sql`
+      DROP TRIGGER IF EXISTS "fin02a_block_update" ON "Expense"
+    `);
+    await observer.$executeRaw(Prisma.sql`
+      DROP TRIGGER IF EXISTS "fin02a_block_update" ON "Income"
+    `);
+    await observer.$executeRaw(Prisma.sql`
+      DROP FUNCTION IF EXISTS "fin02a_block_update"()
+    `);
+  }
+
+  async function holdRaceBarrier(): Promise<{
+    release: () => void;
+    transaction: Promise<void>;
+  }> {
+    let resolveReady!: () => void;
+    let release!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+    const released = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const transaction = observer.$transaction(
+      async (tx) => {
+        await tx.$executeRaw(
+          Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${TEST_BARRIER_KEY}, 0))`,
+        );
+        resolveReady();
+        await released;
+      },
+      { maxWait: 5000, timeout: 30000 },
+    );
+    await ready;
+    return { release, transaction };
+  }
+
+  async function waitForAdvisoryWaiters(expected: number): Promise<void> {
+    for (let attempt = 0; attempt < 100; attempt += 1) {
+      const rows = await observer.$queryRaw<Array<{ waiters: number }>>`
+        SELECT count(*)::int AS waiters
+        FROM pg_locks
+        WHERE locktype = 'advisory' AND granted = false
+      `;
+      if ((rows[0]?.waiters ?? 0) >= expected) {
+        return;
+      }
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error(`Expected ${expected} advisory lock waiters`);
+  }
+
+  async function runControlledRace(
+    firstOperation: () => Promise<unknown>,
+    secondOperation: () => Promise<unknown>,
+  ): Promise<PromiseSettledResult<unknown>[]> {
+    await installRaceBarrier();
+    const barrier = await holdRaceBarrier();
+    try {
+      const first = firstOperation();
+      await waitForAdvisoryWaiters(1);
+
+      const second = secondOperation();
+      await waitForAdvisoryWaiters(2);
+
+      barrier.release();
+      return await Promise.allSettled([first, second]);
+    } finally {
+      barrier.release();
+      await barrier.transaction;
+      await removeRaceBarrier();
+    }
+  }
+
   function expenseDto(ctx: Awaited<ReturnType<typeof fixture>>, scopeType: CreateExpenseDto['scopeType']): CreateExpenseDto {
     return {
       period: '2026-08',
@@ -234,6 +343,23 @@ describePostgres('Atomic movement lifecycle PostgreSQL', () => {
     expect(await observer.movementAllocation.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
   });
 
+  it('rejects an incomplete Expense allocation list without persisting anything', async () => {
+    const ctx = await fixture('expense-invalid-allocation');
+    const { expenses } = services(clientA);
+    const dto = expenseDto(ctx, 'TENANT_SHARED');
+    dto.allocations = [
+      { buildingId: ctx.building.id, percentage: 100 },
+      { buildingId: ctx.secondBuilding.id },
+    ];
+
+    await expect(
+      expenses.createExpense(ctx.tenant.id, ctx.membership.id, ['TENANT_ADMIN'], dto),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(await observer.expense.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+    expect(await observer.movementAllocation.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+  });
+
   it('rejects amount changes for allocated Expenses and allows a valid unallocated update', async () => {
     const ctx = await fixture('expense-update');
     const { expenses } = services(clientA);
@@ -299,6 +425,23 @@ describePostgres('Atomic movement lifecycle PostgreSQL', () => {
     expect(await observer.movementAllocation.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
   });
 
+  it('rejects an incomplete Income allocation list without persisting anything', async () => {
+    const ctx = await fixture('income-invalid-allocation');
+    const { incomes } = services(clientA);
+    const dto = incomeDto(ctx, 'TENANT_SHARED');
+    dto.allocations = [
+      { buildingId: ctx.building.id, amountMinor: 1000 },
+      { buildingId: ctx.secondBuilding.id },
+    ];
+
+    await expect(
+      incomes.createIncome(ctx.tenant.id, ctx.membership.id, ['TENANT_ADMIN'], dto),
+    ).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(await observer.income.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+    expect(await observer.movementAllocation.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+  });
+
   it('rejects currency changes for allocated Incomes and serializes concurrent DRAFT updates', async () => {
     const ctx = await fixture('income-update');
     const { incomes: incomesA } = services(clientA);
@@ -330,26 +473,23 @@ describePostgres('Atomic movement lifecycle PostgreSQL', () => {
       expenseDto(ctx, 'BUILDING'),
     );
 
-    const results = await Promise.allSettled([
-      expensesA.updateExpense(
+    const results = await runControlledRace(
+      () => expensesA.updateExpense(
         ctx.tenant.id,
         draft.id,
         ctx.membership.id,
         ['TENANT_ADMIN'],
         { amountMinor: 2000, description: 'updated before validation' },
       ),
-      expensesB.validateExpense(ctx.tenant.id, draft.id, ctx.membership.id, ['TENANT_ADMIN']),
-    ]);
+      () => expensesB.validateExpense(ctx.tenant.id, draft.id, ctx.membership.id, ['TENANT_ADMIN']),
+    );
 
+    expect(results[0]?.status).toBe('fulfilled');
     expect(results[1]?.status).toBe('fulfilled');
     const updatedExpense = await observer.expense.findUniqueOrThrow({ where: { id: draft.id } });
     expect(updatedExpense.status).toBe('VALIDATED');
     expect(updatedExpense.functionalAmountMinor).toBe(updatedExpense.amountMinor);
-    if (results[0]?.status === 'fulfilled') {
-      expect(updatedExpense.amountMinor).toBe(2000);
-    } else {
-      expect(updatedExpense.amountMinor).toBe(1000);
-    }
+    expect(updatedExpense.amountMinor).toBe(2000);
   });
 
   it('serializes Expense validation against void without state resurrection', async () => {
@@ -363,11 +503,12 @@ describePostgres('Atomic movement lifecycle PostgreSQL', () => {
       expenseDto(ctx, 'BUILDING'),
     );
 
-    const results = await Promise.allSettled([
-      expensesA.validateExpense(ctx.tenant.id, draft.id, ctx.membership.id, ['TENANT_ADMIN']),
-      expensesB.voidExpense(ctx.tenant.id, draft.id, ctx.membership.id, ['TENANT_ADMIN']),
-    ]);
+    const results = await runControlledRace(
+      () => expensesA.validateExpense(ctx.tenant.id, draft.id, ctx.membership.id, ['TENANT_ADMIN']),
+      () => expensesB.voidExpense(ctx.tenant.id, draft.id, ctx.membership.id, ['TENANT_ADMIN']),
+    );
 
+    expect(results[0]?.status).toBe('fulfilled');
     expect(results[1]?.status).toBe('fulfilled');
     expect(await observer.expense.findUniqueOrThrow({ where: { id: draft.id } })).toMatchObject({
       status: 'VOID',
@@ -385,25 +526,22 @@ describePostgres('Atomic movement lifecycle PostgreSQL', () => {
       incomeDto(ctx, 'BUILDING'),
     );
 
-    const results = await Promise.allSettled([
-      incomesA.updateIncome(
+    const results = await runControlledRace(
+      () => incomesA.updateIncome(
         ctx.tenant.id,
         draft.id,
         ctx.membership.id,
         ['TENANT_ADMIN'],
         { amountMinor: 2000, description: 'updated before recording' },
       ),
-      incomesB.recordIncome(ctx.tenant.id, draft.id, ctx.membership.id, ['TENANT_ADMIN']),
-    ]);
+      () => incomesB.recordIncome(ctx.tenant.id, draft.id, ctx.membership.id, ['TENANT_ADMIN']),
+    );
 
+    expect(results[0]?.status).toBe('fulfilled');
     expect(results[1]?.status).toBe('fulfilled');
     const recordedIncome = await observer.income.findUniqueOrThrow({ where: { id: draft.id } });
     expect(recordedIncome.status).toBe('RECORDED');
     expect(recordedIncome.functionalAmountMinor).toBe(recordedIncome.amountMinor);
-    if (results[0]?.status === 'fulfilled') {
-      expect(recordedIncome.amountMinor).toBe(2000);
-    } else {
-      expect(recordedIncome.amountMinor).toBe(1000);
-    }
+    expect(recordedIncome.amountMinor).toBe(2000);
   });
 });

--- a/apps/api/src/finanzas/atomic-movement-lifecycle.postgres.spec.ts
+++ b/apps/api/src/finanzas/atomic-movement-lifecycle.postgres.spec.ts
@@ -1,0 +1,314 @@
+import { ConflictException } from '@nestjs/common';
+import {
+  PrismaClient,
+  TenantType,
+} from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { ResidentAccessService } from '../resident-access/resident-access.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { CurrencyConversionService } from './currency-conversion.service';
+import { MovementAllocationService } from './movement-allocation.service';
+import { ExpensesService } from './expenses.service';
+import { IncomesService } from './incomes.service';
+import { CreateExpenseDto, CreateIncomeDto } from './expense-ledger.dto';
+
+const ACCEPTANCE_DATABASES = new Set(['buildingos_fin02a_acceptance']);
+const expectedDatabaseName = process.env.POSTGRES_TEST_DB_NAME;
+const enabled =
+  process.env.RUN_POSTGRES_INTEGRATION === '1' &&
+  expectedDatabaseName !== undefined &&
+  ACCEPTANCE_DATABASES.has(expectedDatabaseName);
+const describePostgres = enabled ? describe : describe.skip;
+
+describePostgres('Atomic movement lifecycle PostgreSQL', () => {
+  let observer: PrismaClient;
+  let clientA: PrismaClient;
+  let clientB: PrismaClient;
+  const tenantIds: string[] = [];
+  const userIds: string[] = [];
+  const membershipIds: string[] = [];
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required');
+    observer = new PrismaClient();
+    clientA = new PrismaClient();
+    clientB = new PrismaClient();
+    await Promise.all([observer.$connect(), clientA.$connect(), clientB.$connect()]);
+    const [database] = await observer.$queryRaw<Array<{ name: string }>>`
+      SELECT current_database() AS name
+    `;
+    if (database?.name !== expectedDatabaseName || !ACCEPTANCE_DATABASES.has(database.name)) {
+      throw new Error(`Refusing non-disposable test database ${database?.name ?? 'unknown'}`);
+    }
+  });
+
+  afterEach(async () => {
+    for (const membershipId of membershipIds.splice(0)) {
+      await observer.membership.delete({ where: { id: membershipId } }).catch(() => undefined);
+    }
+    for (const tenantId of tenantIds.splice(0)) {
+      await observer.tenant.delete({ where: { id: tenantId } }).catch(() => undefined);
+    }
+    for (const userId of userIds.splice(0)) {
+      await observer.user.delete({ where: { id: userId } }).catch(() => undefined);
+    }
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      observer?.$disconnect(),
+      clientA?.$disconnect(),
+      clientB?.$disconnect(),
+    ]);
+  });
+
+  async function fixture(label: string) {
+    const suffix = `${Date.now()}-${Math.random()}`;
+    const tenant = await observer.tenant.create({
+      data: { name: `fin02a-${label}-${suffix}`, type: TenantType.ADMINISTRADORA },
+    });
+    tenantIds.push(tenant.id);
+    const user = await observer.user.create({
+      data: {
+        email: `fin02a-${suffix}@buildingos.local`,
+        name: 'FIN-02A test user',
+        passwordHash: 'test',
+      },
+    });
+    userIds.push(user.id);
+    const membership = await observer.membership.create({
+      data: { tenantId: tenant.id, userId: user.id },
+    });
+    membershipIds.push(membership.id);
+    const building = await observer.building.create({
+      data: {
+        tenantId: tenant.id,
+        name: `Building ${suffix}`,
+        alias: `F-${suffix}`,
+        address: 'Test address',
+      },
+    });
+    const secondBuilding = await observer.building.create({
+      data: {
+        tenantId: tenant.id,
+        name: `Building 2 ${suffix}`,
+        alias: `G-${suffix}`,
+        address: 'Test address 2',
+      },
+    });
+    const expenseCategory = await observer.expenseLedgerCategory.create({
+      data: {
+        tenantId: tenant.id,
+        name: `Expense ${suffix}`,
+        movementType: 'EXPENSE',
+        catalogScope: 'BUILDING',
+      },
+    });
+    const sharedExpenseCategory = await observer.expenseLedgerCategory.create({
+      data: {
+        tenantId: tenant.id,
+        name: `Shared expense ${suffix}`,
+        movementType: 'EXPENSE',
+        catalogScope: 'CONDOMINIUM_COMMON',
+      },
+    });
+    const incomeCategory = await observer.expenseLedgerCategory.create({
+      data: {
+        tenantId: tenant.id,
+        name: `Income ${suffix}`,
+        movementType: 'INCOME',
+        catalogScope: 'CONDOMINIUM_COMMON',
+      },
+    });
+    const unitGroup = await observer.unitGroup.create({
+      data: {
+        tenantId: tenant.id,
+        buildingId: building.id,
+        name: `Group ${suffix}`,
+      },
+    });
+    return { tenant, membership, building, secondBuilding, expenseCategory, sharedExpenseCategory, incomeCategory, unitGroup };
+  }
+
+  function services(client: PrismaClient, movement?: MovementAllocationService) {
+    const prisma = client as unknown as PrismaService;
+    const audit = { createLog: jest.fn().mockResolvedValue(undefined) } as unknown as AuditService;
+    const validators = new FinanzasValidators(
+      prisma,
+      new ResidentAccessService(prisma),
+    );
+    const allocations = movement ?? new MovementAllocationService(prisma, audit, validators);
+    return {
+      expenses: new ExpensesService(
+        prisma,
+        audit,
+        validators,
+        allocations,
+        new CurrencyConversionService(prisma),
+      ),
+      incomes: new IncomesService(
+        prisma,
+        audit,
+        validators,
+        allocations,
+        new CurrencyConversionService(prisma),
+      ),
+    };
+  }
+
+  function expenseDto(ctx: Awaited<ReturnType<typeof fixture>>, scopeType: CreateExpenseDto['scopeType']): CreateExpenseDto {
+    return {
+      period: '2026-08',
+      categoryId: scopeType === 'TENANT_SHARED'
+        ? ctx.sharedExpenseCategory.id
+        : ctx.expenseCategory.id,
+      amountMinor: 1000,
+      currencyCode: 'ARS',
+      invoiceDate: '2026-08-01',
+      scopeType,
+      buildingId: scopeType === 'BUILDING' ? ctx.building.id : undefined,
+      unitGroupId: scopeType === 'UNIT_GROUP' ? ctx.unitGroup.id : undefined,
+      allocations: scopeType === 'BUILDING'
+        ? undefined
+        : [{ buildingId: ctx.building.id, percentage: 100 }],
+    };
+  }
+
+  function incomeDto(ctx: Awaited<ReturnType<typeof fixture>>, scopeType: CreateIncomeDto['scopeType']): CreateIncomeDto {
+    return {
+      period: '2026-08',
+      categoryId: ctx.incomeCategory.id,
+      amountMinor: 1000,
+      currencyCode: 'ARS',
+      receivedDate: '2026-08-01',
+      scopeType,
+      buildingId: scopeType === 'BUILDING' ? ctx.building.id : undefined,
+      unitGroupId: scopeType === 'UNIT_GROUP' ? ctx.unitGroup.id : undefined,
+      allocations: scopeType === 'BUILDING'
+        ? undefined
+        : [{ buildingId: ctx.building.id, percentage: 100 }],
+    };
+  }
+
+  it('creates BUILDING, TENANT_SHARED and UNIT_GROUP Expenses with exact allocation totals', async () => {
+    const ctx = await fixture('expense-create');
+    const { expenses } = services(clientA);
+
+    await expenses.createExpense(ctx.tenant.id, ctx.membership.id, ['TENANT_ADMIN'], expenseDto(ctx, 'BUILDING'));
+    await expenses.createExpense(ctx.tenant.id, ctx.membership.id, ['TENANT_ADMIN'], expenseDto(ctx, 'TENANT_SHARED'));
+    await expenses.createExpense(ctx.tenant.id, ctx.membership.id, ['TENANT_ADMIN'], expenseDto(ctx, 'UNIT_GROUP'));
+
+    expect(await observer.expense.count({ where: { tenantId: ctx.tenant.id } })).toBe(3);
+    expect(await observer.movementAllocation.count({ where: { tenantId: ctx.tenant.id } })).toBe(2);
+    const total = await observer.movementAllocation.aggregate({
+      where: { tenantId: ctx.tenant.id },
+      _sum: { amountMinor: true },
+    });
+    expect(total._sum.amountMinor).toBe(2000);
+  });
+
+  it('rolls back an Expense parent when allocation persistence fails', async () => {
+    const ctx = await fixture('expense-rollback');
+    const movement = {
+      validateAllocations: jest.fn().mockResolvedValue(undefined),
+      createForExpenseInTx: jest.fn().mockRejectedValue(new Error('forced allocation failure')),
+    } as unknown as MovementAllocationService;
+    const { expenses } = services(clientA, movement);
+
+    await expect(expenses.createExpense(
+      ctx.tenant.id,
+      ctx.membership.id,
+      ['TENANT_ADMIN'],
+      expenseDto(ctx, 'TENANT_SHARED'),
+    )).rejects.toThrow('forced allocation failure');
+
+    expect(await observer.expense.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+    expect(await observer.movementAllocation.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+  });
+
+  it('rejects amount changes for allocated Expenses and allows a valid unallocated update', async () => {
+    const ctx = await fixture('expense-update');
+    const { expenses } = services(clientA);
+    const allocated = await expenses.createExpense(
+      ctx.tenant.id,
+      ctx.membership.id,
+      ['TENANT_ADMIN'],
+      expenseDto(ctx, 'TENANT_SHARED'),
+    );
+
+    await expect(expenses.updateExpense(
+      ctx.tenant.id,
+      allocated.id,
+      ctx.membership.id,
+      ['TENANT_ADMIN'],
+      { amountMinor: 2000 },
+    )).rejects.toBeInstanceOf(ConflictException);
+
+    const building = await expenses.createExpense(
+      ctx.tenant.id,
+      ctx.membership.id,
+      ['TENANT_ADMIN'],
+      expenseDto(ctx, 'BUILDING'),
+    );
+    await expenses.updateExpense(
+      ctx.tenant.id,
+      building.id,
+      ctx.membership.id,
+      ['TENANT_ADMIN'],
+      { amountMinor: 2000 },
+    );
+    expect(await observer.expense.findUniqueOrThrow({ where: { id: building.id } })).toMatchObject({ amountMinor: 2000 });
+  });
+
+  it('creates BUILDING, TENANT_SHARED and UNIT_GROUP Incomes atomically', async () => {
+    const ctx = await fixture('income-create');
+    const { incomes } = services(clientA);
+
+    await incomes.createIncome(ctx.tenant.id, ctx.membership.id, ['TENANT_ADMIN'], incomeDto(ctx, 'BUILDING'));
+    await incomes.createIncome(ctx.tenant.id, ctx.membership.id, ['TENANT_ADMIN'], incomeDto(ctx, 'TENANT_SHARED'));
+    await incomes.createIncome(ctx.tenant.id, ctx.membership.id, ['TENANT_ADMIN'], incomeDto(ctx, 'UNIT_GROUP'));
+
+    expect(await observer.income.count({ where: { tenantId: ctx.tenant.id } })).toBe(3);
+    expect(await observer.movementAllocation.count({ where: { tenantId: ctx.tenant.id } })).toBe(2);
+  });
+
+  it('rolls back an Income parent when allocation persistence fails', async () => {
+    const ctx = await fixture('income-rollback');
+    const movement = {
+      validateAllocations: jest.fn().mockResolvedValue(undefined),
+      createForIncomeInTx: jest.fn().mockRejectedValue(new Error('forced allocation failure')),
+    } as unknown as MovementAllocationService;
+    const { incomes } = services(clientA, movement);
+
+    await expect(incomes.createIncome(
+      ctx.tenant.id,
+      ctx.membership.id,
+      ['TENANT_ADMIN'],
+      incomeDto(ctx, 'TENANT_SHARED'),
+    )).rejects.toThrow('forced allocation failure');
+
+    expect(await observer.income.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+    expect(await observer.movementAllocation.count({ where: { tenantId: ctx.tenant.id } })).toBe(0);
+  });
+
+  it('rejects currency changes for allocated Incomes and serializes concurrent DRAFT updates', async () => {
+    const ctx = await fixture('income-update');
+    const { incomes: incomesA } = services(clientA);
+    const { incomes: incomesB } = services(clientB);
+    const allocated = await incomesA.createIncome(
+      ctx.tenant.id,
+      ctx.membership.id,
+      ['TENANT_ADMIN'],
+      incomeDto(ctx, 'TENANT_SHARED'),
+    );
+
+    const results = await Promise.allSettled([
+      incomesA.updateIncome(ctx.tenant.id, allocated.id, ctx.membership.id, ['TENANT_ADMIN'], { currencyCode: 'USD' }),
+      incomesB.updateIncome(ctx.tenant.id, allocated.id, ctx.membership.id, ['TENANT_ADMIN'], { currencyCode: 'USD' }),
+    ]);
+    expect(results.every((result) => result.status === 'rejected')).toBe(true);
+    expect(await observer.income.findUniqueOrThrow({ where: { id: allocated.id } })).toMatchObject({ currencyCode: 'ARS' });
+    expect(await observer.movementAllocation.count({ where: { incomeId: allocated.id } })).toBe(1);
+  });
+});

--- a/apps/api/src/finanzas/atomic-movement-lifecycle.postgres.spec.ts
+++ b/apps/api/src/finanzas/atomic-movement-lifecycle.postgres.spec.ts
@@ -121,6 +121,12 @@ describePostgres('Atomic movement lifecycle PostgreSQL', () => {
         catalogScope: 'CONDOMINIUM_COMMON',
       },
     });
+    const vendor = await observer.vendor.create({
+      data: {
+        tenantId: tenant.id,
+        name: `Vendor ${suffix}`,
+      },
+    });
     const unitGroup = await observer.unitGroup.create({
       data: {
         tenantId: tenant.id,
@@ -128,7 +134,7 @@ describePostgres('Atomic movement lifecycle PostgreSQL', () => {
         name: `Group ${suffix}`,
       },
     });
-    return { tenant, membership, building, secondBuilding, expenseCategory, sharedExpenseCategory, incomeCategory, unitGroup };
+    return { tenant, membership, building, secondBuilding, expenseCategory, sharedExpenseCategory, incomeCategory, unitGroup, vendor };
   }
 
   function services(client: PrismaClient, movement?: MovementAllocationService) {
@@ -168,6 +174,7 @@ describePostgres('Atomic movement lifecycle PostgreSQL', () => {
       invoiceDate: '2026-08-01',
       scopeType,
       buildingId: scopeType === 'BUILDING' ? ctx.building.id : undefined,
+      vendorId: scopeType === 'BUILDING' ? ctx.vendor.id : undefined,
       unitGroupId: scopeType === 'UNIT_GROUP' ? ctx.unitGroup.id : undefined,
       allocations: scopeType === 'BUILDING'
         ? undefined
@@ -310,5 +317,93 @@ describePostgres('Atomic movement lifecycle PostgreSQL', () => {
     expect(results.every((result) => result.status === 'rejected')).toBe(true);
     expect(await observer.income.findUniqueOrThrow({ where: { id: allocated.id } })).toMatchObject({ currencyCode: 'ARS' });
     expect(await observer.movementAllocation.count({ where: { incomeId: allocated.id } })).toBe(1);
+  });
+
+  it('serializes an Expense update against validation using two PostgreSQL clients', async () => {
+    const ctx = await fixture('expense-update-validate-race');
+    const { expenses: expensesA } = services(clientA);
+    const { expenses: expensesB } = services(clientB);
+    const draft = await expensesA.createExpense(
+      ctx.tenant.id,
+      ctx.membership.id,
+      ['TENANT_ADMIN'],
+      expenseDto(ctx, 'BUILDING'),
+    );
+
+    const results = await Promise.allSettled([
+      expensesA.updateExpense(
+        ctx.tenant.id,
+        draft.id,
+        ctx.membership.id,
+        ['TENANT_ADMIN'],
+        { amountMinor: 2000, description: 'updated before validation' },
+      ),
+      expensesB.validateExpense(ctx.tenant.id, draft.id, ctx.membership.id, ['TENANT_ADMIN']),
+    ]);
+
+    expect(results[1]?.status).toBe('fulfilled');
+    const updatedExpense = await observer.expense.findUniqueOrThrow({ where: { id: draft.id } });
+    expect(updatedExpense.status).toBe('VALIDATED');
+    expect(updatedExpense.functionalAmountMinor).toBe(updatedExpense.amountMinor);
+    if (results[0]?.status === 'fulfilled') {
+      expect(updatedExpense.amountMinor).toBe(2000);
+    } else {
+      expect(updatedExpense.amountMinor).toBe(1000);
+    }
+  });
+
+  it('serializes Expense validation against void without state resurrection', async () => {
+    const ctx = await fixture('expense-validate-void-race');
+    const { expenses: expensesA } = services(clientA);
+    const { expenses: expensesB } = services(clientB);
+    const draft = await expensesA.createExpense(
+      ctx.tenant.id,
+      ctx.membership.id,
+      ['TENANT_ADMIN'],
+      expenseDto(ctx, 'BUILDING'),
+    );
+
+    const results = await Promise.allSettled([
+      expensesA.validateExpense(ctx.tenant.id, draft.id, ctx.membership.id, ['TENANT_ADMIN']),
+      expensesB.voidExpense(ctx.tenant.id, draft.id, ctx.membership.id, ['TENANT_ADMIN']),
+    ]);
+
+    expect(results[1]?.status).toBe('fulfilled');
+    expect(await observer.expense.findUniqueOrThrow({ where: { id: draft.id } })).toMatchObject({
+      status: 'VOID',
+    });
+  });
+
+  it('serializes an Income update against recording with a consistent snapshot', async () => {
+    const ctx = await fixture('income-update-record-race');
+    const { incomes: incomesA } = services(clientA);
+    const { incomes: incomesB } = services(clientB);
+    const draft = await incomesA.createIncome(
+      ctx.tenant.id,
+      ctx.membership.id,
+      ['TENANT_ADMIN'],
+      incomeDto(ctx, 'BUILDING'),
+    );
+
+    const results = await Promise.allSettled([
+      incomesA.updateIncome(
+        ctx.tenant.id,
+        draft.id,
+        ctx.membership.id,
+        ['TENANT_ADMIN'],
+        { amountMinor: 2000, description: 'updated before recording' },
+      ),
+      incomesB.recordIncome(ctx.tenant.id, draft.id, ctx.membership.id, ['TENANT_ADMIN']),
+    ]);
+
+    expect(results[1]?.status).toBe('fulfilled');
+    const recordedIncome = await observer.income.findUniqueOrThrow({ where: { id: draft.id } });
+    expect(recordedIncome.status).toBe('RECORDED');
+    expect(recordedIncome.functionalAmountMinor).toBe(recordedIncome.amountMinor);
+    if (results[0]?.status === 'fulfilled') {
+      expect(recordedIncome.amountMinor).toBe(2000);
+    } else {
+      expect(recordedIncome.amountMinor).toBe(1000);
+    }
   });
 });

--- a/apps/api/src/finanzas/atomic-movement-lifecycle.spec.ts
+++ b/apps/api/src/finanzas/atomic-movement-lifecycle.spec.ts
@@ -24,6 +24,7 @@ function makePrismaMock() {
     },
     movementAllocation: {
       count: jest.fn().mockResolvedValue(0),
+      findMany: jest.fn().mockResolvedValue([]),
     },
     expenseLedgerCategory: { findFirst: jest.fn() },
     vendor: { findFirst: jest.fn() },
@@ -38,7 +39,7 @@ function makePrismaMock() {
   return prismaValue;
 }
 
-function makeExpense() {
+function makeExpense(overrides: Record<string, unknown> = {}) {
   return {
     id: 'expense-1',
     tenantId: 'tenant-1',
@@ -66,10 +67,11 @@ function makeExpense() {
     updatedAt: new Date(),
     category: { name: 'Shared expenses' },
     vendor: null,
+    ...overrides,
   };
 }
 
-function makeIncome() {
+function makeIncome(overrides: Record<string, unknown> = {}) {
   return {
     id: 'income-1',
     tenantId: 'tenant-1',
@@ -95,11 +97,13 @@ function makeIncome() {
     createdAt: new Date(),
     updatedAt: new Date(),
     category: { name: 'Other income' },
+    ...overrides,
   };
 }
 
 function buildExpenseService() {
   const prismaValue = makePrismaMock();
+  const audit = { createLog: jest.fn().mockResolvedValue(undefined) };
   const movement = {
     validateAllocations: jest.fn(),
     createForExpenseInTx: jest.fn(),
@@ -110,16 +114,17 @@ function buildExpenseService() {
   };
   const service = new ExpensesService(
     prismaValue as unknown as PrismaService,
-    { createLog: jest.fn() } as unknown as AuditService,
+    audit as unknown as AuditService,
     validators as unknown as FinanzasValidators,
     movement as unknown as MovementAllocationService,
     { convert: jest.fn() } as unknown as CurrencyConversionService,
   );
-  return { prismaValue, movement, service };
+  return { prismaValue, movement, audit, service };
 }
 
 function buildIncomeService() {
   const prismaValue = makePrismaMock();
+  const audit = { createLog: jest.fn().mockResolvedValue(undefined) };
   const movement = {
     validateAllocations: jest.fn(),
     createForIncomeInTx: jest.fn(),
@@ -129,12 +134,12 @@ function buildIncomeService() {
   };
   const service = new IncomesService(
     prismaValue as unknown as PrismaService,
-    { createLog: jest.fn() } as unknown as AuditService,
+    audit as unknown as AuditService,
     validators as unknown as FinanzasValidators,
     movement as unknown as MovementAllocationService,
     { convert: jest.fn() } as unknown as CurrencyConversionService,
   );
-  return { prismaValue, movement, service };
+  return { prismaValue, movement, audit, service };
 }
 
 const sharedExpenseDto: CreateExpenseDto = {
@@ -159,7 +164,7 @@ const sharedIncomeDto: CreateIncomeDto = {
 
 describe('atomic movement lifecycle', () => {
   it('rolls back an Expense parent when allocation persistence fails', async () => {
-    const { prismaValue, movement, service } = buildExpenseService();
+    const { prismaValue, movement, audit, service } = buildExpenseService();
     prismaValue.expenseLedgerCategory.findFirst.mockResolvedValue({
       id: 'expense-category-1',
       catalogScope: 'CONDOMINIUM_COMMON',
@@ -173,6 +178,7 @@ describe('atomic movement lifecycle', () => {
     expect(prismaValue.$transaction).toHaveBeenCalledTimes(1);
     expect(prismaValue.expense.create).toHaveBeenCalledTimes(1);
     expect(movement.createForExpenseInTx).toHaveBeenCalledTimes(1);
+    expect(audit.createLog).not.toHaveBeenCalled();
   });
 
   it('does not attempt allocations when an Expense parent fails', async () => {
@@ -221,8 +227,44 @@ describe('atomic movement lifecycle', () => {
     expect(prismaValue.expense.update).toHaveBeenCalledTimes(1);
   });
 
+  it('emits Expense allocation audit only after the transaction commits', async () => {
+    const { prismaValue, audit, movement, service } = buildExpenseService();
+    prismaValue.expenseLedgerCategory.findFirst.mockResolvedValue({
+      id: 'expense-category-1',
+      catalogScope: 'CONDOMINIUM_COMMON',
+    });
+    prismaValue.expense.create.mockResolvedValue(makeExpense());
+
+    let committed = false;
+    prismaValue.$transaction.mockImplementation(async (callback: (tx: typeof prismaValue) => unknown) => {
+      const result = await callback(prismaValue);
+      committed = true;
+      return result;
+    });
+    audit.createLog.mockImplementation(async () => {
+      expect(committed).toBe(true);
+    });
+
+    await service.createExpense('tenant-1', 'member-1', ['TENANT_ADMIN'], sharedExpenseDto);
+
+    expect(movement.createForExpenseInTx).toHaveBeenCalledTimes(1);
+    expect(audit.createLog).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        action: 'EXPENSE_ALLOCATION_CREATE',
+        entityType: 'MovementAllocation',
+        entityId: 'expense-1',
+        metadata: { allocationCount: 1, totalAmount: 1000 },
+      }),
+    );
+    expect(audit.createLog).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ action: 'EXPENSE_CREATE', entityId: 'expense-1' }),
+    );
+  });
+
   it('rolls back an Income parent when allocation persistence fails', async () => {
-    const { prismaValue, movement, service } = buildIncomeService();
+    const { prismaValue, movement, audit, service } = buildIncomeService();
     prismaValue.expenseLedgerCategory.findFirst.mockResolvedValue({
       id: 'income-category-1',
       movementType: 'INCOME',
@@ -235,6 +277,7 @@ describe('atomic movement lifecycle', () => {
 
     expect(prismaValue.$transaction).toHaveBeenCalledTimes(1);
     expect(movement.createForIncomeInTx).toHaveBeenCalledTimes(1);
+    expect(audit.createLog).not.toHaveBeenCalled();
   });
 
   it('does not attempt allocations when an Income parent fails', async () => {
@@ -265,5 +308,152 @@ describe('atomic movement lifecycle', () => {
     )).rejects.toBeInstanceOf(ConflictException);
 
     expect(prismaValue.income.update).not.toHaveBeenCalled();
+  });
+
+  it('emits Income allocation audit only after the transaction commits', async () => {
+    const { prismaValue, audit, movement, service } = buildIncomeService();
+    prismaValue.expenseLedgerCategory.findFirst.mockResolvedValue({
+      id: 'income-category-1',
+      movementType: 'INCOME',
+    });
+    prismaValue.income.create.mockResolvedValue(makeIncome());
+
+    let committed = false;
+    prismaValue.$transaction.mockImplementation(async (callback: (tx: typeof prismaValue) => unknown) => {
+      const result = await callback(prismaValue);
+      committed = true;
+      return result;
+    });
+    audit.createLog.mockImplementation(async () => {
+      expect(committed).toBe(true);
+    });
+
+    await service.createIncome('tenant-1', 'member-1', ['TENANT_ADMIN'], sharedIncomeDto);
+
+    expect(movement.createForIncomeInTx).toHaveBeenCalledTimes(1);
+    expect(audit.createLog).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        action: 'INCOME_ALLOCATION_CREATE',
+        entityType: 'MovementAllocation',
+        entityId: 'income-1',
+        metadata: { allocationCount: 1, totalAmount: 1000 },
+      }),
+    );
+    expect(audit.createLog).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ action: 'INCOME_CREATE', entityId: 'income-1' }),
+    );
+  });
+
+  it('passes the active transaction client to the Expense conversion snapshot', async () => {
+    const root = makePrismaMock();
+    const tx = makePrismaMock();
+    root.$transaction.mockImplementation(async (callback: (client: typeof tx) => unknown) => callback(tx));
+    tx.expense.findFirst.mockResolvedValue(makeExpense({
+      vendorId: 'vendor-1',
+      vendor: { name: 'Vendor' },
+    }));
+    tx.tenant.findFirst.mockResolvedValue({ id: 'tenant-1', functionalCurrency: 'ARS' });
+    tx.expense.update.mockResolvedValue(makeExpense({ status: 'VALIDATED' }));
+    const currencyConversion = {
+      convert: jest.fn().mockResolvedValue({
+        functionalAmount: 1000,
+        functionalCurrency: 'ARS',
+        sourceExchangeRateId: null,
+        appliedRate: '1',
+        direction: 'IDENTITY',
+        sourceEffectiveAt: null,
+        conversionDate: new Date('2026-08-01T00:00:00.000Z'),
+      }),
+    };
+    const validators = { isAdminOrOperator: jest.fn().mockReturnValue(true) };
+    const movement = { validateAllocations: jest.fn() };
+    const service = new ExpensesService(
+      root as unknown as PrismaService,
+      { createLog: jest.fn().mockResolvedValue(undefined) } as unknown as AuditService,
+      validators as unknown as FinanzasValidators,
+      movement as unknown as MovementAllocationService,
+      currencyConversion as unknown as CurrencyConversionService,
+    );
+
+    await service.validateExpense('tenant-1', 'expense-1', 'member-1', ['TENANT_ADMIN']);
+
+    expect(root.tenant.findFirst).not.toHaveBeenCalled();
+    expect(tx.tenant.findFirst).toHaveBeenCalledTimes(1);
+    expect(currencyConversion.convert).toHaveBeenCalledWith(expect.any(Object), tx);
+  });
+
+  it('passes the active transaction client to the Income conversion snapshot', async () => {
+    const root = makePrismaMock();
+    const tx = makePrismaMock();
+    root.$transaction.mockImplementation(async (callback: (client: typeof tx) => unknown) => callback(tx));
+    tx.income.findFirst.mockResolvedValue(makeIncome());
+    tx.tenant.findFirst.mockResolvedValue({ id: 'tenant-1', functionalCurrency: 'ARS' });
+    tx.income.update.mockResolvedValue(makeIncome({ status: 'RECORDED' }));
+    const currencyConversion = {
+      convert: jest.fn().mockResolvedValue({
+        functionalAmount: 1000,
+        functionalCurrency: 'ARS',
+        sourceExchangeRateId: null,
+        appliedRate: '1',
+        direction: 'IDENTITY',
+        sourceEffectiveAt: null,
+        conversionDate: new Date('2026-08-01T00:00:00.000Z'),
+      }),
+    };
+    const validators = { isAdminOrOperator: jest.fn().mockReturnValue(true) };
+    const movement = { validateAllocations: jest.fn() };
+    const service = new IncomesService(
+      root as unknown as PrismaService,
+      { createLog: jest.fn().mockResolvedValue(undefined) } as unknown as AuditService,
+      validators as unknown as FinanzasValidators,
+      movement as unknown as MovementAllocationService,
+      currencyConversion as unknown as CurrencyConversionService,
+    );
+
+    await service.recordIncome('tenant-1', 'income-1', 'member-1', ['TENANT_ADMIN']);
+
+    expect(root.tenant.findFirst).not.toHaveBeenCalled();
+    expect(tx.tenant.findFirst).toHaveBeenCalledTimes(1);
+    expect(currencyConversion.convert).toHaveBeenCalledWith(expect.any(Object), tx);
+  });
+
+  it('uses the active transaction client for Expense period checks', async () => {
+    const root = makePrismaMock();
+    const tx = makePrismaMock();
+    root.$transaction.mockImplementation(async (callback: (client: typeof tx) => unknown) => callback(tx));
+    tx.expense.findFirst.mockResolvedValue(makeExpense({
+      buildingId: 'building-1',
+      scopeType: 'BUILDING',
+      vendorId: 'vendor-1',
+      vendor: { name: 'Vendor' },
+    }));
+    tx.liquidation.findFirst.mockResolvedValue(null);
+    tx.expense.update.mockResolvedValue(makeExpense({
+      buildingId: 'building-1',
+      scopeType: 'BUILDING',
+      vendorId: 'vendor-1',
+      vendor: { name: 'Vendor' },
+    }));
+    const validators = { isAdminOrOperator: jest.fn().mockReturnValue(true) };
+    const service = new ExpensesService(
+      root as unknown as PrismaService,
+      { createLog: jest.fn().mockResolvedValue(undefined) } as unknown as AuditService,
+      validators as unknown as FinanzasValidators,
+      { validateAllocations: jest.fn() } as unknown as MovementAllocationService,
+      { convert: jest.fn() } as unknown as CurrencyConversionService,
+    );
+
+    await service.updateExpense(
+      'tenant-1',
+      'expense-1',
+      'member-1',
+      ['TENANT_ADMIN'],
+      { description: 'metadata update' },
+    );
+
+    expect(root.liquidation.findFirst).not.toHaveBeenCalled();
+    expect(tx.liquidation.findFirst).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/finanzas/atomic-movement-lifecycle.spec.ts
+++ b/apps/api/src/finanzas/atomic-movement-lifecycle.spec.ts
@@ -1,0 +1,269 @@
+import { ConflictException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { AuditService } from '../audit/audit.service';
+import { FinanzasValidators } from './finanzas.validators';
+import { CurrencyConversionService } from './currency-conversion.service';
+import { MovementAllocationService } from './movement-allocation.service';
+import { ExpensesService } from './expenses.service';
+import { IncomesService } from './incomes.service';
+import { CreateExpenseDto, CreateIncomeDto } from './expense-ledger.dto';
+
+function makePrismaMock() {
+  const prismaValue = {
+    $transaction: jest.fn(),
+    $executeRaw: jest.fn().mockResolvedValue(1),
+    expense: {
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+    income: {
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      update: jest.fn(),
+    },
+    movementAllocation: {
+      count: jest.fn().mockResolvedValue(0),
+    },
+    expenseLedgerCategory: { findFirst: jest.fn() },
+    vendor: { findFirst: jest.fn() },
+    unitGroup: { findFirst: jest.fn() },
+    liquidation: { findFirst: jest.fn().mockResolvedValue(null) },
+    tenant: { findFirst: jest.fn() },
+    exchangeRate: { findFirst: jest.fn() },
+  };
+  prismaValue.$transaction.mockImplementation(
+    async (callback: (tx: typeof prismaValue) => unknown) => callback(prismaValue),
+  );
+  return prismaValue;
+}
+
+function makeExpense() {
+  return {
+    id: 'expense-1',
+    tenantId: 'tenant-1',
+    buildingId: null,
+    period: '2026-08',
+    liquidationPeriod: '2026-08',
+    categoryId: 'expense-category-1',
+    vendorId: null,
+    amountMinor: 1000,
+    currencyCode: 'ARS',
+    invoiceDate: new Date('2026-08-01T00:00:00.000Z'),
+    description: null,
+    attachmentFileKey: null,
+    status: 'DRAFT' as const,
+    scopeType: 'TENANT_SHARED' as const,
+    unitGroupId: null,
+    functionalAmountMinor: null,
+    functionalCurrencyCode: null,
+    exchangeRateId: null,
+    exchangeRateValue: null,
+    exchangeRateDirection: null,
+    exchangeRateEffectiveAt: null,
+    conversionDate: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    category: { name: 'Shared expenses' },
+    vendor: null,
+  };
+}
+
+function makeIncome() {
+  return {
+    id: 'income-1',
+    tenantId: 'tenant-1',
+    buildingId: null,
+    period: '2026-08',
+    categoryId: 'income-category-1',
+    amountMinor: 1000,
+    currencyCode: 'ARS',
+    receivedDate: new Date('2026-08-01T00:00:00.000Z'),
+    description: null,
+    attachmentFileKey: null,
+    status: 'DRAFT' as const,
+    scopeType: 'TENANT_SHARED' as const,
+    destination: 'APPLY_TO_EXPENSES' as const,
+    unitGroupId: null,
+    functionalAmountMinor: null,
+    functionalCurrencyCode: null,
+    exchangeRateId: null,
+    exchangeRateValue: null,
+    exchangeRateDirection: null,
+    exchangeRateEffectiveAt: null,
+    conversionDate: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    category: { name: 'Other income' },
+  };
+}
+
+function buildExpenseService() {
+  const prismaValue = makePrismaMock();
+  const movement = {
+    validateAllocations: jest.fn(),
+    createForExpenseInTx: jest.fn(),
+  };
+  const validators = {
+    isAdminOrOperator: jest.fn().mockReturnValue(true),
+    validateBuildingBelongsToTenant: jest.fn(),
+  };
+  const service = new ExpensesService(
+    prismaValue as unknown as PrismaService,
+    { createLog: jest.fn() } as unknown as AuditService,
+    validators as unknown as FinanzasValidators,
+    movement as unknown as MovementAllocationService,
+    { convert: jest.fn() } as unknown as CurrencyConversionService,
+  );
+  return { prismaValue, movement, service };
+}
+
+function buildIncomeService() {
+  const prismaValue = makePrismaMock();
+  const movement = {
+    validateAllocations: jest.fn(),
+    createForIncomeInTx: jest.fn(),
+  };
+  const validators = {
+    isAdminOrOperator: jest.fn().mockReturnValue(true),
+  };
+  const service = new IncomesService(
+    prismaValue as unknown as PrismaService,
+    { createLog: jest.fn() } as unknown as AuditService,
+    validators as unknown as FinanzasValidators,
+    movement as unknown as MovementAllocationService,
+    { convert: jest.fn() } as unknown as CurrencyConversionService,
+  );
+  return { prismaValue, movement, service };
+}
+
+const sharedExpenseDto: CreateExpenseDto = {
+  period: '2026-08',
+  categoryId: 'expense-category-1',
+  amountMinor: 1000,
+  currencyCode: 'ARS',
+  invoiceDate: '2026-08-01',
+  scopeType: 'TENANT_SHARED',
+  allocations: [{ buildingId: 'building-1', percentage: 100 }],
+};
+
+const sharedIncomeDto: CreateIncomeDto = {
+  period: '2026-08',
+  categoryId: 'income-category-1',
+  amountMinor: 1000,
+  currencyCode: 'ARS',
+  receivedDate: '2026-08-01',
+  scopeType: 'TENANT_SHARED',
+  allocations: [{ buildingId: 'building-1', percentage: 100 }],
+};
+
+describe('atomic movement lifecycle', () => {
+  it('rolls back an Expense parent when allocation persistence fails', async () => {
+    const { prismaValue, movement, service } = buildExpenseService();
+    prismaValue.expenseLedgerCategory.findFirst.mockResolvedValue({
+      id: 'expense-category-1',
+      catalogScope: 'CONDOMINIUM_COMMON',
+    });
+    prismaValue.expense.create.mockResolvedValue(makeExpense());
+    movement.createForExpenseInTx.mockRejectedValue(new Error('allocation failure'));
+
+    await expect(service.createExpense('tenant-1', 'member-1', ['TENANT_ADMIN'], sharedExpenseDto))
+      .rejects.toThrow('allocation failure');
+
+    expect(prismaValue.$transaction).toHaveBeenCalledTimes(1);
+    expect(prismaValue.expense.create).toHaveBeenCalledTimes(1);
+    expect(movement.createForExpenseInTx).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attempt allocations when an Expense parent fails', async () => {
+    const { prismaValue, movement, service } = buildExpenseService();
+    prismaValue.expenseLedgerCategory.findFirst.mockResolvedValue({
+      id: 'expense-category-1',
+      catalogScope: 'CONDOMINIUM_COMMON',
+    });
+    prismaValue.expense.create.mockRejectedValue(new Error('parent failure'));
+
+    await expect(service.createExpense('tenant-1', 'member-1', ['TENANT_ADMIN'], sharedExpenseDto))
+      .rejects.toThrow('parent failure');
+
+    expect(movement.createForExpenseInTx).not.toHaveBeenCalled();
+  });
+
+  it('rejects an Expense amount change while allocations exist', async () => {
+    const { prismaValue, service } = buildExpenseService();
+    prismaValue.expense.findFirst.mockResolvedValue(makeExpense());
+    prismaValue.movementAllocation.count.mockResolvedValue(1);
+
+    await expect(service.updateExpense(
+      'tenant-1',
+      'expense-1',
+      'member-1',
+      ['TENANT_ADMIN'],
+      { amountMinor: 2000 },
+    )).rejects.toBeInstanceOf(ConflictException);
+
+    expect(prismaValue.expense.update).not.toHaveBeenCalled();
+  });
+
+  it('allows an Expense amount change when no allocations exist', async () => {
+    const { prismaValue, service } = buildExpenseService();
+    prismaValue.expense.findFirst.mockResolvedValue(makeExpense());
+    prismaValue.expense.update.mockResolvedValue(makeExpense());
+
+    await service.updateExpense(
+      'tenant-1',
+      'expense-1',
+      'member-1',
+      ['TENANT_ADMIN'],
+      { amountMinor: 2000 },
+    );
+
+    expect(prismaValue.expense.update).toHaveBeenCalledTimes(1);
+  });
+
+  it('rolls back an Income parent when allocation persistence fails', async () => {
+    const { prismaValue, movement, service } = buildIncomeService();
+    prismaValue.expenseLedgerCategory.findFirst.mockResolvedValue({
+      id: 'income-category-1',
+      movementType: 'INCOME',
+    });
+    prismaValue.income.create.mockResolvedValue(makeIncome());
+    movement.createForIncomeInTx.mockRejectedValue(new Error('allocation failure'));
+
+    await expect(service.createIncome('tenant-1', 'member-1', ['TENANT_ADMIN'], sharedIncomeDto))
+      .rejects.toThrow('allocation failure');
+
+    expect(prismaValue.$transaction).toHaveBeenCalledTimes(1);
+    expect(movement.createForIncomeInTx).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not attempt allocations when an Income parent fails', async () => {
+    const { prismaValue, movement, service } = buildIncomeService();
+    prismaValue.expenseLedgerCategory.findFirst.mockResolvedValue({
+      id: 'income-category-1',
+      movementType: 'INCOME',
+    });
+    prismaValue.income.create.mockRejectedValue(new Error('parent failure'));
+
+    await expect(service.createIncome('tenant-1', 'member-1', ['TENANT_ADMIN'], sharedIncomeDto))
+      .rejects.toThrow('parent failure');
+
+    expect(movement.createForIncomeInTx).not.toHaveBeenCalled();
+  });
+
+  it('rejects an Income currency change while allocations exist', async () => {
+    const { prismaValue, service } = buildIncomeService();
+    prismaValue.income.findFirst.mockResolvedValue(makeIncome());
+    prismaValue.movementAllocation.count.mockResolvedValue(1);
+
+    await expect(service.updateIncome(
+      'tenant-1',
+      'income-1',
+      'member-1',
+      ['TENANT_ADMIN'],
+      { currencyCode: 'USD' },
+    )).rejects.toBeInstanceOf(ConflictException);
+
+    expect(prismaValue.income.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/finanzas/expenses.multicurrency.spec.ts
+++ b/apps/api/src/finanzas/expenses.multicurrency.spec.ts
@@ -66,6 +66,8 @@ describe('ExpensesService multicurrency snapshot', () => {
     exchangeRateFindFirst = jest.fn();
 
     const prismaValue = {
+      $transaction: jest.fn(),
+      $executeRaw: jest.fn().mockResolvedValue(1),
       expense: {
         findFirst: jest.fn(),
         update: jest.fn(),
@@ -82,7 +84,15 @@ describe('ExpensesService multicurrency snapshot', () => {
       vendor: { findFirst: jest.fn() },
       unitGroup: { findFirst: jest.fn() },
       adjustment: { findFirst: jest.fn(), create: jest.fn(), update: jest.fn() },
+      movementAllocation: {
+        count: jest.fn().mockResolvedValue(0),
+        findMany: jest.fn().mockResolvedValue([]),
+        update: jest.fn(),
+      },
     };
+    prismaValue.$transaction.mockImplementation(
+      async (callback: (tx: typeof prismaValue) => unknown) => callback(prismaValue),
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -95,7 +105,11 @@ describe('ExpensesService multicurrency snapshot', () => {
         },
         {
           provide: MovementAllocationService,
-          useValue: { createForExpense: jest.fn() },
+          useValue: {
+            validateAllocations: jest.fn(),
+            createForExpense: jest.fn(),
+            createForExpenseInTx: jest.fn(),
+          },
         },
         {
           provide: CurrencyConversionService,

--- a/apps/api/src/finanzas/expenses.service.spec.ts
+++ b/apps/api/src/finanzas/expenses.service.spec.ts
@@ -74,41 +74,50 @@ describe('ExpensesService', () => {
   let currencyConversion: CurrencyConversionService;
 
   beforeEach(async () => {
+    const prismaValue = {
+      $transaction: jest.fn(),
+      $executeRaw: jest.fn().mockResolvedValue(1),
+      expense: {
+        create: jest.fn(),
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+        update: jest.fn(),
+      },
+      movementAllocation: {
+        count: jest.fn().mockResolvedValue(0),
+        findMany: jest.fn().mockResolvedValue([]),
+        update: jest.fn(),
+      },
+      building: {
+        findMany: jest.fn(),
+      },
+      expenseLedgerCategory: {
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+      },
+      vendor: {
+        findMany: jest.fn(),
+        findFirst: jest.fn(),
+      },
+      tenant: {
+        findFirst: jest.fn().mockResolvedValue({
+          id: 'tenant-1',
+          functionalCurrency: 'ARS',
+        }),
+      },
+      exchangeRate: { findFirst: jest.fn() },
+      liquidation: { findFirst: jest.fn() },
+      unitGroup: { findFirst: jest.fn() },
+      adjustment: { findFirst: jest.fn(), create: jest.fn(), update: jest.fn() },
+    };
+    prismaValue.$transaction.mockImplementation(
+      async (callback: (tx: typeof prismaValue) => unknown) => callback(prismaValue),
+    );
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         ExpensesService,
-        {
-          provide: PrismaService,
-          useValue: {
-            expense: {
-              create: jest.fn(),
-              findMany: jest.fn(),
-              findFirst: jest.fn(),
-              update: jest.fn(),
-            },
-            building: {
-              findMany: jest.fn(),
-            },
-            expenseLedgerCategory: {
-              findMany: jest.fn(),
-              findFirst: jest.fn(),
-            },
-            vendor: {
-              findMany: jest.fn(),
-              findFirst: jest.fn(),
-            },
-            tenant: {
-              findFirst: jest.fn().mockResolvedValue({
-                id: 'tenant-1',
-                functionalCurrency: 'ARS',
-              }),
-            },
-            exchangeRate: { findFirst: jest.fn() },
-            liquidation: { findFirst: jest.fn() },
-            unitGroup: { findFirst: jest.fn() },
-            adjustment: { findFirst: jest.fn(), create: jest.fn(), update: jest.fn() },
-          },
-        },
+        { provide: PrismaService, useValue: prismaValue },
         { provide: AuditService, useValue: { createLog: jest.fn() } },
         {
           provide: FinanzasValidators,
@@ -119,7 +128,11 @@ describe('ExpensesService', () => {
         },
         {
           provide: MovementAllocationService,
-          useValue: { createForExpense: jest.fn() },
+          useValue: {
+            validateAllocations: jest.fn(),
+            createForExpense: jest.fn(),
+            createForExpenseInTx: jest.fn(),
+          },
         },
         {
           provide: CurrencyConversionService,
@@ -230,8 +243,8 @@ describe('ExpensesService', () => {
           }),
         }),
       );
-      expect(movementAllocation.createForExpense).toHaveBeenCalledWith(
-        'tenant-1', 'expense-1', 1000, 'ARS', allocations, 'member-1',
+      expect(movementAllocation.createForExpenseInTx).toHaveBeenCalledWith(
+        expect.anything(), 'tenant-1', 'expense-1', 1000, 'ARS', allocations,
       );
     });
 

--- a/apps/api/src/finanzas/expenses.service.ts
+++ b/apps/api/src/finanzas/expenses.service.ts
@@ -2,9 +2,11 @@ import {
   Injectable,
   NotFoundException,
   BadRequestException,
+  ConflictException,
   ForbiddenException,
   UnprocessableEntityException,
 } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import {
@@ -19,6 +21,7 @@ import {
   allocateFunctionalByLargestRemainder,
 } from './movement-allocation.service';
 import { CurrencyConversionService } from './currency-conversion.service';
+import { acquireExpenseLock } from './movement-locks';
 
 @Injectable()
 export class ExpensesService {
@@ -37,6 +40,7 @@ export class ExpensesService {
   }
 
   private async persistValidatedExpense(
+    tx: Prisma.TransactionClient,
     expense: {
       id: string;
       tenantId: string;
@@ -67,7 +71,7 @@ export class ExpensesService {
     };
 
     if (expense.scopeType !== 'TENANT_SHARED') {
-      return this.prisma.expense.update({
+      return tx.expense.update({
         where: { id: expense.id },
         data: baseData,
         include: {
@@ -77,13 +81,13 @@ export class ExpensesService {
       });
     }
 
-    const allocations = await this.prisma.movementAllocation.findMany({
+    const allocations = await tx.movementAllocation.findMany({
       where: { tenantId: expense.tenantId, expenseId: expense.id },
       select: { id: true, amountMinor: true },
     });
 
     if (allocations.length === 0) {
-      return this.prisma.expense.update({
+      return tx.expense.update({
         where: { id: expense.id },
         data: baseData,
         include: {
@@ -98,28 +102,26 @@ export class ExpensesService {
       allocations.map((allocation) => allocation.amountMinor ?? 0),
     );
 
-    return this.prisma.$transaction(async (tx) => {
-      const updated = await tx.expense.update({
-        where: { id: expense.id },
-        data: baseData,
-        include: {
-          category: { select: { name: true } },
-          vendor: { select: { name: true } },
+    const updated = await tx.expense.update({
+      where: { id: expense.id },
+      data: baseData,
+      include: {
+        category: { select: { name: true } },
+        vendor: { select: { name: true } },
+      },
+    });
+
+    for (const [index, allocation] of allocations.entries()) {
+      await tx.movementAllocation.update({
+        where: { id: allocation.id },
+        data: {
+          functionalAmountMinor: shares[index],
+          functionalCurrencyCode: snapshot.functionalCurrencyCode,
         },
       });
+    }
 
-      for (const [index, allocation] of allocations.entries()) {
-        await tx.movementAllocation.update({
-          where: { id: allocation.id },
-          data: {
-            functionalAmountMinor: shares[index],
-            functionalCurrencyCode: snapshot.functionalCurrencyCode,
-          },
-        });
-      }
-
-      return updated;
-    });
+    return updated;
   }
 
   private toConversionDate(invoiceDate: Date): string {
@@ -403,40 +405,54 @@ export class ExpensesService {
       await this.assertBuildingPeriodIsOpen(tenantId, dto.buildingId, liquidationPeriod);
     }
 
-    const expense = await this.prisma.expense.create({
-      data: {
-        tenantId,
-        buildingId: dto.buildingId ?? null,
-        period: liquidationPeriod,
-        liquidationPeriod,
-        categoryId: dto.categoryId,
-        vendorId: dto.vendorId ?? null,
-        amountMinor: dto.amountMinor,
-        currencyCode: dto.currencyCode,
-        invoiceDate,
-        description: dto.description ?? null,
-        attachmentFileKey: dto.attachmentFileKey ?? null,
-        scopeType,
-        unitGroupId: dto.unitGroupId ?? null,
-        createdByMembershipId: membershipId,
-      },
-      include: {
-        category: { select: { name: true } },
-        vendor: { select: { name: true } },
-      },
-    });
-
-    // Crear allocations si es TENANT_SHARED o UNIT_GROUP
+    // Validate before opening the write transaction, then persist the parent
+    // and canonical allocation rows in the same transaction.
     if ((scopeType === 'TENANT_SHARED' || scopeType === 'UNIT_GROUP') && dto.allocations) {
-      await this.movementAllocationService.createForExpense(
+      await this.movementAllocationService.validateAllocations(
         tenantId,
-        expense.id,
+        dto.allocations,
         dto.amountMinor,
         dto.currencyCode,
-        dto.allocations,
-        membershipId,
       );
     }
+
+    const expense = await this.prisma.$transaction(async (tx) => {
+      const created = await tx.expense.create({
+        data: {
+          tenantId,
+          buildingId: dto.buildingId ?? null,
+          period: liquidationPeriod,
+          liquidationPeriod,
+          categoryId: dto.categoryId,
+          vendorId: dto.vendorId ?? null,
+          amountMinor: dto.amountMinor,
+          currencyCode: dto.currencyCode,
+          invoiceDate,
+          description: dto.description ?? null,
+          attachmentFileKey: dto.attachmentFileKey ?? null,
+          scopeType,
+          unitGroupId: dto.unitGroupId ?? null,
+          createdByMembershipId: membershipId,
+        },
+        include: {
+          category: { select: { name: true } },
+          vendor: { select: { name: true } },
+        },
+      });
+
+      if ((scopeType === 'TENANT_SHARED' || scopeType === 'UNIT_GROUP') && dto.allocations) {
+        await this.movementAllocationService.createForExpenseInTx(
+          tx,
+          tenantId,
+          created.id,
+          dto.amountMinor,
+          dto.currencyCode,
+          dto.allocations,
+        );
+      }
+
+      return created;
+    });
 
     void this.auditService.createLog({
       tenantId,
@@ -469,65 +485,82 @@ export class ExpensesService {
       throw new ForbiddenException('Acceso denegado');
     }
 
-    const expense = await this.prisma.expense.findFirst({
-      where: { id: expenseId, tenantId },
-    });
+    const updated = await this.prisma.$transaction(async (tx) => {
+      await acquireExpenseLock(tx, tenantId, expenseId);
 
-    if (!expense) {
-      throw new NotFoundException(`Gasto no encontrado: ${expenseId}`);
-    }
-
-    if (expense.status !== 'DRAFT') {
-      throw new BadRequestException(
-        `Solo se pueden editar gastos en DRAFT. Estado actual: ${expense.status}`,
-      );
-    }
-
-    if (dto.categoryId && dto.categoryId !== expense.categoryId) {
-      const category = await this.prisma.expenseLedgerCategory.findFirst({
-        where: { id: dto.categoryId, tenantId, isActive: true },
+      const expense = await tx.expense.findFirst({
+        where: { id: expenseId, tenantId },
       });
-      if (!category) {
-        throw new NotFoundException(`Rubro de gasto no encontrado: ${dto.categoryId}`);
-      }
-    }
 
-    if (dto.vendorId !== undefined && dto.vendorId !== null) {
-      const vendor = await this.prisma.vendor.findFirst({
-        where: { id: dto.vendorId, tenantId },
+      if (!expense) {
+        throw new NotFoundException(`Gasto no encontrado: ${expenseId}`);
+      }
+
+      if (expense.status !== 'DRAFT') {
+        throw new BadRequestException(
+          `Solo se pueden editar gastos en DRAFT. Estado actual: ${expense.status}`,
+        );
+      }
+
+      const amountChanged = dto.amountMinor !== undefined && dto.amountMinor !== expense.amountMinor;
+      const currencyChanged = dto.currencyCode !== undefined && dto.currencyCode !== expense.currencyCode;
+      if (amountChanged || currencyChanged) {
+        const allocationCount = await tx.movementAllocation.count({
+          where: { tenantId, expenseId },
+        });
+        if (allocationCount > 0) {
+          throw new ConflictException(
+            'No se puede cambiar monto o moneda de un gasto con allocations. Reemplace las allocations explícitamente antes de editarlo.',
+          );
+        }
+      }
+
+      if (dto.categoryId && dto.categoryId !== expense.categoryId) {
+        const category = await tx.expenseLedgerCategory.findFirst({
+          where: { id: dto.categoryId, tenantId, isActive: true },
+        });
+        if (!category) {
+          throw new NotFoundException(`Rubro de gasto no encontrado: ${dto.categoryId}`);
+        }
+      }
+
+      if (dto.vendorId !== undefined && dto.vendorId !== null) {
+        const vendor = await tx.vendor.findFirst({
+          where: { id: dto.vendorId, tenantId },
+        });
+        if (!vendor) {
+          throw new NotFoundException(`Proveedor no encontrado: ${dto.vendorId}`);
+        }
+      }
+
+      const invoiceDate = dto.invoiceDate ? new Date(dto.invoiceDate) : expense.invoiceDate;
+      const liquidationPeriod = this.getAccountingPeriodFromInvoiceDate(invoiceDate);
+
+      if (expense.scopeType === 'BUILDING' && expense.buildingId) {
+        await this.assertBuildingPeriodIsOpen(tenantId, expense.buildingId, liquidationPeriod);
+      }
+
+      return tx.expense.update({
+        where: { id: expenseId },
+        data: {
+          amountMinor: dto.amountMinor ?? expense.amountMinor,
+          currencyCode: dto.currencyCode ?? expense.currencyCode,
+          invoiceDate,
+          period: liquidationPeriod,
+          liquidationPeriod,
+          categoryId: dto.categoryId ?? expense.categoryId,
+          vendorId: dto.vendorId !== undefined ? dto.vendorId : expense.vendorId,
+          description: dto.description !== undefined ? dto.description : expense.description,
+          attachmentFileKey:
+            dto.attachmentFileKey !== undefined
+              ? dto.attachmentFileKey
+              : expense.attachmentFileKey,
+        },
+        include: {
+          category: { select: { name: true } },
+          vendor: { select: { name: true } },
+        },
       });
-      if (!vendor) {
-        throw new NotFoundException(`Proveedor no encontrado: ${dto.vendorId}`);
-      }
-    }
-
-    const invoiceDate = dto.invoiceDate ? new Date(dto.invoiceDate) : expense.invoiceDate;
-    const liquidationPeriod = this.getAccountingPeriodFromInvoiceDate(invoiceDate);
-
-    if (expense.scopeType === 'BUILDING' && expense.buildingId) {
-      await this.assertBuildingPeriodIsOpen(tenantId, expense.buildingId, liquidationPeriod);
-    }
-
-    const updated = await this.prisma.expense.update({
-      where: { id: expenseId },
-      data: {
-        amountMinor: dto.amountMinor ?? expense.amountMinor,
-        currencyCode: dto.currencyCode ?? expense.currencyCode,
-        invoiceDate,
-        period: liquidationPeriod,
-        liquidationPeriod,
-        categoryId: dto.categoryId ?? expense.categoryId,
-        vendorId: dto.vendorId !== undefined ? dto.vendorId : expense.vendorId,
-        description: dto.description !== undefined ? dto.description : expense.description,
-        attachmentFileKey:
-          dto.attachmentFileKey !== undefined
-            ? dto.attachmentFileKey
-            : expense.attachmentFileKey,
-      },
-      include: {
-        category: { select: { name: true } },
-        vendor: { select: { name: true } },
-      },
     });
 
     void this.auditService.createLog({
@@ -552,26 +585,20 @@ export class ExpensesService {
       throw new ForbiddenException('Acceso denegado');
     }
 
-    const expense = await this.prisma.expense.findFirst({
-      where: { id: expenseId, tenantId },
+    const updated = await this.prisma.$transaction(async (tx) => {
+      await acquireExpenseLock(tx, tenantId, expenseId);
+      const expense = await tx.expense.findFirst({
+        where: { id: expenseId, tenantId },
+      });
+
+      if (!expense) {
+        throw new NotFoundException(`Gasto no encontrado: ${expenseId}`);
+      }
+
+      this.assertExpenseCanBeValidated(expense);
+      const conversionSnapshot = await this.buildExpenseConversionSnapshot(tenantId, expense);
+      return this.persistValidatedExpense(tx, expense, conversionSnapshot, membershipId);
     });
-
-    if (!expense) {
-      throw new NotFoundException(`Gasto no encontrado: ${expenseId}`);
-    }
-
-    this.assertExpenseCanBeValidated(expense);
-
-    const conversionSnapshot = await this.buildExpenseConversionSnapshot(
-      tenantId,
-      expense,
-    );
-
-    const updated = await this.persistValidatedExpense(
-      expense,
-      conversionSnapshot,
-      membershipId,
-    );
 
     void this.auditService.createLog({
       tenantId,
@@ -580,9 +607,9 @@ export class ExpensesService {
       entityType: 'Expense',
       entityId: expenseId,
       metadata: {
-        period: expense.period,
-        amountMinor: expense.amountMinor,
-        currencyCode: expense.currencyCode,
+        period: updated.period,
+        amountMinor: updated.amountMinor,
+        currencyCode: updated.currencyCode,
       },
     });
 
@@ -594,26 +621,20 @@ export class ExpensesService {
     expenseId: string,
     membershipId?: string,
   ): Promise<ExpenseResponseDto> {
-    const expense = await this.prisma.expense.findFirst({
-      where: { id: expenseId, tenantId },
+    const updated = await this.prisma.$transaction(async (tx) => {
+      await acquireExpenseLock(tx, tenantId, expenseId);
+      const expense = await tx.expense.findFirst({
+        where: { id: expenseId, tenantId },
+      });
+
+      if (!expense) {
+        throw new NotFoundException(`Gasto no encontrado: ${expenseId}`);
+      }
+
+      this.assertExpenseCanBeValidated(expense);
+      const conversionSnapshot = await this.buildExpenseConversionSnapshot(tenantId, expense);
+      return this.persistValidatedExpense(tx, expense, conversionSnapshot, membershipId ?? null);
     });
-
-    if (!expense) {
-      throw new NotFoundException(`Gasto no encontrado: ${expenseId}`);
-    }
-
-    this.assertExpenseCanBeValidated(expense);
-
-    const conversionSnapshot = await this.buildExpenseConversionSnapshot(
-      tenantId,
-      expense,
-    );
-
-    const updated = await this.persistValidatedExpense(
-      expense,
-      conversionSnapshot,
-      membershipId ?? null,
-    );
 
     void this.auditService.createLog({
       tenantId,
@@ -622,9 +643,9 @@ export class ExpensesService {
       entityType: 'Expense',
       entityId: expenseId,
       metadata: {
-        period: expense.period,
-        amountMinor: expense.amountMinor,
-        currencyCode: expense.currencyCode,
+        period: updated.period,
+        amountMinor: updated.amountMinor,
+        currencyCode: updated.currencyCode,
       },
     });
 

--- a/apps/api/src/finanzas/expenses.service.ts
+++ b/apps/api/src/finanzas/expenses.service.ts
@@ -134,6 +134,7 @@ export class ExpensesService {
   private async buildExpenseConversionSnapshot(
     tenantId: string,
     expense: { amountMinor: number; currencyCode: string; invoiceDate: Date },
+    db: PrismaService | Prisma.TransactionClient = this.prisma,
   ): Promise<{
     functionalAmountMinor: number;
     functionalCurrencyCode: string;
@@ -143,7 +144,7 @@ export class ExpensesService {
     exchangeRateEffectiveAt: Date | null;
     conversionDate: Date;
   }> {
-    const tenant = await this.prisma.tenant.findFirst({
+    const tenant = await db.tenant.findFirst({
       where: { id: tenantId },
       select: { id: true, functionalCurrency: true },
     });
@@ -162,7 +163,7 @@ export class ExpensesService {
         typeof this.currencyConversionService.convert
       >[0]['functionalCurrency'],
       conversionDate: this.toConversionDate(expense.invoiceDate),
-    });
+    }, db);
 
     return {
       functionalAmountMinor: result.functionalAmount,
@@ -196,8 +197,9 @@ export class ExpensesService {
     tenantId: string,
     buildingId: string,
     liquidationPeriod: string,
+    db: PrismaService | Prisma.TransactionClient = this.prisma,
   ): Promise<void> {
-    const publishedLiq = await this.prisma.liquidation.findFirst({
+    const publishedLiq = await db.liquidation.findFirst({
       where: {
         tenantId,
         buildingId,
@@ -454,6 +456,17 @@ export class ExpensesService {
       return created;
     });
 
+    if ((scopeType === 'TENANT_SHARED' || scopeType === 'UNIT_GROUP') && dto.allocations) {
+      void this.auditService.createLog({
+        tenantId,
+        actorMembershipId: membershipId,
+        action: 'EXPENSE_ALLOCATION_CREATE',
+        entityType: 'MovementAllocation',
+        entityId: expense.id,
+        metadata: { allocationCount: dto.allocations.length, totalAmount: dto.amountMinor },
+      });
+    }
+
     void this.auditService.createLog({
       tenantId,
       actorMembershipId: membershipId,
@@ -537,7 +550,7 @@ export class ExpensesService {
       const liquidationPeriod = this.getAccountingPeriodFromInvoiceDate(invoiceDate);
 
       if (expense.scopeType === 'BUILDING' && expense.buildingId) {
-        await this.assertBuildingPeriodIsOpen(tenantId, expense.buildingId, liquidationPeriod);
+        await this.assertBuildingPeriodIsOpen(tenantId, expense.buildingId, liquidationPeriod, tx);
       }
 
       return tx.expense.update({
@@ -596,7 +609,7 @@ export class ExpensesService {
       }
 
       this.assertExpenseCanBeValidated(expense);
-      const conversionSnapshot = await this.buildExpenseConversionSnapshot(tenantId, expense);
+      const conversionSnapshot = await this.buildExpenseConversionSnapshot(tenantId, expense, tx);
       return this.persistValidatedExpense(tx, expense, conversionSnapshot, membershipId);
     });
 
@@ -632,7 +645,7 @@ export class ExpensesService {
       }
 
       this.assertExpenseCanBeValidated(expense);
-      const conversionSnapshot = await this.buildExpenseConversionSnapshot(tenantId, expense);
+      const conversionSnapshot = await this.buildExpenseConversionSnapshot(tenantId, expense, tx);
       return this.persistValidatedExpense(tx, expense, conversionSnapshot, membershipId ?? null);
     });
 
@@ -662,29 +675,33 @@ export class ExpensesService {
       throw new ForbiddenException('Acceso denegado');
     }
 
-    const expense = await this.prisma.expense.findFirst({
-      where: { id: expenseId, tenantId },
-    });
+    const updated = await this.prisma.$transaction(async (tx) => {
+      await acquireExpenseLock(tx, tenantId, expenseId);
 
-    if (!expense) {
-      throw new NotFoundException(`Gasto no encontrado: ${expenseId}`);
-    }
+      const expense = await tx.expense.findFirst({
+        where: { id: expenseId, tenantId },
+      });
 
-    if (expense.status === 'VOID') {
-      throw new BadRequestException('El gasto ya está anulado');
-    }
+      if (!expense) {
+        throw new NotFoundException(`Gasto no encontrado: ${expenseId}`);
+      }
 
-    const updated = await this.prisma.expense.update({
-      where: { id: expenseId },
-      data: {
-        status: 'VOID',
-        voidedByMembershipId: membershipId,
-        voidedAt: new Date(),
-      },
-      include: {
-        category: { select: { name: true } },
-        vendor: { select: { name: true } },
-      },
+      if (expense.status === 'VOID') {
+        throw new BadRequestException('El gasto ya está anulado');
+      }
+
+      return tx.expense.update({
+        where: { id: expenseId },
+        data: {
+          status: 'VOID',
+          voidedByMembershipId: membershipId,
+          voidedAt: new Date(),
+        },
+        include: {
+          category: { select: { name: true } },
+          vendor: { select: { name: true } },
+        },
+      });
     });
 
     void this.auditService.createLog({
@@ -693,7 +710,7 @@ export class ExpensesService {
       action: 'EXPENSE_VOID',
       entityType: 'Expense',
       entityId: expenseId,
-      metadata: { period: expense.period, reason: 'void requested by admin' },
+      metadata: { period: updated.period, reason: 'void requested by admin' },
     });
 
     return this.toDto(updated);

--- a/apps/api/src/finanzas/expenses.tenant-shared-functional.spec.ts
+++ b/apps/api/src/finanzas/expenses.tenant-shared-functional.spec.ts
@@ -48,6 +48,7 @@ describe('ExpensesService TENANT_SHARED functional allocation', () => {
     allocationUpdates = [];
 
     const prismaValue = {
+      $executeRaw: jest.fn().mockResolvedValue(1),
       expense: {
         findFirst: jest.fn(),
         update: jest.fn(),
@@ -87,7 +88,11 @@ describe('ExpensesService TENANT_SHARED functional allocation', () => {
         },
         {
           provide: MovementAllocationService,
-          useValue: { createForExpense: jest.fn() },
+          useValue: {
+            validateAllocations: jest.fn(),
+            createForExpense: jest.fn(),
+            createForExpenseInTx: jest.fn(),
+          },
         },
         {
           provide: CurrencyConversionService,
@@ -190,6 +195,6 @@ describe('ExpensesService TENANT_SHARED functional allocation', () => {
 
     expect(prisma.movementAllocation.findMany).not.toHaveBeenCalled();
     expect(prisma.movementAllocation.update).not.toHaveBeenCalled();
-    expect(prisma.$transaction).not.toHaveBeenCalled();
+    expect(prisma.$transaction).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/finanzas/incomes.multicurrency.spec.ts
+++ b/apps/api/src/finanzas/incomes.multicurrency.spec.ts
@@ -64,6 +64,8 @@ describe('IncomesService multicurrency snapshot', () => {
     exchangeRateFindFirst = jest.fn();
 
     const prismaValue = {
+      $transaction: jest.fn(),
+      $executeRaw: jest.fn().mockResolvedValue(1),
       income: {
         findFirst: jest.fn(),
         findMany: jest.fn(),
@@ -78,7 +80,11 @@ describe('IncomesService multicurrency snapshot', () => {
       exchangeRate: { findFirst: exchangeRateFindFirst },
       expenseLedgerCategory: { findFirst: jest.fn() },
       unitGroup: { findFirst: jest.fn() },
+      movementAllocation: { count: jest.fn().mockResolvedValue(0) },
     };
+    prismaValue.$transaction.mockImplementation(
+      async (callback: (tx: typeof prismaValue) => unknown) => callback(prismaValue),
+    );
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/apps/api/src/finanzas/incomes.service.ts
+++ b/apps/api/src/finanzas/incomes.service.ts
@@ -5,7 +5,7 @@ import {
   NotFoundException,
   ForbiddenException,
 } from '@nestjs/common';
-import { FundStatus, FundTransactionDirection, IncomeStatus } from '@prisma/client';
+import { FundStatus, FundTransactionDirection, IncomeStatus, Prisma } from '@prisma/client';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
 import { FinanzasValidators } from './finanzas.validators';
@@ -186,6 +186,17 @@ export class IncomesService {
       return created;
     });
 
+    if ((scopeType === 'TENANT_SHARED' || scopeType === 'UNIT_GROUP') && dto.allocations) {
+      void this.auditService.createLog({
+        tenantId,
+        actorMembershipId: membershipId,
+        action: 'INCOME_ALLOCATION_CREATE',
+        entityType: 'MovementAllocation',
+        entityId: income.id,
+        metadata: { allocationCount: dto.allocations.length, totalAmount: dto.amountMinor },
+      });
+    }
+
     void this.auditService.createLog({
       tenantId,
       actorMembershipId: membershipId,
@@ -305,6 +316,7 @@ export class IncomesService {
   private async buildIncomeConversionSnapshot(
     tenantId: string,
     income: { amountMinor: number; currencyCode: string; receivedDate: Date },
+    db: PrismaService | Prisma.TransactionClient = this.prisma,
   ): Promise<{
     functionalAmountMinor: number;
     functionalCurrencyCode: string;
@@ -314,7 +326,7 @@ export class IncomesService {
     exchangeRateEffectiveAt: Date | null;
     conversionDate: Date;
   }> {
-    const tenant = await this.prisma.tenant.findFirst({
+    const tenant = await db.tenant.findFirst({
       where: { id: tenantId },
       select: { id: true, functionalCurrency: true },
     });
@@ -333,7 +345,7 @@ export class IncomesService {
         typeof this.currencyConversionService.convert
       >[0]['functionalCurrency'],
       conversionDate: this.toConversionDate(income.receivedDate),
-    });
+    }, db);
 
     return {
       functionalAmountMinor: result.functionalAmount,
@@ -373,7 +385,7 @@ export class IncomesService {
         );
       }
 
-      const conversionSnapshot = await this.buildIncomeConversionSnapshot(tenantId, income);
+      const conversionSnapshot = await this.buildIncomeConversionSnapshot(tenantId, income, tx);
       return tx.income.update({
         where: { id: incomeId },
         data: {

--- a/apps/api/src/finanzas/incomes.service.ts
+++ b/apps/api/src/finanzas/incomes.service.ts
@@ -142,37 +142,49 @@ export class IncomesService {
       }
     }
 
-    const income = await this.prisma.income.create({
-      data: {
-        tenantId,
-        buildingId: dto.buildingId ?? null,
-        period: dto.period,
-        categoryId: dto.categoryId,
-        amountMinor: dto.amountMinor,
-        currencyCode: dto.currencyCode,
-        receivedDate: new Date(dto.receivedDate),
-        description: dto.description || null,
-        attachmentFileKey: dto.attachmentFileKey || null,
-        scopeType,
-        destination,
-        unitGroupId: dto.unitGroupId ?? null,
-        status: 'DRAFT',
-        createdByMembershipId: membershipId,
-      },
-      include: { category: true },
-    });
-
-    // Crear allocations si es TENANT_SHARED o UNIT_GROUP
     if ((scopeType === 'TENANT_SHARED' || scopeType === 'UNIT_GROUP') && dto.allocations) {
-      await this.movementAllocationService.createForIncome(
+      await this.movementAllocationService.validateAllocations(
         tenantId,
-        income.id,
+        dto.allocations,
         dto.amountMinor,
         dto.currencyCode,
-        dto.allocations,
-        membershipId,
       );
     }
+
+    const income = await this.prisma.$transaction(async (tx) => {
+      const created = await tx.income.create({
+        data: {
+          tenantId,
+          buildingId: dto.buildingId ?? null,
+          period: dto.period,
+          categoryId: dto.categoryId,
+          amountMinor: dto.amountMinor,
+          currencyCode: dto.currencyCode,
+          receivedDate: new Date(dto.receivedDate),
+          description: dto.description || null,
+          attachmentFileKey: dto.attachmentFileKey || null,
+          scopeType,
+          destination,
+          unitGroupId: dto.unitGroupId ?? null,
+          status: 'DRAFT',
+          createdByMembershipId: membershipId,
+        },
+        include: { category: true },
+      });
+
+      if ((scopeType === 'TENANT_SHARED' || scopeType === 'UNIT_GROUP') && dto.allocations) {
+        await this.movementAllocationService.createForIncomeInTx(
+          tx,
+          tenantId,
+          created.id,
+          dto.amountMinor,
+          dto.currencyCode,
+          dto.allocations,
+        );
+      }
+
+      return created;
+    });
 
     void this.auditService.createLog({
       tenantId,
@@ -204,55 +216,71 @@ export class IncomesService {
       throw new ForbiddenException('Solo administradores pueden editar ingresos');
     }
 
-    const income = await this.prisma.income.findFirst({
-      where: { id: incomeId, tenantId },
-      include: { category: true },
-    });
-
-    if (!income) {
-      throw new NotFoundException(`Ingreso no encontrado: ${incomeId}`);
-    }
-
-    if (income.status !== 'DRAFT') {
-      throw new BadRequestException(
-        `Solo se pueden editar ingresos en DRAFT. Estado actual: ${income.status}`,
-      );
-    }
-
-    // If changing category, validate it's INCOME type
-    if (dto.categoryId && dto.categoryId !== income.categoryId) {
-      const newCategory = await this.prisma.expenseLedgerCategory.findFirst({
-        where: { id: dto.categoryId, tenantId },
+    const updated = await this.prisma.$transaction(async (tx) => {
+      await acquireIncomeLock(tx, tenantId, incomeId);
+      const income = await tx.income.findFirst({
+        where: { id: incomeId, tenantId },
+        include: { category: true },
       });
 
-      if (!newCategory) {
-        throw new NotFoundException(`Rubro no encontrado: ${dto.categoryId}`);
+      if (!income) {
+        throw new NotFoundException(`Ingreso no encontrado: ${incomeId}`);
       }
 
-      if (newCategory.movementType !== 'INCOME') {
+      if (income.status !== 'DRAFT') {
         throw new BadRequestException(
-          `El rubro "${newCategory.name}" no es de tipo INGRESO`,
+          `Solo se pueden editar ingresos en DRAFT. Estado actual: ${income.status}`,
         );
       }
-    }
 
-    const updated = await this.prisma.income.update({
-      where: { id: incomeId },
-      data: {
-        amountMinor: dto.amountMinor ?? income.amountMinor,
-        currencyCode: dto.currencyCode ?? income.currencyCode,
-        receivedDate: dto.receivedDate
-          ? new Date(dto.receivedDate)
-          : income.receivedDate,
-        categoryId: dto.categoryId ?? income.categoryId,
-        description:
-          dto.description !== undefined ? dto.description : income.description,
-        attachmentFileKey:
-          dto.attachmentFileKey !== undefined
-            ? dto.attachmentFileKey
-            : income.attachmentFileKey,
-      },
-      include: { category: true },
+      const amountChanged = dto.amountMinor !== undefined && dto.amountMinor !== income.amountMinor;
+      const currencyChanged = dto.currencyCode !== undefined && dto.currencyCode !== income.currencyCode;
+      if (amountChanged || currencyChanged) {
+        const allocationCount = await tx.movementAllocation.count({
+          where: { tenantId, incomeId },
+        });
+        if (allocationCount > 0) {
+          throw new ConflictException(
+            'No se puede cambiar monto o moneda de un ingreso con allocations. Reemplace las allocations explícitamente antes de editarlo.',
+          );
+        }
+      }
+
+      // If changing category, validate it's INCOME type
+      if (dto.categoryId && dto.categoryId !== income.categoryId) {
+        const newCategory = await tx.expenseLedgerCategory.findFirst({
+          where: { id: dto.categoryId, tenantId },
+        });
+
+        if (!newCategory) {
+          throw new NotFoundException(`Rubro no encontrado: ${dto.categoryId}`);
+        }
+
+        if (newCategory.movementType !== 'INCOME') {
+          throw new BadRequestException(
+            `El rubro "${newCategory.name}" no es de tipo INGRESO`,
+          );
+        }
+      }
+
+      return tx.income.update({
+        where: { id: incomeId },
+        data: {
+          amountMinor: dto.amountMinor ?? income.amountMinor,
+          currencyCode: dto.currencyCode ?? income.currencyCode,
+          receivedDate: dto.receivedDate
+            ? new Date(dto.receivedDate)
+            : income.receivedDate,
+          categoryId: dto.categoryId ?? income.categoryId,
+          description:
+            dto.description !== undefined ? dto.description : income.description,
+          attachmentFileKey:
+            dto.attachmentFileKey !== undefined
+              ? dto.attachmentFileKey
+              : income.attachmentFileKey,
+        },
+        include: { category: true },
+      });
     });
 
     void this.auditService.createLog({
@@ -328,41 +356,40 @@ export class IncomesService {
       throw new ForbiddenException('Solo administradores pueden registrar ingresos');
     }
 
-    const income = await this.prisma.income.findFirst({
-      where: { id: incomeId, tenantId },
-      include: { category: true },
-    });
+    const updated = await this.prisma.$transaction(async (tx) => {
+      await acquireIncomeLock(tx, tenantId, incomeId);
+      const income = await tx.income.findFirst({
+        where: { id: incomeId, tenantId },
+        include: { category: true },
+      });
 
-    if (!income) {
-      throw new NotFoundException(`Ingreso no encontrado: ${incomeId}`);
-    }
+      if (!income) {
+        throw new NotFoundException(`Ingreso no encontrado: ${incomeId}`);
+      }
 
-    if (income.status !== 'DRAFT') {
-      throw new BadRequestException(
-        `No se puede registrar un ingreso en estado ${income.status}`,
-      );
-    }
+      if (income.status !== 'DRAFT') {
+        throw new BadRequestException(
+          `No se puede registrar un ingreso en estado ${income.status}`,
+        );
+      }
 
-    const conversionSnapshot = await this.buildIncomeConversionSnapshot(
-      tenantId,
-      income,
-    );
-
-    const updated = await this.prisma.income.update({
-      where: { id: incomeId },
-      data: {
-        status: 'RECORDED',
-        recordedByMembershipId: membershipId,
-        recordedAt: new Date(),
-        functionalAmountMinor: conversionSnapshot.functionalAmountMinor,
-        functionalCurrencyCode: conversionSnapshot.functionalCurrencyCode,
-        exchangeRateId: conversionSnapshot.exchangeRateId,
-        exchangeRateValue: conversionSnapshot.exchangeRateValue,
-        exchangeRateDirection: conversionSnapshot.exchangeRateDirection,
-        exchangeRateEffectiveAt: conversionSnapshot.exchangeRateEffectiveAt,
-        conversionDate: conversionSnapshot.conversionDate,
-      },
-      include: { category: true },
+      const conversionSnapshot = await this.buildIncomeConversionSnapshot(tenantId, income);
+      return tx.income.update({
+        where: { id: incomeId },
+        data: {
+          status: 'RECORDED',
+          recordedByMembershipId: membershipId,
+          recordedAt: new Date(),
+          functionalAmountMinor: conversionSnapshot.functionalAmountMinor,
+          functionalCurrencyCode: conversionSnapshot.functionalCurrencyCode,
+          exchangeRateId: conversionSnapshot.exchangeRateId,
+          exchangeRateValue: conversionSnapshot.exchangeRateValue,
+          exchangeRateDirection: conversionSnapshot.exchangeRateDirection,
+          exchangeRateEffectiveAt: conversionSnapshot.exchangeRateEffectiveAt,
+          conversionDate: conversionSnapshot.conversionDate,
+        },
+        include: { category: true },
+      });
     });
 
     void this.auditService.createLog({
@@ -371,7 +398,7 @@ export class IncomesService {
       action: 'INCOME_RECORD',
       entityType: 'Income',
       entityId: incomeId,
-      metadata: { previousStatus: income.status, newStatus: 'RECORDED' },
+      metadata: { previousStatus: 'DRAFT', newStatus: updated.status },
     });
 
     return this.toDto(updated);

--- a/apps/api/src/finanzas/movement-allocation.service.spec.ts
+++ b/apps/api/src/finanzas/movement-allocation.service.spec.ts
@@ -2,7 +2,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuditService } from '../audit/audit.service';
-import { MovementAllocationService } from './movement-allocation.service';
+import {
+  CreateAllocationInput,
+  MovementAllocationService,
+} from './movement-allocation.service';
 import { FinanzasValidators } from './finanzas.validators';
 
 describe('MovementAllocationService', () => {
@@ -51,6 +54,21 @@ describe('MovementAllocationService', () => {
   });
 
   describe('validateAllocations', () => {
+    const buildings = [
+      { id: 'building-1', name: 'Edificio A' },
+      { id: 'building-2', name: 'Edificio B' },
+    ];
+
+    async function expectInvalidAllocations(
+      allocations: CreateAllocationInput[],
+    ): Promise<void> {
+      jest.spyOn(prisma.building, 'findMany').mockResolvedValue(buildings as any);
+
+      await expect(
+        service.validateAllocations(tenantId, allocations, 100000, 'ARS'),
+      ).rejects.toThrow(BadRequestException);
+    }
+
     it('debería validar allocations por porcentaje sumando 100%', async () => {
       const buildings = [
         { id: 'building-1', name: 'Edificio A' },
@@ -161,6 +179,47 @@ describe('MovementAllocationService', () => {
           'ARS',
         ),
       ).resolves.not.toThrow();
+    });
+
+    it('debería rechazar una lista de porcentajes incompleta', async () => {
+      await expectInvalidAllocations([
+        { buildingId: 'building-1', percentage: 100 },
+        { buildingId: 'building-2' },
+      ]);
+    });
+
+    it('debería rechazar una lista de montos incompleta', async () => {
+      await expectInvalidAllocations([
+        { buildingId: 'building-1', amountMinor: 100000 },
+        { buildingId: 'building-2' },
+      ]);
+    });
+
+    it('debería rechazar una allocation con ambos discriminadores', async () => {
+      await expectInvalidAllocations([
+        { buildingId: 'building-1', percentage: 100, amountMinor: 100000 },
+      ]);
+    });
+
+    it('debería rechazar una allocation sin discriminador', async () => {
+      await expectInvalidAllocations([
+        { buildingId: 'building-1' },
+        { buildingId: 'building-2' },
+      ]);
+    });
+
+    it('debería rechazar porcentajes explícitos que producen una allocation cero', async () => {
+      await expectInvalidAllocations([
+        { buildingId: 'building-1', percentage: 0 },
+        { buildingId: 'building-2', percentage: 100 },
+      ]);
+    });
+
+    it('debería rechazar montos explícitos cero', async () => {
+      await expectInvalidAllocations([
+        { buildingId: 'building-1', amountMinor: 0 },
+        { buildingId: 'building-2', amountMinor: 100000 },
+      ]);
     });
 
     it('debería lanzar error si montos no suman exacto', async () => {

--- a/apps/api/src/finanzas/movement-allocation.service.ts
+++ b/apps/api/src/finanzas/movement-allocation.service.ts
@@ -16,6 +16,8 @@ export interface CreateAllocationInput {
   currencyCode?: string;
 }
 
+type AllocationDbClient = PrismaService | Prisma.TransactionClient;
+
 type MovementAllocationWithBuilding = Prisma.MovementAllocationGetPayload<{
   include: {
     building: {
@@ -260,19 +262,12 @@ export class MovementAllocationService {
   ): Promise<void> {
     await this.validateAllocations(tenantId, allocations, amountMinor, currencyCode);
 
-    const allocatedAmounts = allocations.some((alloc) => alloc.percentage !== undefined && alloc.percentage !== null)
-      ? allocateByLargestRemainder(amountMinor, allocations)
-      : allocations.map((alloc) => alloc.amountMinor!);
-
-    await this.prisma.movementAllocation.createMany({
-      data: allocations.map((alloc, index) => ({
-        tenantId,
-        expenseId,
-        buildingId: alloc.buildingId,
-        percentage: alloc.percentage ?? null,
-        amountMinor: allocatedAmounts[index],
-        currencyCode,
-      })),
+    await this.createForMovement(this.prisma, {
+      tenantId,
+      expenseId,
+      amountMinor,
+      currencyCode,
+      allocations,
     });
 
     // Audit
@@ -299,19 +294,12 @@ export class MovementAllocationService {
     currencyCode: string,
     allocations: CreateAllocationInput[],
   ): Promise<void> {
-    const allocatedAmounts = allocations.some((alloc) => alloc.percentage !== undefined && alloc.percentage !== null)
-      ? allocateByLargestRemainder(amountMinor, allocations)
-      : allocations.map((alloc) => alloc.amountMinor!);
-
-    await tx.movementAllocation.createMany({
-      data: allocations.map((alloc, index) => ({
-        tenantId,
-        expenseId,
-        buildingId: alloc.buildingId,
-        percentage: alloc.percentage ?? null,
-        amountMinor: allocatedAmounts[index],
-        currencyCode,
-      })),
+    await this.createForMovement(tx, {
+      tenantId,
+      expenseId,
+      amountMinor,
+      currencyCode,
+      allocations,
     });
   }
 
@@ -328,19 +316,12 @@ export class MovementAllocationService {
   ): Promise<void> {
     await this.validateAllocations(tenantId, allocations, amountMinor, currencyCode);
 
-    const allocatedAmounts = allocations.some((alloc) => alloc.percentage !== undefined && alloc.percentage !== null)
-      ? allocateByLargestRemainder(amountMinor, allocations)
-      : allocations.map((alloc) => alloc.amountMinor!);
-
-    await this.prisma.movementAllocation.createMany({
-      data: allocations.map((alloc, index) => ({
-        tenantId,
-        incomeId,
-        buildingId: alloc.buildingId,
-        percentage: alloc.percentage ?? null,
-        amountMinor: allocatedAmounts[index],
-        currencyCode,
-      })),
+    await this.createForMovement(this.prisma, {
+      tenantId,
+      incomeId,
+      amountMinor,
+      currencyCode,
+      allocations,
     });
 
     void this.auditService.createLog({
@@ -350,6 +331,54 @@ export class MovementAllocationService {
       entityType: 'MovementAllocation',
       entityId: incomeId,
       metadata: { allocationCount: allocations.length, totalAmount: amountMinor },
+    });
+  }
+
+  /** Persist a fully validated allocation set using the caller's transaction client. */
+  async createForIncomeInTx(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    incomeId: string,
+    amountMinor: number,
+    currencyCode: string,
+    allocations: CreateAllocationInput[],
+  ): Promise<void> {
+    await this.createForMovement(tx, {
+      tenantId,
+      incomeId,
+      amountMinor,
+      currencyCode,
+      allocations,
+    });
+  }
+
+  private async createForMovement(
+    client: AllocationDbClient,
+    input: {
+      tenantId: string;
+      expenseId?: string;
+      incomeId?: string;
+      amountMinor: number;
+      currencyCode: string;
+      allocations: CreateAllocationInput[];
+    },
+  ): Promise<void> {
+    const allocatedAmounts = input.allocations.some(
+      (allocation) => allocation.percentage !== undefined && allocation.percentage !== null,
+    )
+      ? allocateByLargestRemainder(input.amountMinor, input.allocations)
+      : input.allocations.map((allocation) => allocation.amountMinor!);
+
+    await client.movementAllocation.createMany({
+      data: input.allocations.map((allocation, index) => ({
+        tenantId: input.tenantId,
+        expenseId: input.expenseId,
+        incomeId: input.incomeId,
+        buildingId: allocation.buildingId,
+        percentage: allocation.percentage ?? null,
+        amountMinor: allocatedAmounts[index],
+        currencyCode: input.currencyCode,
+      })),
     });
   }
 

--- a/apps/api/src/finanzas/movement-allocation.service.ts
+++ b/apps/api/src/finanzas/movement-allocation.service.ts
@@ -17,6 +17,7 @@ export interface CreateAllocationInput {
 }
 
 type AllocationDbClient = PrismaService | Prisma.TransactionClient;
+type AllocationMode = 'PERCENTAGE' | 'AMOUNT';
 
 type MovementAllocationWithBuilding = Prisma.MovementAllocationGetPayload<{
   include: {
@@ -32,6 +33,47 @@ type MovementAllocationWithBuilding = Prisma.MovementAllocationGetPayload<{
 const PERCENTAGE_SCALE = 10_000;
 const TOTAL_PERCENTAGE_BASIS_POINTS = 100 * PERCENTAGE_SCALE;
 
+function getHomogeneousAllocationMode(
+  allocations: readonly CreateAllocationInput[],
+): AllocationMode {
+  const modes = allocations.map((allocation, index): AllocationMode => {
+    const hasPercentage = allocation.percentage !== null && allocation.percentage !== undefined;
+    const hasAmount = allocation.amountMinor !== null && allocation.amountMinor !== undefined;
+
+    if (hasPercentage === hasAmount) {
+      throw new BadRequestException(
+        `La allocation ${index} debe tener exactamente uno de percentage o amountMinor`,
+      );
+    }
+
+    return hasPercentage ? 'PERCENTAGE' : 'AMOUNT';
+  });
+
+  const mode = modes[0];
+  if (!mode || modes.some((allocationMode) => allocationMode !== mode)) {
+    throw new BadRequestException(
+      'Todas las allocations deben usar el mismo modo: percentage o amountMinor',
+    );
+  }
+
+  return mode;
+}
+
+function requirePositivePersistedAmounts(
+  amounts: readonly (number | null | undefined)[],
+): number[] {
+  const validAmounts: number[] = [];
+  for (const amount of amounts) {
+    if (typeof amount !== 'number' || !Number.isSafeInteger(amount) || amount <= 0) {
+      throw new BadRequestException(
+        'Las allocations deben producir importes enteros positivos',
+      );
+    }
+    validAmounts.push(amount);
+  }
+  return validAmounts;
+}
+
 export function toBasisPoints(percentage: number): number {
   return Math.round(percentage * PERCENTAGE_SCALE);
 }
@@ -41,7 +83,13 @@ export function allocateByLargestRemainder(
   allocations: CreateAllocationInput[],
 ): number[] {
   const exactAllocations = allocations.map((allocation, index) => {
-    const basisPoints = toBasisPoints(allocation.percentage ?? 0);
+    const percentage = allocation.percentage;
+    if (percentage === null || percentage === undefined) {
+      throw new BadRequestException(
+        `La allocation ${index} debe tener percentage para distribuir por porcentaje`,
+      );
+    }
+    const basisPoints = toBasisPoints(percentage);
     const numerator = totalAmountMinor * basisPoints;
     const amountMinor = Math.floor(numerator / TOTAL_PERCENTAGE_BASIS_POINTS);
 
@@ -196,28 +244,26 @@ export class MovementAllocationService {
       );
     }
 
-    // Detectar modo: % o montos
-    const hasPercentages = allocations.some((a) => a.percentage !== null && a.percentage !== undefined);
-    const hasAmounts = allocations.some((a) => a.amountMinor !== null && a.amountMinor !== undefined);
+    const allocationMode = getHomogeneousAllocationMode(allocations);
 
-    if (hasPercentages && hasAmounts) {
-      throw new BadRequestException(
-        'No puedes mezclar allocations por % y por monto',
-      );
-    }
-
-    if (hasPercentages) {
-      for (const alloc of allocations) {
-        const percentage = alloc.percentage ?? 0;
-        if (!Number.isFinite(percentage) || percentage < 0 || percentage > 100) {
+    if (allocationMode === 'PERCENTAGE') {
+      const percentages = allocations.map((alloc) => {
+        const percentage = alloc.percentage;
+        if (
+          typeof percentage !== 'number' ||
+          !Number.isFinite(percentage) ||
+          percentage < 0 ||
+          percentage > 100
+        ) {
           throw new BadRequestException(
             `Porcentaje inválido para buildingId ${alloc.buildingId}: ${percentage}`,
           );
         }
-      }
+        return percentage;
+      });
 
-      const totalPercentageBasisPoints = allocations.reduce(
-        (sum, a) => sum + toBasisPoints(a.percentage ?? 0),
+      const totalPercentageBasisPoints = percentages.reduce(
+        (sum, percentage) => sum + toBasisPoints(percentage),
         0,
       );
 
@@ -226,7 +272,10 @@ export class MovementAllocationService {
           `Los porcentajes deben sumar 100%, sumaron: ${totalPercentageBasisPoints / PERCENTAGE_SCALE}%`,
         );
       }
-    } else if (hasAmounts) {
+      requirePositivePersistedAmounts(
+        allocateByLargestRemainder(parentAmount, allocations),
+      );
+    } else {
       // Verificar que todas las allocations tengan currencyCode = parentCurrency
       for (const alloc of allocations) {
         if (alloc.currencyCode && alloc.currencyCode !== parentCurrency) {
@@ -236,16 +285,14 @@ export class MovementAllocationService {
         }
       }
 
-      const totalAmount = allocations.reduce((sum, a) => sum + (a.amountMinor ?? 0), 0);
+      const amounts = allocations.map((allocation) => allocation.amountMinor);
+      const validAmounts = requirePositivePersistedAmounts(amounts);
+      const totalAmount = validAmounts.reduce((sum, amount) => sum + amount, 0);
       if (totalAmount !== parentAmount) {
         throw new BadRequestException(
           `Los montos deben sumar exactamente ${parentAmount}, sumaron: ${totalAmount}`,
         );
       }
-    } else {
-      throw new BadRequestException(
-        'Cada allocation debe tener percentage o amountMinor',
-      );
     }
   }
 
@@ -363,11 +410,11 @@ export class MovementAllocationService {
       allocations: CreateAllocationInput[];
     },
   ): Promise<void> {
-    const allocatedAmounts = input.allocations.some(
-      (allocation) => allocation.percentage !== undefined && allocation.percentage !== null,
-    )
+    const allocationMode = getHomogeneousAllocationMode(input.allocations);
+    const allocatedAmounts = allocationMode === 'PERCENTAGE'
       ? allocateByLargestRemainder(input.amountMinor, input.allocations)
-      : input.allocations.map((allocation) => allocation.amountMinor!);
+      : input.allocations.map((allocation) => allocation.amountMinor);
+    const validAmounts = requirePositivePersistedAmounts(allocatedAmounts);
 
     await client.movementAllocation.createMany({
       data: input.allocations.map((allocation, index) => ({
@@ -376,7 +423,7 @@ export class MovementAllocationService {
         incomeId: input.incomeId,
         buildingId: allocation.buildingId,
         percentage: allocation.percentage ?? null,
-        amountMinor: allocatedAmounts[index],
+        amountMinor: validAmounts[index],
         currencyCode: input.currencyCode,
       })),
     });

--- a/apps/api/src/finanzas/movement-locks.ts
+++ b/apps/api/src/finanzas/movement-locks.ts
@@ -1,0 +1,15 @@
+import { Prisma } from '@prisma/client';
+
+const EXPENSE_LOCK_NAMESPACE = 'buildingos:expense-movement:v1';
+
+/** Serialize lifecycle mutations for one Expense. */
+export async function acquireExpenseLock(
+  tx: Prisma.TransactionClient,
+  tenantId: string,
+  expenseId: string,
+): Promise<void> {
+  const lockKey = `${EXPENSE_LOCK_NAMESPACE}:${tenantId}:${expenseId}`;
+  await tx.$executeRaw(
+    Prisma.sql`SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`,
+  );
+}

--- a/apps/api/src/finanzas/movement-locks.ts
+++ b/apps/api/src/finanzas/movement-locks.ts
@@ -2,7 +2,12 @@ import { Prisma } from '@prisma/client';
 
 const EXPENSE_LOCK_NAMESPACE = 'buildingos:expense-movement:v1';
 
-/** Serialize lifecycle mutations for one Expense. */
+/**
+ * Serialize lifecycle mutations for one Expense.
+ *
+ * Lifecycle order is always: expense lock, authoritative reads, then writes;
+ * no second lifecycle lock is acquired by these paths.
+ */
 export async function acquireExpenseLock(
   tx: Prisma.TransactionClient,
   tenantId: string,


### PR DESCRIPTION
## Summary

- makes Expense parent + MovementAllocation creation atomic
- makes Income parent + MovementAllocation creation atomic
- prevents allocated DRAFT amount/currency changes from leaving stale allocations
- serializes Expense update/validate/void lifecycle
- serializes Income update/record lifecycle
- keeps transition-dependent DB access on the active transaction client
- restores allocation audit behavior after successful commit
- hardens MovementAllocation validation to require complete homogeneous allocation mode
- rejects zero persisted allocations
- adds deterministic PostgreSQL concurrency coverage

## Financial invariants

- integer minor units remain authoritative
- allocations conserve the exact parent amount
- no mixed percentage/amount allocation mode
- no incomplete allocation rows
- no zero persisted MovementAllocation
- no live FX introduced
- historical snapshots are not reinterpreted
- transaction failure leaves no partial parent/allocation graph

## Validation

- focused tests: 171/171 PASS
- PostgreSQL lifecycle/concurrency: 11/11 PASS
- repeated PostgreSQL race runs: 110/110 PASS
- Finance regression: 1410 PASS, 184 skipped
- API typecheck: PASS
- API lint: PASS
- Prisma validate: PASS
- API build: PASS
- full build:ci: PASS
- git diff --check: PASS

## Scope

- no schema changes
- no migrations
- no dependency manifest changes
- no historical PaymentAuditLog repair
- no historical receipt repair
- no staging mutation
- no production mutation

## Review history

The candidate completed multiple independent review gates.

Final gate:

P0: 0
P1: 0
P2: 0
P3: 0