### PR TITLE
fix(prod): add backup preflight privilege boundary

### DIFF
--- a/.github/workflows/production-backup-preflight.yml
+++ b/.github/workflows/production-backup-preflight.yml
@@ -46,7 +46,7 @@ jobs:
           [[ "$SSH_PORT" =~ ^[0-9]+$ ]]
           test -x scripts/production-backup-preflight.sh
 
-      - name: Stream read-only production backup preflight
+      - name: Invoke installed read-only production backup preflight
         shell: bash
         run: |
           set -Eeuo pipefail
@@ -70,6 +70,5 @@ jobs:
             -p "$SSH_PORT"
           )
           printf -v quoted_candidate '%q' "$CANDIDATE_SHA"
-           cat scripts/lib/endpoint-identity.sh scripts/production-backup-preflight.sh | \
-             ssh "${ssh_opts[@]}" "$SSH_USER@$SSH_HOST" \
-             "sudo -n -u root bash -s -- $quoted_candidate"
+          ssh "${ssh_opts[@]}" "$SSH_USER@$SSH_HOST" \
+            "sudo -n /usr/local/sbin/buildingos-production-backup-preflight $quoted_candidate"

--- a/docs/runbooks/PRODUCTION_BACKUP_ACTIVATION.md
+++ b/docs/runbooks/PRODUCTION_BACKUP_ACTIVATION.md
@@ -207,58 +207,167 @@ This is a **one-time approved production mutation**. It installs only the
 root-owned read-only preflight control and its narrow sudoers authorization.
 It does not run the preflight, deploy, execute a backup, or change systemd.
 
