### PR TITLE
PRODUCTION_BACKUP_SIMPLIFICATION_01

### DIFF
--- a/docs/release/PRODUCTION_DEPLOY_RUNBOOK.md
+++ b/docs/release/PRODUCTION_DEPLOY_RUNBOOK.md
@@ -48,20 +48,32 @@ Require at least one reviewer. Do not store production credentials as repository
 
 ## Versioned Compose
 
-`infra/docker/docker-compose.production.yml` reproduces the active topology:
+`infra/docker/docker-compose.production.yml` is application-only. It manages:
 
-- existing container names, networks, volume name, Traefik routers and restart policies;
-- API and Web on `pawtech_public` plus `pawtech_internal`;
-- existing MinIO route and volume, with its current images pinned by digest;
-- dedicated migration profile;
-- private-bucket initializer isolated behind the `storage-init` profile;
-- no PostgreSQL or Redis service recreation.
+- `buildingos-api`;
+- `buildingos-web`;
+- the dedicated `buildingos-migrate` runner behind the `migrate` profile.
+
+PostgreSQL, Redis, Traefik, and legacy local MinIO remain external to this
+versioned Compose and must not be recreated by application deployment. The
+Compose file uses the existing external networks but does not define a MinIO
+service, MinIO volume, MinIO route, or storage initializer profile.
+
+The current authoritative application document storage is the external
+Contabo Object Storage bucket configured through the protected API environment.
+See [`PRODUCTION_BACKUP_STRATEGY.md`](../runbooks/PRODUCTION_BACKUP_STRATEGY.md)
+for the authoritative backup and storage-recovery strategy. Local MinIO is
+legacy and non-authoritative; removing it or changing its policy or routing
+requires a separately approved infrastructure change.
 
 Real values remain in `/opt/pawtech/env/`. The versioned Compose contains no credential defaults.
 
 The legacy ignored file `infra/docker/.env` may remain in the production checkout only while the root `.dockerignore` excludes nested `.env` files. Any other ignored environment file or sensitive artifact blocks deployment.
 
-Before the first controlled promotion, run the `storage-init` profile under separate production approval. It preserves the existing bucket and explicitly removes the legacy anonymous-download policy with `mc anonymous set none`; verify private access before continuing.
+No storage-initialization profile exists in the current versioned production
+Compose. Object Storage readiness must be validated through the current
+approved read-only and pre-deploy controls. This does not authorize a storage
+mutation; storage policy or routing changes require separate approval.
 
 ## Audited Prisma baseline
 

--- a/docs/runbooks/MINIO_BACKUP_RECOVERY.md
+++ b/docs/runbooks/MINIO_BACKUP_RECOVERY.md
@@ -19,16 +19,25 @@ Credentials are supplied outside Git through
 protected environment injection, Docker secrets, or a mode-0600 server file.
 Never put credentials, signed URLs, or complete environment files in evidence.
 
-Production currently runs a pinned `minio/minio` image with the named Docker
-volume `buildingos_buildingos_miniodata`, bucket identity supplied by
-`S3_BUCKET`. The production initializer intends to disable anonymous access,
-but the 2026-08-28 inventory found anonymous `GetObject` and `ListBucket`
+The 2026-08-28 production audit recorded a pinned `minio/minio` image, the
+named Docker volume `buildingos_buildingos_miniodata`, and bucket identity
+supplied by `S3_BUCKET`. The production initializer then intended to disable
+anonymous access, but that audit found anonymous `GetObject` and `ListBucket`
 permissions still active. The application audit found no dependency on either
-permission; remove them only through the approved activation procedure. The
-repository contains no completed off-host MinIO backup or restore rehearsal.
-The public health endpoint responds, while an anonymous root request is
-denied. Exact object counts, bytes, versioning, object lock, encryption, and
-replication remain production audit values to collect with read-only `mc`.
+permission. The audit also recorded that the repository had no completed
+off-host MinIO backup or restore rehearsal, that the public health endpoint
+responded while an anonymous root request was denied, and that exact object
+counts, bytes, versioning, object lock, encryption, and replication remained
+values to collect with read-only `mc`.
+
+That paragraph is historical audit context, not a current production storage
+authority or an instruction to use the superseded activation procedure. The
+current authoritative production document store is the external Contabo
+Object Storage bucket `buildingos-production`, as defined in
+[`PRODUCTION_BACKUP_STRATEGY.md`](PRODUCTION_BACKUP_STRATEGY.md). Local MinIO
+is legacy and non-authoritative for production documents. Any current removal
+of local MinIO, anonymous-access policy change, routing change, or
+storage-policy change requires a separately reviewed and approved procedure.
 
 ## Database and object consistency
 

