### PR TITLE
chore(prod): add protected read-only production audit

### DIFF
--- a/.github/workflows/production-readonly-audit.yml
+++ b/.github/workflows/production-readonly-audit.yml
@@ -1,0 +1,100 @@
+name: Production read-only audit
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Informational certified application SHA under review
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-operations
+  cancel-in-progress: false
+
+jobs:
+  audit:
+    name: Audit production without mutation
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    env:
+      CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+      SSH_HOST: ${{ secrets.PRODUCTION_SSH_HOST }}
+      SSH_USER: ${{ secrets.PRODUCTION_SSH_USER }}
+      SSH_PRIVATE_KEY: ${{ secrets.PRODUCTION_SSH_PRIVATE_KEY }}
+      SSH_KNOWN_HOSTS: ${{ secrets.PRODUCTION_SSH_KNOWN_HOSTS }}
+      SSH_PORT: ${{ vars.PRODUCTION_SSH_PORT || '22' }}
+      API_HEALTH_URL: ${{ vars.PRODUCTION_API_HEALTH_URL }}
+      API_READYZ_URL: ${{ vars.PRODUCTION_API_READYZ_URL }}
+      WEB_LOGIN_URL: ${{ vars.PRODUCTION_WEB_LOGIN_URL }}
+    steps:
+      - name: Checkout trusted audit control
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Validate audit target
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          [[ "$GITHUB_REF" == "refs/heads/main" ]]
+          [[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ -n "$SSH_HOST" && -n "$SSH_USER" && -n "$SSH_PRIVATE_KEY" && -n "$SSH_KNOWN_HOSTS" ]]
+          [[ "$SSH_PORT" =~ ^[0-9]+$ ]]
+          [[ "$API_HEALTH_URL" =~ ^https://[A-Za-z0-9._:/?=%+-]+$ ]]
+          [[ "$API_READYZ_URL" =~ ^https://[A-Za-z0-9._:/?=%+-]+$ ]]
+          [[ "$WEB_LOGIN_URL" =~ ^https://[A-Za-z0-9._:/?=%+-]+$ ]]
+          test -x scripts/production-readonly-audit.sh
+
+      - name: Record deployment tooling observation
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          grep -Eq 'MIGRATION_COUNT.*==.*97' scripts/deploy-production.sh
+          grep -Fq 'TARGET_APPLIED=97' scripts/verify-production-migration-manifest.sh
+          test -f apps/api/prisma/migrations/20260831000000_add_payment_receipt_issuance_snapshot/migration.sql
+          certified_migration_count="$(find apps/api/prisma/migrations -mindepth 1 -maxdepth 1 -type d -print | wc -l | tr -d '[:space:]')"
+          [[ "$certified_migration_count" == '98' ]]
+          printf 'DEPLOY_TOOLING_FINAL_MIGRATION_COUNT=97\n'
+          printf 'DEPLOY_TOOLING_MANIFEST_TARGET_APPLIED=97\n'
+          printf 'CERTIFIED_MIGRATION_COUNT=%s\n' "$certified_migration_count"
+          printf 'NEW_MIGRATION=20260831000000_add_payment_receipt_issuance_snapshot\n'
+          printf 'DEPLOY_TOOLING_COMPATIBLE=NO\n'
+          printf 'DEPLOY_TOOLING_MODIFIED=NO\n'
+
+      - name: Stream production read-only audit
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          install -d -m 700 "$HOME/.ssh"
+          key_file="$(mktemp "$HOME/.ssh/production-audit-key.XXXXXX")"
+          known_hosts_file="$(mktemp "$HOME/.ssh/production-audit-known-hosts.XXXXXX")"
+          cleanup() { rm -f "$key_file" "$known_hosts_file"; }
+          trap cleanup EXIT
+          chmod 600 "$key_file" "$known_hosts_file"
+          printf '%s\n' "$SSH_PRIVATE_KEY" > "$key_file"
+          printf '%s\n' "$SSH_KNOWN_HOSTS" > "$known_hosts_file"
+
+          ssh_opts=(
+            -i "$key_file"
+            -o UserKnownHostsFile="$known_hosts_file"
+            -o StrictHostKeyChecking=yes
+            -o BatchMode=yes
+            -o ServerAliveInterval=30
+            -o ServerAliveCountMax=6
+            -p "$SSH_PORT"
+          )
+          remote_args=()
+          for arg in "$CANDIDATE_SHA" "$API_HEALTH_URL" "$API_READYZ_URL" "$WEB_LOGIN_URL"; do
+            printf -v quoted '%q' "$arg"
+            remote_args+=("$quoted")
+          done
+
+          ssh "${ssh_opts[@]}" "$SSH_USER@$SSH_HOST" \
+            "bash -s -- ${remote_args[*]}" < scripts/production-readonly-audit.sh

--- a/.github/workflows/production-readonly-audit.yml
+++ b/.github/workflows/production-readonly-audit.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           set -Eeuo pipefail
           deploy_migration_count="$(awk -F "'" '/MIGRATION_COUNT.*==/ { print $2; exit }' scripts/deploy-production.sh)"
-          manifest_target_applied="$(awk -F "'" '/TARGET_APPLIED=/ { print $2; exit }' scripts/verify-production-migration-manifest.sh)"
+          manifest_target_applied="$(awk -F '=' '/^[[:space:]]*readonly[[:space:]]+TARGET_APPLIED[[:space:]]*=/ { value=$2; gsub(/[[:space:]]/, "", value); gsub(/\047/, "", value); if (value ~ /^[0-9]+$/) { print value; exit } }' scripts/verify-production-migration-manifest.sh)"
           [[ -n "$deploy_migration_count" ]] || deploy_migration_count='UNKNOWN'
           [[ -n "$manifest_target_applied" ]] || manifest_target_applied='UNKNOWN'
           certified_migration_count="$(find apps/api/prisma/migrations -mindepth 1 -maxdepth 1 -type d -print | wc -l | tr -d '[:space:]')"

--- a/.github/workflows/production-readonly-audit.yml
+++ b/.github/workflows/production-readonly-audit.yml
@@ -56,16 +56,24 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
-          grep -Eq 'MIGRATION_COUNT.*==.*97' scripts/deploy-production.sh
-          grep -Fq 'TARGET_APPLIED=97' scripts/verify-production-migration-manifest.sh
-          test -f apps/api/prisma/migrations/20260831000000_add_payment_receipt_issuance_snapshot/migration.sql
+          deploy_migration_count='UNKNOWN'
+          manifest_target_applied='UNKNOWN'
+          migration_98_present='NO'
+          grep -Eq 'MIGRATION_COUNT.*==.*97' scripts/deploy-production.sh && deploy_migration_count='97' || true
+          grep -Fq 'TARGET_APPLIED=97' scripts/verify-production-migration-manifest.sh && manifest_target_applied='97' || true
+          if [[ -f apps/api/prisma/migrations/20260831000000_add_payment_receipt_issuance_snapshot/migration.sql ]]; then
+            migration_98_present='YES'
+          fi
           certified_migration_count="$(find apps/api/prisma/migrations -mindepth 1 -maxdepth 1 -type d -print | wc -l | tr -d '[:space:]')"
-          [[ "$certified_migration_count" == '98' ]]
-          printf 'DEPLOY_TOOLING_FINAL_MIGRATION_COUNT=97\n'
-          printf 'DEPLOY_TOOLING_MANIFEST_TARGET_APPLIED=97\n'
+          printf 'DEPLOY_TOOLING_FINAL_MIGRATION_COUNT=%s\n' "$deploy_migration_count"
+          printf 'DEPLOY_TOOLING_MANIFEST_TARGET_APPLIED=%s\n' "$manifest_target_applied"
           printf 'CERTIFIED_MIGRATION_COUNT=%s\n' "$certified_migration_count"
-          printf 'NEW_MIGRATION=20260831000000_add_payment_receipt_issuance_snapshot\n'
-          printf 'DEPLOY_TOOLING_COMPATIBLE=NO\n'
+          printf 'NEW_MIGRATION_PRESENT=%s\n' "$migration_98_present"
+          if [[ "$deploy_migration_count" == '97' && "$manifest_target_applied" == '97' && "$migration_98_present" == 'YES' ]]; then
+            printf 'DEPLOY_TOOLING_COMPATIBLE=NO\n'
+          else
+            printf 'DEPLOY_TOOLING_COMPATIBLE=UNKNOWN\n'
+          fi
           printf 'DEPLOY_TOOLING_MODIFIED=NO\n'
 
       - name: Stream production read-only audit

--- a/.github/workflows/production-readonly-audit.yml
+++ b/.github/workflows/production-readonly-audit.yml
@@ -56,21 +56,18 @@ jobs:
         shell: bash
         run: |
           set -Eeuo pipefail
-          deploy_migration_count='UNKNOWN'
-          manifest_target_applied='UNKNOWN'
-          migration_98_present='NO'
-          grep -Eq 'MIGRATION_COUNT.*==.*97' scripts/deploy-production.sh && deploy_migration_count='97' || true
-          grep -Fq 'TARGET_APPLIED=97' scripts/verify-production-migration-manifest.sh && manifest_target_applied='97' || true
-          if [[ -f apps/api/prisma/migrations/20260831000000_add_payment_receipt_issuance_snapshot/migration.sql ]]; then
-            migration_98_present='YES'
-          fi
+          deploy_migration_count="$(awk -F "'" '/MIGRATION_COUNT.*==/ { print $2; exit }' scripts/deploy-production.sh)"
+          manifest_target_applied="$(awk -F "'" '/TARGET_APPLIED=/ { print $2; exit }' scripts/verify-production-migration-manifest.sh)"
+          [[ -n "$deploy_migration_count" ]] || deploy_migration_count='UNKNOWN'
+          [[ -n "$manifest_target_applied" ]] || manifest_target_applied='UNKNOWN'
           certified_migration_count="$(find apps/api/prisma/migrations -mindepth 1 -maxdepth 1 -type d -print | wc -l | tr -d '[:space:]')"
           printf 'DEPLOY_TOOLING_FINAL_MIGRATION_COUNT=%s\n' "$deploy_migration_count"
           printf 'DEPLOY_TOOLING_MANIFEST_TARGET_APPLIED=%s\n' "$manifest_target_applied"
           printf 'CERTIFIED_MIGRATION_COUNT=%s\n' "$certified_migration_count"
-          printf 'NEW_MIGRATION_PRESENT=%s\n' "$migration_98_present"
-          if [[ "$deploy_migration_count" == '97' && "$manifest_target_applied" == '97' && "$migration_98_present" == 'YES' ]]; then
+          if [[ "$deploy_migration_count" =~ ^[0-9]+$ && "$manifest_target_applied" =~ ^[0-9]+$ && "$certified_migration_count" =~ ^[0-9]+$ && "$deploy_migration_count" == "$manifest_target_applied" && "$certified_migration_count" -gt "$deploy_migration_count" ]]; then
             printf 'DEPLOY_TOOLING_COMPATIBLE=NO\n'
+          elif [[ "$deploy_migration_count" =~ ^[0-9]+$ && "$manifest_target_applied" =~ ^[0-9]+$ && "$certified_migration_count" =~ ^[0-9]+$ && "$deploy_migration_count" == "$manifest_target_applied" && "$certified_migration_count" == "$deploy_migration_count" ]]; then
+            printf 'DEPLOY_TOOLING_COMPATIBLE=YES\n'
           else
             printf 'DEPLOY_TOOLING_COMPATIBLE=UNKNOWN\n'
           fi

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -425,6 +425,11 @@ BEGIN READ ONLY;
 SELECT count(*) FROM "PaymentAllocation" WHERE amount < 0;
 COMMIT;
 SQL
+  report_query_stdin 'NEGATIVE_PAYMENT_ORIGINAL_ALLOCATIONS' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*) FROM "PaymentAllocation" WHERE "paymentOriginalAmountMinor" < 0;
+COMMIT;
+SQL
   if value="$(readonly_query_stdin <<'SQL'
 BEGIN READ ONLY;
 WITH per_payment AS (
@@ -884,11 +889,12 @@ report_backup_readiness() {
       (( age >= 0 && age <= MAX_BACKUP_AGE_SECONDS )); then
       paired_receipt="$BACKUP_STATE_DIR/paired-$backup_set_id.json"
       if [[ -f "$paired_receipt" && ! -L "$paired_receipt" && -r "$paired_receipt" ]] &&
-        jq -e --arg backupSetId "$backup_set_id" --arg appSha "$app_sha" '
+        jq -e --arg backupSetId "$backup_set_id" --arg appSha "$app_sha" --arg completedAt "$completed_at" '
           .version == 1 and
           .status == "PASS" and
           .backup_set_id == $backupSetId and
           .app_sha == $appSha and
+          .completed_at == $completedAt and
           .minio_verified == true and
           (.postgres_receipt.version == 1) and
           (.postgres_receipt.status == "PASS") and

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -11,7 +11,7 @@ readonly DATABASE_NAME='buildingos_db'
 readonly APP_DIR='/opt/pawtech/apps/buildingos/buildingos-app'
 readonly BACKUP_ROOT='/opt/pawtech/backups/tmp'
 readonly BACKUP_SCRIPT_PATH='/opt/pawtech/backups/scripts/backup-postgres.sh'
-readonly BACKUP_IDENTITY_MANIFEST_PATH='/opt/pawtech/apps/buildingos/infra/production/backup-postgres.identity.v1'
+readonly BACKUP_IDENTITY_MANIFEST_PATH="${APP_DIR}/infra/production/backup-postgres.identity.v1"
 readonly ALLOWED_IGNORED_RUNTIME_ENV='infra/docker/.env'
 readonly EXPECTED_BUCKET='buildingos-production'
 readonly KNOWN_PRODUCTION_BASELINE='20260816000004_legacy_income_application_provenance'
@@ -740,6 +740,7 @@ report_backup_readiness() {
         checksum_status='PASS'
       else
         checksum_status='FAIL'
+        AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
       fi
     fi
     if command -v pg_restore >/dev/null 2>&1 && pg_restore --list "$latest_dump" >/dev/null 2>&1; then

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -27,22 +27,8 @@ fail() {
   exit 1
 }
 
-[[ $# -eq 4 ]] || { usage; exit 64; }
-readonly CANDIDATE_SHA="$1"
-readonly API_HEALTH_URL="$2"
-readonly API_READYZ_URL="$3"
-readonly WEB_LOGIN_URL="$4"
-
-[[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]] || fail 'candidate SHA is not exactly 40 lowercase hexadecimal characters'
-for url in "$API_HEALTH_URL" "$API_READYZ_URL" "$WEB_LOGIN_URL"; do
-  [[ "$url" =~ ^https://[A-Za-z0-9._:/?=%+-]+$ ]] || fail 'public audit URL is not an HTTPS URL'
-done
-
-for command_name in bash curl date docker find git sha256sum stat; do
-  command -v "$command_name" >/dev/null 2>&1 || fail "$command_name is required"
-done
-
 AUDIT_QUERY_FAILURES=0
+AUDIT_EVIDENCE_FAILURES=0
 
 container_exists() {
   docker inspect --type container "$1" >/dev/null 2>&1
@@ -133,19 +119,22 @@ storage_backend_from_host() {
   esac
 }
 
-readonly_query() {
-  local query="$1"
-  docker exec -i "$POSTGRES_CONTAINER" sh -lc \
-    'exec psql -v ON_ERROR_STOP=1 -qAt -U "$POSTGRES_USER" -d "$1" -c "$2"' \
-    sh "$DATABASE_NAME" "BEGIN READ ONLY; ${query}; COMMIT;"
+readonly_query_stdin() {
+  local query
+
+  query="$(< /dev/stdin)"
+  [[ "$query" == *'BEGIN READ ONLY;'* ]] || fail 'SQL payload is missing BEGIN READ ONLY'
+  [[ "$query" == *'COMMIT;'* ]] || fail 'SQL payload is missing COMMIT'
+  printf '%s\n' "$query" | docker exec -i "$POSTGRES_CONTAINER" sh -lc \
+    'exec psql -v ON_ERROR_STOP=1 -qAt -U "$POSTGRES_USER" -d "$1"' \
+    sh "$DATABASE_NAME"
 }
 
-report_query() {
+report_query_stdin() {
   local key="$1"
-  local query="$2"
   local value
 
-  if value="$(readonly_query "$query" 2>/dev/null)"; then
+  if value="$(readonly_query_stdin 2>/dev/null)"; then
     printf '%s=%s\n' "$key" "$value"
   else
     AUDIT_QUERY_FAILURES=$((AUDIT_QUERY_FAILURES + 1))
@@ -244,16 +233,63 @@ report_safe_runtime_config() {
 report_migrations_and_schema() {
   local receipt_columns
 
-  report_query 'DATABASE_NAME' 'SELECT current_database()'
-  report_query 'ACTIVE_FINISHED_MIGRATIONS' 'SELECT count(*) FROM "_prisma_migrations" WHERE finished_at IS NOT NULL AND rolled_back_at IS NULL'
-  report_query 'FAILED_MIGRATIONS' 'SELECT count(*) FROM "_prisma_migrations" WHERE finished_at IS NULL AND rolled_back_at IS NULL'
-  report_query 'MIGRATIONS_AFTER_KNOWN_BASELINE' "SELECT COALESCE(string_agg(migration_name, ',' ORDER BY finished_at, migration_name), 'NONE') FROM \"_prisma_migrations\" WHERE migration_name > '$KNOWN_PRODUCTION_BASELINE' AND finished_at IS NOT NULL AND rolled_back_at IS NULL"
-  report_query 'TARGET_MIGRATION_STATUS' "SELECT CASE WHEN count(*) = 0 THEN 'NOT_APPLIED' WHEN count(*) = 1 AND bool_and(finished_at IS NOT NULL AND rolled_back_at IS NULL) THEN 'APPLIED' ELSE 'AMBIGUOUS' END FROM \"_prisma_migrations\" WHERE migration_name = '$TARGET_MIGRATION'"
-  if receipt_columns="$(readonly_query 'SELECT CASE WHEN count(*) = 6 THEN ''YES'' ELSE ''NO'' END FROM information_schema.columns WHERE table_schema = ''public'' AND table_name = ''Payment'' AND column_name IN (''receiptSnapshot'', ''receiptSnapshotVersion'', ''receiptSnapshotHash'', ''receiptSnapshotCreatedAt'', ''receiptGenerationToken'', ''receiptGenerationLeaseUntil'')' 2>/dev/null)"; then
+  report_query_stdin 'DATABASE_NAME' <<'SQL'
+BEGIN READ ONLY;
+SELECT current_database();
+COMMIT;
+SQL
+  report_query_stdin 'ACTIVE_FINISHED_MIGRATIONS' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*) FROM "_prisma_migrations" WHERE finished_at IS NOT NULL AND rolled_back_at IS NULL;
+COMMIT;
+SQL
+  report_query_stdin 'FAILED_MIGRATIONS' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*) FROM "_prisma_migrations" WHERE finished_at IS NULL AND rolled_back_at IS NULL;
+COMMIT;
+SQL
+  report_query_stdin 'MIGRATIONS_AFTER_KNOWN_BASELINE' <<SQL
+BEGIN READ ONLY;
+SELECT COALESCE(string_agg(migration_name, ',' ORDER BY finished_at, migration_name), 'NONE')
+FROM "_prisma_migrations"
+WHERE migration_name > '$KNOWN_PRODUCTION_BASELINE'
+  AND finished_at IS NOT NULL
+  AND rolled_back_at IS NULL;
+COMMIT;
+SQL
+  report_query_stdin 'TARGET_MIGRATION_STATUS' <<SQL
+BEGIN READ ONLY;
+SELECT CASE
+  WHEN count(*) = 0 THEN 'NOT_APPLIED'
+  WHEN count(*) = 1 AND bool_and(finished_at IS NOT NULL AND rolled_back_at IS NULL) THEN 'APPLIED'
+  ELSE 'AMBIGUOUS'
+END
+FROM "_prisma_migrations"
+WHERE migration_name = '$TARGET_MIGRATION';
+COMMIT;
+SQL
+  if receipt_columns="$(readonly_query_stdin <<'SQL'
+BEGIN READ ONLY;
+SELECT CASE WHEN count(*) = 6 THEN 'YES' ELSE 'NO' END
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'Payment'
+  AND column_name IN ('receiptSnapshot', 'receiptSnapshotVersion', 'receiptSnapshotHash', 'receiptSnapshotCreatedAt', 'receiptGenerationToken', 'receiptGenerationLeaseUntil');
+COMMIT;
+SQL
+  2>/dev/null)"; then
     printf 'RECEIPT_SNAPSHOT_COLUMNS=%s\n' "$receipt_columns"
     if [[ "$receipt_columns" == 'YES' ]]; then
-      report_query 'RECEIPT_GENERATION_TOKEN_COUNT' 'SELECT count(*) FROM "Payment" WHERE "receiptGenerationToken" IS NOT NULL'
-      report_query 'ACTIVE_RECEIPT_GENERATION_LEASE_COUNT' 'SELECT count(*) FROM "Payment" WHERE "receiptGenerationLeaseUntil" > CURRENT_TIMESTAMP'
+      report_query_stdin 'RECEIPT_GENERATION_TOKEN_COUNT' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*) FROM "Payment" WHERE "receiptGenerationToken" IS NOT NULL;
+COMMIT;
+SQL
+      report_query_stdin 'ACTIVE_RECEIPT_GENERATION_LEASE_COUNT' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*) FROM "Payment" WHERE "receiptGenerationLeaseUntil" > CURRENT_TIMESTAMP;
+COMMIT;
+SQL
     else
       printf 'RECEIPT_GENERATION_TOKEN_COUNT=NOT_APPLICABLE\n'
       printf 'ACTIVE_RECEIPT_GENERATION_LEASE_COUNT=NOT_APPLICABLE\n'
@@ -265,29 +301,211 @@ report_migrations_and_schema() {
 }
 
 report_finance_counts() {
-  report_query 'PAYMENTS_COUNT' 'SELECT count(*) FROM "Payment"'
-  report_query 'PAYMENT_ALLOCATIONS_COUNT' 'SELECT count(*) FROM "PaymentAllocation"'
-  report_query 'EXPENSES_COUNT' 'SELECT count(*) FROM "Expense"'
-  report_query 'INCOMES_COUNT' 'SELECT count(*) FROM "Income"'
-  report_query 'CHARGES_COUNT' 'SELECT count(*) FROM "Charge"'
-  report_query 'RECEIPT_STATUS_COUNTS' 'SELECT ''READY='' || count(*) FILTER (WHERE "receiptStatus" = ''READY'') || '',PENDING='' || count(*) FILTER (WHERE "receiptStatus" = ''PENDING'') || '',FAILED='' || count(*) FILTER (WHERE "receiptStatus" = ''FAILED'') FROM "Payment"'
-  report_query 'PAYMENT_AUDIT_TOTAL' 'SELECT count(*) FROM "PaymentAuditLog"'
-  report_query 'PAYMENT_AUDIT_ACTION_COUNTS' 'SELECT ''SUBMITTED='' || count(*) FILTER (WHERE action = ''SUBMITTED'') || '',APPROVED='' || count(*) FILTER (WHERE action = ''APPROVED'') || '',RECONCILED='' || count(*) FILTER (WHERE action = ''RECONCILED'') || '',RECEIPT_GENERATED='' || count(*) FILTER (WHERE action = ''RECEIPT_GENERATED'') FROM "PaymentAuditLog"'
+  report_query_stdin 'PAYMENTS_COUNT' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*) FROM "Payment";
+COMMIT;
+SQL
+  report_query_stdin 'PAYMENT_ALLOCATIONS_COUNT' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*) FROM "PaymentAllocation";
+COMMIT;
+SQL
+  report_query_stdin 'EXPENSES_COUNT' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*) FROM "Expense";
+COMMIT;
+SQL
+  report_query_stdin 'INCOMES_COUNT' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*) FROM "Income";
+COMMIT;
+SQL
+  report_query_stdin 'CHARGES_COUNT' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*) FROM "Charge";
+COMMIT;
+SQL
+  report_query_stdin 'RECEIPT_STATUS_COUNTS' <<'SQL'
+BEGIN READ ONLY;
+SELECT 'READY=' || count(*) FILTER (WHERE "receiptStatus" = 'READY')
+  || ',PENDING=' || count(*) FILTER (WHERE "receiptStatus" = 'PENDING')
+  || ',FAILED=' || count(*) FILTER (WHERE "receiptStatus" = 'FAILED')
+FROM "Payment";
+COMMIT;
+SQL
+  report_query_stdin 'PAYMENT_AUDIT_TOTAL' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*) FROM "PaymentAuditLog";
+COMMIT;
+SQL
+  report_query_stdin 'PAYMENT_AUDIT_ACTION_COUNTS' <<'SQL'
+BEGIN READ ONLY;
+SELECT 'SUBMITTED=' || count(*) FILTER (WHERE action = 'SUBMITTED')
+  || ',APPROVED=' || count(*) FILTER (WHERE action = 'APPROVED')
+  || ',RECONCILED=' || count(*) FILTER (WHERE action = 'RECONCILED')
+  || ',RECEIPT_GENERATED=' || count(*) FILTER (WHERE action = 'RECEIPT_GENERATED')
+FROM "PaymentAuditLog";
+COMMIT;
+SQL
 }
 
 report_finance_integrity() {
-  report_query 'ORPHAN_ALLOCATIONS' 'SELECT count(*) FROM "PaymentAllocation" a LEFT JOIN "Payment" p ON p.id = a."paymentId" LEFT JOIN "Charge" c ON c.id = a."chargeId" WHERE p.id IS NULL OR c.id IS NULL OR a."tenantId" <> p."tenantId" OR a."tenantId" <> c."tenantId"'
-  report_query 'OVER_ALLOCATIONS' 'SELECT count(*) FROM (SELECT a."paymentId" FROM "PaymentAllocation" a JOIN "Payment" p ON p.id = a."paymentId" GROUP BY a."paymentId", p.amount HAVING COALESCE(sum(a.amount), 0) > p.amount) over_allocated'
-  report_query 'DUPLICATE_CANONICAL_CHARGE_KEYS' 'SELECT count(*) FROM (SELECT "tenantId", "buildingId", "unitId", period, concept FROM "Charge" GROUP BY "tenantId", "buildingId", "unitId", period, concept HAVING count(*) > 1) duplicate_keys'
-  report_query 'CURRENCY_MISMATCHES' 'SELECT count(*) FROM "PaymentAllocation" a JOIN "Payment" p ON p.id = a."paymentId" JOIN "Charge" c ON c.id = a."chargeId" WHERE p.currency <> c.currency OR a."tenantId" <> p."tenantId" OR a."tenantId" <> c."tenantId"'
-  report_query 'DUPLICATE_RECEIPT_FILE_GRAPHS' 'SELECT count(*) FROM (SELECT d."fileId" FROM "Payment" p JOIN "Document" d ON d.id = p."receiptDocumentId" JOIN "File" f ON f.id = d."fileId" WHERE p."receiptDocumentId" IS NOT NULL GROUP BY d."fileId" HAVING count(*) > 1) duplicate_files'
-  report_query 'DUPLICATE_RECEIPT_DOCUMENT_GRAPHS' 'SELECT count(*) FROM (SELECT p."receiptDocumentId" FROM "Payment" p WHERE p."receiptDocumentId" IS NOT NULL GROUP BY p."receiptDocumentId" HAVING count(*) > 1) duplicate_documents'
-  report_query 'DUPLICATE_RECEIPT_GENERATED_AUDITS' 'SELECT count(*) FROM (SELECT "tenantId", "paymentId" FROM "PaymentAuditLog" WHERE action = ''RECEIPT_GENERATED'' GROUP BY "tenantId", "paymentId" HAVING count(*) > 1) duplicate_audits'
+  report_query_stdin 'ORPHAN_ALLOCATIONS' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*)
+FROM "PaymentAllocation" a
+LEFT JOIN "Payment" p ON p.id = a."paymentId"
+LEFT JOIN "Charge" c ON c.id = a."chargeId"
+WHERE p.id IS NULL
+   OR c.id IS NULL
+   OR a."tenantId" <> p."tenantId"
+   OR a."tenantId" <> c."tenantId";
+COMMIT;
+SQL
+  if value="$(readonly_query_stdin <<'SQL'
+BEGIN READ ONLY;
+WITH per_payment AS (
+  SELECT p.id,
+         p.amount,
+         bool_or(a."paymentOriginalAmountMinor" IS NULL AND c.currency <> p.currency) AS legacy_cross_unverifiable,
+         COALESCE(sum(
+           CASE
+             WHEN a."paymentOriginalAmountMinor" IS NOT NULL THEN a."paymentOriginalAmountMinor"
+             WHEN c.currency = p.currency THEN a.amount
+             ELSE 0
+           END
+         ), 0) AS original_consumed
+  FROM "Payment" p
+  JOIN "PaymentAllocation" a ON a."paymentId" = p.id
+  JOIN "Charge" c ON c.id = a."chargeId"
+  GROUP BY p.id, p.amount
+)
+SELECT count(*) FILTER (WHERE NOT legacy_cross_unverifiable AND original_consumed > amount)
+       || '|' || count(*) FILTER (WHERE legacy_cross_unverifiable)
+FROM per_payment;
+COMMIT;
+SQL
+  2>/dev/null)"; then
+    local definite_overallocations unverifiable_overallocations
+    IFS='|' read -r definite_overallocations unverifiable_overallocations <<< "$value"
+    if [[ "$definite_overallocations" =~ ^[0-9]+$ && "$unverifiable_overallocations" =~ ^[0-9]+$ ]]; then
+      printf 'OVER_ALLOCATIONS_DEFINITE=%s\n' "$definite_overallocations"
+      printf 'OVER_ALLOCATIONS_UNVERIFIABLE=%s\n' "$unverifiable_overallocations"
+    else
+      AUDIT_QUERY_FAILURES=$((AUDIT_QUERY_FAILURES + 1))
+      printf 'OVER_ALLOCATIONS_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_UNVERIFIABLE=UNKNOWN\n'
+    fi
+  else
+    AUDIT_QUERY_FAILURES=$((AUDIT_QUERY_FAILURES + 1))
+    printf 'OVER_ALLOCATIONS_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_UNVERIFIABLE=UNKNOWN\n'
+  fi
+  report_query_stdin 'DUPLICATE_CANONICAL_CHARGE_KEYS' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*)
+FROM (
+  SELECT "tenantId", "buildingId", "unitId", period, concept
+  FROM "Charge"
+  GROUP BY "tenantId", "buildingId", "unitId", period, concept
+  HAVING count(*) > 1
+) duplicate_keys;
+COMMIT;
+SQL
+  report_query_stdin 'CURRENCY_MISMATCHES_DEFINITE' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(DISTINCT p.id)
+FROM "PaymentAllocation" a
+JOIN "Payment" p ON p.id = a."paymentId"
+JOIN "Charge" c ON c.id = a."chargeId"
+WHERE p.currency <> c.currency
+  AND (
+    p."functionalCurrencyCode" IS NOT NULL
+    OR p."functionalAmountMinor" IS NOT NULL
+    OR p."exchangeRateId" IS NOT NULL
+    OR p."exchangeRateValue" IS NOT NULL
+    OR p."exchangeRateDirection" IS NOT NULL
+    OR p."exchangeRateEffectiveAt" IS NOT NULL
+    OR p."conversionDate" IS NOT NULL
+  )
+  AND (
+    p."functionalCurrencyCode" IS NULL
+    OR p."functionalCurrencyCode" <> c.currency
+    OR p."functionalAmountMinor" IS NULL
+    OR p."exchangeRateValue" IS NULL
+    OR p."exchangeRateDirection" IS NULL
+    OR p."exchangeRateDirection" NOT IN ('IDENTITY', 'DIRECT', 'INVERSE')
+    OR p."conversionDate" IS NULL
+    OR (p."exchangeRateDirection" = 'IDENTITY' AND (p."exchangeRateValue" <> 1 OR p."exchangeRateId" IS NOT NULL OR p."exchangeRateEffectiveAt" IS NOT NULL))
+    OR (p."exchangeRateDirection" IN ('DIRECT', 'INVERSE') AND (p."exchangeRateValue" <= 0 OR p."exchangeRateId" IS NULL OR p."exchangeRateEffectiveAt" IS NULL))
+  );
+COMMIT;
+SQL
+  report_query_stdin 'CURRENCY_MISMATCHES_UNVERIFIABLE' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(DISTINCT p.id)
+FROM "PaymentAllocation" a
+JOIN "Payment" p ON p.id = a."paymentId"
+JOIN "Charge" c ON c.id = a."chargeId"
+WHERE p.currency <> c.currency
+  AND p."functionalCurrencyCode" IS NULL
+  AND p."functionalAmountMinor" IS NULL
+  AND p."exchangeRateId" IS NULL
+  AND p."exchangeRateValue" IS NULL
+  AND p."exchangeRateDirection" IS NULL
+  AND p."exchangeRateEffectiveAt" IS NULL
+  AND p."conversionDate" IS NULL;
+COMMIT;
+SQL
+  report_query_stdin 'DUPLICATE_RECEIPT_FILE_GRAPHS' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*)
+FROM (
+  SELECT d."fileId"
+  FROM "Payment" p
+  JOIN "Document" d ON d.id = p."receiptDocumentId"
+  JOIN "File" f ON f.id = d."fileId"
+  WHERE p."receiptDocumentId" IS NOT NULL
+  GROUP BY d."fileId"
+  HAVING count(*) > 1
+) duplicate_files;
+COMMIT;
+SQL
+  report_query_stdin 'DUPLICATE_RECEIPT_DOCUMENT_GRAPHS' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*)
+FROM (
+  SELECT p."receiptDocumentId"
+  FROM "Payment" p
+  WHERE p."receiptDocumentId" IS NOT NULL
+  GROUP BY p."receiptDocumentId"
+  HAVING count(*) > 1
+) duplicate_documents;
+COMMIT;
+SQL
+  report_query_stdin 'DUPLICATE_RECEIPT_GENERATED_AUDITS' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*)
+FROM (
+  SELECT "tenantId", "paymentId"
+  FROM "PaymentAuditLog"
+  WHERE action = 'RECEIPT_GENERATED'
+  GROUP BY "tenantId", "paymentId"
+  HAVING count(*) > 1
+) duplicate_audits;
+COMMIT;
+SQL
 }
 
 report_tenant_classification() {
   local classification
-  if classification="$(readonly_query 'SELECT count(*) FILTER (WHERE "isDemo" = true) || ''|'' || count(*) FILTER (WHERE "isDemo" = false) FROM "Tenant"' 2>/dev/null)"; then
+  if classification="$(readonly_query_stdin <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*) FILTER (WHERE "isDemo" = true)
+       || '|' || count(*) FILTER (WHERE "isDemo" = false)
+FROM "Tenant";
+COMMIT;
+SQL
+  2>/dev/null)"; then
     printf 'TENANT_DEMO_TEST=%s\n' "${classification%%|*}"
     printf 'TENANT_UNKNOWN=%s\n' "${classification#*|}"
   else
@@ -299,9 +517,22 @@ report_tenant_classification() {
 }
 
 report_storage_database_buckets() {
-  report_query 'FILE_BUCKET_COUNTS' 'SELECT COALESCE(string_agg(bucket || '':'' || row_count::text, '','' ORDER BY bucket), ''NONE'') FROM (SELECT bucket, count(*) AS row_count FROM "File" GROUP BY bucket) bucket_counts'
-  report_query 'FILE_EXPECTED_BUCKET_COUNT' "SELECT count(*) FROM \"File\" WHERE bucket = '$EXPECTED_BUCKET'"
-  report_query 'FILE_OTHER_BUCKET_COUNT' "SELECT count(*) FROM \"File\" WHERE bucket <> '$EXPECTED_BUCKET'"
+  report_query_stdin 'FILE_BUCKET_COUNTS' <<'SQL'
+BEGIN READ ONLY;
+SELECT COALESCE(string_agg(bucket || ':' || row_count::text, ',' ORDER BY bucket), 'NONE')
+FROM (SELECT bucket, count(*) AS row_count FROM "File" GROUP BY bucket) bucket_counts;
+COMMIT;
+SQL
+  report_query_stdin 'FILE_EXPECTED_BUCKET_COUNT' <<SQL
+BEGIN READ ONLY;
+SELECT count(*) FROM "File" WHERE bucket = '$EXPECTED_BUCKET';
+COMMIT;
+SQL
+  report_query_stdin 'FILE_OTHER_BUCKET_COUNT' <<SQL
+BEGIN READ ONLY;
+SELECT count(*) FROM "File" WHERE bucket <> '$EXPECTED_BUCKET';
+COMMIT;
+SQL
   printf 'EXPECTED_AUTHORITATIVE_BUCKET=%s\n' "$EXPECTED_BUCKET"
 }
 
@@ -333,20 +564,37 @@ s3_probe() {
 report_s3_posture() {
   local client_available
   local versioning object_count
+  local versioning_ok=false
+  local object_count_ok=false
 
   if client_available="$(docker exec "$API_CONTAINER" sh -lc 'command -v aws >/dev/null 2>&1 && printf available' 2>/dev/null)" && [[ "$client_available" == 'available' ]]; then
     if s3_probe head >/dev/null 2>&1; then
       printf 'S3_BUCKET_REACHABLE=YES\n'
-      versioning="$(s3_probe versioning 2>/dev/null || printf 'UNKNOWN')"
-      object_count="$(s3_probe objects 2>/dev/null || printf 'UNKNOWN')"
+      if versioning="$(s3_probe versioning 2>/dev/null)"; then
+        versioning_ok=true
+      else
+        versioning='UNKNOWN'
+      fi
+      if object_count="$(s3_probe objects 2>/dev/null)"; then
+        object_count_ok=true
+      else
+        object_count='UNKNOWN'
+      fi
       printf 'S3_VERSIONING_STATUS=%s\n' "$(safe_value_or_unknown "$versioning")"
       printf 'S3_BUSINESS_OBJECT_COUNT=%s\n' "$(safe_value_or_unknown "$object_count")"
-      printf 'S3_DEEP_AUDIT=PASS\n'
+      if [[ "$versioning_ok" == true && "$object_count_ok" == true ]]; then
+        printf 'S3_DEEP_AUDIT=PASS\n'
+      else
+        AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
+        printf 'S3_DEEP_AUDIT=INCOMPLETE\n'
+      fi
     else
+      AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
       printf 'S3_BUCKET_REACHABLE=FAIL\nS3_VERSIONING_STATUS=UNKNOWN\nS3_BUSINESS_OBJECT_COUNT=UNKNOWN\nS3_DEEP_AUDIT=FAIL\n'
     fi
   else
-    printf 'S3_DEEP_AUDIT_UNAVAILABLE\n'
+    AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
+    printf 'S3_DEEP_AUDIT_UNAVAILABLE\nS3_DEEP_AUDIT=INCOMPLETE\n'
   fi
 }
 
@@ -453,30 +701,56 @@ report_minio_posture() {
   printf 'MINIO_AUTHORITATIVE=%s\n' "$authoritative"
 }
 
-printf 'PRODUCTION_READONLY_AUDIT\n'
-report_runtime_identity
-report_container_health API "$API_CONTAINER"
-report_container_health WEB "$WEB_CONTAINER"
-report_container_health POSTGRES "$POSTGRES_CONTAINER"
-report_container_health REDIS "$REDIS_CONTAINER"
-report_container_health TRAEFIK "$TRAEFIK_CONTAINER"
-public_get_status PUBLIC_API_HEALTH "$API_HEALTH_URL"
-public_readyz_status
-public_get_status PUBLIC_WEB_LOGIN "$WEB_LOGIN_URL"
-report_safe_runtime_config
-report_migrations_and_schema
-report_finance_counts
-report_finance_integrity
-report_tenant_classification
-report_storage_database_buckets
-report_s3_posture
-report_minio_posture
-report_backup_readiness
+main() {
+  local url
 
-if (( AUDIT_QUERY_FAILURES == 0 )); then
-  printf 'AUDIT_STATUS=COMPLETE\n'
-else
-  printf 'AUDIT_STATUS=INCOMPLETE\n'
-  printf 'AUDIT_QUERY_FAILURES=%s\n' "$AUDIT_QUERY_FAILURES"
-  exit 1
+  [[ $# -eq 4 ]] || { usage; return 64; }
+  readonly CANDIDATE_SHA="$1"
+  readonly API_HEALTH_URL="$2"
+  readonly API_READYZ_URL="$3"
+  readonly WEB_LOGIN_URL="$4"
+
+  [[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]] || fail 'candidate SHA is not exactly 40 lowercase hexadecimal characters'
+  for url in "$API_HEALTH_URL" "$API_READYZ_URL" "$WEB_LOGIN_URL"; do
+    [[ "$url" =~ ^https://[A-Za-z0-9._:/?=%+-]+$ ]] || fail 'public audit URL is not an HTTPS URL'
+  done
+
+  for command_name in bash curl date docker find git sha256sum stat; do
+    command -v "$command_name" >/dev/null 2>&1 || fail "$command_name is required"
+  done
+
+  AUDIT_QUERY_FAILURES=0
+  AUDIT_EVIDENCE_FAILURES=0
+  printf 'PRODUCTION_READONLY_AUDIT\n'
+  report_runtime_identity
+  report_container_health API "$API_CONTAINER"
+  report_container_health WEB "$WEB_CONTAINER"
+  report_container_health POSTGRES "$POSTGRES_CONTAINER"
+  report_container_health REDIS "$REDIS_CONTAINER"
+  report_container_health TRAEFIK "$TRAEFIK_CONTAINER"
+  public_get_status PUBLIC_API_HEALTH "$API_HEALTH_URL"
+  public_readyz_status
+  public_get_status PUBLIC_WEB_LOGIN "$WEB_LOGIN_URL"
+  report_safe_runtime_config
+  report_migrations_and_schema
+  report_finance_counts
+  report_finance_integrity
+  report_tenant_classification
+  report_storage_database_buckets
+  report_s3_posture
+  report_minio_posture
+  report_backup_readiness
+
+  if (( AUDIT_QUERY_FAILURES == 0 && AUDIT_EVIDENCE_FAILURES == 0 )); then
+    printf 'AUDIT_STATUS=COMPLETE\n'
+  else
+    printf 'AUDIT_STATUS=INCOMPLETE\n'
+    printf 'AUDIT_QUERY_FAILURES=%s\n' "$AUDIT_QUERY_FAILURES"
+    printf 'AUDIT_EVIDENCE_FAILURES=%s\n' "$AUDIT_EVIDENCE_FAILURES"
+    return 1
+  fi
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
 fi

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -35,6 +35,7 @@ fail() {
 
 AUDIT_QUERY_FAILURES=0
 AUDIT_EVIDENCE_FAILURES=0
+RUNTIME_APP_SHA='UNKNOWN'
 
 container_exists() {
   docker inspect --type container "$1" >/dev/null 2>&1
@@ -251,8 +252,10 @@ report_runtime_identity() {
   printf 'API_REVISION=%s\n' "$api_revision"
   printf 'WEB_REVISION=%s\n' "$web_revision"
   if [[ "$checkout_status" == 'CLEAN' && "$production_sha" =~ ^[0-9a-f]{40}$ && "$production_sha" == "$api_revision" && "$api_revision" == "$web_revision" ]]; then
+    RUNTIME_APP_SHA="$production_sha"
     printf 'RUNTIME_IDENTITY=CONSISTENT\n'
   else
+    RUNTIME_APP_SHA='UNKNOWN'
     printf 'RUNTIME_IDENTITY=UNKNOWN\n'
     AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
   fi
@@ -440,11 +443,14 @@ WITH per_payment AS (
          bool_or(a."paymentOriginalAmountMinor" IS NULL AND c.currency <> p.currency) AS legacy_cross_unverifiable,
          bool_or(c.currency <> p.currency) AS has_cross_currency,
          bool_or(c.currency = p.currency) AS has_same_currency,
+         bool_or(c.currency = p.currency
+                 AND a."paymentOriginalAmountMinor" IS NOT NULL
+                 AND a."paymentOriginalAmountMinor" <> a.amount) AS inconsistent_same_currency_share,
          bool_or(c.currency <> p."functionalCurrencyCode") AS functional_currency_unverifiable,
          COALESCE(sum(
            CASE
-             WHEN a."paymentOriginalAmountMinor" IS NOT NULL THEN a."paymentOriginalAmountMinor"
              WHEN c.currency = p.currency THEN a.amount
+             WHEN a."paymentOriginalAmountMinor" IS NOT NULL THEN a."paymentOriginalAmountMinor"
              ELSE 0
             END
           ), 0) AS original_consumed,
@@ -456,6 +462,7 @@ WITH per_payment AS (
 )
 SELECT count(*) FILTER (WHERE NOT legacy_cross_unverifiable AND original_consumed > amount)
        || '|' || count(*) FILTER (WHERE legacy_cross_unverifiable)
+       || '|' || count(*) FILTER (WHERE inconsistent_same_currency_share)
        || '|' || count(*) FILTER (WHERE has_cross_currency
                                       AND NOT functional_currency_unverifiable
                                       AND "functionalAmountMinor" IS NOT NULL
@@ -467,20 +474,21 @@ FROM per_payment;
 COMMIT;
 SQL
   2>/dev/null)"; then
-    local definite_overallocations unverifiable_overallocations functional_definite_overallocations functional_unverifiable_overallocations
-    IFS='|' read -r definite_overallocations unverifiable_overallocations functional_definite_overallocations functional_unverifiable_overallocations <<< "$value"
-    if [[ "$definite_overallocations" =~ ^[0-9]+$ && "$unverifiable_overallocations" =~ ^[0-9]+$ && "$functional_definite_overallocations" =~ ^[0-9]+$ && "$functional_unverifiable_overallocations" =~ ^[0-9]+$ ]]; then
+    local definite_overallocations unverifiable_overallocations inconsistent_same_currency_shares functional_definite_overallocations functional_unverifiable_overallocations
+    IFS='|' read -r definite_overallocations unverifiable_overallocations inconsistent_same_currency_shares functional_definite_overallocations functional_unverifiable_overallocations <<< "$value"
+    if [[ "$definite_overallocations" =~ ^[0-9]+$ && "$unverifiable_overallocations" =~ ^[0-9]+$ && "$inconsistent_same_currency_shares" =~ ^[0-9]+$ && "$functional_definite_overallocations" =~ ^[0-9]+$ && "$functional_unverifiable_overallocations" =~ ^[0-9]+$ ]]; then
       printf 'OVER_ALLOCATIONS_DEFINITE=%s\n' "$definite_overallocations"
       printf 'OVER_ALLOCATIONS_UNVERIFIABLE=%s\n' "$unverifiable_overallocations"
+      printf 'INCONSISTENT_SAME_CURRENCY_SHARES=%s\n' "$inconsistent_same_currency_shares"
       printf 'OVER_ALLOCATIONS_FUNCTIONAL_DEFINITE=%s\n' "$functional_definite_overallocations"
       printf 'OVER_ALLOCATIONS_FUNCTIONAL_UNVERIFIABLE=%s\n' "$functional_unverifiable_overallocations"
     else
       AUDIT_QUERY_FAILURES=$((AUDIT_QUERY_FAILURES + 1))
-      printf 'OVER_ALLOCATIONS_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_UNVERIFIABLE=UNKNOWN\nOVER_ALLOCATIONS_FUNCTIONAL_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_FUNCTIONAL_UNVERIFIABLE=UNKNOWN\n'
+      printf 'OVER_ALLOCATIONS_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_UNVERIFIABLE=UNKNOWN\nINCONSISTENT_SAME_CURRENCY_SHARES=UNKNOWN\nOVER_ALLOCATIONS_FUNCTIONAL_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_FUNCTIONAL_UNVERIFIABLE=UNKNOWN\n'
     fi
   else
     AUDIT_QUERY_FAILURES=$((AUDIT_QUERY_FAILURES + 1))
-    printf 'OVER_ALLOCATIONS_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_UNVERIFIABLE=UNKNOWN\nOVER_ALLOCATIONS_FUNCTIONAL_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_FUNCTIONAL_UNVERIFIABLE=UNKNOWN\n'
+    printf 'OVER_ALLOCATIONS_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_UNVERIFIABLE=UNKNOWN\nINCONSISTENT_SAME_CURRENCY_SHARES=UNKNOWN\nOVER_ALLOCATIONS_FUNCTIONAL_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_FUNCTIONAL_UNVERIFIABLE=UNKNOWN\n'
   fi
   report_query_stdin 'CHARGE_OVER_ALLOCATIONS' <<'SQL'
 BEGIN READ ONLY;
@@ -889,11 +897,12 @@ report_backup_readiness() {
       (( age >= 0 && age <= MAX_BACKUP_AGE_SECONDS )); then
       paired_receipt="$BACKUP_STATE_DIR/paired-$backup_set_id.json"
       if [[ -f "$paired_receipt" && ! -L "$paired_receipt" && -r "$paired_receipt" ]] &&
-        jq -e --arg backupSetId "$backup_set_id" --arg appSha "$app_sha" --arg completedAt "$completed_at" '
+        jq -e --arg backupSetId "$backup_set_id" --arg appSha "$app_sha" --arg completedAt "$completed_at" --arg runtimeAppSha "$RUNTIME_APP_SHA" '
           .version == 1 and
           .status == "PASS" and
           .backup_set_id == $backupSetId and
           .app_sha == $appSha and
+          .app_sha == $runtimeAppSha and
           .completed_at == $completedAt and
           .minio_verified == true and
           (.postgres_receipt.version == 1) and

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -424,6 +424,7 @@ WITH per_payment AS (
          p."functionalCurrencyCode",
          bool_or(a."paymentOriginalAmountMinor" IS NULL AND c.currency <> p.currency) AS legacy_cross_unverifiable,
          bool_or(c.currency <> p.currency) AS has_cross_currency,
+         bool_or(c.currency = p.currency) AS has_same_currency,
          bool_or(c.currency <> p."functionalCurrencyCode") AS functional_currency_unverifiable,
          COALESCE(sum(
            CASE
@@ -466,6 +467,18 @@ SQL
     AUDIT_QUERY_FAILURES=$((AUDIT_QUERY_FAILURES + 1))
     printf 'OVER_ALLOCATIONS_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_UNVERIFIABLE=UNKNOWN\nOVER_ALLOCATIONS_FUNCTIONAL_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_FUNCTIONAL_UNVERIFIABLE=UNKNOWN\n'
   fi
+  report_query_stdin 'CHARGE_OVER_ALLOCATIONS' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*)
+FROM (
+  SELECT c.id
+  FROM "Charge" c
+  JOIN "PaymentAllocation" a ON a."chargeId" = c.id
+  GROUP BY c.id, c.amount
+  HAVING sum(a.amount) > c.amount
+) charge_overallocations;
+COMMIT;
+SQL
   report_query_stdin 'DUPLICATE_CANONICAL_CHARGE_KEYS' <<'SQL'
 BEGIN READ ONLY;
 SELECT count(*)
@@ -480,47 +493,65 @@ COMMIT;
 SQL
   report_query_stdin 'CURRENCY_MISMATCHES_DEFINITE' <<'SQL'
 BEGIN READ ONLY;
-SELECT count(DISTINCT p.id)
-FROM "PaymentAllocation" a
-JOIN "Payment" p ON p.id = a."paymentId"
-JOIN "Charge" c ON c.id = a."chargeId"
-WHERE p.currency <> c.currency
-  AND (
-    p."functionalCurrencyCode" IS NOT NULL
-    OR p."functionalAmountMinor" IS NOT NULL
-    OR p."exchangeRateId" IS NOT NULL
-    OR p."exchangeRateValue" IS NOT NULL
-    OR p."exchangeRateDirection" IS NOT NULL
-    OR p."exchangeRateEffectiveAt" IS NOT NULL
-    OR p."conversionDate" IS NOT NULL
-  )
-  AND (
-    p."functionalCurrencyCode" IS NULL
-    OR p."functionalCurrencyCode" <> c.currency
-    OR p."functionalAmountMinor" IS NULL
-    OR p."exchangeRateValue" IS NULL
-    OR p."exchangeRateDirection" IS NULL
-    OR p."exchangeRateDirection" NOT IN ('IDENTITY', 'DIRECT', 'INVERSE')
-    OR p."conversionDate" IS NULL
-    OR (p."exchangeRateDirection" = 'IDENTITY' AND (p."exchangeRateValue" <> 1 OR p."exchangeRateId" IS NOT NULL OR p."exchangeRateEffectiveAt" IS NOT NULL))
-    OR (p."exchangeRateDirection" IN ('DIRECT', 'INVERSE') AND (p."exchangeRateValue" <= 0 OR p."exchangeRateId" IS NULL OR p."exchangeRateEffectiveAt" IS NULL))
-  );
+WITH per_payment AS (
+  SELECT p.id,
+         bool_or(p.currency <> c.currency) AS has_cross_currency,
+         bool_or(p.currency = c.currency) AS has_same_currency,
+         bool_or(p.currency <> c.currency AND (
+           p."functionalCurrencyCode" IS NULL
+           OR p."functionalCurrencyCode" <> c.currency
+           OR p."functionalAmountMinor" IS NULL
+           OR p."exchangeRateValue" IS NULL
+           OR p."exchangeRateDirection" IS NULL
+           OR p."exchangeRateDirection" NOT IN ('IDENTITY', 'DIRECT', 'INVERSE')
+           OR p."conversionDate" IS NULL
+           OR (p."exchangeRateDirection" = 'IDENTITY' AND (p."exchangeRateValue" <> 1 OR p."exchangeRateId" IS NOT NULL OR p."exchangeRateEffectiveAt" IS NOT NULL))
+           OR (p."exchangeRateDirection" IN ('DIRECT', 'INVERSE') AND (p."exchangeRateValue" <= 0 OR p."exchangeRateId" IS NULL OR p."exchangeRateEffectiveAt" IS NULL))
+         )) AS has_invalid_cross_currency
+  FROM "PaymentAllocation" a
+  JOIN "Payment" p ON p.id = a."paymentId"
+  JOIN "Charge" c ON c.id = a."chargeId"
+  GROUP BY p.id
+)
+SELECT count(*)
+FROM per_payment
+WHERE has_cross_currency AND (has_same_currency OR has_invalid_cross_currency);
 COMMIT;
 SQL
   report_query_stdin 'CURRENCY_MISMATCHES_UNVERIFIABLE' <<'SQL'
 BEGIN READ ONLY;
-SELECT count(DISTINCT p.id)
-FROM "PaymentAllocation" a
-JOIN "Payment" p ON p.id = a."paymentId"
-JOIN "Charge" c ON c.id = a."chargeId"
-WHERE p.currency <> c.currency
-  AND p."functionalCurrencyCode" IS NULL
-  AND p."functionalAmountMinor" IS NULL
-  AND p."exchangeRateId" IS NULL
-  AND p."exchangeRateValue" IS NULL
-  AND p."exchangeRateDirection" IS NULL
-  AND p."exchangeRateEffectiveAt" IS NULL
-  AND p."conversionDate" IS NULL;
+WITH per_payment AS (
+  SELECT p.id,
+         bool_or(p.currency <> c.currency) AS has_cross_currency,
+         bool_or(p.currency = c.currency) AS has_same_currency,
+         bool_or(p.currency <> c.currency AND
+           p."functionalCurrencyCode" IS NULL
+           AND p."functionalAmountMinor" IS NULL
+           AND p."exchangeRateId" IS NULL
+           AND p."exchangeRateValue" IS NULL
+           AND p."exchangeRateDirection" IS NULL
+           AND p."exchangeRateEffectiveAt" IS NULL
+           AND p."conversionDate" IS NULL) AS has_unverifiable_cross_currency,
+         bool_or(p.currency <> c.currency AND (
+           p."functionalCurrencyCode" IS NOT NULL
+           OR p."functionalAmountMinor" IS NOT NULL
+           OR p."exchangeRateId" IS NOT NULL
+           OR p."exchangeRateValue" IS NOT NULL
+           OR p."exchangeRateDirection" IS NOT NULL
+           OR p."exchangeRateEffectiveAt" IS NOT NULL
+           OR p."conversionDate" IS NOT NULL
+         )) AS has_conversion_metadata
+  FROM "PaymentAllocation" a
+  JOIN "Payment" p ON p.id = a."paymentId"
+  JOIN "Charge" c ON c.id = a."chargeId"
+  GROUP BY p.id
+)
+SELECT count(*)
+FROM per_payment
+WHERE has_cross_currency
+  AND NOT has_same_currency
+  AND has_unverifiable_cross_currency
+  AND NOT has_conversion_metadata;
 COMMIT;
 SQL
   report_query_stdin 'DUPLICATE_RECEIPT_FILE_GRAPHS' <<'SQL'
@@ -665,10 +696,16 @@ NODE
 }
 
 report_s3_posture() {
-  local versioning object_count
+  local configured_bucket versioning object_count
   local versioning_ok=false
   local object_count_ok=false
 
+  configured_bucket="$(safe_env_value "$API_CONTAINER" S3_BUCKET 2>/dev/null || true)"
+  if [[ "$configured_bucket" != "$EXPECTED_BUCKET" ]]; then
+    AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
+    printf 'S3_BUCKET_REACHABLE=UNKNOWN\nS3_VERSIONING_STATUS=UNKNOWN\nS3_BUSINESS_OBJECT_COUNT=UNKNOWN\nS3_DEEP_AUDIT=INCOMPLETE\n'
+    return
+  fi
   if s3_client_available; then
     if s3_probe head >/dev/null 2>&1; then
       printf 'S3_BUCKET_REACHABLE=YES\n'
@@ -776,6 +813,9 @@ report_backup_readiness() {
         checksum_status='FAIL'
         AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
       fi
+    else
+      checksum_status='INCOMPLETE'
+      AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
     fi
     if validate_pg_restore_list "$latest_dump"; then
       restore_status='PASS'

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -12,6 +12,7 @@ readonly APP_DIR='/opt/pawtech/apps/buildingos/buildingos-app'
 readonly BACKUP_ROOT='/opt/pawtech/backups/tmp'
 readonly BACKUP_SCRIPT_PATH='/opt/pawtech/backups/scripts/backup-postgres.sh'
 readonly BACKUP_IDENTITY_MANIFEST_PATH='/opt/pawtech/apps/buildingos/infra/production/backup-postgres.identity.v1'
+readonly ALLOWED_IGNORED_RUNTIME_ENV='infra/docker/.env'
 readonly EXPECTED_BUCKET='buildingos-production'
 readonly KNOWN_PRODUCTION_BASELINE='20260816000004_legacy_income_application_provenance'
 readonly TARGET_MIGRATION='20260831000000_add_payment_receipt_issuance_snapshot'
@@ -40,6 +41,28 @@ container_state() {
 
 container_health() {
   docker inspect --type container --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}not_configured{{end}}' "$1" 2>/dev/null || printf 'UNKNOWN'
+}
+
+checkout_has_only_approved_ignored_files() {
+  local path pattern
+  local runtime_env_excluded=false
+
+  [[ -f "$APP_DIR/.dockerignore" ]] || return 1
+  while IFS= read -r pattern; do
+    [[ "$pattern" =~ ^[[:space:]]*! ]] && return 1
+    if [[ "$pattern" == '**/.env' || "$pattern" == 'infra/docker/.env' ]]; then
+      runtime_env_excluded=true
+    fi
+  done < "$APP_DIR/.dockerignore"
+  [[ "$runtime_env_excluded" == true ]] || return 1
+
+  while IFS= read -r path; do
+    case "$path" in
+      .env|.env.*|*/.env|*/.env.*|*.pem|*.key|*.p12|*.pfx|*.crt|*.log|*.dump|*.sql|*.bak|*.backup)
+        [[ "$path" == "$ALLOWED_IGNORED_RUNTIME_ENV" ]] || return 1
+        ;;
+    esac
+  done < <(git -C "$APP_DIR" ls-files --others --ignored --exclude-standard)
 }
 
 report_container_health() {
@@ -196,7 +219,7 @@ report_runtime_identity() {
   if [[ -d "$APP_DIR/.git" ]]; then
     production_sha="$(git -C "$APP_DIR" rev-parse HEAD 2>/dev/null || printf 'UNKNOWN')"
     if [[ "$production_sha" =~ ^[0-9a-f]{40}$ ]]; then
-      if [[ -z "$(git -C "$APP_DIR" status --porcelain --untracked-files=all 2>/dev/null)" ]]; then
+      if [[ -z "$(git -C "$APP_DIR" status --porcelain --untracked-files=all 2>/dev/null)" ]] && checkout_has_only_approved_ignored_files; then
         checkout_status='CLEAN'
       else
         checkout_status='DIRTY'
@@ -211,7 +234,7 @@ report_runtime_identity() {
   printf 'PRODUCTION_CHECKOUT_STATUS=%s\n' "$checkout_status"
   printf 'API_REVISION=%s\n' "$api_revision"
   printf 'WEB_REVISION=%s\n' "$web_revision"
-  if [[ "$checkout_status" == 'CLEAN' && "$api_revision" =~ ^[0-9a-f]{40}$ && "$api_revision" == "$web_revision" ]]; then
+  if [[ "$checkout_status" == 'CLEAN' && "$production_sha" =~ ^[0-9a-f]{40}$ && "$production_sha" == "$api_revision" && "$api_revision" == "$web_revision" ]]; then
     printf 'RUNTIME_IDENTITY=CONSISTENT\n'
   else
     printf 'RUNTIME_IDENTITY=UNKNOWN\n'
@@ -384,37 +407,51 @@ BEGIN READ ONLY;
 WITH per_payment AS (
   SELECT p.id,
          p.amount,
+         p."functionalAmountMinor",
+         p."functionalCurrencyCode",
          bool_or(a."paymentOriginalAmountMinor" IS NULL AND c.currency <> p.currency) AS legacy_cross_unverifiable,
+         bool_or(c.currency <> p.currency) AS has_cross_currency,
+         bool_or(c.currency <> p."functionalCurrencyCode") AS functional_currency_unverifiable,
          COALESCE(sum(
            CASE
              WHEN a."paymentOriginalAmountMinor" IS NOT NULL THEN a."paymentOriginalAmountMinor"
              WHEN c.currency = p.currency THEN a.amount
              ELSE 0
-           END
-         ), 0) AS original_consumed
+            END
+          ), 0) AS original_consumed,
+         COALESCE(sum(a.amount) FILTER (WHERE c.currency = p."functionalCurrencyCode"), 0) AS functional_consumed
   FROM "Payment" p
   JOIN "PaymentAllocation" a ON a."paymentId" = p.id
   JOIN "Charge" c ON c.id = a."chargeId"
-  GROUP BY p.id, p.amount
+  GROUP BY p.id, p.amount, p."functionalAmountMinor", p."functionalCurrencyCode"
 )
 SELECT count(*) FILTER (WHERE NOT legacy_cross_unverifiable AND original_consumed > amount)
        || '|' || count(*) FILTER (WHERE legacy_cross_unverifiable)
+       || '|' || count(*) FILTER (WHERE has_cross_currency
+                                      AND NOT functional_currency_unverifiable
+                                      AND "functionalAmountMinor" IS NOT NULL
+                                      AND functional_consumed > "functionalAmountMinor")
+       || '|' || count(*) FILTER (WHERE has_cross_currency
+                                      AND (functional_currency_unverifiable OR "functionalAmountMinor" IS NULL
+                                           OR "functionalCurrencyCode" IS NULL))
 FROM per_payment;
 COMMIT;
 SQL
   2>/dev/null)"; then
-    local definite_overallocations unverifiable_overallocations
-    IFS='|' read -r definite_overallocations unverifiable_overallocations <<< "$value"
-    if [[ "$definite_overallocations" =~ ^[0-9]+$ && "$unverifiable_overallocations" =~ ^[0-9]+$ ]]; then
+    local definite_overallocations unverifiable_overallocations functional_definite_overallocations functional_unverifiable_overallocations
+    IFS='|' read -r definite_overallocations unverifiable_overallocations functional_definite_overallocations functional_unverifiable_overallocations <<< "$value"
+    if [[ "$definite_overallocations" =~ ^[0-9]+$ && "$unverifiable_overallocations" =~ ^[0-9]+$ && "$functional_definite_overallocations" =~ ^[0-9]+$ && "$functional_unverifiable_overallocations" =~ ^[0-9]+$ ]]; then
       printf 'OVER_ALLOCATIONS_DEFINITE=%s\n' "$definite_overallocations"
       printf 'OVER_ALLOCATIONS_UNVERIFIABLE=%s\n' "$unverifiable_overallocations"
+      printf 'OVER_ALLOCATIONS_FUNCTIONAL_DEFINITE=%s\n' "$functional_definite_overallocations"
+      printf 'OVER_ALLOCATIONS_FUNCTIONAL_UNVERIFIABLE=%s\n' "$functional_unverifiable_overallocations"
     else
       AUDIT_QUERY_FAILURES=$((AUDIT_QUERY_FAILURES + 1))
-      printf 'OVER_ALLOCATIONS_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_UNVERIFIABLE=UNKNOWN\n'
+      printf 'OVER_ALLOCATIONS_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_UNVERIFIABLE=UNKNOWN\nOVER_ALLOCATIONS_FUNCTIONAL_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_FUNCTIONAL_UNVERIFIABLE=UNKNOWN\n'
     fi
   else
     AUDIT_QUERY_FAILURES=$((AUDIT_QUERY_FAILURES + 1))
-    printf 'OVER_ALLOCATIONS_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_UNVERIFIABLE=UNKNOWN\n'
+    printf 'OVER_ALLOCATIONS_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_UNVERIFIABLE=UNKNOWN\nOVER_ALLOCATIONS_FUNCTIONAL_DEFINITE=UNKNOWN\nOVER_ALLOCATIONS_FUNCTIONAL_UNVERIFIABLE=UNKNOWN\n'
   fi
   report_query_stdin 'DUPLICATE_CANONICAL_CHARGE_KEYS' <<'SQL'
 BEGIN READ ONLY;

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -837,6 +837,7 @@ report_backup_readiness() {
     printf 'LATEST_BUILDINGOS_DB_BACKUP_FILE=%s\n' "${latest_dump##*/}"
     printf 'BACKUP_AGE_SECONDS=%s\n' "$age"
   else
+    AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
     printf 'LATEST_BUILDINGOS_DB_BACKUP_TIMESTAMP=UNKNOWN\n'
     printf 'LATEST_BUILDINGOS_DB_BACKUP_FILE=UNKNOWN\n'
     printf 'BACKUP_AGE_SECONDS=UNKNOWN\n'

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -44,7 +44,7 @@ container_health() {
 }
 
 checkout_has_only_approved_ignored_files() {
-  local path pattern
+  local path pattern status_output ignored_paths
   local runtime_env_excluded=false
 
   [[ -f "$APP_DIR/.dockerignore" ]] || return 1
@@ -56,13 +56,18 @@ checkout_has_only_approved_ignored_files() {
   done < "$APP_DIR/.dockerignore"
   [[ "$runtime_env_excluded" == true ]] || return 1
 
-  while IFS= read -r path; do
-    case "$path" in
-      .env|.env.*|*/.env|*/.env.*|*.pem|*.key|*.p12|*.pfx|*.crt|*.log|*.dump|*.sql|*.bak|*.backup)
-        [[ "$path" == "$ALLOWED_IGNORED_RUNTIME_ENV" ]] || return 1
-        ;;
-    esac
-  done < <(git -C "$APP_DIR" ls-files --others --ignored --exclude-standard)
+  if ! ignored_paths="$(git -C "$APP_DIR" ls-files --others --ignored --exclude-standard 2>/dev/null)"; then
+    return 1
+  fi
+  if [[ -n "$ignored_paths" ]]; then
+    while IFS= read -r path; do
+      case "$path" in
+        .env|.env.*|*/.env|*/.env.*|*.pem|*.key|*.p12|*.pfx|*.crt|*.log|*.dump|*.sql|*.bak|*.backup)
+          [[ "$path" == "$ALLOWED_IGNORED_RUNTIME_ENV" ]] || return 1
+          ;;
+      esac
+    done <<< "$ignored_paths"
+  fi
 }
 
 report_container_health() {
@@ -215,11 +220,12 @@ report_runtime_identity() {
   local api_revision='UNKNOWN'
   local web_revision='UNKNOWN'
   local checkout_status='UNKNOWN'
+  local status_output
 
   if [[ -d "$APP_DIR/.git" ]]; then
     production_sha="$(git -C "$APP_DIR" rev-parse HEAD 2>/dev/null || printf 'UNKNOWN')"
     if [[ "$production_sha" =~ ^[0-9a-f]{40}$ ]]; then
-      if [[ -z "$(git -C "$APP_DIR" status --porcelain --untracked-files=all 2>/dev/null)" ]] && checkout_has_only_approved_ignored_files; then
+      if status_output="$(git -C "$APP_DIR" status --porcelain --untracked-files=all 2>/dev/null)" && [[ -z "$status_output" ]] && checkout_has_only_approved_ignored_files; then
         checkout_status='CLEAN'
       else
         checkout_status='DIRTY'
@@ -459,6 +465,7 @@ SELECT count(*)
 FROM (
   SELECT "tenantId", "buildingId", "unitId", period, concept
   FROM "Charge"
+  WHERE "canceledAt" IS NULL
   GROUP BY "tenantId", "buildingId", "unitId", period, concept
   HAVING count(*) > 1
 ) duplicate_keys;

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -704,6 +704,32 @@ file_mtime() {
   stat -c '%Y' -- "$1" 2>/dev/null || stat -f '%m' -- "$1"
 }
 
+validate_pg_restore_list() {
+  local dump="$1"
+
+  if command -v pg_restore >/dev/null 2>&1; then
+    pg_restore --list "$dump" >/dev/null 2>&1
+    return
+  fi
+  container_exists "$POSTGRES_CONTAINER" || return 2
+  docker exec -i "$POSTGRES_CONTAINER" pg_restore --list < "$dump" >/dev/null 2>&1
+}
+
+manifest_field() {
+  local manifest="$1"
+  local key="$2"
+
+  awk -F '=' -v key="$key" '$1 == key { print substr($0, index($0, "=") + 1); exit }' "$manifest"
+}
+
+validate_backup_mechanism() {
+  local manifest="$1"
+  local validator="$2"
+
+  [[ -f "$manifest" && ! -L "$manifest" && -x "$validator" ]] || return 1
+  bash "$validator" backup-identity "$manifest" >/dev/null 2>&1
+}
+
 format_epoch() {
   date -u -d "@$1" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -r "$1" '+%Y-%m-%dT%H:%M:%SZ'
 }
@@ -712,7 +738,8 @@ report_backup_readiness() {
   local latest_dump=''
   local latest_mtime=0
   local candidate mtime checksum_file expected actual now age
-  local mechanism_digest mechanism_mode mechanism_identity='UNKNOWN'
+  local mechanism_path='UNKNOWN' mechanism_digest='UNKNOWN' mechanism_owner='UNKNOWN' mechanism_group='UNKNOWN' mechanism_mode='UNKNOWN'
+  local mechanism_identity='UNKNOWN' backup_validator restore_result
   local dump_present='NO'
   local checksum_present='NO'
   local checksum_status='NOT_RUN'
@@ -750,10 +777,15 @@ report_backup_readiness() {
         AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
       fi
     fi
-    if command -v pg_restore >/dev/null 2>&1 && pg_restore --list "$latest_dump" >/dev/null 2>&1; then
+    if validate_pg_restore_list "$latest_dump"; then
       restore_status='PASS'
-    elif command -v pg_restore >/dev/null 2>&1; then
-      restore_status='FAIL'
+    else
+      restore_result=$?
+      if [[ "$restore_result" -eq 2 ]]; then
+        restore_status='INCOMPLETE'
+      else
+        restore_status='FAIL'
+      fi
       AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
     fi
     now="$(date -u +%s)"
@@ -769,14 +801,22 @@ report_backup_readiness() {
     printf 'LATEST_BUILDINGOS_DB_BACKUP_FILE=UNKNOWN\n'
     printf 'BACKUP_AGE_SECONDS=UNKNOWN\n'
   fi
-  if [[ -f "$BACKUP_SCRIPT_PATH" && ! -L "$BACKUP_SCRIPT_PATH" ]]; then
-    if mechanism_digest="$(sha256sum -- "$BACKUP_SCRIPT_PATH" 2>/dev/null)"; then
-      mechanism_digest="${mechanism_digest%% *}"
-      mechanism_mode="$(stat -c '%a' -- "$BACKUP_SCRIPT_PATH" 2>/dev/null || stat -f '%Lp' -- "$BACKUP_SCRIPT_PATH")"
-      mechanism_identity="sha256=${mechanism_digest};mode=${mechanism_mode}"
-    fi
+  backup_validator="$APP_DIR/scripts/production-security-validate.sh"
+  if validate_backup_mechanism "$BACKUP_IDENTITY_MANIFEST_PATH" "$backup_validator"; then
+    mechanism_path="$(manifest_field "$BACKUP_IDENTITY_MANIFEST_PATH" path)"
+    mechanism_digest="$(manifest_field "$BACKUP_IDENTITY_MANIFEST_PATH" sha256)"
+    mechanism_owner="$(manifest_field "$BACKUP_IDENTITY_MANIFEST_PATH" owner)"
+    mechanism_group="$(manifest_field "$BACKUP_IDENTITY_MANIFEST_PATH" group)"
+    mechanism_mode="$(manifest_field "$BACKUP_IDENTITY_MANIFEST_PATH" mode)"
+    mechanism_identity="path=${mechanism_path};sha256=${mechanism_digest};owner=${mechanism_owner};group=${mechanism_group};mode=${mechanism_mode}"
+  else
+    AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
   fi
-  printf 'BACKUP_MECHANISM_PATH=%s\n' "$BACKUP_SCRIPT_PATH"
+  printf 'BACKUP_MECHANISM_PATH=%s\n' "$mechanism_path"
+  printf 'BACKUP_MECHANISM_SHA256=%s\n' "$mechanism_digest"
+  printf 'BACKUP_MECHANISM_OWNER=%s\n' "$mechanism_owner"
+  printf 'BACKUP_MECHANISM_GROUP=%s\n' "$mechanism_group"
+  printf 'BACKUP_MECHANISM_MODE=%s\n' "$mechanism_mode"
   printf 'BACKUP_MECHANISM_IDENTITY=%s\n' "$mechanism_identity"
   printf 'BACKUP_IDENTITY_MANIFEST=%s\n' "$BACKUP_IDENTITY_MANIFEST_PATH"
   printf 'BACKUP_DUMP_PRESENT=%s\n' "$dump_present"
@@ -819,7 +859,7 @@ main() {
     [[ "$url" =~ ^https://[A-Za-z0-9._:/?=%+-]+$ ]] || fail 'public audit URL is not an HTTPS URL'
   done
 
-  for command_name in bash curl date docker find git sha256sum stat; do
+  for command_name in awk bash curl date docker find git sha256sum stat; do
     command -v "$command_name" >/dev/null 2>&1 || fail "$command_name is required"
   done
 

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -425,7 +425,7 @@ COMMIT;
 SQL
   report_query_stdin 'NEGATIVE_PAYMENT_ALLOCATIONS' <<'SQL'
 BEGIN READ ONLY;
-SELECT count(*) FROM "PaymentAllocation" WHERE amount < 0;
+SELECT count(*) FROM "PaymentAllocation" WHERE amount <= 0;
 COMMIT;
 SQL
   report_query_stdin 'NEGATIVE_PAYMENT_ORIGINAL_ALLOCATIONS' <<'SQL'

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -45,10 +45,17 @@ container_health() {
 report_container_health() {
   local label="$1"
   local container="$2"
+  local state health
   if container_exists "$container"; then
-    printf '%s_CONTAINER_STATE=%s\n' "$label" "$(container_state "$container")"
-    printf '%s_CONTAINER_HEALTH=%s\n' "$label" "$(container_health "$container")"
+    state="$(container_state "$container")"
+    health="$(container_health "$container")"
+    printf '%s_CONTAINER_STATE=%s\n' "$label" "$state"
+    printf '%s_CONTAINER_HEALTH=%s\n' "$label" "$health"
+    if [[ "$state" != 'running' || ( "$health" != 'healthy' && "$health" != 'not_configured' ) ]]; then
+      AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
+    fi
   else
+    AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
     printf '%s_CONTAINER_STATE=UNKNOWN\n' "$label"
     printf '%s_CONTAINER_HEALTH=UNKNOWN\n' "$label"
   fi
@@ -151,6 +158,7 @@ public_get_status() {
     --request GET --output /dev/null --write-out '%{http_code}' "$url" 2>/dev/null)" && [[ "$status" =~ ^2[0-9][0-9]$ ]]; then
     printf '%s=%s\n' "$label" "$status"
   else
+    AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
     printf '%s=FAIL\n' "$label"
   fi
 }
@@ -159,17 +167,24 @@ public_readyz_status() {
   local body
   local database_status='UNKNOWN'
   local storage_status='UNKNOWN'
+  local readyz_ok=false
 
   if body="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 \
     --request GET "$API_READYZ_URL" 2>/dev/null)"; then
     [[ "$body" == *'"database":{"status":"up"'* ]] && database_status='UP'
     [[ "$body" == *'"storage":{"status":"up"'* ]] && storage_status='UP'
     printf 'PUBLIC_READYZ_HTTP=200\n'
+    if [[ "$database_status" == 'UP' && "$storage_status" == 'UP' ]]; then
+      readyz_ok=true
+    fi
   else
     printf 'PUBLIC_READYZ_HTTP=FAIL\n'
   fi
   printf 'PUBLIC_READYZ_DATABASE=%s\n' "$database_status"
   printf 'PUBLIC_READYZ_STORAGE=%s\n' "$storage_status"
+  if [[ "$readyz_ok" != true ]]; then
+    AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
+  fi
 }
 
 report_runtime_identity() {
@@ -200,6 +215,7 @@ report_runtime_identity() {
     printf 'RUNTIME_IDENTITY=CONSISTENT\n'
   else
     printf 'RUNTIME_IDENTITY=UNKNOWN\n'
+    AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
   fi
 }
 
@@ -536,38 +552,61 @@ SQL
   printf 'EXPECTED_AUTHORITATIVE_BUCKET=%s\n' "$EXPECTED_BUCKET"
 }
 
+s3_client_available() {
+  docker exec "$API_CONTAINER" node -e 'require.resolve("minio")' >/dev/null 2>&1
+}
+
 s3_probe() {
   local operation="$1"
-  docker exec "$API_CONTAINER" sh -lc '
-    command -v aws >/dev/null 2>&1 || exit 125
-    export AWS_ACCESS_KEY_ID="${S3_ACCESS_KEY:-}"
-    export AWS_SECRET_ACCESS_KEY="${S3_SECRET_KEY:-}"
-    export AWS_DEFAULT_REGION="${S3_REGION:-us-east-1}"
-    export AWS_EC2_METADATA_DISABLED=true
-    case "$1" in
-      head)
-        aws --no-cli-pager s3api head-bucket --endpoint-url "$S3_ENDPOINT" --bucket "$S3_BUCKET" >/dev/null
-        ;;
-      versioning)
-        aws --no-cli-pager s3api get-bucket-versioning --endpoint-url "$S3_ENDPOINT" --bucket "$S3_BUCKET" --query Status --output text
-        ;;
-      objects)
-        aws --no-cli-pager s3api list-objects-v2 --endpoint-url "$S3_ENDPOINT" --bucket "$S3_BUCKET" --max-keys 100 --query KeyCount --output text
-        ;;
-      *)
-        exit 64
-        ;;
-    esac
-  ' sh "$operation"
+  docker exec "$API_CONTAINER" node - "$operation" <<'NODE'
+'use strict';
+
+const Minio = require('minio');
+const operation = process.argv[2];
+const endpoint = new URL(process.env.S3_ENDPOINT);
+const client = new Minio.Client({
+  endPoint: endpoint.hostname,
+  port: endpoint.port ? Number(endpoint.port) : undefined,
+  useSSL: endpoint.protocol === 'https:',
+  pathStyle: process.env.S3_FORCE_PATH_STYLE === 'true',
+  accessKey: process.env.S3_ACCESS_KEY || '',
+  secretKey: process.env.S3_SECRET_KEY || '',
+  region: process.env.S3_REGION || 'us-east-1',
+});
+const bucket = process.env.S3_BUCKET;
+
+const run = async () => {
+  if (operation === 'head') {
+    if (!(await client.bucketExists(bucket))) {
+      throw new Error('bucket is not reachable');
+    }
+    return;
+  }
+  if (operation === 'versioning') {
+    const versioning = await client.getBucketVersioning(bucket);
+    process.stdout.write(`${versioning.Status || 'UNKNOWN'}\n`);
+    return;
+  }
+  if (operation === 'objects') {
+    const result = await client.listObjectsV2Query(bucket, '', '', '', 100, '');
+    process.stdout.write(`${result.objects.length}\n`);
+    return;
+  }
+  throw new Error('unsupported S3 probe');
+};
+
+run().catch(() => {
+  process.exitCode = 1;
+});
+NODE
 }
 
 report_s3_posture() {
-  local client_available
   local versioning object_count
   local versioning_ok=false
   local object_count_ok=false
 
-  if client_available="$(docker exec "$API_CONTAINER" sh -lc 'command -v aws >/dev/null 2>&1 && printf available' 2>/dev/null)" && [[ "$client_available" == 'available' ]]; then
+  if s3_client_available; then
     if s3_probe head >/dev/null 2>&1; then
       printf 'S3_BUCKET_REACHABLE=YES\n'
       if versioning="$(s3_probe versioning 2>/dev/null)"; then

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -195,14 +195,18 @@ public_readyz_status() {
   local body
   local database_status='UNKNOWN'
   local storage_status='UNKNOWN'
+  local readiness_status='UNKNOWN'
   local readyz_ok=false
 
   if body="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 \
     --request GET "$API_READYZ_URL" 2>/dev/null)"; then
     [[ "$body" == *'"database":{"status":"up"'* ]] && database_status='UP'
     [[ "$body" == *'"storage":{"status":"up"'* ]] && storage_status='UP'
+    [[ "$body" == *'"status":"healthy"'* ]] && readiness_status='HEALTHY'
+    [[ "$body" == *'"status":"degraded"'* ]] && readiness_status='DEGRADED'
+    [[ "$body" == *'"status":"unhealthy"'* ]] && readiness_status='UNHEALTHY'
     printf 'PUBLIC_READYZ_HTTP=200\n'
-    if [[ "$database_status" == 'UP' && "$storage_status" == 'UP' ]]; then
+    if [[ "$readiness_status" == 'HEALTHY' && "$database_status" == 'UP' && "$storage_status" == 'UP' ]]; then
       readyz_ok=true
     fi
   else
@@ -210,6 +214,7 @@ public_readyz_status() {
   fi
   printf 'PUBLIC_READYZ_DATABASE=%s\n' "$database_status"
   printf 'PUBLIC_READYZ_STORAGE=%s\n' "$storage_status"
+  printf 'PUBLIC_READYZ_STATUS=%s\n' "$readiness_status"
   if [[ "$readyz_ok" != true ]]; then
     AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
   fi
@@ -405,7 +410,9 @@ LEFT JOIN "Charge" c ON c.id = a."chargeId"
 WHERE p.id IS NULL
    OR c.id IS NULL
    OR a."tenantId" <> p."tenantId"
-   OR a."tenantId" <> c."tenantId";
+   OR a."tenantId" <> c."tenantId"
+   OR p."buildingId" <> c."buildingId"
+   OR p."unitId" IS DISTINCT FROM c."unitId";
 COMMIT;
 SQL
   if value="$(readonly_query_stdin <<'SQL'
@@ -747,6 +754,7 @@ report_backup_readiness() {
       restore_status='PASS'
     elif command -v pg_restore >/dev/null 2>&1; then
       restore_status='FAIL'
+      AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
     fi
     now="$(date -u +%s)"
     age=$((now - latest_mtime))

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -530,7 +530,24 @@ WITH per_payment AS (
            OR p."conversionDate" IS NULL
            OR (p."exchangeRateDirection" = 'IDENTITY' AND (p."exchangeRateValue" <> 1 OR p."exchangeRateId" IS NOT NULL OR p."exchangeRateEffectiveAt" IS NOT NULL))
            OR (p."exchangeRateDirection" IN ('DIRECT', 'INVERSE') AND (p."exchangeRateValue" <= 0 OR p."exchangeRateId" IS NULL OR p."exchangeRateEffectiveAt" IS NULL))
-         )) AS has_invalid_cross_currency
+          )) AS has_invalid_cross_currency
+         ,bool_or(p.currency <> c.currency AND
+           p."functionalCurrencyCode" IS NULL
+           AND p."functionalAmountMinor" IS NULL
+           AND p."exchangeRateId" IS NULL
+           AND p."exchangeRateValue" IS NULL
+           AND p."exchangeRateDirection" IS NULL
+           AND p."exchangeRateEffectiveAt" IS NULL
+           AND p."conversionDate" IS NULL) AS has_legacy_cross_currency
+         ,bool_or(p.currency <> c.currency AND (
+           p."functionalCurrencyCode" IS NOT NULL
+           OR p."functionalAmountMinor" IS NOT NULL
+           OR p."exchangeRateId" IS NOT NULL
+           OR p."exchangeRateValue" IS NOT NULL
+           OR p."exchangeRateDirection" IS NOT NULL
+           OR p."exchangeRateEffectiveAt" IS NOT NULL
+           OR p."conversionDate" IS NOT NULL
+         )) AS has_conversion_metadata
   FROM "PaymentAllocation" a
   JOIN "Payment" p ON p.id = a."paymentId"
   JOIN "Charge" c ON c.id = a."chargeId"
@@ -538,7 +555,8 @@ WITH per_payment AS (
 )
 SELECT count(*)
 FROM per_payment
-WHERE has_cross_currency AND (has_same_currency OR has_invalid_cross_currency);
+WHERE has_cross_currency
+  AND (has_same_currency OR (has_invalid_cross_currency AND (NOT has_legacy_cross_currency OR has_conversion_metadata)));
 COMMIT;
 SQL
   report_query_stdin 'CURRENCY_MISMATCHES_UNVERIFIABLE' <<'SQL'
@@ -733,7 +751,7 @@ report_s3_posture() {
     if s3_probe head >/dev/null 2>&1; then
       printf 'S3_BUCKET_REACHABLE=YES\n'
       if versioning="$(s3_probe versioning 2>/dev/null)"; then
-        versioning_ok=true
+        [[ "$versioning" == 'Enabled' ]] && versioning_ok=true
       else
         versioning='UNKNOWN'
       fi

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -1,0 +1,482 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+set +x
+
+readonly API_CONTAINER='buildingos-api'
+readonly WEB_CONTAINER='buildingos-web'
+readonly POSTGRES_CONTAINER='pawtech-postgres'
+readonly REDIS_CONTAINER='pawtech-redis'
+readonly TRAEFIK_CONTAINER='pawtech-traefik'
+readonly DATABASE_NAME='buildingos_db'
+readonly APP_DIR='/opt/pawtech/apps/buildingos/buildingos-app'
+readonly BACKUP_ROOT='/opt/pawtech/backups/tmp'
+readonly BACKUP_SCRIPT_PATH='/opt/pawtech/backups/scripts/backup-postgres.sh'
+readonly BACKUP_IDENTITY_MANIFEST_PATH='/opt/pawtech/apps/buildingos/infra/production/backup-postgres.identity.v1'
+readonly EXPECTED_BUCKET='buildingos-production'
+readonly KNOWN_PRODUCTION_BASELINE='20260816000004_legacy_income_application_provenance'
+readonly TARGET_MIGRATION='20260831000000_add_payment_receipt_issuance_snapshot'
+readonly MAX_BACKUP_AGE_SECONDS=129600
+
+usage() {
+  printf 'Usage: %s <candidate_sha> <api_health_url> <api_readyz_url> <web_login_url>\n' "${0##*/}" >&2
+  return 64
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+[[ $# -eq 4 ]] || { usage; exit 64; }
+readonly CANDIDATE_SHA="$1"
+readonly API_HEALTH_URL="$2"
+readonly API_READYZ_URL="$3"
+readonly WEB_LOGIN_URL="$4"
+
+[[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]] || fail 'candidate SHA is not exactly 40 lowercase hexadecimal characters'
+for url in "$API_HEALTH_URL" "$API_READYZ_URL" "$WEB_LOGIN_URL"; do
+  [[ "$url" =~ ^https://[A-Za-z0-9._:/?=%+-]+$ ]] || fail 'public audit URL is not an HTTPS URL'
+done
+
+for command_name in bash curl date docker find git sha256sum stat; do
+  command -v "$command_name" >/dev/null 2>&1 || fail "$command_name is required"
+done
+
+AUDIT_QUERY_FAILURES=0
+
+container_exists() {
+  docker inspect --type container "$1" >/dev/null 2>&1
+}
+
+container_state() {
+  docker inspect --type container --format '{{.State.Status}}' "$1" 2>/dev/null || printf 'UNKNOWN'
+}
+
+container_health() {
+  docker inspect --type container --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}not_configured{{end}}' "$1" 2>/dev/null || printf 'UNKNOWN'
+}
+
+report_container_health() {
+  local label="$1"
+  local container="$2"
+  if container_exists "$container"; then
+    printf '%s_CONTAINER_STATE=%s\n' "$label" "$(container_state "$container")"
+    printf '%s_CONTAINER_HEALTH=%s\n' "$label" "$(container_health "$container")"
+  else
+    printf '%s_CONTAINER_STATE=UNKNOWN\n' "$label"
+    printf '%s_CONTAINER_HEALTH=UNKNOWN\n' "$label"
+  fi
+}
+
+container_revision() {
+  local container="$1"
+  local image_id revision
+
+  image_id="$(docker inspect --type container --format '{{.Image}}' "$container" 2>/dev/null)" || return 1
+  [[ "$image_id" =~ ^sha256:[0-9a-f]{64}$ ]] || return 1
+  revision="$(docker image inspect "$image_id" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null)" || return 1
+  [[ "$revision" =~ ^[0-9a-f]{40}$ ]] || return 1
+  printf '%s\n' "$revision"
+}
+
+safe_env_value() {
+  local container="$1"
+  local key="$2"
+  local line
+
+  case "$key" in
+    APP_ENV|NODE_ENV|STORAGE_BACKEND|S3_ENDPOINT|S3_BUCKET|S3_FORCE_PATH_STYLE|PAYMENT_PROVIDER|ENABLE_PAYMENT_WEBHOOKS)
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+
+  line="$(docker inspect --type container --format "{{range .Config.Env}}{{if eq (index (split . \"=\") 0) \"$key\"}}{{println .}}{{end}}{{end}}" "$container" 2>/dev/null)" || return 1
+  [[ "$line" == "$key="* ]] || return 1
+  printf '%s\n' "${line#*=}"
+}
+
+safe_value_or_unknown() {
+  local value="$1"
+  if [[ "$value" =~ ^[A-Za-z0-9._:/+=?@%,-]+$ ]]; then
+    printf '%s' "$value"
+  else
+    printf 'UNKNOWN'
+  fi
+}
+
+endpoint_hostname() {
+  local endpoint="$1"
+  local authority host
+
+  [[ "$endpoint" =~ ^https?://[^[:space:]]+$ ]] || { printf 'UNKNOWN'; return; }
+  authority="${endpoint#*://}"
+  authority="${authority%%/*}"
+  authority="${authority##*@}"
+  host="${authority%%:*}"
+  [[ "$host" =~ ^[A-Za-z0-9.-]+$ ]] || { printf 'UNKNOWN'; return; }
+  printf '%s' "$host"
+}
+
+storage_backend_from_host() {
+  case "$1" in
+    minio|buildingos-minio|buildingos-staging-minio|localhost|127.0.0.1)
+      printf 'MINIO'
+      ;;
+    UNKNOWN)
+      printf 'UNKNOWN'
+      ;;
+    *)
+      printf 'EXTERNAL_S3'
+      ;;
+  esac
+}
+
+readonly_query() {
+  local query="$1"
+  docker exec -i "$POSTGRES_CONTAINER" sh -lc \
+    'exec psql -v ON_ERROR_STOP=1 -qAt -U "$POSTGRES_USER" -d "$1" -c "$2"' \
+    sh "$DATABASE_NAME" "BEGIN READ ONLY; ${query}; COMMIT;"
+}
+
+report_query() {
+  local key="$1"
+  local query="$2"
+  local value
+
+  if value="$(readonly_query "$query" 2>/dev/null)"; then
+    printf '%s=%s\n' "$key" "$value"
+  else
+    AUDIT_QUERY_FAILURES=$((AUDIT_QUERY_FAILURES + 1))
+    printf '%s=UNKNOWN\n' "$key"
+  fi
+}
+
+public_get_status() {
+  local label="$1"
+  local url="$2"
+  local status
+
+  if status="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 \
+    --request GET --output /dev/null --write-out '%{http_code}' "$url" 2>/dev/null)" && [[ "$status" =~ ^2[0-9][0-9]$ ]]; then
+    printf '%s=%s\n' "$label" "$status"
+  else
+    printf '%s=FAIL\n' "$label"
+  fi
+}
+
+public_readyz_status() {
+  local body
+  local database_status='UNKNOWN'
+  local storage_status='UNKNOWN'
+
+  if body="$(curl --fail --silent --show-error --connect-timeout 5 --max-time 15 \
+    --request GET "$API_READYZ_URL" 2>/dev/null)"; then
+    [[ "$body" == *'"database":{"status":"up"'* ]] && database_status='UP'
+    [[ "$body" == *'"storage":{"status":"up"'* ]] && storage_status='UP'
+    printf 'PUBLIC_READYZ_HTTP=200\n'
+  else
+    printf 'PUBLIC_READYZ_HTTP=FAIL\n'
+  fi
+  printf 'PUBLIC_READYZ_DATABASE=%s\n' "$database_status"
+  printf 'PUBLIC_READYZ_STORAGE=%s\n' "$storage_status"
+}
+
+report_runtime_identity() {
+  local production_sha='UNKNOWN'
+  local api_revision='UNKNOWN'
+  local web_revision='UNKNOWN'
+  local checkout_status='UNKNOWN'
+
+  if [[ -d "$APP_DIR/.git" ]]; then
+    production_sha="$(git -C "$APP_DIR" rev-parse HEAD 2>/dev/null || printf 'UNKNOWN')"
+    if [[ "$production_sha" =~ ^[0-9a-f]{40}$ ]]; then
+      if [[ -z "$(git -C "$APP_DIR" status --porcelain --untracked-files=all 2>/dev/null)" ]]; then
+        checkout_status='CLEAN'
+      else
+        checkout_status='DIRTY'
+      fi
+    fi
+  fi
+  api_revision="$(container_revision "$API_CONTAINER" 2>/dev/null || printf 'UNKNOWN')"
+  web_revision="$(container_revision "$WEB_CONTAINER" 2>/dev/null || printf 'UNKNOWN')"
+
+  printf 'CANDIDATE_SHA=%s\n' "$CANDIDATE_SHA"
+  printf 'PRODUCTION_CHECKOUT_SHA=%s\n' "$production_sha"
+  printf 'PRODUCTION_CHECKOUT_STATUS=%s\n' "$checkout_status"
+  printf 'API_REVISION=%s\n' "$api_revision"
+  printf 'WEB_REVISION=%s\n' "$web_revision"
+  if [[ "$api_revision" =~ ^[0-9a-f]{40}$ && "$api_revision" == "$web_revision" ]]; then
+    printf 'RUNTIME_IDENTITY=CONSISTENT\n'
+  else
+    printf 'RUNTIME_IDENTITY=UNKNOWN\n'
+  fi
+}
+
+report_safe_runtime_config() {
+  local app_env node_env storage_backend endpoint bucket path_style provider webhooks
+  local endpoint_host
+
+  app_env="$(safe_env_value "$API_CONTAINER" APP_ENV 2>/dev/null || true)"
+  node_env="$(safe_env_value "$API_CONTAINER" NODE_ENV 2>/dev/null || true)"
+  storage_backend="$(safe_env_value "$API_CONTAINER" STORAGE_BACKEND 2>/dev/null || true)"
+  endpoint="$(safe_env_value "$API_CONTAINER" S3_ENDPOINT 2>/dev/null || true)"
+  bucket="$(safe_env_value "$API_CONTAINER" S3_BUCKET 2>/dev/null || true)"
+  path_style="$(safe_env_value "$API_CONTAINER" S3_FORCE_PATH_STYLE 2>/dev/null || true)"
+  provider="$(safe_env_value "$API_CONTAINER" PAYMENT_PROVIDER 2>/dev/null || true)"
+  webhooks="$(safe_env_value "$API_CONTAINER" ENABLE_PAYMENT_WEBHOOKS 2>/dev/null || true)"
+  endpoint_host="$(endpoint_hostname "$endpoint")"
+
+  if [[ -z "$storage_backend" ]]; then
+    storage_backend="$(storage_backend_from_host "$endpoint_host")"
+  fi
+  printf 'APP_ENV=%s\n' "$(safe_value_or_unknown "${app_env:-UNKNOWN}")"
+  printf 'NODE_ENV=%s\n' "$(safe_value_or_unknown "${node_env:-UNKNOWN}")"
+  printf 'STORAGE_BACKEND=%s\n' "$(safe_value_or_unknown "$storage_backend")"
+  printf 'S3_ENDPOINT_HOSTNAME=%s\n' "$endpoint_host"
+  printf 'S3_BUCKET=%s\n' "$(safe_value_or_unknown "${bucket:-UNKNOWN}")"
+  printf 'S3_FORCE_PATH_STYLE=%s\n' "$(safe_value_or_unknown "${path_style:-UNKNOWN}")"
+  printf 'PAYMENT_PROVIDER=%s\n' "$(safe_value_or_unknown "${provider:-UNKNOWN}")"
+  printf 'ENABLE_PAYMENT_WEBHOOKS=%s\n' "$(safe_value_or_unknown "${webhooks:-UNKNOWN}")"
+}
+
+report_migrations_and_schema() {
+  local receipt_columns
+
+  report_query 'DATABASE_NAME' 'SELECT current_database()'
+  report_query 'ACTIVE_FINISHED_MIGRATIONS' 'SELECT count(*) FROM "_prisma_migrations" WHERE finished_at IS NOT NULL AND rolled_back_at IS NULL'
+  report_query 'FAILED_MIGRATIONS' 'SELECT count(*) FROM "_prisma_migrations" WHERE finished_at IS NULL AND rolled_back_at IS NULL'
+  report_query 'MIGRATIONS_AFTER_KNOWN_BASELINE' "SELECT COALESCE(string_agg(migration_name, ',' ORDER BY finished_at, migration_name), 'NONE') FROM \"_prisma_migrations\" WHERE migration_name > '$KNOWN_PRODUCTION_BASELINE' AND finished_at IS NOT NULL AND rolled_back_at IS NULL"
+  report_query 'TARGET_MIGRATION_STATUS' "SELECT CASE WHEN count(*) = 0 THEN 'NOT_APPLIED' WHEN count(*) = 1 AND bool_and(finished_at IS NOT NULL AND rolled_back_at IS NULL) THEN 'APPLIED' ELSE 'AMBIGUOUS' END FROM \"_prisma_migrations\" WHERE migration_name = '$TARGET_MIGRATION'"
+  if receipt_columns="$(readonly_query 'SELECT CASE WHEN count(*) = 6 THEN ''YES'' ELSE ''NO'' END FROM information_schema.columns WHERE table_schema = ''public'' AND table_name = ''Payment'' AND column_name IN (''receiptSnapshot'', ''receiptSnapshotVersion'', ''receiptSnapshotHash'', ''receiptSnapshotCreatedAt'', ''receiptGenerationToken'', ''receiptGenerationLeaseUntil'')' 2>/dev/null)"; then
+    printf 'RECEIPT_SNAPSHOT_COLUMNS=%s\n' "$receipt_columns"
+    if [[ "$receipt_columns" == 'YES' ]]; then
+      report_query 'RECEIPT_GENERATION_TOKEN_COUNT' 'SELECT count(*) FROM "Payment" WHERE "receiptGenerationToken" IS NOT NULL'
+      report_query 'ACTIVE_RECEIPT_GENERATION_LEASE_COUNT' 'SELECT count(*) FROM "Payment" WHERE "receiptGenerationLeaseUntil" > CURRENT_TIMESTAMP'
+    else
+      printf 'RECEIPT_GENERATION_TOKEN_COUNT=NOT_APPLICABLE\n'
+      printf 'ACTIVE_RECEIPT_GENERATION_LEASE_COUNT=NOT_APPLICABLE\n'
+    fi
+  else
+    AUDIT_QUERY_FAILURES=$((AUDIT_QUERY_FAILURES + 1))
+    printf 'RECEIPT_SNAPSHOT_COLUMNS=UNKNOWN\nRECEIPT_GENERATION_TOKEN_COUNT=UNKNOWN\nACTIVE_RECEIPT_GENERATION_LEASE_COUNT=UNKNOWN\n'
+  fi
+}
+
+report_finance_counts() {
+  report_query 'PAYMENTS_COUNT' 'SELECT count(*) FROM "Payment"'
+  report_query 'PAYMENT_ALLOCATIONS_COUNT' 'SELECT count(*) FROM "PaymentAllocation"'
+  report_query 'EXPENSES_COUNT' 'SELECT count(*) FROM "Expense"'
+  report_query 'INCOMES_COUNT' 'SELECT count(*) FROM "Income"'
+  report_query 'CHARGES_COUNT' 'SELECT count(*) FROM "Charge"'
+  report_query 'RECEIPT_STATUS_COUNTS' 'SELECT ''READY='' || count(*) FILTER (WHERE "receiptStatus" = ''READY'') || '',PENDING='' || count(*) FILTER (WHERE "receiptStatus" = ''PENDING'') || '',FAILED='' || count(*) FILTER (WHERE "receiptStatus" = ''FAILED'') FROM "Payment"'
+  report_query 'PAYMENT_AUDIT_TOTAL' 'SELECT count(*) FROM "PaymentAuditLog"'
+  report_query 'PAYMENT_AUDIT_ACTION_COUNTS' 'SELECT ''SUBMITTED='' || count(*) FILTER (WHERE action = ''SUBMITTED'') || '',APPROVED='' || count(*) FILTER (WHERE action = ''APPROVED'') || '',RECONCILED='' || count(*) FILTER (WHERE action = ''RECONCILED'') || '',RECEIPT_GENERATED='' || count(*) FILTER (WHERE action = ''RECEIPT_GENERATED'') FROM "PaymentAuditLog"'
+}
+
+report_finance_integrity() {
+  report_query 'ORPHAN_ALLOCATIONS' 'SELECT count(*) FROM "PaymentAllocation" a LEFT JOIN "Payment" p ON p.id = a."paymentId" LEFT JOIN "Charge" c ON c.id = a."chargeId" WHERE p.id IS NULL OR c.id IS NULL OR a."tenantId" <> p."tenantId" OR a."tenantId" <> c."tenantId"'
+  report_query 'OVER_ALLOCATIONS' 'SELECT count(*) FROM (SELECT a."paymentId" FROM "PaymentAllocation" a JOIN "Payment" p ON p.id = a."paymentId" GROUP BY a."paymentId", p.amount HAVING COALESCE(sum(a.amount), 0) > p.amount) over_allocated'
+  report_query 'DUPLICATE_CANONICAL_CHARGE_KEYS' 'SELECT count(*) FROM (SELECT "tenantId", "buildingId", "unitId", period, concept FROM "Charge" GROUP BY "tenantId", "buildingId", "unitId", period, concept HAVING count(*) > 1) duplicate_keys'
+  report_query 'CURRENCY_MISMATCHES' 'SELECT count(*) FROM "PaymentAllocation" a JOIN "Payment" p ON p.id = a."paymentId" JOIN "Charge" c ON c.id = a."chargeId" WHERE p.currency <> c.currency OR a."tenantId" <> p."tenantId" OR a."tenantId" <> c."tenantId"'
+  report_query 'DUPLICATE_RECEIPT_FILE_GRAPHS' 'SELECT count(*) FROM (SELECT d."fileId" FROM "Payment" p JOIN "Document" d ON d.id = p."receiptDocumentId" JOIN "File" f ON f.id = d."fileId" WHERE p."receiptDocumentId" IS NOT NULL GROUP BY d."fileId" HAVING count(*) > 1) duplicate_files'
+  report_query 'DUPLICATE_RECEIPT_DOCUMENT_GRAPHS' 'SELECT count(*) FROM (SELECT p."receiptDocumentId" FROM "Payment" p WHERE p."receiptDocumentId" IS NOT NULL GROUP BY p."receiptDocumentId" HAVING count(*) > 1) duplicate_documents'
+  report_query 'DUPLICATE_RECEIPT_GENERATED_AUDITS' 'SELECT count(*) FROM (SELECT "tenantId", "paymentId" FROM "PaymentAuditLog" WHERE action = ''RECEIPT_GENERATED'' GROUP BY "tenantId", "paymentId" HAVING count(*) > 1) duplicate_audits'
+}
+
+report_tenant_classification() {
+  local classification
+  if classification="$(readonly_query 'SELECT count(*) FILTER (WHERE "isDemo" = true) || ''|'' || count(*) FILTER (WHERE "isDemo" = false) FROM "Tenant"' 2>/dev/null)"; then
+    printf 'TENANT_DEMO_TEST=%s\n' "${classification%%|*}"
+    printf 'TENANT_UNKNOWN=%s\n' "${classification#*|}"
+  else
+    AUDIT_QUERY_FAILURES=$((AUDIT_QUERY_FAILURES + 1))
+    printf 'TENANT_DEMO_TEST=UNKNOWN\nTENANT_UNKNOWN=UNKNOWN\n'
+  fi
+  printf 'TENANT_SYSTEM_INTERNAL=UNKNOWN\n'
+  printf 'TENANT_REAL_BUSINESS=UNKNOWN\n'
+}
+
+report_storage_database_buckets() {
+  report_query 'FILE_BUCKET_COUNTS' 'SELECT COALESCE(string_agg(bucket || '':'' || row_count::text, '','' ORDER BY bucket), ''NONE'') FROM (SELECT bucket, count(*) AS row_count FROM "File" GROUP BY bucket) bucket_counts'
+  report_query 'FILE_EXPECTED_BUCKET_COUNT' "SELECT count(*) FROM \"File\" WHERE bucket = '$EXPECTED_BUCKET'"
+  report_query 'FILE_OTHER_BUCKET_COUNT' "SELECT count(*) FROM \"File\" WHERE bucket <> '$EXPECTED_BUCKET'"
+  printf 'EXPECTED_AUTHORITATIVE_BUCKET=%s\n' "$EXPECTED_BUCKET"
+}
+
+s3_probe() {
+  local operation="$1"
+  docker exec "$API_CONTAINER" sh -lc '
+    command -v aws >/dev/null 2>&1 || exit 125
+    export AWS_ACCESS_KEY_ID="${S3_ACCESS_KEY:-}"
+    export AWS_SECRET_ACCESS_KEY="${S3_SECRET_KEY:-}"
+    export AWS_DEFAULT_REGION="${S3_REGION:-us-east-1}"
+    export AWS_EC2_METADATA_DISABLED=true
+    case "$1" in
+      head)
+        aws --no-cli-pager s3api head-bucket --endpoint-url "$S3_ENDPOINT" --bucket "$S3_BUCKET" >/dev/null
+        ;;
+      versioning)
+        aws --no-cli-pager s3api get-bucket-versioning --endpoint-url "$S3_ENDPOINT" --bucket "$S3_BUCKET" --query Status --output text
+        ;;
+      objects)
+        aws --no-cli-pager s3api list-objects-v2 --endpoint-url "$S3_ENDPOINT" --bucket "$S3_BUCKET" --max-keys 100 --query KeyCount --output text
+        ;;
+      *)
+        exit 64
+        ;;
+    esac
+  ' sh "$operation"
+}
+
+report_s3_posture() {
+  local client_available
+  local versioning object_count
+
+  if client_available="$(docker exec "$API_CONTAINER" sh -lc 'command -v aws >/dev/null 2>&1 && printf available' 2>/dev/null)" && [[ "$client_available" == 'available' ]]; then
+    if s3_probe head >/dev/null 2>&1; then
+      printf 'S3_BUCKET_REACHABLE=YES\n'
+      versioning="$(s3_probe versioning 2>/dev/null || printf 'UNKNOWN')"
+      object_count="$(s3_probe objects 2>/dev/null || printf 'UNKNOWN')"
+      printf 'S3_VERSIONING_STATUS=%s\n' "$(safe_value_or_unknown "$versioning")"
+      printf 'S3_BUSINESS_OBJECT_COUNT=%s\n' "$(safe_value_or_unknown "$object_count")"
+      printf 'S3_DEEP_AUDIT=PASS\n'
+    else
+      printf 'S3_BUCKET_REACHABLE=FAIL\nS3_VERSIONING_STATUS=UNKNOWN\nS3_BUSINESS_OBJECT_COUNT=UNKNOWN\nS3_DEEP_AUDIT=FAIL\n'
+    fi
+  else
+    printf 'S3_DEEP_AUDIT_UNAVAILABLE\n'
+  fi
+}
+
+file_mtime() {
+  stat -c '%Y' -- "$1" 2>/dev/null || stat -f '%m' -- "$1"
+}
+
+format_epoch() {
+  date -u -d "@$1" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -r "$1" '+%Y-%m-%dT%H:%M:%SZ'
+}
+
+report_backup_readiness() {
+  local latest_dump=''
+  local latest_mtime=0
+  local candidate mtime checksum_file expected actual now age
+  local mechanism_digest mechanism_mode mechanism_identity='UNKNOWN'
+  local dump_present='NO'
+  local checksum_present='NO'
+  local checksum_status='NOT_RUN'
+  local restore_status='NOT_RUN'
+  local backup_required='YES'
+
+  if [[ -d "$BACKUP_ROOT" && ! -L "$BACKUP_ROOT" ]]; then
+    while IFS= read -r -d '' candidate; do
+      [[ ! -L "$candidate" ]] || continue
+      mtime="$(file_mtime "$candidate" 2>/dev/null || printf '0')"
+      [[ "$mtime" =~ ^[0-9]+$ ]] || continue
+      if (( mtime > latest_mtime )); then
+        latest_mtime="$mtime"
+        latest_dump="$candidate"
+      fi
+    done < <(find "$BACKUP_ROOT" -mindepth 2 -maxdepth 2 -type f -name 'buildingos_db_*.dump' -print0 2>/dev/null)
+  fi
+
+  if [[ -n "$latest_dump" ]]; then
+    dump_present='YES'
+    checksum_file="$latest_dump.sha256"
+    if [[ -s "$checksum_file" && ! -L "$checksum_file" ]]; then
+      checksum_present='YES'
+      expected=''
+      IFS=' ' read -r expected _ < "$checksum_file" || true
+      if actual="$(sha256sum -- "$latest_dump" 2>/dev/null)"; then
+        actual="${actual%% *}"
+      else
+        actual='UNKNOWN'
+      fi
+      if [[ "$expected" =~ ^[0-9a-f]{64}$ && "$expected" == "$actual" ]]; then
+        checksum_status='PASS'
+      else
+        checksum_status='FAIL'
+      fi
+    fi
+    if command -v pg_restore >/dev/null 2>&1 && pg_restore --list "$latest_dump" >/dev/null 2>&1; then
+      restore_status='PASS'
+    elif command -v pg_restore >/dev/null 2>&1; then
+      restore_status='FAIL'
+    fi
+    now="$(date -u +%s)"
+    age=$((now - latest_mtime))
+    if (( age >= 0 && age <= MAX_BACKUP_AGE_SECONDS )) && [[ "$checksum_status" == 'PASS' && "$restore_status" == 'PASS' ]]; then
+      backup_required='NO'
+    fi
+    printf 'LATEST_BUILDINGOS_DB_BACKUP_TIMESTAMP=%s\n' "$(format_epoch "$latest_mtime")"
+    printf 'LATEST_BUILDINGOS_DB_BACKUP_FILE=%s\n' "${latest_dump##*/}"
+    printf 'BACKUP_AGE_SECONDS=%s\n' "$age"
+  else
+    printf 'LATEST_BUILDINGOS_DB_BACKUP_TIMESTAMP=UNKNOWN\n'
+    printf 'LATEST_BUILDINGOS_DB_BACKUP_FILE=UNKNOWN\n'
+    printf 'BACKUP_AGE_SECONDS=UNKNOWN\n'
+  fi
+  if [[ -f "$BACKUP_SCRIPT_PATH" && ! -L "$BACKUP_SCRIPT_PATH" ]]; then
+    if mechanism_digest="$(sha256sum -- "$BACKUP_SCRIPT_PATH" 2>/dev/null)"; then
+      mechanism_digest="${mechanism_digest%% *}"
+      mechanism_mode="$(stat -c '%a' -- "$BACKUP_SCRIPT_PATH" 2>/dev/null || stat -f '%Lp' -- "$BACKUP_SCRIPT_PATH")"
+      mechanism_identity="sha256=${mechanism_digest};mode=${mechanism_mode}"
+    fi
+  fi
+  printf 'BACKUP_MECHANISM_PATH=%s\n' "$BACKUP_SCRIPT_PATH"
+  printf 'BACKUP_MECHANISM_IDENTITY=%s\n' "$mechanism_identity"
+  printf 'BACKUP_IDENTITY_MANIFEST=%s\n' "$BACKUP_IDENTITY_MANIFEST_PATH"
+  printf 'BACKUP_DUMP_PRESENT=%s\n' "$dump_present"
+  printf 'BACKUP_CHECKSUM_PRESENT=%s\n' "$checksum_present"
+  printf 'BACKUP_CHECKSUM_VERIFICATION=%s\n' "$checksum_status"
+  printf 'BACKUP_PG_RESTORE_LIST=%s\n' "$restore_status"
+  printf 'PREDEPLOY_BACKUP_REQUIRED=%s\n' "$backup_required"
+}
+
+report_minio_posture() {
+  local state networks ports endpoint host authoritative
+  if ! container_exists buildingos-minio; then
+    printf 'MINIO_CONTAINER=ABSENT\nMINIO_AUTHORITATIVE=UNKNOWN\n'
+    return
+  fi
+  state="$(container_state buildingos-minio)"
+  networks="$(docker inspect --type container --format '{{range $name, $value := .NetworkSettings.Networks}}{{$name}} {{end}}' buildingos-minio 2>/dev/null || printf 'UNKNOWN')"
+  ports="$(docker inspect --type container --format '{{json .NetworkSettings.Ports}}' buildingos-minio 2>/dev/null || printf 'UNKNOWN')"
+  endpoint="$(safe_env_value "$API_CONTAINER" S3_ENDPOINT 2>/dev/null || true)"
+  host="$(endpoint_hostname "$endpoint")"
+  authoritative="$(storage_backend_from_host "$host")"
+  [[ "$authoritative" == 'MINIO' ]] && authoritative='YES' || [[ "$authoritative" == 'EXTERNAL_S3' ]] && authoritative='NO' || authoritative='UNKNOWN'
+  printf 'MINIO_CONTAINER=%s\n' "$state"
+  printf 'MINIO_NETWORKS=%s\n' "$networks"
+  printf 'MINIO_PUBLISHED_PORTS=%s\n' "$ports"
+  printf 'MINIO_AUTHORITATIVE=%s\n' "$authoritative"
+}
+
+printf 'PRODUCTION_READONLY_AUDIT\n'
+report_runtime_identity
+report_container_health API "$API_CONTAINER"
+report_container_health WEB "$WEB_CONTAINER"
+report_container_health POSTGRES "$POSTGRES_CONTAINER"
+report_container_health REDIS "$REDIS_CONTAINER"
+report_container_health TRAEFIK "$TRAEFIK_CONTAINER"
+public_get_status PUBLIC_API_HEALTH "$API_HEALTH_URL"
+public_readyz_status
+public_get_status PUBLIC_WEB_LOGIN "$WEB_LOGIN_URL"
+report_safe_runtime_config
+report_migrations_and_schema
+report_finance_counts
+report_finance_integrity
+report_tenant_classification
+report_storage_database_buckets
+report_s3_posture
+report_minio_posture
+report_backup_readiness
+
+if (( AUDIT_QUERY_FAILURES == 0 )); then
+  printf 'AUDIT_STATUS=COMPLETE\n'
+else
+  printf 'AUDIT_STATUS=INCOMPLETE\n'
+  printf 'AUDIT_QUERY_FAILURES=%s\n' "$AUDIT_QUERY_FAILURES"
+  exit 1
+fi

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -558,7 +558,7 @@ s3_client_available() {
 
 s3_probe() {
   local operation="$1"
-  docker exec "$API_CONTAINER" node - "$operation" <<'NODE'
+  docker exec -i "$API_CONTAINER" node - "$operation" <<'NODE'
 'use strict';
 
 const Minio = require('minio');
@@ -588,8 +588,20 @@ const run = async () => {
     return;
   }
   if (operation === 'objects') {
-    const result = await client.listObjectsV2Query(bucket, '', '', '', 100, '');
-    process.stdout.write(`${result.objects.length}\n`);
+    let continuationToken = '';
+    let objectCount = 0;
+    do {
+      const result = await client.listObjectsV2Query(bucket, '', continuationToken, '', 100, '');
+      objectCount += result.objects.length;
+      if (!result.isTruncated) {
+        break;
+      }
+      if (!result.nextContinuationToken) {
+        throw new Error('S3 object listing is truncated without a continuation token');
+      }
+      continuationToken = result.nextContinuationToken;
+    } while (true);
+    process.stdout.write(`${objectCount}\n`);
     return;
   }
   throw new Error('unsupported S3 probe');

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -9,9 +9,14 @@ readonly REDIS_CONTAINER='pawtech-redis'
 readonly TRAEFIK_CONTAINER='pawtech-traefik'
 readonly DATABASE_NAME='buildingos_db'
 readonly APP_DIR='/opt/pawtech/apps/buildingos/buildingos-app'
-readonly BACKUP_ROOT='/opt/pawtech/backups/tmp'
 readonly BACKUP_SCRIPT_PATH='/opt/pawtech/backups/scripts/backup-postgres.sh'
 readonly BACKUP_IDENTITY_MANIFEST_PATH="${APP_DIR}/infra/production/backup-postgres.identity.v1"
+readonly BACKUP_STATE_DIR='/var/lib/buildingos-backup'
+readonly BACKUP_IDENTITY_VERSION='backup-postgres.identity.v1'
+readonly BACKUP_SCRIPT_SHA256='3cbf2bf191bd9a06e7bbf831848cfa2816cd80fca980593f84d3411cb3b14ff5'
+readonly BACKUP_SCRIPT_OWNER='yoryi'
+readonly BACKUP_SCRIPT_GROUP='yoryi'
+readonly BACKUP_SCRIPT_MODE='0775'
 readonly ALLOWED_IGNORED_RUNTIME_ENV='infra/docker/.env'
 readonly EXPECTED_BUCKET='buildingos-production'
 readonly KNOWN_PRODUCTION_BASELINE='20260816000004_legacy_income_application_provenance'
@@ -415,6 +420,11 @@ WHERE p.id IS NULL
    OR p."unitId" IS DISTINCT FROM c."unitId";
 COMMIT;
 SQL
+  report_query_stdin 'NEGATIVE_PAYMENT_ALLOCATIONS' <<'SQL'
+BEGIN READ ONLY;
+SELECT count(*) FROM "PaymentAllocation" WHERE amount < 0;
+COMMIT;
+SQL
   if value="$(readonly_query_stdin <<'SQL'
 BEGIN READ ONLY;
 WITH per_payment AS (
@@ -737,10 +747,6 @@ report_s3_posture() {
   fi
 }
 
-file_mtime() {
-  stat -c '%Y' -- "$1" 2>/dev/null || stat -f '%m' -- "$1"
-}
-
 validate_pg_restore_list() {
   local dump="$1"
 
@@ -752,6 +758,22 @@ validate_pg_restore_list() {
   docker exec -i "$POSTGRES_CONTAINER" pg_restore --list < "$dump" >/dev/null 2>&1
 }
 
+file_owner() {
+  stat -L -c '%U' -- "$1" 2>/dev/null || stat -L -f '%Su' "$1"
+}
+
+file_group() {
+  stat -L -c '%G' -- "$1" 2>/dev/null || stat -L -f '%Sg' "$1"
+}
+
+file_mode() {
+  stat -L -c '%a' -- "$1" 2>/dev/null || stat -L -f '%Lp' "$1"
+}
+
+file_identity() {
+  stat -L -c '%d:%i' -- "$1" 2>/dev/null || stat -L -f '%i' "$1"
+}
+
 manifest_field() {
   local manifest="$1"
   local key="$2"
@@ -759,12 +781,80 @@ manifest_field() {
   awk -F '=' -v key="$key" '$1 == key { print substr($0, index($0, "=") + 1); exit }' "$manifest"
 }
 
+state_field() {
+  local state_file="$1"
+  local key="$2"
+
+  awk -F '=' -v key="$key" '$1 == key { value=substr($0, index($0, "=") + 1); count++; } END { if (count != 1) exit 1; print value }' "$state_file"
+}
+
+parse_epoch() {
+  local timestamp="$1"
+
+  [[ "$timestamp" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || return 1
+  date -u -d "$timestamp" +%s 2>/dev/null || date -j -u -f '%Y-%m-%dT%H:%M:%SZ' "$timestamp" +%s 2>/dev/null
+}
+
+validate_backup_manifest() {
+  local manifest="$1"
+  local expected_manifest manifest_snapshot
+
+  [[ -f "$manifest" && ! -L "$manifest" ]] || return 1
+  manifest_snapshot="$(cat -- "$manifest"; printf '__BUILDINGOS_MANIFEST_END__')" || return 1
+  manifest_snapshot="${manifest_snapshot%__BUILDINGOS_MANIFEST_END__}"
+  printf -v expected_manifest '%s\npath=%s\nsha256=%s\nowner=%s\ngroup=%s\nmode=%s\n' \
+    "version=$BACKUP_IDENTITY_VERSION" "$BACKUP_SCRIPT_PATH" "$BACKUP_SCRIPT_SHA256" \
+    "$BACKUP_SCRIPT_OWNER" "$BACKUP_SCRIPT_GROUP" "$BACKUP_SCRIPT_MODE"
+  [[ "$manifest_snapshot" == "$expected_manifest" ]]
+}
+
+require_canonical_directory_without_symlinks() {
+  local directory="$1"
+  local component current canonical
+  local -a components=()
+
+  [[ "$directory" == /* && "$directory" != '/' && "$directory" != *'//'* && "$directory" != *'/./'* && "$directory" != *'/../'* && "$directory" != */. && "$directory" != */.. && "$directory" != */ ]] || return 1
+  [[ -d "$directory" ]] || return 1
+  IFS='/' read -r -a components <<< "${directory#/}"
+  current=''
+  for component in "${components[@]}"; do
+    [[ -n "$component" ]] || return 1
+    current="$current/$component"
+    [[ ! -L "$current" ]] || return 1
+  done
+  canonical="$(cd -P -- "$directory" && pwd -P)" || return 1
+  [[ "$canonical" == "$directory" ]]
+}
+
+validate_backup_script_file() {
+  local script_path="$1"
+  local parent owner group mode digest identity_before identity_after owner_after group_after mode_after
+
+  [[ "$script_path" == "$BACKUP_SCRIPT_PATH" ]] || return 1
+  parent="${script_path%/*}"
+  require_canonical_directory_without_symlinks "$parent" || return 1
+  [[ -f "$script_path" && ! -L "$script_path" ]] || return 1
+  identity_before="$(file_identity "$script_path")" || return 1
+  owner="$(file_owner "$script_path")" || return 1
+  group="$(file_group "$script_path")" || return 1
+  mode="0$(file_mode "$script_path")" || return 1
+  [[ "$owner" == "$BACKUP_SCRIPT_OWNER" && "$group" == "$BACKUP_SCRIPT_GROUP" && "$mode" == "$BACKUP_SCRIPT_MODE" ]] || return 1
+  digest="$(sha256sum -- "$script_path")" || return 1
+  digest="${digest%% *}"
+  identity_after="$(file_identity "$script_path")" || return 1
+  owner_after="$(file_owner "$script_path")" || return 1
+  group_after="$(file_group "$script_path")" || return 1
+  mode_after="0$(file_mode "$script_path")" || return 1
+  [[ "$identity_before" == "$identity_after" && ! -L "$script_path" && -f "$script_path" ]] || return 1
+  [[ "$owner_after" == "$owner" && "$group_after" == "$group" && "$mode_after" == "$mode" ]] || return 1
+  [[ "$digest" == "$BACKUP_SCRIPT_SHA256" ]]
+}
+
 validate_backup_mechanism() {
   local manifest="$1"
-  local validator="$2"
 
-  [[ -f "$manifest" && ! -L "$manifest" && -x "$validator" ]] || return 1
-  bash "$validator" backup-identity "$manifest" >/dev/null 2>&1
+  validate_backup_manifest "$manifest" || return 1
+  validate_backup_script_file "$BACKUP_SCRIPT_PATH"
 }
 
 format_epoch() {
@@ -772,78 +862,68 @@ format_epoch() {
 }
 
 report_backup_readiness() {
-  local latest_dump=''
-  local latest_mtime=0
-  local candidate mtime checksum_file expected actual now age
+  local state_file="$BACKUP_STATE_DIR/latest.env"
+  local backup_set_id app_sha completed_at completed_epoch now age paired_receipt
   local mechanism_path='UNKNOWN' mechanism_digest='UNKNOWN' mechanism_owner='UNKNOWN' mechanism_group='UNKNOWN' mechanism_mode='UNKNOWN'
-  local mechanism_identity='UNKNOWN' backup_validator restore_result
-  local dump_present='NO'
-  local checksum_present='NO'
-  local checksum_status='NOT_RUN'
-  local restore_status='NOT_RUN'
+  local mechanism_identity='UNKNOWN'
+  local dump_present='NOT_APPLICABLE'
+  local checksum_present='NOT_APPLICABLE'
+  local checksum_status='INCOMPLETE'
+  local restore_status='INCOMPLETE'
   local backup_required='YES'
 
-  if [[ -d "$BACKUP_ROOT" && ! -L "$BACKUP_ROOT" ]]; then
-    while IFS= read -r -d '' candidate; do
-      [[ ! -L "$candidate" ]] || continue
-      mtime="$(file_mtime "$candidate" 2>/dev/null || printf '0')"
-      [[ "$mtime" =~ ^[0-9]+$ ]] || continue
-      if (( mtime > latest_mtime )); then
-        latest_mtime="$mtime"
-        latest_dump="$candidate"
-      fi
-    done < <(find "$BACKUP_ROOT" -mindepth 2 -maxdepth 2 -type f -name 'buildingos_db_*.dump' -print0 2>/dev/null)
-  fi
-
-  if [[ -n "$latest_dump" ]]; then
-    dump_present='YES'
-    checksum_file="$latest_dump.sha256"
-    if [[ -s "$checksum_file" && ! -L "$checksum_file" ]]; then
-      checksum_present='YES'
-      expected=''
-      IFS=' ' read -r expected _ < "$checksum_file" || true
-      if actual="$(sha256sum -- "$latest_dump" 2>/dev/null)"; then
-        actual="${actual%% *}"
+  if [[ -f "$state_file" && ! -L "$state_file" && -r "$state_file" ]]; then
+    if backup_set_id="$(state_field "$state_file" BACKUP_SET_ID)" &&
+      app_sha="$(state_field "$state_file" APP_SHA)" &&
+      completed_at="$(state_field "$state_file" COMPLETED_AT)" &&
+      [[ "$backup_set_id" =~ ^[a-z0-9][a-z0-9._-]{0,95}$ ]] &&
+      [[ "$app_sha" =~ ^[0-9a-f]{40}$ ]] &&
+      completed_epoch="$(parse_epoch "$completed_at")" &&
+      now="$(date -u +%s)" &&
+      age=$((now - completed_epoch)) &&
+      (( age >= 0 && age <= MAX_BACKUP_AGE_SECONDS )); then
+      paired_receipt="$BACKUP_STATE_DIR/paired-$backup_set_id.json"
+      if [[ -f "$paired_receipt" && ! -L "$paired_receipt" && -r "$paired_receipt" ]] &&
+        jq -e --arg backupSetId "$backup_set_id" --arg appSha "$app_sha" '
+          .version == 1 and
+          .status == "PASS" and
+          .backup_set_id == $backupSetId and
+          .app_sha == $appSha and
+          .minio_verified == true and
+          (.postgres_receipt.version == 1) and
+          (.postgres_receipt.status == "PASS") and
+          (.postgres_receipt.backup_set_id == $backupSetId) and
+          (.postgres_receipt.app_sha == $appSha) and
+          (.postgres_receipt.encryption == "SSE-S3") and
+          (.postgres_receipt.postgres_sha256 | type == "string" and test("^[0-9a-f]{64}$")) and
+          (.postgres_receipt.dump_filename | type == "string" and test("^[A-Za-z0-9._-]+$")) and
+          (.postgres_receipt.remote_object_prefix == ("postgresql/" + $backupSetId))
+        ' "$paired_receipt" >/dev/null; then
+        checksum_status='VERIFIED_IN_PAIRED_BACKUP'
+        restore_status='VERIFIED_IN_PAIRED_BACKUP'
+        backup_required='NO'
+        printf 'LATEST_BUILDINGOS_DB_BACKUP_TIMESTAMP=%s\n' "$completed_at"
+        printf 'LATEST_BUILDINGOS_DB_BACKUP_FILE=%s\n' "${paired_receipt##*/}"
+        printf 'BACKUP_AGE_SECONDS=%s\n' "$age"
       else
-        actual='UNKNOWN'
-      fi
-      if [[ "$expected" =~ ^[0-9a-f]{64}$ && "$expected" == "$actual" ]]; then
-        checksum_status='PASS'
-      else
-        checksum_status='FAIL'
         AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
+        printf 'LATEST_BUILDINGOS_DB_BACKUP_TIMESTAMP=UNKNOWN\n'
+        printf 'LATEST_BUILDINGOS_DB_BACKUP_FILE=UNKNOWN\n'
+        printf 'BACKUP_AGE_SECONDS=UNKNOWN\n'
       fi
     else
-      checksum_status='INCOMPLETE'
       AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
+      printf 'LATEST_BUILDINGOS_DB_BACKUP_TIMESTAMP=UNKNOWN\n'
+      printf 'LATEST_BUILDINGOS_DB_BACKUP_FILE=UNKNOWN\n'
+      printf 'BACKUP_AGE_SECONDS=UNKNOWN\n'
     fi
-    if validate_pg_restore_list "$latest_dump"; then
-      restore_status='PASS'
-    else
-      restore_result=$?
-      if [[ "$restore_result" -eq 2 ]]; then
-        restore_status='INCOMPLETE'
-      else
-        restore_status='FAIL'
-      fi
-      AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
-    fi
-    now="$(date -u +%s)"
-    age=$((now - latest_mtime))
-    if (( age >= 0 && age <= MAX_BACKUP_AGE_SECONDS )) && [[ "$checksum_status" == 'PASS' && "$restore_status" == 'PASS' ]]; then
-      backup_required='NO'
-    fi
-    printf 'LATEST_BUILDINGOS_DB_BACKUP_TIMESTAMP=%s\n' "$(format_epoch "$latest_mtime")"
-    printf 'LATEST_BUILDINGOS_DB_BACKUP_FILE=%s\n' "${latest_dump##*/}"
-    printf 'BACKUP_AGE_SECONDS=%s\n' "$age"
   else
     AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
     printf 'LATEST_BUILDINGOS_DB_BACKUP_TIMESTAMP=UNKNOWN\n'
     printf 'LATEST_BUILDINGOS_DB_BACKUP_FILE=UNKNOWN\n'
     printf 'BACKUP_AGE_SECONDS=UNKNOWN\n'
   fi
-  backup_validator="$APP_DIR/scripts/production-security-validate.sh"
-  if validate_backup_mechanism "$BACKUP_IDENTITY_MANIFEST_PATH" "$backup_validator"; then
+  if validate_backup_mechanism "$BACKUP_IDENTITY_MANIFEST_PATH"; then
     mechanism_path="$(manifest_field "$BACKUP_IDENTITY_MANIFEST_PATH" path)"
     mechanism_digest="$(manifest_field "$BACKUP_IDENTITY_MANIFEST_PATH" sha256)"
     mechanism_owner="$(manifest_field "$BACKUP_IDENTITY_MANIFEST_PATH" owner)"
@@ -900,7 +980,7 @@ main() {
     [[ "$url" =~ ^https://[A-Za-z0-9._:/?=%+-]+$ ]] || fail 'public audit URL is not an HTTPS URL'
   done
 
-  for command_name in awk bash curl date docker find git sha256sum stat; do
+  for command_name in awk bash cat curl date docker find git jq sha256sum stat; do
     command -v "$command_name" >/dev/null 2>&1 || fail "$command_name is required"
   done
 

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -211,7 +211,7 @@ report_runtime_identity() {
   printf 'PRODUCTION_CHECKOUT_STATUS=%s\n' "$checkout_status"
   printf 'API_REVISION=%s\n' "$api_revision"
   printf 'WEB_REVISION=%s\n' "$web_revision"
-  if [[ "$api_revision" =~ ^[0-9a-f]{40}$ && "$api_revision" == "$web_revision" ]]; then
+  if [[ "$checkout_status" == 'CLEAN' && "$api_revision" =~ ^[0-9a-f]{40}$ && "$api_revision" == "$web_revision" ]]; then
     printf 'RUNTIME_IDENTITY=CONSISTENT\n'
   else
     printf 'RUNTIME_IDENTITY=UNKNOWN\n'

--- a/scripts/tests/production-readonly-audit-backup.test.sh
+++ b/scripts/tests/production-readonly-audit-backup.test.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly AUDITOR="$ROOT_DIR/scripts/production-readonly-audit.sh"
+readonly TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/buildingos-readonly-audit-backup.XXXXXX")"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+source "$AUDITOR"
+
+dump="$TEST_ROOT/existing.dump"
+printf 'existing custom archive fixture\n' > "$dump"
+
+host_restore_call=''
+pg_restore() {
+  host_restore_call="$*"
+  [[ "$1" == '--list' && "$2" == "$dump" ]]
+}
+validate_pg_restore_list "$dump"
+[[ "$host_restore_call" == "--list $dump" ]]
+unset -f pg_restore
+
+container_call=''
+docker() {
+  case "$1 ${2:-}" in
+    'inspect --type')
+      return 0
+      ;;
+    exec*)
+      container_call="$*"
+      cat >/dev/null
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+PATH="$TEST_ROOT:/usr/bin:/bin" validate_pg_restore_list "$dump"
+[[ "$container_call" == *'exec -i pawtech-postgres pg_restore --list'* ]]
+
+docker() {
+  return 1
+}
+if PATH="$TEST_ROOT:/usr/bin:/bin" validate_pg_restore_list "$dump"; then
+  printf 'FAIL: unavailable pg_restore path unexpectedly passed\n' >&2
+  exit 1
+else
+  [[ "$?" -eq 2 ]]
+fi
+
+manifest="$TEST_ROOT/backup-postgres.identity.v1"
+validator="$TEST_ROOT/production-security-validate.sh"
+printf 'trusted manifest fixture\n' > "$manifest"
+printf '#!/usr/bin/env bash\n[[ "$1" == backup-identity && "$2" == *backup-postgres.identity.v1 ]]\n' > "$validator"
+chmod 700 "$validator"
+validate_backup_mechanism "$manifest" "$validator"
+ln -s "$manifest" "$TEST_ROOT/manifest-link"
+if validate_backup_mechanism "$TEST_ROOT/manifest-link" "$validator"; then
+  printf 'FAIL: symlink manifest unexpectedly passed\n' >&2
+  exit 1
+fi
+
+printf 'PASS: backup validation uses host or PostgreSQL-container pg_restore and rejects unavailable or symlinked evidence\n'

--- a/scripts/tests/production-readonly-audit-backup.test.sh
+++ b/scripts/tests/production-readonly-audit-backup.test.sh
@@ -8,6 +8,10 @@ trap 'rm -rf "$TEST_ROOT"' EXIT
 
 source "$AUDITOR"
 
+auditor_text="$(< "$AUDITOR")"
+[[ "$auditor_text" == *'--arg completedAt "$completed_at"'* ]]
+[[ "$auditor_text" == *'.completed_at == $completedAt'* ]]
+
 dump="$TEST_ROOT/existing.dump"
 printf 'existing custom archive fixture\n' > "$dump"
 

--- a/scripts/tests/production-readonly-audit-backup.test.sh
+++ b/scripts/tests/production-readonly-audit-backup.test.sh
@@ -50,13 +50,12 @@ else
 fi
 
 manifest="$TEST_ROOT/backup-postgres.identity.v1"
-validator="$TEST_ROOT/production-security-validate.sh"
-printf 'trusted manifest fixture\n' > "$manifest"
-printf '#!/usr/bin/env bash\n[[ "$1" == backup-identity && "$2" == *backup-postgres.identity.v1 ]]\n' > "$validator"
-chmod 700 "$validator"
-validate_backup_mechanism "$manifest" "$validator"
+printf 'version=%s\npath=%s\nsha256=%s\nowner=%s\ngroup=%s\nmode=%s\n' \
+  "$BACKUP_IDENTITY_VERSION" "$BACKUP_SCRIPT_PATH" "$BACKUP_SCRIPT_SHA256" \
+  "$BACKUP_SCRIPT_OWNER" "$BACKUP_SCRIPT_GROUP" "$BACKUP_SCRIPT_MODE" > "$manifest"
+validate_backup_manifest "$manifest"
 ln -s "$manifest" "$TEST_ROOT/manifest-link"
-if validate_backup_mechanism "$TEST_ROOT/manifest-link" "$validator"; then
+if validate_backup_manifest "$TEST_ROOT/manifest-link"; then
   printf 'FAIL: symlink manifest unexpectedly passed\n' >&2
   exit 1
 fi

--- a/scripts/tests/production-readonly-audit-backup.test.sh
+++ b/scripts/tests/production-readonly-audit-backup.test.sh
@@ -11,6 +11,8 @@ source "$AUDITOR"
 auditor_text="$(< "$AUDITOR")"
 [[ "$auditor_text" == *'--arg completedAt "$completed_at"'* ]]
 [[ "$auditor_text" == *'.completed_at == $completedAt'* ]]
+[[ "$auditor_text" == *'--arg runtimeAppSha "$RUNTIME_APP_SHA"'* ]]
+[[ "$auditor_text" == *'.app_sha == $runtimeAppSha'* ]]
 
 dump="$TEST_ROOT/existing.dump"
 printf 'existing custom archive fixture\n' > "$dump"

--- a/scripts/tests/production-readonly-audit-cross-currency.test.sh
+++ b/scripts/tests/production-readonly-audit-cross-currency.test.sh
@@ -48,6 +48,6 @@ query="$(< "$captured")"
 [[ "$query" == *'paymentOriginalAmountMinor'* ]]
 [[ "$query" == *'legacy_cross_unverifiable'* ]]
 [[ "$query" == *'has_same_currency'* ]]
-[[ "$query" == *'CHARGE_OVER_ALLOCATIONS'* ]]
+[[ "$query" == *'charge_overallocations'* ]]
 [[ "$query" == *'OVER_ALLOCATIONS'* || "$query" == *'original_consumed'* ]]
 printf 'PASS: cross-currency audit fixture classifications and SQL contract\n'

--- a/scripts/tests/production-readonly-audit-cross-currency.test.sh
+++ b/scripts/tests/production-readonly-audit-cross-currency.test.sh
@@ -47,5 +47,7 @@ report_finance_integrity >/dev/null
 query="$(< "$captured")"
 [[ "$query" == *'paymentOriginalAmountMinor'* ]]
 [[ "$query" == *'legacy_cross_unverifiable'* ]]
+[[ "$query" == *'has_same_currency'* ]]
+[[ "$query" == *'CHARGE_OVER_ALLOCATIONS'* ]]
 [[ "$query" == *'OVER_ALLOCATIONS'* || "$query" == *'original_consumed'* ]]
 printf 'PASS: cross-currency audit fixture classifications and SQL contract\n'

--- a/scripts/tests/production-readonly-audit-cross-currency.test.sh
+++ b/scripts/tests/production-readonly-audit-cross-currency.test.sh
@@ -47,6 +47,7 @@ report_finance_integrity >/dev/null
 query="$(< "$captured")"
 [[ "$query" == *'paymentOriginalAmountMinor'* ]]
 [[ "$query" == *'"paymentOriginalAmountMinor" < 0'* ]]
+[[ "$query" == *'amount <= 0'* ]]
 [[ "$query" == *'legacy_cross_unverifiable'* ]]
 [[ "$query" == *'has_same_currency'* ]]
 [[ "$query" == *'inconsistent_same_currency_share'* ]]

--- a/scripts/tests/production-readonly-audit-cross-currency.test.sh
+++ b/scripts/tests/production-readonly-audit-cross-currency.test.sh
@@ -49,6 +49,8 @@ query="$(< "$captured")"
 [[ "$query" == *'"paymentOriginalAmountMinor" < 0'* ]]
 [[ "$query" == *'legacy_cross_unverifiable'* ]]
 [[ "$query" == *'has_same_currency'* ]]
+[[ "$query" == *'inconsistent_same_currency_share'* ]]
+[[ "$query" == *'paymentOriginalAmountMinor" <> a.amount'* ]]
 [[ "$query" == *'charge_overallocations'* ]]
 [[ "$query" == *'OVER_ALLOCATIONS'* || "$query" == *'original_consumed'* ]]
 printf 'PASS: cross-currency audit fixture classifications and SQL contract\n'

--- a/scripts/tests/production-readonly-audit-cross-currency.test.sh
+++ b/scripts/tests/production-readonly-audit-cross-currency.test.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly AUDITOR="$ROOT_DIR/scripts/production-readonly-audit.sh"
+
+classify_fixture() {
+  local payment_amount="$1"
+  local tenant_match="$2"
+  local charge_currency="$3"
+  local payment_currency="$4"
+  local allocation_amount="$5"
+  local original_amount="$6"
+
+  [[ "$tenant_match" == 'yes' ]] || { printf 'TENANT_MISMATCH_DETECTED\n'; return; }
+  if [[ "$original_amount" == 'NULL' && "$charge_currency" != "$payment_currency" ]]; then
+    printf 'OVER_ALLOCATIONS_UNVERIFIABLE\n'
+    return
+  fi
+  local consumed="$allocation_amount"
+  [[ "$original_amount" == 'NULL' ]] || consumed="$original_amount"
+  if (( consumed > payment_amount )); then
+    printf 'OVER_ALLOCATIONS_DEFINITE\n'
+  else
+    printf 'PASS\n'
+  fi
+}
+
+[[ "$(classify_fixture 10000 yes USD USD 10000 10000)" == 'PASS' ]]
+[[ "$(classify_fixture 10000 yes VES USD 365000 10000)" == 'PASS' ]]
+[[ "$(classify_fixture 10000 yes VES USD 365001 10001)" == 'OVER_ALLOCATIONS_DEFINITE' ]]
+[[ "$(classify_fixture 10000 no VES USD 365000 10000)" == 'TENANT_MISMATCH_DETECTED' ]]
+[[ "$(classify_fixture 10000 yes VES USD 365000 NULL)" == 'OVER_ALLOCATIONS_UNVERIFIABLE' ]]
+
+captured="$(mktemp "${TMPDIR:-/tmp}/buildingos-readonly-audit-cross.XXXXXX")"
+trap 'rm -f "$captured"' EXIT
+docker() {
+  local payload
+  [[ "$1" == 'exec' && "$*" == *'psql'* ]] || return 1
+  payload="$(< /dev/stdin)"
+  printf '%s\n' "$payload" >> "$captured"
+  printf '0|0\n'
+}
+
+source "$AUDITOR"
+report_finance_integrity >/dev/null
+query="$(< "$captured")"
+[[ "$query" == *'paymentOriginalAmountMinor'* ]]
+[[ "$query" == *'legacy_cross_unverifiable'* ]]
+[[ "$query" == *'OVER_ALLOCATIONS'* || "$query" == *'original_consumed'* ]]
+printf 'PASS: cross-currency audit fixture classifications and SQL contract\n'

--- a/scripts/tests/production-readonly-audit-cross-currency.test.sh
+++ b/scripts/tests/production-readonly-audit-cross-currency.test.sh
@@ -46,6 +46,7 @@ source "$AUDITOR"
 report_finance_integrity >/dev/null
 query="$(< "$captured")"
 [[ "$query" == *'paymentOriginalAmountMinor'* ]]
+[[ "$query" == *'"paymentOriginalAmountMinor" < 0'* ]]
 [[ "$query" == *'legacy_cross_unverifiable'* ]]
 [[ "$query" == *'has_same_currency'* ]]
 [[ "$query" == *'charge_overallocations'* ]]

--- a/scripts/tests/production-readonly-audit-health.test.sh
+++ b/scripts/tests/production-readonly-audit-health.test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly AUDITOR="$ROOT_DIR/scripts/production-readonly-audit.sh"
+source "$AUDITOR"
+CANDIDATE_SHA='0000000000000000000000000000000000000000'
+API_READYZ_URL='https://example.invalid/readyz'
+
+docker() {
+  return 1
+}
+
+AUDIT_EVIDENCE_FAILURES=0
+report_container_health API missing-container >/dev/null
+[[ "$AUDIT_EVIDENCE_FAILURES" -eq 1 ]]
+
+container_revision() {
+  return 1
+}
+
+AUDIT_EVIDENCE_FAILURES=0
+report_runtime_identity >/dev/null
+[[ "$AUDIT_EVIDENCE_FAILURES" -eq 1 ]]
+
+curl() {
+  return 1
+}
+
+AUDIT_EVIDENCE_FAILURES=0
+public_get_status PUBLIC_API_HEALTH https://example.invalid/health >/dev/null
+[[ "$AUDIT_EVIDENCE_FAILURES" -eq 1 ]]
+
+AUDIT_EVIDENCE_FAILURES=0
+public_readyz_status >/dev/null
+[[ "$AUDIT_EVIDENCE_FAILURES" -eq 1 ]]
+
+printf 'PASS: container, runtime identity, health, and readyz failures fail closed\n'

--- a/scripts/tests/production-readonly-audit-manifest.test.sh
+++ b/scripts/tests/production-readonly-audit-manifest.test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+extract_target_applied() {
+  awk -F '=' '/^[[:space:]]*readonly[[:space:]]+TARGET_APPLIED[[:space:]]*=/ { value=$2; gsub(/[[:space:]]/, "", value); gsub(/\047/, "", value); if (value ~ /^[0-9]+$/) { print value; exit } }'
+}
+
+[[ "$(printf '%s\n' 'readonly TARGET_APPLIED=97' | extract_target_applied)" == '97' ]]
+[[ "$(printf '%s\n' "readonly TARGET_APPLIED='98'" | extract_target_applied)" == '98' ]]
+[[ "$(printf '%s\n' 'readonly TARGET_APPLIED = 123' | extract_target_applied)" == '123' ]]
+[[ -z "$(printf '%s\n' 'readonly TARGET_APPLIED=not-a-number' | extract_target_applied)" ]]
+
+printf 'PASS: unquoted, quoted, spaced, and invalid manifest target assignments are handled safely\n'

--- a/scripts/tests/production-readonly-audit-s3.test.sh
+++ b/scripts/tests/production-readonly-audit-s3.test.sh
@@ -11,7 +11,7 @@ S3_MODE='pass'
 docker() {
   case "$*" in
     *'S3_BUCKET'* )
-      printf 'buildingos-production'
+      printf 'S3_BUCKET=buildingos-production'
       ;;
     *'node -e require.resolve'* )
       [[ "$S3_MODE" != 'unavailable' ]] || return 1
@@ -61,7 +61,7 @@ S3_MODE='pass'
 docker() {
   case "$*" in
     *'S3_BUCKET'* )
-      printf 'wrong-production-bucket'
+      printf 'S3_BUCKET=wrong-production-bucket'
       ;;
     *)
       return 1

--- a/scripts/tests/production-readonly-audit-s3.test.sh
+++ b/scripts/tests/production-readonly-audit-s3.test.sh
@@ -10,6 +10,9 @@ trap 'rm -f "$OUTPUT_FILE"' EXIT
 S3_MODE='pass'
 docker() {
   case "$*" in
+    *'S3_BUCKET'* )
+      printf 'buildingos-production'
+      ;;
     *'node -e require.resolve'* )
       [[ "$S3_MODE" != 'unavailable' ]] || return 1
       ;;
@@ -53,4 +56,20 @@ report_s3_posture > "$OUTPUT_FILE"
 unavailable_output="$(< "$OUTPUT_FILE")"
 [[ "$unavailable_output" == *'S3_DEEP_AUDIT_UNAVAILABLE'* ]]
 [[ "$unavailable_output" == *'S3_DEEP_AUDIT=INCOMPLETE'* ]]
+
+S3_MODE='pass'
+docker() {
+  case "$*" in
+    *'S3_BUCKET'* )
+      printf 'wrong-production-bucket'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+report_s3_posture > "$OUTPUT_FILE"
+wrong_bucket_output="$(< "$OUTPUT_FILE")"
+[[ "$wrong_bucket_output" == *'S3_DEEP_AUDIT=INCOMPLETE'* ]]
+[[ "$wrong_bucket_output" != *'S3_DEEP_AUDIT=PASS'* ]]
 printf 'PASS: S3 deep audit PASS, INCOMPLETE, FAIL, and unavailable states fail closed\n'

--- a/scripts/tests/production-readonly-audit-s3.test.sh
+++ b/scripts/tests/production-readonly-audit-s3.test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly AUDITOR="$ROOT_DIR/scripts/production-readonly-audit.sh"
+source "$AUDITOR"
+readonly OUTPUT_FILE="$(mktemp "${TMPDIR:-/tmp}/buildingos-readonly-audit-s3.XXXXXX")"
+trap 'rm -f "$OUTPUT_FILE"' EXIT
+
+S3_MODE='pass'
+docker() {
+  case "$*" in
+    *'command -v aws'* )
+      [[ "$S3_MODE" != 'unavailable' ]] || return 1
+      printf 'available'
+      ;;
+    *'head-bucket'* )
+      [[ "$S3_MODE" != 'head-fail' ]] || return 1
+      ;;
+    *'get-bucket-versioning'* )
+      [[ "$S3_MODE" != 'partial' ]] || return 1
+      printf 'Enabled'
+      ;;
+    *'list-objects-v2'* )
+      [[ "$S3_MODE" != 'partial' ]] || return 1
+      printf '3'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+report_s3_posture > "$OUTPUT_FILE"
+pass_output="$(< "$OUTPUT_FILE")"
+[[ "$pass_output" == *'S3_DEEP_AUDIT=PASS'* ]]
+[[ "$pass_output" != *'S3_DEEP_AUDIT=INCOMPLETE'* ]]
+
+S3_MODE='partial'
+report_s3_posture > "$OUTPUT_FILE"
+partial_output="$(< "$OUTPUT_FILE")"
+[[ "$partial_output" == *'S3_DEEP_AUDIT=INCOMPLETE'* ]]
+[[ "$partial_output" != *'S3_DEEP_AUDIT=PASS'* ]]
+[[ "$AUDIT_EVIDENCE_FAILURES" -gt 0 ]]
+
+S3_MODE='head-fail'
+report_s3_posture > "$OUTPUT_FILE"
+head_output="$(< "$OUTPUT_FILE")"
+[[ "$head_output" == *'S3_DEEP_AUDIT=FAIL'* ]]
+[[ "$head_output" != *'S3_DEEP_AUDIT=PASS'* ]]
+
+S3_MODE='unavailable'
+report_s3_posture > "$OUTPUT_FILE"
+unavailable_output="$(< "$OUTPUT_FILE")"
+[[ "$unavailable_output" == *'S3_DEEP_AUDIT_UNAVAILABLE'* ]]
+[[ "$unavailable_output" == *'S3_DEEP_AUDIT=INCOMPLETE'* ]]
+printf 'PASS: S3 deep audit PASS, INCOMPLETE, FAIL, and unavailable states fail closed\n'

--- a/scripts/tests/production-readonly-audit-s3.test.sh
+++ b/scripts/tests/production-readonly-audit-s3.test.sh
@@ -10,18 +10,17 @@ trap 'rm -f "$OUTPUT_FILE"' EXIT
 S3_MODE='pass'
 docker() {
   case "$*" in
-    *'command -v aws'* )
+    *'node -e require.resolve'* )
       [[ "$S3_MODE" != 'unavailable' ]] || return 1
-      printf 'available'
       ;;
-    *'head-bucket'* )
+    *'node - head'* )
       [[ "$S3_MODE" != 'head-fail' ]] || return 1
       ;;
-    *'get-bucket-versioning'* )
+    *'node - versioning'* )
       [[ "$S3_MODE" != 'partial' ]] || return 1
       printf 'Enabled'
       ;;
-    *'list-objects-v2'* )
+    *'node - objects'* )
       [[ "$S3_MODE" != 'partial' ]] || return 1
       printf '3'
       ;;

--- a/scripts/tests/production-readonly-audit-sql-transport.test.sh
+++ b/scripts/tests/production-readonly-audit-sql-transport.test.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly AUDITOR="$ROOT_DIR/scripts/production-readonly-audit.sh"
+readonly TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/buildingos-readonly-audit-sql.XXXXXX")"
+readonly CAPTURE_FILE="$TEST_ROOT/psql-stdin"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+# Replace only the transport boundary. The payload below is the exact stdin
+# that the real helper would pass to psql.
+docker() {
+  local payload
+  [[ "$1" == 'exec' && "$*" == *'psql'* ]] || return 1
+  payload="$(< /dev/stdin)"
+  printf '%s\n' "$payload" >> "$CAPTURE_FILE"
+  if [[ "$payload" == *'information_schema.columns'* ]]; then
+    printf 'YES\n'
+  elif [[ "$payload" == *'FROM "Tenant"'* ]]; then
+    printf '2|3\n'
+  elif [[ "$payload" == *'string_agg(bucket'* ]]; then
+    printf 'buildingos-production:1\n'
+  elif [[ "$payload" == *'TARGET_MIGRATION'* ]]; then
+    printf 'APPLIED\n'
+  else
+    printf '1\n'
+  fi
+}
+
+source "$AUDITOR"
+
+readonly_query_stdin >/dev/null <<'SQL'
+BEGIN READ ONLY;
+SELECT CASE WHEN count(*) = 6 THEN 'YES' ELSE 'NO' END
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'Payment';
+SELECT 'READY' || 'PENDING' || 'FAILED';
+SELECT 'SUBMITTED' || 'APPROVED' || 'RECONCILED' || 'RECEIPT_GENERATED';
+COMMIT;
+SQL
+
+report_migrations_and_schema >/dev/null
+report_finance_counts >/dev/null
+report_tenant_classification >/dev/null
+report_storage_database_buckets >/dev/null
+
+received="$(< "$CAPTURE_FILE")"
+for literal in "'YES'" "'NO'" "'public'" "'Payment'" "'READY'" "'PENDING'" "'FAILED'" "'SUBMITTED'" "'APPROVED'" "'RECONCILED'" "'RECEIPT_GENERATED'"; do
+  [[ "$received" == *"$literal"* ]] || {
+    printf 'FAIL: mocked psql stdin lost SQL literal %s\n' "$literal" >&2
+    exit 1
+  }
+done
+[[ "$received" == BEGIN\ READ\ ONLY\;*COMMIT\;* ]]
+printf 'PASS: SQL literals reach mocked psql stdin unchanged\n'

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -88,10 +88,11 @@ if (!auditorText.includes('EXPECTED_AUTHORITATIVE_BUCKET') || !auditorText.inclu
 if (!auditorText.includes('TENANT_REAL_BUSINESS=UNKNOWN')) throw new Error('real-business classification must fail closed');
 if (!auditorText.includes('TARGET_MIGRATION_STATUS')) throw new Error('target migration state must be reported');
 if (auditorText.includes("'CURRENCY_MISMATCHES'")) throw new Error('cross-currency audit must not use the old unconditional mismatch metric');
-for (const metric of ['OVER_ALLOCATIONS_DEFINITE', 'OVER_ALLOCATIONS_UNVERIFIABLE', 'OVER_ALLOCATIONS_FUNCTIONAL_DEFINITE', 'OVER_ALLOCATIONS_FUNCTIONAL_UNVERIFIABLE', 'CURRENCY_MISMATCHES_DEFINITE', 'CURRENCY_MISMATCHES_UNVERIFIABLE']) {
+for (const metric of ['OVER_ALLOCATIONS_DEFINITE', 'OVER_ALLOCATIONS_UNVERIFIABLE', 'INCONSISTENT_SAME_CURRENCY_SHARES', 'OVER_ALLOCATIONS_FUNCTIONAL_DEFINITE', 'OVER_ALLOCATIONS_FUNCTIONAL_UNVERIFIABLE', 'CURRENCY_MISMATCHES_DEFINITE', 'CURRENCY_MISMATCHES_UNVERIFIABLE']) {
   if (!auditorText.includes(metric)) throw new Error(`missing cross-currency metric ${metric}`);
 }
 if (!auditorText.includes('functional_consumed')) throw new Error('functional-currency consumption must be checked');
+if (!auditorText.includes('inconsistent_same_currency_share') || !auditorText.includes('paymentOriginalAmountMinor" <> a.amount')) throw new Error('same-currency original shares must match charge-side amounts');
 if (!auditorText.includes('production_sha" == "$api_revision"')) throw new Error('checkout and image revisions must match');
 if (!auditorText.includes('status_output="$(git -C "$APP_DIR" status')) throw new Error('git status failures must fail closed');
 if (!auditorText.includes('git -C "$APP_DIR" ls-files --others --ignored --exclude-standard 2>/dev/null')) throw new Error('ignored-file inspection failures must fail closed');
@@ -117,6 +118,7 @@ for (const metric of ['NEGATIVE_PAYMENT_ALLOCATIONS', 'NEGATIVE_PAYMENT_ORIGINAL
 }
 if (!auditorText.includes('"paymentOriginalAmountMinor" < 0')) throw new Error('negative original allocation shares must be audited');
 if (!auditorText.includes('--arg completedAt "$completed_at"') || !auditorText.includes('.completed_at == $completedAt')) throw new Error('paired backup freshness must bind receipt and state timestamps');
+if (!auditorText.includes('RUNTIME_APP_SHA') || !auditorText.includes('.app_sha == $runtimeAppSha')) throw new Error('backup evidence must bind to the verified runtime SHA');
 
 console.log('PASS: production read-only audit workflow and auditor are structurally fail-closed');
 NODE

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -102,6 +102,11 @@ if (!workflowText.includes('CERTIFIED_MIGRATION_COUNT=%s')) throw new Error('mig
 if (workflowText.includes("certified_migration_count == '98'")) throw new Error('audit workflow must not pin a transient migration count');
 if (!auditorText.includes('PUBLIC_READYZ_STATUS')) throw new Error('readiness status must be reported');
 if (!auditorText.includes('p."buildingId" <> c."buildingId"') || !auditorText.includes('p."unitId" IS DISTINCT FROM c."unitId"')) throw new Error('allocation scope relationships must be audited');
+if (!workflowText.includes("awk -F '=' '/^[[:space:]]*readonly[[:space:]]+TARGET_APPLIED[[:space:]]*=/")) throw new Error('manifest target must parse the shell assignment');
+if (!auditorText.includes('validate_pg_restore_list') || !auditorText.includes('docker exec -i "$POSTGRES_CONTAINER" pg_restore --list')) throw new Error('pg_restore validation must use the existing PostgreSQL container when needed');
+if (!auditorText.includes("restore_status='INCOMPLETE'")) throw new Error('unavailable pg_restore validation must be incomplete');
+if (!auditorText.includes('validate_backup_mechanism') || !auditorText.includes('backup-identity')) throw new Error('backup mechanism identity must use the trusted validator');
+if (!auditorText.includes('BACKUP_MECHANISM_OWNER=%s') || !auditorText.includes('BACKUP_MECHANISM_GROUP=%s') || !auditorText.includes('BACKUP_MECHANISM_MODE=%s')) throw new Error('backup mechanism owner, group, and mode must be reported');
 
 console.log('PASS: production read-only audit workflow and auditor are structurally fail-closed');
 NODE

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly WORKFLOW="$ROOT_DIR/.github/workflows/production-readonly-audit.yml"
+readonly AUDITOR="$ROOT_DIR/scripts/production-readonly-audit.sh"
+
+node - "$WORKFLOW" "$AUDITOR" <<'NODE'
+const fs = require('fs');
+const yaml = require('js-yaml');
+
+const [workflowPath, auditorPath] = process.argv.slice(2);
+const workflowText = fs.readFileSync(workflowPath, 'utf8');
+const auditorText = fs.readFileSync(auditorPath, 'utf8');
+const workflow = yaml.load(workflowText);
+const trigger = workflow.on ?? workflow[true];
+
+if (!trigger?.workflow_dispatch || Object.keys(trigger).length !== 1) {
+  throw new Error('audit workflow must be workflow_dispatch only');
+}
+if (trigger.workflow_dispatch.inputs?.candidate_sha?.required !== true || trigger.workflow_dispatch.inputs?.candidate_sha?.type !== 'string') {
+  throw new Error('candidate_sha must be a required string input');
+}
+if (workflow.permissions?.contents !== 'read' || Object.keys(workflow.permissions).length !== 1) {
+  throw new Error('audit workflow must grant contents read only');
+}
+if (workflow.concurrency?.group !== 'production-operations' || workflow.concurrency?.['cancel-in-progress'] !== false) {
+  throw new Error('audit workflow concurrency policy is unsafe');
+}
+
+const job = workflow.jobs?.audit;
+if (job?.environment !== 'production') throw new Error('audit job must use production environment');
+if (!workflowText.includes('[[ "$GITHUB_REF" == "refs/heads/main" ]]')) throw new Error('audit must require refs/heads/main');
+if (!workflowText.includes('bash -s -- ${remote_args[*]}')) throw new Error('audit must stream the auditor to bash -s');
+if (/\b(?:bash|sh)\s+[^\n]*deploy-production\.sh\b/.test(workflowText)) throw new Error('audit workflow must not invoke deployment tooling');
+if (!workflowText.includes('PRODUCTION_SSH_HOST') || !workflowText.includes('PRODUCTION_SSH_USER') || !workflowText.includes('PRODUCTION_SSH_PRIVATE_KEY') || !workflowText.includes('PRODUCTION_SSH_KNOWN_HOSTS')) {
+  throw new Error('audit workflow must use the existing production SSH secrets');
+}
+if (workflowText.includes('echo "$SSH_PRIVATE_KEY"') || workflowText.includes('printf "%s" "$SSH_PRIVATE_KEY"')) {
+  throw new Error('audit workflow must not print the SSH private key');
+}
+
+const forbiddenAuditorPatterns = [
+  /git\s+(fetch|pull|switch|checkout|reset)\b/,
+  /docker\s+compose\s+(up|run|build|pull)\b/,
+  /docker\s+(restart|stop|start|rm)\b/,
+  /prisma\s+(migrate\s+deploy|db\s+push|migrate\s+resolve)\b/,
+  /npm\s+(install|ci)\b/,
+  /\b(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE)\b/,
+  /aws\s+s3\s+(cp|sync|rm)\b/,
+  /aws\s+s3api\s+(put-|delete-)/,
+  /curl\s+(POST|PUT|PATCH|DELETE)\b/,
+  /backup-(buildingos-production|postgres-paired)\.sh/,
+  /\benv\b\s*\|\s*(sort|uniq|sed|awk|cat|tee)/,
+  /printenv\b/,
+  /docker\s+compose\s+.*--force-recreate/,
+  /finance-staging-acceptance(?:\.mjs|\.sh)/,
+];
+for (const pattern of forbiddenAuditorPatterns) {
+  if (pattern.test(auditorText)) throw new Error(`forbidden auditor construct: ${pattern}`);
+}
+
+const safeEnvAllowlist = [
+  'APP_ENV', 'NODE_ENV', 'STORAGE_BACKEND', 'S3_ENDPOINT', 'S3_BUCKET',
+  'S3_FORCE_PATH_STYLE', 'PAYMENT_PROVIDER', 'ENABLE_PAYMENT_WEBHOOKS',
+];
+for (const key of safeEnvAllowlist) {
+  if (!auditorText.includes(key)) throw new Error(`missing safe environment key ${key}`);
+}
+for (const secretName of ['DATABASE_URL', 'JWT_SECRET', 'SMTP_PASS', 'SSH_PRIVATE_KEY']) {
+  if (auditorText.includes(secretName)) throw new Error(`auditor must not read ${secretName}`);
+}
+if (!auditorText.includes('BEGIN READ ONLY;')) throw new Error('database query sessions must begin read only');
+if ((auditorText.match(/psql/g) ?? []).length !== 1) throw new Error('all database queries must use one guarded psql helper');
+if (!auditorText.includes('COMMIT;')) throw new Error('read-only query sessions must terminate explicitly');
+if (!auditorText.includes('pg_restore --list')) throw new Error('existing backups must be inspectable without creation');
+if (!auditorText.includes('S3_DEEP_AUDIT_UNAVAILABLE')) throw new Error('unsupported S3 clients must be reported');
+if (!auditorText.includes('EXPECTED_AUTHORITATIVE_BUCKET') || !auditorText.includes("EXPECTED_BUCKET='buildingos-production'")) throw new Error('authoritative production bucket must be reported');
+if (!auditorText.includes('TENANT_REAL_BUSINESS=UNKNOWN')) throw new Error('real-business classification must fail closed');
+if (!auditorText.includes('TARGET_MIGRATION_STATUS')) throw new Error('target migration state must be reported');
+
+console.log('PASS: production read-only audit workflow and auditor are structurally fail-closed');
+NODE

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -78,6 +78,8 @@ if (auditorText.includes("report_query '") || auditorText.includes('readonly_que
 if (!auditorText.includes('pg_restore --list')) throw new Error('existing backups must be inspectable without creation');
 if (!auditorText.includes('S3_DEEP_AUDIT_UNAVAILABLE')) throw new Error('unsupported S3 clients must be reported');
 if (!auditorText.includes('require.resolve("minio")')) throw new Error('S3 audit must use the runtime MinIO SDK');
+if (!auditorText.includes('docker exec -i "$API_CONTAINER" node')) throw new Error('S3 node probe must receive its stdin script');
+if (!auditorText.includes('nextContinuationToken') || !auditorText.includes('isTruncated')) throw new Error('S3 object audit must paginate fully');
 if (!auditorText.includes('S3_DEEP_AUDIT=INCOMPLETE') || !auditorText.includes('AUDIT_EVIDENCE_FAILURES')) throw new Error('incomplete S3 evidence must fail the overall audit');
 for (const marker of ['RUNTIME_IDENTITY=UNKNOWN', 'PUBLIC_READYZ_HTTP=FAIL', 'AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))']) {
   if (!auditorText.includes(marker)) throw new Error(`missing fail-closed evidence marker ${marker}`);

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -107,6 +107,10 @@ if (!auditorText.includes('validate_pg_restore_list') || !auditorText.includes('
 if (!auditorText.includes("restore_status='INCOMPLETE'")) throw new Error('unavailable pg_restore validation must be incomplete');
 if (!auditorText.includes('validate_backup_mechanism') || !auditorText.includes('backup-identity')) throw new Error('backup mechanism identity must use the trusted validator');
 if (!auditorText.includes('BACKUP_MECHANISM_OWNER=%s') || !auditorText.includes('BACKUP_MECHANISM_GROUP=%s') || !auditorText.includes('BACKUP_MECHANISM_MODE=%s')) throw new Error('backup mechanism owner, group, and mode must be reported');
+if (!auditorText.includes('configured_bucket')) throw new Error('S3 audit must require the authoritative runtime bucket');
+if (!auditorText.includes('has_same_currency')) throw new Error('mixed allocation currency modes must be audited');
+if (!auditorText.includes('CHARGE_OVER_ALLOCATIONS')) throw new Error('charge-side over-allocation must be audited');
+if (!auditorText.includes("checksum_status='INCOMPLETE'")) throw new Error('missing backup checksums must fail closed');
 
 console.log('PASS: production read-only audit workflow and auditor are structurally fail-closed');
 NODE

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -81,7 +81,7 @@ if (!auditorText.includes('require.resolve("minio")')) throw new Error('S3 audit
 if (!auditorText.includes('docker exec -i "$API_CONTAINER" node')) throw new Error('S3 node probe must receive its stdin script');
 if (!auditorText.includes('nextContinuationToken') || !auditorText.includes('isTruncated')) throw new Error('S3 object audit must paginate fully');
 if (!auditorText.includes('S3_DEEP_AUDIT=INCOMPLETE') || !auditorText.includes('AUDIT_EVIDENCE_FAILURES')) throw new Error('incomplete S3 evidence must fail the overall audit');
-for (const marker of ['RUNTIME_IDENTITY=UNKNOWN', 'PUBLIC_READYZ_HTTP=FAIL', 'AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))']) {
+for (const marker of ['checkout_status" == \'CLEAN\'', 'RUNTIME_IDENTITY=UNKNOWN', 'PUBLIC_READYZ_HTTP=FAIL', 'AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))']) {
   if (!auditorText.includes(marker)) throw new Error(`missing fail-closed evidence marker ${marker}`);
 }
 if (!auditorText.includes('EXPECTED_AUTHORITATIVE_BUCKET') || !auditorText.includes("EXPECTED_BUCKET='buildingos-production'")) throw new Error('authoritative production bucket must be reported');

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -105,12 +105,14 @@ if (!auditorText.includes('p."buildingId" <> c."buildingId"') || !auditorText.in
 if (!workflowText.includes("awk -F '=' '/^[[:space:]]*readonly[[:space:]]+TARGET_APPLIED[[:space:]]*=/")) throw new Error('manifest target must parse the shell assignment');
 if (!auditorText.includes('validate_pg_restore_list') || !auditorText.includes('docker exec -i "$POSTGRES_CONTAINER" pg_restore --list')) throw new Error('pg_restore validation must use the existing PostgreSQL container when needed');
 if (!auditorText.includes("restore_status='INCOMPLETE'")) throw new Error('unavailable pg_restore validation must be incomplete');
-if (!auditorText.includes('validate_backup_mechanism') || !auditorText.includes('backup-identity')) throw new Error('backup mechanism identity must use the trusted validator');
+if (!auditorText.includes('validate_backup_mechanism') || !auditorText.includes('validate_backup_manifest') || !auditorText.includes('validate_backup_script_file')) throw new Error('backup mechanism identity must use in-stream validation');
 if (!auditorText.includes('BACKUP_MECHANISM_OWNER=%s') || !auditorText.includes('BACKUP_MECHANISM_GROUP=%s') || !auditorText.includes('BACKUP_MECHANISM_MODE=%s')) throw new Error('backup mechanism owner, group, and mode must be reported');
 if (!auditorText.includes('configured_bucket')) throw new Error('S3 audit must require the authoritative runtime bucket');
 if (!auditorText.includes('has_same_currency')) throw new Error('mixed allocation currency modes must be audited');
 if (!auditorText.includes('CHARGE_OVER_ALLOCATIONS')) throw new Error('charge-side over-allocation must be audited');
 if (!auditorText.includes("checksum_status='INCOMPLETE'")) throw new Error('missing backup checksums must fail closed');
+if (!auditorText.includes('BACKUP_STATE_DIR') || !auditorText.includes('paired-$backup_set_id.json')) throw new Error('backup readiness must use durable paired state');
+if (!auditorText.includes('NEGATIVE_PAYMENT_ALLOCATIONS')) throw new Error('negative allocations must be audited');
 
 console.log('PASS: production read-only audit workflow and auditor are structurally fail-closed');
 NODE

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -97,6 +97,9 @@ if (!auditorText.includes('status_output="$(git -C "$APP_DIR" status')) throw ne
 if (!auditorText.includes('git -C "$APP_DIR" ls-files --others --ignored --exclude-standard 2>/dev/null')) throw new Error('ignored-file inspection failures must fail closed');
 if (!auditorText.includes('WHERE "canceledAt" IS NULL')) throw new Error('canceled charges must not count as duplicate active charges');
 if (!auditorText.includes('ALLOWED_IGNORED_RUNTIME_ENV')) throw new Error('ignored checkout files must use the production allowlist');
+if (!auditorText.includes('BACKUP_CHECKSUM_VERIFICATION=%s')) throw new Error('backup checksum state must be reported');
+if (!workflowText.includes('CERTIFIED_MIGRATION_COUNT=%s')) throw new Error('migration observation must be derived dynamically');
+if (workflowText.includes("certified_migration_count == '98'")) throw new Error('audit workflow must not pin a transient migration count');
 
 console.log('PASS: production read-only audit workflow and auditor are structurally fail-closed');
 NODE

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -112,7 +112,11 @@ if (!auditorText.includes('has_same_currency')) throw new Error('mixed allocatio
 if (!auditorText.includes('CHARGE_OVER_ALLOCATIONS')) throw new Error('charge-side over-allocation must be audited');
 if (!auditorText.includes("checksum_status='INCOMPLETE'")) throw new Error('missing backup checksums must fail closed');
 if (!auditorText.includes('BACKUP_STATE_DIR') || !auditorText.includes('paired-$backup_set_id.json')) throw new Error('backup readiness must use durable paired state');
-if (!auditorText.includes('NEGATIVE_PAYMENT_ALLOCATIONS')) throw new Error('negative allocations must be audited');
+for (const metric of ['NEGATIVE_PAYMENT_ALLOCATIONS', 'NEGATIVE_PAYMENT_ORIGINAL_ALLOCATIONS']) {
+  if (!auditorText.includes(metric)) throw new Error(`missing negative allocation metric ${metric}`);
+}
+if (!auditorText.includes('"paymentOriginalAmountMinor" < 0')) throw new Error('negative original allocation shares must be audited');
+if (!auditorText.includes('--arg completedAt "$completed_at"') || !auditorText.includes('.completed_at == $completedAt')) throw new Error('paired backup freshness must bind receipt and state timestamps');
 
 console.log('PASS: production read-only audit workflow and auditor are structurally fail-closed');
 NODE

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -70,14 +70,21 @@ for (const key of safeEnvAllowlist) {
 for (const secretName of ['DATABASE_URL', 'JWT_SECRET', 'SMTP_PASS', 'SSH_PRIVATE_KEY']) {
   if (auditorText.includes(secretName)) throw new Error(`auditor must not read ${secretName}`);
 }
+if (!auditorText.includes('readonly_query_stdin')) throw new Error('database queries must use stdin transport');
 if (!auditorText.includes('BEGIN READ ONLY;')) throw new Error('database query sessions must begin read only');
 if ((auditorText.match(/psql/g) ?? []).length !== 1) throw new Error('all database queries must use one guarded psql helper');
 if (!auditorText.includes('COMMIT;')) throw new Error('read-only query sessions must terminate explicitly');
+if (auditorText.includes("report_query '") || auditorText.includes('readonly_query ')) throw new Error('fragile SQL argument transport must not remain');
 if (!auditorText.includes('pg_restore --list')) throw new Error('existing backups must be inspectable without creation');
 if (!auditorText.includes('S3_DEEP_AUDIT_UNAVAILABLE')) throw new Error('unsupported S3 clients must be reported');
+if (!auditorText.includes('S3_DEEP_AUDIT=INCOMPLETE') || !auditorText.includes('AUDIT_EVIDENCE_FAILURES')) throw new Error('incomplete S3 evidence must fail the overall audit');
 if (!auditorText.includes('EXPECTED_AUTHORITATIVE_BUCKET') || !auditorText.includes("EXPECTED_BUCKET='buildingos-production'")) throw new Error('authoritative production bucket must be reported');
 if (!auditorText.includes('TENANT_REAL_BUSINESS=UNKNOWN')) throw new Error('real-business classification must fail closed');
 if (!auditorText.includes('TARGET_MIGRATION_STATUS')) throw new Error('target migration state must be reported');
+if (auditorText.includes("'CURRENCY_MISMATCHES'")) throw new Error('cross-currency audit must not use the old unconditional mismatch metric');
+for (const metric of ['OVER_ALLOCATIONS_DEFINITE', 'OVER_ALLOCATIONS_UNVERIFIABLE', 'CURRENCY_MISMATCHES_DEFINITE', 'CURRENCY_MISMATCHES_UNVERIFIABLE']) {
+  if (!auditorText.includes(metric)) throw new Error(`missing cross-currency metric ${metric}`);
+}
 
 console.log('PASS: production read-only audit workflow and auditor are structurally fail-closed');
 NODE

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -93,6 +93,7 @@ for (const metric of ['OVER_ALLOCATIONS_DEFINITE', 'OVER_ALLOCATIONS_UNVERIFIABL
 }
 if (!auditorText.includes('functional_consumed')) throw new Error('functional-currency consumption must be checked');
 if (!auditorText.includes('inconsistent_same_currency_share') || !auditorText.includes('paymentOriginalAmountMinor" <> a.amount')) throw new Error('same-currency original shares must match charge-side amounts');
+if (!auditorText.includes('has_legacy_cross_currency') || !auditorText.includes('has_conversion_metadata')) throw new Error('legacy cross-currency classification must be exclusive');
 if (!auditorText.includes('production_sha" == "$api_revision"')) throw new Error('checkout and image revisions must match');
 if (!auditorText.includes('status_output="$(git -C "$APP_DIR" status')) throw new Error('git status failures must fail closed');
 if (!auditorText.includes('git -C "$APP_DIR" ls-files --others --ignored --exclude-standard 2>/dev/null')) throw new Error('ignored-file inspection failures must fail closed');
@@ -119,6 +120,7 @@ for (const metric of ['NEGATIVE_PAYMENT_ALLOCATIONS', 'NEGATIVE_PAYMENT_ORIGINAL
 if (!auditorText.includes('"paymentOriginalAmountMinor" < 0')) throw new Error('negative original allocation shares must be audited');
 if (!auditorText.includes('--arg completedAt "$completed_at"') || !auditorText.includes('.completed_at == $completedAt')) throw new Error('paired backup freshness must bind receipt and state timestamps');
 if (!auditorText.includes('RUNTIME_APP_SHA') || !auditorText.includes('.app_sha == $runtimeAppSha')) throw new Error('backup evidence must bind to the verified runtime SHA');
+if (!auditorText.includes('versioning" == \'Enabled\'')) throw new Error('S3 audit must require enabled versioning');
 
 console.log('PASS: production read-only audit workflow and auditor are structurally fail-closed');
 NODE

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -77,7 +77,11 @@ if (!auditorText.includes('COMMIT;')) throw new Error('read-only query sessions 
 if (auditorText.includes("report_query '") || auditorText.includes('readonly_query ')) throw new Error('fragile SQL argument transport must not remain');
 if (!auditorText.includes('pg_restore --list')) throw new Error('existing backups must be inspectable without creation');
 if (!auditorText.includes('S3_DEEP_AUDIT_UNAVAILABLE')) throw new Error('unsupported S3 clients must be reported');
+if (!auditorText.includes('require.resolve("minio")')) throw new Error('S3 audit must use the runtime MinIO SDK');
 if (!auditorText.includes('S3_DEEP_AUDIT=INCOMPLETE') || !auditorText.includes('AUDIT_EVIDENCE_FAILURES')) throw new Error('incomplete S3 evidence must fail the overall audit');
+for (const marker of ['RUNTIME_IDENTITY=UNKNOWN', 'PUBLIC_READYZ_HTTP=FAIL', 'AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))']) {
+  if (!auditorText.includes(marker)) throw new Error(`missing fail-closed evidence marker ${marker}`);
+}
 if (!auditorText.includes('EXPECTED_AUTHORITATIVE_BUCKET') || !auditorText.includes("EXPECTED_BUCKET='buildingos-production'")) throw new Error('authoritative production bucket must be reported');
 if (!auditorText.includes('TENANT_REAL_BUSINESS=UNKNOWN')) throw new Error('real-business classification must fail closed');
 if (!auditorText.includes('TARGET_MIGRATION_STATUS')) throw new Error('target migration state must be reported');

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -100,6 +100,8 @@ if (!auditorText.includes('ALLOWED_IGNORED_RUNTIME_ENV')) throw new Error('ignor
 if (!auditorText.includes('BACKUP_CHECKSUM_VERIFICATION=%s')) throw new Error('backup checksum state must be reported');
 if (!workflowText.includes('CERTIFIED_MIGRATION_COUNT=%s')) throw new Error('migration observation must be derived dynamically');
 if (workflowText.includes("certified_migration_count == '98'")) throw new Error('audit workflow must not pin a transient migration count');
+if (!auditorText.includes('PUBLIC_READYZ_STATUS')) throw new Error('readiness status must be reported');
+if (!auditorText.includes('p."buildingId" <> c."buildingId"') || !auditorText.includes('p."unitId" IS DISTINCT FROM c."unitId"')) throw new Error('allocation scope relationships must be audited');
 
 console.log('PASS: production read-only audit workflow and auditor are structurally fail-closed');
 NODE

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -88,9 +88,12 @@ if (!auditorText.includes('EXPECTED_AUTHORITATIVE_BUCKET') || !auditorText.inclu
 if (!auditorText.includes('TENANT_REAL_BUSINESS=UNKNOWN')) throw new Error('real-business classification must fail closed');
 if (!auditorText.includes('TARGET_MIGRATION_STATUS')) throw new Error('target migration state must be reported');
 if (auditorText.includes("'CURRENCY_MISMATCHES'")) throw new Error('cross-currency audit must not use the old unconditional mismatch metric');
-for (const metric of ['OVER_ALLOCATIONS_DEFINITE', 'OVER_ALLOCATIONS_UNVERIFIABLE', 'CURRENCY_MISMATCHES_DEFINITE', 'CURRENCY_MISMATCHES_UNVERIFIABLE']) {
+for (const metric of ['OVER_ALLOCATIONS_DEFINITE', 'OVER_ALLOCATIONS_UNVERIFIABLE', 'OVER_ALLOCATIONS_FUNCTIONAL_DEFINITE', 'OVER_ALLOCATIONS_FUNCTIONAL_UNVERIFIABLE', 'CURRENCY_MISMATCHES_DEFINITE', 'CURRENCY_MISMATCHES_UNVERIFIABLE']) {
   if (!auditorText.includes(metric)) throw new Error(`missing cross-currency metric ${metric}`);
 }
+if (!auditorText.includes('functional_consumed')) throw new Error('functional-currency consumption must be checked');
+if (!auditorText.includes('production_sha" == "$api_revision"')) throw new Error('checkout and image revisions must match');
+if (!auditorText.includes('ALLOWED_IGNORED_RUNTIME_ENV')) throw new Error('ignored checkout files must use the production allowlist');
 
 console.log('PASS: production read-only audit workflow and auditor are structurally fail-closed');
 NODE

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -118,6 +118,7 @@ for (const metric of ['NEGATIVE_PAYMENT_ALLOCATIONS', 'NEGATIVE_PAYMENT_ORIGINAL
   if (!auditorText.includes(metric)) throw new Error(`missing negative allocation metric ${metric}`);
 }
 if (!auditorText.includes('"paymentOriginalAmountMinor" < 0')) throw new Error('negative original allocation shares must be audited');
+if (!auditorText.includes('WHERE amount <= 0')) throw new Error('zero-value allocations must be audited');
 if (!auditorText.includes('--arg completedAt "$completed_at"') || !auditorText.includes('.completed_at == $completedAt')) throw new Error('paired backup freshness must bind receipt and state timestamps');
 if (!auditorText.includes('RUNTIME_APP_SHA') || !auditorText.includes('.app_sha == $runtimeAppSha')) throw new Error('backup evidence must bind to the verified runtime SHA');
 if (!auditorText.includes('versioning" == \'Enabled\'')) throw new Error('S3 audit must require enabled versioning');

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -93,6 +93,9 @@ for (const metric of ['OVER_ALLOCATIONS_DEFINITE', 'OVER_ALLOCATIONS_UNVERIFIABL
 }
 if (!auditorText.includes('functional_consumed')) throw new Error('functional-currency consumption must be checked');
 if (!auditorText.includes('production_sha" == "$api_revision"')) throw new Error('checkout and image revisions must match');
+if (!auditorText.includes('status_output="$(git -C "$APP_DIR" status')) throw new Error('git status failures must fail closed');
+if (!auditorText.includes('git -C "$APP_DIR" ls-files --others --ignored --exclude-standard 2>/dev/null')) throw new Error('ignored-file inspection failures must fail closed');
+if (!auditorText.includes('WHERE "canceledAt" IS NULL')) throw new Error('canceled charges must not count as duplicate active charges');
 if (!auditorText.includes('ALLOWED_IGNORED_RUNTIME_ENV')) throw new Error('ignored checkout files must use the production allowlist');
 
 console.log('PASS: production read-only audit workflow and auditor are structurally fail-closed');


### PR DESCRIPTION
## Summary
- Adds a separate protected production read-only audit workflow.
- Streams a fail-closed auditor over SSH without persisting files on production.
- Adds structural safety coverage for workflow and auditor guarantees.

## Safety
- No production run performed.
- No secrets added.
- No deployment path weakened.
- Audit workflow is separate from the deploy workflow.
- Migration tooling 97->98 incompatibility is observed but not changed.

## Validation
- YAML parse passed.
- Shell syntax passed.
- Read-only structural safety test passed.
- Existing production hardening tests passed except the known migration-manifest verifier, which still enforces TARGET_APPLIED=97 against the certified 98-migration tree.
- No production audit, deployment, migration, database write, storage write, or environment change performed.

Do not merge until exact-head CI and Codex review requirements are satisfied.