### PR TITLE
OBJECT_BACKUP_01A_OBJECT_COPY

### DIFF
--- a/scripts/backup-object-storage.sh
+++ b/scripts/backup-object-storage.sh
@@ -8,13 +8,17 @@ validate_location() {
   local label="$1"
   local value="$2"
   [[ -n "$value" ]] || fail "$label is required"
-  [[ "$value" != *'://'* && "$value" != *'@'* && "$value" != *'?'* && "$value" != *'#'* ]] || fail "$label must not contain a URL, credentials, or query string"
-  [[ "$value" =~ ^[A-Za-z0-9._:/+=%,-]+$ ]] || fail "$label contains unsupported characters"
-  case "$value" in
-    /|.|./|*:)
-      fail "$label must not be an empty or root location"
-      ;;
-  esac
+  if [[ ! "$value" =~ ^([A-Za-z0-9][A-Za-z0-9._-]*):([A-Za-z0-9][A-Za-z0-9._-]*)$ ]]; then
+    fail "$label must be a named rclone remote and bucket root (REMOTE_NAME:BUCKET_NAME)"
+  fi
+
+  if [[ "$label" == OBJECT_BACKUP_SOURCE ]]; then
+    source_remote="${BASH_REMATCH[1]}"
+    source_bucket="${BASH_REMATCH[2]}"
+  else
+    destination_remote="${BASH_REMATCH[1]}"
+    destination_bucket="${BASH_REMATCH[2]}"
+  fi
 }
 
 receipt_file="${OBJECT_BACKUP_RECEIPT:-${TMPDIR:-/tmp}/buildingos-object-backup-receipt.json}"
@@ -29,7 +33,7 @@ source_location="${OBJECT_BACKUP_SOURCE:-}"
 destination_location="${OBJECT_BACKUP_DESTINATION:-}"
 validate_location OBJECT_BACKUP_SOURCE "$source_location"
 validate_location OBJECT_BACKUP_DESTINATION "$destination_location"
-[[ "$source_location" != "$destination_location" ]] || fail 'source and destination must differ'
+[[ "$source_bucket" != "$destination_bucket" ]] || fail 'source and destination bucket names must differ'
 command -v rclone >/dev/null 2>&1 || fail 'rclone is required'
 
 started_at_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/scripts/backup-object-storage.sh