--- a/docs/runbooks/MINIO_BACKUP_RECOVERY.md
+++ b/docs/runbooks/MINIO_BACKUP_RECOVERY.md
@@ -1,11 +1,21 @@
-# MinIO Backup and Recovery
+# SUPERSEDED FOR CURRENT PRODUCTION USE: MinIO Backup and Recovery
+
+> **HISTORICAL/REFERENCE MATERIAL ONLY.** This document describes the old
+> paired MinIO backup design and is not the current production backup plan.
+> Do not activate its paired PostgreSQL/MinIO coordinator under the current
+> strategy. The authoritative plan is
+> [`PRODUCTION_BACKUP_STRATEGY.md`](PRODUCTION_BACKUP_STRATEGY.md).
+>
+> Any future Object Storage backup implementation will be introduced
+> separately. Every actual restore still requires a separately reviewed and
+> approved recovery procedure.
 
 ## Scope and current state
 
-This runbook is an executable, fail-closed recovery procedure. Production
-activation is controlled by `PRODUCTION_BACKUP_ACTIVATION.md`. It
-does not create production backups, change bucket policy, restart containers,
-or restore production data. Credentials are supplied outside Git through
+This historical runbook describes an executable, fail-closed recovery
+procedure for the superseded design. It does not create production backups,
+change bucket policy, restart containers, or restore production data.
+Credentials are supplied outside Git through
 protected environment injection, Docker secrets, or a mode-0600 server file.
 Never put credentials, signed URLs, or complete environment files in evidence.
 
@@ -235,8 +245,8 @@ here.
 ## Production activation controls
 
 The repository-managed coordinator, schedulers, failure hooks, policy
-templates, and provider gate are installed only through the separately
-approved steps in `PRODUCTION_BACKUP_ACTIVATION.md`. No unencrypted production
-backup is allowed. A first paired backup is not successful until PostgreSQL,
-MinIO upload, and independent MinIO verification all pass for the same
-`BACKUP_SET_ID` and actual deployed `APP_SHA`.
+templates, and provider gate belong to the superseded paired design and must
+not be activated under the current strategy. Direct operators to
+`PRODUCTION_BACKUP_STRATEGY.md` for the current production plan. No actual
+restore may proceed without a separately reviewed and approved recovery
+procedure.

--- a/docs/runbooks/PRODUCTION_BACKUP_ACTIVATION.md
+++ b/docs/runbooks/PRODUCTION_BACKUP_ACTIVATION.md
@@ -1,4 +1,12 @@
-# Production Backup Activation
+# SUPERSEDED FOR NEW ACTIVATION: Production Backup Activation
+
+> **DO NOT EXECUTE AS THE CURRENT BACKUP PLAN.** This historical runbook is
+> retained temporarily for reference only. The authoritative plan is
+> [`PRODUCTION_BACKUP_STRATEGY.md`](PRODUCTION_BACKUP_STRATEGY.md).
+>
+> The large paired PostgreSQL/MinIO and privileged `CONTROL_UPDATE` design
+> described here is not planned for activation. Every future production
+> mutation still requires separate explicit approval.
 
 This runbook prepares and activates paired PostgreSQL and MinIO recovery for
 BuildingOS. Every command that changes production, Contabo, or systemd requires

--- a/docs/runbooks/PRODUCTION_BACKUP_LEGACY_INVENTORY.md
+++ b/docs/runbooks/PRODUCTION_BACKUP_LEGACY_INVENTORY.md
@@ -31,9 +31,27 @@ or policy is removed by this change.
 | `infra/production/systemd/pawtech-buildingos-backup-verify.timer` | `pawtech-buildingos-backup-verify.service` | `REPOSITORY_ONLY_UNUSED` | New paired verification timer; absent from audited production |
 | `scripts/backup-buildingos-production.sh` | `backup-buildingos-production`, `backup-postgres-paired` | `REPOSITORY_ONLY_UNUSED` | Paired PostgreSQL/MinIO coordinator; not deployed as current scheduler |
 | `scripts/backup-postgres-paired.sh` | `backup-postgres-paired` | `REPOSITORY_ONLY_UNUSED` | Repository-managed paired PostgreSQL contract; legacy production script remains active |
+| `scripts/backup-minio.sh` | MinIO paired backup | `REPOSITORY_ONLY_UNUSED` | Superseded object-storage backup script |
+| `scripts/verify-minio-backup.sh` | MinIO paired verification, SSE gate | `REPOSITORY_ONLY_UNUSED` | Superseded object-storage verification script |
+| `scripts/restore-minio.sh` | MinIO paired restore, SSE gate | `REPOSITORY_ONLY_UNUSED` | Historical isolated restore script; never current production plan |
+| `scripts/check-production-backup-freshness.sh` | Paired backup freshness | `REPOSITORY_ONLY_UNUSED` | Superseded freshness check |
+| `scripts/notify-production-backup-failure.sh` | Paired backup failure notification | `REPOSITORY_ONLY_UNUSED` | Superseded systemd failure hook |
+| `scripts/render-minio-restore-target-policy.sh` | MinIO restore policy | `REPOSITORY_ONLY_UNUSED` | Historical restore-policy generator |
+| `scripts/probe-contabo-sse-s3.sh` | Contabo SSE-S3 capability probe | `REPOSITORY_ONLY_UNUSED` | Paired-design provider capability gate |
+| `scripts/validate-sse-capability.sh` | SSE-S3 capability validation | `REPOSITORY_ONLY_UNUSED` | Paired-design validation gate |
 | `scripts/tests/production-backup-preflight.test.sh` | All preflight, coordinator, unit, and artifact references | `TEST_DEPENDENCY` | Regression coverage for repository artifacts |
 | `scripts/tests/production-backup-activation.test.sh` | `backup-buildingos-production`, `backup-postgres-paired` | `TEST_DEPENDENCY` | Isolated paired-backup contract tests |
 | `scripts/tests/endpoint-identity-parity.test.sh` | `production-backup-preflight`, `backup-postgres-paired` | `TEST_DEPENDENCY` | Identity/reference parity tests |