-Preconditions: the operator has an approved exact `CANDIDATE_SHA`, the checkout
-is clean at that SHA, the three source artifacts below passed local review and
-`bash -n`, and none of the destination paths already exists. Updates to an
-existing installation require a separate reviewed replacement procedure.
+This bootstrap deliberately separates three identities:
+
+- `CURRENT_RUNTIME_SHA` is the current application revision. For this first
+  installation it remains `db82d3d37fc6184a6d4063709b9a15b923371695`; the
+  active checkout must remain clean and at that exact SHA throughout.
+- `CONTROL_SOURCE_SHA` is the explicit reviewed and merged 40-character commit
+  that contains this launcher, sudoers template, and preflight control. It must
+  be reachable from `origin/main`; never infer it from the current `main` ref.
+  It may differ from `CURRENT_RUNTIME_SHA` during this bootstrap.
+- `RUNTIME_CANDIDATE_SHA` is the later preflight argument. Immediately after
+  this bootstrap it remains `db82d3d37fc6184a6d4063709b9a15b923371695`, not
+  `CONTROL_SOURCE_SHA`.
+
+Preconditions: approved values for all three identities are recorded, the
+active checkout is clean, the source artifacts passed local review, and none of
+the destination paths already exists. Updates to an existing installation
+require a separate reviewed replacement procedure.
 
 ```bash
+set -Eeuo pipefail
+set +x
+
 readonly app_dir='/opt/pawtech/apps/buildingos/buildingos-app'
 readonly control_dir='/usr/local/libexec/buildingos-backup-preflight'
 readonly launcher='/usr/local/sbin/buildingos-production-backup-preflight'
 readonly sudoers_policy='/etc/sudoers.d/buildingos-production-backup-preflight'
-readonly candidate_sha='<approved-40-character-sha>'
+readonly CURRENT_RUNTIME_SHA='db82d3d37fc6184a6d4063709b9a15b923371695'
+readonly CONTROL_SOURCE_SHA='<exact-reviewed-merged-control-commit>'
+readonly RUNTIME_CANDIDATE_SHA="$CURRENT_RUNTIME_SHA"
+source_tree=''
+control_stage=''
+launcher_stage='/usr/local/sbin/.buildingos-production-backup-preflight.new'
+sudoers_stage='/etc/sudoers.d/buildingos-production-backup-preflight.new'
+control_stage_created=false
+launcher_stage_created=false
+sudoers_stage_created=false
+control_published=false
+launcher_published=false
+sudoers_published=false
+activated=false
 
-test "$(git -C "$app_dir" rev-parse HEAD)" = "$candidate_sha"
+cleanup() {
+  local status=$?
+  local cleanup_status=0
+  trap - EXIT
+  set +e
+  if [[ "$activated" != true ]]; then
+    if [[ "$sudoers_stage_created" == true ]]; then
+      sudo rm -f -- "$sudoers_stage" || cleanup_status=$?
+    fi
+    if [[ "$launcher_stage_created" == true ]]; then
+      sudo rm -f -- "$launcher_stage" || cleanup_status=$?
+    fi
+    if [[ "$sudoers_published" == true ]]; then
+      sudo rm -f -- "$sudoers_policy" || cleanup_status=$?
+    fi
+    if [[ "$launcher_published" == true ]]; then
+      sudo rm -f -- "$launcher" || cleanup_status=$?
+    fi
+    if [[ "$control_published" == true ]]; then
+      sudo rm -f -- "$control_dir/production-backup-preflight.sh" || cleanup_status=$?
+      sudo rm -f -- "$control_dir/lib/endpoint-identity.sh" || cleanup_status=$?
+      sudo rmdir -- "$control_dir/lib" "$control_dir" || cleanup_status=$?
+    fi
+    if [[ "$control_stage_created" == true && -n "$control_stage" ]]; then
+      sudo rm -f -- "$control_stage/production-backup-preflight.sh" "$control_stage/lib/endpoint-identity.sh" || cleanup_status=$?
+      sudo rmdir -- "$control_stage/lib" "$control_stage" || cleanup_status=$?
+    fi
+  fi
+  if [[ -n "$source_tree" ]]; then
+    git -C "$app_dir" worktree remove --force "$source_tree" || cleanup_status=$?
+  fi
+  if (( status == 0 && cleanup_status != 0 )); then
+    printf 'ERROR: temporary preflight control cleanup failed\n' >&2
+    status=$cleanup_status
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+[[ "$CURRENT_RUNTIME_SHA" =~ ^[0-9a-f]{40}$ ]]
+[[ "$CONTROL_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+[[ "$RUNTIME_CANDIDATE_SHA" == "$CURRENT_RUNTIME_SHA" ]]
+active_checkout_start="$(git -C "$app_dir" rev-parse HEAD)"
+[[ "$active_checkout_start" == "$CURRENT_RUNTIME_SHA" ]]
 test -z "$(git -C "$app_dir" status --porcelain --untracked-files=all)"
-bash -n "$app_dir/scripts/production-backup-preflight.sh"
-bash -n "$app_dir/scripts/lib/endpoint-identity.sh"
-sh -n "$app_dir/infra/production/launchers/buildingos-production-backup-preflight"
+
+git -C "$app_dir" fetch --no-tags origin main
+git -C "$app_dir" rev-parse --verify "$CONTROL_SOURCE_SHA^{commit}" >/dev/null
+git -C "$app_dir" merge-base --is-ancestor "$CONTROL_SOURCE_SHA" origin/main
+source_tree="$(mktemp -d /tmp/buildingos-backup-preflight-control.XXXXXX)"
+rmdir -- "$source_tree"
+git -C "$app_dir" worktree add --detach "$source_tree" "$CONTROL_SOURCE_SHA"
+
+preflight_sha="$(git -C "$app_dir" show "$CONTROL_SOURCE_SHA:scripts/production-backup-preflight.sh" | sha256sum | awk '{print $1}')"
+helper_sha="$(git -C "$app_dir" show "$CONTROL_SOURCE_SHA:scripts/lib/endpoint-identity.sh" | sha256sum | awk '{print $1}')"
+launcher_sha="$(git -C "$app_dir" show "$CONTROL_SOURCE_SHA:infra/production/launchers/buildingos-production-backup-preflight" | sha256sum | awk '{print $1}')"
+sudoers_sha="$(git -C "$app_dir" show "$CONTROL_SOURCE_SHA:infra/production/sudoers/buildingos-production-backup-preflight" | sha256sum | awk '{print $1}')"
+[[ "$preflight_sha" =~ ^[0-9a-f]{64}$ && "$helper_sha" =~ ^[0-9a-f]{64}$ && "$launcher_sha" =~ ^[0-9a-f]{64}$ && "$sudoers_sha" =~ ^[0-9a-f]{64}$ ]]
+bash -n "$source_tree/scripts/production-backup-preflight.sh"
+bash -n "$source_tree/scripts/lib/endpoint-identity.sh"
+sh -n "$source_tree/infra/production/launchers/buildingos-production-backup-preflight"
 
 sudo test ! -e "$control_dir" && sudo test ! -L "$control_dir"
 sudo test ! -e "$launcher" && sudo test ! -L "$launcher"
 sudo test ! -e "$sudoers_policy" && sudo test ! -L "$sudoers_policy"
-sudo test ! -e /usr/local/sbin/.buildingos-production-backup-preflight.new && sudo test ! -L /usr/local/sbin/.buildingos-production-backup-preflight.new
-sudo test ! -e /etc/sudoers.d/buildingos-production-backup-preflight.new && sudo test ! -L /etc/sudoers.d/buildingos-production-backup-preflight.new
-sudo visudo -cf "$app_dir/infra/production/sudoers/buildingos-production-backup-preflight"
+sudo test ! -e "$launcher_stage" && sudo test ! -L "$launcher_stage"
+sudo test ! -e "$sudoers_stage" && sudo test ! -L "$sudoers_stage"
+sudo visudo -cf "$source_tree/infra/production/sudoers/buildingos-production-backup-preflight"
 
 sudo install -d -o root -g root -m 0755 /usr/local/libexec
 control_stage="$(sudo mktemp -d /usr/local/libexec/.buildingos-backup-preflight.XXXXXX)"
+control_stage_created=true
+sudo chmod 0755 "$control_stage"
 sudo install -d -o root -g root -m 0755 "$control_stage/lib"
 sudo install -o root -g root -m 0755 \
-  "$app_dir/scripts/production-backup-preflight.sh" \
+  "$source_tree/scripts/production-backup-preflight.sh" \
   "$control_stage/production-backup-preflight.sh"
 sudo install -o root -g root -m 0644 \
-  "$app_dir/scripts/lib/endpoint-identity.sh" \
+  "$source_tree/scripts/lib/endpoint-identity.sh" \
   "$control_stage/lib/endpoint-identity.sh"
-sudo mv -- "$control_stage" "$control_dir"
-
+launcher_stage_created=true
 sudo install -o root -g root -m 0755 \
-  "$app_dir/infra/production/launchers/buildingos-production-backup-preflight" \
-  /usr/local/sbin/.buildingos-production-backup-preflight.new
-sudo mv -- /usr/local/sbin/.buildingos-production-backup-preflight.new "$launcher"
-
+  "$source_tree/infra/production/launchers/buildingos-production-backup-preflight" \
+  "$launcher_stage"
+sudoers_stage_created=true
 sudo install -o root -g root -m 0440 \
-  "$app_dir/infra/production/sudoers/buildingos-production-backup-preflight" \
-  /etc/sudoers.d/buildingos-production-backup-preflight.new
-sudo visudo -cf /etc/sudoers.d/buildingos-production-backup-preflight.new
-sudo mv -- /etc/sudoers.d/buildingos-production-backup-preflight.new "$sudoers_policy"
-sudo visudo -cf /etc/sudoers
+  "$source_tree/infra/production/sudoers/buildingos-production-backup-preflight" \
+  "$sudoers_stage"
+sudo visudo -cf "$sudoers_stage"
+
+test "$(sudo sha256sum "$control_stage/production-backup-preflight.sh" | awk '{print $1}')" = "$preflight_sha"
+test "$(sudo sha256sum "$control_stage/lib/endpoint-identity.sh" | awk '{print $1}')" = "$helper_sha"
+test "$(sudo sha256sum "$launcher_stage" | awk '{print $1}')" = "$launcher_sha"
+test "$(sudo sha256sum "$sudoers_stage" | awk '{print $1}')" = "$sudoers_sha"
 
 sudo stat -c '%U:%G %a %n' \
-  "$control_dir" "$control_dir/lib" \
-  "$control_dir/production-backup-preflight.sh" \
-  "$control_dir/lib/endpoint-identity.sh" "$launcher" "$sudoers_policy"
+  "$control_stage" "$control_stage/lib" \
+  "$control_stage/production-backup-preflight.sh" \
+  "$control_stage/lib/endpoint-identity.sh" "$launcher_stage" "$sudoers_stage"
+test "$(sudo stat -c '%u:%g:%a' "$control_stage")" = '0:0:755'
+test "$(sudo stat -c '%u:%g:%a' "$control_stage/lib")" = '0:0:755'
+test "$(sudo stat -c '%u:%g:%a' "$control_stage/production-backup-preflight.sh")" = '0:0:755'
+test "$(sudo stat -c '%u:%g:%a' "$control_stage/lib/endpoint-identity.sh")" = '0:0:644'
+test "$(sudo stat -c '%u:%g:%a' "$launcher_stage")" = '0:0:755'
+test "$(sudo stat -c '%u:%g:%a' "$sudoers_stage")" = '0:0:440'
+
+sudo mv -- "$control_stage" "$control_dir"
+control_stage=''
+control_stage_created=false
+control_published=true
+sudo mv -- "$launcher_stage" "$launcher"
+launcher_stage_created=false
+launcher_published=true
+active_checkout_end="$(git -C "$app_dir" rev-parse HEAD)"
+[[ "$active_checkout_end" == "$CURRENT_RUNTIME_SHA" ]]
+test -z "$(git -C "$app_dir" status --porcelain --untracked-files=all)"
+sudo mv -- "$sudoers_stage" "$sudoers_policy"
+sudoers_stage_created=false
+sudoers_published=true
+activated=true
 ```
 
 Expected metadata is `root:root`: `0755` for both directories, the preflight
