### PR TITLE
fix(prod): harden backup activation readiness

### DIFF
--- a/docs/runbooks/PRODUCTION_BACKUP_ACTIVATION.md
+++ b/docs/runbooks/PRODUCTION_BACKUP_ACTIVATION.md
@@ -30,10 +30,11 @@ those commands automatically.
   `ListBucket`. It uses presigned URLs and authenticated API streams. The public
   S3 endpoint and required CORS must remain available for presigned browser
   operations.
-- Production currently runs `c987eacdfe5e9f5b3772d498bb1b4fd77859dfdc`,
-  behind repository main `b1a3dd8e14cd9e98e4ac81fe52a6162680343d22`.
-  Activation cannot be claimed until an approved exact SHA containing these
-  artifacts is deployed and API/Web OCI revision labels agree.
+- At execution time, discover the actual production runtime SHA from the
+  running API/Web OCI revision labels. Activation requires those labels to
+  agree with each other and with the explicitly approved candidate SHA.
+  Never infer the deployment candidate from a branch name or the current
+  `main` ref; record the approved exact SHA in the activation evidence.
 - The repository did not contain the bytes of the legacy production-only
   `/opt/pawtech/backups/scripts/backup-postgres.sh`. Its v1 identity remains
   pinned for the existing deploy preflight. Activation installs the separate

--- a/infra/production/buildingos-backup.env.example
+++ b/infra/production/buildingos-backup.env.example
@@ -1,7 +1,7 @@
 # Install as /etc/buildingos/buildingos-backup.env with root:root mode 0600.
 SOURCE_ENVIRONMENT=production
 EXPECTED_SOURCE_ENVIRONMENT=production
-SOURCE_ENDPOINT=https://<internal-minio-endpoint>
+SOURCE_ENDPOINT=https://usc1.contabostorage.com
 SOURCE_ACCESS_KEY=<source-read-access-key>
 SOURCE_SECRET_KEY=<source-read-secret-key>
 SOURCE_BUCKET=buildingos-production

--- a/scripts/production-backup-preflight.sh
+++ b/scripts/production-backup-preflight.sh
@@ -2,7 +2,6 @@
 set -Eeuo pipefail
 set +x
 
-readonly EXPECTED_RUNTIME_SHA='db82d3d37fc6184a6d4063709b9a15b923371695'
 readonly DEFAULT_APP_DIR='/opt/pawtech/apps/buildingos/buildingos-app'
 readonly EXPECTED_BACKUP_SERVICE='pawtech-buildingos-backup.service'
 readonly EXPECTED_VERIFY_SERVICE='pawtech-buildingos-backup-verify.service'
@@ -22,6 +21,7 @@ readonly MAX_INT64_DIV_1024=9007199254740991
 readonly MAX_POSTGRES_ESTIMATE_BASE_BYTES=6000000000000000000
 
 failures=0
+ENV_FILE_AVAILABLE=false
 
 if ! declare -F endpoint_identity >/dev/null 2>&1; then
   helper_dir="${BASH_SOURCE[0]%/*}"