+| `scripts/tests/minio-paired-backup.test.sh` | MinIO backup, verification, restore, SSE probe | `TEST_DEPENDENCY` | Dedicated paired MinIO test suite |
+| `infra/production/systemd/pawtech-buildingos-backup-freshness.service` | Paired freshness service | `REPOSITORY_ONLY_UNUSED` | Absent from audited production |
+| `infra/production/systemd/pawtech-buildingos-backup-freshness.timer` | Paired freshness timer | `REPOSITORY_ONLY_UNUSED` | Absent from audited production |
+| `infra/production/systemd/pawtech-buildingos-backup-alert@.service` | Paired failure alert hook | `REPOSITORY_ONLY_UNUSED` | Absent from audited production |
+| `infra/production/buildingos-backup.env.example` | Paired backup environment template | `REPOSITORY_ONLY_UNUSED` | Template for superseded coordinator |
+| `infra/production/backup-alert.env.example` | Paired alert environment template | `REPOSITORY_ONLY_UNUSED` | Template for superseded failure hook |
+| `infra/production/policies/backup-write.json` | Paired backup-write policy | `REPOSITORY_ONLY_UNUSED` | Superseded object-storage write policy |
+| `infra/production/policies/verify-read.json` | Paired verify-read policy | `REPOSITORY_ONLY_UNUSED` | Superseded object-storage verify policy |
+| `infra/production/policies/source-read.json` | Paired source-read policy | `REPOSITORY_ONLY_UNUSED` | Superseded object-storage source policy |
+| `infra/production/policies/restore-write.json` | Paired restore-write policy | `REPOSITORY_ONLY_UNUSED` | Superseded isolated-restore policy |
 
 ## Current Production Boundary
 

--- a/docs/runbooks/PRODUCTION_BACKUP_LEGACY_INVENTORY.md
+++ b/docs/runbooks/PRODUCTION_BACKUP_LEGACY_INVENTORY.md
@@ -18,7 +18,7 @@ change.
 
 ## Reference Inventory
 
-The inventory contains 37 artifact entries.
+The inventory contains 38 artifact entries.
 
 | Path | References | Classification | Notes |
 | --- | --- | --- | --- |
@@ -50,6 +50,7 @@ The inventory contains 37 artifact entries.
 | `scripts/tests/production-backup-activation.test.sh` | `backup-buildingos-production`, `backup-postgres-paired` | `TEST_DEPENDENCY` | Isolated paired-backup contract tests |
 | `scripts/tests/endpoint-identity-parity.test.sh` | `production-backup-preflight`, `backup-postgres-paired` | `TEST_DEPENDENCY` | Identity/reference parity tests |
 | `scripts/tests/minio-paired-backup.test.sh` | MinIO backup, verification, restore, SSE probe | `TEST_DEPENDENCY` | Dedicated paired MinIO test suite |
+| `scripts/tests/production-readonly-audit.test.sh` | `production-readonly-audit.sh`, `paired-$backup_set_id.json`, `minio_verified=true` | `TEST_DEPENDENCY` | Directly enforces the current legacy paired-readiness contract; must migrate with `production-readonly-audit.sh` in `OBJECT-BACKUP-01` |
 | `infra/production/systemd/pawtech-buildingos-backup-freshness.service` | Paired freshness service | `REPOSITORY_ONLY_UNUSED` | Absent from audited production |
 | `infra/production/systemd/pawtech-buildingos-backup-freshness.timer` | Paired freshness timer | `REPOSITORY_ONLY_UNUSED` | Absent from audited production |
 | `infra/production/systemd/pawtech-buildingos-backup-alert@.service` | Paired failure alert hook | `REPOSITORY_ONLY_UNUSED` | Absent from audited production |