@@ -266,7 +375,11 @@ script, and launcher; `0644` for the helper; and `0440` for sudoers. The policy
 grants `yoryi` only `NOPASSWD:NOSETENV` access to the fixed launcher. The
 launcher itself rejects zero, multiple, malformed, path, and command arguments,
 verifies installed metadata, resets the environment, closes stdin, and invokes
-only the installed control path.
+only the installed control path. The trap removes staged or partially published
+control artifacts on any failed validation; the sudoers policy is published
+last, only after all validation and active-checkout revalidation pass. Each
+root-owned staged file is SHA-256 checked against the exact
+`CONTROL_SOURCE_SHA` Git object before publication.
 
 Rollback under the same approved change window removes the authorization
 first, validates sudoers, and then removes only these newly installed paths:

--- a/docs/runbooks/PRODUCTION_BACKUP_ACTIVATION.md
+++ b/docs/runbooks/PRODUCTION_BACKUP_ACTIVATION.md
@@ -35,6 +35,12 @@ those commands automatically.
   agree with each other and with the explicitly approved candidate SHA.
   Never infer the deployment candidate from a branch name or the current
   `main` ref; record the approved exact SHA in the activation evidence.
+- GitHub Actions receives passwordless privilege only for the fixed
+  `/usr/local/sbin/buildingos-production-backup-preflight` launcher. That
+  root-owned launcher validates one SHA, clears caller-controlled environment
+  state, and executes only root-owned control files under
+  `/usr/local/libexec/buildingos-backup-preflight`; it never executes mutable
+  checkout bytes as root.
 - The repository did not contain the bytes of the legacy production-only
   `/opt/pawtech/backups/scripts/backup-postgres.sh`. Its v1 identity remains
   pinned for the existing deploy preflight. Activation installs the separate
@@ -54,6 +60,9 @@ those commands automatically.
 | Protected environment template | `infra/production/buildingos-backup.env.example` | `/etc/buildingos/buildingos-backup.env` |
 | SSE proof | generated outside Git | `/etc/buildingos/contabo-sse-s3-capability.json` |
 | Restore target policy | generated outside Git | `/etc/buildingos/minio-restore-target-policy.json` |
+| Privileged preflight launcher | `infra/production/launchers/buildingos-production-backup-preflight` | `/usr/local/sbin/buildingos-production-backup-preflight` |
+| Privileged preflight control | `scripts/production-backup-preflight.sh` and `scripts/lib/endpoint-identity.sh` | `/usr/local/libexec/buildingos-backup-preflight/` |
+| Preflight sudoers policy | `infra/production/sudoers/buildingos-production-backup-preflight` | `/etc/sudoers.d/buildingos-production-backup-preflight` |
 | systemd units | `infra/production/systemd/` | `/etc/systemd/system/` |
 | Non-secret policy semantics | `infra/production/policies/` | Contabo Panel/API and source MinIO IAM |
 
@@ -191,6 +200,90 @@ Expected: regular non-symlink files, root-owned, mode `0600` for secrets,
 for the non-secret restore policy. Production
 must not appear in the policy. On failure, remove only newly installed config
 files under the same approval and revoke new credentials; do not alter app env.