@@ -445,7 +445,7 @@ inspect_runtime() {
   printf 'API_REVISION=%s\n' "$(safe_output "$api_revision")"
   printf 'WEB_REVISION=%s\n' "$(safe_output "$web_revision")"
   printf 'PRODUCTION_CHECKOUT_STATUS=%s\n' "$checkout_status"
-  if [[ "$production_sha" == "$EXPECTED_RUNTIME_SHA" && "$api_revision" == "$EXPECTED_RUNTIME_SHA" && "$web_revision" == "$EXPECTED_RUNTIME_SHA" && "$checkout_status" == CLEAN ]]; then
+  if [[ "$production_sha" == "$CANDIDATE_SHA" && "$api_revision" == "$CANDIDATE_SHA" && "$web_revision" == "$CANDIDATE_SHA" && "$checkout_status" == CLEAN ]]; then
     printf 'RUNTIME_IDENTITY=CONSISTENT\n'
   else
     printf 'RUNTIME_IDENTITY=INCONSISTENT\n'
@@ -488,6 +488,7 @@ inspect_environment() {
   )
 
   if file_is_regular_non_symlink "$ENV_FILE"; then
+    ENV_FILE_AVAILABLE=true
     owner="$(file_owner "$ENV_FILE")"
     group="$(file_group "$ENV_FILE")"
     mode="0$(file_mode "$ENV_FILE")"
@@ -507,6 +508,8 @@ inspect_environment() {
     printf 'REQUIRED_ENV_NAMES_PRESENT=YES\n'
   else
     printf 'REQUIRED_ENV_NAMES_PRESENT=NO\n'
+    ENV_FILE_AVAILABLE=false
+    return
   fi
 
   source_environment="$(env_value "$ENV_FILE" SOURCE_ENVIRONMENT 2>/dev/null || true)"
@@ -590,6 +593,44 @@ inspect_environment() {
   printf 'POSTGRES_RCLONE_WRITE_DESTINATION=%s\n' "$(safe_output "$write_destination")"
   printf 'POSTGRES_RCLONE_VERIFY_DESTINATION=%s\n' "$(safe_output "$verify_destination")"
   printf 'BACKUP_PREFIX_VALID=%s\n' "$prefix_valid"
+}
+
+emit_unavailable_environment_outputs() {
+  printf 'SOURCE_ENVIRONMENT=UNKNOWN\n'
+  printf 'EXPECTED_SOURCE_ENVIRONMENT=UNKNOWN\n'
+  printf 'SOURCE_ENDPOINT_HOSTNAME=UNKNOWN\n'
+  printf 'SOURCE_BUCKET=UNKNOWN\n'
+  printf 'BACKUP_ENDPOINT_HOSTNAME=UNKNOWN\n'
+  printf 'BACKUP_BUCKET=UNKNOWN\n'
+  printf 'SOURCE_AND_BACKUP_SEPARATE=UNKNOWN\n'
+  printf 'DEPLOYED_RUNTIME_SOURCE_AND_BACKUP_SEPARATE=UNKNOWN\n'
+  printf 'BACKUP_STATE_DIR_MATCH=UNKNOWN\n'
+  printf 'POSTGRES_CONTAINER=UNKNOWN\n'
+  printf 'POSTGRES_DATABASE=UNKNOWN\n'
+  printf 'POSTGRES_USER=UNKNOWN\n'
+  printf 'POSTGRES_BACKUP_ROOT=UNKNOWN\n'
+  printf 'POSTGRES_SSE_MODE=UNKNOWN\n'
+  printf 'POSTGRES_RCLONE_WRITE_DESTINATION=UNKNOWN\n'
+  printf 'POSTGRES_RCLONE_VERIFY_DESTINATION=UNKNOWN\n'
+  printf 'BACKUP_PREFIX_VALID=UNKNOWN\n'
+  printf 'SSE_EVIDENCE_VALID=UNKNOWN\n'
+  printf 'SSE_STATUS=UNKNOWN\n'
+  printf 'SSE_ALGORITHM=UNKNOWN\n'
+  printf 'SSE_PATH_MATCH=UNKNOWN\n'
+  printf 'SSE_PROBED_AT_VALID=UNKNOWN\n'
+  printf 'SSE_ENDPOINT_MATCH=UNKNOWN\n'
+  printf 'DEPLOYED_RUNTIME_SSE_ENDPOINT_MATCH=UNKNOWN\n'
+  printf 'SSE_BUCKET_MATCH=UNKNOWN\n'
+  printf 'POSTGRES_CONTAINER_STATE=UNKNOWN\n'
+  printf 'POSTGRES_CONTAINER_HEALTH=UNKNOWN\n'
+  printf 'POSTGRES_BACKUP_ROOT_FREE_BYTES=UNKNOWN\n'
+  printf 'POSTGRES_DATABASE_SIZE_BYTES=UNKNOWN\n'
+  printf 'POSTGRES_BACKUP_SAFETY_MARGIN_BYTES=UNKNOWN\n'
+  printf 'POSTGRES_BACKUP_REQUIRED_BYTES=UNKNOWN\n'
+  printf 'POSTGRES_BACKUP_SPACE_SAFE=UNKNOWN\n'
+  printf 'TMP_FREE_BYTES=UNKNOWN\n'
+  printf 'TMP_REQUIRED_BYTES=UNKNOWN\n'
+  printf 'TMP_SPACE_SAFE=UNKNOWN\n'
 }
 
 inspect_sse_evidence() {
@@ -906,9 +947,13 @@ main() {
     inspect_unit VERIFY_SERVICE "$EXPECTED_VERIFY_SERVICE" "$EXPECTED_BACKUP_ENTRYPOINT" "$EXPECTED_ENV_FILE" yoryi "$EXPECTED_APP_DIR" true
     inspect_concurrency
     inspect_environment
-    inspect_sse_evidence
     inspect_state
-    inspect_postgres_and_space "$(env_value "$ENV_FILE" POSTGRES_CONTAINER 2>/dev/null || printf 'invalid-container')"
+    if [[ "$ENV_FILE_AVAILABLE" == true ]]; then
+      inspect_sse_evidence
+      inspect_postgres_and_space "$(env_value "$ENV_FILE" POSTGRES_CONTAINER 2>/dev/null || printf 'invalid-container')"
+    else
+      emit_unavailable_environment_outputs
+    fi
   else
     printf 'PRODUCTION_RUNTIME_SHA=UNKNOWN\nAPI_REVISION=UNKNOWN\nWEB_REVISION=UNKNOWN\nPRODUCTION_CHECKOUT_STATUS=UNKNOWN\nRUNTIME_IDENTITY=UNKNOWN\n'
     printf 'BACKUP_SERVICE_EXISTS=UNKNOWN\nBACKUP_SERVICE_USER=UNKNOWN\nBACKUP_SERVICE_EXECSTART_MATCH=UNKNOWN\nBACKUP_SERVICE_EXECSTARTPRE_MATCH=UNKNOWN\nBACKUP_SERVICE_EXECSTARTPOST_MATCH=UNKNOWN\nBACKUP_SERVICE_ENV_FILE_MATCH=UNKNOWN\nBACKUP_SERVICE_ACTIVE=UNKNOWN\n'

--- a/scripts/production-backup-preflight.sh
+++ b/scripts/production-backup-preflight.sh
@@ -500,6 +500,8 @@ inspect_environment() {
     done
   else
     fail_check 'protected backup environment is not a regular non-symlink file'
+    printf 'REQUIRED_ENV_NAMES_PRESENT=NO\n'
+    return
   fi
   if [[ "$env_ok" == true ]]; then
     printf 'REQUIRED_ENV_NAMES_PRESENT=YES\n'

--- a/scripts/tests/production-backup-preflight.test.sh
+++ b/scripts/tests/production-backup-preflight.test.sh
@@ -83,7 +83,7 @@ cat > "$BIN_DIR/git" <<'MOCK'
 #!/usr/bin/env bash
 set -Eeuo pipefail
 case "$*" in
-  *'rev-parse HEAD'*) printf '%s\n' "${MOCK_RUNTIME_SHA:-db82d3d37fc6184a6d4063709b9a15b923371695}" ;;
+  *'rev-parse HEAD'*) printf '%s\n' "${MOCK_CHECKOUT_SHA:-${MOCK_RUNTIME_SHA:-2ac603be8018ffc3df67fb4e84149aea4f780cea}}" ;;
   *'status --porcelain'*) [[ "${MOCK_DIRTY:-NO}" == NO ]] || printf ' M application.env\n' ;;
   *) exit 1 ;;
 esac
@@ -111,7 +111,12 @@ if [[ "$1 ${2:-}" == 'inspect --type' ]]; then
     printf '%s\n' "${MOCK_PG_HEALTH:-healthy}"
   fi
 elif [[ "$1 ${2:-}" == 'image inspect' ]]; then
-  printf '%s\n' "${MOCK_RUNTIME_SHA:-db82d3d37fc6184a6d4063709b9a15b923371695}"
+  image="$3"
+  if [[ "$image" == "sha256:$(printf '%064d' 1)" ]]; then
+    printf '%s\n' "${MOCK_API_REVISION:-${MOCK_RUNTIME_SHA:-2ac603be8018ffc3df67fb4e84149aea4f780cea}}"
+  else
+    printf '%s\n' "${MOCK_WEB_REVISION:-${MOCK_RUNTIME_SHA:-2ac603be8018ffc3df67fb4e84149aea4f780cea}}"
+  fi
 elif [[ "$1" == exec ]]; then
   [[ "${MOCK_DB_SIZE_UNAVAILABLE:-NO}" == YES ]] && exit 1
   printf '%s\n' "${MOCK_DB_SIZE_BYTES:-104857600}"
@@ -286,7 +291,7 @@ run_preflight() {
   set -e
 }
 
-readonly CANDIDATE_SHA='2ac603be8018ffc3df67fb4e84149aea4f780cea'
+CANDIDATE_SHA='2ac603be8018ffc3df67fb4e84149aea4f780cea'
 write_env buildingos-backup production
 write_sse
 run_preflight
@@ -302,10 +307,42 @@ for sentinel in VERIFY_ACCESS_SENTINEL VERIFY_SECRET_SENTINEL WRITE_ACCESS_SENTI
   assert_absent "secret $sentinel is not emitted" "$sentinel" "$RUN_OUTPUT"
 done
 
+CANDIDATE_SHA='db82d3d37fc6184a6d4063709b9a15b923371695' run_preflight
+assert_failure 'candidate mismatch fails runtime identity gate'
+assert_contains 'candidate mismatch reports inconsistent identity' 'RUNTIME_IDENTITY=INCONSISTENT' "$RUN_OUTPUT"
+assert_contains 'candidate mismatch reports failed preflight' 'PREFLIGHT_STATUS=FAIL' "$RUN_OUTPUT"
+CANDIDATE_SHA='2ac603be8018ffc3df67fb4e84149aea4f780cea'
+
+MOCK_API_REVISION='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' run_preflight
+assert_failure 'API revision mismatch fails runtime identity gate'
+assert_contains 'API mismatch reports inconsistent identity' 'RUNTIME_IDENTITY=INCONSISTENT' "$RUN_OUTPUT"
+unset MOCK_API_REVISION
+
+MOCK_WEB_REVISION='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' run_preflight
+assert_failure 'Web revision mismatch fails runtime identity gate'
+assert_contains 'Web mismatch reports inconsistent identity' 'RUNTIME_IDENTITY=INCONSISTENT' "$RUN_OUTPUT"
+unset MOCK_WEB_REVISION
+
+MOCK_CHECKOUT_SHA='cccccccccccccccccccccccccccccccccccccccc' run_preflight
+assert_failure 'checkout revision mismatch fails runtime identity gate'
+assert_contains 'checkout mismatch reports inconsistent identity' 'RUNTIME_IDENTITY=INCONSISTENT' "$RUN_OUTPUT"
+unset MOCK_CHECKOUT_SHA
+
+MOCK_DIRTY=YES run_preflight
+assert_failure 'dirty checkout fails runtime identity gate'
+assert_contains 'dirty checkout reports inconsistent identity' 'RUNTIME_IDENTITY=INCONSISTENT' "$RUN_OUTPUT"
+unset MOCK_DIRTY
+
 rm "$ENV_FILE"
 run_preflight
 assert_failure 'missing environment fails closed'
 assert_contains 'missing environment reports unavailable names' 'REQUIRED_ENV_NAMES_PRESENT=NO' "$RUN_OUTPUT"
+assert_contains 'missing environment reaches final failure summary' 'PREFLIGHT_STATUS=FAIL' "$RUN_OUTPUT"
+assert_contains 'missing environment reports no writes' 'PRODUCTION_WRITES=0' "$RUN_OUTPUT"
+assert_contains 'missing environment reports no backup' 'BACKUP_STARTED=NO' "$RUN_OUTPUT"
+assert_contains 'missing environment reports unknown source endpoint' 'SOURCE_ENDPOINT_HOSTNAME=UNKNOWN' "$RUN_OUTPUT"
+assert_contains 'missing environment reports unknown SSE evidence' 'SSE_EVIDENCE_VALID=UNKNOWN' "$RUN_OUTPUT"
+assert_contains 'missing environment reports unknown database state' 'POSTGRES_CONTAINER_STATE=UNKNOWN' "$RUN_OUTPUT"
 assert_absent 'missing environment has no awk fatal' 'awk: fatal' "$RUN_OUTPUT"
 assert_absent 'missing environment has no awk open error' 'cannot open file' "$RUN_OUTPUT"
 write_env buildingos-backup production

--- a/scripts/tests/production-backup-preflight.test.sh
+++ b/scripts/tests/production-backup-preflight.test.sh
@@ -290,8 +290,10 @@ readonly CANDIDATE_SHA='2ac603be8018ffc3df67fb4e84149aea4f780cea'
 write_env buildingos-backup production
 write_sse
 run_preflight
-assert_success 'happy path passes' 
+assert_success 'happy path passes'
 assert_contains 'happy path emits PASS' 'PREFLIGHT_STATUS=PASS' "$RUN_OUTPUT"
+assert_contains 'happy path reports authoritative source endpoint' 'SOURCE_ENDPOINT_HOSTNAME=usc1.contabostorage.com' "$RUN_OUTPUT"
+assert_contains 'happy path reports authoritative source bucket' 'SOURCE_BUCKET=buildingos-production' "$RUN_OUTPUT"
 assert_contains 'happy path reports separate destinations' 'SOURCE_AND_BACKUP_SEPARATE=YES' "$RUN_OUTPUT"
 assert_contains 'happy path reports db82 destination compatibility' 'DEPLOYED_RUNTIME_SOURCE_AND_BACKUP_SEPARATE=YES' "$RUN_OUTPUT"
 assert_contains 'happy path reports db82 SSE compatibility' 'DEPLOYED_RUNTIME_SSE_ENDPOINT_MATCH=YES' "$RUN_OUTPUT"
@@ -299,6 +301,14 @@ assert_contains 'happy path reports inactive backup' 'BACKUP_ALREADY_RUNNING=NO'
 for sentinel in VERIFY_ACCESS_SENTINEL VERIFY_SECRET_SENTINEL WRITE_ACCESS_SENTINEL WRITE_SECRET_SENTINEL SOURCE_ACCESS_SENTINEL SOURCE_SECRET_SENTINEL; do
   assert_absent "secret $sentinel is not emitted" "$sentinel" "$RUN_OUTPUT"
 done
+
+rm "$ENV_FILE"
+run_preflight
+assert_failure 'missing environment fails closed'
+assert_contains 'missing environment reports unavailable names' 'REQUIRED_ENV_NAMES_PRESENT=NO' "$RUN_OUTPUT"
+assert_absent 'missing environment has no awk fatal' 'awk: fatal' "$RUN_OUTPUT"
+assert_absent 'missing environment has no awk open error' 'cannot open file' "$RUN_OUTPUT"
+write_env buildingos-backup production
 
 MOCK_BACKUP_UNIT_MISSING=YES run_preflight
 assert_failure 'missing backup unit fails closed'


### PR DESCRIPTION
## Summary
- replace stale production SHA prose with execution-time runtime/candidate invariants
- align the backup environment example with the certified production source endpoint
- fail cleanly when the protected backup environment is missing
- add regression coverage for missing env, source contract, bucket separation, and db82 compatibility

## Validation
- bash syntax checks passed
- production backup preflight: 110 assertions passed
- endpoint identity parity: 22 assertions passed
- production backup activation: 69 assertions passed
- MinIO paired backup: 29 assertions passed
- PostgreSQL recovery: 13 assertions passed
- production readonly audit dependencies: passed
- git diff --check passed

No production connections or mutations were performed.