--- a/docs/runbooks/PRODUCTION_BACKUP_LEGACY_INVENTORY.md
+++ b/docs/runbooks/PRODUCTION_BACKUP_LEGACY_INVENTORY.md
@@ -1,0 +1,51 @@
+# Production Backup Legacy Inventory
+
+This inventory records repository references to the superseded paired-backup
+and privileged preflight designs. No referenced script, unit, workflow, test,
+or policy is removed by this change.
+
+## Classification
+
+- `ACTIVE_PRODUCTION`: confirmed as the current production mechanism.
+- `REPOSITORY_ONLY_UNUSED`: present in the repository but not active in the
+  audited production runtime.
+- `DEPLOY_DEPENDENCY`: used by deployment or preflight validation when that
+  flow is explicitly invoked.
+- `TEST_DEPENDENCY`: used by repository tests or fixtures.
+- `HISTORICAL_CANDIDATE_FOR_LATER_REMOVAL`: documentation or design material
+  retained until a separately approved cleanup.
+
+## Reference Inventory
+
+| Path | References | Classification | Notes |
+| --- | --- | --- | --- |
+| `docs/runbooks/PRODUCTION_BACKUP_ACTIVATION.md` | Historical activation runbook, `pawtech-buildingos-backup.service`, `pawtech-buildingos-backup-verify.service`, `production-backup-preflight`, `backup-buildingos-production`, `backup-postgres-paired` | `HISTORICAL_CANDIDATE_FOR_LATER_REMOVAL` | Superseded by `PRODUCTION_BACKUP_STRATEGY.md`; retained for reference |
+| `docs/runbooks/MINIO_BACKUP_RECOVERY.md` | Historical activation reference, `backup-postgres-paired` | `HISTORICAL_CANDIDATE_FOR_LATER_REMOVAL` | Paired MinIO recovery documentation |
+| `.github/workflows/production-backup-preflight.yml` | `production-backup-preflight` | `DEPLOY_DEPENDENCY` | Manual preflight workflow; not a backup scheduler |
+| `scripts/production-backup-preflight.sh` | `pawtech-buildingos-backup.service`, `pawtech-buildingos-backup-verify.service`, `production-backup-preflight`, `backup-buildingos-production`, `backup-postgres-paired` | `DEPLOY_DEPENDENCY` | Candidate/runtime and installed-control validation |
+| `infra/production/launchers/buildingos-production-backup-preflight` | `production-backup-preflight` | `DEPLOY_DEPENDENCY` | Privileged launcher artifact |
+| `infra/production/sudoers/buildingos-production-backup-preflight` | `production-backup-preflight` | `DEPLOY_DEPENDENCY` | Narrow launcher policy artifact |
+| `infra/production/systemd/pawtech-buildingos-backup.service` | `backup-buildingos-production` | `REPOSITORY_ONLY_UNUSED` | New paired coordinator unit; absent from audited production |
+| `infra/production/systemd/pawtech-buildingos-backup.timer` | `pawtech-buildingos-backup.service` | `REPOSITORY_ONLY_UNUSED` | New paired timer; absent from audited production |
+| `infra/production/systemd/pawtech-buildingos-backup-verify.service` | `backup-buildingos-production` | `REPOSITORY_ONLY_UNUSED` | New paired verification unit; absent from audited production |
+| `infra/production/systemd/pawtech-buildingos-backup-verify.timer` | `pawtech-buildingos-backup-verify.service` | `REPOSITORY_ONLY_UNUSED` | New paired verification timer; absent from audited production |
+| `scripts/backup-buildingos-production.sh` | `backup-buildingos-production`, `backup-postgres-paired` | `REPOSITORY_ONLY_UNUSED` | Paired PostgreSQL/MinIO coordinator; not deployed as current scheduler |
+| `scripts/backup-postgres-paired.sh` | `backup-postgres-paired` | `REPOSITORY_ONLY_UNUSED` | Repository-managed paired PostgreSQL contract; legacy production script remains active |
+| `scripts/tests/production-backup-preflight.test.sh` | All preflight, coordinator, unit, and artifact references | `TEST_DEPENDENCY` | Regression coverage for repository artifacts |
+| `scripts/tests/production-backup-activation.test.sh` | `backup-buildingos-production`, `backup-postgres-paired` | `TEST_DEPENDENCY` | Isolated paired-backup contract tests |
+| `scripts/tests/endpoint-identity-parity.test.sh` | `production-backup-preflight`, `backup-postgres-paired` | `TEST_DEPENDENCY` | Identity/reference parity tests |
+
+## Current Production Boundary
+
+The audited production backup boundary is the legacy PostgreSQL systemd job:
+
+- `pawtech-postgres-backup.timer`
+- `pawtech-postgres-backup.service`
+- `/opt/pawtech/backups/scripts/backup-postgres.sh`
+
+Classification: `ACTIVE_PRODUCTION`.
+
+The paired coordinator, paired systemd units, and privileged `CONTROL_UPDATE`
+flow are not part of the current production backup plan. Removing them, or
+changing their deployment/preflight behavior, requires a separate cleanup PR
+with its own review and validation.

--- a/docs/runbooks/PRODUCTION_BACKUP_LEGACY_INVENTORY.md
+++ b/docs/runbooks/PRODUCTION_BACKUP_LEGACY_INVENTORY.md
@@ -1,30 +1,33 @@
 # Production Backup Legacy Inventory
 
 This inventory records repository references to the superseded paired-backup