+
+## 5A. INSTALL PRIVILEGED PREFLIGHT CONTROL
+
+This is a **one-time approved production mutation**. It installs only the
+root-owned read-only preflight control and its narrow sudoers authorization.
+It does not run the preflight, deploy, execute a backup, or change systemd.
+
+Preconditions: the operator has an approved exact `CANDIDATE_SHA`, the checkout
+is clean at that SHA, the three source artifacts below passed local review and
+`bash -n`, and none of the destination paths already exists. Updates to an
+existing installation require a separate reviewed replacement procedure.
+
+```bash
+readonly app_dir='/opt/pawtech/apps/buildingos/buildingos-app'
+readonly control_dir='/usr/local/libexec/buildingos-backup-preflight'
+readonly launcher='/usr/local/sbin/buildingos-production-backup-preflight'
+readonly sudoers_policy='/etc/sudoers.d/buildingos-production-backup-preflight'
+readonly candidate_sha='<approved-40-character-sha>'
+
+test "$(git -C "$app_dir" rev-parse HEAD)" = "$candidate_sha"
+test -z "$(git -C "$app_dir" status --porcelain --untracked-files=all)"
+bash -n "$app_dir/scripts/production-backup-preflight.sh"
+bash -n "$app_dir/scripts/lib/endpoint-identity.sh"
+sh -n "$app_dir/infra/production/launchers/buildingos-production-backup-preflight"
+
+sudo test ! -e "$control_dir" && sudo test ! -L "$control_dir"
+sudo test ! -e "$launcher" && sudo test ! -L "$launcher"
+sudo test ! -e "$sudoers_policy" && sudo test ! -L "$sudoers_policy"
+sudo test ! -e /usr/local/sbin/.buildingos-production-backup-preflight.new && sudo test ! -L /usr/local/sbin/.buildingos-production-backup-preflight.new
+sudo test ! -e /etc/sudoers.d/buildingos-production-backup-preflight.new && sudo test ! -L /etc/sudoers.d/buildingos-production-backup-preflight.new
+sudo visudo -cf "$app_dir/infra/production/sudoers/buildingos-production-backup-preflight"
+
+sudo install -d -o root -g root -m 0755 /usr/local/libexec
+control_stage="$(sudo mktemp -d /usr/local/libexec/.buildingos-backup-preflight.XXXXXX)"
+sudo install -d -o root -g root -m 0755 "$control_stage/lib"
+sudo install -o root -g root -m 0755 \
+  "$app_dir/scripts/production-backup-preflight.sh" \
+  "$control_stage/production-backup-preflight.sh"
+sudo install -o root -g root -m 0644 \
+  "$app_dir/scripts/lib/endpoint-identity.sh" \
+  "$control_stage/lib/endpoint-identity.sh"
+sudo mv -- "$control_stage" "$control_dir"
+
+sudo install -o root -g root -m 0755 \
+  "$app_dir/infra/production/launchers/buildingos-production-backup-preflight" \
+  /usr/local/sbin/.buildingos-production-backup-preflight.new
+sudo mv -- /usr/local/sbin/.buildingos-production-backup-preflight.new "$launcher"
+
+sudo install -o root -g root -m 0440 \
+  "$app_dir/infra/production/sudoers/buildingos-production-backup-preflight" \
+  /etc/sudoers.d/buildingos-production-backup-preflight.new
+sudo visudo -cf /etc/sudoers.d/buildingos-production-backup-preflight.new
+sudo mv -- /etc/sudoers.d/buildingos-production-backup-preflight.new "$sudoers_policy"
+sudo visudo -cf /etc/sudoers
+
+sudo stat -c '%U:%G %a %n' \
+  "$control_dir" "$control_dir/lib" \
+  "$control_dir/production-backup-preflight.sh" \
+  "$control_dir/lib/endpoint-identity.sh" "$launcher" "$sudoers_policy"
+```
+
+Expected metadata is `root:root`: `0755` for both directories, the preflight
+script, and launcher; `0644` for the helper; and `0440` for sudoers. The policy
+grants `yoryi` only `NOPASSWD:NOSETENV` access to the fixed launcher. The
+launcher itself rejects zero, multiple, malformed, path, and command arguments,
+verifies installed metadata, resets the environment, closes stdin, and invokes
+only the installed control path.
+
+Rollback under the same approved change window removes the authorization
+first, validates sudoers, and then removes only these newly installed paths:
+
+```bash
+sudo rm -- "$sudoers_policy"
+sudo visudo -cf /etc/sudoers
+sudo rm -- "$launcher"
+sudo rm -- "$control_dir/production-backup-preflight.sh"
+sudo rm -- "$control_dir/lib/endpoint-identity.sh"
+sudo rmdir -- "$control_dir/lib"
+sudo rmdir -- "$control_dir"
+```
+
+Stop on any installation or validation failure. Do not fall back to granting
+passwordless access to `bash`, `sh`, `env`, `systemctl`, Docker, or checkout
+scripts.
 
 ## 6. DEPLOY APPROVED SHA
 

--- a/infra/production/launchers/buildingos-production-backup-preflight
+++ b/infra/production/launchers/buildingos-production-backup-preflight
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+readonly CONTROL_DIR='/usr/local/libexec/buildingos-backup-preflight'
+readonly CONTROL_LIB_DIR='/usr/local/libexec/buildingos-backup-preflight/lib'
+readonly PREFLIGHT_SCRIPT='/usr/local/libexec/buildingos-backup-preflight/production-backup-preflight.sh'
+readonly ENDPOINT_HELPER='/usr/local/libexec/buildingos-backup-preflight/lib/endpoint-identity.sh'
+readonly INSTALLED_LAUNCHER='/usr/local/sbin/buildingos-production-backup-preflight'
+readonly STAT_COMMAND='/usr/bin/stat'
+readonly SAFE_PATH='/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
+
+fail() {
+  printf 'ERROR: %s\n' "$1" >&2
+  exit 1
+}
+
+assert_metadata() {
+  path="$1"
+  expected_mode="$2"
+  metadata="$($STAT_COMMAND -c '%u:%g:%a' -- "$path")" || fail "unable to inspect trusted control metadata: $path"
+  [ "$metadata" = "0:0:$expected_mode" ] || fail "unsafe trusted control metadata: $path"
+}
+
+[ "$#" -eq 1 ] || fail 'exactly one candidate SHA is required'
+candidate_sha="$1"
+[ "${#candidate_sha}" -eq 40 ] || fail 'candidate SHA must be exactly 40 lowercase hexadecimal characters'
+case "$candidate_sha" in
+  *[!0-9a-f]*) fail 'candidate SHA must be exactly 40 lowercase hexadecimal characters' ;;
+esac
+
+[ -d "$CONTROL_DIR" ] && [ ! -L "$CONTROL_DIR" ] || fail 'trusted control directory is unavailable'
+[ -d "$CONTROL_LIB_DIR" ] && [ ! -L "$CONTROL_LIB_DIR" ] || fail 'trusted control library directory is unavailable'
+[ -f "$PREFLIGHT_SCRIPT" ] && [ ! -L "$PREFLIGHT_SCRIPT" ] || fail 'trusted preflight control is unavailable'
+[ -f "$ENDPOINT_HELPER" ] && [ ! -L "$ENDPOINT_HELPER" ] || fail 'trusted endpoint helper is unavailable'
+[ -f "$INSTALLED_LAUNCHER" ] && [ ! -L "$INSTALLED_LAUNCHER" ] || fail 'trusted launcher is unavailable'
+assert_metadata "$CONTROL_DIR" 755
+assert_metadata "$CONTROL_LIB_DIR" 755
+assert_metadata "$PREFLIGHT_SCRIPT" 755
+assert_metadata "$ENDPOINT_HELPER" 644
+assert_metadata "$INSTALLED_LAUNCHER" 755
+
+unset BASH_ENV ENV CDPATH GLOBIGNORE \
+  LD_PRELOAD LD_LIBRARY_PATH \
+  BUILDINGOS_PREFLIGHT_TEST_MODE \
+  PREFLIGHT_APP_DIR PREFLIGHT_ENV_FILE PREFLIGHT_SSE_FILE PREFLIGHT_STATE_DIR \
+  PREFLIGHT_EXPECTED_ENV_OWNER PREFLIGHT_EXPECTED_ENV_GROUP \
+  PREFLIGHT_EXPECTED_STATE_OWNER PREFLIGHT_EXPECTED_STATE_GROUP \
+  PREFLIGHT_EXPECTED_SSE_OWNER PREFLIGHT_EXPECTED_SSE_GROUP
+
+exec /usr/bin/env -i \
+  PATH="$SAFE_PATH" \
+  HOME=/root \
+  USER=root \
+  LOGNAME=root \
+  LANG=C.UTF-8 \
+  LC_ALL=C.UTF-8 \
+  /bin/bash --noprofile --norc "$PREFLIGHT_SCRIPT" "$candidate_sha" </dev/null