+++ b/scripts/backup-object-storage.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+set +x
+
+fail() { printf 'ERROR: %s\n' "$1" >&2; exit 1; }
+
+validate_location() {
+  local label="$1"
+  local value="$2"
+  [[ -n "$value" ]] || fail "$label is required"
+  [[ "$value" != *'://'* && "$value" != *'@'* && "$value" != *'?'* && "$value" != *'#'* ]] || fail "$label must not contain a URL, credentials, or query string"
+  [[ "$value" =~ ^[A-Za-z0-9._:/+=%,-]+$ ]] || fail "$label contains unsupported characters"
+  case "$value" in
+    /|.|./|*:)
+      fail "$label must not be an empty or root location"
+      ;;
+  esac
+}
+
+receipt_file="${OBJECT_BACKUP_RECEIPT:-${TMPDIR:-/tmp}/buildingos-object-backup-receipt.json}"
+[[ "$receipt_file" == /* ]] || fail 'OBJECT_BACKUP_RECEIPT must be an absolute path'
+[[ "$receipt_file" != *$'\n'* && "$receipt_file" != *$'\r'* ]] || fail 'OBJECT_BACKUP_RECEIPT contains a control character'
+receipt_dir="${receipt_file%/*}"
+[[ -d "$receipt_dir" ]] || fail 'OBJECT_BACKUP_RECEIPT parent directory is unavailable'
+[[ ! -L "$receipt_file" ]] || fail 'OBJECT_BACKUP_RECEIPT must not be a symlink'
+rm -f "$receipt_file" || fail 'unable to clear the previous object backup receipt'
+
+source_location="${OBJECT_BACKUP_SOURCE:-}"
+destination_location="${OBJECT_BACKUP_DESTINATION:-}"
+validate_location OBJECT_BACKUP_SOURCE "$source_location"
+validate_location OBJECT_BACKUP_DESTINATION "$destination_location"
+[[ "$source_location" != "$destination_location" ]] || fail 'source and destination must differ'
+command -v rclone >/dev/null 2>&1 || fail 'rclone is required'
+
+started_at_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+temporary_receipt=''
+cleanup() {
+  [[ -z "$temporary_receipt" ]] || rm -f "$temporary_receipt"
+}
+trap cleanup EXIT
+
+if ! rclone copy "$source_location" "$destination_location" >/dev/null; then
+  fail 'object storage copy failed'
+fi
+
+if ! rclone check --one-way "$source_location" "$destination_location" >/dev/null; then
+  fail 'object storage verification failed'
+fi
+
+completed_at_utc="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+temporary_receipt="$(mktemp "${receipt_file}.tmp.XXXXXX")" || fail 'unable to create temporary object backup receipt'
+umask 077
+printf '{"receipt_version":1,"started_at_utc":"%s","completed_at_utc":"%s","source":"%s","destination":"%s","copy_status":"PASS","verification_status":"PASS","status":"PASS","recovery_point_valid":"NOT_EVALUATED"}\n' \
+  "$started_at_utc" "$completed_at_utc" "$source_location" "$destination_location" > "$temporary_receipt" || fail 'unable to write object backup receipt'
+mv -f "$temporary_receipt" "$receipt_file" || fail 'unable to publish object backup receipt'
+temporary_receipt=''
+
+printf 'OBJECT_BACKUP_COMPLETE\nSTATUS=PASS\nRECOVERY_POINT_VALID=NOT_EVALUATED\nRECEIPT=%s\n' "$receipt_file"

--- a/scripts/tests/backup-object-storage.test.sh
+++ b/scripts/tests/backup-object-storage.test.sh
@@ -9,6 +9,8 @@ readonly BIN_DIR="$TEST_ROOT/bin"
 readonly RECEIPT="$TEST_ROOT/object-backup-receipt.json"
 readonly LOG_FILE="$TEST_ROOT/rclone.log"
 readonly OUTPUT_FILE="$TEST_ROOT/output"
+readonly VALID_SOURCE='prod:buildingos-production'
+readonly VALID_DESTINATION='backup:buildingos-production-backup'
 trap 'rm -rf "$TEST_ROOT"' EXIT
 
 PASS_COUNT=0
@@ -40,7 +42,7 @@ assert_absent() {
   local name="$1"
   local value="$2"
   local file="$3"
-  if grep -Fq -- "$value" "$file"; then fail_test "$name"; else pass "$name"; fi
+  if [[ -e "$file" ]] && grep -Fq -- "$value" "$file"; then fail_test "$name"; else pass "$name"; fi
 }
 
 mkdir -p "$BIN_DIR"
@@ -66,8 +68,8 @@ MOCK
 chmod +x "$BIN_DIR/rclone"
 
 run_case() {
-  local source="${1-source:buildingos-production}"
-  local destination="${2-backup:buildingos-production}"
+  local source="${1-$VALID_SOURCE}"
+  local destination="${2-$VALID_DESTINATION}"
   local copy_result="${3-PASS}"
   local check_result="${4-PASS}"
   EXPECTED_SOURCE="$source" EXPECTED_DESTINATION="$destination" \
@@ -78,38 +80,64 @@ run_case() {
 }
 
 assert_success 'valid copy and verification pass' run_case
-assert_contains 'copy is invoked' 'copy source:buildingos-production backup:buildingos-production' "$LOG_FILE"
-assert_contains 'check uses one-way verification' 'check --one-way source:buildingos-production backup:buildingos-production' "$LOG_FILE"
+assert_contains 'copy is invoked' "copy $VALID_SOURCE $VALID_DESTINATION" "$LOG_FILE"
+assert_contains 'check uses one-way verification' "check --one-way $VALID_SOURCE $VALID_DESTINATION" "$LOG_FILE"
 assert_contains 'PASS receipt is written' '"status":"PASS"' "$RECEIPT"
 assert_contains 'recovery point remains unevaluated' '"recovery_point_valid":"NOT_EVALUATED"' "$RECEIPT"
 assert_absent 'credentials are absent from evidence' 'credential-sentinel' "$RECEIPT"
 
 rm -f "$RECEIPT"
-assert_failure 'missing source fails closed' run_case '' 'backup:buildingos-production'
+assert_failure 'missing source fails closed' run_case '' "$VALID_DESTINATION"
 [[ ! -e "$RECEIPT" ]] && pass 'missing source leaves no PASS receipt' || fail_test 'missing source leaves no PASS receipt'
 
 rm -f "$RECEIPT"
-assert_failure 'missing destination fails closed' run_case 'source:buildingos-production' ''
+assert_failure 'missing destination fails closed' run_case "$VALID_SOURCE" ''
 [[ ! -e "$RECEIPT" ]] && pass 'missing destination leaves no PASS receipt' || fail_test 'missing destination leaves no PASS receipt'
 
 rm -f "$RECEIPT"
-assert_failure 'identical source and destination fail closed' run_case 'same:location' 'same:location'
-[[ ! -e "$RECEIPT" ]] && pass 'identical locations leave no PASS receipt' || fail_test 'identical locations leave no PASS receipt'
+assert_failure 'same bucket name fails closed' run_case 'prod:buildingos-production' 'backup:buildingos-production'
+[[ ! -e "$RECEIPT" ]] && pass 'same bucket name leaves no PASS receipt' || fail_test 'same bucket name leaves no PASS receipt'
 
 rm -f "$RECEIPT"
-assert_failure 'root destination fails closed' run_case 'source:buildingos-production' '/'
-[[ ! -e "$RECEIPT" ]] && pass 'root destination leaves no PASS receipt' || fail_test 'root destination leaves no PASS receipt'
+assert_failure 'inline rclone connection string fails closed' run_case ':s3,access_key_id=FAKE_SECRET,secret_access_key=FAKE_SECRET:bucket' "$VALID_DESTINATION"
+assert_absent 'rejected inline secret is absent from receipt' 'FAKE_SECRET' "$RECEIPT"
+[[ ! -e "$RECEIPT" ]] && pass 'inline connection string leaves no PASS receipt' || fail_test 'inline connection string leaves no PASS receipt'
+
+rm -f "$RECEIPT" "$LOG_FILE"
+assert_failure 'remote root fails closed' run_case 'remote:' "$VALID_DESTINATION"
+[[ ! -e "$RECEIPT" ]] && pass 'remote root leaves no PASS receipt' || fail_test 'remote root leaves no PASS receipt'
+
+rm -f "$RECEIPT" "$LOG_FILE"
+assert_failure 'remote slash root fails closed' run_case 'remote:/' "$VALID_DESTINATION"
+[[ ! -e "$RECEIPT" ]] && pass 'remote slash root leaves no PASS receipt' || fail_test 'remote slash root leaves no PASS receipt'
+
+rm -f "$RECEIPT" "$LOG_FILE"
+assert_failure 'absolute local root fails closed' run_case '/' "$VALID_DESTINATION"
+[[ ! -e "$RECEIPT" ]] && pass 'absolute local root leaves no PASS receipt' || fail_test 'absolute local root leaves no PASS receipt'
+
+rm -f "$RECEIPT" "$LOG_FILE"
+assert_failure 'relative local root fails closed' run_case './' "$VALID_DESTINATION"
+[[ ! -e "$RECEIPT" ]] && pass 'relative local root leaves no PASS receipt' || fail_test 'relative local root leaves no PASS receipt'
+
+rm -f "$RECEIPT" "$LOG_FILE"
+assert_failure 'local root-equivalent path fails closed' run_case '/tmp/..' "$VALID_DESTINATION"
+[[ ! -e "$RECEIPT" ]] && pass 'local root-equivalent path leaves no PASS receipt' || fail_test 'local root-equivalent path leaves no PASS receipt'
+
+rm -f "$RECEIPT" "$LOG_FILE"
+assert_failure 'same bucket with different aliases fails closed' run_case 'prod:buildingos-production' 'backup:buildingos-production'
+[[ ! -e "$RECEIPT" ]] && pass 'same bucket aliases leave no PASS receipt' || fail_test 'same bucket aliases leave no PASS receipt'
+[[ ! -s "$LOG_FILE" ]] && pass 'invalid locations do not invoke rclone' || fail_test 'invalid locations do not invoke rclone'
 
 rm -f "$RECEIPT"
-assert_failure 'copy failure fails backup' run_case 'source:buildingos-production' 'backup:buildingos-production' FAIL PASS
+assert_failure 'copy failure fails backup' run_case "$VALID_SOURCE" "$VALID_DESTINATION" FAIL PASS
 [[ ! -e "$RECEIPT" ]] && pass 'copy failure leaves no PASS receipt' || fail_test 'copy failure leaves no PASS receipt'
 
 rm -f "$RECEIPT"
-assert_failure 'verification failure fails backup' run_case 'source:buildingos-production' 'backup:buildingos-production' PASS FAIL
+assert_failure 'verification failure fails backup' run_case "$VALID_SOURCE" "$VALID_DESTINATION" PASS FAIL
 [[ ! -e "$RECEIPT" ]] && pass 'verification failure leaves no PASS receipt' || fail_test 'verification failure leaves no PASS receipt'
 
 rm -f "$RECEIPT"
-assert_failure 'unavailable rclone fails closed' env OBJECT_BACKUP_SOURCE='source:buildingos-production' OBJECT_BACKUP_DESTINATION='backup:buildingos-production' OBJECT_BACKUP_RECEIPT="$RECEIPT" PATH="$TEST_ROOT/no-rclone:/usr/bin:/bin" "$SCRIPT"
+assert_failure 'unavailable rclone fails closed' env OBJECT_BACKUP_SOURCE="$VALID_SOURCE" OBJECT_BACKUP_DESTINATION="$VALID_DESTINATION" OBJECT_BACKUP_RECEIPT="$RECEIPT" PATH="$TEST_ROOT/no-rclone:/usr/bin:/bin" "$SCRIPT"
 [[ ! -e "$RECEIPT" ]] && pass 'unavailable rclone leaves no PASS receipt' || fail_test 'unavailable rclone leaves no PASS receipt'
 
 assert_absent 'script never invokes sync' 'rclone sync' "$SCRIPT"

--- a/scripts/tests/backup-object-storage.test.sh
+++ b/scripts/tests/backup-object-storage.test.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+readonly ROOT_DIR
+readonly SCRIPT="$ROOT_DIR/scripts/backup-object-storage.sh"
+readonly TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/buildingos-object-backup-test.XXXXXX")"
+readonly BIN_DIR="$TEST_ROOT/bin"
+readonly RECEIPT="$TEST_ROOT/object-backup-receipt.json"
+readonly LOG_FILE="$TEST_ROOT/rclone.log"
+readonly OUTPUT_FILE="$TEST_ROOT/output"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); printf 'ok %s - %s\n' "$PASS_COUNT" "$1"; }
+fail_test() { FAIL_COUNT=$((FAIL_COUNT + 1)); printf 'not ok %s - %s\n' "$FAIL_COUNT" "$1" >&2; }
+
+assert_success() {
+  local name="$1"
+  shift
+  if "$@" > "$OUTPUT_FILE" 2>&1; then pass "$name"; else fail_test "$name"; cat "$OUTPUT_FILE" >&2; fi
+}
+
+assert_failure() {
+  local name="$1"
+  shift
+  if "$@" > "$OUTPUT_FILE" 2>&1; then fail_test "$name (unexpected success)"; else pass "$name"; fi
+}
+
+assert_contains() {
+  local name="$1"
+  local value="$2"
+  local file="$3"
+  if grep -Fq -- "$value" "$file"; then pass "$name"; else fail_test "$name"; fi
+}
+
+assert_absent() {
+  local name="$1"
+  local value="$2"
+  local file="$3"
+  if grep -Fq -- "$value" "$file"; then fail_test "$name"; else pass "$name"; fi
+}
+
+mkdir -p "$BIN_DIR"
+cat > "$BIN_DIR/rclone" <<'MOCK'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+printf '%s\n' "$*" >> "$RCLONE_LOG"
+case "${1:-}" in
+  copy)
+    [[ "${2:-}" == "$EXPECTED_SOURCE" && "${3:-}" == "$EXPECTED_DESTINATION" ]] || exit 10
+    [[ "${RCLONE_COPY_RESULT:-PASS}" == PASS ]] || exit 11
+    ;;
+  check)
+    [[ "${2:-}" == --one-way ]] || exit 12
+    [[ "${3:-}" == "$EXPECTED_SOURCE" && "${4:-}" == "$EXPECTED_DESTINATION" ]] || exit 13
+    [[ "${RCLONE_CHECK_RESULT:-PASS}" == PASS ]] || exit 14
+    ;;
+  *)
+    exit 15
+    ;;
+esac
+MOCK
+chmod +x "$BIN_DIR/rclone"
+
+run_case() {
+  local source="${1-source:buildingos-production}"
+  local destination="${2-backup:buildingos-production}"
+  local copy_result="${3-PASS}"
+  local check_result="${4-PASS}"
+  EXPECTED_SOURCE="$source" EXPECTED_DESTINATION="$destination" \
+    RCLONE_LOG="$LOG_FILE" RCLONE_COPY_RESULT="$copy_result" RCLONE_CHECK_RESULT="$check_result" \
+    OBJECT_BACKUP_SOURCE="$source" OBJECT_BACKUP_DESTINATION="$destination" OBJECT_BACKUP_RECEIPT="$RECEIPT" \
+    RCLONE_CONFIG="$TEST_ROOT/rclone-config-with-credential-sentinel" PATH="$BIN_DIR:/usr/bin:/bin" \
+    "$SCRIPT"
+}
+
+assert_success 'valid copy and verification pass' run_case
+assert_contains 'copy is invoked' 'copy source:buildingos-production backup:buildingos-production' "$LOG_FILE"
+assert_contains 'check uses one-way verification' 'check --one-way source:buildingos-production backup:buildingos-production' "$LOG_FILE"
+assert_contains 'PASS receipt is written' '"status":"PASS"' "$RECEIPT"
+assert_contains 'recovery point remains unevaluated' '"recovery_point_valid":"NOT_EVALUATED"' "$RECEIPT"
+assert_absent 'credentials are absent from evidence' 'credential-sentinel' "$RECEIPT"
+
+rm -f "$RECEIPT"
+assert_failure 'missing source fails closed' run_case '' 'backup:buildingos-production'
+[[ ! -e "$RECEIPT" ]] && pass 'missing source leaves no PASS receipt' || fail_test 'missing source leaves no PASS receipt'
+
+rm -f "$RECEIPT"
+assert_failure 'missing destination fails closed' run_case 'source:buildingos-production' ''
+[[ ! -e "$RECEIPT" ]] && pass 'missing destination leaves no PASS receipt' || fail_test 'missing destination leaves no PASS receipt'
+
+rm -f "$RECEIPT"
+assert_failure 'identical source and destination fail closed' run_case 'same:location' 'same:location'
+[[ ! -e "$RECEIPT" ]] && pass 'identical locations leave no PASS receipt' || fail_test 'identical locations leave no PASS receipt'
+
+rm -f "$RECEIPT"
+assert_failure 'root destination fails closed' run_case 'source:buildingos-production' '/'
+[[ ! -e "$RECEIPT" ]] && pass 'root destination leaves no PASS receipt' || fail_test 'root destination leaves no PASS receipt'
+
+rm -f "$RECEIPT"
+assert_failure 'copy failure fails backup' run_case 'source:buildingos-production' 'backup:buildingos-production' FAIL PASS
+[[ ! -e "$RECEIPT" ]] && pass 'copy failure leaves no PASS receipt' || fail_test 'copy failure leaves no PASS receipt'
+
+rm -f "$RECEIPT"
+assert_failure 'verification failure fails backup' run_case 'source:buildingos-production' 'backup:buildingos-production' PASS FAIL
+[[ ! -e "$RECEIPT" ]] && pass 'verification failure leaves no PASS receipt' || fail_test 'verification failure leaves no PASS receipt'
+
+rm -f "$RECEIPT"
+assert_failure 'unavailable rclone fails closed' env OBJECT_BACKUP_SOURCE='source:buildingos-production' OBJECT_BACKUP_DESTINATION='backup:buildingos-production' OBJECT_BACKUP_RECEIPT="$RECEIPT" PATH="$TEST_ROOT/no-rclone:/usr/bin:/bin" "$SCRIPT"
+[[ ! -e "$RECEIPT" ]] && pass 'unavailable rclone leaves no PASS receipt' || fail_test 'unavailable rclone leaves no PASS receipt'
+
+assert_absent 'script never invokes sync' 'rclone sync' "$SCRIPT"
+assert_absent 'script never invokes move' 'rclone move' "$SCRIPT"
+assert_absent 'script never invokes delete' 'rclone delete' "$SCRIPT"
+assert_absent 'script never invokes purge' 'rclone purge' "$SCRIPT"
+assert_absent 'script never uses delete-before' '--delete-before' "$SCRIPT"
+assert_absent 'script never uses delete-after' '--delete-after' "$SCRIPT"
+
+if (( FAIL_COUNT > 0 )); then
+  printf 'FAILED: %s failed, %s passed\n' "$FAIL_COUNT" "$PASS_COUNT" >&2
+  exit 1
+fi
+printf 'PASSED: %s assertions\n' "$PASS_COUNT"


### PR DESCRIPTION
## Summary

- Adds the smallest repository-side Object Storage copy primitive.
- Local implementation only.
- No production or staging connections.
- No real backup, restore, deploy, or provider mutation was executed.

## Safety Contract

- Uses `rclone copy`, never a synchronization or destructive destination operation.
- Verifies with `rclone check --one-way`.
- Writes an atomic PASS receipt without credentials or signed URLs.
- Reports `RECOVERY_POINT_VALID=NOT_EVALUATED`; this does not claim a valid DB/object recovery point.
- Systemd activation is deferred.
- Production audit/preflight migration is deferred.

## Tests

- Focused stub-rclone suite: 26 assertions passed.
- `bash -n` passed for both new scripts.
- `git diff --check` passed.

No existing scripts, workflows, systemd units, policies, Compose, application code, database schema, or production configuration were modified.