-and privileged preflight designs. No referenced script, unit, workflow, test,
-or policy is removed by this change.
+and privileged preflight designs, plus current production-readiness controls.
+No referenced script, unit, workflow, test, or policy is removed by this
+change.
 
 ## Classification
 
 - `ACTIVE_PRODUCTION`: confirmed as the current production mechanism.
 - `REPOSITORY_ONLY_UNUSED`: present in the repository but not active in the
   audited production runtime.
-- `DEPLOY_DEPENDENCY`: used by deployment or preflight validation when that
-  flow is explicitly invoked.
+- `DEPLOY_DEPENDENCY`: used by deployment, preflight, or production-readiness
+  validation when that flow is explicitly invoked.
 - `TEST_DEPENDENCY`: used by repository tests or fixtures.
 - `HISTORICAL_CANDIDATE_FOR_LATER_REMOVAL`: documentation or design material
   retained until a separately approved cleanup.
 
 ## Reference Inventory
 
-The inventory contains 35 artifact entries.
+The inventory contains 37 artifact entries.
 
 | Path | References | Classification | Notes |
 | --- | --- | --- | --- |
 | `docs/runbooks/PRODUCTION_BACKUP_ACTIVATION.md` | Historical activation runbook, `pawtech-buildingos-backup.service`, `pawtech-buildingos-backup-verify.service`, `production-backup-preflight`, `backup-buildingos-production`, `backup-postgres-paired` | `HISTORICAL_CANDIDATE_FOR_LATER_REMOVAL` | Superseded by `PRODUCTION_BACKUP_STRATEGY.md`; retained for reference |
 | `docs/runbooks/MINIO_BACKUP_RECOVERY.md` | Historical activation reference, `backup-postgres-paired` | `HISTORICAL_CANDIDATE_FOR_LATER_REMOVAL` | Paired MinIO recovery documentation |
 | `.github/workflows/production-backup-preflight.yml` | `production-backup-preflight` | `DEPLOY_DEPENDENCY` | Manual preflight workflow; not a backup scheduler |
+| `.github/workflows/production-readonly-audit.yml` | `production-readonly-audit.sh` | `DEPLOY_DEPENDENCY` | Current production-readiness workflow; backup readiness still depends on the superseded paired receipt and must migrate in `OBJECT-BACKUP-01` |
 | `scripts/production-backup-preflight.sh` | `pawtech-buildingos-backup.service`, `pawtech-buildingos-backup-verify.service`, `production-backup-preflight`, `backup-buildingos-production`, `backup-postgres-paired` | `DEPLOY_DEPENDENCY` | Candidate/runtime and installed-control validation |
+| `scripts/production-readonly-audit.sh` | `paired-<backup_set_id>.json`, `minio_verified=true`, `production-readonly-audit.yml` | `DEPLOY_DEPENDENCY` | Current production-readiness audit; backup readiness remains on the superseded paired-receipt contract until `OBJECT-BACKUP-01` migrates it |
 | `scripts/lib/endpoint-identity.sh` | `production-backup-preflight`, MinIO/S3 runtime scripts, `endpoint-identity-parity.test.sh` | `DEPLOY_DEPENDENCY` | Shared endpoint canonicalization helper sourced by preflight; required by the explicitly invoked deployment validation flow |
 | `infra/production/launchers/buildingos-production-backup-preflight` | `production-backup-preflight` | `DEPLOY_DEPENDENCY` | Privileged launcher artifact |
 | `infra/production/sudoers/buildingos-production-backup-preflight` | `production-backup-preflight` | `DEPLOY_DEPENDENCY` | Narrow launcher policy artifact |

--- a/docs/runbooks/PRODUCTION_BACKUP_LEGACY_INVENTORY.md
+++ b/docs/runbooks/PRODUCTION_BACKUP_LEGACY_INVENTORY.md
@@ -17,12 +17,15 @@ or policy is removed by this change.
 
 ## Reference Inventory
 
+The inventory contains 35 artifact entries.
+
 | Path | References | Classification | Notes |
 | --- | --- | --- | --- |
 | `docs/runbooks/PRODUCTION_BACKUP_ACTIVATION.md` | Historical activation runbook, `pawtech-buildingos-backup.service`, `pawtech-buildingos-backup-verify.service`, `production-backup-preflight`, `backup-buildingos-production`, `backup-postgres-paired` | `HISTORICAL_CANDIDATE_FOR_LATER_REMOVAL` | Superseded by `PRODUCTION_BACKUP_STRATEGY.md`; retained for reference |
 | `docs/runbooks/MINIO_BACKUP_RECOVERY.md` | Historical activation reference, `backup-postgres-paired` | `HISTORICAL_CANDIDATE_FOR_LATER_REMOVAL` | Paired MinIO recovery documentation |
 | `.github/workflows/production-backup-preflight.yml` | `production-backup-preflight` | `DEPLOY_DEPENDENCY` | Manual preflight workflow; not a backup scheduler |
 | `scripts/production-backup-preflight.sh` | `pawtech-buildingos-backup.service`, `pawtech-buildingos-backup-verify.service`, `production-backup-preflight`, `backup-buildingos-production`, `backup-postgres-paired` | `DEPLOY_DEPENDENCY` | Candidate/runtime and installed-control validation |