--- a/infra/production/sudoers/buildingos-production-backup-preflight
+++ b/infra/production/sudoers/buildingos-production-backup-preflight
@@ -1,0 +1,2 @@
+Defaults!/usr/local/sbin/buildingos-production-backup-preflight env_reset,secure_path=/usr/local/sbin\:/usr/local/bin\:/usr/sbin\:/usr/bin\:/sbin\:/bin
+yoryi ALL=(root) NOPASSWD: NOSETENV: /usr/local/sbin/buildingos-production-backup-preflight *

--- a/scripts/tests/production-backup-preflight.test.sh
+++ b/scripts/tests/production-backup-preflight.test.sh
@@ -5,6 +5,9 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 readonly ROOT_DIR
 readonly PREFLIGHT="$ROOT_DIR/scripts/production-backup-preflight.sh"
 readonly WORKFLOW="$ROOT_DIR/.github/workflows/production-backup-preflight.yml"
+readonly PRIVILEGED_LAUNCHER="$ROOT_DIR/infra/production/launchers/buildingos-production-backup-preflight"
+readonly SUDOERS_POLICY="$ROOT_DIR/infra/production/sudoers/buildingos-production-backup-preflight"
+readonly ACTIVATION_RUNBOOK="$ROOT_DIR/docs/runbooks/PRODUCTION_BACKUP_ACTIVATION.md"
 readonly TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/buildingos-backup-preflight.XXXXXX")"
 trap 'rm -rf "$TEST_ROOT"' EXIT
 
@@ -617,6 +620,129 @@ assert_failure 'missing dependency fails closed'
 assert_contains 'missing dependency is reported' 'required dependency is missing: rclone' "$RUN_OUTPUT"
 ln -s "$(command -v true)" "$BIN_DIR/rclone"
 
