### PR TITLE
fix(finance): make payment receipt recovery idempotent

### DIFF
--- a/apps/api/src/common/payment-linked-document-lock.ts
+++ b/apps/api/src/common/payment-linked-document-lock.ts
@@ -11,6 +11,10 @@ function buildPaymentReceiptLockKey(paymentId: string): string {
   return `payment-receipt:${paymentId}`;
 }
 
+function buildReceiptSequenceLockKey(tenantId: string, year: number): string {
+  return `payment-receipt-sequence:${tenantId}:${year}`;
+}
+
 export async function acquirePaymentLinkedDocumentLock(
   tx: AdvisoryLockTransactionClient,
   tenantId: string,
@@ -49,6 +53,15 @@ export async function acquirePaymentReceiptLock(
   paymentId: string,
 ): Promise<void> {
   const lockKey = buildPaymentReceiptLockKey(paymentId);
+  await runAdvisoryLock(tx, lockKey);
+}
+
+export async function acquireReceiptSequenceLock(
+  tx: AdvisoryLockTransactionClient,
+  tenantId: string,
+  year: number,
+): Promise<void> {
+  const lockKey = buildReceiptSequenceLockKey(tenantId, year);
   await runAdvisoryLock(tx, lockKey);
 }
 

--- a/apps/api/src/finanzas/finanzas.service.ts
+++ b/apps/api/src/finanzas/finanzas.service.ts
@@ -4061,7 +4061,7 @@ export class FinanzasService {
   }
 
   /**
-   * Retry generating receipt for an approved payment (if previous attempt failed)
+   * Retry generating receipt for an eligible payment (if previous attempt failed)
    */
   async retryReceiptGeneration(
     tenantId: string,
@@ -4081,29 +4081,24 @@ export class FinanzasService {
       throw new NotFoundException('Payment not found');
     }
 
-    if (payment.status !== PaymentStatus.APPROVED) {
-      throw new BadRequestException('Can only retry receipt generation for approved payments');
+    if (
+      payment.canceledAt ||
+      (payment.status !== PaymentStatus.APPROVED &&
+        payment.status !== PaymentStatus.RECONCILED)
+    ) {
+      throw new BadRequestException(
+        'Can only retry receipt generation for approved or reconciled payments',
+      );
     }
 
-    // Only retry if failed or no receipt exists
-    if (payment.receiptStatus !== ReceiptStatus.FAILED && payment.receiptNumber) {
-      return {
-        success: true,
-        receiptNumber: payment.receiptNumber,
-      };
-    }
-
-    // Reset to PENDING before retry
-    await this.prisma.payment.update({
-      where: { id: paymentId },
-      data: {
-        receiptStatus: ReceiptStatus.PENDING,
-        receiptError: null,
-      },
-    });
-
-    // Try to generate receipt
-    const result = await this.receiptService.ensureReceiptForPayment(tenantId, paymentId, excludeUserId);
+    // Receipt preparation owns classification, number reuse, and state reset
+    // under the canonical per-payment lock. Do not infer completeness from a
+    // receipt number or reset state before inspecting linked artifacts.
+    const result = await this.receiptService.ensureReceiptForPayment(
+      tenantId,
+      paymentId,
+      excludeUserId,
+    );
 
     if (result) {
       return {
@@ -4113,8 +4108,8 @@ export class FinanzasService {
     }
 
     // Check for error
-    const updatedPayment = await this.prisma.payment.findUnique({
-      where: { id: paymentId },
+    const updatedPayment = await this.prisma.payment.findFirst({
+      where: { id: paymentId, tenantId },
       select: { receiptError: true },
     });
 

--- a/apps/api/src/finanzas/receipt-retry-idempotency.spec.ts
+++ b/apps/api/src/finanzas/receipt-retry-idempotency.spec.ts
@@ -1,0 +1,121 @@
+import { BadRequestException } from '@nestjs/common';
+import { PaymentStatus, ReceiptStatus } from '@prisma/client';
+import { FinanzasService } from './finanzas.service';
+
+interface RetryPayment {
+  readonly status: PaymentStatus;
+  readonly canceledAt: Date | null;
+  readonly receiptStatus: ReceiptStatus;
+  readonly receiptNumber: string | null;
+}
+
+describe('FinanzasService receipt retry eligibility', () => {
+  function buildService(payment: RetryPayment, result: object | null) {
+    const findFirst = jest
+      .fn()
+      .mockResolvedValueOnce(payment)
+      .mockResolvedValue({ receiptError: 'generation failed' });
+    const receiptService = {
+      ensureReceiptForPayment: jest.fn().mockResolvedValue(result),
+    };
+    const validators = {
+      canReviewPayments: jest.fn().mockReturnValue(true),
+      throwForbidden: jest.fn(),
+    };
+    const service = Object.create(FinanzasService.prototype) as FinanzasService;
+    Reflect.set(service, 'validators', validators);
+    Reflect.set(service, 'prisma', { payment: { findFirst } });
+    Reflect.set(service, 'receiptService', receiptService);
+    return { service, findFirst, receiptService };
+  }
+
+  it.each([PaymentStatus.APPROVED, PaymentStatus.RECONCILED])(
+    'allows %s payments to recover a missing receipt without trusting receiptNumber',
+    async (status) => {
+      const ctx = buildService(
+        {
+          status,
+          canceledAt: null,
+          receiptStatus: ReceiptStatus.PENDING,
+          receiptNumber: 'R-LEGACY-2026-000001',
+        },
+        { receiptNumber: 'R-LEGACY-2026-000001' },
+      );
+
+      await expect(
+        ctx.service.retryReceiptGeneration('tenant-1', 'payment-1', [
+          'TENANT_ADMIN',
+        ]),
+      ).resolves.toEqual({
+        success: true,
+        receiptNumber: 'R-LEGACY-2026-000001',
+      });
+
+      expect(ctx.receiptService.ensureReceiptForPayment).toHaveBeenCalledWith(
+        'tenant-1',
+        'payment-1',
+        undefined,
+      );
+    },
+  );
+
+  it('does not report success when a numbered pending receipt cannot be recovered', async () => {
+    const ctx = buildService(
+      {
+        status: PaymentStatus.APPROVED,
+        canceledAt: null,
+        receiptStatus: ReceiptStatus.PENDING,
+        receiptNumber: 'R-LEGACY-2026-000001',
+      },
+      null,
+    );
+
+    await expect(
+      ctx.service.retryReceiptGeneration('tenant-1', 'payment-1', [
+        'TENANT_ADMIN',
+      ]),
+    ).resolves.toEqual({ success: false, error: 'generation failed' });
+    expect(ctx.receiptService.ensureReceiptForPayment).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([PaymentStatus.SUBMITTED, PaymentStatus.REJECTED])(
+    'rejects %s payments as ineligible for receipt recovery',
+    async (status) => {
+      const ctx = buildService(
+        {
+          status,
+          canceledAt: null,
+          receiptStatus: ReceiptStatus.PENDING,
+          receiptNumber: null,
+        },
+        null,
+      );
+
+      await expect(
+        ctx.service.retryReceiptGeneration('tenant-1', 'payment-1', [
+          'TENANT_ADMIN',
+        ]),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(ctx.receiptService.ensureReceiptForPayment).not.toHaveBeenCalled();
+    },
+  );
+
+  it('rejects a canceled approved payment', async () => {
+    const ctx = buildService(
+      {
+        status: PaymentStatus.APPROVED,
+        canceledAt: new Date('2026-08-01T00:00:00.000Z'),
+        receiptStatus: ReceiptStatus.PENDING,
+        receiptNumber: null,
+      },
+      null,
+    );
+
+    await expect(
+      ctx.service.retryReceiptGeneration('tenant-1', 'payment-1', [
+        'TENANT_ADMIN',
+      ]),
+    ).rejects.toBeInstanceOf(BadRequestException);
+    expect(ctx.receiptService.ensureReceiptForPayment).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/receipts/payment-receipt-concurrency.postgres.spec.ts
+++ b/apps/api/src/receipts/payment-receipt-concurrency.postgres.spec.ts
@@ -1,0 +1,310 @@
+import {
+  ChargeStatus,
+  PaymentMethod,
+  PaymentStatus,
+  PrismaClient,
+  TenantType,
+} from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { PaymentReceiptService } from './payment-receipt.service';
+
+const enabled =
+  process.env.RUN_POSTGRES_INTEGRATION === '1' &&
+  (process.env.POSTGRES_TEST_DB_NAME === 'buildingos_local_v2_test' ||
+    process.env.POSTGRES_TEST_DB_NAME === 'buildingos_3e3_acceptance');
+const describePostgres = enabled ? describe : describe.skip;
+
+class LocalReceiptStorage {
+  private readonly objects = new Map<string, Buffer>();
+  readonly uploadCalls: string[] = [];
+
+  getDefaultBucket(): string {
+    return 'buildingos-receipt-test';
+  }
+
+  async uploadBuffer(
+    bucket: string,
+    objectKey: string,
+    content: Buffer,
+  ): Promise<void> {
+    this.uploadCalls.push(`${bucket}/${objectKey}`);
+    this.objects.set(`${bucket}/${objectKey}`, Buffer.from(content));
+  }
+
+  async objectExists(bucket: string, objectKey: string): Promise<boolean> {
+    return this.objects.has(`${bucket}/${objectKey}`);
+  }
+
+  async statObject(
+    bucket: string,
+    objectKey: string,
+  ): Promise<{ size: number }> {
+    const object = this.objects.get(`${bucket}/${objectKey}`);
+    if (!object) throw new Error('NotFound');
+    return { size: object.length };
+  }
+
+  async getObjectBuffer(bucket: string, objectKey: string): Promise<Buffer> {
+    const object = this.objects.get(`${bucket}/${objectKey}`);
+    if (!object) throw new Error('NotFound');
+    return Buffer.from(object);
+  }
+
+  async presignDownload(bucket: string, objectKey: string): Promise<string> {
+    return `http://local.test/${bucket}/${objectKey}`;
+  }
+}
+
+describePostgres('Payment receipt PostgreSQL concurrency', () => {
+  let observer: PrismaClient;
+  let firstPrisma: PrismaService;
+  let secondPrisma: PrismaService;
+  let storage: LocalReceiptStorage;
+  const tenantIds: string[] = [];
+  const userIds: string[] = [];
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required');
+    const clientUrl = (applicationName: string) => {
+      const url = new URL(process.env.DATABASE_URL!);
+      url.searchParams.set('application_name', applicationName);
+      return url.toString();
+    };
+    observer = new PrismaClient();
+    firstPrisma = new PrismaService({
+      datasources: { db: { url: clientUrl('receipt-concurrency-first') } },
+    });
+    secondPrisma = new PrismaService({
+      datasources: { db: { url: clientUrl('receipt-concurrency-second') } },
+    });
+    await Promise.all([
+      observer.$connect(),
+      firstPrisma.$connect(),
+      secondPrisma.$connect(),
+    ]);
+    const [database] = await observer.$queryRaw<Array<{ name: string }>>`
+      SELECT current_database() AS name
+    `;
+    if (
+      database?.name !== process.env.POSTGRES_TEST_DB_NAME ||
+      (database.name !== 'buildingos_local_v2_test' &&
+        database.name !== 'buildingos_3e3_acceptance')
+    ) {
+      throw new Error(
+        `Refusing destructive test database ${database?.name ?? 'unknown'}`,
+      );
+    }
+  });
+
+  beforeEach(() => {
+    storage = new LocalReceiptStorage();
+  });
+
+  afterEach(async () => {
+    for (const tenantId of tenantIds.splice(0)) {
+      await observer.tenant.delete({ where: { id: tenantId } });
+    }
+    for (const userId of userIds.splice(0)) {
+      await observer.user.delete({ where: { id: userId } });
+    }
+  });
+
+  afterAll(async () => {
+    await Promise.all([
+      observer?.$disconnect(),
+      firstPrisma?.$disconnect(),
+      secondPrisma?.$disconnect(),
+    ]);
+  });
+
+  async function tenantFixture() {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const tenant = await observer.tenant.create({
+      data: {
+        name: `Receipt concurrency ${suffix}`,
+        type: TenantType.ADMINISTRADORA,
+        functionalCurrency: 'ARS',
+      },
+    });
+    tenantIds.push(tenant.id);
+    const user = await observer.user.create({
+      data: {
+        email: `receipt-concurrency-${suffix}@buildingos.local`,
+        name: 'Receipt concurrency resident',
+        passwordHash: 'test',
+      },
+    });
+    userIds.push(user.id);
+    const building = await observer.building.create({
+      data: {
+        tenantId: tenant.id,
+        name: `Receipt building ${suffix}`,
+        alias: `RC-${suffix}`,
+        address: 'Test',
+      },
+    });
+    const unit = await observer.unit.create({
+      data: {
+        tenantId: tenant.id,
+        buildingId: building.id,
+        code: '1',
+        label: '1',
+        unitType: 'APARTAMENTO',
+        occupancyStatus: 'OCCUPIED',
+        isBillable: true,
+      },
+    });
+    return { tenant, user, building, unit };
+  }
+
+  async function paymentFixture() {
+    const fixture = await tenantFixture();
+    const payment = await observer.payment.create({
+      data: {
+        tenantId: fixture.tenant.id,
+        buildingId: fixture.building.id,
+        unitId: fixture.unit.id,
+        amount: 10000,
+        currency: 'ARS',
+        method: PaymentMethod.TRANSFER,
+        status: PaymentStatus.APPROVED,
+        createdByUserId: fixture.user.id,
+        approvedByUserId: fixture.user.id,
+        approvedAt: new Date('2026-08-10T00:00:00.000Z'),
+      },
+    });
+    return { ...fixture, payment };
+  }
+
+  function service(prisma: PrismaService): PaymentReceiptService {
+    return new PaymentReceiptService(
+      prisma,
+      storage as never,
+      { createNotification: jest.fn().mockResolvedValue(undefined) } as never,
+    );
+  }
+
+  it('serializes two retries for the same Payment into one receipt', async () => {
+    const fixture = await paymentFixture();
+    const first = service(firstPrisma).ensureReceiptForPayment(
+      fixture.tenant.id,
+      fixture.payment.id,
+    );
+    const second = service(secondPrisma).ensureReceiptForPayment(
+      fixture.tenant.id,
+      fixture.payment.id,
+    );
+
+    const results = await Promise.all([first, second]);
+    const [payment, files, documents, audits] = await Promise.all([
+      observer.payment.findUniqueOrThrow({ where: { id: fixture.payment.id } }),
+      observer.file.findMany({ where: { tenantId: fixture.tenant.id } }),
+      observer.document.findMany({ where: { tenantId: fixture.tenant.id } }),
+      observer.paymentAuditLog.findMany({
+        where: { paymentId: fixture.payment.id, action: 'RECEIPT_GENERATED' },
+      }),
+    ]);
+
+    expect(results.every((result) => result !== null)).toBe(true);
+    expect(payment.receiptStatus).toBe('READY');
+    expect(payment.receiptNumber).toMatch(/-000001$/);
+    expect(files).toHaveLength(1);
+    expect(documents).toHaveLength(1);
+    expect(audits).toHaveLength(1);
+    expect(storage.uploadCalls).toHaveLength(1);
+  }, 20000);
+
+  it('allocates distinct numbers when different Payments share a sequence', async () => {
+    const fixture = await tenantFixture();
+    const payments = await Promise.all(
+      [1, 2].map((index) =>
+        observer.payment.create({
+          data: {
+            tenantId: fixture.tenant.id,
+            buildingId: fixture.building.id,
+            unitId: fixture.unit.id,
+            amount: 10000 + index,
+            currency: 'ARS',
+            method: PaymentMethod.TRANSFER,
+            status: PaymentStatus.APPROVED,
+            createdByUserId: fixture.user.id,
+            approvedByUserId: fixture.user.id,
+            approvedAt: new Date('2026-08-10T00:00:00.000Z'),
+          },
+        }),
+      ),
+    );
+
+    await Promise.all([
+      service(firstPrisma).ensureReceiptForPayment(
+        fixture.tenant.id,
+        payments[0]!.id,
+      ),
+      service(secondPrisma).ensureReceiptForPayment(
+        fixture.tenant.id,
+        payments[1]!.id,
+      ),
+    ]);
+
+    const persisted = await observer.payment.findMany({
+      where: { id: { in: payments.map(({ id }) => id) } },
+      orderBy: { receiptNumber: 'asc' },
+    });
+    expect(persisted.map(({ receiptNumber }) => receiptNumber)).toEqual([
+      expect.stringMatching(/-000001$/),
+      expect.stringMatching(/-000002$/),
+    ]);
+    expect(storage.uploadCalls).toHaveLength(2);
+  }, 20000);
+
+  it('recovers a RECONCILED Payment without changing financial state', async () => {
+    const fixture = await paymentFixture();
+    const charge = await observer.charge.create({
+      data: {
+        tenantId: fixture.tenant.id,
+        buildingId: fixture.building.id,
+        unitId: fixture.unit.id,
+        period: '2026-08',
+        concept: 'Receipt recovery charge',
+        amount: 10000,
+        currency: 'ARS',
+        status: ChargeStatus.PAID,
+        dueDate: new Date('2026-08-31T00:00:00.000Z'),
+      },
+    });
+    await observer.payment.update({
+      where: { id: fixture.payment.id },
+      data: { status: PaymentStatus.RECONCILED },
+    });
+    const allocation = await observer.paymentAllocation.create({
+      data: {
+        tenantId: fixture.tenant.id,
+        paymentId: fixture.payment.id,
+        chargeId: charge.id,
+        amount: 10000,
+        paymentOriginalAmountMinor: 10000,
+      },
+    });
+
+    await expect(
+      service(firstPrisma).ensureReceiptForPayment(
+        fixture.tenant.id,
+        fixture.payment.id,
+      ),
+    ).resolves.toEqual(
+      expect.objectContaining({ receiptNumber: expect.any(String) }),
+    );
+
+    const [payment, persistedAllocation, persistedCharge] = await Promise.all([
+      observer.payment.findUniqueOrThrow({ where: { id: fixture.payment.id } }),
+      observer.paymentAllocation.findUniqueOrThrow({
+        where: { id: allocation.id },
+      }),
+      observer.charge.findUniqueOrThrow({ where: { id: charge.id } }),
+    ]);
+    expect(payment.status).toBe(PaymentStatus.RECONCILED);
+    expect(payment.receiptStatus).toBe('READY');
+    expect(persistedAllocation.amount).toBe(10000);
+    expect(persistedCharge.status).toBe(ChargeStatus.PAID);
+  }, 20000);
+});

--- a/apps/api/src/receipts/payment-receipt-recovery.minio.postgres.spec.ts
+++ b/apps/api/src/receipts/payment-receipt-recovery.minio.postgres.spec.ts
@@ -1,0 +1,340 @@
+import * as Minio from 'minio';
+import { Readable } from 'node:stream';
+import {
+  ChargeStatus,
+  PaymentMethod,
+  PaymentStatus,
+  Prisma,
+  PrismaClient,
+  TenantType,
+} from '@prisma/client';
+import { PrismaService } from '../prisma/prisma.service';
+import { PaymentReceiptService } from './payment-receipt.service';
+
+const databaseEnabled =
+  process.env.RUN_POSTGRES_INTEGRATION === '1' &&
+  (process.env.POSTGRES_TEST_DB_NAME === 'buildingos_local_v2_test' ||
+    process.env.POSTGRES_TEST_DB_NAME === 'buildingos_3e3_acceptance');
+const minioEnabled =
+  process.env.RUN_MINIO_INTEGRATION === '1' &&
+  Boolean(
+    process.env.MINIO_ENDPOINT &&
+      process.env.MINIO_ACCESS_KEY &&
+      process.env.MINIO_SECRET_KEY &&
+      process.env.MINIO_BUCKET,
+  );
+const describeMinioRecovery = databaseEnabled && minioEnabled ? describe : describe.skip;
+
+interface ReceiptStorage {
+  getDefaultBucket(): string;
+  uploadBuffer(bucket: string, objectKey: string, content: Buffer, contentType: string): Promise<void>;
+  objectExists(bucket: string, objectKey: string): Promise<boolean>;
+  statObject(bucket: string, objectKey: string): Promise<{ size: number }>;
+  getObjectBuffer(bucket: string, objectKey: string): Promise<Buffer>;
+  presignDownload(bucket: string, objectKey: string, expirySeconds: number): Promise<string>;
+  deleteObject(bucket: string, objectKey: string): Promise<void>;
+  listObjects(bucket: string, prefix: string): Promise<string[]>;
+}
+
+class MinioReceiptStorage implements ReceiptStorage {
+  private readonly client: Minio.Client;
+
+  constructor(
+    private readonly bucket: string,
+    endpoint: string,
+    accessKey: string,
+    secretKey: string,
+  ) {
+    const url = new URL(endpoint);
+    this.client = new Minio.Client({
+      endPoint: url.hostname,
+      port: Number(url.port || (url.protocol === 'https:' ? 443 : 80)),
+      useSSL: url.protocol === 'https:',
+      accessKey,
+      secretKey,
+      region: 'us-east-1',
+      pathStyle: true,
+    });
+  }
+
+  getDefaultBucket(): string {
+    return this.bucket;
+  }
+
+  async ensureBucket(): Promise<void> {
+    if (!(await this.client.bucketExists(this.bucket))) {
+      await this.client.makeBucket(this.bucket, 'us-east-1');
+    }
+  }
+
+  async uploadBuffer(
+    bucket: string,
+    objectKey: string,
+    content: Buffer,
+    contentType: string,
+  ): Promise<void> {
+    await this.client.putObject(
+      bucket,
+      objectKey,
+      Readable.from([content]),
+      content.length,
+      { 'Content-Type': contentType },
+    );
+  }
+
+  async objectExists(bucket: string, objectKey: string): Promise<boolean> {
+    try {
+      await this.client.statObject(bucket, objectKey);
+      return true;
+    } catch (error: unknown) {
+      const errorLike = error as { code?: string; statusCode?: number };
+      if (errorLike.code === 'NotFound' || errorLike.statusCode === 404) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  async statObject(bucket: string, objectKey: string): Promise<{ size: number }> {
+    return this.client.statObject(bucket, objectKey);
+  }
+
+  async getObjectBuffer(bucket: string, objectKey: string): Promise<Buffer> {
+    const stream = await this.client.getObject(bucket, objectKey);
+    const chunks: Buffer[] = [];
+    return new Promise<Buffer>((resolve, reject) => {
+      stream.on('data', (chunk: Buffer | string) => {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      });
+      stream.on('error', reject);
+      stream.on('end', () => resolve(Buffer.concat(chunks)));
+    });
+  }
+
+  async presignDownload(
+    bucket: string,
+    objectKey: string,
+    expirySeconds: number,
+  ): Promise<string> {
+    return this.client.presignedGetObject(bucket, objectKey, expirySeconds);
+  }
+
+  async deleteObject(bucket: string, objectKey: string): Promise<void> {
+    await this.client.removeObject(bucket, objectKey);
+  }
+
+  async listObjects(bucket: string, prefix: string): Promise<string[]> {
+    const names: string[] = [];
+    const stream = this.client.listObjects(bucket, prefix, true);
+    return new Promise<string[]>((resolve, reject) => {
+      stream.on('data', (item) => {
+        if (item.name) names.push(item.name);
+      });
+      stream.on('error', reject);
+      stream.on('end', () => resolve(names));
+    });
+  }
+}
+
+describeMinioRecovery('Payment receipt PostgreSQL/MinIO recovery', () => {
+  let observer: PrismaClient;
+  let firstPrisma: PrismaService;
+  let secondPrisma: PrismaService;
+  let storage: MinioReceiptStorage;
+  let tenantId: string;
+  let userId: string;
+  let objectKey: string;
+
+  beforeAll(async () => {
+    if (!process.env.DATABASE_URL || !process.env.POSTGRES_TEST_DB_NAME) {
+      throw new Error('DATABASE_URL and POSTGRES_TEST_DB_NAME are required');
+    }
+    storage = new MinioReceiptStorage(
+      process.env.MINIO_BUCKET!,
+      process.env.MINIO_ENDPOINT!,
+      process.env.MINIO_ACCESS_KEY!,
+      process.env.MINIO_SECRET_KEY!,
+    );
+    await storage.ensureBucket();
+
+    const clientUrl = (applicationName: string) => {
+      const url = new URL(process.env.DATABASE_URL!);
+      url.searchParams.set('application_name', applicationName);
+      return url.toString();
+    };
+    observer = new PrismaClient();
+    firstPrisma = new PrismaService({
+      datasources: { db: { url: clientUrl('receipt-recovery-minio-first') } },
+    });
+    secondPrisma = new PrismaService({
+      datasources: { db: { url: clientUrl('receipt-recovery-minio-second') } },
+    });
+    await Promise.all([
+      observer.$connect(),
+      firstPrisma.$connect(),
+      secondPrisma.$connect(),
+    ]);
+    const [database] = await observer.$queryRaw<Array<{ name: string }>>`
+      SELECT current_database() AS name
+    `;
+    if (
+      database?.name !== process.env.POSTGRES_TEST_DB_NAME ||
+      (database.name !== 'buildingos_local_v2_test' &&
+        database.name !== 'buildingos_3e3_acceptance')
+    ) {
+      throw new Error(`Refusing destructive test database ${database?.name ?? 'unknown'}`);
+    }
+  });
+
+  afterAll(async () => {
+    if (objectKey) {
+      await storage.deleteObject(storage.getDefaultBucket(), objectKey).catch(() => undefined);
+    }
+    if (tenantId) {
+      await observer.tenant.delete({ where: { id: tenantId } });
+    }
+    if (userId) {
+      await observer.user.delete({ where: { id: userId } });
+    }
+    await Promise.all([
+      observer?.$disconnect(),
+      firstPrisma?.$disconnect(),
+      secondPrisma?.$disconnect(),
+    ]);
+  });
+
+  it('recovers a failed finalization with a fresh service and durable MinIO object', async () => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const tenant = await observer.tenant.create({
+      data: {
+        name: `Receipt MinIO recovery ${suffix}`,
+        type: TenantType.ADMINISTRADORA,
+        functionalCurrency: 'ARS',
+      },
+    });
+    tenantId = tenant.id;
+    const user = await observer.user.create({
+      data: {
+        email: `receipt-minio-${suffix}@buildingos.local`,
+        name: 'Receipt MinIO resident',
+        passwordHash: 'test',
+      },
+    });
+    userId = user.id;
+    const building = await observer.building.create({
+      data: {
+        tenantId,
+        name: `Receipt MinIO building ${suffix}`,
+        alias: `RM-${suffix}`,
+        address: 'Test',
+      },
+    });
+    const unit = await observer.unit.create({
+      data: {
+        tenantId,
+        buildingId: building.id,
+        code: '1',
+        label: '1',
+        unitType: 'APARTAMENTO',
+        occupancyStatus: 'OCCUPIED',
+        isBillable: true,
+      },
+    });
+    const payment = await observer.payment.create({
+      data: {
+        tenantId,
+        buildingId: building.id,
+        unitId: unit.id,
+        amount: 10000,
+        currency: 'ARS',
+        method: PaymentMethod.TRANSFER,
+        status: PaymentStatus.APPROVED,
+        createdByUserId: userId,
+        approvedByUserId: userId,
+        approvedAt: new Date('2026-08-10T00:00:00.000Z'),
+      },
+    });
+
+    const runTransaction = firstPrisma.$transaction.bind(firstPrisma) as unknown as (
+      callback: (tx: Prisma.TransactionClient) => Promise<unknown>,
+    ) => Promise<unknown>;
+    let transactionCount = 0;
+    const failingPrisma = {
+      $transaction: async (
+        callback: (tx: Prisma.TransactionClient) => Promise<unknown>,
+      ): Promise<unknown> => {
+        transactionCount += 1;
+        return runTransaction(async (tx) => {
+          if (transactionCount !== 2) return callback(tx);
+          const failingTx = new Proxy(tx, {
+            get(target, property, receiver) {
+              if (property === 'document') {
+                return {
+                  ...target.document,
+                  create: async (
+                    ..._args: Parameters<Prisma.TransactionClient['document']['create']>
+                  ) => {
+                    throw new Error('simulated DB finalization failure');
+                  },
+                };
+              }
+              return Reflect.get(target, property, receiver);
+            },
+          });
+          return callback(failingTx);
+        });
+      },
+    };
+    const firstService = new PaymentReceiptService(
+      failingPrisma as unknown as PrismaService,
+      storage as unknown as never,
+      { createNotification: jest.fn().mockResolvedValue(undefined) } as never,
+    );
+
+    await expect(
+      firstService.ensureReceiptForPayment(tenantId, payment.id),
+    ).resolves.toBeNull();
+
+    const failedPayment = await observer.payment.findUniqueOrThrow({
+      where: { id: payment.id },
+      select: { receiptNumber: true, receiptStatus: true },
+    });
+    expect(failedPayment.receiptNumber).toMatch(/-000001$/);
+    expect(failedPayment.receiptStatus).toBe('FAILED');
+    objectKey = `tenant/${tenantId}/payments/${payment.id}/receipts/${failedPayment.receiptNumber}.pdf`;
+    await expect(
+      storage.objectExists(storage.getDefaultBucket(), objectKey),
+    ).resolves.toBe(true);
+
+    const freshStorage = new MinioReceiptStorage(
+      storage.getDefaultBucket(),
+      process.env.MINIO_ENDPOINT!,
+      process.env.MINIO_ACCESS_KEY!,
+      process.env.MINIO_SECRET_KEY!,
+    );
+    const freshService = new PaymentReceiptService(
+      secondPrisma,
+      freshStorage as unknown as never,
+      { createNotification: jest.fn().mockResolvedValue(undefined) } as never,
+    );
+    const result = await freshService.ensureReceiptForPayment(tenantId, payment.id);
+
+    expect(result?.receiptNumber).toBe(failedPayment.receiptNumber);
+    expect(result?.fileKey).toBe(objectKey);
+    const [persistedPayment, files, documents, audits, objects] = await Promise.all([
+      observer.payment.findUniqueOrThrow({ where: { id: payment.id } }),
+      observer.file.findMany({ where: { tenantId } }),
+      observer.document.findMany({ where: { tenantId } }),
+      observer.paymentAuditLog.findMany({
+        where: { tenantId, paymentId: payment.id, action: 'RECEIPT_GENERATED' },
+      }),
+      freshStorage.listObjects(storage.getDefaultBucket(), `tenant/${tenantId}/`),
+    ]);
+    expect(persistedPayment.receiptStatus).toBe('READY');
+    expect(persistedPayment.receiptNumber).toBe(failedPayment.receiptNumber);
+    expect(files).toHaveLength(1);
+    expect(documents).toHaveLength(1);
+    expect(audits).toHaveLength(1);
+    expect(objects).toEqual([objectKey]);
+  }, 30000);
+});

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -58,6 +58,7 @@ describe('PaymentReceiptService', () => {
     },
     paymentAuditLog: {
       create: jest.fn(),
+      findFirst: jest.fn(),
     },
     receiptSequence: {
       findUnique: jest.fn(),
@@ -72,6 +73,9 @@ describe('PaymentReceiptService', () => {
   const minio = {
     getDefaultBucket: jest.fn(() => DEFAULT_BUCKET),
     uploadBuffer: jest.fn(),
+    objectExists: jest.fn(),
+    statObject: jest.fn(),
+    getObjectBuffer: jest.fn(),
     presignDownload: jest.fn(),
     deleteObject: jest.fn(),
   };
@@ -207,12 +211,15 @@ describe('PaymentReceiptService', () => {
     insideTransaction = false;
     minio.getDefaultBucket.mockReturnValue(DEFAULT_BUCKET);
     minio.uploadBuffer.mockImplementation(async () => {
-      expect(insideTransaction).toBe(false);
+      expect(insideTransaction).toBe(true);
     });
     minio.presignDownload.mockImplementation(async () => {
       expect(insideTransaction).toBe(false);
       return 'https://download.example/receipt.pdf';
     });
+    minio.objectExists.mockResolvedValue(false);
+    minio.statObject.mockResolvedValue({ size: 1 });
+    minio.getObjectBuffer.mockResolvedValue(Buffer.from("existing-receipt"));
     notificationsService.createNotification.mockImplementation(async () => {
       expect(insideTransaction).toBe(false);
       return {};
@@ -242,21 +249,26 @@ describe('PaymentReceiptService', () => {
       buildingId: 'building-1',
       unitId: 'unit-1',
       amount: 4050000,
-      currency: 'ARS',
-      method: 'TRANSFER',
-      createdByUserId: 'resident-1',
-      approvedByUserId: 'admin-1',
-      approvedAt: '2026-07-24T12:00:00.000Z',
-      reference: 'TRX-001',
-      paymentAllocations: [{
-        chargeId: 'charge-1',
-        amount: 4050000,
-        charge: {
-          period: '2025-10',
-          concept: 'Condominio ordinario 2025-10',
-          expensePeriod: { year: 2025, month: 10 },
+      currency: "ARS",
+      method: "TRANSFER",
+      status: "APPROVED",
+      canceledAt: null,
+      receiptStatus: ReceiptStatus.PENDING,
+      createdByUserId: "resident-1",
+      approvedByUserId: "admin-1",
+      approvedAt: "2026-07-24T12:00:00.000Z",
+      reference: "TRX-001",
+      paymentAllocations: [
+        {
+          chargeId: "charge-1",
+          amount: 4050000,
+          charge: {
+            period: "2025-10",
+            concept: "Condominio ordinario 2025-10",
+            expensePeriod: { year: 2025, month: 10 },
+          },
         },
-      }],
+      ],
       unit: { label: 'TN-01-01' },
       building: { name: 'Complejo Horizonte' },
       receiptDocumentId: null,
@@ -278,6 +290,7 @@ describe('PaymentReceiptService', () => {
     prisma.document.create.mockResolvedValue({ id: 'document-1', file: { bucket: DEFAULT_BUCKET, objectKey: 'object-1' } } as never);
     prisma.payment.update.mockResolvedValue({} as never);
     prisma.paymentAuditLog.create.mockResolvedValue({} as never);
+    prisma.paymentAuditLog.findFirst.mockResolvedValue(null);
     notificationsService.createNotification.mockResolvedValue({} as never);
     minio.presignDownload.mockResolvedValue('https://download.example/receipt.pdf');
   });
@@ -321,22 +334,24 @@ describe('PaymentReceiptService', () => {
       expect(pdfInfo.status).toBe(0);
       expect(pdfInfo.stdout).toContain('Pages:');
     }
-    expect(prisma.file.create).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        bucket: DEFAULT_BUCKET,
-        originalName: expect.stringMatching(/\.pdf$/),
-        mimeType: 'application/pdf',
-        size: uploadedBuffer.length,
-      }),
+     expect(prisma.file.create).toHaveBeenCalledWith(expect.objectContaining({
+       data: expect.objectContaining({
+         bucket: DEFAULT_BUCKET,
+         originalName: expect.stringMatching(/\.pdf$/),
+         mimeType: 'application/pdf',
+         size: uploadedBuffer.length,
+       }),
     }));
     expect(prisma.$transaction).toHaveBeenCalledTimes(2);
-    expect(transactionQueryRawMock).toHaveBeenCalledTimes(2);
-    expect(prisma.payment.update).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        receiptStatus: ReceiptStatus.READY,
-        receiptError: null,
-      }),
-    }));
+    expect(transactionQueryRawMock).toHaveBeenCalledTimes(3);
+     expect(prisma.payment.update).toHaveBeenCalledWith(
+       expect.objectContaining({
+         data: expect.objectContaining({
+           receiptStatus: ReceiptStatus.READY,
+           receiptError: null,
+         }),
+        }),
+      );
     expect(prisma.paymentAuditLog.create).toHaveBeenCalledWith({
       data: expect.objectContaining({
         paymentId: 'payment-1',
@@ -358,21 +373,25 @@ describe('PaymentReceiptService', () => {
       buildingId: 'building-1',
       unitId: 'unit-1',
       amount: 4050000,
-      currency: 'ARS',
-      method: 'TRANSFER',
-      createdByUserId: 'resident-1',
-      approvedByUserId: 'admin-1',
-      approvedAt: '2026-07-24T12:00:00.000Z',
-      reference: 'TRX-001',
-      paymentAllocations: [{
-        chargeId: 'charge-1',
-        amount: 4050000,
-        charge: {
-          period: '2025-10',
-          concept: 'Condominio ordinario 2025-10',
-          expensePeriod: { year: 2025, month: 10 },
+      currency: "ARS",
+      method: "TRANSFER",
+      createdByUserId: "resident-1",
+      approvedByUserId: "admin-1",
+      status: "APPROVED",
+      canceledAt: null,
+      approvedAt: "2026-07-24T12:00:00.000Z",
+      reference: "TRX-001",
+      paymentAllocations: [
+        {
+          chargeId: "charge-1",
+          amount: 4050000,
+          charge: {
+            period: "2025-10",
+            concept: "Condominio ordinario 2025-10",
+            expensePeriod: { year: 2025, month: 10 },
+          },
         },
-      }],
+      ],
       unit: { label: 'TN-01-01' },
       building: { name: 'Complejo Horizonte' },
       receiptDocumentId: null,
@@ -396,7 +415,7 @@ describe('PaymentReceiptService', () => {
     expect(paymentState.receiptStatus).toBe(ReceiptStatus.FAILED);
     expect(prisma.receiptSequence.create).toHaveBeenCalledTimes(1);
     expect(prisma.receiptSequence.update).toHaveBeenCalledTimes(1);
-    expect(transactionQueryRawMock).toHaveBeenCalledTimes(2);
+    expect(transactionQueryRawMock).toHaveBeenCalledTimes(4);
     expect(minio.deleteObject).not.toHaveBeenCalled();
 
     minio.uploadBuffer.mockResolvedValueOnce(undefined);
@@ -407,29 +426,29 @@ describe('PaymentReceiptService', () => {
     expect(retryResult?.fileKey).toBe('tenant/tenant-1/payments/payment-1/receipts/R-COMPLE-2026-000001.pdf');
     expect(prisma.receiptSequence.create).toHaveBeenCalledTimes(1);
     expect(prisma.receiptSequence.update).toHaveBeenCalledTimes(1);
-    expect(prisma.payment.update).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        receiptStatus: ReceiptStatus.READY,
-      }),
+     expect(prisma.payment.update).toHaveBeenCalledWith(expect.objectContaining({
+       data: expect.objectContaining({
+         receiptStatus: ReceiptStatus.READY,
+       }),
     }));
   });
 
-  it('keeps an uploaded receipt object when finalization already confirmed the same key', async () => {
-    prisma.document.create.mockRejectedValueOnce(new Error('database unavailable'));
-    const warnSpy = jest.spyOn(Reflect.get(service, 'logger') as { warn: (...args: unknown[]) => void }, 'warn');
+  it("marks generation failed while retaining an uploaded object for recovery", async () => {
+    prisma.document.create.mockRejectedValueOnce(
+      new Error("database unavailable"),
+    );
 
     await expect(service.ensureReceiptForPayment('tenant-1', 'payment-1')).resolves.toBeNull();
 
     expect(minio.uploadBuffer).toHaveBeenCalled();
     expect(minio.deleteObject).not.toHaveBeenCalled();
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('reusable unconfirmed receipt object'),
-    );
-    expect(prisma.payment.update).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        receiptStatus: ReceiptStatus.FAILED,
-      }),
-    }));
+     expect(prisma.payment.update).toHaveBeenCalledWith(
+       expect.objectContaining({
+         data: expect.objectContaining({
+           receiptStatus: ReceiptStatus.FAILED,
+         }),
+        }),
+      );
   });
 
   it('marks receipt generation failed under the receipt lock only when still pending', async () => {
@@ -484,11 +503,13 @@ describe('PaymentReceiptService', () => {
 
     await markFailed.call(service, 'tenant-1', 'payment-1', 'notify failed');
 
-    expect(prisma.payment.update).not.toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        receiptStatus: ReceiptStatus.FAILED,
-      }),
-    }));
+     expect(prisma.payment.update).toHaveBeenCalledWith(
+       expect.objectContaining({
+         data: expect.objectContaining({
+           receiptStatus: ReceiptStatus.FAILED,
+         }),
+        }),
+      );
   });
 
   it('keeps READY receipts stable when presign fails after confirmation', async () => {
@@ -498,21 +519,25 @@ describe('PaymentReceiptService', () => {
       buildingId: 'building-1',
       unitId: 'unit-1',
       amount: 4050000,
-      currency: 'ARS',
-      method: 'TRANSFER',
-      createdByUserId: 'resident-1',
-      approvedByUserId: 'admin-1',
-      approvedAt: '2026-07-24T12:00:00.000Z',
-      reference: 'TRX-001',
-      paymentAllocations: [{
-        chargeId: 'charge-1',
-        amount: 4050000,
-        charge: {
-          period: '2025-10',
-          concept: 'Condominio ordinario 2025-10',
-          expensePeriod: { year: 2025, month: 10 },
+      currency: "ARS",
+      method: "TRANSFER",
+      createdByUserId: "resident-1",
+      approvedByUserId: "admin-1",
+      status: "APPROVED",
+      canceledAt: null,
+      approvedAt: "2026-07-24T12:00:00.000Z",
+      reference: "TRX-001",
+      paymentAllocations: [
+        {
+          chargeId: "charge-1",
+          amount: 4050000,
+          charge: {
+            period: "2025-10",
+            concept: "Condominio ordinario 2025-10",
+            expensePeriod: { year: 2025, month: 10 },
+          },
         },
-      }],
+      ],
       unit: { label: 'TN-01-01' },
       building: { name: 'Complejo Horizonte' },
       receiptDocumentId: null,
@@ -544,7 +569,7 @@ describe('PaymentReceiptService', () => {
       }),
     }));
     expect(paymentState.receiptStatus).toBe(ReceiptStatus.READY);
-    expect(transactionQueryRawMock).toHaveBeenCalledTimes(3);
+    expect(transactionQueryRawMock).toHaveBeenCalledTimes(4);
   });
 
   it('keeps READY receipts stable when notification fails after confirmation', async () => {
@@ -572,21 +597,25 @@ describe('PaymentReceiptService', () => {
       buildingId: 'building-1',
       unitId: 'unit-1',
       amount: 4050000,
-      currency: 'ARS',
-      method: 'TRANSFER',
-      createdByUserId: 'resident-1',
-      approvedByUserId: 'admin-1',
-      approvedAt: '2026-07-24T12:00:00.000Z',
-      reference: 'TRX-001',
-      paymentAllocations: [{
-        chargeId: 'charge-1',
-        amount: 4050000,
-        charge: {
-          period: '2025-10',
-          concept: 'Condominio ordinario 2025-10',
-          expensePeriod: { year: 2025, month: 10 },
+      currency: "ARS",
+      method: "TRANSFER",
+      createdByUserId: "resident-1",
+      approvedByUserId: "admin-1",
+      status: "APPROVED",
+      canceledAt: null,
+      approvedAt: "2026-07-24T12:00:00.000Z",
+      reference: "TRX-001",
+      paymentAllocations: [
+        {
+          chargeId: "charge-1",
+          amount: 4050000,
+          charge: {
+            period: "2025-10",
+            concept: "Condominio ordinario 2025-10",
+            expensePeriod: { year: 2025, month: 10 },
+          },
         },
-      }],
+      ],
       unit: { label: 'TN-01-01' },
       building: { name: 'Complejo Horizonte' },
       receiptDocumentId: null,
@@ -639,28 +668,32 @@ describe('PaymentReceiptService', () => {
       name: 'Consorcio “Central”',
       brandName: 'Administración “Central” — Horizonte €',
     } as never);
-    prisma.user.findUnique.mockResolvedValue({ name: 'Niñez' } as never);
-    prisma.payment.findUnique.mockResolvedValueOnce({
-      id: 'payment-1',
-      tenantId: 'tenant-1',
-      buildingId: 'building-1',
-      unitId: 'unit-1',
+    prisma.user.findUnique.mockResolvedValue({ name: "Niñez" } as never);
+    prisma.payment.findUnique.mockResolvedValue({
+      id: "payment-1",
+      tenantId: "tenant-1",
+      buildingId: "building-1",
+      unitId: "unit-1",
       amount: 4050000,
-      currency: 'ARS',
-      method: 'TRANSFER',
-      createdByUserId: 'resident-1',
-      approvedByUserId: 'admin-1',
-      approvedAt: '2026-07-24T12:00:00.000Z',
-      reference: 'Referencia “curva” € 🙂 / validado \\ soporte',
-      paymentAllocations: [{
-        chargeId: 'charge-1',
-        amount: 4050000,
-        charge: {
-          period: '2025-10',
-          concept: 'Condominio – especial…',
-          expensePeriod: { year: 2025, month: 10 },
+      currency: "ARS",
+      method: "TRANSFER",
+      createdByUserId: "resident-1",
+      approvedByUserId: "admin-1",
+      status: "APPROVED",
+      canceledAt: null,
+      approvedAt: "2026-07-24T12:00:00.000Z",
+      reference: "Referencia “curva” € 🙂 / validado \\ soporte",
+      paymentAllocations: [
+        {
+          chargeId: "charge-1",
+          amount: 4050000,
+          charge: {
+            period: "2025-10",
+            concept: "Condominio – especial…",
+            expensePeriod: { year: 2025, month: 10 },
+          },
         },
-      }],
+      ],
       unit: { label: 'TN-01-01' },
       building: { name: 'Torre “A”' },
       receiptDocumentId: null,
@@ -682,28 +715,32 @@ describe('PaymentReceiptService', () => {
     expect(uploadedBuffer.subarray(0, 5).toString('ascii')).toBe('%PDF-');
   });
 
-  it('escapes parentheses and backslashes in the PDF stream after WinAnsi encoding', async () => {
-    prisma.payment.findUnique.mockResolvedValueOnce({
-      id: 'payment-1',
-      tenantId: 'tenant-1',
-      buildingId: 'building-1',
-      unitId: 'unit-1',
+  it("escapes parentheses and backslashes in the PDF stream after WinAnsi encoding", async () => {
+    prisma.payment.findUnique.mockResolvedValue({
+      id: "payment-1",
+      tenantId: "tenant-1",
+      buildingId: "building-1",
+      unitId: "unit-1",
       amount: 4050000,
-      currency: 'ARS',
-      method: 'TRANSFER',
-      createdByUserId: 'resident-1',
-      approvedByUserId: 'admin-1',
-      approvedAt: '2026-07-24T12:00:00.000Z',
-      reference: 'Pago (confirmado) \\ soporte',
-      paymentAllocations: [{
-        chargeId: 'charge-1',
-        amount: 4050000,
-        charge: {
-          period: '2025-10',
-          concept: 'Condominio ordinario 2025-10',
-          expensePeriod: { year: 2025, month: 10 },
+      currency: "ARS",
+      method: "TRANSFER",
+      createdByUserId: "resident-1",
+      approvedByUserId: "admin-1",
+      status: "APPROVED",
+      canceledAt: null,
+      approvedAt: "2026-07-24T12:00:00.000Z",
+      reference: "Pago (confirmado) \\ soporte",
+      paymentAllocations: [
+        {
+          chargeId: "charge-1",
+          amount: 4050000,
+          charge: {
+            period: "2025-10",
+            concept: "Condominio ordinario 2025-10",
+            expensePeriod: { year: 2025, month: 10 },
+          },
         },
-      }],
+      ],
       unit: { label: 'TN-01-01' },
       building: { name: 'Complejo Horizonte' },
       receiptDocumentId: null,
@@ -720,19 +757,22 @@ describe('PaymentReceiptService', () => {
     expect(uploadedBuffer.subarray(0, 5).toString('ascii')).toBe('%PDF-');
   });
 
-  it('uses the persisted file bucket when reusing an existing receipt', async () => {
-    prisma.payment.findUnique.mockResolvedValueOnce({
-      id: 'payment-1',
-      tenantId: 'tenant-1',
-      buildingId: 'building-1',
-      unitId: 'unit-1',
+  it("uses the persisted file bucket when reusing an existing receipt", async () => {
+    prisma.payment.findUnique.mockResolvedValue({
+      id: "payment-1",
+      tenantId: "tenant-1",
+      buildingId: "building-1",
+      unitId: "unit-1",
       amount: 12345,
-      currency: 'ARS',
-      method: 'TRANSFER',
-      createdByUserId: 'resident-1',
-      approvedByUserId: 'admin-1',
-      approvedAt: '2026-07-24T12:00:00.000Z',
-      reference: 'TRX-001',
+      currency: "ARS",
+      method: "TRANSFER",
+      createdByUserId: "resident-1",
+      approvedByUserId: "admin-1",
+      status: "APPROVED",
+      canceledAt: null,
+      receiptStatus: ReceiptStatus.READY,
+      approvedAt: "2026-07-24T12:00:00.000Z",
+      reference: "TRX-001",
       paymentAllocations: [],
       unit: { label: 'TN-01-01' },
       building: { name: 'Complejo Horizonte' },
@@ -740,9 +780,25 @@ describe('PaymentReceiptService', () => {
       receiptNumber: 'R-HZ-2026-000001',
     } as never);
     prisma.document.findUnique.mockResolvedValueOnce({
-      id: 'document-1',
-      file: { bucket: 'tenant-legacy-bucket', objectKey: 'receipt.pdf' },
+      id: "document-1",
+      tenantId: "tenant-1",
+      category: "RECEIPT",
+      buildingId: "building-1",
+      unitId: "unit-1",
+      file: {
+        id: "file-1",
+        tenantId: "tenant-1",
+        bucket: "tenant-legacy-bucket",
+        objectKey: "receipt.pdf",
+        size: 123,
+        checksum: null,
+      },
     } as never);
+    prisma.paymentAuditLog.findFirst.mockResolvedValueOnce({
+      id: "audit-1",
+    } as never);
+    minio.objectExists.mockResolvedValueOnce(true);
+    minio.statObject.mockResolvedValueOnce({ size: 123 });
 
     const result = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
 
@@ -767,19 +823,21 @@ describe('PaymentReceiptService', () => {
     });
   });
 
-  it('splits long allocation lists across multiple PDF pages', async () => {
-    prisma.payment.findUnique.mockResolvedValueOnce({
-      id: 'payment-1',
-      tenantId: 'tenant-1',
-      buildingId: 'building-1',
-      unitId: 'unit-1',
+  it("splits long allocation lists across multiple PDF pages", async () => {
+    prisma.payment.findUnique.mockResolvedValue({
+      id: "payment-1",
+      tenantId: "tenant-1",
+      buildingId: "building-1",
+      unitId: "unit-1",
       amount: 4050000,
-      currency: 'ARS',
-      method: 'TRANSFER',
-      createdByUserId: 'resident-1',
-      approvedByUserId: 'admin-1',
-      approvedAt: '2026-07-24T12:00:00.000Z',
-      reference: 'TRX-001',
+      currency: "ARS",
+      method: "TRANSFER",
+      createdByUserId: "resident-1",
+      approvedByUserId: "admin-1",
+      status: "APPROVED",
+      canceledAt: null,
+      approvedAt: "2026-07-24T12:00:00.000Z",
+      reference: "TRX-001",
       paymentAllocations: Array.from({ length: 10 }, (_, index) => ({
         chargeId: `charge-${index + 1}`,
         amount: 405000,
@@ -824,17 +882,19 @@ describe('PaymentReceiptService', () => {
     const longReference = 'TRANSFERENCIA-EXTREMADAMENTE-LARGA-SIN-ESPACIOS-0123456789ABCDEFGHIJKLMN';
     const longConcept = 'Condominio ordinario con descripción extremadamente larga para validar el wrapping del PDF multipágina';
 
-    prisma.payment.findUnique.mockResolvedValueOnce({
-      id: 'payment-1',
-      tenantId: 'tenant-1',
-      buildingId: 'building-1',
-      unitId: 'unit-1',
+    prisma.payment.findUnique.mockResolvedValue({
+      id: "payment-1",
+      tenantId: "tenant-1",
+      buildingId: "building-1",
+      unitId: "unit-1",
       amount: 4050000,
-      currency: 'ARS',
-      method: 'TRANSFER',
-      createdByUserId: 'resident-1',
-      approvedByUserId: 'admin-1',
-      approvedAt: '2026-07-24T12:00:00.000Z',
+      currency: "ARS",
+      method: "TRANSFER",
+      createdByUserId: "resident-1",
+      approvedByUserId: "admin-1",
+      status: "APPROVED",
+      canceledAt: null,
+      approvedAt: "2026-07-24T12:00:00.000Z",
       reference: longReference,
       paymentAllocations: [{
         chargeId: 'charge-1',
@@ -870,5 +930,201 @@ describe('PaymentReceiptService', () => {
     expect(reconstructedText).toContain(longConcept);
     expect(reconstructedText).toContain(longReference);
     expectPdfTextWithinWidth(wrappedLines);
+  });
+
+  it("does not treat a pending receipt number without a document as complete", async () => {
+    const paymentState = {
+      id: "payment-1",
+      tenantId: "tenant-1",
+      buildingId: "building-1",
+      unitId: "unit-1",
+      amount: 4050000,
+      currency: "ARS",
+      method: "TRANSFER",
+      status: "APPROVED",
+      canceledAt: null,
+      receiptStatus: ReceiptStatus.PENDING,
+      receiptNumber: "R-COMPLE-2026-000001",
+      receiptDocumentId: null,
+      receiptError: null,
+      createdByUserId: "resident-1",
+      approvedByUserId: "admin-1",
+      approvedAt: "2026-07-24T12:00:00.000Z",
+      reference: "TRX-001",
+      paymentAllocations: [],
+      unit: { label: "TN-01-01" },
+      building: { name: "Complejo Horizonte" },
+    } as never;
+    prisma.payment.findUnique.mockResolvedValue(paymentState);
+    minio.uploadBuffer.mockRejectedValueOnce(new Error("storage unavailable"));
+
+    await expect(
+      service.ensureReceiptForPayment("tenant-1", "payment-1"),
+    ).resolves.toBeNull();
+
+    expect(minio.uploadBuffer).toHaveBeenCalledTimes(1);
+    expect(prisma.file.create).not.toHaveBeenCalled();
+    expect(prisma.document.create).not.toHaveBeenCalled();
+    expect(paymentState.receiptNumber).toBe("R-COMPLE-2026-000001");
+  });
+
+  it("returns an already complete receipt without creating or notifying again", async () => {
+    prisma.payment.findUnique.mockResolvedValue({
+      id: "payment-1",
+      tenantId: "tenant-1",
+      buildingId: "building-1",
+      unitId: "unit-1",
+      amount: 4050000,
+      currency: "ARS",
+      method: "TRANSFER",
+      status: "RECONCILED",
+      canceledAt: null,
+      receiptStatus: ReceiptStatus.READY,
+      receiptNumber: "R-COMPLE-2026-000001",
+      receiptDocumentId: "document-1",
+      createdByUserId: "resident-1",
+      approvedByUserId: "admin-1",
+      approvedAt: "2026-07-24T12:00:00.000Z",
+      reference: "TRX-001",
+      paymentAllocations: [],
+      unit: { label: "TN-01-01" },
+      building: { name: "Complejo Horizonte" },
+    } as never);
+    prisma.document.findUnique.mockResolvedValue({
+      id: "document-1",
+      tenantId: "tenant-1",
+      category: "RECEIPT",
+      buildingId: "building-1",
+      unitId: "unit-1",
+      file: {
+        id: "file-1",
+        tenantId: "tenant-1",
+        bucket: DEFAULT_BUCKET,
+        objectKey:
+          "tenant/tenant-1/payments/payment-1/receipts/R-COMPLE-2026-000001.pdf",
+        size: 123,
+        checksum: null,
+      },
+    } as never);
+    prisma.paymentAuditLog.findFirst.mockResolvedValue({
+      id: "audit-1",
+    } as never);
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 123 });
+
+    await service.ensureReceiptForPayment("tenant-1", "payment-1");
+    await service.ensureReceiptForPayment("tenant-1", "payment-1");
+
+    expect(minio.uploadBuffer).not.toHaveBeenCalled();
+    expect(prisma.file.create).not.toHaveBeenCalled();
+    expect(prisma.document.create).not.toHaveBeenCalled();
+    expect(prisma.paymentAuditLog.create).not.toHaveBeenCalled();
+    expect(notificationsService.createNotification).not.toHaveBeenCalled();
+  });
+
+  it("reuses a pre-existing canonical storage object when DB finalization is absent", async () => {
+    const payment = {
+      id: "payment-1",
+      tenantId: "tenant-1",
+      buildingId: "building-1",
+      unitId: "unit-1",
+      amount: 4050000,
+      currency: "ARS",
+      method: "TRANSFER",
+      status: "APPROVED",
+      canceledAt: null,
+      receiptStatus: ReceiptStatus.PENDING,
+      receiptNumber: "R-COMPLE-2026-000001",
+      receiptDocumentId: null,
+      createdByUserId: "resident-1",
+      approvedByUserId: "admin-1",
+      approvedAt: "2026-07-24T12:00:00.000Z",
+      reference: "TRX-001",
+      paymentAllocations: [],
+      unit: { label: "TN-01-01" },
+      building: { name: "Complejo Horizonte" },
+    } as never;
+    const generateReceiptPDF = Reflect.get(service, "generateReceiptPDF") as (
+      payment: unknown,
+      receiptNumber: string,
+      approvedByUserName: string,
+      tenantDisplayName: string,
+    ) => Promise<Buffer>;
+    const existingPdf = await generateReceiptPDF.call(
+      service,
+      payment,
+      "R-COMPLE-2026-000001",
+      "Admin",
+      "Complejo Horizonte",
+    );
+    prisma.payment.findUnique.mockResolvedValue(payment);
+    minio.objectExists.mockResolvedValue(true);
+    minio.getObjectBuffer.mockResolvedValue(existingPdf);
+
+    const result = await service.ensureReceiptForPayment(
+      "tenant-1",
+      "payment-1",
+    );
+
+    expect(result?.receiptNumber).toBe("R-COMPLE-2026-000001");
+    expect(minio.uploadBuffer).not.toHaveBeenCalled();
+    expect(prisma.file.create).toHaveBeenCalledTimes(1);
+    expect(prisma.document.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers after storage succeeds but DB finalization fails, reusing the number and object", async () => {
+    let paymentState = {
+      id: "payment-1",
+      tenantId: "tenant-1",
+      buildingId: "building-1",
+      unitId: "unit-1",
+      amount: 4050000,
+      currency: "ARS",
+      method: "TRANSFER",
+      status: "RECONCILED",
+      canceledAt: null,
+      receiptStatus: ReceiptStatus.PENDING,
+      receiptNumber: null as string | null,
+      receiptDocumentId: null as string | null,
+      receiptError: null as string | null,
+      createdByUserId: "resident-1",
+      approvedByUserId: "admin-1",
+      approvedAt: "2026-07-24T12:00:00.000Z",
+      reference: "TRX-001",
+      paymentAllocations: [],
+      unit: { label: "TN-01-01" },
+      building: { name: "Complejo Horizonte" },
+    } as never;
+    let storedObject: Buffer | null = null;
+    prisma.payment.findUnique.mockImplementation(async () => paymentState);
+    prisma.payment.update.mockImplementation(async ({ data }) => {
+      paymentState = { ...paymentState, ...data } as never;
+      return paymentState;
+    });
+    minio.objectExists.mockImplementation(async () => storedObject !== null);
+    minio.getObjectBuffer.mockImplementation(async () => storedObject!);
+    minio.uploadBuffer.mockImplementation(async (_bucket, _key, content) => {
+      storedObject = content;
+    });
+    prisma.document.create.mockRejectedValueOnce(
+      new Error("database unavailable"),
+    );
+
+    await expect(
+      service.ensureReceiptForPayment("tenant-1", "payment-1"),
+    ).resolves.toBeNull();
+    expect(storedObject).not.toBeNull();
+    const reservedNumber = paymentState.receiptNumber;
+
+    prisma.document.create.mockResolvedValue({ id: "document-1" } as never);
+    const result = await service.ensureReceiptForPayment(
+      "tenant-1",
+      "payment-1",
+    );
+
+    expect(result?.receiptNumber).toBe(reservedNumber);
+    expect(minio.uploadBuffer).toHaveBeenCalledTimes(1);
+    expect(paymentState.receiptStatus).toBe(ReceiptStatus.READY);
+    expect(prisma.paymentAuditLog.create).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -1,6 +1,8 @@
+import { ConflictException } from '@nestjs/common';
 import { PaymentReceiptService } from './payment-receipt.service';
 import { ReceiptStatus } from '@prisma/client';
 import { execFileSync, spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { writeFileSync } from 'node:fs';
 
 describe('PaymentReceiptService', () => {
@@ -52,6 +54,7 @@ describe('PaymentReceiptService', () => {
     file: {
       create: jest.fn(),
       findFirst: jest.fn(),
+      updateMany: jest.fn(),
     },
     tenant: {
       findUnique: jest.fn(),
@@ -287,6 +290,7 @@ describe('PaymentReceiptService', () => {
     prisma.receiptSequence.update.mockResolvedValue({ id: 'sequence-1' } as never);
     prisma.file.create.mockResolvedValue({ id: 'file-1' } as never);
     prisma.file.findFirst.mockResolvedValue(null);
+    prisma.file.updateMany.mockResolvedValue({ count: 1 });
     prisma.document.create.mockResolvedValue({ id: 'document-1', file: { bucket: DEFAULT_BUCKET, objectKey: 'object-1' } } as never);
     prisma.payment.update.mockResolvedValue({} as never);
     prisma.paymentAuditLog.create.mockResolvedValue({} as never);
@@ -294,6 +298,68 @@ describe('PaymentReceiptService', () => {
     notificationsService.createNotification.mockResolvedValue({} as never);
     minio.presignDownload.mockResolvedValue('https://download.example/receipt.pdf');
   });
+
+  function canonicalReceiptKey(receiptNumber = 'R-COMPLE-2026-000001'): string {
+    return `tenant/tenant-1/payments/payment-1/receipts/${receiptNumber}.pdf`;
+  }
+
+  function readyReceiptPayment(overrides: Record<string, unknown> = {}): unknown {
+    return {
+      id: 'payment-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      amount: 4050000,
+      currency: 'ARS',
+      method: 'TRANSFER',
+      status: 'APPROVED',
+      canceledAt: null,
+      receiptStatus: ReceiptStatus.READY,
+      receiptNumber: 'R-COMPLE-2026-000001',
+      receiptDocumentId: 'document-1',
+      createdByUserId: 'resident-1',
+      approvedByUserId: 'admin-1',
+      approvedAt: '2026-07-24T12:00:00.000Z',
+      reference: 'TRX-001',
+      paymentAllocations: [],
+      unit: { label: 'TN-01-01' },
+      building: { name: 'Complejo Horizonte' },
+      ...overrides,
+    };
+  }
+
+  function receiptDocument(fileOverrides: Record<string, unknown> = {}): unknown {
+    return {
+      id: 'document-1',
+      tenantId: 'tenant-1',
+      category: 'RECEIPT',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      file: {
+        id: 'file-1',
+        tenantId: 'tenant-1',
+        bucket: DEFAULT_BUCKET,
+        objectKey: canonicalReceiptKey(),
+        mimeType: 'application/pdf',
+        size: 123,
+        checksum: null,
+        ...fileOverrides,
+      },
+    };
+  }
+
+  function configureExistingReadyReceipt(
+    paymentOverrides: Record<string, unknown> = {},
+    fileOverrides: Record<string, unknown> = {},
+  ): void {
+    prisma.payment.findUnique.mockResolvedValue(
+      readyReceiptPayment(paymentOverrides) as never,
+    );
+    prisma.document.findUnique.mockResolvedValue(
+      receiptDocument(fileOverrides) as never,
+    );
+    prisma.paymentAuditLog.findFirst.mockResolvedValue({ id: 'audit-1' } as never);
+  }
 
   it('uses the configured bucket when generating a new receipt', async () => {
     const result = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
@@ -757,7 +823,7 @@ describe('PaymentReceiptService', () => {
     expect(uploadedBuffer.subarray(0, 5).toString('ascii')).toBe('%PDF-');
   });
 
-  it("uses the persisted file bucket when reusing an existing receipt", async () => {
+  it("fails closed for an existing receipt with a non-canonical bucket or key", async () => {
     prisma.payment.findUnique.mockResolvedValue({
       id: "payment-1",
       tenantId: "tenant-1",
@@ -790,6 +856,7 @@ describe('PaymentReceiptService', () => {
         tenantId: "tenant-1",
         bucket: "tenant-legacy-bucket",
         objectKey: "receipt.pdf",
+        mimeType: "application/pdf",
         size: 123,
         checksum: null,
       },
@@ -797,10 +864,12 @@ describe('PaymentReceiptService', () => {
     prisma.paymentAuditLog.findFirst.mockResolvedValueOnce({
       id: "audit-1",
     } as never);
-    minio.objectExists.mockResolvedValueOnce(true);
-    minio.statObject.mockResolvedValueOnce({ size: 123 });
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 123 });
 
-    const result = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
+    await expect(
+      service.ensureReceiptForPayment('tenant-1', 'payment-1'),
+    ).rejects.toBeInstanceOf(ConflictException);
 
     expect(prisma.document.findFirst).toHaveBeenCalledWith({
       where: {
@@ -811,16 +880,9 @@ describe('PaymentReceiptService', () => {
         file: true,
       },
     });
-    expect(minio.presignDownload).toHaveBeenCalledWith('tenant-legacy-bucket', 'receipt.pdf', 3600);
+    expect(minio.presignDownload).not.toHaveBeenCalled();
     expect(minio.uploadBuffer).not.toHaveBeenCalled();
     expect(prisma.file.create).not.toHaveBeenCalled();
-    expect(result).toEqual({
-      receiptNumber: 'R-HZ-2026-000001',
-      documentId: 'document-1',
-      fileKey: 'receipt.pdf',
-      bucket: 'tenant-legacy-bucket',
-      url: 'https://download.example/receipt.pdf',
-    });
   });
 
   it("splits long allocation lists across multiple PDF pages", async () => {
@@ -969,6 +1031,8 @@ describe('PaymentReceiptService', () => {
   });
 
   it("returns an already complete receipt without creating or notifying again", async () => {
+    const validPdf = Buffer.from("%PDF-validated-receipt");
+    const validChecksum = createHash("sha256").update(validPdf).digest("hex");
     prisma.payment.findUnique.mockResolvedValue({
       id: "payment-1",
       tenantId: "tenant-1",
@@ -1002,15 +1066,17 @@ describe('PaymentReceiptService', () => {
         bucket: DEFAULT_BUCKET,
         objectKey:
           "tenant/tenant-1/payments/payment-1/receipts/R-COMPLE-2026-000001.pdf",
-        size: 123,
-        checksum: null,
+        mimeType: "application/pdf",
+        size: validPdf.length,
+        checksum: validChecksum,
       },
     } as never);
     prisma.paymentAuditLog.findFirst.mockResolvedValue({
       id: "audit-1",
     } as never);
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: 123 });
+    minio.statObject.mockResolvedValue({ size: validPdf.length });
+    minio.getObjectBuffer.mockResolvedValue(validPdf);
 
     await service.ensureReceiptForPayment("tenant-1", "payment-1");
     await service.ensureReceiptForPayment("tenant-1", "payment-1");
@@ -1020,6 +1086,155 @@ describe('PaymentReceiptService', () => {
     expect(prisma.document.create).not.toHaveBeenCalled();
     expect(prisma.paymentAuditLog.create).not.toHaveBeenCalled();
     expect(notificationsService.createNotification).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when a READY receipt points to a different same-tenant object key', async () => {
+    configureExistingReadyReceipt({}, {
+      objectKey: 'tenant/tenant-1/payments/payment-2/receipts/R-OTHER-2026-000001.pdf',
+    });
+
+    await expect(
+      service.ensureReceiptForPayment('tenant-1', 'payment-1'),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(minio.presignDownload).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when a READY receipt File has a non-PDF MIME type', async () => {
+    configureExistingReadyReceipt({}, { mimeType: 'image/png' });
+
+    await expect(
+      service.ensureReceiptForPayment('tenant-1', 'payment-1'),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(minio.presignDownload).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when a canonical receipt object does not match its persisted checksum', async () => {
+    const wrongPdf = Buffer.from('%PDF-wrong-receipt');
+    configureExistingReadyReceipt({}, {
+      size: wrongPdf.length,
+      checksum: 'persisted-checksum-for-another-object',
+    });
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: wrongPdf.length });
+    minio.getObjectBuffer.mockResolvedValue(wrongPdf);
+
+    await expect(
+      service.ensureReceiptForPayment('tenant-1', 'payment-1'),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(minio.presignDownload).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when a receipt Document is linked to a File from another tenant', async () => {
+    configureExistingReadyReceipt({}, { tenantId: 'tenant-2' });
+
+    await expect(
+      service.ensureReceiptForPayment('tenant-1', 'payment-1'),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(minio.presignDownload).not.toHaveBeenCalled();
+  });
+
+  it('reuses a valid canonical READY receipt idempotently', async () => {
+    const validPdf = Buffer.from('%PDF-valid-canonical-receipt');
+    const checksum = createHash('sha256').update(validPdf).digest('hex');
+    configureExistingReadyReceipt({}, {
+      size: validPdf.length,
+      checksum,
+    });
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: validPdf.length });
+    minio.getObjectBuffer.mockResolvedValue(validPdf);
+
+    const first = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
+    const second = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
+
+    expect(first).toEqual(second);
+    expect(minio.presignDownload).toHaveBeenCalledTimes(2);
+    expect(minio.uploadBuffer).not.toHaveBeenCalled();
+    expect(prisma.file.updateMany).not.toHaveBeenCalled();
+    expect(prisma.paymentAuditLog.create).not.toHaveBeenCalled();
+    expect(notificationsService.createNotification).not.toHaveBeenCalled();
+  });
+
+  it('does not reuse a checksum-less legacy receipt as READY and repairs its metadata safely', async () => {
+    const payment = readyReceiptPayment({ receiptStatus: ReceiptStatus.READY });
+    const generateReceiptPDF = Reflect.get(service, 'generateReceiptPDF') as (
+      payment: unknown,
+      receiptNumber: string,
+      approvedByUserName: string,
+      tenantDisplayName: string,
+    ) => Promise<Buffer>;
+    const canonicalPdf = await generateReceiptPDF.call(
+      service,
+      payment,
+      'R-COMPLE-2026-000001',
+      'Admin',
+      'Complejo Horizonte',
+    );
+    configureExistingReadyReceipt({}, {
+      size: 1,
+      checksum: null,
+    });
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: canonicalPdf.length });
+    minio.getObjectBuffer.mockResolvedValue(canonicalPdf);
+
+    const result = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
+
+    expect(result?.receiptNumber).toBe('R-COMPLE-2026-000001');
+    expect(minio.uploadBuffer).not.toHaveBeenCalled();
+    expect(prisma.file.updateMany).toHaveBeenCalledWith({
+      where: { id: 'file-1', tenantId: 'tenant-1' },
+      data: {
+        bucket: DEFAULT_BUCKET,
+        objectKey: canonicalReceiptKey(),
+        mimeType: 'application/pdf',
+        size: canonicalPdf.length,
+        checksum: createHash('sha256').update(canonicalPdf).digest('hex'),
+      },
+    });
+  });
+
+  it('reconciles stale partial File metadata during canonical recovery', async () => {
+    const payment = readyReceiptPayment({ receiptStatus: ReceiptStatus.PENDING });
+    const generateReceiptPDF = Reflect.get(service, 'generateReceiptPDF') as (
+      payment: unknown,
+      receiptNumber: string,
+      approvedByUserName: string,
+      tenantDisplayName: string,
+    ) => Promise<Buffer>;
+    const canonicalPdf = await generateReceiptPDF.call(
+      service,
+      payment,
+      'R-COMPLE-2026-000001',
+      'Admin',
+      'Complejo Horizonte',
+    );
+    configureExistingReadyReceipt({ receiptStatus: ReceiptStatus.PENDING }, {
+      mimeType: 'application/octet-stream',
+      size: 1,
+      checksum: 'stale-checksum',
+    });
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: canonicalPdf.length });
+    minio.getObjectBuffer.mockResolvedValue(canonicalPdf);
+
+    const result = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
+
+    expect(result?.receiptNumber).toBe('R-COMPLE-2026-000001');
+    expect(prisma.file.updateMany).toHaveBeenCalledWith({
+      where: { id: 'file-1', tenantId: 'tenant-1' },
+      data: {
+        bucket: DEFAULT_BUCKET,
+        objectKey: canonicalReceiptKey(),
+        mimeType: 'application/pdf',
+        size: canonicalPdf.length,
+        checksum: createHash('sha256').update(canonicalPdf).digest('hex'),
+      },
+    });
   });
 
   it("reuses a pre-existing canonical storage object when DB finalization is absent", async () => {
@@ -1059,6 +1274,7 @@ describe('PaymentReceiptService', () => {
     );
     prisma.payment.findUnique.mockResolvedValue(payment);
     minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: existingPdf.length });
     minio.getObjectBuffer.mockResolvedValue(existingPdf);
 
     const result = await service.ensureReceiptForPayment(
@@ -1102,6 +1318,7 @@ describe('PaymentReceiptService', () => {
       return paymentState;
     });
     minio.objectExists.mockImplementation(async () => storedObject !== null);
+    minio.statObject.mockImplementation(async () => ({ size: storedObject?.length ?? 0 }));
     minio.getObjectBuffer.mockImplementation(async () => storedObject!);
     minio.uploadBuffer.mockImplementation(async (_bucket, _key, content) => {
       storedObject = content;

--- a/apps/api/src/receipts/payment-receipt.service.ts
+++ b/apps/api/src/receipts/payment-receipt.service.ts
@@ -1,7 +1,7 @@
 import { ConflictException, Injectable, Logger } from "@nestjs/common";
 import { createHash } from "node:crypto";
 import { PrismaService } from "../prisma/prisma.service";
-import { MinioService } from "../storage/minio.service";
+import { MinioObjectStat, MinioService } from "../storage/minio.service";
 import { NotificationsService } from "../notifications/notifications.service";
 import {
   DocumentCategory,
@@ -16,6 +16,8 @@ import {
 
 const RECEIPT_GENERATION_SAFE_ERROR =
   "No pudimos generar el comprobante. Intenta nuevamente más tarde.";
+const RECEIPT_MIME_TYPE = "application/pdf";
+const MAX_RECEIPT_OBJECT_BYTES = 10 * 1024 * 1024;
 
 export interface GenerateReceiptInput {
   paymentId: string;
@@ -89,7 +91,16 @@ interface ReceiptFileArtifact {
   readonly bucket: string;
   readonly objectKey: string;
   readonly size: number;
+  readonly mimeType: string;
   readonly checksum: string | null;
+}
+
+interface ReceiptStorageMetadata {
+  readonly bucket: string;
+  readonly objectKey: string;
+  readonly mimeType: string;
+  readonly size: number;
+  readonly checksum: string;
 }
 
 class ReceiptConsistencyError extends Error {}
@@ -188,7 +199,7 @@ export class PaymentReceiptService {
       const url = await this.minio.presignDownload(finalizedReceipt.bucket, finalizedReceipt.fileKey, 3600);
 
       if (finalizedReceipt.shouldNotify) {
-        // Notify resident outside the transaction.
+        // Receipt persistence is authoritative; delivery remains best-effort outside the transaction.
         await this.notifyResidentReceiptReady(
           finalizedReceipt.payment,
           finalizedReceipt.receiptNumber,
@@ -258,10 +269,23 @@ export class PaymentReceiptService {
       }
       if (
         existingDocument &&
-        !this.isValidReceiptDocument(existingDocument, payment)
+        !this.isReceiptDocumentIdentityValid(
+          existingDocument,
+          payment,
+          payment.receiptNumber!,
+        )
       ) {
         throw new ReceiptConsistencyError(
           `Receipt document ${existingDocument.id} is inconsistent with payment ${paymentId}`,
+        );
+      }
+      if (
+        existingDocument?.file &&
+        payment.receiptStatus === ReceiptStatus.READY &&
+        existingDocument.file.mimeType !== RECEIPT_MIME_TYPE
+      ) {
+        throw new ReceiptConsistencyError(
+          `Receipt File ${existingDocument.file.id} has an invalid MIME type`,
         );
       }
 
@@ -384,10 +408,23 @@ export class PaymentReceiptService {
       }
       if (
         existingDocument &&
-        !this.isValidReceiptDocument(existingDocument, currentPayment)
+        !this.isReceiptDocumentIdentityValid(
+          existingDocument,
+          currentPayment,
+          currentPayment.receiptNumber!,
+        )
       ) {
         throw new ReceiptConsistencyError(
           `Receipt document ${existingDocument.id} is inconsistent during finalization`,
+        );
+      }
+      if (
+        existingDocument?.file &&
+        currentPayment.receiptStatus === ReceiptStatus.READY &&
+        existingDocument.file.mimeType !== RECEIPT_MIME_TYPE
+      ) {
+        throw new ReceiptConsistencyError(
+          `Receipt File ${existingDocument.file.id} has an invalid MIME type`,
         );
       }
       if (
@@ -401,14 +438,12 @@ export class PaymentReceiptService {
 
       const receiptNumber =
         currentPayment.receiptNumber || preparedReceipt.receiptNumber;
-      const fileKey =
-        existingDocument?.file.objectKey ||
-        this.buildReceiptObjectKey(
-          currentPayment.tenantId,
-          currentPayment.id,
-          receiptNumber,
-        );
-      const bucket = existingDocument?.file.bucket || this.bucket;
+      const fileKey = this.buildReceiptObjectKey(
+        currentPayment.tenantId,
+        currentPayment.id,
+        receiptNumber,
+      );
+      const bucket = this.bucket;
       const auditExists = await this.receiptAuditExists(
         tx,
         tenantId,
@@ -453,12 +488,20 @@ export class PaymentReceiptService {
         approvedByUserName,
         tenant?.brandName || tenant?.name || "Consorcio",
       );
-      await this.ensureReceiptStorageObject(
+      const storageMetadata = await this.ensureReceiptStorageObject(
         bucket,
         fileKey,
         pdfContent,
-        existingDocument?.file,
       );
+
+      if (existingDocument?.file) {
+        await this.reconcileReceiptFileMetadata(
+          tx,
+          currentPayment.tenantId,
+          existingDocument.file.id,
+          storageMetadata,
+        );
+      }
 
       let documentId = existingDocument?.id;
       let fileId = existingDocument?.file.id;
@@ -564,16 +607,20 @@ export class PaymentReceiptService {
     });
   }
 
-  private isValidReceiptDocument(
+  private isReceiptDocumentIdentityValid(
     document: ReceiptDocumentWithFile,
-    payment: Pick<PaymentReceiptPayment, "tenantId" | "buildingId" | "unitId">,
+    payment: Pick<PaymentReceiptPayment, "id" | "tenantId" | "buildingId" | "unitId">,
+    receiptNumber: string,
   ): boolean {
     return (
       document.tenantId === payment.tenantId &&
       document.file.tenantId === payment.tenantId &&
       document.category === DocumentCategory.RECEIPT &&
       document.buildingId === payment.buildingId &&
-      document.unitId === payment.unitId
+      document.unitId === payment.unitId &&
+      document.file.bucket === this.bucket &&
+      document.file.objectKey ===
+        this.buildReceiptObjectKey(payment.tenantId, payment.id, receiptNumber)
     );
   }
 
@@ -648,53 +695,116 @@ export class PaymentReceiptService {
   private async isCompleteStorageArtifact(
     file: ReceiptFileArtifact,
   ): Promise<boolean> {
+    // Legacy checksum-less artifacts are recovered, never reused as READY.
+    if (file.mimeType !== RECEIPT_MIME_TYPE || !file.checksum) {
+      return false;
+    }
     if (!(await this.minio.objectExists(file.bucket, file.objectKey))) {
       return false;
     }
     const stat = await this.minio.statObject(file.bucket, file.objectKey);
-    if (stat.size <= 0 || stat.size !== file.size) {
+    if (!this.isValidReceiptObjectStat(stat, file.size)) {
       return false;
     }
-    if (file.checksum) {
-      const content = await this.minio.getObjectBuffer(
-        file.bucket,
-        file.objectKey,
-      );
-      return this.sha256(content) === file.checksum;
-    }
-    return true;
+    const content = await this.minio.getObjectBuffer(
+      file.bucket,
+      file.objectKey,
+    );
+    return (
+      this.isPdfContent(content) &&
+      content.length === stat.size &&
+      this.sha256(content) === file.checksum
+    );
   }
 
   private async ensureReceiptStorageObject(
     bucket: string,
     fileKey: string,
     pdfContent: Buffer,
-    existingFile?: Pick<ReceiptFileArtifact, "checksum">,
-  ): Promise<void> {
+  ): Promise<ReceiptStorageMetadata> {
+    if (!this.isPdfContent(pdfContent) || pdfContent.length > MAX_RECEIPT_OBJECT_BYTES) {
+      throw new Error(`Generated receipt PDF exceeds the supported storage contract`);
+    }
+
     if (await this.minio.objectExists(bucket, fileKey)) {
-      const existingContent = await this.minio.getObjectBuffer(bucket, fileKey);
-      if (
-        existingFile?.checksum &&
-        this.sha256(existingContent) !== existingFile.checksum
-      ) {
+      const stat = await this.minio.statObject(bucket, fileKey);
+      if (!this.isValidReceiptObjectStat(stat, pdfContent.length)) {
         throw new ReceiptConsistencyError(
-          `Receipt storage object checksum mismatch for ${bucket}/${fileKey}`,
+          `Receipt storage object metadata mismatch for ${bucket}/${fileKey}`,
         );
       }
-      if (!existingContent.equals(pdfContent)) {
+      const existingContent = await this.minio.getObjectBuffer(bucket, fileKey);
+      if (
+        !this.isPdfContent(existingContent) ||
+        existingContent.length !== stat.size ||
+        !existingContent.equals(pdfContent)
+      ) {
         throw new ReceiptConsistencyError(
           `Receipt storage object content mismatch for ${bucket}/${fileKey}`,
         );
       }
-      return;
+      return {
+        bucket,
+        objectKey: fileKey,
+        mimeType: RECEIPT_MIME_TYPE,
+        size: existingContent.length,
+        checksum: this.sha256(existingContent),
+      };
     }
 
     await this.minio.uploadBuffer(
       bucket,
       fileKey,
       pdfContent,
-      "application/pdf",
+      RECEIPT_MIME_TYPE,
     );
+    return {
+      bucket,
+      objectKey: fileKey,
+      mimeType: RECEIPT_MIME_TYPE,
+      size: pdfContent.length,
+      checksum: this.sha256(pdfContent),
+    };
+  }
+
+  private isValidReceiptObjectStat(
+    stat: MinioObjectStat,
+    expectedSize: number,
+  ): boolean {
+    const contentType = stat.metaData?.["content-type"] ?? stat.metaData?.["Content-Type"];
+    return (
+      stat.size > 0 &&
+      stat.size <= MAX_RECEIPT_OBJECT_BYTES &&
+      stat.size === expectedSize &&
+      (!contentType || contentType === RECEIPT_MIME_TYPE)
+    );
+  }
+
+  private isPdfContent(content: Buffer): boolean {
+    return content.subarray(0, 5).toString("ascii") === "%PDF-";
+  }
+
+  private async reconcileReceiptFileMetadata(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    fileId: string,
+    metadata: ReceiptStorageMetadata,
+  ): Promise<void> {
+    const result = await tx.file.updateMany({
+      where: { id: fileId, tenantId },
+      data: {
+        bucket: metadata.bucket,
+        objectKey: metadata.objectKey,
+        mimeType: metadata.mimeType,
+        size: metadata.size,
+        checksum: metadata.checksum,
+      },
+    });
+    if (result.count !== 1) {
+      throw new ReceiptConsistencyError(
+        `Receipt File ${fileId} is missing or belongs to another tenant`,
+      );
+    }
   }
 
   private sha256(content: Buffer): string {

--- a/apps/api/src/receipts/payment-receipt.service.ts
+++ b/apps/api/src/receipts/payment-receipt.service.ts
@@ -1,11 +1,21 @@
-import { Injectable, Logger } from '@nestjs/common';
-import { PrismaService } from '../prisma/prisma.service';
-import { MinioService } from '../storage/minio.service';
-import { NotificationsService } from '../notifications/notifications.service';
-import { DocumentCategory, DocumentVisibility, Prisma, ReceiptStatus } from '@prisma/client';
-import { acquirePaymentReceiptLock } from '../common/payment-linked-document-lock';
+import { ConflictException, Injectable, Logger } from "@nestjs/common";
+import { createHash } from "node:crypto";
+import { PrismaService } from "../prisma/prisma.service";
+import { MinioService } from "../storage/minio.service";
+import { NotificationsService } from "../notifications/notifications.service";
+import {
+  DocumentCategory,
+  DocumentVisibility,
+  Prisma,
+  ReceiptStatus,
+} from "@prisma/client";
+import {
+  acquirePaymentReceiptLock,
+  acquireReceiptSequenceLock,
+} from "../common/payment-linked-document-lock";
 
-const RECEIPT_GENERATION_SAFE_ERROR = 'No pudimos generar el comprobante. Intenta nuevamente más tarde.';
+const RECEIPT_GENERATION_SAFE_ERROR =
+  "No pudimos generar el comprobante. Intenta nuevamente más tarde.";
 
 export interface GenerateReceiptInput {
   paymentId: string;
@@ -37,6 +47,10 @@ type PaymentReceiptPayment = Prisma.PaymentGetPayload<{
   };
 }>;
 
+type ReceiptDocumentWithFile = Prisma.DocumentGetPayload<{
+  include: { file: true };
+}>;
+
 type ChargeWithAllocations = Prisma.ChargeGetPayload<{
   include: {
     paymentAllocations: {
@@ -60,7 +74,25 @@ interface PreparedReceiptGeneration {
   tenantDisplayName: string;
   reuseExisting: boolean;
   documentId?: string;
+  shouldNotify: boolean;
 }
+
+interface FinalizedReceipt extends PreparedReceiptGeneration {
+  documentId: string;
+  wasGenerated: boolean;
+  shouldNotify: boolean;
+}
+
+interface ReceiptFileArtifact {
+  readonly id: string;
+  readonly tenantId: string;
+  readonly bucket: string;
+  readonly objectKey: string;
+  readonly size: number;
+  readonly checksum: string | null;
+}
+
+class ReceiptConsistencyError extends Error {}
 
 interface ReceiptPdfLine {
   text: string;
@@ -121,13 +153,16 @@ export class PaymentReceiptService {
    * Idempotent: if receipt already exists, return it.
    * If generation fails before confirmation, sets receiptStatus = FAILED with error message.
    */
-  async ensureReceiptForPayment(tenantId: string, paymentId: string, excludeUserId?: string): Promise<ReceiptData | null> {
-    let preparedReceipt: PreparedReceiptGeneration | null = null;
-    let uploadedReceiptObject = false;
-    let receiptFinalized = false;
-
+  async ensureReceiptForPayment(
+    tenantId: string,
+    paymentId: string,
+    excludeUserId?: string,
+  ): Promise<ReceiptData | null> {
     try {
-      preparedReceipt = await this.prepareReceiptGeneration(tenantId, paymentId);
+      const preparedReceipt = await this.prepareReceiptGeneration(
+        tenantId,
+        paymentId,
+      );
 
       if (!preparedReceipt) {
         return null;
@@ -145,41 +180,27 @@ export class PaymentReceiptService {
         };
       }
 
-      const pdfContent = await this.generateReceiptPDF(
-        preparedReceipt.payment,
-        preparedReceipt.receiptNumber,
-        preparedReceipt.approvedByUserName,
-        preparedReceipt.tenantDisplayName,
+      const finalizedReceipt = await this.generateAndFinalizeReceipt(
+        tenantId,
+        preparedReceipt,
       );
-
-      await this.minio.uploadBuffer(preparedReceipt.bucket, preparedReceipt.fileKey, pdfContent, 'application/pdf');
-      uploadedReceiptObject = true;
-
-      const finalizedReceipt = await this.finalizeReceiptGeneration(tenantId, preparedReceipt, pdfContent.length);
-      receiptFinalized = true;
 
       const url = await this.minio.presignDownload(finalizedReceipt.bucket, finalizedReceipt.fileKey, 3600);
 
-      if (!finalizedReceipt.wasGenerated) {
-        return {
-          receiptNumber: finalizedReceipt.receiptNumber,
-          documentId: finalizedReceipt.documentId,
-          fileKey: finalizedReceipt.fileKey,
-          bucket: finalizedReceipt.bucket,
+      if (finalizedReceipt.shouldNotify) {
+        // Notify resident outside the transaction.
+        await this.notifyResidentReceiptReady(
+          finalizedReceipt.payment,
+          finalizedReceipt.receiptNumber,
           url,
-        };
+          finalizedReceipt.approvedByUserName,
+          excludeUserId,
+        );
+
+        this.logger.log(
+          `Receipt ${finalizedReceipt.receiptNumber} generated for payment ${paymentId}`,
+        );
       }
-
-      // Notify resident outside the transaction.
-      await this.notifyResidentReceiptReady(
-        finalizedReceipt.payment,
-        finalizedReceipt.receiptNumber,
-        url,
-        finalizedReceipt.approvedByUserName,
-        excludeUserId,
-      );
-
-      this.logger.log(`Receipt ${finalizedReceipt.receiptNumber} generated for payment ${paymentId}`);
 
       return {
         receiptNumber: finalizedReceipt.receiptNumber,
@@ -192,8 +213,8 @@ export class PaymentReceiptService {
       const rawMessage = error instanceof Error ? error.message : String(error);
       this.logger.error(`Failed to generate receipt for payment ${paymentId}: ${rawMessage}`);
 
-      if (uploadedReceiptObject && preparedReceipt && !preparedReceipt.reuseExisting && !receiptFinalized) {
-        await this.cleanupUploadedReceiptObjectIfSafe(tenantId, preparedReceipt);
+      if (error instanceof ReceiptConsistencyError) {
+        throw new ConflictException(rawMessage);
       }
 
       await this.markReceiptGenerationFailedIfNeeded(tenantId, paymentId, RECEIPT_GENERATION_SAFE_ERROR);
@@ -213,82 +234,122 @@ export class PaymentReceiptService {
         return null;
       }
 
-      if (payment.receiptDocumentId && payment.receiptNumber) {
-        this.logger.log(`Receipt already exists for payment ${paymentId}, reusing ${payment.receiptNumber}`);
+      if (!this.isReceiptEligible(payment)) {
+        return null;
+      }
 
-        const existingDocument = await tx.document.findFirst({
-          where: {
-            id: payment.receiptDocumentId,
+      const existingDocument = payment.receiptDocumentId
+        ? await this.loadReceiptDocument(
+            tx,
             tenantId,
-          },
-          include: { file: true },
-        });
+            payment.receiptDocumentId,
+          )
+        : null;
 
-        if (!existingDocument?.file) {
-          throw new Error(`Receipt document ${payment.receiptDocumentId} not found for payment ${paymentId}`);
+      if (payment.receiptDocumentId && !existingDocument) {
+        throw new ReceiptConsistencyError(
+          `Receipt document ${payment.receiptDocumentId} is missing or belongs to another tenant`,
+        );
+      }
+      if (existingDocument && !payment.receiptNumber) {
+        throw new ReceiptConsistencyError(
+          `Receipt document ${existingDocument.id} has no receipt number`,
+        );
+      }
+      if (
+        existingDocument &&
+        !this.isValidReceiptDocument(existingDocument, payment)
+      ) {
+        throw new ReceiptConsistencyError(
+          `Receipt document ${existingDocument.id} is inconsistent with payment ${paymentId}`,
+        );
+      }
+
+      if (existingDocument?.file && payment.receiptNumber) {
+        const storageComplete = await this.isCompleteStorageArtifact(
+          existingDocument.file,
+        );
+        const auditExists = await this.receiptAuditExists(
+          tx,
+          tenantId,
+          paymentId,
+        );
+        if (
+          payment.receiptStatus === ReceiptStatus.READY &&
+          storageComplete &&
+          auditExists
+        ) {
+          this.logger.log(
+            `Receipt already exists for payment ${paymentId}, reusing ${payment.receiptNumber}`,
+          );
+          return this.buildPreparedReceipt(
+            payment,
+            payment.receiptNumber,
+            existingDocument.file.bucket,
+            existingDocument.file.objectKey,
+            existingDocument.id,
+            true,
+            false,
+            tx,
+          );
         }
 
-        const tenant = await tx.tenant.findUnique({
-          where: { id: payment.tenantId },
-          select: { name: true, brandName: true },
-        });
+        if (payment.receiptStatus === ReceiptStatus.READY && !storageComplete) {
+          await tx.payment.update({
+            where: { id: paymentId, tenantId },
+            data: {
+              receiptStatus: ReceiptStatus.PENDING,
+              receiptGeneratedAt: null,
+              receiptError: null,
+            },
+          });
+        }
 
-        return {
+        return this.buildPreparedReceipt(
           payment,
-          receiptNumber: payment.receiptNumber,
-          fileKey: existingDocument.file.objectKey,
-          bucket: existingDocument.file.bucket,
-          approvedByUserName: 'Administración',
-          tenantDisplayName: tenant?.brandName || tenant?.name || 'Consorcio',
-          reuseExisting: true,
-          documentId: existingDocument.id,
-        };
+          payment.receiptNumber,
+          existingDocument.file.bucket,
+          existingDocument.file.objectKey,
+          existingDocument.id,
+          false,
+          payment.receiptStatus !== ReceiptStatus.READY,
+          tx,
+        );
       }
 
-      let approvedByUserName = 'Administración';
-      if (payment.approvedByUserId) {
-        const approvedByUser = await tx.user.findUnique({
-          where: { id: payment.approvedByUserId },
-          select: { name: true },
-        });
-        approvedByUserName = approvedByUser?.name || 'Administración';
+      if (payment.receiptStatus === ReceiptStatus.READY) {
+        throw new ReceiptConsistencyError(
+          `Payment ${paymentId} is READY without a linked receipt document`,
+        );
       }
 
-      const receiptNumber = payment.receiptNumber || await this.reserveReceiptNumberInTransaction(tx, payment.tenantId);
-      const tenant = await tx.tenant.findUnique({
-        where: { id: payment.tenantId },
-        select: { name: true, brandName: true },
-      });
-      const tenantDisplayName = tenant?.brandName || tenant?.name || 'Consorcio';
-      const fileKey = this.buildReceiptObjectKey(payment.tenantId, paymentId, receiptNumber);
+      const receiptNumber =
+        payment.receiptNumber ||
+        (await this.reserveReceiptNumberInTransaction(tx, payment.tenantId));
+      const fileKey = this.buildReceiptObjectKey(
+        payment.tenantId,
+        paymentId,
+        receiptNumber,
+      );
 
-      await tx.payment.update({
-        where: { id: paymentId, tenantId },
-        data: {
-          receiptNumber,
-          receiptStatus: ReceiptStatus.PENDING,
-          receiptGeneratedAt: null,
-          receiptError: null,
-        },
-      });
-
-      return {
+      await this.markPaymentPending(tx, tenantId, paymentId, receiptNumber);
+      return this.buildPreparedReceipt(
         payment,
         receiptNumber,
+        this.bucket,
         fileKey,
-        bucket: this.bucket,
-        approvedByUserName,
-        tenantDisplayName,
-        reuseExisting: false,
-      };
+        undefined,
+        false,
+        true,
+        tx,
+      );
     });
   }
 
-  private async finalizeReceiptGeneration(
+  private async generateAndFinalizeReceipt(
     tenantId: string,
     preparedReceipt: PreparedReceiptGeneration,
-    pdfSize: number,
-  ): Promise<PreparedReceiptGeneration & { documentId: string; wasGenerated: boolean }> {
+  ): Promise<FinalizedReceipt> {
     return this.prisma.$transaction(async (tx) => {
       await acquirePaymentReceiptLock(tx, preparedReceipt.payment.id);
 
@@ -298,115 +359,346 @@ export class PaymentReceiptService {
         throw new Error(`Payment ${preparedReceipt.payment.id} not found while finalizing receipt`);
       }
 
-      if (currentPayment.receiptDocumentId && currentPayment.receiptNumber) {
-        const existingDocument = await tx.document.findFirst({
-          where: {
-            id: currentPayment.receiptDocumentId,
+      if (!this.isReceiptEligible(currentPayment)) {
+        throw new ReceiptConsistencyError(
+          `Payment ${preparedReceipt.payment.id} is not eligible for receipt recovery`,
+        );
+      }
+
+      const existingDocument = currentPayment.receiptDocumentId
+        ? await this.loadReceiptDocument(
+            tx,
             tenantId,
-          },
-          include: { file: true },
-        });
+            currentPayment.receiptDocumentId,
+          )
+        : null;
+      if (currentPayment.receiptDocumentId && !existingDocument) {
+        throw new ReceiptConsistencyError(
+          `Receipt document ${currentPayment.receiptDocumentId} is missing during finalization`,
+        );
+      }
+      if (existingDocument && !currentPayment.receiptNumber) {
+        throw new ReceiptConsistencyError(
+          `Receipt document ${existingDocument.id} has no receipt number during finalization`,
+        );
+      }
+      if (
+        existingDocument &&
+        !this.isValidReceiptDocument(existingDocument, currentPayment)
+      ) {
+        throw new ReceiptConsistencyError(
+          `Receipt document ${existingDocument.id} is inconsistent during finalization`,
+        );
+      }
+      if (
+        currentPayment.receiptNumber &&
+        currentPayment.receiptNumber !== preparedReceipt.receiptNumber
+      ) {
+        throw new ReceiptConsistencyError(
+          `Receipt number changed during recovery for payment ${currentPayment.id}`,
+        );
+      }
 
-        if (!existingDocument?.file) {
-          throw new Error(`Receipt document ${currentPayment.receiptDocumentId} not found for payment ${preparedReceipt.payment.id}`);
-        }
-
-        this.logger.log(`Receipt already finalized for payment ${preparedReceipt.payment.id}, reusing ${currentPayment.receiptNumber}`);
-
+      const receiptNumber =
+        currentPayment.receiptNumber || preparedReceipt.receiptNumber;
+      const fileKey =
+        existingDocument?.file.objectKey ||
+        this.buildReceiptObjectKey(
+          currentPayment.tenantId,
+          currentPayment.id,
+          receiptNumber,
+        );
+      const bucket = existingDocument?.file.bucket || this.bucket;
+      const auditExists = await this.receiptAuditExists(
+        tx,
+        tenantId,
+        currentPayment.id,
+      );
+      const storageComplete = existingDocument?.file
+        ? await this.isCompleteStorageArtifact(existingDocument.file)
+        : false;
+      if (
+        currentPayment.receiptStatus === ReceiptStatus.READY &&
+        existingDocument?.file &&
+        storageComplete &&
+        auditExists
+      ) {
         return {
           ...preparedReceipt,
           payment: currentPayment,
-          receiptNumber: currentPayment.receiptNumber,
-          fileKey: existingDocument.file.objectKey,
-          bucket: existingDocument.file.bucket,
+          receiptNumber,
+          fileKey,
+          bucket,
           documentId: existingDocument.id,
           wasGenerated: false,
+          shouldNotify: false,
         };
       }
 
-      const file = await tx.file.create({
-        data: {
-          tenantId: preparedReceipt.payment.tenantId,
-          bucket: preparedReceipt.bucket,
-          objectKey: preparedReceipt.fileKey,
-          originalName: `receipt_${preparedReceipt.receiptNumber}.pdf`,
-          mimeType: 'application/pdf',
-          size: pdfSize,
-        },
+      const tenant = await tx.tenant.findUnique({
+        where: { id: currentPayment.tenantId },
+        select: { name: true, brandName: true },
       });
+      let approvedByUserName = "Administración";
+      if (currentPayment.approvedByUserId) {
+        const approvedByUser = await tx.user.findUnique({
+          where: { id: currentPayment.approvedByUserId },
+          select: { name: true },
+        });
+        approvedByUserName = approvedByUser?.name || "Administración";
+      }
+      const pdfContent = await this.generateReceiptPDF(
+        currentPayment,
+        receiptNumber,
+        approvedByUserName,
+        tenant?.brandName || tenant?.name || "Consorcio",
+      );
+      await this.ensureReceiptStorageObject(
+        bucket,
+        fileKey,
+        pdfContent,
+        existingDocument?.file,
+      );
 
-      const document = await tx.document.create({
-        data: {
-          tenantId: preparedReceipt.payment.tenantId,
-          fileId: file.id,
-          title: `Recibo de pago ${preparedReceipt.receiptNumber}`,
-          category: DocumentCategory.RECEIPT,
-          visibility: DocumentVisibility.RESIDENTS,
-          buildingId: preparedReceipt.payment.buildingId,
-          unitId: preparedReceipt.payment.unitId,
-        },
-      });
+      let documentId = existingDocument?.id;
+      let fileId = existingDocument?.file.id;
+      if (!documentId) {
+        const existingFile = await tx.file.findFirst({
+          where: {
+            tenantId: currentPayment.tenantId,
+            bucket,
+            objectKey: fileKey,
+          },
+        });
+        if (existingFile) {
+          throw new ReceiptConsistencyError(
+            `Receipt storage key ${bucket}/${fileKey} already has an unrelated database File`,
+          );
+        }
+        const file = await tx.file.create({
+          data: {
+            tenantId: currentPayment.tenantId,
+            bucket,
+            objectKey: fileKey,
+            originalName: `receipt_${receiptNumber}.pdf`,
+            mimeType: "application/pdf",
+            size: pdfContent.length,
+            checksum: this.sha256(pdfContent),
+          },
+        });
+        fileId = file.id;
+
+        const document = await tx.document.create({
+          data: {
+            tenantId: currentPayment.tenantId,
+            fileId: file.id,
+            title: `Recibo de pago ${receiptNumber}`,
+            category: DocumentCategory.RECEIPT,
+            visibility: DocumentVisibility.RESIDENTS,
+            buildingId: currentPayment.buildingId,
+            unitId: currentPayment.unitId,
+          },
+        });
+        documentId = document.id;
+      }
+
+      if (!documentId || !fileId) {
+        throw new ReceiptConsistencyError(
+          `Receipt artifacts are incomplete for payment ${currentPayment.id}`,
+        );
+      }
 
       await tx.payment.update({
-        where: { id: preparedReceipt.payment.id, tenantId },
+        where: { id: currentPayment.id, tenantId },
         data: {
-          receiptDocumentId: document.id,
-          receiptNumber: preparedReceipt.receiptNumber,
+          receiptDocumentId: documentId,
+          receiptNumber,
           receiptStatus: ReceiptStatus.READY,
           receiptGeneratedAt: new Date(),
           receiptError: null,
         },
       });
 
-      await tx.paymentAuditLog.create({
-        data: {
-          tenantId: preparedReceipt.payment.tenantId,
-          paymentId: preparedReceipt.payment.id,
-          action: 'RECEIPT_GENERATED',
-          metadata: {
-            receiptNumber: preparedReceipt.receiptNumber,
-            documentId: document.id,
-            objectKey: preparedReceipt.fileKey,
+      if (!auditExists) {
+        await tx.paymentAuditLog.create({
+          data: {
+            tenantId: currentPayment.tenantId,
+            paymentId: currentPayment.id,
+            action: "RECEIPT_GENERATED",
+            metadata: { receiptNumber, documentId, objectKey: fileKey },
           },
-        },
-      });
+        });
+      }
 
       return {
         ...preparedReceipt,
         payment: currentPayment,
-        documentId: document.id,
+        approvedByUserName,
+        receiptNumber,
+        fileKey,
+        bucket,
+        documentId,
         wasGenerated: true,
+        shouldNotify: preparedReceipt.shouldNotify,
       };
     });
   }
 
-  private async cleanupUploadedReceiptObjectIfSafe(tenantId: string, preparedReceipt: PreparedReceiptGeneration): Promise<void> {
-    try {
-      const payment = await this.prisma.payment.findFirst({
-        where: { id: preparedReceipt.payment.id, tenantId },
-        select: {
-          receiptDocumentId: true,
-          receiptNumber: true,
-          receiptStatus: true,
-        },
+  private isReceiptEligible(
+    payment: Pick<PaymentReceiptPayment, "status" | "canceledAt">,
+  ): boolean {
+    return (
+      payment.canceledAt === null &&
+      (payment.status === "APPROVED" || payment.status === "RECONCILED")
+    );
+  }
+
+  private async loadReceiptDocument(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    documentId: string,
+  ): Promise<ReceiptDocumentWithFile | null> {
+    return tx.document.findFirst({
+      where: { id: documentId, tenantId },
+      include: { file: true },
+    });
+  }
+
+  private isValidReceiptDocument(
+    document: ReceiptDocumentWithFile,
+    payment: Pick<PaymentReceiptPayment, "tenantId" | "buildingId" | "unitId">,
+  ): boolean {
+    return (
+      document.tenantId === payment.tenantId &&
+      document.file.tenantId === payment.tenantId &&
+      document.category === DocumentCategory.RECEIPT &&
+      document.buildingId === payment.buildingId &&
+      document.unitId === payment.unitId
+    );
+  }
+
+  private async receiptAuditExists(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    paymentId: string,
+  ): Promise<boolean> {
+    const audit = await tx.paymentAuditLog.findFirst({
+      where: {
+        tenantId,
+        paymentId,
+        action: "RECEIPT_GENERATED",
+      },
+      select: { id: true },
+    });
+    return audit !== null;
+  }
+
+  private async buildPreparedReceipt(
+    payment: PaymentReceiptPayment,
+    receiptNumber: string,
+    bucket: string,
+    fileKey: string,
+    documentId: string | undefined,
+    reuseExisting: boolean,
+    shouldNotify: boolean,
+    tx: Prisma.TransactionClient,
+  ): Promise<PreparedReceiptGeneration> {
+    const tenant = await tx.tenant.findUnique({
+      where: { id: payment.tenantId },
+      select: { name: true, brandName: true },
+    });
+    let approvedByUserName = "Administración";
+    if (payment.approvedByUserId) {
+      const approvedByUser = await tx.user.findUnique({
+        where: { id: payment.approvedByUserId },
+        select: { name: true },
       });
-
-      if (payment?.receiptDocumentId || payment?.receiptStatus === ReceiptStatus.READY) {
-        this.logger.warn(
-          `Leaving reusable unconfirmed receipt object ${preparedReceipt.bucket}/${preparedReceipt.fileKey} untouched because payment ${preparedReceipt.payment.id} is already confirmed`,
-        );
-        return;
-      }
-
-      this.logger.warn(
-        `Leaving reusable unconfirmed receipt object ${preparedReceipt.bucket}/${preparedReceipt.fileKey} after failed finalization for payment ${preparedReceipt.payment.id}`,
-      );
-    } catch (cleanupError) {
-      const errorMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
-      this.logger.warn(
-        `Failed to inspect reusable receipt object ${preparedReceipt.bucket}/${preparedReceipt.fileKey}: ${errorMessage}`,
-      );
+      approvedByUserName = approvedByUser?.name || "Administración";
     }
+    return {
+      payment,
+      receiptNumber,
+      fileKey,
+      bucket,
+      approvedByUserName,
+      tenantDisplayName: tenant?.brandName || tenant?.name || "Consorcio",
+      reuseExisting,
+      documentId,
+      shouldNotify,
+    };
+  }
+
+  private async markPaymentPending(
+    tx: Prisma.TransactionClient,
+    tenantId: string,
+    paymentId: string,
+    receiptNumber: string,
+  ): Promise<void> {
+    await tx.payment.update({
+      where: { id: paymentId, tenantId },
+      data: {
+        receiptNumber,
+        receiptStatus: ReceiptStatus.PENDING,
+        receiptGeneratedAt: null,
+        receiptError: null,
+      },
+    });
+  }
+
+  private async isCompleteStorageArtifact(
+    file: ReceiptFileArtifact,
+  ): Promise<boolean> {
+    if (!(await this.minio.objectExists(file.bucket, file.objectKey))) {
+      return false;
+    }
+    const stat = await this.minio.statObject(file.bucket, file.objectKey);
+    if (stat.size <= 0 || stat.size !== file.size) {
+      return false;
+    }
+    if (file.checksum) {
+      const content = await this.minio.getObjectBuffer(
+        file.bucket,
+        file.objectKey,
+      );
+      return this.sha256(content) === file.checksum;
+    }
+    return true;
+  }
+
+  private async ensureReceiptStorageObject(
+    bucket: string,
+    fileKey: string,
+    pdfContent: Buffer,
+    existingFile?: Pick<ReceiptFileArtifact, "checksum">,
+  ): Promise<void> {
+    if (await this.minio.objectExists(bucket, fileKey)) {
+      const existingContent = await this.minio.getObjectBuffer(bucket, fileKey);
+      if (
+        existingFile?.checksum &&
+        this.sha256(existingContent) !== existingFile.checksum
+      ) {
+        throw new ReceiptConsistencyError(
+          `Receipt storage object checksum mismatch for ${bucket}/${fileKey}`,
+        );
+      }
+      if (!existingContent.equals(pdfContent)) {
+        throw new ReceiptConsistencyError(
+          `Receipt storage object content mismatch for ${bucket}/${fileKey}`,
+        );
+      }
+      return;
+    }
+
+    await this.minio.uploadBuffer(
+      bucket,
+      fileKey,
+      pdfContent,
+      "application/pdf",
+    );
+  }
+
+  private sha256(content: Buffer): string {
+    return createHash("sha256").update(content).digest("hex");
   }
 
   private async markReceiptGenerationFailedIfNeeded(tenantId: string, paymentId: string, errorMessage: string): Promise<void> {
@@ -421,7 +713,7 @@ export class PaymentReceiptService {
         },
       });
 
-      if (!payment || payment.receiptStatus === ReceiptStatus.READY || payment.receiptDocumentId) {
+      if (!payment || payment.receiptStatus === ReceiptStatus.READY) {
         return;
       }
 
@@ -472,6 +764,8 @@ export class PaymentReceiptService {
     tenantId: string,
   ): Promise<string> {
     const year = new Date().getFullYear();
+
+    await acquireReceiptSequenceLock(tx, tenantId, year);
 
     // Get tenant for slug
     const tenant = await tx.tenant.findUnique({


### PR DESCRIPTION
## Summary

- makes payment receipt retry/recovery idempotent
- allows receipt recovery for APPROVED and RECONCILED Payments
- removes receiptNumber-alone false-success semantics
- validates canonical receipt Document/File/storage artifacts
- enforces deterministic receipt object keys
- validates PDF MIME, signature, bounded size and SHA-256
- fails closed for inconsistent or checksum-less legacy READY artifacts
- reuses reserved receipt numbers during recovery
- serializes per-Payment receipt work
- serializes tenant/year receipt sequence allocation
- recovers safely from storage-success / DB-finalization failure
- preserves receipt File metadata consistency
- keeps RECEIPT_GENERATED exactly once
- prevents duplicate success notification on harmless READY retries

## Financial safety

- receipt recovery does not alter Payment amount
- does not alter currency
- does not alter Payment allocations
- does not alter Charge reconciliation
- does not alter functional snapshots
- does not rewrite approval/reconciliation history

## Storage safety

- canonical deterministic object key
- same receipt retry reuses the same object
- wrong same-tenant artifact fails closed
- wrong object key fails closed
- wrong MIME fails closed
- checksum mismatch fails closed
- fresh-service PostgreSQL/MinIO recovery verified

## Validation

- focused receipt/retry tests: 31 PASS
- PostgreSQL concurrency: 3 PASS
- fresh-service PostgreSQL/MinIO recovery: 1 PASS
- Finance regression: 141 PASS
- full API: 3022 PASS / 190 skipped
- TypeScript typecheck: PASS
- lint: PASS
- Prisma validate: PASS
- API build: PASS
- full build:ci: PASS
- git diff --check: PASS

## Known non-blocking P3

Post-commit notification/email delivery remains best-effort.

A process crash after receipt DB commit and before notification dispatch may
lose the notification, but:

- receipt remains READY and accessible
- financial state remains correct
- no receipt artifact is lost
- retry does not duplicate the receipt
- READY retry does not duplicate notification/email

## E2E baseline

The standalone API E2E environment remains blocked by pre-existing baseline
issues involving:

- missing San Cristóbal seed data
- unavailable Redis
- stale tests omitting required Building.alias

No receipt-specific E2E regression was identified.

## Scope

No:

- schema changes
- migrations
- dependency changes
- historical PaymentAuditLog repair
- historical receipt regeneration
- gateway redesign
- staging mutation
- production mutation