+| `scripts/lib/endpoint-identity.sh` | `production-backup-preflight`, MinIO/S3 runtime scripts, `endpoint-identity-parity.test.sh` | `DEPLOY_DEPENDENCY` | Shared endpoint canonicalization helper sourced by preflight; required by the explicitly invoked deployment validation flow |
 | `infra/production/launchers/buildingos-production-backup-preflight` | `production-backup-preflight` | `DEPLOY_DEPENDENCY` | Privileged launcher artifact |
 | `infra/production/sudoers/buildingos-production-backup-preflight` | `production-backup-preflight` | `DEPLOY_DEPENDENCY` | Narrow launcher policy artifact |
 | `infra/production/systemd/pawtech-buildingos-backup.service` | `backup-buildingos-production` | `REPOSITORY_ONLY_UNUSED` | New paired coordinator unit; absent from audited production |
@@ -30,6 +33,7 @@ or policy is removed by this change.
 | `infra/production/systemd/pawtech-buildingos-backup-verify.service` | `backup-buildingos-production` | `REPOSITORY_ONLY_UNUSED` | New paired verification unit; absent from audited production |
 | `infra/production/systemd/pawtech-buildingos-backup-verify.timer` | `pawtech-buildingos-backup-verify.service` | `REPOSITORY_ONLY_UNUSED` | New paired verification timer; absent from audited production |
 | `scripts/backup-buildingos-production.sh` | `backup-buildingos-production`, `backup-postgres-paired` | `REPOSITORY_ONLY_UNUSED` | Paired PostgreSQL/MinIO coordinator; not deployed as current scheduler |
+| `scripts/resolve-production-app-sha.sh` | `backup-buildingos-production`, `production-backup-preflight`, paired-backup tests | `REPOSITORY_ONLY_UNUSED` | Runtime dependency of the superseded paired coordinator; preflight checks its presence but current production does not invoke the coordinator |
 | `scripts/backup-postgres-paired.sh` | `backup-postgres-paired` | `REPOSITORY_ONLY_UNUSED` | Repository-managed paired PostgreSQL contract; legacy production script remains active |
 | `scripts/backup-minio.sh` | MinIO paired backup | `REPOSITORY_ONLY_UNUSED` | Superseded object-storage backup script |
 | `scripts/verify-minio-backup.sh` | MinIO paired verification, SSE gate | `REPOSITORY_ONLY_UNUSED` | Superseded object-storage verification script |

--- a/docs/runbooks/PRODUCTION_BACKUP_STRATEGY.md
+++ b/docs/runbooks/PRODUCTION_BACKUP_STRATEGY.md
@@ -1,0 +1,80 @@
+# BuildingOS Production Backup Strategy
+
+**Status:** authoritative recovery strategy after the production backup audit.
+
+This document describes the minimum backup architecture for BuildingOS. It is
+documentation only. It does not authorize a backup, restore, deployment,
+systemd change, sudoers change, storage mutation, or production configuration
+change.
+
+## Recovery Layers
+
+| Asset | Protection | Status | High-level RPO/RTO |
+| --- | --- | --- | --- |
+| VPS, local configuration, PostgreSQL volume, Redis volume, local runtime state | Contabo VPS Auto Backup | Enabled externally; daily, 10 copies | Host-level disaster recovery; provider restore time applies |
+| PostgreSQL logical data | `pawtech-postgres-backup.service` and `.timer` | **CURRENT / ACTIVE** | Daily logical recovery; current job retains 7 local days and 30 remote days |
+| Uploaded documents and receipts | External Contabo S3-compatible Object Storage, bucket `buildingos-production` | **PENDING** independent backup | Object backup RPO/RTO is undefined until the separate implementation exists |
+| Application source and repository configuration | GitHub | Available for source recovery | Rebuild-based recovery; deployment and dependency installation time applies |
+| Redis | Reconstructable runtime state | No dedicated backup | Data is treated as ephemeral/rebuildable |
+| Local MinIO | Existing local legacy service | **LEGACY / NON-AUTHORITATIVE** | Not a recovery source for production documents |
+
+## Current PostgreSQL Protection
+
+The existing local systemd mechanism remains the production PostgreSQL backup
+mechanism. It currently performs all of the following:
+
+- Daily `pg_dump -Fc` logical dumps.
+- SHA-256 sidecar generation.
+- Read-only `pg_restore --list` validation.
+- External `rclone` copies.
+- Seven-day local retention.
+- Thirty-day remote retention.
+
+The current PostgreSQL mechanism must remain unchanged until a separately
+approved replacement exists and has been validated. The active service and
+timer are the legacy `pawtech-postgres-backup.service` and
+`pawtech-postgres-backup.timer`.
+
+## Pending Object Storage Protection
+
+The authoritative document store is the external S3-compatible bucket
+`buildingos-production` at Contabo Object Storage. PostgreSQL dumps do not
+contain those objects, and a VPS snapshot does not provide independent
+protection for an external bucket.
+
+The next small implementation PR should define an independent object-storage
+backup with these minimum properties:
+
+- A destination separate from the source bucket.
+- Versioning and retention enabled at the destination.
+- Source deletion never propagating to the backup destination.
+- Read-only verification of object count, size, and recoverability.
+- Credentials scoped to the required read/write operations only.
+- A separately approved schedule and recovery test.
+
+That implementation is intentionally deferred. This PR does not add a backup
+script or change storage configuration.
+
+## Scheduling and Automation
+
+- Local systemd may continue to own PostgreSQL backup scheduling.
+- GitHub Actions must not execute production backups or restores.
+- GitHub remains a source-code recovery mechanism, not a production data-plane
+  scheduler.
+- PostgreSQL and object-storage backup schedules should remain independent so a
+  database job cannot mask an object-storage failure.
+- Every production mutation requires separate explicit approval, including
+  changes to systemd, sudoers, credentials, buckets, retention, or runtime
+  services.
+
+## Superseded Designs
+
+`PRODUCTION_BACKUP_ACTIVATION.md` is retained as historical/reference material
+only. Its paired PostgreSQL/MinIO activation flow and privileged
+`CONTROL_UPDATE` publication mechanism are not part of the target architecture
+and must not be activated under this strategy.
+
+The repository still contains related scripts, units, policies, workflows, and
+tests. They are intentionally not deleted in this documentation-only change;
+their classifications are recorded in
+[`PRODUCTION_BACKUP_LEGACY_INVENTORY.md`](PRODUCTION_BACKUP_LEGACY_INVENTORY.md).