+launcher_control="$TEST_ROOT/installed-control"
+launcher_path="$TEST_ROOT/installed-launcher"
+launcher_stat="$TEST_ROOT/launcher-stat"
+mkdir -p "$launcher_control/lib"
+cat > "$launcher_control/production-backup-preflight.sh" <<'MOCK'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+if IFS= read -r _; then
+  printf '%s\n' 'STDIN=CUSTOM'
+  exit 1
+fi
+printf 'CANDIDATE_SHA=%s\n' "$1"
+printf 'PREFLIGHT_APP_DIR=%s\n' "${PREFLIGHT_APP_DIR-UNSET}"
+printf 'PREFLIGHT_ENV_FILE=%s\n' "${PREFLIGHT_ENV_FILE-UNSET}"
+printf 'PREFLIGHT_SSE_FILE=%s\n' "${PREFLIGHT_SSE_FILE-UNSET}"
+printf 'PREFLIGHT_STATE_DIR=%s\n' "${PREFLIGHT_STATE_DIR-UNSET}"
+printf 'PREFLIGHT_EXPECTED_ENV_OWNER=%s\n' "${PREFLIGHT_EXPECTED_ENV_OWNER-UNSET}"
+printf 'PREFLIGHT_EXPECTED_ENV_GROUP=%s\n' "${PREFLIGHT_EXPECTED_ENV_GROUP-UNSET}"
+printf 'PREFLIGHT_EXPECTED_STATE_OWNER=%s\n' "${PREFLIGHT_EXPECTED_STATE_OWNER-UNSET}"
+printf 'PREFLIGHT_EXPECTED_STATE_GROUP=%s\n' "${PREFLIGHT_EXPECTED_STATE_GROUP-UNSET}"
+printf 'PREFLIGHT_EXPECTED_SSE_OWNER=%s\n' "${PREFLIGHT_EXPECTED_SSE_OWNER-UNSET}"
+printf 'PREFLIGHT_EXPECTED_SSE_GROUP=%s\n' "${PREFLIGHT_EXPECTED_SSE_GROUP-UNSET}"
+printf 'BUILDINGOS_PREFLIGHT_TEST_MODE=%s\n' "${BUILDINGOS_PREFLIGHT_TEST_MODE-UNSET}"
+printf 'PATH=%s\n' "$PATH"
+printf '%s\n' 'STDIN=CLOSED'
+MOCK
+printf '# endpoint fixture\n' > "$launcher_control/lib/endpoint-identity.sh"
+cat > "$launcher_stat" <<'MOCK'
+#!/bin/sh
+set -eu
+path=''
+for argument do path="$argument"; done
+case "$path" in
+  */endpoint-identity.sh) mode=644 ;;
+  *) mode=755 ;;
+esac
+printf '0:0:%s\n' "$mode"
+MOCK
+sed \
+  -e "s|/usr/local/libexec/buildingos-backup-preflight|$launcher_control|g" \
+  -e "s|/usr/local/sbin/buildingos-production-backup-preflight|$launcher_path|g" \
+  -e "s|/usr/bin/stat|$launcher_stat|g" \
+  "$PRIVILEGED_LAUNCHER" > "$launcher_path"
+chmod 0755 "$launcher_control" "$launcher_control/lib" "$launcher_control/production-backup-preflight.sh" "$launcher_path" "$launcher_stat"
+chmod 0644 "$launcher_control/lib/endpoint-identity.sh"
+
+run_launcher() {
+  set +e
+  LAUNCHER_OUTPUT="$("$launcher_path" "$@" 2>&1)"
+  LAUNCHER_RC=$?
+  set -e
+}
+
+run_launcher "$CANDIDATE_SHA"
+RUN_RC=$LAUNCHER_RC
+assert_success 'privileged launcher accepts exactly one lowercase SHA'
+assert_contains 'privileged launcher passes the exact SHA' "CANDIDATE_SHA=$CANDIDATE_SHA" "$LAUNCHER_OUTPUT"
+assert_contains 'privileged launcher closes caller stdin' 'STDIN=CLOSED' "$LAUNCHER_OUTPUT"
+
+run_launcher
+RUN_RC=$LAUNCHER_RC
+assert_failure 'privileged launcher rejects zero arguments'
+run_launcher "$CANDIDATE_SHA" id
+RUN_RC=$LAUNCHER_RC
+assert_failure 'privileged launcher rejects multiple arguments'
+run_launcher AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+RUN_RC=$LAUNCHER_RC
+assert_failure 'privileged launcher rejects uppercase SHA'
+run_launcher abc123
+RUN_RC=$LAUNCHER_RC
+assert_failure 'privileged launcher rejects short SHA'
+run_launcher 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;'
+RUN_RC=$LAUNCHER_RC
+assert_failure 'privileged launcher rejects shell metacharacters'
+run_launcher /tmp/preflight.sh
+RUN_RC=$LAUNCHER_RC
+assert_failure 'privileged launcher rejects path arguments'
+run_launcher id
+RUN_RC=$LAUNCHER_RC
+assert_failure 'privileged launcher rejects arbitrary commands'
+
+printf 'printf "BASH_ENV_EXECUTED\\n"; exit 99\n' > "$TEST_ROOT/attacker-bash-env"
+set +e
+LAUNCHER_OUTPUT="$(env \
+  BASH_ENV="$TEST_ROOT/attacker-bash-env" \
+  PATH="$TEST_ROOT:$PATH" \
+  PREFLIGHT_APP_DIR=/tmp/attacker-app \
+  PREFLIGHT_ENV_FILE=/tmp/attacker.env \
+  PREFLIGHT_SSE_FILE=/tmp/attacker-sse.json \
+  PREFLIGHT_STATE_DIR=/tmp/attacker-state \
+  PREFLIGHT_EXPECTED_ENV_OWNER=attacker \
+  PREFLIGHT_EXPECTED_ENV_GROUP=attacker \
+  PREFLIGHT_EXPECTED_STATE_OWNER=attacker \
+  PREFLIGHT_EXPECTED_STATE_GROUP=attacker \
+  PREFLIGHT_EXPECTED_SSE_OWNER=attacker \
+  PREFLIGHT_EXPECTED_SSE_GROUP=attacker \
+  BUILDINGOS_PREFLIGHT_TEST_MODE=LOCAL_ISOLATED_ONLY \
+  "$launcher_path" "$CANDIDATE_SHA" 2>&1)"
+LAUNCHER_RC=$?
+set -e
+RUN_RC=$LAUNCHER_RC
+assert_success 'privileged launcher ignores protected path and test-mode overrides'
+assert_contains 'app directory override is cleared' 'PREFLIGHT_APP_DIR=UNSET' "$LAUNCHER_OUTPUT"
+assert_contains 'environment path override is cleared' 'PREFLIGHT_ENV_FILE=UNSET' "$LAUNCHER_OUTPUT"
+assert_contains 'SSE path override is cleared' 'PREFLIGHT_SSE_FILE=UNSET' "$LAUNCHER_OUTPUT"
+assert_contains 'state path override is cleared' 'PREFLIGHT_STATE_DIR=UNSET' "$LAUNCHER_OUTPUT"
+assert_contains 'environment owner override is cleared' 'PREFLIGHT_EXPECTED_ENV_OWNER=UNSET' "$LAUNCHER_OUTPUT"
+assert_contains 'environment group override is cleared' 'PREFLIGHT_EXPECTED_ENV_GROUP=UNSET' "$LAUNCHER_OUTPUT"
+assert_contains 'state owner override is cleared' 'PREFLIGHT_EXPECTED_STATE_OWNER=UNSET' "$LAUNCHER_OUTPUT"
+assert_contains 'state group override is cleared' 'PREFLIGHT_EXPECTED_STATE_GROUP=UNSET' "$LAUNCHER_OUTPUT"
+assert_contains 'SSE owner override is cleared' 'PREFLIGHT_EXPECTED_SSE_OWNER=UNSET' "$LAUNCHER_OUTPUT"
+assert_contains 'SSE group override is cleared' 'PREFLIGHT_EXPECTED_SSE_GROUP=UNSET' "$LAUNCHER_OUTPUT"
+assert_contains 'test mode override is cleared' 'BUILDINGOS_PREFLIGHT_TEST_MODE=UNSET' "$LAUNCHER_OUTPUT"
+assert_contains 'launcher replaces caller PATH' 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' "$LAUNCHER_OUTPUT"
+assert_absent 'launcher prevents BASH_ENV execution' 'BASH_ENV_EXECUTED' "$LAUNCHER_OUTPUT"
+
+launcher_text="$(< "$PRIVILEGED_LAUNCHER")"
+assert_contains 'launcher pins the installed control directory' "readonly CONTROL_DIR='/usr/local/libexec/buildingos-backup-preflight'" "$launcher_text"
+assert_contains 'launcher verifies root ownership and exact modes' '"0:0:$expected_mode"' "$launcher_text"
+assert_contains 'launcher executes only the installed preflight control' '/bin/bash --noprofile --norc "$PREFLIGHT_SCRIPT" "$candidate_sha" </dev/null' "$launcher_text"
+assert_absent 'launcher never executes mutable checkout scripts' '/opt/pawtech/apps/buildingos/buildingos-app' "$launcher_text"
+assert_absent 'launcher never evaluates caller input' 'eval ' "$launcher_text"
+
 preflight_text="$(< "$PREFLIGHT")"
 static_text="$(printf '%s\n' "$preflight_text" | grep -v 'EXPECTED_PROPOSED_COMMAND')"
 if printf '%s\n' "$static_text" | grep -Eq 'systemctl (start|restart|stop|enable|disable|daemon-reload)|pg_dump|prisma|(^|[[:space:]])(INSERT|UPDATE|DELETE|CREATE)[[:space:]]|git (switch|pull|reset)|mc (mirror|cp|rm)|rclone (copy|copyto|delete|move)|(^|[[:space:]])(chmod|chown)[[:space:]]'; then
