### PR TITLE
test(finance): add safe staging runtime diagnostic mode

### DIFF
--- a/.github/workflows/finance-staging-acceptance.yml
+++ b/.github/workflows/finance-staging-acceptance.yml
@@ -37,14 +37,9 @@ jobs:
         shell: bash
         env:
           TESTED_SHA: ${{ inputs.tested_sha }}
-          DIAGNOSTIC_ONLY: ${{ inputs.diagnostic_only }}
         run: |
           set -Eeuo pipefail
-          if [[ "$DIAGNOSTIC_ONLY" == 'true' ]]; then
-            [[ "$GITHUB_REF" == "refs/heads/chore/finance-staging-runtime-env-diagnostic" ]] || { echo "Diagnostic mode must run from the diagnostic branch" >&2; exit 1; }
-          else
-            [[ "$GITHUB_REF" == "refs/heads/main" ]] || { echo "Finance staging acceptance must run from refs/heads/main" >&2; exit 1; }
-          fi
+          [[ "$GITHUB_REF" == "refs/heads/main" ]] || { echo "Finance staging acceptance must run from refs/heads/main" >&2; exit 1; }
           [[ "$TESTED_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "tested_sha must be exactly 40 lowercase hex characters" >&2; exit 1; }
           git cat-file -e "$TESTED_SHA^{commit}"
           git fetch --no-tags origin main

--- a/.github/workflows/finance-staging-acceptance.yml
+++ b/.github/workflows/finance-staging-acceptance.yml
@@ -7,6 +7,11 @@ on:
         description: Exact application SHA already deployed in staging
         required: true
         type: string
+      diagnostic_only:
+        description: Read-only staging runtime environment diagnostic
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: staging-deploy
@@ -32,9 +37,14 @@ jobs:
         shell: bash
         env:
           TESTED_SHA: ${{ inputs.tested_sha }}
+          DIAGNOSTIC_ONLY: ${{ inputs.diagnostic_only }}
         run: |
           set -Eeuo pipefail
-          [[ "$GITHUB_REF" == "refs/heads/main" ]] || { echo "Finance staging acceptance must run from refs/heads/main" >&2; exit 1; }
+          if [[ "$DIAGNOSTIC_ONLY" == 'true' ]]; then
+            [[ "$GITHUB_REF" == "refs/heads/chore/finance-staging-runtime-env-diagnostic" ]] || { echo "Diagnostic mode must run from the diagnostic branch" >&2; exit 1; }
+          else
+            [[ "$GITHUB_REF" == "refs/heads/main" ]] || { echo "Finance staging acceptance must run from refs/heads/main" >&2; exit 1; }
+          fi
           [[ "$TESTED_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo "tested_sha must be exactly 40 lowercase hex characters" >&2; exit 1; }
           git cat-file -e "$TESTED_SHA^{commit}"
           git fetch --no-tags origin main
@@ -42,8 +52,89 @@ jobs:
           printf 'control_sha=%s\n' "$(git rev-parse HEAD)"
           printf 'tested_application_sha=%s\n' "$TESTED_SHA"
 
+      - name: Inspect staging runtime environment (diagnostic only)
+        if: ${{ inputs.diagnostic_only == true }}
+        shell: bash
+        env:
+          TESTED_SHA: ${{ inputs.tested_sha }}
+          SSH_HOST: ${{ secrets.STAGING_SSH_HOST }}
+          SSH_USER: ${{ secrets.STAGING_SSH_USER }}
+          SSH_PRIVATE_KEY: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
+          SSH_PORT: ${{ vars.STAGING_SSH_PORT || '22' }}
+          KNOWN_HOSTS: ${{ secrets.STAGING_SSH_KNOWN_HOSTS }}
+          APP_PATH: /opt/pawtech/apps/buildingos-staging/buildingos-app
+          COMPOSE_FILE: infra/docker/docker-compose.staging.yml
+          COMPOSE_PROJECT: buildingos-staging
+          ENV_FILE: /opt/pawtech/env/buildingos-staging.env
+        run: |
+          set -Eeuo pipefail
+          [[ -n "$SSH_HOST" && -n "$SSH_USER" && -n "$SSH_PRIVATE_KEY" && -n "$SSH_PORT" && -n "$KNOWN_HOSTS" ]] || { echo "Staging SSH settings are incomplete" >&2; exit 1; }
+          key_file="$(mktemp)"
+          known_hosts_file="$(mktemp)"
+          cleanup_ssh() {
+            rm -f "$key_file" "$known_hosts_file"
+            unset SSH_PRIVATE_KEY KNOWN_HOSTS
+          }
+          trap cleanup_ssh EXIT
+          chmod 600 "$key_file" "$known_hosts_file"
+          printf '%s\n' "$SSH_PRIVATE_KEY" > "$key_file"
+          printf '%s\n' "$KNOWN_HOSTS" > "$known_hosts_file"
+
+          ssh_opts=(-i "$key_file" -o UserKnownHostsFile="$known_hosts_file" -p "$SSH_PORT" -o BatchMode=yes -o StrictHostKeyChecking=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=6)
+          remote_args=()
+          for arg in "$TESTED_SHA" "$APP_PATH" "$COMPOSE_FILE" "$COMPOSE_PROJECT" "$ENV_FILE"; do
+            printf -v quoted '%q' "$arg"
+            remote_args+=("$quoted")
+          done
+          printf -v remote_command 'bash -s -- %s' "${remote_args[*]}"
+          ssh "${ssh_opts[@]}" "$SSH_USER@$SSH_HOST" "$remote_command" <<'REMOTE'
+          set -Eeuo pipefail
+          tested_sha="$1"
+          app_path="$2"
+          compose_file="$3"
+          compose_project="$4"
+          env_file="$5"
+
+          [[ "$app_path" == '/opt/pawtech/apps/buildingos-staging/buildingos-app' ]] || { echo 'Unexpected staging application path' >&2; exit 1; }
+          [[ "$compose_file" == 'infra/docker/docker-compose.staging.yml' ]] || { echo 'Unexpected staging Compose file' >&2; exit 1; }
+          [[ "$compose_project" == 'buildingos-staging' ]] || { echo 'Unexpected staging Compose project' >&2; exit 1; }
+          [[ "$env_file" == '/opt/pawtech/env/buildingos-staging.env' ]] || { echo 'Unexpected staging environment file' >&2; exit 1; }
+
+          get_env() {
+            local container="$1"
+            local expected_name="$2"
+            local name
+            local value
+            while IFS='=' read -r name value; do
+              if [[ "$name" == "$expected_name" ]]; then
+                printf '%s' "$value"
+                return 0
+              fi
+            done < <(docker inspect -f '{{range .Config.Env}}{{println .}}{{end}}' "$container")
+            return 1
+          }
+
+          api_app_env="$(get_env buildingos-staging-api APP_ENV)"
+          api_node_env="$(get_env buildingos-staging-api NODE_ENV)"
+          web_app_env="$(get_env buildingos-staging-web APP_ENV)"
+          web_node_env="$(get_env buildingos-staging-web NODE_ENV)"
+          api_revision="$(docker inspect -f '{{index .Config.Labels "org.opencontainers.image.revision"}}' buildingos-staging-api)"
+          web_revision="$(docker inspect -f '{{index .Config.Labels "org.opencontainers.image.revision"}}' buildingos-staging-web)"
+
+          [[ "$api_revision" == "$tested_sha" ]] || { echo 'API revision is not the tested SHA' >&2; exit 1; }
+          [[ "$web_revision" == "$tested_sha" ]] || { echo 'web revision is not the tested SHA' >&2; exit 1; }
+
+          printf 'api_app_env=%s\n' "$api_app_env"
+          printf 'api_node_env=%s\n' "$api_node_env"
+          printf 'web_app_env=%s\n' "$web_app_env"
+          printf 'web_node_env=%s\n' "$web_node_env"
+          printf 'api_revision=%s\n' "$api_revision"
+          printf 'web_revision=%s\n' "$web_revision"
+          REMOTE
+
       - name: Generate ephemeral Golden QA password
         id: qa-password
+        if: ${{ inputs.diagnostic_only != true }}
         shell: bash
         run: |
           set -Eeuo pipefail
@@ -52,6 +143,7 @@ jobs:
           printf 'password=%s\n' "$qa_password" >> "$GITHUB_OUTPUT"
 
       - name: Run controlled staging acceptance over SSH
+        if: ${{ inputs.diagnostic_only != true }}
         shell: bash
         env:
           TESTED_SHA: ${{ inputs.tested_sha }}

--- a/scripts/tests/finance-staging-workflow.test.sh
+++ b/scripts/tests/finance-staging-workflow.test.sh
@@ -14,6 +14,7 @@ const acceptance = yaml.load(fs.readFileSync(acceptancePath, 'utf8'));
 const deploy = yaml.load(fs.readFileSync(deployPath, 'utf8'));
 const workflowDispatch = (acceptance.on ?? acceptance[true])?.workflow_dispatch;
 const acceptanceSteps = acceptance.jobs?.acceptance?.steps ?? [];
+const validationStep = acceptanceSteps.find((step) => step.name === 'Validate control and tested SHAs');
 const diagnosticStep = acceptanceSteps.find((step) => step.name === 'Inspect staging runtime environment (diagnostic only)');
 const passwordStep = acceptanceSteps.find((step) => step.name === 'Generate ephemeral Golden QA password');
 const financeStep = acceptanceSteps.find((step) => step.name === 'Run controlled staging acceptance over SSH');
@@ -39,6 +40,13 @@ if (workflowDispatch.inputs.diagnostic_only.default !== false) {
 if (diagnosticStep?.if !== '${{ inputs.diagnostic_only == true }}') {
   throw new Error('diagnostic step must run only in diagnostic mode');
 }
+const validationRun = validationStep?.run ?? '';
+if (!validationRun.includes('[[ "$GITHUB_REF" == "refs/heads/main" ]]')) {
+  throw new Error('diagnostic and normal modes must require main');
+}
+if (validationRun.includes('chore/finance-staging-runtime-env-diagnostic')) {
+  throw new Error('temporary diagnostic branch must not retain staging access');
+}
 if (passwordStep?.if !== '${{ inputs.diagnostic_only != true }}' || financeStep?.if !== '${{ inputs.diagnostic_only != true }}') {
   throw new Error('finance acceptance steps must be excluded in diagnostic mode');
 }
@@ -51,6 +59,11 @@ for (const forbidden of ['finance-staging-acceptance.sh', 'finance-staging-accep
 for (const output of ['api_app_env=', 'api_node_env=', 'web_app_env=', 'web_node_env=', 'api_revision=', 'web_revision=']) {
   if (!diagnosticRun.includes(output)) {
     throw new Error(`diagnostic mode must report ${output}`);
+  }
+}
+for (const secret of ['DATABASE_URL', 'JWT_SECRET', 'S3_ACCESS_KEY', 'S3_SECRET_KEY', 'SMTP_PASS', 'SSH_PRIVATE_KEY', 'PAYMENT_PROVIDER']) {
+  if (diagnosticRun.includes(`printf '${secret}=`) || diagnosticRun.includes(`printf "%s" "$${secret}"`)) {
+    throw new Error(`diagnostic mode must not print ${secret}`);
   }
 }
 

--- a/scripts/tests/finance-staging-workflow.test.sh
+++ b/scripts/tests/finance-staging-workflow.test.sh
@@ -12,6 +12,11 @@ const yaml = require('js-yaml');
 const [acceptancePath, deployPath] = process.argv.slice(2);
 const acceptance = yaml.load(fs.readFileSync(acceptancePath, 'utf8'));
 const deploy = yaml.load(fs.readFileSync(deployPath, 'utf8'));
+const workflowDispatch = (acceptance.on ?? acceptance[true])?.workflow_dispatch;
+const acceptanceSteps = acceptance.jobs?.acceptance?.steps ?? [];
+const diagnosticStep = acceptanceSteps.find((step) => step.name === 'Inspect staging runtime environment (diagnostic only)');
+const passwordStep = acceptanceSteps.find((step) => step.name === 'Generate ephemeral Golden QA password');
+const financeStep = acceptanceSteps.find((step) => step.name === 'Run controlled staging acceptance over SSH');
 
 if (acceptance.concurrency?.group !== 'staging-deploy') {
   throw new Error('finance acceptance must use the staging-deploy concurrency group');
@@ -24,6 +29,29 @@ if (deploy.concurrency?.group !== 'staging-deploy') {
 }
 if (deploy.concurrency?.['cancel-in-progress'] !== false) {
   throw new Error('staging deployment cancellation policy changed unexpectedly');
+}
+if (workflowDispatch?.inputs?.diagnostic_only?.type !== 'boolean') {
+  throw new Error('finance acceptance diagnostic_only input must be boolean');
+}
+if (workflowDispatch.inputs.diagnostic_only.default !== false) {
+  throw new Error('finance acceptance diagnostic_only input must default to false');
+}
+if (diagnosticStep?.if !== '${{ inputs.diagnostic_only == true }}') {
+  throw new Error('diagnostic step must run only in diagnostic mode');
+}
+if (passwordStep?.if !== '${{ inputs.diagnostic_only != true }}' || financeStep?.if !== '${{ inputs.diagnostic_only != true }}') {
+  throw new Error('finance acceptance steps must be excluded in diagnostic mode');
+}
+const diagnosticRun = diagnosticStep?.run ?? '';
+for (const forbidden of ['finance-staging-acceptance.sh', 'finance-staging-acceptance.mjs', 'api-seed-staging-golden', 'migrate']) {
+  if (diagnosticRun.includes(forbidden)) {
+    throw new Error(`diagnostic mode must not invoke ${forbidden}`);
+  }
+}
+for (const output of ['api_app_env=', 'api_node_env=', 'web_app_env=', 'web_node_env=', 'api_revision=', 'web_revision=']) {
+  if (!diagnosticRun.includes(output)) {
+    throw new Error(`diagnostic mode must report ${output}`);
+  }
 }
 
 console.log('PASS: finance acceptance serializes with staging deployment');


### PR DESCRIPTION
## Summary
- run the existing finance workflow in read-only diagnostic mode from protected main
- inspect only staging APP_ENV, NODE_ENV, and image revision labels
- keep normal finance acceptance steps disabled in diagnostic mode

## Safety
- no application or Prisma changes
- no seed, finance API, migration, or production execution in diagnostic mode
- staging environment protection remains unchanged

## Validation
- YAML parse
- shell syntax
- workflow, acceptance guard, deployment entrypoint, and storage cutover tests
- git diff --check