--- a/docs/runbooks/PRODUCTION_BACKUP_STRATEGY.md
+++ b/docs/runbooks/PRODUCTION_BACKUP_STRATEGY.md
@@ -55,6 +55,52 @@ backup with these minimum properties:
 That implementation is intentionally deferred. This PR does not add a backup
 script or change storage configuration.
 
+## Recovery-Point Consistency Contract
+
+PostgreSQL and Object Storage backup jobs may remain independently scheduled
+and may retain independent failure domains. Independent scheduling does not
+mean that recovery points are independent or uncoordinated. Freshness of each
+job alone is insufficient evidence for a restorable production recovery point.
+
+No PostgreSQL dump and Object Storage backup combination may be advertised as
+restorable until reconciliation proves that every object referenced by the
+selected database recovery point is available in the selected object backup.
+The future `OBJECT-BACKUP-01` implementation must produce enough durable
+evidence to bind and select that database/object recovery point, including the
+result of this reconciliation. If any referenced object is missing,
+reconciliation fails closed and that recovery point must not be advertised as
+restorable.
+
+The validity contract is:
+
+```text
+POSTGRES_BACKUP_VALID
++ OBJECT_BACKUP_VALID
++ DB_OBJECT_RECONCILIATION_PASS
+= RECOVERY_POINT_VALID
+```
+
+This contract does not require reintroducing the superseded paired
+`CONTROL_UPDATE` or coordinator architecture. Scheduling and execution may
+remain separate while recovery-point selection is bound by explicit evidence.
+
+## Current Production Audit Transition
+
+The current `production-readonly-audit.sh` control and
+`production-readonly-audit.yml` workflow still validate the old paired
+readiness contract: a paired receipt must be present and must contain
+`minio_verified=true`. They are current production-readiness dependencies, but
+their backup-readiness check has not yet been migrated to the simplified
+Object Storage evidence and reconciliation contract.
+
+Accordingly, this PR intentionally does not claim full production backup
+readiness. Under the simplified architecture, backup readiness remains
+**FAIL-CLOSED / INCOMPLETE** until Object Storage backup is implemented and
+the audit can validate the recovery-point contract above. `OBJECT-BACKUP-01`
+must update the production-readonly-audit contract together with the new
+Object Storage evidence and reconciliation mechanism. No operator may bypass,
+suppress, or manually mark the current audit `PASS`.
+
 ## Scheduling and Automation
 
 - Local systemd may continue to own PostgreSQL backup scheduling.
@@ -62,7 +108,8 @@ script or change storage configuration.
 - GitHub remains a source-code recovery mechanism, not a production data-plane
   scheduler.
 - PostgreSQL and object-storage backup schedules should remain independent so a
-  database job cannot mask an object-storage failure.
+  database job cannot mask an object-storage failure; the recovery-point
+  consistency contract above still applies when selecting a restorable point.
 - Every production mutation requires separate explicit approval, including
   changes to systemd, sudoers, credentials, buckets, retention, or runtime
   services.