@@ -630,8 +756,10 @@ assert_contains 'workflow uses production environment' 'environment: production'
 assert_contains 'workflow uses operations concurrency group' 'group: production-operations' "$workflow_text"
 assert_contains 'workflow uses strict host key checking' 'StrictHostKeyChecking=yes' "$workflow_text"
 assert_contains 'workflow uses batch mode' 'BatchMode=yes' "$workflow_text"
-assert_contains 'workflow streams script over stdin' 'bash -s --' "$workflow_text"
-assert_contains 'workflow runs streamed preflight as root without a password' 'sudo -n -u root bash -s --' "$workflow_text"
+assert_contains 'workflow invokes only the installed privileged launcher' 'sudo -n /usr/local/sbin/buildingos-production-backup-preflight $quoted_candidate' "$workflow_text"
+assert_absent 'workflow does not authorize a streamed root bash' 'sudo -n -u root bash -s --' "$workflow_text"
+assert_absent 'workflow does not invoke bash over SSH stdin' 'bash -s --' "$workflow_text"
+assert_absent 'workflow does not stream executable checkout code' 'cat scripts/lib/endpoint-identity.sh scripts/production-backup-preflight.sh' "$workflow_text"
 assert_contains 'workflow uses protected SSH host secret' 'PRODUCTION_SSH_HOST' "$workflow_text"
 assert_contains 'workflow is manually dispatched' 'workflow_dispatch:' "$workflow_text"
 assert_absent 'workflow has no push trigger' 'push:' "$workflow_text"
@@ -645,6 +773,21 @@ assert_absent 'workflow never uses ssh-keyscan' 'ssh-keyscan' "$workflow_text"
 assert_absent 'workflow has no automatic retry controls' 'continue-on-error' "$workflow_text"
 assert_absent 'workflow has no retry strategy' 'strategy:' "$workflow_text"
 assert_contains 'workflow has read-only permissions' 'contents: read' "$workflow_text"
+
+sudoers_text="$(< "$SUDOERS_POLICY")"
+assert_contains 'sudoers grants only the fixed launcher to yoryi' 'yoryi ALL=(root) NOPASSWD: NOSETENV: /usr/local/sbin/buildingos-production-backup-preflight *' "$sudoers_text"
+assert_contains 'sudoers resets the launcher environment' 'env_reset' "$sudoers_text"
+if printf '%s\n' "$sudoers_text" | grep -Eq '(^|[[:space:]])(/[^[:space:]]*/)?(bash|sh|env|cat)([[:space:]]|$)|(^|[[:space:]])(systemctl|docker)[[:space:]]+\*'; then
+  fail_test 'sudoers excludes generic interpreters and privileged commands'
+else
+  pass 'sudoers excludes generic interpreters and privileged commands'
+fi
+
+runbook_text="$(< "$ACTIVATION_RUNBOOK")"
+assert_contains 'runbook classifies privilege installation as a one-time mutation' 'one-time approved production mutation' "$runbook_text"
+assert_contains 'runbook validates staged sudoers before activation' 'visudo -cf /etc/sudoers.d/buildingos-production-backup-preflight.new' "$runbook_text"
+assert_contains 'runbook installs preflight control as root' 'sudo install -o root -g root -m 0755' "$runbook_text"
+assert_contains 'runbook documents privilege-boundary rollback' 'sudo rm -- "$sudoers_policy"' "$runbook_text"
 
 if (( FAIL_COUNT > 0 )); then
   printf 'FAILED: %s test(s) failed; %s passed\n' "$FAIL_COUNT" "$PASS_COUNT" >&2

--- a/scripts/tests/production-backup-preflight.test.sh
+++ b/scripts/tests/production-backup-preflight.test.sh
@@ -37,6 +37,16 @@ assert_failure() {
   if [[ "$RUN_RC" -ne 0 ]]; then pass "$name"; else fail_test "$name"; fi
 }
 
+assert_order() {
+  local name="$1" first="$2" second="$3" text="$4" line first_line=0 second_line=0 line_number=0
+  while IFS= read -r line; do
+    line_number=$((line_number + 1))
+    [[ "$first_line" -ne 0 || "$line" != *"$first"* ]] || first_line=$line_number
+    [[ "$second_line" -ne 0 || "$line" != *"$second"* ]] || second_line=$line_number
+  done <<< "$text"
+  if [[ "$first_line" -gt 0 && "$second_line" -gt "$first_line" ]]; then pass "$name"; else fail_test "$name"; fi
+}
+
 readonly APP_DIR="$TEST_ROOT/app"
 readonly ENV_FILE="$TEST_ROOT/buildingos-backup.env"
 readonly SSE_FILE="$TEST_ROOT/contabo-sse-s3-capability.json"
