### PR TITLE
test(finance): add controlled staging acceptance harness

### DIFF
--- a/.github/workflows/finance-staging-acceptance.yml
+++ b/.github/workflows/finance-staging-acceptance.yml
@@ -6,7 +6,6 @@ on:
       tested_sha:
         description: Exact application SHA already deployed in staging
         required: true
-        default: 15b8587c4e4740abd6d91e6c795c83ceeaf6bdcf
         type: string
 
 concurrency:
@@ -15,9 +14,6 @@ concurrency:
 
 permissions:
   contents: read
-
-env:
-  CERTIFIED_TESTED_SHA: 15b8587c4e4740abd6d91e6c795c83ceeaf6bdcf
 
 jobs:
   acceptance:
@@ -40,7 +36,6 @@ jobs:
           set -Eeuo pipefail
           [[ "$GITHUB_REF" == "refs/heads/main" ]] || { echo "Finance staging acceptance must run from refs/heads/main" >&2; exit 1; }
           [[ "$TESTED_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "tested_sha must be exactly 40 lowercase hex characters" >&2; exit 1; }
-          [[ "$TESTED_SHA" == "$CERTIFIED_TESTED_SHA" ]] || { echo "tested_sha must equal the certified staging application SHA" >&2; exit 1; }
           git cat-file -e "$TESTED_SHA^{commit}"
           git fetch --no-tags origin main
           git merge-base --is-ancestor "$TESTED_SHA" FETCH_HEAD

--- a/.github/workflows/finance-staging-acceptance.yml
+++ b/.github/workflows/finance-staging-acceptance.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 concurrency:
-  group: finance-staging-acceptance
+  group: staging-deploy
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/finance-staging-acceptance.yml
+++ b/.github/workflows/finance-staging-acceptance.yml
@@ -91,7 +91,8 @@ jobs:
             printf -v quoted '%q' "$arg"
             remote_args+=("$quoted")
           done
-          printf -v remote_command 'STAGING_GOLDEN_QA_PASSWORD=%q FINANCE_ACCEPTANCE_RUN_ID=%q bash -c '\''set -Eeuo pipefail; tmp_dir="$(mktemp -d /tmp/finance-02c-acceptance.XXXXXX)"; cleanup_tmp() { rm -rf "$tmp_dir"; }; trap cleanup_tmp EXIT; tar -xf - -C "$tmp_dir"; bash "$tmp_dir/scripts/finance-staging-acceptance.sh" %s'\''' "$QA_PASSWORD" "$GITHUB_RUN_ID" "${remote_args[*]}"
+          printf -v run_id_quoted '%q' "$GITHUB_RUN_ID"
+          printf -v remote_command 'bash -c '\''set -Eeuo pipefail; IFS= read -r -N 64 STAGING_GOLDEN_QA_PASSWORD; export STAGING_GOLDEN_QA_PASSWORD FINANCE_ACCEPTANCE_RUN_ID=%s; tmp_dir="$(mktemp -d /tmp/finance-02c-acceptance.XXXXXX)"; cleanup_tmp() { unset STAGING_GOLDEN_QA_PASSWORD; rm -rf "$tmp_dir"; }; trap cleanup_tmp EXIT; tar -xf - -C "$tmp_dir"; bash "$tmp_dir/scripts/finance-staging-acceptance.sh" %s'\''' "$run_id_quoted" "${remote_args[*]}"
 
-          tar -cf - scripts/finance-staging-acceptance.sh scripts/finance-staging-acceptance.mjs | \
+          { printf '%s' "$QA_PASSWORD"; tar -cf - scripts/finance-staging-acceptance.sh scripts/finance-staging-acceptance.mjs; } | \
             ssh "${ssh_opts[@]}" "$SSH_USER@$SSH_HOST" "$remote_command"

--- a/.github/workflows/finance-staging-acceptance.yml
+++ b/.github/workflows/finance-staging-acceptance.yml
@@ -94,5 +94,9 @@ jobs:
           printf -v run_id_quoted '%q' "$GITHUB_RUN_ID"
           printf -v remote_command 'bash -c '\''set -Eeuo pipefail; IFS= read -r -N 64 STAGING_GOLDEN_QA_PASSWORD; export STAGING_GOLDEN_QA_PASSWORD FINANCE_ACCEPTANCE_RUN_ID=%s; tmp_dir="$(mktemp -d /tmp/finance-02c-acceptance.XXXXXX)"; cleanup_tmp() { unset STAGING_GOLDEN_QA_PASSWORD; rm -rf "$tmp_dir"; }; trap cleanup_tmp EXIT; tar -xf - -C "$tmp_dir"; bash "$tmp_dir/scripts/finance-staging-acceptance.sh" %s'\''' "$run_id_quoted" "${remote_args[*]}"
 
-          { printf '%s' "$QA_PASSWORD"; tar -cf - scripts/finance-staging-acceptance.sh scripts/finance-staging-acceptance.mjs; } | \
+          { printf '%s' "$QA_PASSWORD"; tar -cf - \
+              scripts/finance-staging-acceptance.sh \
+              scripts/finance-staging-acceptance.mjs \
+              apps/api/prisma/seed-staging-golden.ts \
+              apps/api/prisma/lib/staging-seed/staging-golden-seed.ts; } | \
             ssh "${ssh_opts[@]}" "$SSH_USER@$SSH_HOST" "$remote_command"

--- a/.github/workflows/finance-staging-acceptance.yml
+++ b/.github/workflows/finance-staging-acceptance.yml
@@ -1,0 +1,97 @@
+name: Finance staging acceptance
+
+on:
+  workflow_dispatch:
+    inputs:
+      tested_sha:
+        description: Exact application SHA already deployed in staging
+        required: true
+        default: 15b8587c4e4740abd6d91e6c795c83ceeaf6bdcf
+        type: string
+
+concurrency:
+  group: finance-staging-acceptance
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CERTIFIED_TESTED_SHA: 15b8587c4e4740abd6d91e6c795c83ceeaf6bdcf
+
+jobs:
+  acceptance:
+    name: Golden QA finance acceptance
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    environment: staging
+    steps:
+      - name: Checkout control code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+
+      - name: Validate control and tested SHAs
+        shell: bash
+        env:
+          TESTED_SHA: ${{ inputs.tested_sha }}
+        run: |
+          set -Eeuo pipefail
+          [[ "$GITHUB_REF" == "refs/heads/main" ]] || { echo "Finance staging acceptance must run from refs/heads/main" >&2; exit 1; }
+          [[ "$TESTED_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "tested_sha must be exactly 40 lowercase hex characters" >&2; exit 1; }
+          [[ "$TESTED_SHA" == "$CERTIFIED_TESTED_SHA" ]] || { echo "tested_sha must equal the certified staging application SHA" >&2; exit 1; }
+          git cat-file -e "$TESTED_SHA^{commit}"
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$TESTED_SHA" FETCH_HEAD
+          printf 'control_sha=%s\n' "$(git rev-parse HEAD)"
+          printf 'tested_application_sha=%s\n' "$TESTED_SHA"
+
+      - name: Generate ephemeral Golden QA password
+        id: qa-password
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          qa_password="$(openssl rand -hex 32)"
+          echo "::add-mask::$qa_password"
+          printf 'password=%s\n' "$qa_password" >> "$GITHUB_OUTPUT"
+
+      - name: Run controlled staging acceptance over SSH
+        shell: bash
+        env:
+          TESTED_SHA: ${{ inputs.tested_sha }}
+          SSH_HOST: ${{ secrets.STAGING_SSH_HOST }}
+          SSH_USER: ${{ secrets.STAGING_SSH_USER }}
+          SSH_PRIVATE_KEY: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+          SSH_PORT: ${{ vars.STAGING_SSH_PORT || '22' }}
+          KNOWN_HOSTS: ${{ secrets.STAGING_SSH_KNOWN_HOSTS }}
+          QA_PASSWORD: ${{ steps.qa-password.outputs.password }}
+          APP_PATH: /opt/pawtech/apps/buildingos-staging/buildingos-app
+          COMPOSE_FILE: infra/docker/docker-compose.staging.yml
+          COMPOSE_PROJECT: buildingos-staging
+          ENV_FILE: /opt/pawtech/env/buildingos-staging.env
+          API_BASE_URL: http://buildingos-api:3000
+        run: |
+          set -Eeuo pipefail
+          [[ -n "$SSH_HOST" && -n "$SSH_USER" && -n "$SSH_PRIVATE_KEY" && -n "$SSH_PORT" && -n "$KNOWN_HOSTS" ]] || { echo "Staging SSH settings are incomplete" >&2; exit 1; }
+          key_file="$(mktemp)"
+          known_hosts_file="$(mktemp)"
+          cleanup_ssh() {
+            rm -f "$key_file" "$known_hosts_file"
+            unset QA_PASSWORD
+          }
+          trap cleanup_ssh EXIT
+          chmod 600 "$key_file" "$known_hosts_file"
+          printf '%s\n' "$SSH_PRIVATE_KEY" > "$key_file"
+          printf '%s\n' "$KNOWN_HOSTS" > "$known_hosts_file"
+
+          ssh_opts=(-i "$key_file" -o UserKnownHostsFile="$known_hosts_file" -p "$SSH_PORT" -o BatchMode=yes -o StrictHostKeyChecking=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=6)
+          remote_args=()
+          for arg in "$TESTED_SHA" "$APP_PATH" "$COMPOSE_FILE" "$COMPOSE_PROJECT" "$ENV_FILE" "$API_BASE_URL"; do
+            printf -v quoted '%q' "$arg"
+            remote_args+=("$quoted")
+          done
+          printf -v remote_command 'STAGING_GOLDEN_QA_PASSWORD=%q FINANCE_ACCEPTANCE_RUN_ID=%q bash -c '\''set -Eeuo pipefail; tmp_dir="$(mktemp -d /tmp/finance-02c-acceptance.XXXXXX)"; cleanup_tmp() { rm -rf "$tmp_dir"; }; trap cleanup_tmp EXIT; tar -xf - -C "$tmp_dir"; bash "$tmp_dir/scripts/finance-staging-acceptance.sh" %s'\''' "$QA_PASSWORD" "$GITHUB_RUN_ID" "${remote_args[*]}"
+
+          tar -cf - scripts/finance-staging-acceptance.sh scripts/finance-staging-acceptance.mjs | \
+            ssh "${ssh_opts[@]}" "$SSH_USER@$SSH_HOST" "$remote_command"

--- a/.github/workflows/finance-staging-acceptance.yml
+++ b/.github/workflows/finance-staging-acceptance.yml
@@ -91,8 +91,8 @@ jobs:
             printf -v quoted '%q' "$arg"
             remote_args+=("$quoted")
           done
-          printf -v run_id_quoted '%q' "$GITHUB_RUN_ID"
-          printf -v remote_command 'bash -c '\''set -Eeuo pipefail; IFS= read -r -N 64 STAGING_GOLDEN_QA_PASSWORD; export STAGING_GOLDEN_QA_PASSWORD FINANCE_ACCEPTANCE_RUN_ID=%s; tmp_dir="$(mktemp -d /tmp/finance-02c-acceptance.XXXXXX)"; cleanup_tmp() { unset STAGING_GOLDEN_QA_PASSWORD; rm -rf "$tmp_dir"; }; trap cleanup_tmp EXIT; tar -xf - -C "$tmp_dir"; bash "$tmp_dir/scripts/finance-staging-acceptance.sh" %s'\''' "$run_id_quoted" "${remote_args[*]}"
+          printf -v run_identity_quoted '%q' "$GITHUB_RUN_ID.$GITHUB_RUN_ATTEMPT"
+          printf -v remote_command 'bash -c '\''set -Eeuo pipefail; IFS= read -r -N 64 STAGING_GOLDEN_QA_PASSWORD; export STAGING_GOLDEN_QA_PASSWORD FINANCE_ACCEPTANCE_RUN_ID=%s; tmp_dir="$(mktemp -d /tmp/finance-02c-acceptance.XXXXXX)"; cleanup_tmp() { unset STAGING_GOLDEN_QA_PASSWORD; rm -rf "$tmp_dir"; }; trap cleanup_tmp EXIT; tar -xf - -C "$tmp_dir"; bash "$tmp_dir/scripts/finance-staging-acceptance.sh" %s'\''' "$run_identity_quoted" "${remote_args[*]}"
 
           { printf '%s' "$QA_PASSWORD"; tar -cf - \
               scripts/finance-staging-acceptance.sh \

--- a/apps/api/prisma/lib/staging-seed/staging-golden-seed.ts
+++ b/apps/api/prisma/lib/staging-seed/staging-golden-seed.ts
@@ -3,6 +3,7 @@ import { Prisma } from '@prisma/client';
 export const STAGING_GOLDEN_MARKER = 'STG-DATA-01:GOLDEN';
 export const STAGING_GOLDEN_CONFIRMATION = 'STG-DATA-01';
 export const STAGING_GOLDEN_PASSWORD_ENV = 'STAGING_GOLDEN_QA_PASSWORD';
+export const STAGING_GOLDEN_TENANTS_ENV = 'STAGING_GOLDEN_TENANTS';
 
 const STAGING_DATABASE = 'buildingos_staging_db';
 const STAGING_DATABASE_HOST = 'postgres';
@@ -274,6 +275,32 @@ const tenantC: TenantSpec = {
 
 export const STAGING_GOLDEN_DATASET: readonly TenantSpec[] = [tenantA, tenantB, tenantC];
 
+const STAGING_GOLDEN_ACCEPTANCE_TENANTS = new Set([
+  'stg-golden-tenant-auto',
+  'stg-golden-tenant-multi',
+]);
+
+export function selectStagingGoldenDataset(
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+): readonly TenantSpec[] {
+  const requested = environment[STAGING_GOLDEN_TENANTS_ENV]?.trim();
+  if (!requested) return STAGING_GOLDEN_DATASET;
+
+  const tenantIds = requested.split(',').map((value) => value.trim()).filter(Boolean);
+  if (tenantIds.length === 0 || new Set(tenantIds).size !== tenantIds.length) {
+    throw new Error(`${STAGING_GOLDEN_TENANTS_ENV} must contain unique tenant IDs`);
+  }
+  if (!tenantIds.every((tenantId) => STAGING_GOLDEN_ACCEPTANCE_TENANTS.has(tenantId))) {
+    throw new Error(`${STAGING_GOLDEN_TENANTS_ENV} contains an unauthorized acceptance tenant`);
+  }
+
+  const selected = STAGING_GOLDEN_DATASET.filter((tenant) => tenantIds.includes(tenant.id));
+  if (selected.length !== tenantIds.length) {
+    throw new Error(`${STAGING_GOLDEN_TENANTS_ENV} contains an unknown Golden tenant`);
+  }
+  return selected;
+}
+
 function assertCompatible(existing: RecordValue, expected: Readonly<Record<string, unknown>>, label: string): void {
   const normalize = (value: unknown): unknown => {
     if (value instanceof Date) return value.toISOString();
@@ -371,7 +398,11 @@ function findBuilding(tenant: TenantSpec, alias: string): BuildingSpec {
   return building;
 }
 
-export async function applyStagingGoldenSeed(database: StagingGoldenWriteClient, passwordHash: string): Promise<void> {
+export async function applyStagingGoldenSeed(
+  database: StagingGoldenWriteClient,
+  passwordHash: string,
+  dataset: readonly TenantSpec[] = STAGING_GOLDEN_DATASET,
+): Promise<void> {
   await database.$transaction(async (tx) => {
     const plans = new Map<string, RecordValue>();
     for (const planId of ['FREE', 'PRO'] as const) {
@@ -380,7 +411,7 @@ export async function applyStagingGoldenSeed(database: StagingGoldenWriteClient,
       plans.set(planId, plan);
     }
 
-    for (const tenantSpec of STAGING_GOLDEN_DATASET) {
+    for (const tenantSpec of dataset) {
       const existingById = await tx.tenant.findFirst({ where: { id: tenantSpec.id } });
       const existingByName = await tx.tenant.findFirst({ where: { name: tenantSpec.name } });
       const tenant = existingById ?? existingByName;

--- a/apps/api/prisma/lib/staging-seed/staging-golden-seed.ts
+++ b/apps/api/prisma/lib/staging-seed/staging-golden-seed.ts
@@ -277,7 +277,6 @@ export const STAGING_GOLDEN_DATASET: readonly TenantSpec[] = [tenantA, tenantB, 
 
 const STAGING_GOLDEN_ACCEPTANCE_TENANTS = new Set([
   'stg-golden-tenant-auto',
-  'stg-golden-tenant-multi',
 ]);
 
 export function selectStagingGoldenDataset(

--- a/apps/api/prisma/lib/staging-seed/staging-golden-seed.ts
+++ b/apps/api/prisma/lib/staging-seed/staging-golden-seed.ts
@@ -57,6 +57,7 @@ export interface StagingGoldenWriteClient {
   readonly membershipRole: RecordDelegate;
   readonly tenantMember: RecordDelegate;
   readonly unitOccupant: RecordDelegate;
+  readonly expenseLedgerCategory: RecordDelegate;
   readonly exchangeRate: RecordDelegate;
   readonly charge: RecordDelegate;
   readonly payment: RecordDelegate;
@@ -431,6 +432,37 @@ export async function applyStagingGoldenSeed(
         }
       }
       const tenantId = tenantRecord.id;
+      const categories = [
+        {
+          id: `stg-golden-category-${tenantSpec.id}-expense`,
+          code: 'STG_QA_BUILDING_EXPENSE',
+          name: 'STG QA Building Expense',
+          description: 'Controlled Golden acceptance expense category',
+          movementType: 'EXPENSE',
+          catalogScope: 'BUILDING',
+          sortOrder: 1,
+          isActive: true,
+        },
+        {
+          id: `stg-golden-category-${tenantSpec.id}-income`,
+          code: 'STG_QA_INCOME',
+          name: 'STG QA Income',
+          description: 'Controlled Golden acceptance income category',
+          movementType: 'INCOME',
+          catalogScope: 'BUILDING',
+          sortOrder: 2,
+          isActive: true,
+        },
+      ] as const;
+      for (const category of categories) {
+        await ensureRecord(
+          tx.expenseLedgerCategory,
+          category.id,
+          { tenantId, ...category },
+          `expense ledger category ${category.name}`,
+          false,
+        );
+      }
       const plan = plans.get(tenantSpec.planId);
       if (!plan) throw new Error(`Golden plan lookup failed: ${tenantSpec.planId}`);
       await ensureRecord(tx.subscription, `stg-golden-subscription-${tenantSpec.id}`, { tenantId, planId: plan.id, status: 'ACTIVE', currentPeriodStart: date(SEED_DATE) }, `subscription ${tenantSpec.name}`, false);

--- a/apps/api/prisma/seed-staging-golden.ts
+++ b/apps/api/prisma/seed-staging-golden.ts
@@ -6,6 +6,7 @@ import {
   applyStagingGoldenSeed,
   assertConnectedStagingGoldenTarget,
   assertSafeStagingGoldenEnvironment,
+  selectStagingGoldenDataset,
   STAGING_GOLDEN_PASSWORD_ENV,
   StagingGoldenConnectionClient,
   StagingGoldenWriteClient,
@@ -40,7 +41,11 @@ async function main(): Promise<void> {
     await assertConnectedStagingGoldenTarget(connection, target);
     // The adapter boundary is intentionally unknown-only; the seed itself exposes no
     // generic SQL or destructive delegate and remains tenant/ID scoped.
-    await applyStagingGoldenSeed(prisma as unknown as StagingGoldenWriteClient, passwordHash);
+    await applyStagingGoldenSeed(
+      prisma as unknown as StagingGoldenWriteClient,
+      passwordHash,
+      selectStagingGoldenDataset(process.env),
+    );
     console.log('STG-DATA-01 Golden Dataset applied to verified staging database.');
   } finally {
     await prisma.$disconnect();

--- a/apps/api/src/staging-seed/staging-golden-seed.spec.ts
+++ b/apps/api/src/staging-seed/staging-golden-seed.spec.ts
@@ -46,7 +46,7 @@ interface FakeDatabase {
 }
 
 function createFakeDatabase(): FakeDatabase {
-  const names = ['tenant', 'billingPlan', 'subscription', 'building', 'unit', 'user', 'membership', 'membershipRole', 'tenantMember', 'unitOccupant', 'exchangeRate', 'charge', 'payment', 'paymentAllocation', 'paymentAuditLog', 'ticket'];
+  const names = ['tenant', 'billingPlan', 'subscription', 'building', 'unit', 'user', 'membership', 'membershipRole', 'tenantMember', 'unitOccupant', 'expenseLedgerCategory', 'exchangeRate', 'charge', 'payment', 'paymentAllocation', 'paymentAuditLog', 'ticket'];
   const delegates = Object.fromEntries(names.map((name) => [name, new FakeDelegate()])) as Record<string, FakeDelegate>;
   delegates.billingPlan.records.push(
     { id: 'plan-free', planId: 'FREE' },

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -190,7 +190,10 @@ require_storage_cutover_preconditions
   --no-deps \
   -T \
   api-migrate < /dev/null
-"${compose[@]}" build buildingos-api buildingos-web
+"${compose[@]}" build \
+  --build-arg BUILD_REVISION="$TARGET_SHA" \
+  --build-arg BUILD_VERSION="$TARGET_SHA" \
+  buildingos-api buildingos-web
 "${compose[@]}" up --detach --no-deps --force-recreate buildingos-api buildingos-web
 
 check_http() {

--- a/scripts/finance-staging-acceptance.mjs
+++ b/scripts/finance-staging-acceptance.mjs
@@ -69,7 +69,7 @@ async function request(method, requestPath, body) {
   return payload;
 }
 
-async function expectRejected(method, requestPath, body) {
+async function expectRejected(method, requestPath, body, expectedStatus) {
   const headers = {
     accept: "application/json",
     "content-type": "application/json",
@@ -83,6 +83,10 @@ async function expectRejected(method, requestPath, body) {
     body: JSON.stringify(body),
   });
   await response.arrayBuffer();
+  assert(
+    response.status === expectedStatus,
+    `${method} ${requestPath} returned an unexpected rejection status`,
+  );
   assert(!response.ok, `${method} ${requestPath} unexpectedly succeeded`);
 }
 
@@ -108,7 +112,9 @@ async function login() {
       : [response.headers.get("set-cookie") ?? ""];
   const values = [];
   for (const cookie of setCookies) {
-    for (const match of cookie.matchAll(/(bo_(?:access|refresh)_token=[^;,]+)/g)) {
+    for (const match of cookie.matchAll(
+      /(bo_(?:access|refresh)_token=[^;,]+)/g,
+    )) {
       values.push(match[1]);
     }
   }
@@ -176,15 +182,20 @@ async function findFinanceCategories() {
 
 async function acceptExpense(expenseCategoryId, period) {
   const invalidDescription = `${marker}:expense-invalid`;
-  await expectRejected("POST", `/tenants/${tenantId}/finance/expenses`, {
-    buildingId,
-    period,
-    categoryId: `stg-golden-invalid-category-${runId}`,
-    amountMinor: 1001,
-    currencyCode: "ARS",
-    invoiceDate: `${acceptanceDate}T12:00:00.000Z`,
-    description: invalidDescription,
-  });
+  await expectRejected(
+    "POST",
+    `/tenants/${tenantId}/finance/expenses`,
+    {
+      buildingId,
+      period,
+      categoryId: `stg-golden-invalid-category-${runId}`,
+      amountMinor: 1001,
+      currencyCode: "ARS",
+      invoiceDate: `${acceptanceDate}T12:00:00.000Z`,
+      description: invalidDescription,
+    },
+    404,
+  );
   const invalidCount = await prisma.expense.count({
     where: { tenantId, description: invalidDescription },
   });
@@ -237,15 +248,20 @@ async function acceptExpense(expenseCategoryId, period) {
 
 async function acceptIncome(incomeCategoryId, period) {
   const invalidDescription = `${marker}:income-invalid`;
-  await expectRejected("POST", `/tenants/${tenantId}/finance/incomes`, {
-    buildingId,
-    period,
-    categoryId: `stg-golden-invalid-income-category-${runId}`,
-    amountMinor: 1002,
-    currencyCode: "ARS",
-    receivedDate: `${acceptanceDate}T12:00:00.000Z`,
-    description: invalidDescription,
-  });
+  await expectRejected(
+    "POST",
+    `/tenants/${tenantId}/finance/incomes`,
+    {
+      buildingId,
+      period,
+      categoryId: `stg-golden-invalid-income-category-${runId}`,
+      amountMinor: 1002,
+      currencyCode: "ARS",
+      receivedDate: `${acceptanceDate}T12:00:00.000Z`,
+      description: invalidDescription,
+    },
+    404,
+  );
   const invalidCount = await prisma.income.count({
     where: { tenantId, description: invalidDescription },
   });
@@ -725,7 +741,7 @@ async function main() {
   );
   const completed = await waitForReceipt(payment.id);
   const receipt = await inspectReceipt(completed);
-  await retryReceipt(payment.id, receipt.persisted);
+  await retryReceipt(payment.id, receipt);
   const finalPayment = await prisma.payment.findUnique({
     where: { id: payment.id },
     select: { id: true, amount: true, currency: true },

--- a/scripts/finance-staging-acceptance.mjs
+++ b/scripts/finance-staging-acceptance.mjs
@@ -418,7 +418,9 @@ async function inspectReceipt(payment) {
     where: { tenantId, objectKey: { startsWith: receiptObjectPrefix } },
     select: { id: true, document: { select: { id: true } } },
   });
-  const documentCount = receiptFiles.filter((file) => file.document !== null).length;
+  const documentCount = receiptFiles.filter(
+    (file) => file.document !== null,
+  ).length;
   const fileCount = receiptFiles.length;
   assert(
     documentCount === 1 &&

--- a/scripts/finance-staging-acceptance.mjs
+++ b/scripts/finance-staging-acceptance.mjs
@@ -1,0 +1,752 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { PrismaClient } from "@prisma/client";
+
+const tenantId = "stg-golden-tenant-auto";
+const buildingId = "stg-golden-building-auto";
+const unitId = "stg-golden-unit-auto-102";
+const qaEmail = "admin.autogestionada@staging.buildingos.local";
+const password = process.env.STAGING_GOLDEN_QA_PASSWORD;
+const apiBaseUrl =
+  process.env.FINANCE_ACCEPTANCE_API_BASE_URL ?? "http://buildingos-api:3000";
+const runId = process.env.FINANCE_ACCEPTANCE_RUN_ID;
+const marker = `FIN-02C-STAGING:${runId}`;
+const acceptanceDate = new Date().toISOString().slice(0, 10);
+const prisma = new PrismaClient();
+const tempDirectory = fs.mkdtempSync(
+  path.join(os.tmpdir(), "finance-02c-auth-"),
+);
+const cookiePath = path.join(tempDirectory, "cookies");
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function assert(condition, message) {
+  if (!condition) fail(message);
+}
+
+function readCookies() {
+  try {
+    return fs.readFileSync(cookiePath, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function persistCookies(values) {
+  fs.writeFileSync(cookiePath, values.join("; "), { mode: 0o600 });
+}
+
+async function parseResponse(response) {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function request(method, requestPath, body) {
+  const headers = { accept: "application/json", "x-tenant-id": tenantId };
+  const cookies = readCookies();
+  if (cookies) headers.cookie = cookies;
+  if (body !== undefined) {
+    headers["content-type"] = "application/json";
+  }
+  const response = await fetch(`${apiBaseUrl}${requestPath}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const payload = await parseResponse(response);
+  if (!response.ok) {
+    fail(`${method} ${requestPath} returned HTTP ${response.status}`);
+  }
+  return payload;
+}
+
+async function expectRejected(method, requestPath, body) {
+  const headers = {
+    accept: "application/json",
+    "content-type": "application/json",
+    "x-tenant-id": tenantId,
+  };
+  const cookies = readCookies();
+  if (cookies) headers.cookie = cookies;
+  const response = await fetch(`${apiBaseUrl}${requestPath}`, {
+    method,
+    headers,
+    body: JSON.stringify(body),
+  });
+  await response.arrayBuffer();
+  assert(!response.ok, `${method} ${requestPath} unexpectedly succeeded`);
+}
+
+async function login() {
+  assert(
+    typeof password === "string" && password.length >= 12,
+    "Golden QA password is unavailable",
+  );
+  assert(
+    typeof runId === "string" && runId.length > 0,
+    "acceptance run identity is unavailable",
+  );
+  const response = await fetch(`${apiBaseUrl}/auth/login`, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-tenant-id": tenantId },
+    body: JSON.stringify({ email: qaEmail, password }),
+  });
+  const payload = await parseResponse(response);
+  if (!response.ok) fail(`POST /auth/login returned HTTP ${response.status}`);
+  const setCookies =
+    typeof response.headers.getSetCookie === "function"
+      ? response.headers.getSetCookie()
+      : [response.headers.get("set-cookie") ?? ""];
+  const values = [];
+  for (const cookie of setCookies) {
+    for (const match of cookie.matchAll(/(bo_(?:access|refresh)_token=[^;,]+)/g)) {
+      values.push(match[1]);
+    }
+  }
+  assert(
+    values.length === 2,
+    "staging login did not issue both temporary auth cookies",
+  );
+  persistCookies(values);
+  const memberships = Array.isArray(payload?.memberships)
+    ? payload.memberships
+    : [];
+  const activeMembership = memberships.find(
+    (membership) => membership.tenantId === tenantId,
+  );
+  assert(
+    activeMembership,
+    "Golden QA account did not resolve to the allowlisted tenant",
+  );
+  assert(
+    activeMembership.roles?.includes("TENANT_ADMIN"),
+    "Golden QA account lacks TENANT_ADMIN role",
+  );
+  assert(
+    memberships.every(
+      (membership) =>
+        typeof membership.tenantId === "string" &&
+        membership.tenantId.startsWith("stg-golden-"),
+    ),
+    "login returned a non-Golden tenant",
+  );
+  const profile = await request("GET", "/auth/me");
+  assert(
+    profile?.memberships?.some(
+      (membership) => membership.tenantId === tenantId,
+    ),
+    "authenticated session has no allowlisted tenant context",
+  );
+  console.log("login=PASS");
+  console.log("authenticated_tenant=stg-golden-tenant-auto");
+}
+
+async function findFinanceCategories() {
+  const categories = await prisma.expenseLedgerCategory.findMany({
+    where: { tenantId, isActive: true },
+    select: { id: true, movementType: true, catalogScope: true },
+  });
+  const expenseCategory = categories.find(
+    (category) =>
+      category.movementType === "EXPENSE" &&
+      category.catalogScope === "BUILDING",
+  );
+  const incomeCategory = categories.find(
+    (category) => category.movementType === "INCOME",
+  );
+  assert(
+    expenseCategory,
+    "Golden tenant has no active BUILDING expense category",
+  );
+  assert(incomeCategory, "Golden tenant has no active income category");
+  return {
+    expenseCategoryId: expenseCategory.id,
+    incomeCategoryId: incomeCategory.id,
+  };
+}
+
+async function acceptExpense(expenseCategoryId, period) {
+  const invalidDescription = `${marker}:expense-invalid`;
+  await expectRejected("POST", `/tenants/${tenantId}/finance/expenses`, {
+    buildingId,
+    period,
+    categoryId: `stg-golden-invalid-category-${runId}`,
+    amountMinor: 1001,
+    currencyCode: "ARS",
+    invoiceDate: `${acceptanceDate}T12:00:00.000Z`,
+    description: invalidDescription,
+  });
+  const invalidCount = await prisma.expense.count({
+    where: { tenantId, description: invalidDescription },
+  });
+  assert(
+    invalidCount === 0,
+    "failed Expense request left a partial financial record",
+  );
+
+  const expense = await request(
+    "POST",
+    `/tenants/${tenantId}/finance/expenses`,
+    {
+      buildingId,
+      period,
+      categoryId: expenseCategoryId,
+      amountMinor: 1001,
+      currencyCode: "ARS",
+      invoiceDate: `${acceptanceDate}T12:00:00.000Z`,
+      description: `${marker}:expense`,
+    },
+  );
+  assert(
+    expense?.tenantId === tenantId && expense?.status === "DRAFT",
+    "Expense did not persist as a Golden DRAFT",
+  );
+  const updated = await request(
+    "PATCH",
+    `/tenants/${tenantId}/finance/expenses/${expense.id}`,
+    {
+      description: `${marker}:expense-updated`,
+    },
+  );
+  assert(
+    updated?.id === expense.id && updated?.status === "DRAFT",
+    "Expense DRAFT update failed",
+  );
+  const persisted = await prisma.expense.findUnique({
+    where: { id: expense.id },
+    select: { tenantId: true, status: true, description: true },
+  });
+  assert(
+    persisted?.tenantId === tenantId &&
+      persisted.status === "DRAFT" &&
+      persisted.description === `${marker}:expense-updated`,
+    "Expense persistence is inconsistent",
+  );
+  console.log("expense_atomic_flow=PASS");
+  return expense.id;
+}
+
+async function acceptIncome(incomeCategoryId, period) {
+  const invalidDescription = `${marker}:income-invalid`;
+  await expectRejected("POST", `/tenants/${tenantId}/finance/incomes`, {
+    buildingId,
+    period,
+    categoryId: `stg-golden-invalid-income-category-${runId}`,
+    amountMinor: 1002,
+    currencyCode: "ARS",
+    receivedDate: `${acceptanceDate}T12:00:00.000Z`,
+    description: invalidDescription,
+  });
+  const invalidCount = await prisma.income.count({
+    where: { tenantId, description: invalidDescription },
+  });
+  assert(
+    invalidCount === 0,
+    "failed Income request left a partial financial record",
+  );
+
+  const income = await request("POST", `/tenants/${tenantId}/finance/incomes`, {
+    buildingId,
+    period,
+    categoryId: incomeCategoryId,
+    amountMinor: 1002,
+    currencyCode: "ARS",
+    receivedDate: `${acceptanceDate}T12:00:00.000Z`,
+    description: `${marker}:income`,
+  });
+  assert(
+    income?.tenantId === tenantId && income?.status === "DRAFT",
+    "Income did not persist as a Golden DRAFT",
+  );
+  const persisted = await prisma.income.findUnique({
+    where: { id: income.id },
+    select: { tenantId: true, status: true, description: true },
+  });
+  assert(
+    persisted?.tenantId === tenantId &&
+      persisted.status === "DRAFT" &&
+      persisted.description === `${marker}:income`,
+    "Income persistence is inconsistent",
+  );
+  console.log("income_atomic_flow=PASS");
+  return income.id;
+}
+
+async function createPaymentProof() {
+  const proof = Buffer.from("%PDF-1.4\n% FIN-02C-STAGING\n", "utf8");
+  const originalName = `fin-02c-${runId}.pdf`;
+  const checksum = crypto.createHash("sha256").update(proof).digest("hex");
+  const presign = await request(
+    "POST",
+    `/tenants/${tenantId}/documents/presign`,
+    {
+      originalName,
+      mimeType: "application/pdf",
+      size: proof.length,
+      purpose: "PAYMENT_PROOF",
+    },
+  );
+  assert(
+    typeof presign?.url === "string" && typeof presign?.objectKey === "string",
+    "payment proof presign response is incomplete",
+  );
+  const upload = await fetch(presign.url, {
+    method: "PUT",
+    headers: { "content-type": "application/pdf" },
+    body: proof,
+  });
+  await upload.arrayBuffer();
+  assert(upload.ok, "payment proof upload failed");
+  const document = await request("POST", `/tenants/${tenantId}/documents`, {
+    title: `${marker}:payment-proof`,
+    category: "RECEIPT",
+    visibility: "TENANT_ADMINS",
+    buildingId,
+    unitId,
+    file: {
+      objectKey: presign.objectKey,
+      originalName,
+      mimeType: "application/pdf",
+      size: proof.length,
+      checksum,
+    },
+  });
+  assert(
+    document?.id && document?.file?.id,
+    "payment proof document response is incomplete",
+  );
+  return document.file.id;
+}
+
+async function waitForReceipt(paymentId) {
+  let payment;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    payment = await request(
+      "GET",
+      `/buildings/${buildingId}/payments/${paymentId}`,
+    );
+    if (payment.status === "RECONCILED" && payment.receiptStatus === "READY")
+      return payment;
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+  fail(`payment ${paymentId} did not reach RECONCILED and READY receipt state`);
+}
+
+async function inspectReceipt(payment) {
+  const persisted = await prisma.payment.findUnique({
+    where: { id: payment.id },
+    select: {
+      id: true,
+      tenantId: true,
+      buildingId: true,
+      unitId: true,
+      amount: true,
+      currency: true,
+      status: true,
+      receiptStatus: true,
+      receiptNumber: true,
+      receiptDocumentId: true,
+      receiptGeneratedAt: true,
+      receiptSnapshot: true,
+      receiptSnapshotVersion: true,
+      receiptSnapshotHash: true,
+      receiptSnapshotCreatedAt: true,
+      receiptGenerationToken: true,
+      receiptGenerationLeaseUntil: true,
+    },
+  });
+  assert(
+    persisted?.tenantId === tenantId &&
+      persisted.buildingId === buildingId &&
+      persisted.unitId === unitId,
+    "payment tenant/building/unit scope is invalid",
+  );
+  assert(
+    persisted.status === "RECONCILED" && persisted.receiptStatus === "READY",
+    "payment receipt state is not complete",
+  );
+  assert(
+    persisted.receiptNumber &&
+      persisted.receiptDocumentId &&
+      persisted.receiptGeneratedAt,
+    "receipt identity is incomplete",
+  );
+  assert(
+    persisted.receiptSnapshot &&
+      persisted.receiptSnapshotVersion &&
+      persisted.receiptSnapshotHash &&
+      persisted.receiptSnapshotCreatedAt,
+    "immutable receipt snapshot is incomplete",
+  );
+  assert(
+    persisted.receiptGenerationToken === null &&
+      persisted.receiptGenerationLeaseUntil === null,
+    "receipt generation lease was not cleared",
+  );
+
+  const documentCount = await prisma.document.count({
+    where: { id: persisted.receiptDocumentId, tenantId },
+  });
+  const document = await prisma.document.findUnique({
+    where: { id: persisted.receiptDocumentId },
+    select: { id: true, tenantId: true, fileId: true },
+  });
+  const fileCount = document
+    ? await prisma.file.count({ where: { id: document.fileId, tenantId } })
+    : 0;
+  assert(
+    documentCount === 1 && fileCount === 1,
+    "receipt Document/File cardinality is invalid",
+  );
+
+  const download = await request(
+    "GET",
+    `/tenants/${tenantId}/documents/${persisted.receiptDocumentId}/download`,
+  );
+  assert(
+    typeof download?.url === "string",
+    "receipt download response is incomplete",
+  );
+  const objectResponse = await fetch(download.url);
+  const bytes = Buffer.from(await objectResponse.arrayBuffer());
+  const contentType = objectResponse.headers.get("content-type") ?? "";
+  assert(
+    objectResponse.ok && bytes.length > 0,
+    "receipt storage object is unreadable or empty",
+  );
+  assert(
+    bytes.subarray(0, 5).toString("ascii") === "%PDF-",
+    "receipt storage object is not a PDF",
+  );
+  assert(
+    contentType.toLowerCase().includes("application/pdf"),
+    "receipt storage content type is not application/pdf",
+  );
+  const file = await prisma.file.findUnique({
+    where: { id: document.fileId },
+    select: {
+      bucket: true,
+      objectKey: true,
+      mimeType: true,
+      size: true,
+      checksum: true,
+    },
+  });
+  assert(
+    file?.mimeType === "application/pdf" && file.size === bytes.length,
+    "receipt File metadata does not match storage object",
+  );
+  if (file.checksum) {
+    assert(
+      file.checksum === crypto.createHash("sha256").update(bytes).digest("hex"),
+      "receipt File checksum does not match storage object",
+    );
+  }
+
+  const audits = await prisma.paymentAuditLog.findMany({
+    where: { tenantId, paymentId: payment.id },
+    orderBy: { createdAt: "asc" },
+    select: { action: true, paymentId: true, tenantId: true, createdAt: true },
+  });
+  const actions = audits.map((audit) => audit.action);
+  assert(
+    JSON.stringify(actions) ===
+      JSON.stringify([
+        "SUBMITTED",
+        "APPROVED",
+        "RECONCILED",
+        "RECEIPT_GENERATED",
+      ]),
+    "payment audit sequence is not canonical",
+  );
+  assert(
+    audits.every(
+      (audit) => audit.paymentId === payment.id && audit.tenantId === tenantId,
+    ),
+    "payment audit scope is invalid",
+  );
+  assert(
+    audits.every(
+      (audit, index) =>
+        index === 0 || audits[index - 1].createdAt <= audit.createdAt,
+    ),
+    "payment audit sequence is not chronological",
+  );
+
+  const allocations = await prisma.paymentAllocation.findMany({
+    where: { tenantId, paymentId: payment.id },
+    select: {
+      id: true,
+      amount: true,
+      paymentId: true,
+      chargeId: true,
+      tenantId: true,
+      charge: {
+        select: {
+          tenantId: true,
+          buildingId: true,
+          currency: true,
+          status: true,
+        },
+      },
+    },
+  });
+  assert(
+    allocations.length === 1,
+    "payment has duplicate or missing allocation",
+  );
+  const allocatedTotal = allocations.reduce(
+    (total, allocation) => total + allocation.amount,
+    0,
+  );
+  assert(allocatedTotal <= persisted.amount, "payment is over-allocated");
+  assert(
+    allocations.every(
+      (allocation) =>
+        allocation.tenantId === tenantId &&
+        allocation.charge.tenantId === tenantId &&
+        allocation.charge.buildingId === buildingId &&
+        allocation.charge.currency === persisted.currency,
+    ),
+    "allocation tenant/building/currency relationship is invalid",
+  );
+  assert(
+    allocations[0].charge.status === "PAID",
+    "allocated charge is not PAID after reconciliation",
+  );
+
+  console.log("payment_submitted=PASS");
+  console.log("payment_approved=PASS");
+  console.log("payment_reconciled=PASS");
+  console.log("receipt_generated=PASS");
+  console.log("audit_sequence=PASS");
+  console.log("allocation=PASS");
+  console.log("receipt=PASS");
+  console.log(`payment_id=${payment.id}`);
+  console.log(`charge_id=${allocations[0].chargeId}`);
+  console.log(`receipt_document_id=${persisted.receiptDocumentId}`);
+  console.log(`receipt_file_id=${document.fileId}`);
+  return { persisted, document, file, audits };
+}
+
+async function retryReceipt(paymentId, before) {
+  const retry = await request(
+    "POST",
+    `/tenants/${tenantId}/finance/payments/${paymentId}/retry-receipt`,
+  );
+  assert(
+    retry?.success === true && retry.receiptNumber === before.receiptNumber,
+    "completed receipt retry did not reuse receipt identity",
+  );
+  const after = await prisma.payment.findUnique({
+    where: { id: paymentId },
+    select: {
+      receiptNumber: true,
+      receiptDocumentId: true,
+      receiptGeneratedAt: true,
+      receiptSnapshot: true,
+      receiptSnapshotHash: true,
+      receiptGenerationToken: true,
+      receiptGenerationLeaseUntil: true,
+    },
+  });
+  assert(
+    after?.receiptNumber === before.receiptNumber &&
+      after.receiptDocumentId === before.receiptDocumentId,
+    "receipt retry changed persisted identity",
+  );
+  assert(
+    after.receiptGeneratedAt?.toISOString() ===
+      before.receiptGeneratedAt?.toISOString(),
+    "receipt retry changed generatedAt",
+  );
+  assert(
+    JSON.stringify(after.receiptSnapshot) ===
+      JSON.stringify(before.receiptSnapshot) &&
+      after.receiptSnapshotHash === before.receiptSnapshotHash,
+    "receipt retry changed immutable snapshot",
+  );
+  assert(
+    after.receiptGenerationToken === null &&
+      after.receiptGenerationLeaseUntil === null,
+    "receipt retry left a generation lease",
+  );
+  const documentCount = await prisma.document.count({
+    where: { id: before.receiptDocumentId, tenantId },
+  });
+  const fileCount = before.document
+    ? await prisma.file.count({
+        where: { id: before.document.fileId, tenantId },
+      })
+    : 0;
+  const auditCount = await prisma.paymentAuditLog.count({
+    where: { tenantId, paymentId, action: "RECEIPT_GENERATED" },
+  });
+  assert(
+    documentCount === 1 && fileCount === 1 && auditCount === 1,
+    "receipt retry created duplicate evidence",
+  );
+  console.log("receipt_retry_idempotent=PASS");
+}
+
+async function databaseIntegrity(payment, chargeId) {
+  const allocationRows = await prisma.paymentAllocation.findMany({
+    where: { tenantId, paymentId: payment.id },
+    select: { paymentId: true, chargeId: true, amount: true },
+  });
+  assert(
+    allocationRows.every(
+      (row) => row.paymentId === payment.id && row.chargeId === chargeId,
+    ),
+    "orphan allocation detected",
+  );
+  assert(
+    allocationRows.reduce((total, row) => total + row.amount, 0) <=
+      payment.amount,
+    "over-allocation detected",
+  );
+  const charge = await prisma.charge.findUnique({
+    where: { id: chargeId },
+    select: {
+      tenantId: true,
+      buildingId: true,
+      unitId: true,
+      period: true,
+      concept: true,
+      currency: true,
+    },
+  });
+  assert(
+    charge?.tenantId === tenantId &&
+      charge.buildingId === buildingId &&
+      charge.unitId === unitId &&
+      charge.currency === payment.currency,
+    "charge tenant/building/unit/currency relationship is invalid",
+  );
+  const chargeKeyCount = await prisma.charge.count({
+    where: {
+      tenantId,
+      unitId,
+      period: charge.period,
+      concept: `${marker}:charge`,
+    },
+  });
+  assert(chargeKeyCount === 1, "duplicate canonical charge key detected");
+  assert(payment.currency === "ARS", "payment currency mismatch");
+  const receiptAuditCount = await prisma.paymentAuditLog.count({
+    where: { tenantId, paymentId: payment.id, action: "RECEIPT_GENERATED" },
+  });
+  assert(receiptAuditCount === 1, "duplicate RECEIPT_GENERATED audit detected");
+  const leaseCount = await prisma.payment.count({
+    where: {
+      tenantId,
+      id: payment.id,
+      OR: [
+        { receiptGenerationToken: { not: null } },
+        { receiptGenerationLeaseUntil: { not: null } },
+      ],
+    },
+  });
+  assert(leaseCount === 0, "stuck receipt generation lease detected");
+  console.log("integrity_orphan_allocations=0");
+  console.log("integrity_over_allocations=0");
+  console.log("integrity_duplicate_charge_keys=0");
+  console.log("integrity_currency_mismatch=0");
+  console.log("integrity_duplicate_receipt_files=0");
+  console.log("integrity_duplicate_receipt_documents=0");
+  console.log("integrity_duplicate_receipt_audits=0");
+  console.log("integrity_stuck_leases=0");
+}
+
+async function main() {
+  assert(
+    apiBaseUrl === "http://buildingos-api:3000",
+    "acceptance API must be the internal staging API",
+  );
+  assert(
+    tenantId.startsWith("stg-golden-") &&
+      buildingId.startsWith("stg-golden-") &&
+      unitId.startsWith("stg-golden-"),
+    "acceptance identifiers are not Golden-scoped",
+  );
+  await login();
+  const period = new Date().toISOString().slice(0, 7);
+  const categories = await findFinanceCategories();
+  const expenseId = await acceptExpense(categories.expenseCategoryId, period);
+  const incomeId = await acceptIncome(categories.incomeCategoryId, period);
+  const charge = await request("POST", `/buildings/${buildingId}/charges`, {
+    unitId,
+    type: "COMMON_EXPENSE",
+    concept: `${marker}:charge`,
+    amount: 12345,
+    currency: "ARS",
+    period,
+    dueDate: `${period}-10T00:00:00.000Z`,
+  });
+  assert(
+    charge?.id && charge?.tenantId === tenantId,
+    "synthetic charge creation failed",
+  );
+  const proofFileId = await createPaymentProof();
+  const payment = await request("POST", `/buildings/${buildingId}/payments`, {
+    unitId,
+    chargeId: charge.id,
+    chargeIds: [charge.id],
+    amount: 12345,
+    currency: "ARS",
+    method: "TRANSFER",
+    reference: `${marker}:payment`,
+    proofFileId,
+    transferDate: acceptanceDate,
+  });
+  assert(
+    payment?.id &&
+      payment.status === "SUBMITTED" &&
+      payment.tenantId === tenantId,
+    "synthetic payment was not SUBMITTED in the allowlisted tenant",
+  );
+  const approved = await request(
+    "PATCH",
+    `/tenants/${tenantId}/finance/payments/${payment.id}/approve`,
+    { paidAt: new Date().toISOString() },
+  );
+  assert(
+    approved?.id === payment.id && approved.status === "RECONCILED",
+    "payment approval did not reconcile through the application flow",
+  );
+  const completed = await waitForReceipt(payment.id);
+  const receipt = await inspectReceipt(completed);
+  await retryReceipt(payment.id, receipt.persisted);
+  const finalPayment = await prisma.payment.findUnique({
+    where: { id: payment.id },
+    select: { id: true, amount: true, currency: true },
+  });
+  assert(finalPayment, "synthetic payment disappeared after retry");
+  await databaseIntegrity(finalPayment, charge.id);
+  console.log(`expense_id=${expenseId}`);
+  console.log(`income_id=${incomeId}`);
+  console.log(`tenant_id=${tenantId}`);
+  console.log(`building_id=${buildingId}`);
+  console.log("gateway_mutations=0");
+}
+
+try {
+  await main();
+} catch (error) {
+  console.error(
+    `FINANCE_02C_ACCEPTANCE_FAILED: ${error instanceof Error ? error.message : "unknown error"}`,
+  );
+  process.exitCode = 1;
+} finally {
+  await prisma.$disconnect();
+  fs.rmSync(tempDirectory, { recursive: true, force: true });
+}

--- a/scripts/finance-staging-acceptance.mjs
+++ b/scripts/finance-staging-acceptance.mjs
@@ -232,8 +232,8 @@ async function acceptExpense(expenseCategoryId, period) {
     updated?.id === expense.id && updated?.status === "DRAFT",
     "Expense DRAFT update failed",
   );
-  const persisted = await prisma.expense.findUnique({
-    where: { id: expense.id },
+  const persisted = await prisma.expense.findFirst({
+    where: { id: expense.id, tenantId },
     select: { tenantId: true, status: true, description: true },
   });
   assert(
@@ -283,8 +283,8 @@ async function acceptIncome(incomeCategoryId, period) {
     income?.tenantId === tenantId && income?.status === "DRAFT",
     "Income did not persist as a Golden DRAFT",
   );
-  const persisted = await prisma.income.findUnique({
-    where: { id: income.id },
+  const persisted = await prisma.income.findFirst({
+    where: { id: income.id, tenantId },
     select: { tenantId: true, status: true, description: true },
   });
   assert(
@@ -358,8 +358,8 @@ async function waitForReceipt(paymentId) {
 }
 
 async function inspectReceipt(payment) {
-  const persisted = await prisma.payment.findUnique({
-    where: { id: payment.id },
+  const persisted = await prisma.payment.findFirst({
+    where: { id: payment.id, tenantId },
     select: {
       id: true,
       tenantId: true,
@@ -409,18 +409,21 @@ async function inspectReceipt(payment) {
     "receipt generation lease was not cleared",
   );
 
-  const documentCount = await prisma.document.count({
+  const document = await prisma.document.findFirst({
     where: { id: persisted.receiptDocumentId, tenantId },
-  });
-  const document = await prisma.document.findUnique({
-    where: { id: persisted.receiptDocumentId },
     select: { id: true, tenantId: true, fileId: true },
   });
-  const fileCount = document
-    ? await prisma.file.count({ where: { id: document.fileId, tenantId } })
-    : 0;
+  const receiptObjectPrefix = `tenant/${tenantId}/payments/${payment.id}/receipts/`;
+  const receiptFiles = await prisma.file.findMany({
+    where: { tenantId, objectKey: { startsWith: receiptObjectPrefix } },
+    select: { id: true, document: { select: { id: true } } },
+  });
+  const documentCount = receiptFiles.filter((file) => file.document !== null).length;
+  const fileCount = receiptFiles.length;
   assert(
-    documentCount === 1 && fileCount === 1,
+    documentCount === 1 &&
+      fileCount === 1 &&
+      document?.fileId === receiptFiles[0]?.id,
     "receipt Document/File cardinality is invalid",
   );
 
@@ -447,8 +450,8 @@ async function inspectReceipt(payment) {
     contentType.toLowerCase().includes("application/pdf"),
     "receipt storage content type is not application/pdf",
   );
-  const file = await prisma.file.findUnique({
-    where: { id: document.fileId },
+  const file = await prisma.file.findFirst({
+    where: { id: document.fileId, tenantId },
     select: {
       bucket: true,
       objectKey: true,
@@ -555,16 +558,19 @@ async function inspectReceipt(payment) {
 }
 
 async function retryReceipt(paymentId, before) {
+  const beforeState = before.persisted;
+  const beforeDocument = before.document;
   const retry = await request(
     "POST",
     `/tenants/${tenantId}/finance/payments/${paymentId}/retry-receipt`,
   );
   assert(
-    retry?.success === true && retry.receiptNumber === before.receiptNumber,
+    retry?.success === true &&
+      retry.receiptNumber === beforeState.receiptNumber,
     "completed receipt retry did not reuse receipt identity",
   );
-  const after = await prisma.payment.findUnique({
-    where: { id: paymentId },
+  const after = await prisma.payment.findFirst({
+    where: { id: paymentId, tenantId },
     select: {
       receiptNumber: true,
       receiptDocumentId: true,
@@ -576,19 +582,19 @@ async function retryReceipt(paymentId, before) {
     },
   });
   assert(
-    after?.receiptNumber === before.receiptNumber &&
-      after.receiptDocumentId === before.receiptDocumentId,
+    after?.receiptNumber === beforeState.receiptNumber &&
+      after.receiptDocumentId === beforeState.receiptDocumentId,
     "receipt retry changed persisted identity",
   );
   assert(
     after.receiptGeneratedAt?.toISOString() ===
-      before.receiptGeneratedAt?.toISOString(),
+      beforeState.receiptGeneratedAt?.toISOString(),
     "receipt retry changed generatedAt",
   );
   assert(
     JSON.stringify(after.receiptSnapshot) ===
-      JSON.stringify(before.receiptSnapshot) &&
-      after.receiptSnapshotHash === before.receiptSnapshotHash,
+      JSON.stringify(beforeState.receiptSnapshot) &&
+      after.receiptSnapshotHash === beforeState.receiptSnapshotHash,
     "receipt retry changed immutable snapshot",
   );
   assert(
@@ -596,19 +602,23 @@ async function retryReceipt(paymentId, before) {
       after.receiptGenerationLeaseUntil === null,
     "receipt retry left a generation lease",
   );
-  const documentCount = await prisma.document.count({
-    where: { id: before.receiptDocumentId, tenantId },
+  const receiptObjectPrefix = `tenant/${tenantId}/payments/${paymentId}/receipts/`;
+  const receiptFiles = await prisma.file.findMany({
+    where: { tenantId, objectKey: { startsWith: receiptObjectPrefix } },
+    select: { id: true, document: { select: { id: true } } },
   });
-  const fileCount = before.document
-    ? await prisma.file.count({
-        where: { id: before.document.fileId, tenantId },
-      })
-    : 0;
+  const documentCount = receiptFiles.filter(
+    (file) => file.document?.id === beforeState.receiptDocumentId,
+  ).length;
+  const fileCount = receiptFiles.length;
   const auditCount = await prisma.paymentAuditLog.count({
     where: { tenantId, paymentId, action: "RECEIPT_GENERATED" },
   });
   assert(
-    documentCount === 1 && fileCount === 1 && auditCount === 1,
+    documentCount === 1 &&
+      fileCount === 1 &&
+      receiptFiles[0]?.id === beforeDocument?.fileId &&
+      auditCount === 1,
     "receipt retry created duplicate evidence",
   );
   console.log("receipt_retry_idempotent=PASS");
@@ -630,8 +640,8 @@ async function databaseIntegrity(payment, chargeId) {
       payment.amount,
     "over-allocation detected",
   );
-  const charge = await prisma.charge.findUnique({
-    where: { id: chargeId },
+  const charge = await prisma.charge.findFirst({
+    where: { id: chargeId, tenantId },
     select: {
       tenantId: true,
       buildingId: true,
@@ -742,8 +752,8 @@ async function main() {
   const completed = await waitForReceipt(payment.id);
   const receipt = await inspectReceipt(completed);
   await retryReceipt(payment.id, receipt);
-  const finalPayment = await prisma.payment.findUnique({
-    where: { id: payment.id },
+  const finalPayment = await prisma.payment.findFirst({
+    where: { id: payment.id, tenantId },
     select: { id: true, amount: true, currency: true },
   });
   assert(finalPayment, "synthetic payment disappeared after retry");

--- a/scripts/finance-staging-acceptance.sh
+++ b/scripts/finance-staging-acceptance.sh
@@ -6,7 +6,6 @@ readonly EXPECTED_COMPOSE_FILE='infra/docker/docker-compose.staging.yml'
 readonly EXPECTED_PROJECT_NAME='buildingos-staging'
 readonly EXPECTED_ENV_FILE='/opt/pawtech/env/buildingos-staging.env'
 readonly EXPECTED_DATABASE='buildingos_staging_db'
-readonly EXPECTED_TESTED_SHA='15b8587c4e4740abd6d91e6c795c83ceeaf6bdcf'
 readonly ALLOWED_TENANT='stg-golden-tenant-auto'
 readonly ALLOWED_BUILDING='stg-golden-building-auto'
 readonly ALLOWED_UNIT='stg-golden-unit-auto-102'
@@ -66,7 +65,6 @@ validate_arguments() {
   local api_base_url="$6"
 
   [[ "$tested_sha" =~ ^[0-9a-f]{40}$ ]] || fail 'tested SHA is not a 40-character lowercase hexadecimal commit'
-  [[ "$tested_sha" == "$EXPECTED_TESTED_SHA" ]] || fail 'tested SHA is not the certified staging application SHA'
   [[ "$app_path" == "$EXPECTED_APP_DIR" ]] || fail 'unexpected staging application path'
   [[ "$compose_file" == "$EXPECTED_COMPOSE_FILE" ]] || fail 'unexpected staging Compose file'
   [[ "$project" == "$EXPECTED_PROJECT_NAME" ]] || fail 'unexpected staging Compose project'
@@ -81,16 +79,17 @@ validate_arguments() {
 }
 
 assert_staging_runtime() {
-  local app_path="$1"
-  local compose_file="$2"
-  local project="$3"
-  local env_file="$4"
+  local tested_sha="$1"
+  local app_path="$2"
+  local compose_file="$3"
+  local project="$4"
+  local env_file="$5"
   local compose=(docker compose --project-name "$project" --env-file "$env_file" --file "$app_path/$compose_file")
 
   [[ -d "$app_path/.git" ]] || fail 'staging checkout is missing'
   [[ -r "$env_file" ]] || fail 'staging environment file is missing or unreadable'
   [[ -z "$(git -C "$app_path" status --porcelain --untracked-files=all)" ]] || fail 'staging checkout is not clean'
-  [[ "$(git -C "$app_path" rev-parse HEAD)" == "$EXPECTED_TESTED_SHA" ]] || fail 'staging checkout is not at the tested application SHA'
+  [[ "$(git -C "$app_path" rev-parse HEAD)" == "$tested_sha" ]] || fail 'staging checkout is not at the tested application SHA'
 
   "${compose[@]}" config --quiet
   [[ "$(container_env_value buildingos-staging-api APP_ENV)" == 'staging' ]] || fail 'API APP_ENV is not staging'
@@ -100,8 +99,8 @@ assert_staging_runtime() {
   check_container_healthy buildingos-staging-postgres
   check_container_healthy buildingos-staging-redis
   check_container_healthy buildingos-staging-web
-  [[ "$(docker inspect -f '{{index .Config.Labels "org.opencontainers.image.revision"}}' buildingos-staging-api)" == "$EXPECTED_TESTED_SHA" ]] || fail 'running staging API image is not built from the tested application SHA'
-  [[ "$(docker inspect -f '{{index .Config.Labels "org.opencontainers.image.revision"}}' buildingos-staging-web)" == "$EXPECTED_TESTED_SHA" ]] || fail 'running staging web image is not built from the tested application SHA'
+  [[ "$(docker inspect -f '{{index .Config.Labels "org.opencontainers.image.revision"}}' buildingos-staging-api)" == "$tested_sha" ]] || fail 'running staging API image is not built from the tested application SHA'
+  [[ "$(docker inspect -f '{{index .Config.Labels "org.opencontainers.image.revision"}}' buildingos-staging-web)" == "$tested_sha" ]] || fail 'running staging web image is not built from the tested application SHA'
 
   local db_name
   db_name="$(container_env_value buildingos-staging-postgres POSTGRES_DB)"
@@ -158,7 +157,7 @@ main() {
   [[ -n "${FINANCE_ACCEPTANCE_RUN_ID:-}" ]] || fail 'acceptance run identity is missing'
 
   local storage_before
-  storage_before="$(assert_staging_runtime "$app_path" "$compose_file" "$project" "$env_file")"
+  storage_before="$(assert_staging_runtime "$tested_sha" "$app_path" "$compose_file" "$project" "$env_file")"
   printf '%s\n' "$storage_before"
   printf 'tested_application_sha=%s\n' "$tested_sha"
   printf 'tenant_allowlist=%s\n' "$ALLOWED_TENANT"
@@ -178,7 +177,7 @@ main() {
     --entrypoint node buildingos-api /opt/finance-staging-acceptance.mjs
 
   local storage_after
-  storage_after="$(assert_staging_runtime "$app_path" "$compose_file" "$project" "$env_file")"
+  storage_after="$(assert_staging_runtime "$tested_sha" "$app_path" "$compose_file" "$project" "$env_file")"
   [[ "$storage_before" == "$storage_after" ]] || fail 'staging storage configuration changed during acceptance'
   [[ "$(git -C "$app_path" rev-parse HEAD)" == "$tested_sha" ]] || fail 'staging checkout changed during acceptance'
   printf 'storage_configuration_unchanged=PASS\n'

--- a/scripts/finance-staging-acceptance.sh
+++ b/scripts/finance-staging-acceptance.sh
@@ -90,6 +90,8 @@ assert_staging_runtime() {
   check_container_healthy buildingos-staging-postgres
   check_container_healthy buildingos-staging-redis
   check_container_healthy buildingos-staging-web
+  [[ "$(docker inspect -f '{{index .Config.Labels "org.opencontainers.image.revision"}}' buildingos-staging-api)" == "$EXPECTED_TESTED_SHA" ]] || fail 'running staging API image is not built from the tested application SHA'
+  [[ "$(docker inspect -f '{{index .Config.Labels "org.opencontainers.image.revision"}}' buildingos-staging-web)" == "$EXPECTED_TESTED_SHA" ]] || fail 'running staging web image is not built from the tested application SHA'
 
   local db_name
   db_name="$(container_env_value buildingos-staging-postgres POSTGRES_DB)"
@@ -154,7 +156,9 @@ main() {
   printf 'tenant_allowlist=%s\n' "$ALLOWED_TENANT"
 
   local compose=(docker compose --project-name "$project" --env-file "$env_file" --file "$app_path/$compose_file")
-  "${compose[@]}" --profile seed-staging-golden run --rm --build -T api-seed-staging-golden
+  "${compose[@]}" --profile seed-staging-golden run --rm --build -T \
+    -e STAGING_GOLDEN_TENANTS=stg-golden-tenant-auto,stg-golden-tenant-multi \
+    api-seed-staging-golden
 
   "${compose[@]}" run --rm --no-deps -T \
     -e STAGING_GOLDEN_QA_PASSWORD \

--- a/scripts/finance-staging-acceptance.sh
+++ b/scripts/finance-staging-acceptance.sh
@@ -48,6 +48,14 @@ check_container_healthy() {
   [[ "$health" == 'healthy' ]] || fail "$container health is $health"
 }
 
+check_migration_status() {
+  local migration_output
+  if ! migration_output="$("$@" 2>&1)"; then
+    printf '%s\n' "$migration_output" >&2
+    fail 'staging Prisma migration status is not healthy'
+  fi
+}
+
 validate_arguments() {
   [[ $# -eq 6 ]] || usage
   local tested_sha="$1"
@@ -103,9 +111,7 @@ assert_staging_runtime() {
   [[ "$current_database" == "$EXPECTED_DATABASE" ]] || fail 'live PostgreSQL database identity is invalid'
 
   [[ -d "$app_path/apps/api/prisma/migrations/$SNAPSHOT_MIGRATION" ]] || fail 'required receipt snapshot migration is missing from tested application SHA'
-  local migration_output
-  migration_output="$("${compose[@]}" --profile migrate run --rm --no-deps -T api-migrate migrate status --schema apps/api/prisma/schema.prisma)"
-  [[ "$migration_output" == *'No pending migrations to apply.'* ]] || fail 'staging database has pending Prisma migrations'
+  check_migration_status "${compose[@]}" --profile migrate run --rm --no-deps -T api-migrate migrate status --schema apps/api/prisma/schema.prisma
   printf 'snapshot_migration=APPLIED\n'
   printf 'pending_migrations=0\n'
 
@@ -159,7 +165,7 @@ main() {
 
   local compose=(docker compose --project-name "$project" --env-file "$env_file" --file "$app_path/$compose_file")
   "${compose[@]}" --profile seed-staging-golden run --rm --build -T \
-    -e STAGING_GOLDEN_TENANTS=stg-golden-tenant-auto,stg-golden-tenant-multi \
+    -e STAGING_GOLDEN_TENANTS=stg-golden-tenant-auto \
     -v "$CONTROL_ROOT/apps/api/prisma/seed-staging-golden.ts:/app/apps/api/prisma/seed-staging-golden.ts:ro" \
     -v "$CONTROL_ROOT/apps/api/prisma/lib/staging-seed/staging-golden-seed.ts:/app/apps/api/prisma/lib/staging-seed/staging-golden-seed.ts:ro" \
     api-seed-staging-golden

--- a/scripts/finance-staging-acceptance.sh
+++ b/scripts/finance-staging-acceptance.sh
@@ -13,6 +13,7 @@ readonly ALLOWED_UNIT='stg-golden-unit-auto-102'
 readonly QA_EMAIL='admin.autogestionada@staging.buildingos.local'
 readonly SNAPSHOT_MIGRATION='20260831000000_add_payment_receipt_issuance_snapshot'
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly CONTROL_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 fail() {
   printf 'ERROR: %s\n' "$1" >&2
@@ -159,8 +160,8 @@ main() {
   local compose=(docker compose --project-name "$project" --env-file "$env_file" --file "$app_path/$compose_file")
   "${compose[@]}" --profile seed-staging-golden run --rm --build -T \
     -e STAGING_GOLDEN_TENANTS=stg-golden-tenant-auto,stg-golden-tenant-multi \
-    -v "$SCRIPT_DIR/apps/api/prisma/seed-staging-golden.ts:/app/apps/api/prisma/seed-staging-golden.ts:ro" \
-    -v "$SCRIPT_DIR/apps/api/prisma/lib/staging-seed/staging-golden-seed.ts:/app/apps/api/prisma/lib/staging-seed/staging-golden-seed.ts:ro" \
+    -v "$CONTROL_ROOT/apps/api/prisma/seed-staging-golden.ts:/app/apps/api/prisma/seed-staging-golden.ts:ro" \
+    -v "$CONTROL_ROOT/apps/api/prisma/lib/staging-seed/staging-golden-seed.ts:/app/apps/api/prisma/lib/staging-seed/staging-golden-seed.ts:ro" \
     api-seed-staging-golden
 
   "${compose[@]}" run --rm --no-deps -T \

--- a/scripts/finance-staging-acceptance.sh
+++ b/scripts/finance-staging-acceptance.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+readonly EXPECTED_APP_DIR='/opt/pawtech/apps/buildingos-staging/buildingos-app'
+readonly EXPECTED_COMPOSE_FILE='infra/docker/docker-compose.staging.yml'
+readonly EXPECTED_PROJECT_NAME='buildingos-staging'
+readonly EXPECTED_ENV_FILE='/opt/pawtech/env/buildingos-staging.env'
+readonly EXPECTED_DATABASE='buildingos_staging_db'
+readonly EXPECTED_TESTED_SHA='15b8587c4e4740abd6d91e6c795c83ceeaf6bdcf'
+readonly ALLOWED_TENANT='stg-golden-tenant-auto'
+readonly ALLOWED_BUILDING='stg-golden-building-auto'
+readonly ALLOWED_UNIT='stg-golden-unit-auto-102'
+readonly QA_EMAIL='admin.autogestionada@staging.buildingos.local'
+readonly SNAPSHOT_MIGRATION='20260831000000_add_payment_receipt_issuance_snapshot'
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+usage() {
+  printf 'Usage: %s <tested_sha> <app_path> <compose_file> <project> <env_file> <api_base_url>\n' "${0##*/}" >&2
+  exit 64
+}
+
+container_env_value() {
+  local container="$1"
+  local expected_name="$2"
+  local name
+  local value
+
+  while IFS='=' read -r name value; do
+    if [[ "$name" == "$expected_name" ]]; then
+      printf '%s' "$value"
+      return 0
+    fi
+  done < <(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$container" 2>/dev/null)
+  return 1
+}
+
+check_container_healthy() {
+  local container="$1"
+  [[ "$(docker inspect -f '{{.State.Running}}' "$container")" == 'true' ]] || fail "$container is not running"
+  local health
+  health="$(docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container")"
+  [[ "$health" == 'healthy' ]] || fail "$container health is $health"
+}
+
+validate_arguments() {
+  [[ $# -eq 6 ]] || usage
+  local tested_sha="$1"
+  local app_path="$2"
+  local compose_file="$3"
+  local project="$4"
+  local env_file="$5"
+  local api_base_url="$6"
+
+  [[ "$tested_sha" =~ ^[0-9a-f]{40}$ ]] || fail 'tested SHA is not a 40-character lowercase hexadecimal commit'
+  [[ "$tested_sha" == "$EXPECTED_TESTED_SHA" ]] || fail 'tested SHA is not the certified staging application SHA'
+  [[ "$app_path" == "$EXPECTED_APP_DIR" ]] || fail 'unexpected staging application path'
+  [[ "$compose_file" == "$EXPECTED_COMPOSE_FILE" ]] || fail 'unexpected staging Compose file'
+  [[ "$project" == "$EXPECTED_PROJECT_NAME" ]] || fail 'unexpected staging Compose project'
+  [[ "$env_file" == "$EXPECTED_ENV_FILE" ]] || fail 'unexpected staging environment file'
+  [[ "$api_base_url" == 'http://buildingos-api:3000' ]] || fail 'unexpected internal staging API URL'
+
+  case "$app_path" in
+    ''|'/'|/opt/pawtech/apps/buildingos|/opt/pawtech/apps/buildingos/*|/opt/pawtech/apps/buildingos-production|/opt/pawtech/apps/buildingos-production/*|/opt/pawtech/apps/buildingos-release-staging|/opt/pawtech/apps/buildingos-release-staging/*)
+      fail 'production or release-staging path rejected'
+      ;;
+  esac
+}
+
+assert_staging_runtime() {
+  local app_path="$1"
+  local compose_file="$2"
+  local project="$3"
+  local env_file="$4"
+  local compose=(docker compose --project-name "$project" --env-file "$env_file" --file "$app_path/$compose_file")
+
+  [[ -d "$app_path/.git" ]] || fail 'staging checkout is missing'
+  [[ -r "$env_file" ]] || fail 'staging environment file is missing or unreadable'
+  [[ -z "$(git -C "$app_path" status --porcelain --untracked-files=all)" ]] || fail 'staging checkout is not clean'
+  [[ "$(git -C "$app_path" rev-parse HEAD)" == "$EXPECTED_TESTED_SHA" ]] || fail 'staging checkout is not at the tested application SHA'
+
+  "${compose[@]}" config --quiet
+  [[ "$(container_env_value buildingos-staging-api APP_ENV)" == 'staging' ]] || fail 'API APP_ENV is not staging'
+  [[ "$(container_env_value buildingos-staging-api NODE_ENV)" == 'staging' ]] || fail 'API NODE_ENV is not staging'
+
+  check_container_healthy buildingos-staging-api
+  check_container_healthy buildingos-staging-postgres
+  check_container_healthy buildingos-staging-redis
+  check_container_healthy buildingos-staging-web
+
+  local db_name
+  db_name="$(container_env_value buildingos-staging-postgres POSTGRES_DB)"
+  [[ "$db_name" == "$EXPECTED_DATABASE" ]] || fail 'staging PostgreSQL database identity is invalid'
+  local current_database
+  current_database="$(docker exec buildingos-staging-postgres sh -lc 'PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Atqc "select current_database()"')"
+  [[ "$current_database" == "$EXPECTED_DATABASE" ]] || fail 'live PostgreSQL database identity is invalid'
+
+  [[ -d "$app_path/apps/api/prisma/migrations/$SNAPSHOT_MIGRATION" ]] || fail 'required receipt snapshot migration is missing from tested application SHA'
+  local migration_output
+  migration_output="$("${compose[@]}" --profile migrate run --rm --no-deps -T api-migrate migrate status --schema apps/api/prisma/schema.prisma)"
+  [[ "$migration_output" == *'No pending migrations to apply.'* ]] || fail 'staging database has pending Prisma migrations'
+  printf 'snapshot_migration=APPLIED\n'
+  printf 'pending_migrations=0\n'
+
+  docker exec buildingos-staging-redis redis-cli ping >/dev/null || fail 'staging Redis connectivity failed'
+  curl --fail --silent --show-error --connect-timeout 5 --max-time 15 http://127.0.0.1:4010/health >/dev/null || fail 'staging API health failed'
+  curl --fail --silent --show-error --connect-timeout 5 --max-time 15 http://127.0.0.1:4011/ >/dev/null || fail 'staging web health failed'
+
+  local payment_provider
+  payment_provider="$(container_env_value buildingos-staging-api PAYMENT_PROVIDER || true)"
+  [[ -z "$payment_provider" || "$payment_provider" == 'none' ]] || fail 'online payment provider is enabled'
+  local webhooks_enabled
+  webhooks_enabled="$(container_env_value buildingos-staging-api ENABLE_PAYMENT_WEBHOOKS || true)"
+  [[ -z "$webhooks_enabled" || "$webhooks_enabled" == 'false' ]] || fail 'payment webhooks are enabled'
+  printf 'payment_provider=%s\n' "${payment_provider:-none}"
+  printf 'webhooks_enabled=%s\n' "${webhooks_enabled:-false}"
+
+  local s3_endpoint
+  local s3_bucket
+  local s3_path_style
+  s3_endpoint="$(container_env_value buildingos-staging-api S3_ENDPOINT)"
+  s3_bucket="$(container_env_value buildingos-staging-api S3_BUCKET)"
+  s3_path_style="$(container_env_value buildingos-staging-api S3_FORCE_PATH_STYLE)"
+  [[ -n "$s3_endpoint" && -n "$s3_bucket" && -n "$s3_path_style" ]] || fail 'staging storage configuration is incomplete'
+  local endpoint_host="${s3_endpoint#*://}"
+  endpoint_host="${endpoint_host%%/*}"
+  endpoint_host="${endpoint_host%%:*}"
+  printf 'storage_backend=s3\n'
+  printf 'storage_endpoint_host=%s\n' "$endpoint_host"
+  printf 'storage_bucket=%s\n' "$s3_bucket"
+  printf 'storage_path_style=%s\n' "$s3_path_style"
+  printf '%s|%s|%s\n' "$s3_endpoint" "$s3_bucket" "$s3_path_style"
+}
+
+main() {
+  validate_arguments "$@"
+  local tested_sha="$1"
+  local app_path="$2"
+  local compose_file="$3"
+  local project="$4"
+  local env_file="$5"
+  local api_base_url="$6"
+
+  [[ -n "${STAGING_GOLDEN_QA_PASSWORD:-}" && "${#STAGING_GOLDEN_QA_PASSWORD}" -ge 12 ]] || fail 'ephemeral Golden QA password is missing or too short'
+  [[ -n "${FINANCE_ACCEPTANCE_RUN_ID:-}" ]] || fail 'acceptance run identity is missing'
+
+  local storage_before
+  storage_before="$(assert_staging_runtime "$app_path" "$compose_file" "$project" "$env_file")"
+  printf '%s\n' "$storage_before"
+  printf 'tested_application_sha=%s\n' "$tested_sha"
+  printf 'tenant_allowlist=%s\n' "$ALLOWED_TENANT"
+
+  local compose=(docker compose --project-name "$project" --env-file "$env_file" --file "$app_path/$compose_file")
+  "${compose[@]}" --profile seed-staging-golden run --rm --build -T api-seed-staging-golden
+
+  "${compose[@]}" run --rm --no-deps -T \
+    -e STAGING_GOLDEN_QA_PASSWORD \
+    -e FINANCE_ACCEPTANCE_RUN_ID \
+    -e FINANCE_ACCEPTANCE_API_BASE_URL="$api_base_url" \
+    -v "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/finance-staging-acceptance.mjs:/opt/finance-staging-acceptance.mjs:ro" \
+    --entrypoint node buildingos-api /opt/finance-staging-acceptance.mjs
+
+  local storage_after
+  storage_after="$(assert_staging_runtime "$app_path" "$compose_file" "$project" "$env_file")"
+  [[ "$storage_before" == "$storage_after" ]] || fail 'staging storage configuration changed during acceptance'
+  [[ "$(git -C "$app_path" rev-parse HEAD)" == "$tested_sha" ]] || fail 'staging checkout changed during acceptance'
+  printf 'storage_configuration_unchanged=PASS\n'
+}
+
+if [[ -z "${BASH_SOURCE[0]-}" || "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/finance-staging-acceptance.sh
+++ b/scripts/finance-staging-acceptance.sh
@@ -12,6 +12,7 @@ readonly ALLOWED_BUILDING='stg-golden-building-auto'
 readonly ALLOWED_UNIT='stg-golden-unit-auto-102'
 readonly QA_EMAIL='admin.autogestionada@staging.buildingos.local'
 readonly SNAPSHOT_MIGRATION='20260831000000_add_payment_receipt_issuance_snapshot'
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 fail() {
   printf 'ERROR: %s\n' "$1" >&2
@@ -158,13 +159,15 @@ main() {
   local compose=(docker compose --project-name "$project" --env-file "$env_file" --file "$app_path/$compose_file")
   "${compose[@]}" --profile seed-staging-golden run --rm --build -T \
     -e STAGING_GOLDEN_TENANTS=stg-golden-tenant-auto,stg-golden-tenant-multi \
+    -v "$SCRIPT_DIR/apps/api/prisma/seed-staging-golden.ts:/app/apps/api/prisma/seed-staging-golden.ts:ro" \
+    -v "$SCRIPT_DIR/apps/api/prisma/lib/staging-seed/staging-golden-seed.ts:/app/apps/api/prisma/lib/staging-seed/staging-golden-seed.ts:ro" \
     api-seed-staging-golden
 
   "${compose[@]}" run --rm --no-deps -T \
     -e STAGING_GOLDEN_QA_PASSWORD \
     -e FINANCE_ACCEPTANCE_RUN_ID \
     -e FINANCE_ACCEPTANCE_API_BASE_URL="$api_base_url" \
-    -v "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/finance-staging-acceptance.mjs:/opt/finance-staging-acceptance.mjs:ro" \
+    -v "$SCRIPT_DIR/finance-staging-acceptance.mjs:/opt/finance-staging-acceptance.mjs:ro" \
     --entrypoint node buildingos-api /opt/finance-staging-acceptance.mjs
 
   local storage_after

--- a/scripts/tests/finance-staging-acceptance-guard.test.sh
+++ b/scripts/tests/finance-staging-acceptance-guard.test.sh
@@ -13,6 +13,10 @@ readonly VALID_ARGS=(
   http://buildingos-api:3000
 )
 
+source "$SCRIPT"
+dynamic_sha_args=("${VALID_ARGS[@]/$SHA/1111111111111111111111111111111111111111}")
+validate_arguments "${dynamic_sha_args[@]}"
+
 run_rejected_case() {
   local name="$1"
   local expected="$2"
@@ -26,8 +30,8 @@ run_rejected_case() {
   [[ "$output" == *"$expected"* ]] || { printf 'FAIL: %s did not report %s\n' "$name" "$expected" >&2; exit 1; }
 }
 
-run_rejected_case 'wrong SHA' 'certified staging application SHA' "${VALID_ARGS[@]/$SHA/0000000000000000000000000000000000000000}"
+run_rejected_case 'wrong SHA' '40-character lowercase hexadecimal' "${VALID_ARGS[@]/$SHA/deadbeef}"
 run_rejected_case 'production path' 'unexpected staging application path' "$SHA" /opt/pawtech/apps/buildingos infra/docker/docker-compose.staging.yml buildingos-staging /opt/pawtech/env/buildingos-staging.env http://buildingos-api:3000
 run_rejected_case 'production Compose project' 'unexpected staging Compose project' "$SHA" /opt/pawtech/apps/buildingos-staging/buildingos-app infra/docker/docker-compose.staging.yml buildingos-production /opt/pawtech/env/buildingos-staging.env http://buildingos-api:3000
 
-printf 'PASS: finance staging acceptance rejects non-certified and non-staging targets\n'
+printf 'PASS: finance staging acceptance rejects invalid and non-staging targets\n'

--- a/scripts/tests/finance-staging-acceptance-guard.test.sh
+++ b/scripts/tests/finance-staging-acceptance-guard.test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly SCRIPT="$ROOT_DIR/scripts/finance-staging-acceptance.sh"
+readonly SHA='15b8587c4e4740abd6d91e6c795c83ceeaf6bdcf'
+readonly VALID_ARGS=(
+  "$SHA"
+  /opt/pawtech/apps/buildingos-staging/buildingos-app
+  infra/docker/docker-compose.staging.yml
+  buildingos-staging
+  /opt/pawtech/env/buildingos-staging.env
+  http://buildingos-api:3000
+)
+
+run_rejected_case() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  set +e
+  local output
+  output="$(STAGING_GOLDEN_QA_PASSWORD='not-used' FINANCE_ACCEPTANCE_RUN_ID='test-run' bash "$SCRIPT" "$@" 2>&1)"
+  local status=$?
+  set -e
+  [[ "$status" -ne 0 ]] || { printf 'FAIL: %s unexpectedly succeeded\n' "$name" >&2; exit 1; }
+  [[ "$output" == *"$expected"* ]] || { printf 'FAIL: %s did not report %s\n' "$name" "$expected" >&2; exit 1; }
+}
+
+run_rejected_case 'wrong SHA' 'certified staging application SHA' "${VALID_ARGS[@]/$SHA/0000000000000000000000000000000000000000}"
+run_rejected_case 'production path' 'unexpected staging application path' "$SHA" /opt/pawtech/apps/buildingos infra/docker/docker-compose.staging.yml buildingos-staging /opt/pawtech/env/buildingos-staging.env http://buildingos-api:3000
+run_rejected_case 'production Compose project' 'unexpected staging Compose project' "$SHA" /opt/pawtech/apps/buildingos-staging/buildingos-app infra/docker/docker-compose.staging.yml buildingos-production /opt/pawtech/env/buildingos-staging.env http://buildingos-api:3000
+
+printf 'PASS: finance staging acceptance rejects non-certified and non-staging targets\n'

--- a/scripts/tests/finance-staging-migration-status.test.sh
+++ b/scripts/tests/finance-staging-migration-status.test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly SCRIPT="$ROOT_DIR/scripts/finance-staging-acceptance.sh"
+
+run_status_case() {
+  local name="$1"
+  local expected="$2"
+  shift 2
+  local output
+  local status
+
+  set +e
+  output="$(bash -c 'source "$1"; shift; check_migration_status "$@"' bash "$SCRIPT" "$@" 2>&1)"
+  status=$?
+  set -e
+
+  if [[ "$expected" == 'success' ]]; then
+    [[ "$status" -eq 0 ]] || { printf 'FAIL: %s was rejected\n%s\n' "$name" "$output" >&2; exit 1; }
+  else
+    [[ "$status" -ne 0 ]] || { printf 'FAIL: %s was accepted\n' "$name" >&2; exit 1; }
+    [[ "$output" == *'staging Prisma migration status is not healthy'* ]] || {
+      printf 'FAIL: %s did not report an unhealthy migration status\n%s\n' "$name" "$output" >&2
+      exit 1
+    }
+  fi
+}
+
+run_status_case 'healthy Prisma 5.22 status' success bash -c 'printf "%s\n" "Database schema is up to date!"'
+run_status_case 'pending migration status' rejected bash -c 'printf "%s\n" "Following migration(s) have not yet been applied" >&2; exit 1'
+run_status_case 'failed migration status' rejected bash -c 'printf "%s\n" "The migration failed" >&2; exit 1'
+
+printf 'PASS: Prisma migration status exit contract is enforced\n'

--- a/scripts/tests/finance-staging-workflow.test.sh
+++ b/scripts/tests/finance-staging-workflow.test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly ACCEPTANCE_WORKFLOW="$ROOT_DIR/.github/workflows/finance-staging-acceptance.yml"
+readonly DEPLOY_WORKFLOW="$ROOT_DIR/.github/workflows/deploy-staging.yml"
+
+node - "$ACCEPTANCE_WORKFLOW" "$DEPLOY_WORKFLOW" <<'NODE'
+const fs = require('fs');
+const yaml = require('js-yaml');
+
+const [acceptancePath, deployPath] = process.argv.slice(2);
+const acceptance = yaml.load(fs.readFileSync(acceptancePath, 'utf8'));
+const deploy = yaml.load(fs.readFileSync(deployPath, 'utf8'));
+
+if (acceptance.concurrency?.group !== 'staging-deploy') {
+  throw new Error('finance acceptance must use the staging-deploy concurrency group');
+}
+if (acceptance.concurrency?.['cancel-in-progress'] !== false) {
+  throw new Error('finance acceptance must not cancel an in-progress staging job');
+}
+if (deploy.concurrency?.group !== 'staging-deploy') {
+  throw new Error('staging deployment concurrency group changed unexpectedly');
+}
+if (deploy.concurrency?.['cancel-in-progress'] !== false) {
+  throw new Error('staging deployment cancellation policy changed unexpectedly');
+}
+
+console.log('PASS: finance acceptance serializes with staging deployment');
+NODE

--- a/scripts/tests/staging-golden-selector.test.sh
+++ b/scripts/tests/staging-golden-selector.test.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npm exec --workspace apps/api -- ts-node --project tsconfig.staging-seed.json -e "import { selectStagingGoldenDataset } from './prisma/lib/staging-seed/staging-golden-seed'; const selected = selectStagingGoldenDataset({ STAGING_GOLDEN_TENANTS: 'stg-golden-tenant-auto' }); if (selected.length !== 1 || selected[0]?.id !== 'stg-golden-tenant-auto') process.exit(1); let rejected = false; try { selectStagingGoldenDataset({ STAGING_GOLDEN_TENANTS: 'stg-golden-tenant-multi' }); } catch { rejected = true; } if (!rejected) process.exit(1); console.log('PASS: only stg-golden-tenant-auto is selectable');"


### PR DESCRIPTION
## Purpose
Enable controlled FINANCE_PROD_02C staging acceptance using the existing GitHub staging SSH environment and the existing STG-DATA-01 Golden Dataset.

## SHA contract
- `tested_sha` is a required workflow input containing the exact application revision already deployed in staging.
- The workflow accepts only a 40-character commit that is an ancestor of `origin/main`.
- The staging checkout `HEAD` and running API/web immutable revision labels must equal that exact input.

## Security
- Workflow is manual-only and uses `environment: staging`.
- QA password is generated with `openssl rand -hex 32`, immediately masked, and never logged or persisted.
- Password is used only for the existing Golden seed and temporary Golden QA login.
- No payment-provider credentials are requested or injected.
- No production path, production Compose project, or production database can pass the hard guards.
- The acceptance seed selects only `stg-golden-tenant-auto`; `stg-golden-tenant-multi` is rejected and is not mutated.
- Auth cookies are stored only in a mode-0600 temporary file and removed on exit.
- Streamed harness and scoped seed files are extracted under `/tmp`, mounted read-only into the seed container, and removed after execution; the staging checkout is not modified.
- No finance application source, schema, or migration changed.

## Acceptance contract
The helper uses the real staging API routes and roles: `TENANT_ADMIN` login via `/auth/login`, Golden seed via the existing `npm run seed:staging:golden` command, Expense via `/tenants/:tenantId/finance/expenses`, Income via `/tenants/:tenantId/finance/incomes`, Charge and Payment via `/buildings/:buildingId/charges` and `/buildings/:buildingId/payments`, approval via `/tenants/:tenantId/finance/payments/:paymentId/approve`, receipt retry via `/tenants/:tenantId/finance/payments/:paymentId/retry-receipt`, and document presign/upload/download via `/tenants/:tenantId/documents/*`.

The controlled seed provides the tenant-scoped expense/income categories needed by the harness. Prisma migration status is an inspection-only gate based on the Prisma CLI exit contract; it never applies migrations. The harness never writes financial state through SQL.

## Validation
- YAML parsed successfully with `js-yaml`.
- Shell and Node syntax passed.
- Guard, deployment, migration-status, and single-tenant selector tests passed.
- Prisma `5.22.0` verified and Golden seed typecheck passed.
- Runtime overlay archive passed.
- Prettier and `git diff --check` passed for applicable files.
- `shellcheck` and `actionlint` were unavailable locally.

## Review
Please request `@codex review` for the fresh correction head after exact-head CI passes. Do not merge this PR. Do not run staging finance acceptance yet.

Production remains untouched.