--- a/docs/runbooks/PRODUCTION_BACKUP_STRATEGY.md
+++ b/docs/runbooks/PRODUCTION_BACKUP_STRATEGY.md
@@ -104,7 +104,15 @@ suppress, or manually mark the current audit `PASS`.
 ## Scheduling and Automation
 
 - Local systemd may continue to own PostgreSQL backup scheduling.
-- GitHub Actions must not execute production backups or restores.
+- GitHub Actions must not be used as a periodic backup scheduler or expose a
+  standalone production backup execution path.
+- The existing approved production deployment workflow may invoke its
+  mandatory validated PostgreSQL pre-deploy backup as a deployment safety
+  prerequisite. That invocation is not the regular backup scheduler and does
+  not replace the daily PostgreSQL systemd backup; it remains unchanged by
+  this PR.
+- Object Storage backup scheduling will also be local and independent when
+  that backup is implemented.
 - GitHub remains a source-code recovery mechanism, not a production data-plane
   scheduler.
 - PostgreSQL and object-storage backup schedules should remain independent so a

--- a/docs/runbooks/PRODUCTION_BACKUP_STRATEGY.md
+++ b/docs/runbooks/PRODUCTION_BACKUP_STRATEGY.md
@@ -65,24 +65,48 @@ job alone is insufficient evidence for a restorable production recovery point.
 No PostgreSQL dump and Object Storage backup combination may be advertised as
 restorable until reconciliation proves that every object referenced by the
 selected database recovery point is available in the selected object backup.
-The future `OBJECT-BACKUP-01` implementation must produce enough durable
-evidence to bind and select that database/object recovery point, including the
-result of this reconciliation. If any referenced object is missing,
-reconciliation fails closed and that recovery point must not be advertised as
-restorable.
+Object-key presence alone is insufficient. Current application evidence allows
+presigned PUT URLs to remain valid for 24 hours, so a referenced key may be
+overwritten after the selected database point. `File.checksum` is not
+currently a mandatory trusted server-bound immutable content identity, and an
+optional or client-supplied checksum must not be treated as authoritative
+recovery identity.
+
+For every `File`/object reference selected from the database recovery point,
+the Object Storage recovery point must prove that the exact object bytes
+belonging to that database point are recoverable. The future
+`OBJECT-BACKUP-01` implementation owns the mechanism and its tests. It must
+choose and prove one safe mechanism, without this PR selecting or
+implementing it:
+
+- Immutable object identity, such as an S3 `VersionId` bound to the selected
+  database recovery point, or a trusted cryptographic digest/object identity
+  bound to that point and verified against the backed-up object.
+- An explicitly proven write-quiescence window spanning recovery-point capture
+  so referenced objects cannot be overwritten or deleted between the database
+  point and object capture.
+
+The implementation must produce enough durable evidence to bind and select
+the database/object recovery point, including reference reconciliation and
+exact content identity. If any referenced object is missing, mismatched, or
+otherwise not proven to have the exact bytes, the recovery point fails closed
+and must not be advertised as restorable. Current backup readiness remains
+**FAIL-CLOSED / INCOMPLETE** until this mechanism exists.
 
 The validity contract is:
 
 ```text
 POSTGRES_BACKUP_VALID
 + OBJECT_BACKUP_VALID
-+ DB_OBJECT_RECONCILIATION_PASS
++ DB_OBJECT_REFERENCE_RECONCILIATION_PASS
++ DB_OBJECT_CONTENT_IDENTITY_PASS
 = RECOVERY_POINT_VALID
 ```
 
 This contract does not require reintroducing the superseded paired
-`CONTROL_UPDATE` or coordinator architecture. Scheduling and execution may
-remain separate while recovery-point selection is bound by explicit evidence.
+`CONTROL_UPDATE` or coordinator architecture merely to satisfy the contract.
+Scheduling and execution may remain separate while recovery-point selection is
+bound by explicit evidence.
 
 ## Current Production Audit Transition
 


### PR DESCRIPTION
## Summary

- Supersedes closed PR #225.
- Adds the authoritative production backup strategy and classifies legacy paired-backup references.
- Marks `PRODUCTION_BACKUP_ACTIVATION.md` as superseded for new activation.
- Documentation-only change.

## Production Boundaries

- No production connections.
- No production mutations.
- No backup executions.
- No restore executions.
- No deploys.
- PostgreSQL current backup remains unchanged.
- Object Storage backup implementation is intentionally deferred to the next small PR.
- GitHub Actions must not be used as a periodic backup scheduler or expose a standalone production backup execution path.
- The approved production deployment workflow may invoke its mandatory validated PostgreSQL pre-deploy backup as a deployment safety prerequisite; this does not replace the daily PostgreSQL systemd backup.

## Scope

- Contabo VPS Auto Backup remains host-level protection.
- Existing local PostgreSQL systemd backup remains current/active.
- Independent Object Storage backup is pending.
- Redis remains reconstructable runtime state.
- Local MinIO remains legacy/non-authoritative.
- No scripts, units, workflows, tests, or policies were removed.