@@ -785,9 +795,36 @@ fi
 
 runbook_text="$(< "$ACTIVATION_RUNBOOK")"
 assert_contains 'runbook classifies privilege installation as a one-time mutation' 'one-time approved production mutation' "$runbook_text"
-assert_contains 'runbook validates staged sudoers before activation' 'visudo -cf /etc/sudoers.d/buildingos-production-backup-preflight.new' "$runbook_text"
+assert_contains 'runbook enables strict installation failure handling' 'set -Eeuo pipefail' "$runbook_text"
+assert_contains 'runbook cleans staged artifacts on failure' 'trap cleanup EXIT' "$runbook_text"
+assert_contains 'runbook only removes launcher when this execution published it' 'if [[ "$launcher_published" == true ]]; then' "$runbook_text"
+assert_contains 'runbook only removes control when this execution published it' 'if [[ "$control_published" == true ]]; then' "$runbook_text"
+assert_contains 'runbook only removes sudoers when this execution published it' 'if [[ "$sudoers_published" == true ]]; then' "$runbook_text"
+assert_contains 'runbook only removes launcher staging when this execution created it' 'if [[ "$launcher_stage_created" == true ]]; then' "$runbook_text"
+assert_contains 'runbook only removes sudoers staging when this execution created it' 'if [[ "$sudoers_stage_created" == true ]]; then' "$runbook_text"
+assert_contains 'runbook sets the control staging directory mode to 0755' 'sudo chmod 0755 "$control_stage"' "$runbook_text"
+assert_contains 'runbook validates staged control directory metadata as root 0755' 'test "$(sudo stat -c' "$runbook_text"
+assert_contains 'runbook requires staged control directory mode 0755' "\"\$control_stage\")\" = '0:0:755'" "$runbook_text"
+assert_contains 'runbook validates staged sudoers before activation' 'sudo visudo -cf "$sudoers_stage"' "$runbook_text"
 assert_contains 'runbook installs preflight control as root' 'sudo install -o root -g root -m 0755' "$runbook_text"
 assert_contains 'runbook documents privilege-boundary rollback' 'sudo rm -- "$sudoers_policy"' "$runbook_text"
+assert_contains 'runbook distinguishes the current application runtime SHA' 'CURRENT_RUNTIME_SHA' "$runbook_text"
+assert_contains 'runbook requires an explicit control source SHA' 'CONTROL_SOURCE_SHA' "$runbook_text"
+assert_contains 'runbook permits control source SHA to differ from runtime' 'It may differ from `CURRENT_RUNTIME_SHA` during this bootstrap.' "$runbook_text"
+assert_contains 'runbook binds the first runtime candidate to current runtime' 'readonly RUNTIME_CANDIDATE_SHA="$CURRENT_RUNTIME_SHA"' "$runbook_text"
+assert_contains 'runbook fetches control source without updating active checkout' 'git -C "$app_dir" fetch --no-tags origin main' "$runbook_text"
+assert_contains 'runbook requires control source reachability from origin main' 'git -C "$app_dir" merge-base --is-ancestor "$CONTROL_SOURCE_SHA" origin/main' "$runbook_text"
+assert_contains 'runbook materializes a detached control source worktree' 'git -C "$app_dir" worktree add --detach "$source_tree" "$CONTROL_SOURCE_SHA"' "$runbook_text"
+assert_contains 'runbook removes the temporary control worktree' 'git -C "$app_dir" worktree remove --force "$source_tree"' "$runbook_text"
+assert_contains 'runbook derives preflight integrity from the exact control source commit' 'git -C "$app_dir" show "$CONTROL_SOURCE_SHA:scripts/production-backup-preflight.sh"' "$runbook_text"
+assert_contains 'runbook verifies staged privileged control integrity before publication' 'test "$(sudo sha256sum "$control_stage/production-backup-preflight.sh" | awk' "$runbook_text"
+assert_contains 'runbook revalidates active checkout after staged installation' 'active_checkout_end="$(git -C "$app_dir" rev-parse HEAD)"' "$runbook_text"
+assert_absent 'runbook never switches the active checkout' 'git -C "$app_dir" switch' "$runbook_text"
+assert_absent 'runbook never resets the active checkout' 'git -C "$app_dir" reset' "$runbook_text"
+assert_absent 'runbook never pulls the active checkout' 'git -C "$app_dir" pull' "$runbook_text"
+assert_order 'runbook fixes stage mode before publishing control directory' 'sudo chmod 0755 "$control_stage"' 'sudo mv -- "$control_stage" "$control_dir"' "$runbook_text"
+assert_order 'runbook validates staged sudoers before publishing it' 'sudo visudo -cf "$sudoers_stage"' 'sudo mv -- "$sudoers_stage" "$sudoers_policy"' "$runbook_text"
+assert_order 'runbook revalidates active checkout before authorizing launcher' 'active_checkout_end="$(git -C "$app_dir" rev-parse HEAD)"' 'sudo mv -- "$sudoers_stage" "$sudoers_policy"' "$runbook_text"
 
 if (( FAIL_COUNT > 0 )); then
   printf 'FAILED: %s test(s) failed; %s passed\n' "$FAIL_COUNT" "$PASS_COUNT" >&2


### PR DESCRIPTION
## Summary
- replace streamed root shell execution with a fixed root-owned preflight launcher
- add a narrow NOPASSWD:NOSETENV sudoers policy for only that launcher
- document one-time, atomic installation, validation, and rollback steps
- add abuse-case coverage for argument, stdin, environment, path, workflow, and sudoers boundaries

## Validation
- shell syntax checks passed
- visudo template validation passed
- production backup preflight: 165 assertions passed
- endpoint identity parity: 22 assertions passed
- production backup activation: 69 assertions passed
- MinIO paired backup: 29 assertions passed
- PostgreSQL recovery: 13 assertions passed
- read-only dependency audit: passed
- git diff --check passed

No production connections, installation, backup, restore, deploy, or provider mutation occurred.