### PR TITLE
OBJECT_BACKUP_01C_READINESS_TRANSITION

### DIFF
--- a/scripts/production-backup-preflight.sh
+++ b/scripts/production-backup-preflight.sh
@@ -151,6 +151,7 @@ systemd_command_list_matches() {
   trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
   trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
   [[ -n "$trimmed" ]] || { [[ -z "$expected_exec" ]]; return; }
+  [[ -n "$expected_exec" ]] || return 1
   [[ "$trimmed" == *'{'* && "$trimmed" == *'}'* && "$trimmed" == *'path='* && "$trimmed" == *'argv[]='* ]] || return 1
   rest="$trimmed"
   while :; do
@@ -175,6 +176,10 @@ systemd_exec_matches() {
   local actual="$1"
   local expected="$2"
   systemd_command_list_matches "$actual" "$expected" "$expected"
+}
+
+systemd_no_command_list_matches() {
+  systemd_command_list_matches "$1" '' ''
 }
 
 systemd_timeout_matches() {
@@ -287,6 +292,47 @@ inspect_runtime() {
   fi
 }
 
+inspect_auxiliary_commands() {
+  local label="$1"
+  local unit="$2"
+  local condition pre post
+  local condition_available='YES' pre_available='YES' post_available='YES'
+  local condition_empty='NO' pre_empty='NO' post_empty='NO'
+
+  if ! condition="$(systemctl_value "$unit" ExecCondition)"; then
+    condition_available='NO'
+    fail_check "$unit ExecCondition is unavailable"
+  fi
+  if ! pre="$(systemctl_value "$unit" ExecStartPre)"; then
+    pre_available='NO'
+    fail_check "$unit ExecStartPre is unavailable"
+  fi
+  if ! post="$(systemctl_value "$unit" ExecStartPost)"; then
+    post_available='NO'
+    fail_check "$unit ExecStartPost is unavailable"
+  fi
+
+  if [[ "$condition_available" == YES ]] && systemd_no_command_list_matches "$condition"; then
+    condition_empty='YES'
+  else
+    fail_check "$unit ExecCondition is not empty"
+  fi
+  if [[ "$pre_available" == YES ]] && systemd_no_command_list_matches "$pre"; then
+    pre_empty='YES'
+  else
+    fail_check "$unit ExecStartPre is not empty"
+  fi
+  if [[ "$post_available" == YES ]] && systemd_no_command_list_matches "$post"; then
+    post_empty='YES'
+  else
+    fail_check "$unit ExecStartPost is not empty"
+  fi
+
+  printf '%s_EXEC_CONDITION_EMPTY=%s\n' "$label" "$condition_empty"
+  printf '%s_EXEC_START_PRE_EMPTY=%s\n' "$label" "$pre_empty"
+  printf '%s_EXEC_START_POST_EMPTY=%s\n' "$label" "$post_empty"
+}
+
 inspect_service() {
   local label="$1"
   local unit="$2"
@@ -328,6 +374,7 @@ inspect_service() {
   [[ "$workdir" == "$EXPECTED_APP_DIR" ]] || fail_check "$unit WorkingDirectory is unexpected"
   systemd_exec_matches "$exec_start" "$expected_exec" || fail_check "$unit ExecStart is unexpected"
   systemd_timeout_matches "$timeout" || fail_check "$unit TimeoutStartSec is not 6h"
+  inspect_auxiliary_commands "$label" "$unit"
 
   if (( failures == before )); then contract='YES'; fi
   printf '%s_EXISTS=%s\n' "$label" "$exists"
@@ -361,6 +408,7 @@ inspect_current_service_state() {
   esac
   [[ "$unit_type" == oneshot ]] || fail_check "$unit Type is not oneshot"
   systemd_exec_matches "$exec_start" "$expected_exec" || fail_check "$unit ExecStart is unexpected"
+  inspect_auxiliary_commands "$label" "$unit"
   (( failures == before )) && contract='YES'
   printf '%s_EXISTS=%s\n' "$label" "$exists"
   printf '%s_STATE=%s\n' "$label" "$(safe_output "$state")"
@@ -425,10 +473,16 @@ inspect_timer() {
 
 inspect_object_environment() {
   local source destination receipt rclone source_bucket destination_bucket
-  local env_ok='NO' config_mode before=$failures
+  local env_ok='NO' env_owner env_group env_mode config_mode before=$failures
   if ! file_is_regular_non_symlink "$OBJECT_BACKUP_ENV_FILE" || [[ ! -r "$OBJECT_BACKUP_ENV_FILE" ]]; then
     fail_check 'Object Storage environment is not a readable regular non-symlink file'
   else
+    env_owner="$(file_owner "$OBJECT_BACKUP_ENV_FILE")"
+    env_group="$(file_group "$OBJECT_BACKUP_ENV_FILE")"
+    env_mode="0$(file_mode "$OBJECT_BACKUP_ENV_FILE")"
+    [[ "$env_owner" == root ]] || fail_check 'Object Storage environment owner is not root'
+    [[ "$env_group" == root ]] || fail_check 'Object Storage environment group is not root'
+    [[ "$env_mode" == 0600 ]] || fail_check 'Object Storage environment mode is not 0600'
     source="$(env_value "$OBJECT_BACKUP_ENV_FILE" OBJECT_BACKUP_SOURCE 2>/dev/null || true)"
     destination="$(env_value "$OBJECT_BACKUP_ENV_FILE" OBJECT_BACKUP_DESTINATION 2>/dev/null || true)"
     receipt="$(env_value "$OBJECT_BACKUP_ENV_FILE" OBJECT_BACKUP_RECEIPT 2>/dev/null || true)"

--- a/scripts/production-backup-preflight.sh
+++ b/scripts/production-backup-preflight.sh
@@ -3,25 +3,19 @@ set -Eeuo pipefail
 set +x
 
 readonly DEFAULT_APP_DIR='/opt/pawtech/apps/buildingos/buildingos-app'
-readonly EXPECTED_BACKUP_SERVICE='pawtech-buildingos-backup.service'
-readonly EXPECTED_VERIFY_SERVICE='pawtech-buildingos-backup-verify.service'
-readonly EXPECTED_LEGACY_BACKUP_SERVICE='pawtech-postgres-backup.service'
-readonly EXPECTED_LEGACY_BACKUP_TIMER='pawtech-postgres-backup.timer'
-readonly EXPECTED_BACKUP_ENTRYPOINT='/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-buildingos-production.sh'
-readonly DEFAULT_ENV_FILE='/etc/buildingos/buildingos-backup.env'
-readonly DEFAULT_SSE_FILE='/etc/buildingos/contabo-sse-s3-capability.json'
-readonly DEFAULT_STATE_DIR='/var/lib/buildingos-backup'
-readonly EXPECTED_SOURCE_HOST='usc1.contabostorage.com'
-readonly EXPECTED_SOURCE_BUCKET='buildingos-production'
-readonly EXPECTED_PROPOSED_COMMAND='sudo systemctl start pawtech-buildingos-backup.service'
-readonly EXPECTED_BACKUP_TIMEOUT_USEC=21600000000
-readonly EXPECTED_VERIFY_TIMEOUT_USEC=14400000000
-readonly POSTGRES_BACKUP_MIN_SAFETY_MARGIN_BYTES=104857600
-readonly MAX_INT64_DIV_1024=9007199254740991
-readonly MAX_POSTGRES_ESTIMATE_BASE_BYTES=6000000000000000000
+readonly POSTGRES_BACKUP_SERVICE='pawtech-postgres-backup.service'
+readonly POSTGRES_BACKUP_TIMER='pawtech-postgres-backup.timer'
+readonly OBJECT_BACKUP_SERVICE='pawtech-buildingos-object-backup.service'
+readonly OBJECT_BACKUP_TIMER='pawtech-buildingos-object-backup.timer'
+readonly OBJECT_BACKUP_EXEC='/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh'
+readonly DEFAULT_OBJECT_BACKUP_ENV_FILE='/etc/buildingos/object-backup.env'
+readonly OBJECT_BACKUP_RECEIPT='/var/lib/buildingos-object-backup/object-backup-receipt.json'
+readonly OBJECT_BACKUP_RCLONE_CONFIG='/etc/buildingos/object-backup-rclone.conf'
+readonly EXPECTED_TIMEOUT_USEC=21600000000
 
 failures=0
-ENV_FILE_AVAILABLE=false
+POSTGRES_BACKUP_SERVICE_STATE='UNKNOWN'
+OBJECT_BACKUP_SERVICE_STATE='UNKNOWN'
 
 if ! declare -F endpoint_identity >/dev/null 2>&1; then
   helper_dir="${BASH_SOURCE[0]%/*}"
@@ -43,87 +37,15 @@ safe_output() {
   fi
 }
 
-# Frozen compatibility contract for the currently deployed db82 runtime.
-legacy_endpoint_identity() {
-  local value="$1"
-  value="${value#*://}"
-  printf '%s\n' "${value%%/*}"
-}
-
-file_owner() {
-  stat -L -c '%U' -- "$1" 2>/dev/null || stat -L -f '%Su' "$1"
-}
-
-file_group() {
-  stat -L -c '%G' -- "$1" 2>/dev/null || stat -L -f '%Sg' "$1"
-}
-
-file_mode() {
-  stat -L -c '%a' -- "$1" 2>/dev/null || stat -L -f '%Lp' "$1"
-}
-
 file_is_regular_non_symlink() {
   [[ -f "$1" && ! -L "$1" ]]
-}
-
-directory_is_regular_non_symlink() {
-  [[ -d "$1" && ! -L "$1" ]]
 }
 
 env_value() {
   local file="$1"
   local key="$2"
   awk -v key="$key" '
-    function trim(value) {
-      sub(/^[[:space:]]+/, "", value)
-      sub(/[[:space:]]+$/, "", value)
-      return value
-    }
-    function decode(value,    result,i,character,next_character) {
-      result=""
-      for (i=1; i<=length(value); i++) {
-        character=substr(value,i,1)
-        if (character != "\\") {
-          result=result character
-          continue
-        }
-        i++
-        if (i > length(value)) { invalid=1; return "" }
-        next_character=substr(value,i,1)
-        if (next_character == "n") result=result "\n"
-        else if (next_character == "r") result=result "\r"
-        else if (next_character == "t") result=result "\t"
-        else if (next_character == "s") result=result " "
-        else result=result next_character
-      }
-      return result
-    }
-    function parse_value(raw,    first,last,inner,i,character,escaped) {
-      raw=trim(raw)
-      if (raw == "") return ""
-      first=substr(raw,1,1)
-      if (first == "\"") {
-        last=0
-        escaped=0
-        for (i=2; i<=length(raw); i++) {
-          character=substr(raw,i,1)
-          if (escaped) { escaped=0; continue }
-          if (character == "\\") { escaped=1; continue }
-          if (character == "\"") { last=i; break }
-        }
-        if (last == 0 || trim(substr(raw,last+1)) != "") { invalid=1; return "" }
-        inner=substr(raw,2,last-2)
-        return decode(inner)
-      }
-      if (first == sprintf("%c", 39)) {
-        last=index(substr(raw,2), sprintf("%c", 39))
-        if (last == 0 || trim(substr(raw,last+2)) != "") { invalid=1; return "" }
-        return substr(raw,2,last-1)
-      }
-      if (index(raw, sprintf("%c", 39)) > 0 || index(raw, "\"") > 0 || raw ~ /[[:cntrl:]]/) { invalid=1; return "" }
-      return decode(raw)
-    }
-    /^[[:space:]]*#/ { next }
+    /^[[:space:]]*#/ || /^[[:space:]]*$/ { next }
     /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=/ {
       assignment=$0
       sub(/^[[:space:]]*/, "", assignment)
@@ -131,42 +53,16 @@ env_value() {
       sub(/=.*/, "", name)
       if (name == key) {
         count++
-        raw=substr(assignment, length(name)+2)
+        value=substr(assignment, length(name) + 2)
       }
       next
     }
-    /^[[:space:]]*$/ { next }
     { invalid=1 }
     END {
-      if (count != 1 || invalid) exit 1
-      printf "%s\n", parse_value(raw)
-      if (invalid) exit 1
+      if (count != 1 || invalid || value !~ /[^[:space:]]/) exit 1
+      print value
     }
   ' "$file"
-}
-
-env_name_count() {
-  local file="$1"
-  local key="$2"
-  awk -v key="$key" '
-    /^[[:space:]]*#/ { next }
-    /^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=/ {
-      assignment=$0
-      sub(/^[[:space:]]*/, "", assignment)
-      name=assignment
-      sub(/=.*/, "", name)
-      if (name == key) count++
-    }
-    END { print count + 0 }
-  ' "$file"
-}
-
-env_name_present() {
-  local file="$1"
-  local key="$2"
-  local value
-  value="$(env_value "$file" "$key" 2>/dev/null)" || return 1
-  [[ "$value" =~ [^[:space:]] ]]
 }
 
 systemctl_value() {
@@ -177,753 +73,191 @@ systemctl_value() {
 
 unit_active_state() {
   local unit="$1"
-  systemctl is-active "$unit" 2>/dev/null || true
+  systemctl_value "$unit" ActiveState || true
 }
 
-systemd_serialized_entry_matches() {
-  local entry="$1"
-  local expected_exec="$2"
-  local expected_argv="$3"
-  local parsed
-
-  parsed="$(printf '%s\n' "$entry" | awk -F ';' '
-    function trim(value) {
-      sub(/^[[:space:]]+/, "", value)
-      sub(/[[:space:]]+$/, "", value)
-      return value
-    }
-    {
-      path_count=0
-      argv_count=0
-      invalid=0
-      path=""
-      argv=""
-      for (i=1; i<=NF; i++) {
-        field=trim($i)
-        if (field == "") continue
-        if (field ~ /^path=/) {
-          path_count++
-          path=substr(field, 6)
-        } else if (field ~ /^argv\[\]=/) {
-          argv_count++
-          argv=substr(field, 8)
-        } else if (field ~ /^ignore_errors=/) {
-          ignore_count++
-          ignore_errors=substr(field, 15)
-          if (ignore_errors != "no") invalid=1
-        } else if (field ~ /^(start_time|stop_time|pid|code|status)=/) {
-          continue
-        } else {
-          invalid=1
-        }
-      }
-      if (path_count == 1 && argv_count == 1 && ignore_count == 1 && invalid == 0) {
-        printf "%s\034%s\n", path, argv
-      } else {
-        exit 1
-      }
-    }
-  ' )" || return 1
-  [[ "$parsed" == "$expected_exec"$'\034'"$expected_argv" ]]
-}
-
-systemd_command_list_matches() {
-  local raw="$1"
-  local expected_exec="$2"
-  local expected_argv="${3:-$expected_exec}"
-  local rest entry tail count=0
-  local trimmed
-
-  trimmed="$raw"
-  trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
-  trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
-  if [[ -z "$trimmed" ]]; then
-    [[ -z "$expected_exec" ]]
-    return
-  fi
-  if [[ "$trimmed" != *'{'* && "$trimmed" != *'}'* && "$trimmed" != *'path='* && "$trimmed" != *'argv[]='* ]]; then
-    return 1
-  fi
-
-  rest="$trimmed"
-  while :; do
-    rest="${rest#"${rest%%[![:space:]]*}"}"
-    [[ "${rest:0:1}" == '{' ]] || return 1
-    rest="${rest:1}"
-    [[ "$rest" == *'}'* ]] || return 1
-    entry="${rest%%\}*}"
-    tail="${rest#*\}}"
-    systemd_serialized_entry_matches "$entry" "$expected_exec" "$expected_argv" || return 1
-    count=$((count + 1))
-    rest="$tail"
-    trimmed="$rest"
-    trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
-    trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
-    [[ -z "$trimmed" ]] && break
-  done
-  [[ "$count" -eq 1 && -n "$expected_exec" ]]
+systemd_exec_matches() {
+  local actual="$1"
+  local expected="$2"
+  [[ "$actual" == "$expected" || "$actual" == "{ path=$expected ; argv[]=$expected ; ignore_errors=no }" ]]
 }
 
 systemd_timeout_matches() {
   local actual="$1"
-  local expected="$2"
-  local microseconds
-
-  [[ -n "$actual" && "$actual" != infinity && "$actual" != inf ]] || return 1
-  if [[ "$actual" =~ ^[0-9]+$ ]]; then
-    microseconds="$actual"
-  elif [[ "$actual" =~ ^([0-9]+)h$ ]]; then
-    microseconds=$((BASH_REMATCH[1] * 3600000000))
-  elif [[ "$actual" =~ ^([0-9]+)min$ ]]; then
-    microseconds=$((BASH_REMATCH[1] * 60000000))
-  elif [[ "$actual" =~ ^([0-9]+)s$ ]]; then
-    microseconds=$((BASH_REMATCH[1] * 1000000))
-  elif [[ "$actual" =~ ^([0-9]+)us$ ]]; then
-    microseconds="${BASH_REMATCH[1]}"
-  elif [[ "$actual" =~ ^([0-9]+)h[[:space:]]+([0-9]+)min[[:space:]]+([0-9]+)s$ ]]; then
-    microseconds=$((BASH_REMATCH[1] * 3600000000 + BASH_REMATCH[2] * 60000000 + BASH_REMATCH[3] * 1000000))
-  elif [[ "$actual" =~ ^([0-9]+)min[[:space:]]+([0-9]+)s$ ]]; then
-    microseconds=$((BASH_REMATCH[1] * 60000000 + BASH_REMATCH[2] * 1000000))
-  else
-    return 1
-  fi
-  [[ "$microseconds" == "$expected" ]]
+  [[ "$actual" =~ ^[0-9]+$ && "$actual" == "$EXPECTED_TIMEOUT_USEC" ]]
 }
 
-validate_backup_prefix() {
-  local prefix="$1"
-  [[ -z "$prefix" ]] && return 0
-  [[ "$prefix" =~ ^[A-Za-z0-9._-]+(/[A-Za-z0-9._-]+)*$ ]] || return 1
-  local segment
-  local -a segments
-  IFS='/' read -r -a segments <<< "$prefix"
-  for segment in "${segments[@]}"; do
-    [[ "$segment" != '.' && "$segment" != '..' ]] || return 1
-  done
-}
-
-inspect_unit() {
+inspect_service() {
   local label="$1"
   local unit="$2"
   local expected_exec="$3"
   local expected_env="$4"
-  local expected_user="$5"
-  local expected_workdir="$6"
-  local require_verify_arg="$7"
-  local load_state active_state user exec_start exec_condition exec_start_pre exec_start_post env_files workdir restart unit_type timeout_start_usec expected_argv expected_timeout
-  local exists='NO' active='UNKNOWN' exec_match='NO' exec_condition_match='NO' exec_pre_match='NO' exec_post_match='NO' env_match='NO' timeout_match='NO'
-
-  if ! systemctl cat "$unit" >/dev/null 2>&1; then
-    printf '%s_EXISTS=NO\n' "$label"
-    printf '%s_USER=UNKNOWN\n' "$label"
-    printf '%s_EXECSTART_MATCH=NO\n' "$label"
-    printf '%s_EXECCONDITION_MATCH=NO\n' "$label"
-    printf '%s_EXECSTARTPRE_MATCH=NO\n' "$label"
-    printf '%s_EXECSTARTPOST_MATCH=NO\n' "$label"
-    printf '%s_ENV_FILE_MATCH=NO\n' "$label"
-    printf '%s_TIMEOUTSTARTUSec_MATCH=NO\n' "$label"
-    printf '%s_ACTIVE=UNKNOWN\n' "$label"
-    fail_check "$unit is unavailable"
-    return
-  fi
+  local state load_state user group env_files workdir exec_start timeout unit_type
+  local exists='NO' contract='NO' running='NO' before
+  before=$failures
 
   load_state="$(systemctl_value "$unit" LoadState || true)"
-  active_state="$(systemctl_value "$unit" ActiveState || true)"
+  state="$(unit_active_state "$unit")"
+  [[ "$load_state" == loaded ]] && exists='YES' || fail_check "$unit is not loaded"
+
+  case "$state" in
+    inactive) ;;
+    active|activating)
+      running='YES'
+      fail_check "$unit is active or activating"
+      ;;
+    failed|unknown|'')
+      fail_check "$unit active state is unavailable or failed"
+      ;;
+    *)
+      fail_check "$unit active state is ambiguous"
+      ;;
+  esac
+
   user="$(systemctl_value "$unit" User || true)"
-  exec_condition="$(systemctl_value "$unit" ExecCondition || true)"
-  exec_start_pre="$(systemctl_value "$unit" ExecStartPre || true)"
-  exec_start="$(systemctl_value "$unit" ExecStart || true)"
-  exec_start_post="$(systemctl_value "$unit" ExecStartPost || true)"
+  group="$(systemctl_value "$unit" Group || true)"
   env_files="$(systemctl_value "$unit" EnvironmentFiles || true)"
   workdir="$(systemctl_value "$unit" WorkingDirectory || true)"
-  restart="$(systemctl_value "$unit" Restart || true)"
+  exec_start="$(systemctl_value "$unit" ExecStart || true)"
+  timeout="$(systemctl_value "$unit" TimeoutStartUSec || true)"
   unit_type="$(systemctl_value "$unit" Type || true)"
-  timeout_start_usec="$(systemctl_value "$unit" TimeoutStartUSec || true)"
+  [[ "$user" == yoryi ]] || fail_check "$unit User is not yoryi"
+  [[ "$group" == yoryi ]] || fail_check "$unit Group is not yoryi"
+  [[ "$unit_type" == oneshot ]] || fail_check "$unit Type is not oneshot"
+  [[ "$env_files" == "$expected_env" || "$env_files" == "-$expected_env" || "$env_files" == "$expected_env (ignore_errors=no)" || "$env_files" == "-$expected_env (ignore_errors=no)" ]] || fail_check "$unit EnvironmentFile is unexpected"
+  [[ "$workdir" == "$DEFAULT_APP_DIR" ]] || fail_check "$unit WorkingDirectory is unexpected"
+  systemd_exec_matches "$exec_start" "$expected_exec" || fail_check "$unit ExecStart is unexpected"
+  systemd_timeout_matches "$timeout" || fail_check "$unit TimeoutStartSec is not 6h"
 
-  if [[ "$load_state" == loaded ]]; then
-    exists='YES'
-  else
-    fail_check "$unit is not loaded"
-  fi
-  if [[ "$active_state" == active ]] || [[ "$(unit_active_state "$unit")" == active ]]; then
-    active='YES'
-    fail_check "$unit is active"
-  elif [[ "$active_state" == inactive || "$active_state" == failed || "$active_state" == dead ]]; then
-    active='NO'
-    [[ "$active_state" == failed ]] && fail_check "$unit is failed"
-  else
-    fail_check "$unit active state is unavailable"
-  fi
-  if [[ "$user" == "$expected_user" ]]; then
-    :
-  else
-    fail_check "$unit user is not $expected_user"
-  fi
-  expected_argv="$expected_exec"
-  [[ "$require_verify_arg" == true ]] && expected_argv+=' --verify-latest'
-  systemd_command_list_matches "$exec_start" "$expected_exec" "$expected_argv" && exec_match='YES'
-  if [[ "$exec_match" != YES ]]; then
-    fail_check "$unit ExecStart is not the trusted read-only contract"
-  fi
-  systemd_command_list_matches "$exec_condition" '' && exec_condition_match='YES'
-  if [[ "$exec_condition_match" != YES ]]; then
-    fail_check "$unit has an unexpected ExecCondition command"
-  fi
-  systemd_command_list_matches "$exec_start_pre" '' && exec_pre_match='YES'
-  if [[ "$exec_pre_match" != YES ]]; then
-    fail_check "$unit has an unexpected ExecStartPre command"
-  fi
-  systemd_command_list_matches "$exec_start_post" '' && exec_post_match='YES'
-  if [[ "$exec_post_match" != YES ]]; then
-    fail_check "$unit has an unexpected ExecStartPost command"
-  fi
-  if [[ "$env_files" == "$expected_env" || "$env_files" == "-$expected_env" || "$env_files" == "$expected_env (ignore_errors=no)" || "$env_files" == "-$expected_env (ignore_errors=no)" ]]; then
-    env_match='YES'
-  else
-    fail_check "$unit EnvironmentFile is not the protected backup environment"
-  fi
-  [[ "$workdir" == "$EXPECTED_APP_DIR" ]] || fail_check "$unit WorkingDirectory is unexpected"
-  [[ "$restart" == '' || "$restart" == 'no' ]] || fail_check "$unit has an unexpected restart policy"
-  [[ "$unit_type" == 'oneshot' ]] || fail_check "$unit is not a oneshot service"
-  if [[ "$require_verify_arg" == true ]]; then expected_timeout="$EXPECTED_VERIFY_TIMEOUT_USEC"; else expected_timeout="$EXPECTED_BACKUP_TIMEOUT_USEC"; fi
-  systemd_timeout_matches "$timeout_start_usec" "$expected_timeout" && timeout_match='YES'
-  if [[ "$timeout_match" != YES ]]; then
-    fail_check "$unit TimeoutStartUSec does not match the trusted timeout contract"
-  fi
-
+  if (( failures == before )); then contract='YES'; fi
   printf '%s_EXISTS=%s\n' "$label" "$exists"
-  printf '%s_USER=%s\n' "$label" "$(safe_output "$user")"
-  printf '%s_EXECSTART_MATCH=%s\n' "$label" "$exec_match"
-  printf '%s_EXECCONDITION_MATCH=%s\n' "$label" "$exec_condition_match"
-  printf '%s_EXECSTARTPRE_MATCH=%s\n' "$label" "$exec_pre_match"
-  printf '%s_EXECSTARTPOST_MATCH=%s\n' "$label" "$exec_post_match"
-  printf '%s_ENV_FILE_MATCH=%s\n' "$label" "$env_match"
-  printf '%s_TIMEOUTSTARTUSec_MATCH=%s\n' "$label" "$timeout_match"
-  printf '%s_ACTIVE=%s\n' "$label" "$active"
+  printf '%s_STATE=%s\n' "$label" "$(safe_output "$state")"
+  printf '%s_CONTRACT=%s\n' "$label" "$contract"
+  printf '%s_RUNNING=%s\n' "$label" "$running"
+  if [[ "$unit" == "$POSTGRES_BACKUP_SERVICE" ]]; then
+    POSTGRES_BACKUP_SERVICE_STATE="$state"
+  else
+    OBJECT_BACKUP_SERVICE_STATE="$state"
+  fi
 }
 
-inspect_regular_file() {
+inspect_current_service_state() {
   local label="$1"
-  local file="$2"
-  local expected_owner="$3"
-  local expected_group="$4"
-  local expected_mode="$5"
-  local owner group mode
+  local unit="$2"
+  local load_state state exists='NO'
 
-  if ! file_is_regular_non_symlink "$file"; then
-    fail_check "$label is not a regular non-symlink file"
-    return 1
-  fi
-  owner="$(file_owner "$file")"
-  group="$(file_group "$file")"
-  mode="0$(file_mode "$file")"
-  [[ "$owner" == "$expected_owner" ]] || fail_check "$label owner is unexpected"
-  [[ "$group" == "$expected_group" ]] || fail_check "$label group is unexpected"
-  [[ "$mode" == "$expected_mode" ]] || fail_check "$label mode is unexpected"
-  return 0
-}
-
-inspect_runtime() {
-  local production_sha='UNKNOWN' api_revision='UNKNOWN' web_revision='UNKNOWN' checkout_status='DIRTY'
-  local api_image web_image
-
-  if [[ -d "$EXPECTED_APP_DIR/.git" && ! -L "$EXPECTED_APP_DIR/.git" ]] && command -v git >/dev/null 2>&1; then
-    production_sha="$(git --no-optional-locks -C "$EXPECTED_APP_DIR" rev-parse HEAD 2>/dev/null || printf 'UNKNOWN')"
-    if [[ "$production_sha" =~ ^[0-9a-f]{40}$ ]] && git --no-optional-locks -C "$EXPECTED_APP_DIR" status --porcelain --untracked-files=all >/dev/null 2>&1; then
-      if [[ -z "$(git --no-optional-locks -C "$EXPECTED_APP_DIR" status --porcelain --untracked-files=all 2>/dev/null)" ]]; then
-        checkout_status='CLEAN'
-      fi
-    fi
-  fi
-  if command -v docker >/dev/null 2>&1; then
-    api_image="$(docker inspect --type container --format '{{.Image}}' buildingos-api 2>/dev/null || true)"
-    web_image="$(docker inspect --type container --format '{{.Image}}' buildingos-web 2>/dev/null || true)"
-    [[ "$api_image" =~ ^sha256:[0-9a-f]{64}$ ]] && api_revision="$(docker image inspect "$api_image" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || printf 'UNKNOWN')"
-    [[ "$web_image" =~ ^sha256:[0-9a-f]{64}$ ]] && web_revision="$(docker image inspect "$web_image" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || printf 'UNKNOWN')"
-  fi
-  printf 'PRODUCTION_RUNTIME_SHA=%s\n' "$(safe_output "$production_sha")"
-  printf 'API_REVISION=%s\n' "$(safe_output "$api_revision")"
-  printf 'WEB_REVISION=%s\n' "$(safe_output "$web_revision")"
-  printf 'PRODUCTION_CHECKOUT_STATUS=%s\n' "$checkout_status"
-  if [[ "$production_sha" == "$CANDIDATE_SHA" && "$api_revision" == "$CANDIDATE_SHA" && "$web_revision" == "$CANDIDATE_SHA" && "$checkout_status" == CLEAN ]]; then
-    printf 'RUNTIME_IDENTITY=CONSISTENT\n'
-  else
-    printf 'RUNTIME_IDENTITY=INCONSISTENT\n'
-    fail_check 'production runtime identity is not the expected clean, matching revision'
-  fi
-}
-
-inspect_scripts() {
-  local script_name scripts_ok=true
-  local required_scripts=(
-    backup-buildingos-production.sh backup-postgres-paired.sh backup-minio.sh
-    verify-minio-backup.sh validate-sse-capability.sh resolve-production-app-sha.sh
-    check-production-backup-freshness.sh
-  )
-  for script_name in "${required_scripts[@]}"; do
-    if ! file_is_regular_non_symlink "$EXPECTED_APP_DIR/scripts/$script_name" || [[ ! -x "$EXPECTED_APP_DIR/scripts/$script_name" ]]; then
-      scripts_ok=false
-      fail_check "required backup script is missing, non-executable, or unsafe: $script_name"
-    fi
-  done
-  if [[ "$scripts_ok" == true ]]; then
-    printf 'REQUIRED_SCRIPTS_PRESENT=YES\n'
-  else
-    printf 'REQUIRED_SCRIPTS_PRESENT=NO\n'
-  fi
-}
-
-inspect_environment() {
-  local env_ok=false owner group mode
-  local source_environment expected_source_environment source_endpoint source_bucket backup_endpoint backup_bucket state_dir sse_file postgres_container postgres_database postgres_user postgres_backup_root postgres_sse_mode
-  local source_host backup_host source_identity backup_identity legacy_source_identity legacy_backup_identity separate='NO' deployed_runtime_separate='NO'
-  local write_destination verify_destination write_remote verify_remote write_path verify_path
-  local backup_prefix backup_prefix_count prefix_valid='YES'
-  local required_names=(
-    BACKUP_ENDPOINT BACKUP_BUCKET BACKUP_VERIFY_ACCESS_KEY BACKUP_VERIFY_SECRET_KEY
-    BACKUP_SSE_CAPABILITY_FILE BACKUP_STATE_DIR BACKUP_WRITE_ACCESS_KEY BACKUP_WRITE_SECRET_KEY
-    SOURCE_ENVIRONMENT EXPECTED_SOURCE_ENVIRONMENT SOURCE_ENDPOINT SOURCE_ACCESS_KEY SOURCE_SECRET_KEY
-    SOURCE_BUCKET POSTGRES_CONTAINER POSTGRES_DATABASE POSTGRES_USER POSTGRES_BACKUP_ROOT
-    POSTGRES_RCLONE_DESTINATION POSTGRES_VERIFY_RCLONE_DESTINATION POSTGRES_SSE_MODE
-  )
-
-  if file_is_regular_non_symlink "$ENV_FILE"; then
-    ENV_FILE_AVAILABLE=true
-    owner="$(file_owner "$ENV_FILE")"
-    group="$(file_group "$ENV_FILE")"
-    mode="0$(file_mode "$ENV_FILE")"
-    [[ "$owner" == "$EXPECTED_ENV_OWNER" ]] || fail_check 'backup environment owner is unexpected'
-    [[ "$group" == "$EXPECTED_ENV_GROUP" ]] || fail_check 'backup environment group is unexpected'
-    [[ "$mode" == '0600' ]] || fail_check 'backup environment mode must be 0600'
-    env_ok=true
-    for name in "${required_names[@]}"; do
-      env_name_present "$ENV_FILE" "$name" || { env_ok=false; fail_check "required environment name is missing or duplicated: $name"; }
-    done
-  else
-    fail_check 'protected backup environment is not a regular non-symlink file'
-    printf 'REQUIRED_ENV_NAMES_PRESENT=NO\n'
-    return
-  fi
-  if [[ "$env_ok" == true ]]; then
-    printf 'REQUIRED_ENV_NAMES_PRESENT=YES\n'
-  else
-    printf 'REQUIRED_ENV_NAMES_PRESENT=NO\n'
-    ENV_FILE_AVAILABLE=false
-    return
-  fi
-
-  source_environment="$(env_value "$ENV_FILE" SOURCE_ENVIRONMENT 2>/dev/null || true)"
-  expected_source_environment="$(env_value "$ENV_FILE" EXPECTED_SOURCE_ENVIRONMENT 2>/dev/null || true)"
-  source_endpoint="$(env_value "$ENV_FILE" SOURCE_ENDPOINT 2>/dev/null || true)"
-  source_bucket="$(env_value "$ENV_FILE" SOURCE_BUCKET 2>/dev/null || true)"
-  backup_endpoint="$(env_value "$ENV_FILE" BACKUP_ENDPOINT 2>/dev/null || true)"
-  backup_bucket="$(env_value "$ENV_FILE" BACKUP_BUCKET 2>/dev/null || true)"
-  state_dir="$(env_value "$ENV_FILE" BACKUP_STATE_DIR 2>/dev/null || true)"
-  sse_file="$(env_value "$ENV_FILE" BACKUP_SSE_CAPABILITY_FILE 2>/dev/null || true)"
-  postgres_container="$(env_value "$ENV_FILE" POSTGRES_CONTAINER 2>/dev/null || true)"
-  postgres_database="$(env_value "$ENV_FILE" POSTGRES_DATABASE 2>/dev/null || true)"
-  postgres_user="$(env_value "$ENV_FILE" POSTGRES_USER 2>/dev/null || true)"
-  postgres_backup_root="$(env_value "$ENV_FILE" POSTGRES_BACKUP_ROOT 2>/dev/null || true)"
-  postgres_sse_mode="$(env_value "$ENV_FILE" POSTGRES_SSE_MODE 2>/dev/null || true)"
-  write_destination="$(env_value "$ENV_FILE" POSTGRES_RCLONE_DESTINATION 2>/dev/null || true)"
-  verify_destination="$(env_value "$ENV_FILE" POSTGRES_VERIFY_RCLONE_DESTINATION 2>/dev/null || true)"
-  write_remote="${write_destination%%:*}"
-  verify_remote="${verify_destination%%:*}"
-  write_path="${write_destination#*:}"
-  verify_path="${verify_destination#*:}"
-  backup_prefix_count="$(env_name_count "$ENV_FILE" BACKUP_PREFIX)"
-  case "$backup_prefix_count" in
-    0) backup_prefix='' ;;
-    1) backup_prefix="$(env_value "$ENV_FILE" BACKUP_PREFIX 2>/dev/null || true)" ;;
-    *) backup_prefix=''; prefix_valid='NO'; fail_check 'BACKUP_PREFIX is duplicated' ;;
+  load_state="$(systemctl_value "$unit" LoadState || true)"
+  state="$(unit_active_state "$unit")"
+  [[ "$load_state" == loaded ]] && exists='YES' || fail_check "$unit is not loaded"
+  case "$state" in
+    inactive) ;;
+    active|activating) fail_check "$unit is active or activating" ;;
+    failed|unknown|'') fail_check "$unit active state is unavailable or failed" ;;
+    *) fail_check "$unit active state is ambiguous" ;;
   esac
-  if [[ "$prefix_valid" == YES ]] && ! validate_backup_prefix "$backup_prefix"; then
-    prefix_valid='NO'
-    fail_check 'BACKUP_PREFIX is unsafe'
-  fi
-
-  source_host="$(endpoint_hostname "$source_endpoint" 2>/dev/null || true)"
-  backup_host="$(endpoint_hostname "$backup_endpoint" 2>/dev/null || true)"
-  source_identity="$(endpoint_identity "$source_endpoint")"
-  backup_identity="$(endpoint_identity "$backup_endpoint")"
-  if [[ -n "$source_identity" && -n "$backup_identity" && -n "$source_bucket" && -n "$backup_bucket" && ( "$source_identity" != "$backup_identity" || "$source_bucket" != "$backup_bucket" ) ]]; then
-    separate='YES'
+  printf '%s_EXISTS=%s\n' "$label" "$exists"
+  printf '%s_STATE=%s\n' "$label" "$(safe_output "$state")"
+  if [[ "$unit" == "$POSTGRES_BACKUP_SERVICE" ]]; then
+    POSTGRES_BACKUP_SERVICE_STATE="$state"
   else
-    fail_check 'source and backup destinations are not provably separate'
+    OBJECT_BACKUP_SERVICE_STATE="$state"
   fi
-  legacy_source_identity="$(legacy_endpoint_identity "$source_endpoint")"
-  legacy_backup_identity="$(legacy_endpoint_identity "$backup_endpoint")"
-  if [[ -n "$legacy_source_identity" && -n "$legacy_backup_identity" && -n "$source_bucket" && -n "$backup_bucket" && ( "$legacy_source_identity" != "$legacy_backup_identity" || "$source_bucket" != "$backup_bucket" ) ]]; then
-    deployed_runtime_separate='YES'
-  else
-    fail_check 'deployed db82 backup runtime would reject source and backup destinations'
-  fi
-  [[ "$source_environment" == production ]] || fail_check 'SOURCE_ENVIRONMENT must be production'
-  [[ "$expected_source_environment" == production ]] || fail_check 'EXPECTED_SOURCE_ENVIRONMENT must be production'
-  [[ "$source_host" == "$EXPECTED_SOURCE_HOST" ]] || fail_check 'source endpoint hostname is unexpected'
-  [[ "$source_bucket" == "$EXPECTED_SOURCE_BUCKET" ]] || fail_check 'source bucket is unexpected'
-  [[ "$backup_bucket" =~ ^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$ ]] || fail_check 'backup bucket is invalid'
-  [[ "$state_dir" == "$EXPECTED_STATE_DIR" ]] || fail_check 'BACKUP_STATE_DIR is unexpected'
-  [[ "$sse_file" == "$SSE_FILE" ]] || fail_check 'BACKUP_SSE_CAPABILITY_FILE is unexpected'
-  [[ "$postgres_container" =~ ^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$ ]] || fail_check 'PostgreSQL container name is invalid'
-  [[ "$postgres_database" =~ ^[A-Za-z_][A-Za-z0-9_]{0,62}$ ]] || fail_check 'PostgreSQL database name is invalid'
-  [[ "$postgres_user" =~ ^[A-Za-z_][A-Za-z0-9_]{0,62}$ ]] || fail_check 'PostgreSQL user name is invalid'
-  [[ "$postgres_backup_root" == /* && "$postgres_backup_root" != '/' ]] || fail_check 'PostgreSQL backup root is invalid'
-  [[ "$postgres_sse_mode" == SSE-S3 ]] || fail_check 'PostgreSQL SSE mode is not SSE-S3'
-  [[ "$write_destination" =~ ^[A-Za-z0-9._-]+:[A-Za-z0-9._/-]+$ ]] || fail_check 'write rclone destination is invalid'
-  [[ "$verify_destination" =~ ^[A-Za-z0-9._-]+:[A-Za-z0-9._/-]+$ ]] || fail_check 'verify rclone destination is invalid'
-  [[ "$write_path" == "$backup_bucket/postgresql" ]] || fail_check 'write rclone destination is not the dedicated PostgreSQL prefix'
-  [[ "$verify_path" == "$backup_bucket/postgresql" ]] || fail_check 'verify rclone destination is not the dedicated PostgreSQL prefix'
-  [[ -n "$write_remote" && "$write_remote" != "$verify_remote" ]] || fail_check 'rclone write and verify identities must be separate'
-
-  printf 'SOURCE_ENVIRONMENT=%s\n' "$(safe_output "$source_environment")"
-  printf 'EXPECTED_SOURCE_ENVIRONMENT=%s\n' "$(safe_output "$expected_source_environment")"
-  printf 'SOURCE_ENDPOINT_HOSTNAME=%s\n' "$(safe_output "${source_host:-UNKNOWN}")"
-  printf 'SOURCE_BUCKET=%s\n' "$(safe_output "$source_bucket")"
-  printf 'BACKUP_ENDPOINT_HOSTNAME=%s\n' "$(safe_output "${backup_host:-UNKNOWN}")"
-  printf 'BACKUP_BUCKET=%s\n' "$(safe_output "$backup_bucket")"
-  printf 'SOURCE_AND_BACKUP_SEPARATE=%s\n' "$separate"
-  printf 'DEPLOYED_RUNTIME_SOURCE_AND_BACKUP_SEPARATE=%s\n' "$deployed_runtime_separate"
-  printf 'BACKUP_STATE_DIR_MATCH=%s\n' "$([[ "$state_dir" == "$EXPECTED_STATE_DIR" ]] && printf YES || printf NO)"
-  printf 'POSTGRES_CONTAINER=%s\n' "$(safe_output "$postgres_container")"
-  printf 'POSTGRES_DATABASE=%s\n' "$(safe_output "$postgres_database")"
-  printf 'POSTGRES_USER=%s\n' "$(safe_output "$postgres_user")"
-  printf 'POSTGRES_BACKUP_ROOT=%s\n' "$(safe_output "$postgres_backup_root")"
-  printf 'POSTGRES_SSE_MODE=%s\n' "$(safe_output "$postgres_sse_mode")"
-  printf 'POSTGRES_RCLONE_WRITE_DESTINATION=%s\n' "$(safe_output "$write_destination")"
-  printf 'POSTGRES_RCLONE_VERIFY_DESTINATION=%s\n' "$(safe_output "$verify_destination")"
-  printf 'BACKUP_PREFIX_VALID=%s\n' "$prefix_valid"
 }
 
-emit_unavailable_environment_outputs() {
-  printf 'SOURCE_ENVIRONMENT=UNKNOWN\n'
-  printf 'EXPECTED_SOURCE_ENVIRONMENT=UNKNOWN\n'
-  printf 'SOURCE_ENDPOINT_HOSTNAME=UNKNOWN\n'
-  printf 'SOURCE_BUCKET=UNKNOWN\n'
-  printf 'BACKUP_ENDPOINT_HOSTNAME=UNKNOWN\n'
-  printf 'BACKUP_BUCKET=UNKNOWN\n'
-  printf 'SOURCE_AND_BACKUP_SEPARATE=UNKNOWN\n'
-  printf 'DEPLOYED_RUNTIME_SOURCE_AND_BACKUP_SEPARATE=UNKNOWN\n'
-  printf 'BACKUP_STATE_DIR_MATCH=UNKNOWN\n'
-  printf 'POSTGRES_CONTAINER=UNKNOWN\n'
-  printf 'POSTGRES_DATABASE=UNKNOWN\n'
-  printf 'POSTGRES_USER=UNKNOWN\n'
-  printf 'POSTGRES_BACKUP_ROOT=UNKNOWN\n'
-  printf 'POSTGRES_SSE_MODE=UNKNOWN\n'
-  printf 'POSTGRES_RCLONE_WRITE_DESTINATION=UNKNOWN\n'
-  printf 'POSTGRES_RCLONE_VERIFY_DESTINATION=UNKNOWN\n'
-  printf 'BACKUP_PREFIX_VALID=UNKNOWN\n'
-  printf 'SSE_EVIDENCE_VALID=UNKNOWN\n'
-  printf 'SSE_STATUS=UNKNOWN\n'
-  printf 'SSE_ALGORITHM=UNKNOWN\n'
-  printf 'SSE_PATH_MATCH=UNKNOWN\n'
-  printf 'SSE_PROBED_AT_VALID=UNKNOWN\n'
-  printf 'SSE_ENDPOINT_MATCH=UNKNOWN\n'
-  printf 'DEPLOYED_RUNTIME_SSE_ENDPOINT_MATCH=UNKNOWN\n'
-  printf 'SSE_BUCKET_MATCH=UNKNOWN\n'
-  printf 'POSTGRES_CONTAINER_STATE=UNKNOWN\n'
-  printf 'POSTGRES_CONTAINER_HEALTH=UNKNOWN\n'
-  printf 'POSTGRES_BACKUP_ROOT_FREE_BYTES=UNKNOWN\n'
-  printf 'POSTGRES_DATABASE_SIZE_BYTES=UNKNOWN\n'
-  printf 'POSTGRES_BACKUP_SAFETY_MARGIN_BYTES=UNKNOWN\n'
-  printf 'POSTGRES_BACKUP_REQUIRED_BYTES=UNKNOWN\n'
-  printf 'POSTGRES_BACKUP_SPACE_SAFE=UNKNOWN\n'
-  printf 'TMP_FREE_BYTES=UNKNOWN\n'
-  printf 'TMP_REQUIRED_BYTES=UNKNOWN\n'
-  printf 'TMP_SPACE_SAFE=UNKNOWN\n'
+timer_has_future_trigger() {
+  local trigger="$1"
+  local trigger_epoch now_epoch
+  [[ -n "$trigger" && "$trigger" != n/a && "$trigger" != '-' ]] || return 1
+  trigger_epoch="$(date -u -d "$trigger" +%s 2>/dev/null || date -j -u -f '%Y-%m-%d %H:%M:%S %Z' "$trigger" +%s 2>/dev/null || true)"
+  now_epoch="$(date -u +%s)"
+  [[ "$trigger_epoch" =~ ^[0-9]+$ && "$trigger_epoch" -gt "$now_epoch" ]]
 }
 
-inspect_sse_evidence() {
-  local owner group mode status algorithm raw_endpoint endpoint bucket expected_endpoint expected_bucket legacy_expected_endpoint
-  local valid='NO' endpoint_match='NO' deployed_runtime_endpoint_match='NO' bucket_match='NO' path_match='NO' probed_at='UNKNOWN' probed_at_valid='NO'
+inspect_timer() {
+  local label="$1"
+  local unit="$2"
+  local expected_unit="$3"
+  local load_state unit_file_state active_state next_trigger
+  local exists='NO' contract='NO' before
+  before=$failures
 
-  status='UNKNOWN'
-  algorithm='UNKNOWN'
-  endpoint='UNKNOWN'
-  bucket='UNKNOWN'
-  expected_endpoint="$(env_value "$ENV_FILE" BACKUP_ENDPOINT 2>/dev/null || true)"
-  expected_bucket="$(env_value "$ENV_FILE" BACKUP_BUCKET 2>/dev/null || true)"
-  if [[ "$(env_value "$ENV_FILE" BACKUP_SSE_CAPABILITY_FILE 2>/dev/null || true)" == "$SSE_FILE" ]]; then
-    path_match='YES'
-  else
-    fail_check 'SSE capability path does not match the protected evidence path'
-  fi
-  if file_is_regular_non_symlink "$SSE_FILE"; then
-    owner="$(file_owner "$SSE_FILE")"
-    group="$(file_group "$SSE_FILE")"
-    mode="0$(file_mode "$SSE_FILE")"
-    status="$(jq -er '.status // "UNKNOWN"' "$SSE_FILE" 2>/dev/null || printf 'UNKNOWN')"
-    algorithm="$(jq -er '.algorithm // "UNKNOWN"' "$SSE_FILE" 2>/dev/null || printf 'UNKNOWN')"
-    raw_endpoint="$(jq -er '.endpoint_identity // "UNKNOWN"' "$SSE_FILE" 2>/dev/null || printf 'UNKNOWN')"
-    bucket="$(jq -er '.bucket // "UNKNOWN"' "$SSE_FILE" 2>/dev/null || printf 'UNKNOWN')"
-    probed_at="$(jq -er '.probed_at // "UNKNOWN"' "$SSE_FILE" 2>/dev/null || printf 'UNKNOWN')"
-    legacy_expected_endpoint="$(legacy_endpoint_identity "$expected_endpoint")"
-    endpoint="$(endpoint_identity "$raw_endpoint" 2>/dev/null || printf 'UNKNOWN')"
-    expected_endpoint="$(endpoint_identity "$expected_endpoint")"
-    [[ "$owner" == "$EXPECTED_SSE_OWNER" ]] || fail_check 'SSE evidence owner is unexpected'
-    [[ "$group" == "$EXPECTED_SSE_GROUP" ]] || fail_check 'SSE evidence group is unexpected'
-    mode_value=$((8#${mode#0}))
-    (( (mode_value & 0022) == 0 )) || fail_check 'SSE evidence is group/world writable'
-    [[ "$mode" == '0640' ]] || fail_check 'SSE evidence mode must be 0640 for the backup service'
-    [[ "$status" == SSE_S3_SUPPORTED && "$algorithm" == AES256 ]] || fail_check 'SSE evidence status or algorithm is invalid'
-    if [[ "$probed_at" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then probed_at_valid='YES'; else fail_check 'SSE evidence probed_at is invalid'; fi
-    if [[ "$endpoint" == "$expected_endpoint" ]]; then endpoint_match='YES'; else fail_check 'SSE evidence endpoint does not match backup endpoint'; fi
-    if [[ "$raw_endpoint" == "$legacy_expected_endpoint" ]]; then deployed_runtime_endpoint_match='YES'; else fail_check 'SSE evidence endpoint does not match the deployed db82 runtime'; fi
-    if [[ "$bucket" == "$expected_bucket" ]]; then bucket_match='YES'; else fail_check 'SSE evidence bucket does not match backup bucket'; fi
-    if [[ "$owner" == "$EXPECTED_SSE_OWNER" && "$group" == "$EXPECTED_SSE_GROUP" && "$status" == SSE_S3_SUPPORTED && "$algorithm" == AES256 && "$endpoint_match" == YES && "$deployed_runtime_endpoint_match" == YES && "$bucket_match" == YES && "$path_match" == YES && "$probed_at_valid" == YES ]]; then
-      valid='YES'
-    fi
-  else
-    fail_check 'SSE capability evidence is not a regular non-symlink file'
-  fi
-  printf 'SSE_EVIDENCE_VALID=%s\n' "$valid"
-  printf 'SSE_STATUS=%s\n' "$(safe_output "$status")"
-  printf 'SSE_ALGORITHM=%s\n' "$(safe_output "$algorithm")"
-  printf 'SSE_PATH_MATCH=%s\n' "$path_match"
-  printf 'SSE_PROBED_AT_VALID=%s\n' "$probed_at_valid"
-  printf 'SSE_ENDPOINT_MATCH=%s\n' "$endpoint_match"
-  printf 'DEPLOYED_RUNTIME_SSE_ENDPOINT_MATCH=%s\n' "$deployed_runtime_endpoint_match"
-  printf 'SSE_BUCKET_MATCH=%s\n' "$bucket_match"
+  load_state="$(systemctl_value "$unit" LoadState || true)"
+  unit_file_state="$(systemctl_value "$unit" UnitFileState || true)"
+  active_state="$(unit_active_state "$unit")"
+  next_trigger="$(systemctl_value "$unit" NextElapseUSecRealtime || true)"
+  [[ "$load_state" == loaded ]] && exists='YES' || fail_check "$unit is not loaded"
+  [[ "$unit_file_state" == enabled ]] || fail_check "$unit is not enabled"
+  [[ "$active_state" == active ]] || fail_check "$unit is not active or waiting"
+  [[ "$(systemctl_value "$unit" Unit || true)" == "$expected_unit" ]] || fail_check "$unit points to an unexpected service"
+  timer_has_future_trigger "$next_trigger" || fail_check "$unit has no future trigger"
+
+  if (( failures == before )); then contract='YES'; fi
+  printf '%s_EXISTS=%s\n' "$label" "$exists"
+  printf '%s_ENABLED=%s\n' "$label" "$([[ "$unit_file_state" == enabled ]] && printf YES || printf NO)"
+  printf '%s_ACTIVE=%s\n' "$label" "$([[ "$active_state" == active ]] && printf YES || printf NO)"
+  printf '%s_FUTURE_TRIGGER=%s\n' "$label" "$([[ "$next_trigger" != n/a && "$next_trigger" != '-' ]] && timer_has_future_trigger "$next_trigger" && printf YES || printf NO)"
+  printf '%s_CONTRACT=%s\n' "$label" "$contract"
 }
 
-inspect_state() {
-  local state_owner state_group state_mode latest='NO' receipt_count=0 receipt
-  if ! directory_is_regular_non_symlink "$STATE_DIR"; then
-    fail_check 'backup state directory is not a regular non-symlink directory'
-    printf 'LATEST_STATE_EXISTS=NO\nPAIRED_RECEIPT_COUNT=0\n'
-    return
-  fi
-  state_owner="$(file_owner "$STATE_DIR")"
-  state_group="$(file_group "$STATE_DIR")"
-  state_mode="0$(file_mode "$STATE_DIR")"
-  [[ "$state_owner" == "$EXPECTED_STATE_OWNER" ]] || fail_check 'backup state directory owner is unexpected'
-  [[ "$state_group" == "$EXPECTED_STATE_GROUP" ]] || fail_check 'backup state directory group is unexpected'
-  [[ "$state_mode" == '0700' ]] || fail_check 'backup state directory mode must be 0700'
-
-  if [[ -e "$STATE_DIR/latest.env" || -L "$STATE_DIR/latest.env" ]]; then
-    latest='YES'
-    if ! inspect_regular_file 'latest.env' "$STATE_DIR/latest.env" "$EXPECTED_STATE_OWNER" "$EXPECTED_STATE_GROUP" '0600'; then
-      :
-    fi
-  fi
-  for receipt in "$STATE_DIR"/paired-*.json; do
-    [[ -e "$receipt" || -L "$receipt" ]] || continue
-    if file_is_regular_non_symlink "$receipt"; then
-      receipt_count=$((receipt_count + 1))
-      receipt_owner="$(file_owner "$receipt")"
-      receipt_group="$(file_group "$receipt")"
-      receipt_mode="0$(file_mode "$receipt")"
-      [[ "$receipt_owner" == "$EXPECTED_STATE_OWNER" && "$receipt_group" == "$EXPECTED_STATE_GROUP" && "$receipt_mode" == '0600' ]] || fail_check 'paired receipt metadata is unsafe'
+inspect_object_environment() {
+  local source destination receipt rclone source_bucket destination_bucket
+  local env_ok='NO'
+  if ! file_is_regular_non_symlink "$OBJECT_BACKUP_ENV_FILE" || [[ ! -r "$OBJECT_BACKUP_ENV_FILE" ]]; then
+    fail_check 'Object Storage environment is not a readable regular non-symlink file'
+  else
+    source="$(env_value "$OBJECT_BACKUP_ENV_FILE" OBJECT_BACKUP_SOURCE 2>/dev/null || true)"
+    destination="$(env_value "$OBJECT_BACKUP_ENV_FILE" OBJECT_BACKUP_DESTINATION 2>/dev/null || true)"
+    receipt="$(env_value "$OBJECT_BACKUP_ENV_FILE" OBJECT_BACKUP_RECEIPT 2>/dev/null || true)"
+    rclone="$(env_value "$OBJECT_BACKUP_ENV_FILE" RCLONE_CONFIG 2>/dev/null || true)"
+    if [[ "$source" =~ ^([A-Za-z0-9][A-Za-z0-9._-]*):([A-Za-z0-9][A-Za-z0-9._-]*)$ ]] &&
+      [[ "$destination" =~ ^([A-Za-z0-9][A-Za-z0-9._-]*):([A-Za-z0-9][A-Za-z0-9._-]*)$ ]]; then
+      source_bucket="${source#*:}"
+      destination_bucket="${destination#*:}"
+      [[ "$source_bucket" != "$destination_bucket" ]] || fail_check 'Object Storage source and destination buckets must differ'
     else
-      fail_check 'paired receipt is not a regular non-symlink file'
+      fail_check 'Object Storage source or destination is not a safe remote bucket root'
     fi
-  done
-  printf 'LATEST_STATE_EXISTS=%s\n' "$latest"
-  printf 'PAIRED_RECEIPT_COUNT=%s\n' "$receipt_count"
+    [[ "$receipt" == "$OBJECT_BACKUP_RECEIPT" ]] || fail_check 'Object Storage receipt path is unexpected'
+    [[ "$rclone" == "$OBJECT_BACKUP_RCLONE_CONFIG" ]] || fail_check 'Object Storage rclone config path is unexpected'
+    if (( failures == 0 )); then env_ok='YES'; fi
+  fi
+  printf 'OBJECT_BACKUP_ENV=%s\n' "$env_ok"
 }
 
-inspect_legacy_concurrency() {
-  local service_exists='NO' service_active='NO' timer_exists='NO' timer_active='NO' timer_enabled='NO'
-  local next_trigger='n/a' service_state service_probe timer_state timer_probe timer_unit_state
-  LEGACY_BACKUP_OVERLAP_SAFE='NO'
+inspect_topology() {
+  local before
+  before=$failures
+  inspect_current_service_state POSTGRES_BACKUP_SERVICE "$POSTGRES_BACKUP_SERVICE"
+  inspect_timer POSTGRES_BACKUP_TIMER "$POSTGRES_BACKUP_TIMER" "$POSTGRES_BACKUP_SERVICE"
+  [[ "$failures" -eq "$before" ]] && printf 'POSTGRES_BACKUP_TOPOLOGY=PASS\n' || printf 'POSTGRES_BACKUP_TOPOLOGY=FAIL\n'
 
-  if systemctl cat "$EXPECTED_LEGACY_BACKUP_SERVICE" >/dev/null 2>&1; then
-    service_exists='YES'
-    service_state="$(systemctl_value "$EXPECTED_LEGACY_BACKUP_SERVICE" ActiveState || true)"
-    service_probe="$(unit_active_state "$EXPECTED_LEGACY_BACKUP_SERVICE")"
-    if [[ "$service_state" == active || "$service_probe" == active || "$service_state" == activating || "$service_probe" == activating ]]; then
-      service_active='YES'
-      fail_check 'legacy PostgreSQL backup service is active'
-    elif [[ "$service_state" != inactive || "$service_probe" != inactive ]]; then
-      service_active='UNKNOWN'
-      fail_check 'legacy PostgreSQL backup service state is ambiguous'
-    fi
-  else
-    service_state='not-found'
-    service_probe='inactive'
-  fi
-
-  if systemctl cat "$EXPECTED_LEGACY_BACKUP_TIMER" >/dev/null 2>&1; then
-    timer_exists='YES'
-    timer_state="$(systemctl_value "$EXPECTED_LEGACY_BACKUP_TIMER" ActiveState || true)"
-    timer_probe="$(unit_active_state "$EXPECTED_LEGACY_BACKUP_TIMER")"
-    timer_unit_state="$(systemctl_value "$EXPECTED_LEGACY_BACKUP_TIMER" UnitFileState || true)"
-    next_trigger="$(systemctl_value "$EXPECTED_LEGACY_BACKUP_TIMER" NextElapseUSecRealtime || true)"
-    [[ -n "$next_trigger" ]] || next_trigger='UNKNOWN'
-    case "$timer_unit_state" in
-      enabled) timer_enabled='YES' ;;
-      disabled|masked|static) timer_enabled='NO' ;;
-      *) timer_enabled='UNKNOWN'; fail_check 'legacy PostgreSQL backup timer enablement is ambiguous' ;;
-    esac
-    if [[ "$timer_state" == active || "$timer_probe" == active ]]; then
-      timer_active='YES'
-      fail_check 'legacy PostgreSQL backup timer is active'
-    elif [[ "$timer_state" != inactive || "$timer_probe" != inactive ]]; then
-      timer_active='UNKNOWN'
-      fail_check 'legacy PostgreSQL backup timer state is ambiguous'
-    fi
-    if [[ "$next_trigger" != n/a && "$next_trigger" != '-' && -n "$next_trigger" ]]; then
-      fail_check 'legacy PostgreSQL backup timer has a scheduled next trigger'
-    fi
-  else
-    timer_state='not-found'
-    timer_probe='inactive'
-    timer_unit_state='not-found'
-  fi
-
-  if [[ "$service_active" == NO && "$timer_active" == NO && "$timer_enabled" != UNKNOWN && "$next_trigger" == n/a ]]; then
-    LEGACY_BACKUP_OVERLAP_SAFE='YES'
-  else
-    fail_check 'legacy PostgreSQL backup overlap safety is not proven'
-  fi
-  printf 'LEGACY_BACKUP_SERVICE_EXISTS=%s\n' "$service_exists"
-  printf 'LEGACY_BACKUP_SERVICE_ACTIVE=%s\n' "$service_active"
-  printf 'LEGACY_BACKUP_TIMER_EXISTS=%s\n' "$timer_exists"
-  printf 'LEGACY_BACKUP_TIMER_ACTIVE=%s\n' "$timer_active"
-  printf 'LEGACY_BACKUP_TIMER_ENABLED=%s\n' "$timer_enabled"
-  printf 'LEGACY_BACKUP_NEXT_TRIGGER=%s\n' "$(safe_output "$next_trigger")"
-  printf 'LEGACY_BACKUP_OVERLAP_SAFE=%s\n' "$LEGACY_BACKUP_OVERLAP_SAFE"
-}
-
-inspect_postgres_and_space() {
-  local container="$1"
-  local state='UNKNOWN' health='UNKNOWN' root free_bytes tmp_dir tmp_free_bytes
-  local database database_user database_size_bytes='UNKNOWN' safety_margin_bytes='UNKNOWN' required_bytes='UNKNOWN' tmp_required_bytes='UNKNOWN'
-  local postgres_space_safe='NO' tmp_space_safe='NO' free_kib
-  if command -v docker >/dev/null 2>&1; then
-    state="$(docker inspect --type container --format '{{.State.Status}}' "$container" 2>/dev/null || printf 'UNKNOWN')"
-    health="$(docker inspect --type container --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}not_configured{{end}}' "$container" 2>/dev/null || printf 'UNKNOWN')"
-  fi
-  [[ "$state" == running ]] || fail_check 'PostgreSQL container is not running'
-  [[ "$health" == healthy ]] || fail_check 'PostgreSQL container is not healthy'
-  printf 'POSTGRES_CONTAINER_STATE=%s\n' "$(safe_output "$state")"
-  printf 'POSTGRES_CONTAINER_HEALTH=%s\n' "$(safe_output "$health")"
-
-  root="$(env_value "$ENV_FILE" POSTGRES_BACKUP_ROOT 2>/dev/null || true)"
-  if ! directory_is_regular_non_symlink "$root"; then
-    fail_check 'PostgreSQL backup root is not a regular non-symlink directory'
-    free_bytes='UNKNOWN'
-  else
-    free_kib="$(df -Pk "$root" 2>/dev/null | awk 'NR == 2 { print $4; exit }' || true)"
-    if [[ "$free_kib" =~ ^[0-9]+$ && "$free_kib" -le "$MAX_INT64_DIV_1024" ]]; then
-      free_bytes=$((free_kib * 1024))
-    else
-      free_bytes='UNKNOWN'
-      fail_check 'PostgreSQL backup root free space is unavailable or has invalid units'
-    fi
-  fi
-
-  database="$(env_value "$ENV_FILE" POSTGRES_DATABASE 2>/dev/null || true)"
-  database_user="$(env_value "$ENV_FILE" POSTGRES_USER 2>/dev/null || true)"
-  if [[ "$state" == running && "$health" == healthy && "$database" =~ ^[A-Za-z_][A-Za-z0-9_]{0,62}$ && "$database_user" =~ ^[A-Za-z_][A-Za-z0-9_]{0,62}$ ]]; then
-    database_size_bytes="$(docker exec "$container" psql -U "$database_user" -d "$database" -Atqc 'SELECT pg_database_size(current_database());' 2>/dev/null || true)"
-  fi
-  if [[ "$database_size_bytes" =~ ^[0-9]+$ && "$database_size_bytes" -le "$MAX_POSTGRES_ESTIMATE_BASE_BYTES" ]]; then
-    safety_margin_bytes=$((database_size_bytes / 2))
-    (( safety_margin_bytes < POSTGRES_BACKUP_MIN_SAFETY_MARGIN_BYTES )) && safety_margin_bytes=$POSTGRES_BACKUP_MIN_SAFETY_MARGIN_BYTES
-    required_bytes=$((database_size_bytes + safety_margin_bytes))
-    tmp_required_bytes="$required_bytes"
-  else
-    fail_check 'PostgreSQL database size estimate is unavailable or invalid'
-  fi
-
-  if [[ "$free_bytes" =~ ^[0-9]+$ && "$required_bytes" =~ ^[0-9]+$ ]]; then
-    if (( free_bytes >= required_bytes )); then postgres_space_safe='YES'; else fail_check 'PostgreSQL backup root lacks required free space'; fi
-  else
-    fail_check 'PostgreSQL backup root capacity safety is not provable'
-  fi
-
-  tmp_dir="$(cd -P -- /tmp 2>/dev/null && pwd -P || true)"
-  if [[ -n "$tmp_dir" ]] && directory_is_regular_non_symlink "$tmp_dir"; then
-    free_kib="$(df -Pk "$tmp_dir" 2>/dev/null | awk 'NR == 2 { print $4; exit }' || true)"
-    if [[ "$free_kib" =~ ^[0-9]+$ && "$free_kib" -le "$MAX_INT64_DIV_1024" ]]; then
-      tmp_free_bytes=$((free_kib * 1024))
-    else
-      tmp_free_bytes='UNKNOWN'
-      fail_check 'temporary directory free space is unavailable or has invalid units'
-    fi
-  else
-    tmp_free_bytes='UNKNOWN'
-    fail_check 'temporary directory is not a regular non-symlink directory'
-  fi
-  if [[ "$tmp_free_bytes" =~ ^[0-9]+$ && "$tmp_required_bytes" =~ ^[0-9]+$ ]]; then
-    if (( tmp_free_bytes >= tmp_required_bytes )); then tmp_space_safe='YES'; else fail_check 'temporary directory lacks required free space'; fi
-  else
-    fail_check 'temporary directory capacity safety is not provable'
-  fi
-  printf 'POSTGRES_BACKUP_ROOT_FREE_BYTES=%s\n' "$free_bytes"
-  printf 'POSTGRES_DATABASE_SIZE_BYTES=%s\n' "$(safe_output "$database_size_bytes")"
-  printf 'POSTGRES_BACKUP_SAFETY_MARGIN_BYTES=%s\n' "$(safe_output "$safety_margin_bytes")"
-  printf 'POSTGRES_BACKUP_REQUIRED_BYTES=%s\n' "$(safe_output "$required_bytes")"
-  printf 'POSTGRES_BACKUP_SPACE_SAFE=%s\n' "$postgres_space_safe"
-  printf 'TMP_FREE_BYTES=%s\n' "$tmp_free_bytes"
-  printf 'TMP_REQUIRED_BYTES=%s\n' "$(safe_output "$tmp_required_bytes")"
-  printf 'TMP_SPACE_SAFE=%s\n' "$tmp_space_safe"
+  before=$failures
+  inspect_service OBJECT_BACKUP_SERVICE "$OBJECT_BACKUP_SERVICE" "$OBJECT_BACKUP_EXEC" "$OBJECT_BACKUP_ENV_FILE"
+  inspect_timer OBJECT_BACKUP_TIMER "$OBJECT_BACKUP_TIMER" "$OBJECT_BACKUP_SERVICE"
+  [[ "$failures" -eq "$before" ]] && printf 'OBJECT_BACKUP_TOPOLOGY=PASS\n' || printf 'OBJECT_BACKUP_TOPOLOGY=FAIL\n'
 }
 
 inspect_concurrency() {
-  local backup_state timer_state timer_load_state concurrency='NO'
-  backup_state="$(unit_active_state "$EXPECTED_BACKUP_SERVICE")"
-  timer_load_state="$(systemctl_value 'pawtech-buildingos-backup.timer' LoadState || true)"
-  if [[ "$timer_load_state" == not-found ]]; then
-    timer_state='inactive'
-  else
-    timer_state="$(unit_active_state 'pawtech-buildingos-backup.timer')"
+  local safe='YES'
+  if [[ "$POSTGRES_BACKUP_SERVICE_STATE" == active || "$POSTGRES_BACKUP_SERVICE_STATE" == activating || "$OBJECT_BACKUP_SERVICE_STATE" == active || "$OBJECT_BACKUP_SERVICE_STATE" == activating ]]; then
+    safe='NO'
   fi
-  [[ "$backup_state" != active ]] || fail_check 'backup service is already running'
-  [[ "$timer_state" != active ]] || fail_check 'backup timer is active and could race the manual operation'
-  inspect_legacy_concurrency
-  if [[ "$backup_state" == inactive || "$backup_state" == dead || "$backup_state" == failed ]] && [[ "$timer_state" == inactive || "$timer_state" == dead || -z "$timer_state" ]]; then
-    [[ "$LEGACY_BACKUP_OVERLAP_SAFE" == YES ]] && concurrency='YES'
-  else
-    fail_check 'backup concurrency state is unknown'
-  fi
-  printf 'BACKUP_ALREADY_RUNNING=%s\n' "$([[ "$backup_state" == active ]] && printf YES || printf NO)"
-  printf 'CONCURRENCY_SAFE=%s\n' "$concurrency"
+  [[ "$safe" == YES ]] || fail_check 'a backup service is active or activating'
+  printf 'BACKUP_CONCURRENCY_SAFE=%s\n' "$safe"
 }
 
 main() {
-  local required_commands=(awk bash cat date df docker git id jq mc pg_restore rclone sha256sum stat systemctl tr)
   local command_name missing_dependency=false
-  local app_dir env_file sse_file state_dir
+  local required_commands=(awk bash date systemctl)
 
   [[ $# -eq 1 ]] || { printf 'Usage: %s <candidate_sha>\n' "${0##*/}" >&2; return 64; }
   [[ "$1" =~ ^[0-9a-f]{40}$ ]] || { printf 'ERROR: candidate SHA is not exactly 40 lowercase hexadecimal characters\n' >&2; return 1; }
   readonly CANDIDATE_SHA="$1"
 
+  OBJECT_BACKUP_ENV_FILE="$DEFAULT_OBJECT_BACKUP_ENV_FILE"
   if [[ "${BUILDINGOS_PREFLIGHT_TEST_MODE:-}" == LOCAL_ISOLATED_ONLY ]]; then
-    test_mode=true
-    app_dir="${PREFLIGHT_APP_DIR:?}"
-    env_file="${PREFLIGHT_ENV_FILE:?}"
-    sse_file="${PREFLIGHT_SSE_FILE:?}"
-    state_dir="${PREFLIGHT_STATE_DIR:?}"
-    EXPECTED_APP_DIR="$app_dir"
-    EXPECTED_STATE_DIR="$state_dir"
-    ENV_FILE="$env_file"
-    SSE_FILE="$sse_file"
-    STATE_DIR="$state_dir"
-    EXPECTED_ENV_OWNER="${PREFLIGHT_EXPECTED_ENV_OWNER:-$(id -un)}"
-    EXPECTED_ENV_GROUP="${PREFLIGHT_EXPECTED_ENV_GROUP:-$(id -gn)}"
-    EXPECTED_STATE_OWNER="${PREFLIGHT_EXPECTED_STATE_OWNER:-$(id -un)}"
-    EXPECTED_STATE_GROUP="${PREFLIGHT_EXPECTED_STATE_GROUP:-$(id -gn)}"
-    EXPECTED_SSE_OWNER="${PREFLIGHT_EXPECTED_SSE_OWNER:-$(id -un)}"
-    EXPECTED_SSE_GROUP="${PREFLIGHT_EXPECTED_SSE_GROUP:-$(id -gn)}"
-  else
-    [[ -z "${PREFLIGHT_APP_DIR:-}${PREFLIGHT_ENV_FILE:-}${PREFLIGHT_SSE_FILE:-}${PREFLIGHT_STATE_DIR:-}" ]] || { printf 'ERROR: test path overrides require LOCAL_ISOLATED_ONLY\n' >&2; return 1; }
-    EXPECTED_APP_DIR="$DEFAULT_APP_DIR"
-    EXPECTED_STATE_DIR="$DEFAULT_STATE_DIR"
-    ENV_FILE="$DEFAULT_ENV_FILE"
-    SSE_FILE="$DEFAULT_SSE_FILE"
-    STATE_DIR="$DEFAULT_STATE_DIR"
-    EXPECTED_ENV_OWNER='root'
-    EXPECTED_ENV_GROUP='root'
-    EXPECTED_STATE_OWNER='yoryi'
-    EXPECTED_STATE_GROUP='yoryi'
-    EXPECTED_SSE_OWNER='root'
-    EXPECTED_SSE_GROUP='yoryi'
+    OBJECT_BACKUP_ENV_FILE="${PREFLIGHT_ENV_FILE:?}"
   fi
-  EXPECTED_ENV_FILE="$DEFAULT_ENV_FILE"
-  readonly EXPECTED_APP_DIR EXPECTED_ENV_FILE EXPECTED_STATE_DIR ENV_FILE SSE_FILE STATE_DIR EXPECTED_ENV_OWNER EXPECTED_ENV_GROUP EXPECTED_STATE_OWNER EXPECTED_STATE_GROUP EXPECTED_SSE_OWNER EXPECTED_SSE_GROUP
 
   for command_name in "${required_commands[@]}"; do
     if ! command -v "$command_name" >/dev/null 2>&1; then
@@ -932,35 +266,15 @@ main() {
     fi
   done
 
-  printf 'PRODUCTION_BACKUP_PREFLIGHT\n'
-  printf 'CANDIDATE_SHA=%s\n' "$CANDIDATE_SHA"
+  printf 'PRODUCTION_BACKUP_PREFLIGHT\nCANDIDATE_SHA=%s\n' "$CANDIDATE_SHA"
   if [[ "$missing_dependency" == true ]]; then
-    printf 'DEPENDENCIES_READY=NO\n'
+    printf 'DEPENDENCIES_READY=NO\nPOSTGRES_BACKUP_TOPOLOGY=FAIL\nOBJECT_BACKUP_TOPOLOGY=FAIL\nOBJECT_BACKUP_ENV=FAIL\nBACKUP_CONCURRENCY_SAFE=NO\n'
   else
     printf 'DEPENDENCIES_READY=YES\n'
-  fi
-
-  if [[ "$missing_dependency" == false ]]; then
-    inspect_runtime
-    inspect_scripts
-    inspect_unit BACKUP_SERVICE "$EXPECTED_BACKUP_SERVICE" "$EXPECTED_BACKUP_ENTRYPOINT" "$EXPECTED_ENV_FILE" yoryi "$EXPECTED_APP_DIR" false
-    inspect_unit VERIFY_SERVICE "$EXPECTED_VERIFY_SERVICE" "$EXPECTED_BACKUP_ENTRYPOINT" "$EXPECTED_ENV_FILE" yoryi "$EXPECTED_APP_DIR" true
+    inspect_topology
+    inspect_object_environment
     inspect_concurrency
-    inspect_environment
-    inspect_state
-    if [[ "$ENV_FILE_AVAILABLE" == true ]]; then
-      inspect_sse_evidence
-      inspect_postgres_and_space "$(env_value "$ENV_FILE" POSTGRES_CONTAINER 2>/dev/null || printf 'invalid-container')"
-    else
-      emit_unavailable_environment_outputs
-    fi
-  else
-    printf 'PRODUCTION_RUNTIME_SHA=UNKNOWN\nAPI_REVISION=UNKNOWN\nWEB_REVISION=UNKNOWN\nPRODUCTION_CHECKOUT_STATUS=UNKNOWN\nRUNTIME_IDENTITY=UNKNOWN\n'
-    printf 'BACKUP_SERVICE_EXISTS=UNKNOWN\nBACKUP_SERVICE_USER=UNKNOWN\nBACKUP_SERVICE_EXECSTART_MATCH=UNKNOWN\nBACKUP_SERVICE_EXECSTARTPRE_MATCH=UNKNOWN\nBACKUP_SERVICE_EXECSTARTPOST_MATCH=UNKNOWN\nBACKUP_SERVICE_ENV_FILE_MATCH=UNKNOWN\nBACKUP_SERVICE_ACTIVE=UNKNOWN\n'
-    printf 'VERIFY_SERVICE_EXISTS=UNKNOWN\nVERIFY_SERVICE_USER=UNKNOWN\nVERIFY_SERVICE_EXECSTART_MATCH=UNKNOWN\nVERIFY_SERVICE_EXECSTARTPRE_MATCH=UNKNOWN\nVERIFY_SERVICE_EXECSTARTPOST_MATCH=UNKNOWN\nVERIFY_SERVICE_ACTIVE=UNKNOWN\n'
-    printf 'REQUIRED_ENV_NAMES_PRESENT=UNKNOWN\nSOURCE_ENVIRONMENT=UNKNOWN\nEXPECTED_SOURCE_ENVIRONMENT=UNKNOWN\nSOURCE_ENDPOINT_HOSTNAME=UNKNOWN\nSOURCE_BUCKET=UNKNOWN\nBACKUP_ENDPOINT_HOSTNAME=UNKNOWN\nBACKUP_BUCKET=UNKNOWN\nSOURCE_AND_BACKUP_SEPARATE=UNKNOWN\nDEPLOYED_RUNTIME_SOURCE_AND_BACKUP_SEPARATE=UNKNOWN\nBACKUP_STATE_DIR_MATCH=UNKNOWN\nLATEST_STATE_EXISTS=UNKNOWN\nPAIRED_RECEIPT_COUNT=UNKNOWN\nSSE_EVIDENCE_VALID=UNKNOWN\nSSE_STATUS=UNKNOWN\nSSE_ALGORITHM=UNKNOWN\nSSE_PATH_MATCH=UNKNOWN\nSSE_PROBED_AT_VALID=UNKNOWN\nSSE_ENDPOINT_MATCH=UNKNOWN\nDEPLOYED_RUNTIME_SSE_ENDPOINT_MATCH=UNKNOWN\nSSE_BUCKET_MATCH=UNKNOWN\nPOSTGRES_CONTAINER_STATE=UNKNOWN\nPOSTGRES_CONTAINER_HEALTH=UNKNOWN\nPOSTGRES_BACKUP_ROOT_FREE_BYTES=UNKNOWN\nPOSTGRES_DATABASE_SIZE_BYTES=UNKNOWN\nPOSTGRES_BACKUP_SAFETY_MARGIN_BYTES=UNKNOWN\nPOSTGRES_BACKUP_REQUIRED_BYTES=UNKNOWN\nPOSTGRES_BACKUP_SPACE_SAFE=UNKNOWN\nTMP_FREE_BYTES=UNKNOWN\nTMP_REQUIRED_BYTES=UNKNOWN\nTMP_SPACE_SAFE=UNKNOWN\nLEGACY_BACKUP_SERVICE_EXISTS=UNKNOWN\nLEGACY_BACKUP_SERVICE_ACTIVE=UNKNOWN\nLEGACY_BACKUP_TIMER_EXISTS=UNKNOWN\nLEGACY_BACKUP_TIMER_ACTIVE=UNKNOWN\nLEGACY_BACKUP_TIMER_ENABLED=UNKNOWN\nLEGACY_BACKUP_NEXT_TRIGGER=UNKNOWN\nLEGACY_BACKUP_OVERLAP_SAFE=UNKNOWN\nBACKUP_ALREADY_RUNNING=UNKNOWN\nCONCURRENCY_SAFE=UNKNOWN\n'
   fi
-  printf 'PROPOSED_BACKUP_COMMAND=%s\n' "$EXPECTED_PROPOSED_COMMAND"
   printf 'PRODUCTION_WRITES=0\nBACKUP_STARTED=NO\n'
   if (( failures == 0 )); then
     printf 'PREFLIGHT_STATUS=PASS\n'

--- a/scripts/production-backup-preflight.sh
+++ b/scripts/production-backup-preflight.sh
@@ -89,6 +89,10 @@ systemctl_value() {
   systemctl show "$unit" --property="$property" --value 2>/dev/null
 }
 
+systemd_timers_calendar() {
+  systemctl show "$1" --property=TimersCalendar --value 2>/dev/null
+}
+
 unit_active_state() {
   local unit="$1"
   systemctl_value "$unit" ActiveState || true
@@ -234,33 +238,58 @@ systemd_calendar_matches() {
   local actual="$1"
   local expected="$2"
   local calendar
+  calendar="$(systemd_timers_calendar_value "$actual")" || return 1
+  [[ "$calendar" == "$expected" ]]
+}
+
+systemd_timers_calendar_value() {
+  local actual="$1"
+  local inner calendar
   actual="${actual#"${actual%%[![:space:]]*}"}"
   actual="${actual%"${actual##*[![:space:]]}"}"
-  if [[ "$actual" == *'calendar='* ]]; then
-    calendar="${actual#*calendar=}"
-    calendar="${calendar%%;*}"
-    calendar="${calendar%%\}*}"
-    calendar="${calendar%"${calendar##*[![:space:]]}"}"
+  if [[ "$actual" == \{*\} ]]; then
+    inner="${actual#\{}"
+    inner="${inner%\}}"
+    calendar="$(printf '%s\n' "$inner" | awk -F ';' '
+      function trim(value) {
+        sub(/^[[:space:]]+/, "", value)
+        sub(/[[:space:]]+$/, "", value)
+        return value
+      }
+      {
+        calendar_count=0
+        invalid=0
+        value=""
+        for (i=1; i<=NF; i++) {
+          field=trim($i)
+          if (field == "") continue
+          if (field ~ /^OnCalendar=/) {
+            calendar_count++
+            value=substr(field, 12)
+          } else if (field ~ /^next_elapse(_realtime)?=/) {
+            continue
+          } else {
+            invalid=1
+          }
+        }
+        if (calendar_count != 1 || invalid || value !~ /[^[:space:]]/) exit 1
+        print value
+      }
+    ')" || return 1
   else
+    [[ "$actual" != *'='* ]] || return 1
     calendar="$actual"
   fi
-  [[ "$calendar" == "$expected" ]]
+  calendar="${calendar#"${calendar%%[![:space:]]*}"}"
+  calendar="${calendar%"${calendar##*[![:space:]]}"}"
+  [[ -n "$calendar" ]] || return 1
+  printf '%s' "$calendar"
 }
 
 systemd_daily_calendar_present() {
   local actual="$1"
   local calendar
-  [[ -n "$actual" && "$actual" != n/a && "$actual" != '-' ]] || return 1
-  if [[ "$actual" == *'calendar='* ]]; then
-    calendar="${actual#*calendar=}"
-    calendar="${calendar%%;*}"
-    calendar="${calendar%%\}*}"
-    calendar="${calendar%"${calendar##*[![:space:]]}"}"
-  else
-    calendar="$actual"
-  fi
-  calendar="${calendar#"${calendar%%[![:space:]]*}"}"
-  calendar="${calendar%"${calendar##*[![:space:]]}"}"
+  calendar="$(systemd_timers_calendar_value "$actual")" || return 1
   [[ "$calendar" == daily || "$calendar" == *'*-*-*'* ]]
 }
 
@@ -444,7 +473,7 @@ inspect_timer() {
   unit_file_state="$(systemctl_value "$unit" UnitFileState || true)"
   active_state="$(unit_active_state "$unit")"
   next_trigger="$(systemctl_value "$unit" NextElapseUSecRealtime || true)"
-  calendar="$(systemctl_value "$unit" OnCalendar || true)"
+  calendar="$(systemd_timers_calendar "$unit" || true)"
   persistent="$(systemctl_value "$unit" Persistent || true)"
   randomized="$(systemctl_value "$unit" RandomizedDelayUSec || true)"
   [[ "$load_state" == loaded ]] && exists='YES' || fail_check "$unit is not loaded"

--- a/scripts/production-backup-preflight.sh
+++ b/scripts/production-backup-preflight.sh
@@ -15,6 +15,7 @@ readonly EXPECTED_TIMEOUT_USEC=21600000000
 readonly TIMER_HORIZON_SECONDS=129600
 readonly OBJECT_BACKUP_CALENDAR='*-*-* 02:15:00'
 readonly OBJECT_BACKUP_RANDOMIZED_DELAY_USEC=900000000
+readonly ALLOWED_IGNORED_RUNTIME_ENV='infra/docker/.env'
 
 failures=0
 POSTGRES_BACKUP_SERVICE_STATE='UNKNOWN'
@@ -186,6 +187,33 @@ systemd_no_command_list_matches() {
   systemd_command_list_matches "$1" '' ''
 }
 
+checkout_has_only_approved_ignored_files() {
+  local path pattern ignored_paths
+  local runtime_env_excluded=false
+
+  [[ -f "$EXPECTED_APP_DIR/.dockerignore" ]] || return 1
+  while IFS= read -r pattern; do
+    [[ "$pattern" =~ ^[[:space:]]*! ]] && return 1
+    if [[ "$pattern" == '**/.env' || "$pattern" == 'infra/docker/.env' ]]; then
+      runtime_env_excluded=true
+    fi
+  done < "$EXPECTED_APP_DIR/.dockerignore"
+  [[ "$runtime_env_excluded" == true ]] || return 1
+
+  if ! ignored_paths="$(git --no-optional-locks -C "$EXPECTED_APP_DIR" ls-files --others --ignored --exclude-standard 2>/dev/null)"; then
+    return 1
+  fi
+  if [[ -n "$ignored_paths" ]]; then
+    while IFS= read -r path; do
+      case "$path" in
+        .env|.env.*|*/.env|*/.env.*|*.pem|*.key|*.p12|*.pfx|*.crt|*.log|*.dump|*.sql|*.bak|*.backup)
+          [[ "$path" == "$ALLOWED_IGNORED_RUNTIME_ENV" ]] || return 1
+          ;;
+      esac
+    done <<< "$ignored_paths"
+  fi
+}
+
 systemd_timeout_matches() {
   local actual="$1"
   local microseconds
@@ -299,8 +327,9 @@ inspect_runtime() {
 
   if [[ -d "$EXPECTED_APP_DIR/.git" && ! -L "$EXPECTED_APP_DIR/.git" ]] && command -v git >/dev/null 2>&1; then
     production_sha="$(git --no-optional-locks -C "$EXPECTED_APP_DIR" rev-parse HEAD 2>/dev/null || printf 'UNKNOWN')"
-    if [[ "$production_sha" =~ ^[0-9a-f]{40}$ ]] && status_output="$(git --no-optional-locks -C "$EXPECTED_APP_DIR" status --porcelain --untracked-files=all 2>/dev/null)"; then
-      [[ -z "$status_output" ]] && checkout_status='CLEAN'
+    if [[ "$production_sha" =~ ^[0-9a-f]{40}$ ]] && status_output="$(git --no-optional-locks -C "$EXPECTED_APP_DIR" status --porcelain --untracked-files=all 2>/dev/null)" &&
+      [[ -z "$status_output" ]] && checkout_has_only_approved_ignored_files; then
+      checkout_status='CLEAN'
     fi
   fi
   if command -v docker >/dev/null 2>&1; then

--- a/scripts/production-backup-preflight.sh
+++ b/scripts/production-backup-preflight.sh
@@ -12,6 +12,9 @@ readonly DEFAULT_OBJECT_BACKUP_ENV_FILE='/etc/buildingos/object-backup.env'
 readonly DEFAULT_OBJECT_BACKUP_RCLONE_CONFIG='/etc/buildingos/object-backup-rclone.conf'
 readonly OBJECT_BACKUP_RECEIPT='/var/lib/buildingos-object-backup/object-backup-receipt.json'
 readonly EXPECTED_TIMEOUT_USEC=21600000000
+readonly TIMER_HORIZON_SECONDS=129600
+readonly OBJECT_BACKUP_CALENDAR='*-*-* 02:15:00'
+readonly OBJECT_BACKUP_RANDOMIZED_DELAY_USEC=900000000
 
 failures=0
 POSTGRES_BACKUP_SERVICE_STATE='UNKNOWN'
@@ -46,6 +49,14 @@ file_is_regular_non_symlink() {
 
 file_mode() {
   stat -L -c '%a' -- "$1" 2>/dev/null || stat -L -f '%Lp' "$1"
+}
+
+file_owner() {
+  stat -L -c '%U' -- "$1" 2>/dev/null || stat -L -f '%Su' "$1"
+}
+
+file_group() {
+  stat -L -c '%G' -- "$1" 2>/dev/null || stat -L -f '%Sg' "$1"
 }
 
 env_value() {
@@ -190,6 +201,64 @@ systemd_timeout_matches() {
   [[ "$microseconds" == "$EXPECTED_TIMEOUT_USEC" ]]
 }
 
+systemd_delay_matches() {
+  local actual="$1"
+  local microseconds
+  [[ -n "$actual" && "$actual" != infinity && "$actual" != inf ]] || return 1
+  if [[ "$actual" =~ ^[0-9]+$ ]]; then
+    microseconds="$actual"
+  elif [[ "$actual" =~ ^([0-9]+)m$ ]]; then
+    microseconds=$((BASH_REMATCH[1] * 60000000))
+  elif [[ "$actual" =~ ^([0-9]+)min$ ]]; then
+    microseconds=$((BASH_REMATCH[1] * 60000000))
+  elif [[ "$actual" =~ ^([0-9]+)s$ ]]; then
+    microseconds=$((BASH_REMATCH[1] * 1000000))
+  elif [[ "$actual" =~ ^([0-9]+)us$ ]]; then
+    microseconds="${BASH_REMATCH[1]}"
+  elif [[ "$actual" =~ ^([0-9]+)min[[:space:]]+([0-9]+)s$ ]]; then
+    microseconds=$((BASH_REMATCH[1] * 60000000 + BASH_REMATCH[2] * 1000000))
+  elif [[ "$actual" =~ ^([0-9]+)h[[:space:]]+([0-9]+)min[[:space:]]+([0-9]+)s$ ]]; then
+    microseconds=$((BASH_REMATCH[1] * 3600000000 + BASH_REMATCH[2] * 60000000 + BASH_REMATCH[3] * 1000000))
+  else
+    return 1
+  fi
+  [[ "$microseconds" == "$OBJECT_BACKUP_RANDOMIZED_DELAY_USEC" ]]
+}
+
+systemd_calendar_matches() {
+  local actual="$1"
+  local expected="$2"
+  local calendar
+  actual="${actual#"${actual%%[![:space:]]*}"}"
+  actual="${actual%"${actual##*[![:space:]]}"}"
+  if [[ "$actual" == *'calendar='* ]]; then
+    calendar="${actual#*calendar=}"
+    calendar="${calendar%%;*}"
+    calendar="${calendar%%\}*}"
+    calendar="${calendar%"${calendar##*[![:space:]]}"}"
+  else
+    calendar="$actual"
+  fi
+  [[ "$calendar" == "$expected" ]]
+}
+
+systemd_daily_calendar_present() {
+  local actual="$1"
+  local calendar
+  [[ -n "$actual" && "$actual" != n/a && "$actual" != '-' ]] || return 1
+  if [[ "$actual" == *'calendar='* ]]; then
+    calendar="${actual#*calendar=}"
+    calendar="${calendar%%;*}"
+    calendar="${calendar%%\}*}"
+    calendar="${calendar%"${calendar##*[![:space:]]}"}"
+  else
+    calendar="$actual"
+  fi
+  calendar="${calendar#"${calendar%%[![:space:]]*}"}"
+  calendar="${calendar%"${calendar##*[![:space:]]}"}"
+  [[ "$calendar" == daily || "$calendar" == *'*-*-*'* ]]
+}
+
 inspect_runtime() {
   local production_sha='UNKNOWN' api_revision='UNKNOWN' web_revision='UNKNOWN' checkout_status='DIRTY'
   local api_image web_image status_output
@@ -311,14 +380,15 @@ timer_has_future_trigger() {
   [[ -n "$trigger" && "$trigger" != n/a && "$trigger" != '-' ]] || return 1
   trigger_epoch="$(date -u -d "$trigger" +%s 2>/dev/null || date -j -u -f '%Y-%m-%d %H:%M:%S %Z' "$trigger" +%s 2>/dev/null || true)"
   now_epoch="$(date -u +%s)"
-  [[ "$trigger_epoch" =~ ^[0-9]+$ && "$trigger_epoch" -gt "$now_epoch" ]]
+  [[ "$trigger_epoch" =~ ^[0-9]+$ && "$trigger_epoch" -gt "$now_epoch" && $((trigger_epoch - now_epoch)) -le "$TIMER_HORIZON_SECONDS" ]]
 }
 
 inspect_timer() {
   local label="$1"
   local unit="$2"
   local expected_unit="$3"
-  local load_state unit_file_state active_state next_trigger
+  local expected_calendar="${4:-}"
+  local load_state unit_file_state active_state next_trigger calendar persistent randomized
   local exists='NO' contract='NO' before
   before=$failures
 
@@ -326,10 +396,20 @@ inspect_timer() {
   unit_file_state="$(systemctl_value "$unit" UnitFileState || true)"
   active_state="$(unit_active_state "$unit")"
   next_trigger="$(systemctl_value "$unit" NextElapseUSecRealtime || true)"
+  calendar="$(systemctl_value "$unit" OnCalendar || true)"
+  persistent="$(systemctl_value "$unit" Persistent || true)"
+  randomized="$(systemctl_value "$unit" RandomizedDelayUSec || true)"
   [[ "$load_state" == loaded ]] && exists='YES' || fail_check "$unit is not loaded"
   [[ "$unit_file_state" == enabled ]] || fail_check "$unit is not enabled"
   [[ "$active_state" == active ]] || fail_check "$unit is not active or waiting"
   [[ "$(systemctl_value "$unit" Unit || true)" == "$expected_unit" ]] || fail_check "$unit points to an unexpected service"
+  if [[ -n "$expected_calendar" ]]; then
+    systemd_calendar_matches "$calendar" "$expected_calendar" || fail_check "$unit calendar is unexpected"
+    [[ "$persistent" == yes || "$persistent" == true ]] || fail_check "$unit is not persistent"
+    systemd_delay_matches "$randomized" || fail_check "$unit randomized delay is not 15 minutes"
+  else
+    systemd_daily_calendar_present "$calendar" || fail_check "$unit calendar is not a daily schedule"
+  fi
   timer_has_future_trigger "$next_trigger" || fail_check "$unit has no future trigger"
 
   if (( failures == before )); then contract='YES'; fi
@@ -337,6 +417,9 @@ inspect_timer() {
   printf '%s_ENABLED=%s\n' "$label" "$([[ "$unit_file_state" == enabled ]] && printf YES || printf NO)"
   printf '%s_ACTIVE=%s\n' "$label" "$([[ "$active_state" == active ]] && printf YES || printf NO)"
   printf '%s_FUTURE_TRIGGER=%s\n' "$label" "$([[ "$next_trigger" != n/a && "$next_trigger" != '-' ]] && timer_has_future_trigger "$next_trigger" && printf YES || printf NO)"
+  printf '%s_CALENDAR_MATCH=%s\n' "$label" "$([[ -n "$expected_calendar" ]] && systemd_calendar_matches "$calendar" "$expected_calendar" && printf YES || [[ -z "$expected_calendar" ]] && systemd_daily_calendar_present "$calendar" && printf YES || printf NO)"
+  printf '%s_PERSISTENT=%s\n' "$label" "$([[ "$persistent" == yes || "$persistent" == true ]] && printf YES || printf NO)"
+  printf '%s_RANDOMIZED_DELAY_MATCH=%s\n' "$label" "$([[ -n "$expected_calendar" ]] && systemd_delay_matches "$randomized" && printf YES || printf NOT_REQUIRED)"
   printf '%s_CONTRACT=%s\n' "$label" "$contract"
 }
 
@@ -362,8 +445,16 @@ inspect_object_environment() {
     [[ "$receipt" == "$OBJECT_BACKUP_RECEIPT" ]] || fail_check 'Object Storage receipt path is unexpected'
     [[ "$rclone" == "$OBJECT_BACKUP_RCLONE_CONFIG" ]] || fail_check 'Object Storage rclone config path is unexpected'
     if file_is_regular_non_symlink "$rclone" && [[ -r "$rclone" ]]; then
+      local config_owner config_group
+      config_owner="$(file_owner "$rclone")"
+      config_group="$(file_group "$rclone")"
       config_mode="0$(file_mode "$rclone")"
+      (( (8#${config_mode#0} & 004) == 0 )) || fail_check 'Object Storage rclone config is world-readable'
       (( (8#${config_mode#0} & 0022) == 0 )) || fail_check 'Object Storage rclone config is writable by group or world'
+      if ! { [[ "$config_owner" == yoryi ]] && (( (8#${config_mode#0} & 0400) != 0 )); } &&
+        ! { [[ "$config_group" == yoryi ]] && (( (8#${config_mode#0} & 0040) != 0 )); }; then
+        fail_check 'Object Storage rclone config is not readable by yoryi'
+      fi
     else
       fail_check 'Object Storage rclone config is not a readable regular non-symlink file'
     fi
@@ -382,7 +473,7 @@ inspect_topology() {
 
   before=$failures
   inspect_service OBJECT_BACKUP_SERVICE "$OBJECT_BACKUP_SERVICE" "$OBJECT_BACKUP_EXEC" "$OBJECT_BACKUP_ENV_FILE"
-  inspect_timer OBJECT_BACKUP_TIMER "$OBJECT_BACKUP_TIMER" "$OBJECT_BACKUP_SERVICE"
+  inspect_timer OBJECT_BACKUP_TIMER "$OBJECT_BACKUP_TIMER" "$OBJECT_BACKUP_SERVICE" "$OBJECT_BACKUP_CALENDAR"
   [[ "$failures" -eq "$before" ]] && printf 'OBJECT_BACKUP_TOPOLOGY=PASS\n' || printf 'OBJECT_BACKUP_TOPOLOGY=FAIL\n'
 }
 

--- a/scripts/production-backup-preflight.sh
+++ b/scripts/production-backup-preflight.sh
@@ -205,11 +205,7 @@ checkout_has_only_approved_ignored_files() {
   fi
   if [[ -n "$ignored_paths" ]]; then
     while IFS= read -r path; do
-      case "$path" in
-        .env|.env.*|*/.env|*/.env.*|*.pem|*.key|*.p12|*.pfx|*.crt|*.log|*.dump|*.sql|*.bak|*.backup)
-          [[ "$path" == "$ALLOWED_IGNORED_RUNTIME_ENV" ]] || return 1
-          ;;
-      esac
+      [[ "$path" == "$ALLOWED_IGNORED_RUNTIME_ENV" ]] || return 1
     done <<< "$ignored_paths"
   fi
 }

--- a/scripts/production-backup-preflight.sh
+++ b/scripts/production-backup-preflight.sh
@@ -9,13 +9,16 @@ readonly OBJECT_BACKUP_SERVICE='pawtech-buildingos-object-backup.service'
 readonly OBJECT_BACKUP_TIMER='pawtech-buildingos-object-backup.timer'
 readonly OBJECT_BACKUP_EXEC='/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh'
 readonly DEFAULT_OBJECT_BACKUP_ENV_FILE='/etc/buildingos/object-backup.env'
+readonly DEFAULT_OBJECT_BACKUP_RCLONE_CONFIG='/etc/buildingos/object-backup-rclone.conf'
 readonly OBJECT_BACKUP_RECEIPT='/var/lib/buildingos-object-backup/object-backup-receipt.json'
-readonly OBJECT_BACKUP_RCLONE_CONFIG='/etc/buildingos/object-backup-rclone.conf'
 readonly EXPECTED_TIMEOUT_USEC=21600000000
 
 failures=0
 POSTGRES_BACKUP_SERVICE_STATE='UNKNOWN'
 OBJECT_BACKUP_SERVICE_STATE='UNKNOWN'
+EXPECTED_APP_DIR="$DEFAULT_APP_DIR"
+OBJECT_BACKUP_ENV_FILE="$DEFAULT_OBJECT_BACKUP_ENV_FILE"
+OBJECT_BACKUP_RCLONE_CONFIG="$DEFAULT_OBJECT_BACKUP_RCLONE_CONFIG"
 
 if ! declare -F endpoint_identity >/dev/null 2>&1; then
   helper_dir="${BASH_SOURCE[0]%/*}"
@@ -39,6 +42,10 @@ safe_output() {
 
 file_is_regular_non_symlink() {
   [[ -f "$1" && ! -L "$1" ]]
+}
+
+file_mode() {
+  stat -L -c '%a' -- "$1" 2>/dev/null || stat -L -f '%Lp' "$1"
 }
 
 env_value() {
@@ -76,15 +83,139 @@ unit_active_state() {
   systemctl_value "$unit" ActiveState || true
 }
 
+systemd_serialized_entry_matches() {
+  local entry="$1"
+  local expected_exec="$2"
+  local expected_argv="$3"
+  local parsed
+
+  parsed="$(printf '%s\n' "$entry" | awk -F ';' '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+    {
+      path_count=0
+      argv_count=0
+      ignore_count=0
+      invalid=0
+      path=""
+      argv=""
+      for (i=1; i<=NF; i++) {
+        field=trim($i)
+        if (field == "") continue
+        if (field ~ /^path=/) {
+          path_count++
+          path=substr(field, 6)
+        } else if (field ~ /^argv\[\]=/) {
+          argv_count++
+          argv=substr(field, 8)
+        } else if (field ~ /^ignore_errors=/) {
+          ignore_count++
+          if (substr(field, 15) != "no") invalid=1
+        } else if (field ~ /^(start_time|stop_time|pid|code|status)=/) {
+          continue
+        } else {
+          invalid=1
+        }
+      }
+      if (path_count == 1 && argv_count == 1 && ignore_count == 1 && invalid == 0) {
+        printf "%s\034%s\n", path, argv
+      } else {
+        exit 1
+      }
+    }
+  ' )" || return 1
+  [[ "$parsed" == "$expected_exec"$'\034'"$expected_argv" ]]
+}
+
+systemd_command_list_matches() {
+  local raw="$1"
+  local expected_exec="$2"
+  local expected_argv="${3:-$expected_exec}"
+  local rest entry tail count=0 trimmed
+
+  trimmed="$raw"
+  trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
+  trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+  [[ -n "$trimmed" ]] || { [[ -z "$expected_exec" ]]; return; }
+  [[ "$trimmed" == *'{'* && "$trimmed" == *'}'* && "$trimmed" == *'path='* && "$trimmed" == *'argv[]='* ]] || return 1
+  rest="$trimmed"
+  while :; do
+    rest="${rest#"${rest%%[![:space:]]*}"}"
+    [[ "${rest:0:1}" == '{' ]] || return 1
+    rest="${rest:1}"
+    [[ "$rest" == *'}'* ]] || return 1
+    entry="${rest%%\}*}"
+    tail="${rest#*\}}"
+    systemd_serialized_entry_matches "$entry" "$expected_exec" "$expected_argv" || return 1
+    count=$((count + 1))
+    rest="$tail"
+    trimmed="$rest"
+    trimmed="${trimmed#"${trimmed%%[![:space:]]*}"}"
+    trimmed="${trimmed%"${trimmed##*[![:space:]]}"}"
+    [[ -z "$trimmed" ]] && break
+  done
+  [[ "$count" -eq 1 && -n "$expected_exec" ]]
+}
+
 systemd_exec_matches() {
   local actual="$1"
   local expected="$2"
-  [[ "$actual" == "$expected" || "$actual" == "{ path=$expected ; argv[]=$expected ; ignore_errors=no }" ]]
+  systemd_command_list_matches "$actual" "$expected" "$expected"
 }
 
 systemd_timeout_matches() {
   local actual="$1"
-  [[ "$actual" =~ ^[0-9]+$ && "$actual" == "$EXPECTED_TIMEOUT_USEC" ]]
+  local microseconds
+  [[ -n "$actual" && "$actual" != infinity && "$actual" != inf ]] || return 1
+  if [[ "$actual" =~ ^[0-9]+$ ]]; then
+    microseconds="$actual"
+  elif [[ "$actual" =~ ^([0-9]+)h$ ]]; then
+    microseconds=$((BASH_REMATCH[1] * 3600000000))
+  elif [[ "$actual" =~ ^([0-9]+)min$ ]]; then
+    microseconds=$((BASH_REMATCH[1] * 60000000))
+  elif [[ "$actual" =~ ^([0-9]+)s$ ]]; then
+    microseconds=$((BASH_REMATCH[1] * 1000000))
+  elif [[ "$actual" =~ ^([0-9]+)us$ ]]; then
+    microseconds="${BASH_REMATCH[1]}"
+  elif [[ "$actual" =~ ^([0-9]+)h[[:space:]]+([0-9]+)min[[:space:]]+([0-9]+)s$ ]]; then
+    microseconds=$((BASH_REMATCH[1] * 3600000000 + BASH_REMATCH[2] * 60000000 + BASH_REMATCH[3] * 1000000))
+  elif [[ "$actual" =~ ^([0-9]+)h[[:space:]]+([0-9]+)min[[:space:]]+([0-9]+)s[[:space:]]*$ ]]; then
+    microseconds=$((BASH_REMATCH[1] * 3600000000 + BASH_REMATCH[2] * 60000000 + BASH_REMATCH[3] * 1000000))
+  else
+    return 1
+  fi
+  [[ "$microseconds" == "$EXPECTED_TIMEOUT_USEC" ]]
+}
+
+inspect_runtime() {
+  local production_sha='UNKNOWN' api_revision='UNKNOWN' web_revision='UNKNOWN' checkout_status='DIRTY'
+  local api_image web_image status_output
+
+  if [[ -d "$EXPECTED_APP_DIR/.git" && ! -L "$EXPECTED_APP_DIR/.git" ]] && command -v git >/dev/null 2>&1; then
+    production_sha="$(git --no-optional-locks -C "$EXPECTED_APP_DIR" rev-parse HEAD 2>/dev/null || printf 'UNKNOWN')"
+    if [[ "$production_sha" =~ ^[0-9a-f]{40}$ ]] && status_output="$(git --no-optional-locks -C "$EXPECTED_APP_DIR" status --porcelain --untracked-files=all 2>/dev/null)"; then
+      [[ -z "$status_output" ]] && checkout_status='CLEAN'
+    fi
+  fi
+  if command -v docker >/dev/null 2>&1; then
+    api_image="$(docker inspect --type container --format '{{.Image}}' buildingos-api 2>/dev/null || true)"
+    web_image="$(docker inspect --type container --format '{{.Image}}' buildingos-web 2>/dev/null || true)"
+    [[ "$api_image" =~ ^sha256:[0-9a-f]{64}$ ]] && api_revision="$(docker image inspect "$api_image" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || printf 'UNKNOWN')"
+    [[ "$web_image" =~ ^sha256:[0-9a-f]{64}$ ]] && web_revision="$(docker image inspect "$web_image" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || printf 'UNKNOWN')"
+  fi
+  printf 'PRODUCTION_RUNTIME_SHA=%s\n' "$(safe_output "$production_sha")"
+  printf 'API_REVISION=%s\n' "$(safe_output "$api_revision")"
+  printf 'WEB_REVISION=%s\n' "$(safe_output "$web_revision")"
+  printf 'PRODUCTION_CHECKOUT_STATUS=%s\n' "$checkout_status"
+  if [[ "$production_sha" == "$CANDIDATE_SHA" && "$api_revision" == "$CANDIDATE_SHA" && "$web_revision" == "$CANDIDATE_SHA" && "$checkout_status" == CLEAN ]]; then
+    printf 'RUNTIME_IDENTITY=CONSISTENT\n'
+  else
+    printf 'RUNTIME_IDENTITY=INCONSISTENT\n'
+    fail_check 'production runtime identity is not the expected clean, matching revision'
+  fi
 }
 
 inspect_service() {
@@ -125,7 +256,7 @@ inspect_service() {
   [[ "$group" == yoryi ]] || fail_check "$unit Group is not yoryi"
   [[ "$unit_type" == oneshot ]] || fail_check "$unit Type is not oneshot"
   [[ "$env_files" == "$expected_env" || "$env_files" == "-$expected_env" || "$env_files" == "$expected_env (ignore_errors=no)" || "$env_files" == "-$expected_env (ignore_errors=no)" ]] || fail_check "$unit EnvironmentFile is unexpected"
-  [[ "$workdir" == "$DEFAULT_APP_DIR" ]] || fail_check "$unit WorkingDirectory is unexpected"
+  [[ "$workdir" == "$EXPECTED_APP_DIR" ]] || fail_check "$unit WorkingDirectory is unexpected"
   systemd_exec_matches "$exec_start" "$expected_exec" || fail_check "$unit ExecStart is unexpected"
   systemd_timeout_matches "$timeout" || fail_check "$unit TimeoutStartSec is not 6h"
 
@@ -144,10 +275,14 @@ inspect_service() {
 inspect_current_service_state() {
   local label="$1"
   local unit="$2"
-  local load_state state exists='NO'
+  local expected_exec="$3"
+  local load_state state unit_type exec_start exists='NO' contract='NO' before
+  before=$failures
 
   load_state="$(systemctl_value "$unit" LoadState || true)"
   state="$(unit_active_state "$unit")"
+  unit_type="$(systemctl_value "$unit" Type || true)"
+  exec_start="$(systemctl_value "$unit" ExecStart || true)"
   [[ "$load_state" == loaded ]] && exists='YES' || fail_check "$unit is not loaded"
   case "$state" in
     inactive) ;;
@@ -155,8 +290,14 @@ inspect_current_service_state() {
     failed|unknown|'') fail_check "$unit active state is unavailable or failed" ;;
     *) fail_check "$unit active state is ambiguous" ;;
   esac
+  [[ "$unit_type" == oneshot ]] || fail_check "$unit Type is not oneshot"
+  systemd_exec_matches "$exec_start" "$expected_exec" || fail_check "$unit ExecStart is unexpected"
+  (( failures == before )) && contract='YES'
   printf '%s_EXISTS=%s\n' "$label" "$exists"
   printf '%s_STATE=%s\n' "$label" "$(safe_output "$state")"
+  printf '%s_TYPE=%s\n' "$label" "$(safe_output "$unit_type")"
+  printf '%s_EXECSTART_MATCH=%s\n' "$label" "$([[ "$contract" == YES ]] && printf YES || printf NO)"
+  printf '%s_CONTRACT=%s\n' "$label" "$contract"
   if [[ "$unit" == "$POSTGRES_BACKUP_SERVICE" ]]; then
     POSTGRES_BACKUP_SERVICE_STATE="$state"
   else
@@ -201,7 +342,7 @@ inspect_timer() {
 
 inspect_object_environment() {
   local source destination receipt rclone source_bucket destination_bucket
-  local env_ok='NO'
+  local env_ok='NO' config_mode before=$failures
   if ! file_is_regular_non_symlink "$OBJECT_BACKUP_ENV_FILE" || [[ ! -r "$OBJECT_BACKUP_ENV_FILE" ]]; then
     fail_check 'Object Storage environment is not a readable regular non-symlink file'
   else
@@ -213,13 +354,20 @@ inspect_object_environment() {
       [[ "$destination" =~ ^([A-Za-z0-9][A-Za-z0-9._-]*):([A-Za-z0-9][A-Za-z0-9._-]*)$ ]]; then
       source_bucket="${source#*:}"
       destination_bucket="${destination#*:}"
+      [[ "$source_bucket" == buildingos-production ]] || fail_check 'Object Storage source bucket is not authoritative'
       [[ "$source_bucket" != "$destination_bucket" ]] || fail_check 'Object Storage source and destination buckets must differ'
     else
       fail_check 'Object Storage source or destination is not a safe remote bucket root'
     fi
     [[ "$receipt" == "$OBJECT_BACKUP_RECEIPT" ]] || fail_check 'Object Storage receipt path is unexpected'
     [[ "$rclone" == "$OBJECT_BACKUP_RCLONE_CONFIG" ]] || fail_check 'Object Storage rclone config path is unexpected'
-    if (( failures == 0 )); then env_ok='YES'; fi
+    if file_is_regular_non_symlink "$rclone" && [[ -r "$rclone" ]]; then
+      config_mode="0$(file_mode "$rclone")"
+      (( (8#${config_mode#0} & 0022) == 0 )) || fail_check 'Object Storage rclone config is writable by group or world'
+    else
+      fail_check 'Object Storage rclone config is not a readable regular non-symlink file'
+    fi
+    if (( failures == before )); then env_ok='YES'; fi
   fi
   printf 'OBJECT_BACKUP_ENV=%s\n' "$env_ok"
 }
@@ -227,7 +375,8 @@ inspect_object_environment() {
 inspect_topology() {
   local before
   before=$failures
-  inspect_current_service_state POSTGRES_BACKUP_SERVICE "$POSTGRES_BACKUP_SERVICE"
+  before=$failures
+  inspect_current_service_state POSTGRES_BACKUP_SERVICE "$POSTGRES_BACKUP_SERVICE" '/opt/pawtech/backups/scripts/backup-postgres.sh'
   inspect_timer POSTGRES_BACKUP_TIMER "$POSTGRES_BACKUP_TIMER" "$POSTGRES_BACKUP_SERVICE"
   [[ "$failures" -eq "$before" ]] && printf 'POSTGRES_BACKUP_TOPOLOGY=PASS\n' || printf 'POSTGRES_BACKUP_TOPOLOGY=FAIL\n'
 
@@ -248,15 +397,20 @@ inspect_concurrency() {
 
 main() {
   local command_name missing_dependency=false
-  local required_commands=(awk bash date systemctl)
+  local required_commands=(awk bash date docker git stat systemctl)
+  local runtime_app_dir
 
   [[ $# -eq 1 ]] || { printf 'Usage: %s <candidate_sha>\n' "${0##*/}" >&2; return 64; }
   [[ "$1" =~ ^[0-9a-f]{40}$ ]] || { printf 'ERROR: candidate SHA is not exactly 40 lowercase hexadecimal characters\n' >&2; return 1; }
   readonly CANDIDATE_SHA="$1"
 
   OBJECT_BACKUP_ENV_FILE="$DEFAULT_OBJECT_BACKUP_ENV_FILE"
+  OBJECT_BACKUP_RCLONE_CONFIG="$DEFAULT_OBJECT_BACKUP_RCLONE_CONFIG"
+  EXPECTED_APP_DIR="$DEFAULT_APP_DIR"
   if [[ "${BUILDINGOS_PREFLIGHT_TEST_MODE:-}" == LOCAL_ISOLATED_ONLY ]]; then
+    EXPECTED_APP_DIR="${PREFLIGHT_APP_DIR:?}"
     OBJECT_BACKUP_ENV_FILE="${PREFLIGHT_ENV_FILE:?}"
+    OBJECT_BACKUP_RCLONE_CONFIG="${PREFLIGHT_RCLONE_CONFIG_FILE:?}"
   fi
 
   for command_name in "${required_commands[@]}"; do
@@ -271,6 +425,7 @@ main() {
     printf 'DEPENDENCIES_READY=NO\nPOSTGRES_BACKUP_TOPOLOGY=FAIL\nOBJECT_BACKUP_TOPOLOGY=FAIL\nOBJECT_BACKUP_ENV=FAIL\nBACKUP_CONCURRENCY_SAFE=NO\n'
   else
     printf 'DEPENDENCIES_READY=YES\n'
+    inspect_runtime
     inspect_topology
     inspect_object_environment
     inspect_concurrency

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -11,7 +11,7 @@ readonly DATABASE_NAME='buildingos_db'
 readonly APP_DIR='/opt/pawtech/apps/buildingos/buildingos-app'
 readonly BACKUP_SCRIPT_PATH='/opt/pawtech/backups/scripts/backup-postgres.sh'
 readonly BACKUP_IDENTITY_MANIFEST_PATH="${APP_DIR}/infra/production/backup-postgres.identity.v1"
-readonly BACKUP_STATE_DIR='/var/lib/buildingos-backup'
+readonly OBJECT_BACKUP_RECEIPT='/var/lib/buildingos-object-backup/object-backup-receipt.json'
 readonly BACKUP_IDENTITY_VERSION='backup-postgres.identity.v1'
 readonly BACKUP_SCRIPT_SHA256='3cbf2bf191bd9a06e7bbf831848cfa2816cd80fca980593f84d3411cb3b14ff5'
 readonly BACKUP_SCRIPT_OWNER='yoryi'
@@ -941,70 +941,66 @@ format_epoch() {
   date -u -d "@$1" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -r "$1" '+%Y-%m-%dT%H:%M:%SZ'
 }
 
-report_backup_readiness() {
-  local state_file="$BACKUP_STATE_DIR/latest.env"
-  local backup_set_id app_sha completed_at completed_epoch now age paired_receipt
-  local mechanism_path='UNKNOWN' mechanism_digest='UNKNOWN' mechanism_owner='UNKNOWN' mechanism_group='UNKNOWN' mechanism_mode='UNKNOWN'
-  local mechanism_identity='UNKNOWN'
-  local dump_present='NOT_APPLICABLE'
-  local checksum_present='NOT_APPLICABLE'
-  local checksum_status='INCOMPLETE'
-  local restore_status='INCOMPLETE'
-  local backup_required='YES'
+validate_object_location() {
+  local location="$1"
+  [[ "$location" =~ ^[A-Za-z0-9][A-Za-z0-9._-]*:[A-Za-z0-9][A-Za-z0-9._-]*$ ]]
+}
 
-  if [[ -f "$state_file" && ! -L "$state_file" && -r "$state_file" ]]; then
-    if backup_set_id="$(state_field "$state_file" BACKUP_SET_ID)" &&
-      app_sha="$(state_field "$state_file" APP_SHA)" &&
-      completed_at="$(state_field "$state_file" COMPLETED_AT)" &&
-      [[ "$backup_set_id" =~ ^[a-z0-9][a-z0-9._-]{0,95}$ ]] &&
-      [[ "$app_sha" =~ ^[0-9a-f]{40}$ ]] &&
-      completed_epoch="$(parse_epoch "$completed_at")" &&
-      now="$(date -u +%s)" &&
-      age=$((now - completed_epoch)) &&
-      (( age >= 0 && age <= MAX_BACKUP_AGE_SECONDS )); then
-      paired_receipt="$BACKUP_STATE_DIR/paired-$backup_set_id.json"
-      if [[ -f "$paired_receipt" && ! -L "$paired_receipt" && -r "$paired_receipt" ]] &&
-        jq -e --arg backupSetId "$backup_set_id" --arg appSha "$app_sha" --arg completedAt "$completed_at" --arg runtimeAppSha "$RUNTIME_APP_SHA" '
-          .version == 1 and
-          .status == "PASS" and
-          .backup_set_id == $backupSetId and
-          .app_sha == $appSha and
-          .app_sha == $runtimeAppSha and
-          .completed_at == $completedAt and
-          .minio_verified == true and
-          (.postgres_receipt.version == 1) and
-          (.postgres_receipt.status == "PASS") and
-          (.postgres_receipt.backup_set_id == $backupSetId) and
-          (.postgres_receipt.app_sha == $appSha) and
-          (.postgres_receipt.encryption == "SSE-S3") and
-          (.postgres_receipt.postgres_sha256 | type == "string" and test("^[0-9a-f]{64}$")) and
-          (.postgres_receipt.dump_filename | type == "string" and test("^[A-Za-z0-9._-]+$")) and
-          (.postgres_receipt.remote_object_prefix == ("postgresql/" + $backupSetId))
-        ' "$paired_receipt" >/dev/null; then
-        checksum_status='VERIFIED_IN_PAIRED_BACKUP'
-        restore_status='VERIFIED_IN_PAIRED_BACKUP'
-        backup_required='NO'
-        printf 'LATEST_BUILDINGOS_DB_BACKUP_TIMESTAMP=%s\n' "$completed_at"
-        printf 'LATEST_BUILDINGOS_DB_BACKUP_FILE=%s\n' "${paired_receipt##*/}"
-        printf 'BACKUP_AGE_SECONDS=%s\n' "$age"
-      else
-        AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
-        printf 'LATEST_BUILDINGOS_DB_BACKUP_TIMESTAMP=UNKNOWN\n'
-        printf 'LATEST_BUILDINGOS_DB_BACKUP_FILE=UNKNOWN\n'
-        printf 'BACKUP_AGE_SECONDS=UNKNOWN\n'
-      fi
-    else
-      AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
-      printf 'LATEST_BUILDINGOS_DB_BACKUP_TIMESTAMP=UNKNOWN\n'
-      printf 'LATEST_BUILDINGOS_DB_BACKUP_FILE=UNKNOWN\n'
-      printf 'BACKUP_AGE_SECONDS=UNKNOWN\n'
-    fi
+validate_object_backup_receipt() {
+  local receipt="$1"
+  local source destination started_at completed_at started_epoch completed_epoch now age
+
+  [[ -f "$receipt" && ! -L "$receipt" && -r "$receipt" ]] || return 1
+  jq -e '
+    type == "object" and
+    .receipt_version == 1 and
+    .status == "PASS" and
+    .copy_status == "PASS" and
+    .verification_status == "PASS" and
+    .recovery_point_valid == "NOT_EVALUATED" and
+    (.source | type == "string" and test("^[A-Za-z0-9][A-Za-z0-9._-]*:[A-Za-z0-9][A-Za-z0-9._-]*$")) and
+    (.destination | type == "string" and test("^[A-Za-z0-9][A-Za-z0-9._-]*:[A-Za-z0-9][A-Za-z0-9._-]*$")) and
+    (.started_at_utc | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
+    (.completed_at_utc | type == "string" and test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"))
+  ' "$receipt" >/dev/null 2>&1 || return 1
+
+  source="$(jq -er '.source' "$receipt")"
+  destination="$(jq -er '.destination' "$receipt")"
+  validate_object_location "$source" || return 1
+  validate_object_location "$destination" || return 1
+  [[ "${source#*:}" != "${destination#*:}" ]] || return 1
+  started_at="$(jq -er '.started_at_utc' "$receipt")"
+  completed_at="$(jq -er '.completed_at_utc' "$receipt")"
+  started_epoch="$(parse_epoch "$started_at")" || return 1
+  completed_epoch="$(parse_epoch "$completed_at")" || return 1
+  now="$(date -u +%s)"
+  age=$((now - completed_epoch))
+  (( started_epoch <= completed_epoch && age >= 0 && age <= MAX_BACKUP_AGE_SECONDS ))
+}
+
+report_object_backup_receipt() {
+  local receipt="$1"
+  local receipt_status='INCOMPLETE' copy_status='INCOMPLETE'
+  if validate_object_backup_receipt "$receipt"; then
+    receipt_status='PASS'
+    copy_status='PASS'
   else
     AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
-    printf 'LATEST_BUILDINGOS_DB_BACKUP_TIMESTAMP=UNKNOWN\n'
-    printf 'LATEST_BUILDINGOS_DB_BACKUP_FILE=UNKNOWN\n'
-    printf 'BACKUP_AGE_SECONDS=UNKNOWN\n'
   fi
+  printf 'OBJECT_BACKUP_RECEIPT=%s\n' "$receipt_status"
+  printf 'OBJECT_BACKUP_COPY=%s\n' "$copy_status"
+  printf 'DB_OBJECT_REFERENCE_RECONCILIATION=NOT_IMPLEMENTED\n'
+  printf 'DB_OBJECT_CONTENT_IDENTITY=NOT_IMPLEMENTED\n'
+  printf 'RECOVERY_POINT_VALID=NOT_EVALUATED\n'
+  printf 'BACKUP_READINESS=INCOMPLETE\n'
+  AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
+}
+
+report_backup_readiness() {
+  local mechanism_path='UNKNOWN' mechanism_digest='UNKNOWN' mechanism_owner='UNKNOWN' mechanism_group='UNKNOWN' mechanism_mode='UNKNOWN'
+  local mechanism_identity='UNKNOWN' mechanism_status='INCOMPLETE'
+
+  report_object_backup_receipt "$OBJECT_BACKUP_RECEIPT"
   if validate_backup_mechanism "$BACKUP_IDENTITY_MANIFEST_PATH"; then
     mechanism_path="$(manifest_field "$BACKUP_IDENTITY_MANIFEST_PATH" path)"
     mechanism_digest="$(manifest_field "$BACKUP_IDENTITY_MANIFEST_PATH" sha256)"
@@ -1012,6 +1008,7 @@ report_backup_readiness() {
     mechanism_group="$(manifest_field "$BACKUP_IDENTITY_MANIFEST_PATH" group)"
     mechanism_mode="$(manifest_field "$BACKUP_IDENTITY_MANIFEST_PATH" mode)"
     mechanism_identity="path=${mechanism_path};sha256=${mechanism_digest};owner=${mechanism_owner};group=${mechanism_group};mode=${mechanism_mode}"
+    mechanism_status='PASS'
   else
     AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))
   fi
@@ -1022,11 +1019,8 @@ report_backup_readiness() {
   printf 'BACKUP_MECHANISM_MODE=%s\n' "$mechanism_mode"
   printf 'BACKUP_MECHANISM_IDENTITY=%s\n' "$mechanism_identity"
   printf 'BACKUP_IDENTITY_MANIFEST=%s\n' "$BACKUP_IDENTITY_MANIFEST_PATH"
-  printf 'BACKUP_DUMP_PRESENT=%s\n' "$dump_present"
-  printf 'BACKUP_CHECKSUM_PRESENT=%s\n' "$checksum_present"
-  printf 'BACKUP_CHECKSUM_VERIFICATION=%s\n' "$checksum_status"
-  printf 'BACKUP_PG_RESTORE_LIST=%s\n' "$restore_status"
-  printf 'PREDEPLOY_BACKUP_REQUIRED=%s\n' "$backup_required"
+  printf 'POSTGRES_BACKUP_MECHANISM=%s\n' "$mechanism_status"
+  printf 'POSTGRES_BACKUP_EVIDENCE=INCOMPLETE\n'
 }
 
 report_minio_posture() {

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -978,6 +978,7 @@ validate_object_backup_receipt() {
   (( started_epoch <= completed_epoch && age >= 0 && age <= MAX_BACKUP_AGE_SECONDS ))
 }
 
+# Object copy evidence remains separate from the unimplemented recovery-point contract.
 report_object_backup_receipt() {
   local receipt="$1"
   local receipt_status='INCOMPLETE' copy_status='INCOMPLETE'

--- a/scripts/production-readonly-audit.sh
+++ b/scripts/production-readonly-audit.sh
@@ -968,6 +968,7 @@ validate_object_backup_receipt() {
   destination="$(jq -er '.destination' "$receipt")"
   validate_object_location "$source" || return 1
   validate_object_location "$destination" || return 1
+  [[ "${source#*:}" == buildingos-production ]] || return 1
   [[ "${source#*:}" != "${destination#*:}" ]] || return 1
   started_at="$(jq -er '.started_at_utc' "$receipt")"
   completed_at="$(jq -er '.completed_at_utc' "$receipt")"

--- a/scripts/tests/production-backup-preflight.test.sh
+++ b/scripts/tests/production-backup-preflight.test.sh
@@ -33,9 +33,21 @@ assert_success() { local name="$1"; [[ "$RUN_RC" -eq 0 ]] && pass "$name" || fai
 assert_failure() { local name="$1"; [[ "$RUN_RC" -ne 0 ]] && pass "$name" || fail_test "$name"; }
 
 mkdir -p "$BIN_DIR" "$APP_DIR/.git"
-for command_name in awk bash date stat; do
+for command_name in awk bash date; do
   ln -s "$(command -v "$command_name")" "$BIN_DIR/$command_name"
 done
+
+cat > "$BIN_DIR/stat" <<'MOCK'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+case "$*" in
+  *'%U'*) printf '%s\n' "${MOCK_CONFIG_OWNER:-yoryi}" ;;
+  *'%G'*) printf '%s\n' "${MOCK_CONFIG_GROUP:-yoryi}" ;;
+  *'%a'*) printf '%s\n' "${MOCK_CONFIG_MODE:-600}" ;;
+  *) exit 1 ;;
+esac
+MOCK
+chmod +x "$BIN_DIR/stat"
 
 cat > "$BIN_DIR/git" <<'MOCK'
 #!/usr/bin/env bash
@@ -94,7 +106,13 @@ case "$property:$unit" in
   ActiveState:pawtech-postgres-backup.timer|ActiveState:pawtech-buildingos-object-backup.timer) printf '%s\n' "${MOCK_TIMER_STATE:-active}" ;;
   Unit:pawtech-postgres-backup.timer) printf 'pawtech-postgres-backup.service\n' ;;
   Unit:pawtech-buildingos-object-backup.timer) printf 'pawtech-buildingos-object-backup.service\n' ;;
-  NextElapseUSecRealtime:*) printf '%s\n' "${MOCK_NEXT_TRIGGER:-2099-01-01 00:00:00 UTC}" ;;
+  NextElapseUSecRealtime:*)
+    if [[ -n "${MOCK_NEXT_TRIGGER:-}" ]]; then printf '%s\n' "$MOCK_NEXT_TRIGGER"; else date -u -v+12H '+%Y-%m-%d %H:%M:%S UTC' 2>/dev/null || date -u -d '+12 hours' '+%Y-%m-%d %H:%M:%S UTC'; fi
+    ;;
+  OnCalendar:pawtech-postgres-backup.timer) printf '%s\n' "${MOCK_POSTGRES_CALENDAR:-daily}" ;;
+  OnCalendar:pawtech-buildingos-object-backup.timer) printf '%s\n' "${MOCK_OBJECT_CALENDAR:-*-*-* 02:15:00}" ;;
+  Persistent:pawtech-buildingos-object-backup.timer) printf '%s\n' "${MOCK_OBJECT_PERSISTENT:-true}" ;;
+  RandomizedDelayUSec:pawtech-buildingos-object-backup.timer) printf '%s\n' "${MOCK_OBJECT_RANDOMIZED_DELAY:-900000000}" ;;
   User:pawtech-buildingos-object-backup.service|Group:pawtech-buildingos-object-backup.service) printf 'yoryi\n' ;;
   EnvironmentFiles:pawtech-buildingos-object-backup.service) printf '%s\n' "${PREFLIGHT_ENV_FILE:-/etc/buildingos/object-backup.env}" ;;
   WorkingDirectory:pawtech-buildingos-object-backup.service) printf '%s\n' "${PREFLIGHT_APP_DIR:-/opt/pawtech/apps/buildingos/buildingos-app}" ;;
@@ -161,9 +179,34 @@ assert_contains 'PostgreSQL ExecStart is validated' 'POSTGRES_BACKUP_SERVICE_EXE
 assert_contains 'Object timer enabled is accepted' 'OBJECT_BACKUP_TIMER_ENABLED=YES' "$RUN_OUTPUT"
 assert_contains 'Object timer active is accepted' 'OBJECT_BACKUP_TIMER_ACTIVE=YES' "$RUN_OUTPUT"
 assert_contains 'Object timer future trigger is accepted' 'OBJECT_BACKUP_TIMER_FUTURE_TRIGGER=YES' "$RUN_OUTPUT"
+assert_contains 'Object timer calendar is accepted' 'OBJECT_BACKUP_TIMER_CALENDAR_MATCH=YES' "$RUN_OUTPUT"
+assert_contains 'Object timer persistence is accepted' 'OBJECT_BACKUP_TIMER_PERSISTENT=YES' "$RUN_OUTPUT"
+assert_contains 'Object timer randomized delay is accepted' 'OBJECT_BACKUP_TIMER_RANDOMIZED_DELAY_MATCH=YES' "$RUN_OUTPUT"
 assert_contains 'Object service contract is accepted' 'OBJECT_BACKUP_SERVICE_CONTRACT=YES' "$RUN_OUTPUT"
 assert_contains 'Object environment contract is accepted' 'OBJECT_BACKUP_ENV=YES' "$RUN_OUTPUT"
 assert_contains 'backup concurrency is safe' 'BACKUP_CONCURRENCY_SAFE=YES' "$RUN_OUTPUT"
+
+MOCK_OBJECT_CALENDAR='*-*-* 03:15:00' run_preflight
+assert_failure 'wrong Object Storage timer calendar fails closed'
+unset MOCK_OBJECT_CALENDAR
+MOCK_OBJECT_PERSISTENT=false run_preflight
+assert_failure 'non-persistent Object Storage timer fails closed'
+unset MOCK_OBJECT_PERSISTENT
+MOCK_OBJECT_RANDOMIZED_DELAY=600000000 run_preflight
+assert_failure 'wrong Object Storage timer delay fails closed'
+unset MOCK_OBJECT_RANDOMIZED_DELAY
+MOCK_OBJECT_CALENDAR='calendar=*-*-* 02:15:00 ; next_elapse=2026-09-06T02:15:00Z' MOCK_OBJECT_RANDOMIZED_DELAY=15min run_preflight
+assert_success 'serialized calendar and 15min delay representations pass'
+unset MOCK_OBJECT_CALENDAR MOCK_OBJECT_RANDOMIZED_DELAY
+MOCK_OBJECT_RANDOMIZED_DELAY='15min 0s' run_preflight
+assert_success 'verbose 15 minute delay representation passes'
+unset MOCK_OBJECT_RANDOMIZED_DELAY
+MOCK_POSTGRES_CALENDAR=weekly run_preflight
+assert_failure 'non-daily PostgreSQL timer calendar fails closed'
+unset MOCK_POSTGRES_CALENDAR
+MOCK_NEXT_TRIGGER='2099-01-01 00:00:00 UTC' run_preflight
+assert_failure 'absurd future Object Storage trigger fails closed'
+unset MOCK_NEXT_TRIGGER
 
 run_preflight deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 assert_failure 'candidate SHA mismatch fails runtime identity gate'
@@ -278,14 +321,27 @@ run_preflight
 assert_failure 'missing rclone config fails closed'
 printf '[prod]\ntype = s3\n' > "$RCLONE_CONFIG_FILE"
 chmod 0600 "$RCLONE_CONFIG_FILE"
+
+MOCK_CONFIG_OWNER=root MOCK_CONFIG_GROUP=yoryi MOCK_CONFIG_MODE=640 run_preflight
+assert_success 'root-owned rclone config is readable through yoryi group'
+MOCK_CONFIG_OWNER=root MOCK_CONFIG_GROUP=root MOCK_CONFIG_MODE=600 run_preflight
+assert_failure 'root-owned root-group rclone config fails yoryi readability'
+MOCK_CONFIG_OWNER=root MOCK_CONFIG_GROUP=root MOCK_CONFIG_MODE=640 run_preflight
+assert_failure 'root-owned root-group 0640 rclone config fails yoryi readability'
+MOCK_CONFIG_OWNER=yoryi MOCK_CONFIG_GROUP=yoryi MOCK_CONFIG_MODE=644 run_preflight
+assert_failure 'world-readable rclone config fails closed'
+MOCK_CONFIG_OWNER=yoryi MOCK_CONFIG_GROUP=yoryi MOCK_CONFIG_MODE=660 run_preflight
+assert_failure 'group-writable rclone config fails closed'
+unset MOCK_CONFIG_OWNER MOCK_CONFIG_GROUP MOCK_CONFIG_MODE
 ln -s "$TEST_ROOT/missing-rclone.conf" "$TEST_ROOT/rclone-symlink.conf"
 sed -i.bak "s|$RCLONE_CONFIG_FILE|$TEST_ROOT/rclone-symlink.conf|" "$ENV_FILE"
 run_preflight
 assert_failure 'symlink rclone config fails closed'
 mv "$ENV_FILE.bak" "$ENV_FILE"
 chmod 0660 "$RCLONE_CONFIG_FILE"
-run_preflight
+MOCK_CONFIG_MODE=660 run_preflight
 assert_failure 'writable rclone config fails closed'
+unset MOCK_CONFIG_MODE
 chmod 0600 "$RCLONE_CONFIG_FILE"
 
 preflight_text="$(< "$PREFLIGHT")"

--- a/scripts/tests/production-backup-preflight.test.sh
+++ b/scripts/tests/production-backup-preflight.test.sh
@@ -4,18 +4,15 @@ set -Eeuo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 readonly ROOT_DIR
 readonly PREFLIGHT="$ROOT_DIR/scripts/production-backup-preflight.sh"
-readonly WORKFLOW="$ROOT_DIR/.github/workflows/production-backup-preflight.yml"
-readonly PRIVILEGED_LAUNCHER="$ROOT_DIR/infra/production/launchers/buildingos-production-backup-preflight"
-readonly SUDOERS_POLICY="$ROOT_DIR/infra/production/sudoers/buildingos-production-backup-preflight"
-readonly ACTIVATION_RUNBOOK="$ROOT_DIR/docs/runbooks/PRODUCTION_BACKUP_ACTIVATION.md"
 readonly TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/buildingos-backup-preflight.XXXXXX")"
+readonly BIN_DIR="$TEST_ROOT/bin"
+readonly ENV_FILE="$TEST_ROOT/object-backup.env"
 trap 'rm -rf "$TEST_ROOT"' EXIT
 
 PASS_COUNT=0
 FAIL_COUNT=0
-
 pass() { PASS_COUNT=$((PASS_COUNT + 1)); printf 'ok %s - %s\n' "$PASS_COUNT" "$1"; }
-fail_test() { FAIL_COUNT=$((FAIL_COUNT + 1)); printf 'not ok - %s\n' "$1" >&2; }
+fail_test() { FAIL_COUNT=$((FAIL_COUNT + 1)); printf 'not ok %s - %s\n' "$FAIL_COUNT" "$1" >&2; }
 
 assert_contains() {
   local name="$1" value="$2" text="$3"
@@ -27,807 +24,173 @@ assert_absent() {
   if [[ "$text" != *"$value"* ]]; then pass "$name"; else fail_test "$name"; fi
 }
 
-assert_success() {
-  local name="$1"
-  if [[ "$RUN_RC" -eq 0 ]]; then pass "$name"; else fail_test "$name"; fi
-}
+assert_success() { local name="$1"; [[ "$RUN_RC" -eq 0 ]] && pass "$name" || fail_test "$name"; }
+assert_failure() { local name="$1"; [[ "$RUN_RC" -ne 0 ]] && pass "$name" || fail_test "$name"; }
 
-assert_failure() {
-  local name="$1"
-  if [[ "$RUN_RC" -ne 0 ]]; then pass "$name"; else fail_test "$name"; fi
-}
-
-assert_order() {
-  local name="$1" first="$2" second="$3" text="$4" line first_line=0 second_line=0 line_number=0
-  while IFS= read -r line; do
-    line_number=$((line_number + 1))
-    [[ "$first_line" -ne 0 || "$line" != *"$first"* ]] || first_line=$line_number
-    [[ "$second_line" -ne 0 || "$line" != *"$second"* ]] || second_line=$line_number
-  done <<< "$text"
-  if [[ "$first_line" -gt 0 && "$second_line" -gt "$first_line" ]]; then pass "$name"; else fail_test "$name"; fi
-}
-
-readonly APP_DIR="$TEST_ROOT/app"
-readonly ENV_FILE="$TEST_ROOT/buildingos-backup.env"
-readonly SSE_FILE="$TEST_ROOT/contabo-sse-s3-capability.json"
-readonly STATE_DIR="$TEST_ROOT/state"
-readonly BIN_DIR="$TEST_ROOT/bin"
-mkdir -p "$APP_DIR/.git" "$APP_DIR/scripts" "$STATE_DIR" "$BIN_DIR"
-chmod 0700 "$STATE_DIR"
-
-for script_name in \
-  backup-buildingos-production.sh \
-  backup-postgres-paired.sh \
-  backup-minio.sh \
-  verify-minio-backup.sh \
-  validate-sse-capability.sh \
-  resolve-production-app-sha.sh \
-  check-production-backup-freshness.sh; do
-  printf '# isolated fixture\n' > "$APP_DIR/scripts/$script_name"
-  chmod 0755 "$APP_DIR/scripts/$script_name"
-done
-if [[ -e "$APP_DIR/scripts/lib/endpoint-identity.sh" ]]; then
-  fail_test 'db82 fixture does not deploy the new shared endpoint helper'
-else
-  pass 'db82 fixture does not deploy the new shared endpoint helper'
-fi
-
-link_command() {
-  local command_name="$1"
+mkdir -p "$BIN_DIR"
+for command_name in awk bash date; do
   ln -s "$(command -v "$command_name")" "$BIN_DIR/$command_name"
-}
-
-for command_name in awk bash cat date id jq sha256sum stat tr; do link_command "$command_name"; done
-
-cat > "$BIN_DIR/df" <<'MOCK'
-#!/usr/bin/env bash
-set -Eeuo pipefail
-path="${@: -1}"
-if [[ "$path" == *pg-root* ]]; then
-  available="${MOCK_ROOT_FREE_KIB:-1000000}"
-else
-  available="${MOCK_TMP_FREE_KIB:-1000000}"
-fi
-printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\nmock 1000000 0 %s 0%% /\n' "$available"
-MOCK
-chmod 0755 "$BIN_DIR/df"
-
-cat > "$BIN_DIR/git" <<'MOCK'
-#!/usr/bin/env bash
-set -Eeuo pipefail
-case "$*" in
-  *'rev-parse HEAD'*) printf '%s\n' "${MOCK_CHECKOUT_SHA:-${MOCK_RUNTIME_SHA:-2ac603be8018ffc3df67fb4e84149aea4f780cea}}" ;;
-  *'status --porcelain'*) [[ "${MOCK_DIRTY:-NO}" == NO ]] || printf ' M application.env\n' ;;
-  *) exit 1 ;;
-esac
-MOCK
-
-cat > "$BIN_DIR/docker" <<'MOCK'
-#!/usr/bin/env bash
-set -Eeuo pipefail
-if [[ "$1 ${2:-}" == 'inspect --type' ]]; then
-  target="${@: -1}"
-  format=''
-  args=("$@")
-  for ((index = 0; index < ${#args[@]}; index++)); do
-    if [[ "${args[index]}" == --format=* ]]; then
-      format="${args[index]#--format=}"
-    elif [[ "${args[index]}" == --format && $((index + 1)) -lt ${#args[@]} ]]; then
-      format="${args[index + 1]}"
-    fi
-  done
-  if [[ "$target" == buildingos-api || "$target" == buildingos-web ]]; then
-    printf 'sha256:%064d\n' "$([[ "$target" == buildingos-api ]] && printf 1 || printf 2)"
-  elif [[ "$format" == *'.State.Status'* ]]; then
-    printf 'running\n'
-  elif [[ "$format" == *'.State.Health'* ]]; then
-    printf '%s\n' "${MOCK_PG_HEALTH:-healthy}"
-  fi
-elif [[ "$1 ${2:-}" == 'image inspect' ]]; then
-  image="$3"
-  if [[ "$image" == "sha256:$(printf '%064d' 1)" ]]; then
-    printf '%s\n' "${MOCK_API_REVISION:-${MOCK_RUNTIME_SHA:-2ac603be8018ffc3df67fb4e84149aea4f780cea}}"
-  else
-    printf '%s\n' "${MOCK_WEB_REVISION:-${MOCK_RUNTIME_SHA:-2ac603be8018ffc3df67fb4e84149aea4f780cea}}"
-  fi
-elif [[ "$1" == exec ]]; then
-  [[ "${MOCK_DB_SIZE_UNAVAILABLE:-NO}" == YES ]] && exit 1
-  printf '%s\n' "${MOCK_DB_SIZE_BYTES:-104857600}"
-else
-  exit 1
-fi
-MOCK
+done
 
 cat > "$BIN_DIR/systemctl" <<'MOCK'
 #!/usr/bin/env bash
 set -Eeuo pipefail
-command_name="$1"
 unit="${2:-}"
-if [[ "$command_name" == cat ]]; then
-  [[ "$unit" == pawtech-buildingos-backup.service && "${MOCK_BACKUP_UNIT_MISSING:-NO}" == YES ]] && exit 1
-  [[ "$unit" == pawtech-buildingos-backup-verify.service && "${MOCK_VERIFY_UNIT_MISSING:-NO}" == YES ]] && exit 1
-  [[ "$unit" == pawtech-postgres-backup.service && "${MOCK_LEGACY_SERVICE_MISSING:-NO}" == YES ]] && exit 1
-  [[ "$unit" == pawtech-postgres-backup.timer && "${MOCK_LEGACY_TIMER_MISSING:-NO}" == YES ]] && exit 1
-  exit 0
-fi
-if [[ "$command_name" == is-active ]]; then
-  if [[ "$unit" == pawtech-buildingos-backup.service && "${MOCK_BACKUP_ACTIVE:-NO}" == YES ]] ||
-    [[ "$unit" == pawtech-buildingos-backup-verify.service && "${MOCK_VERIFY_ACTIVE:-NO}" == YES ]]; then
-    printf 'active\n'; exit 0
-  fi
-  if [[ "$unit" == pawtech-buildingos-backup.timer && "${MOCK_TIMER_ACTIVE:-NO}" == YES ]]; then
-    printf 'active\n'; exit 0
-  fi
-  if [[ "$unit" == pawtech-postgres-backup.service && "${MOCK_LEGACY_SERVICE_ACTIVE:-NO}" == YES ]]; then
-    printf 'active\n'; exit 0
-  fi
-  if [[ "$unit" == pawtech-postgres-backup.timer && "${MOCK_LEGACY_TIMER_ACTIVE:-NO}" == YES ]]; then
-    printf 'active\n'; exit 0
-  fi
-  if [[ "$unit" == pawtech-postgres-backup.timer && "${MOCK_LEGACY_TIMER_AMBIGUOUS:-NO}" == YES ]]; then
-    printf 'unknown\n'; exit 3
-  fi
-  printf 'inactive\n'; exit 3
-fi
-if [[ "$command_name" == show ]]; then
-  property=''
-  for arg in "$@"; do [[ "$arg" == --property=* ]] && property="${arg#--property=}"; done
-  case "$property:$unit" in
-    LoadState:*)
-      if [[ "$unit" == pawtech-postgres-backup.service && "${MOCK_LEGACY_SERVICE_MISSING:-NO}" == YES ]] || [[ "$unit" == pawtech-postgres-backup.timer && "${MOCK_LEGACY_TIMER_MISSING:-NO}" == YES ]]; then printf 'not-found\n'; else printf 'loaded\n'; fi
-      ;;
-    ActiveState:*)
-      if [[ "$unit" == pawtech-buildingos-backup.service && "${MOCK_BACKUP_ACTIVE:-NO}" == YES ]] || [[ "$unit" == pawtech-buildingos-backup-verify.service && "${MOCK_VERIFY_ACTIVE:-NO}" == YES ]] || [[ "$unit" == pawtech-postgres-backup.service && "${MOCK_LEGACY_SERVICE_ACTIVE:-NO}" == YES ]] || [[ "$unit" == pawtech-postgres-backup.timer && "${MOCK_LEGACY_TIMER_ACTIVE:-NO}" == YES ]]; then
-        printf 'active\n'
-      elif [[ "$unit" == pawtech-postgres-backup.service && "${MOCK_LEGACY_SERVICE_AMBIGUOUS:-NO}" == YES ]] || [[ "$unit" == pawtech-postgres-backup.timer && "${MOCK_LEGACY_TIMER_AMBIGUOUS:-NO}" == YES ]]; then
-        printf 'unknown\n'
-      else
-        printf 'inactive\n'
-      fi
-      ;;
-    UnitFileState:pawtech-postgres-backup.timer) [[ "${MOCK_LEGACY_TIMER_AMBIGUOUS:-NO}" == YES ]] && printf 'unknown\n' || printf '%s\n' "${MOCK_LEGACY_TIMER_STATE:-disabled}" ;;
-    NextElapseUSecRealtime:pawtech-postgres-backup.timer) [[ "${MOCK_LEGACY_TIMER_AMBIGUOUS:-NO}" == YES ]] && printf 'unknown\n' || printf '%s\n' "${MOCK_LEGACY_TIMER_NEXT_TRIGGER:-n/a}" ;;
-    User:*) printf 'yoryi\n' ;;
-    Type:*) printf 'oneshot\n' ;;
-    Restart:*) printf 'no\n' ;;
-    WorkingDirectory:*) printf '%s\n' "${PREFLIGHT_APP_DIR:?}" ;;
-    EnvironmentFiles:*) [[ "${MOCK_BAD_ENV_FILE:-NO}" == YES && "$unit" == pawtech-buildingos-backup.service ]] && printf '/etc/buildingos/wrong.env\n' || printf '/etc/buildingos/buildingos-backup.env\n' ;;
-    ExecCondition:*)
-      case "${MOCK_EXEC_CONDITION_MODE:-EMPTY}" in
-        ONE) printf '{ path=/bin/true ; argv[]=/bin/true ; ignore_errors=no }\n' ;;
-        MALFORMED) printf '{ path=/bin/true ; argv[]=/bin/true\n' ;;
-        *) printf '\n' ;;
-      esac
-      ;;
-    ExecStart:*)
-      if [[ "$unit" == pawtech-buildingos-backup.service && "${MOCK_BAD_EXECSTART:-NO}" == YES ]]; then
-        printf '/opt/pawtech/apps/buildingos/buildingos-app/scripts/not-the-backup.sh\n'
-      elif [[ "${MOCK_MALFORMED_EXECSTART:-NO}" == YES ]]; then
-        printf '{ path=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-buildingos-production.sh ; argv[]=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-buildingos-production.sh\n'
-      elif [[ "${MOCK_SECOND_EXECSTART:-NO}" == YES && "$unit" == pawtech-buildingos-backup.service ]]; then
-        printf '{ path=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-buildingos-production.sh ; argv[]=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-buildingos-production.sh ; ignore_errors=no } { path=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-buildingos-production.sh ; argv[]=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-buildingos-production.sh ; ignore_errors=no }\n'
-      elif [[ "$unit" == pawtech-buildingos-backup-verify.service ]]; then
-        if [[ "${MOCK_SERIALIZED_EXECSTART:-NO}" == YES ]]; then
-          ignore_errors_field=' ; ignore_errors=no'
-          case "${MOCK_IGNORE_ERRORS_MODE:-NO}" in
-            YES) ignore_errors_field=' ; ignore_errors=yes' ;;
-            MISSING) ignore_errors_field='' ;;
-            MALFORMED) ignore_errors_field=' ; ignore_errors=maybe' ;;
-          esac
-          printf '{ path=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-buildingos-production.sh ; argv[]=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-buildingos-production.sh --verify-latest%s }\n' "$ignore_errors_field"
-        else
-          printf '{ path=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-buildingos-production.sh ; argv[]=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-buildingos-production.sh --verify-latest ; ignore_errors=no }\n'
-        fi
-      else
-        printf '{ path=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-buildingos-production.sh ; argv[]=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-buildingos-production.sh ; ignore_errors=no }\n'
-      fi
-      ;;
-    ExecStartPre:*) [[ "${MOCK_BAD_EXECSTARTPRE:-NO}" == YES ]] && printf '{ path=/bin/true ; argv[]=/bin/true ; ignore_errors=no }\n' || printf '\n' ;;
-    ExecStartPost:*) [[ "${MOCK_BAD_EXECSTARTPOST:-NO}" == YES ]] && printf '{ path=/bin/true ; argv[]=/bin/true ; ignore_errors=no }\n' || printf '\n' ;;
-    TimeoutStartUSec:*)
-      case "${MOCK_TIMEOUT_MODE:-EXACT}" in
-        SHORTER) printf '1000000\n' ;;
-        MALFORMED) printf 'not-a-timeout\n' ;;
-        MISSING) exit 1 ;;
-        *) [[ "$unit" == pawtech-buildingos-backup-verify.service ]] && printf '14400000000\n' || printf '21600000000\n' ;;
-      esac
-      ;;
-    *) exit 1 ;;
-  esac
-  exit 0
-fi
-exit 1
-MOCK
-
-for command_name in mc pg_restore rclone; do
-  printf '#!/usr/bin/env bash\nexit 0\n' > "$BIN_DIR/$command_name"
-  chmod 0755 "$BIN_DIR/$command_name"
+property=''
+for argument in "$@"; do
+  [[ "$argument" == --property=* ]] && property="${argument#--property=}"
 done
-chmod 0755 "$BIN_DIR/git" "$BIN_DIR/docker" "$BIN_DIR/systemctl"
+
+is_missing() {
+  case "$1" in
+    pawtech-postgres-backup.service) [[ "${MOCK_MISSING_POSTGRES_SERVICE:-NO}" == YES ]] ;;
+    pawtech-postgres-backup.timer) [[ "${MOCK_MISSING_POSTGRES_TIMER:-NO}" == YES ]] ;;
+    pawtech-buildingos-object-backup.service) [[ "${MOCK_MISSING_OBJECT_SERVICE:-NO}" == YES ]] ;;
+    pawtech-buildingos-object-backup.timer) [[ "${MOCK_MISSING_OBJECT_TIMER:-NO}" == YES ]] ;;
+    *) return 1 ;;
+  esac
+}
+
+if [[ "${1:-}" != show ]]; then exit 1; fi
+if is_missing "$unit"; then
+  [[ "$property" == LoadState ]] && printf 'not-found\n'
+  exit 0
+fi
+
+case "$property:$unit" in
+  LoadState:*) printf 'loaded\n' ;;
+  UnitFileState:pawtech-postgres-backup.timer|UnitFileState:pawtech-buildingos-object-backup.timer) printf '%s\n' "${MOCK_TIMER_ENABLED:-enabled}" ;;
+  ActiveState:pawtech-postgres-backup.service) printf '%s\n' "${MOCK_POSTGRES_SERVICE_STATE:-inactive}" ;;
+  ActiveState:pawtech-buildingos-object-backup.service) printf '%s\n' "${MOCK_OBJECT_SERVICE_STATE:-inactive}" ;;
+  ActiveState:pawtech-postgres-backup.timer|ActiveState:pawtech-buildingos-object-backup.timer) printf '%s\n' "${MOCK_TIMER_STATE:-active}" ;;
+  Unit:pawtech-postgres-backup.timer) printf 'pawtech-postgres-backup.service\n' ;;
+  Unit:pawtech-buildingos-object-backup.timer) printf 'pawtech-buildingos-object-backup.service\n' ;;
+  NextElapseUSecRealtime:*) printf '%s\n' "${MOCK_NEXT_TRIGGER:-2099-01-01 00:00:00 UTC}" ;;
+  User:pawtech-buildingos-object-backup.service|Group:pawtech-buildingos-object-backup.service) printf 'yoryi\n' ;;
+  EnvironmentFiles:pawtech-buildingos-object-backup.service) printf '%s\n' "${PREFLIGHT_ENV_FILE:-/etc/buildingos/object-backup.env}" ;;
+  WorkingDirectory:pawtech-buildingos-object-backup.service) printf '%s\n' '/opt/pawtech/apps/buildingos/buildingos-app' ;;
+  Type:pawtech-buildingos-object-backup.service) printf 'oneshot\n' ;;
+  ExecStart:pawtech-buildingos-object-backup.service)
+    if [[ "${MOCK_BAD_OBJECT_EXECSTART:-NO}" == YES ]]; then printf '%s\n' '/opt/wrong/backup.sh'; else printf '%s\n' '{ path=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh ; argv[]=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh ; ignore_errors=no }'; fi
+    ;;
+  TimeoutStartUSec:pawtech-buildingos-object-backup.service) printf '21600000000\n' ;;
+  *) exit 1 ;;
+esac
+MOCK
+chmod +x "$BIN_DIR/systemctl"
 
 write_env() {
-  local backup_bucket="$1"
-  local source_environment="$2"
-  local omit_secret="${3:-NO}"
-  local backup_endpoint="${4:-https://backup.example.invalid}"
-  local postgres_destination_bucket="${5:-$backup_bucket}"
-  local write_remote="${6:-contabowrite}"
-  local verify_remote="${7:-contaboverify}"
-  local backup_prefix="${8-__ABSENT__}"
+  local source="${1-prod:buildingos-production}"
+  local destination="${2-backup:buildingos-production-backup}"
   {
-    printf 'BACKUP_ENDPOINT=%s\n' "$backup_endpoint"
-    printf 'BACKUP_BUCKET=%s\n' "$backup_bucket"
-    [[ "$omit_secret" == VERIFY ]] || printf 'BACKUP_VERIFY_ACCESS_KEY=VERIFY_ACCESS_SENTINEL\nBACKUP_VERIFY_SECRET_KEY=VERIFY_SECRET_SENTINEL\n'
-    [[ "$omit_secret" == VERIFY ]] && printf 'BACKUP_VERIFY_ACCESS_KEY=VERIFY_ACCESS_SENTINEL\n'
-    printf 'BACKUP_SSE_CAPABILITY_FILE=%s\n' "$SSE_FILE"
-    printf 'BACKUP_STATE_DIR=%s\n' "$STATE_DIR"
-    printf 'BACKUP_WRITE_ACCESS_KEY=WRITE_ACCESS_SENTINEL\nBACKUP_WRITE_SECRET_KEY=WRITE_SECRET_SENTINEL\n'
-    printf 'SOURCE_ENVIRONMENT=%s\nEXPECTED_SOURCE_ENVIRONMENT=%s\n' "$source_environment" "$source_environment"
-    printf 'SOURCE_ENDPOINT=https://usc1.contabostorage.com\nSOURCE_ACCESS_KEY=SOURCE_ACCESS_SENTINEL\nSOURCE_SECRET_KEY=SOURCE_SECRET_SENTINEL\nSOURCE_BUCKET=buildingos-production\n'
-    printf 'POSTGRES_CONTAINER=pawtech-postgres\nPOSTGRES_DATABASE=buildingos_db\nPOSTGRES_USER=buildingos\nPOSTGRES_BACKUP_ROOT=%s\n' "$TEST_ROOT/pg-root"
-    printf 'POSTGRES_RCLONE_DESTINATION=%s:%s/postgresql\n' "$write_remote" "$postgres_destination_bucket"
-    printf 'POSTGRES_VERIFY_RCLONE_DESTINATION=%s:%s/postgresql\n' "$verify_remote" "$postgres_destination_bucket"
-    printf 'POSTGRES_SSE_MODE=SSE-S3\n'
-    [[ "$backup_prefix" == __ABSENT__ ]] || printf 'BACKUP_PREFIX=%s\n' "$backup_prefix"
+    printf '# protected fixture\n'
+    printf 'OBJECT_BACKUP_SOURCE=%s\n' "$source"
+    printf 'OBJECT_BACKUP_DESTINATION=%s\n' "$destination"
+    printf 'OBJECT_BACKUP_RECEIPT=/var/lib/buildingos-object-backup/object-backup-receipt.json\n'
+    printf 'RCLONE_CONFIG=/etc/buildingos/object-backup-rclone.conf\n'
   } > "$ENV_FILE"
-  chmod 0600 "$ENV_FILE"
-  mkdir -p "$TEST_ROOT/pg-root"
-}
-
-set_env_line() {
-  local key="$1" value="$2" replacement_file="$ENV_FILE.replacement"
-  awk -v key="$key" -v value="$value" '$0 ~ "^[[:space:]]*" key "=" { print key "=" value; replaced=1; next } { print } END { exit replaced ? 0 : 1 }' "$ENV_FILE" > "$replacement_file"
-  mv "$replacement_file" "$ENV_FILE"
-  chmod 0600 "$ENV_FILE"
-}
-
-write_sse() {
-  local status="${1:-SSE_S3_SUPPORTED}" algorithm="${2:-AES256}" endpoint="${3:-backup.example.invalid}" bucket="${4:-buildingos-backup}" probed_at="${5:-2026-09-03T00:00:00Z}"
-  jq -n --arg status "$status" --arg algorithm "$algorithm" --arg endpoint "$endpoint" --arg bucket "$bucket" --arg probed_at "$probed_at" \
-    '{status:$status,algorithm:$algorithm,endpoint_identity:$endpoint,bucket:$bucket,probed_at:$probed_at}' > "$SSE_FILE"
-  chmod 0640 "$SSE_FILE"
 }
 
 run_preflight() {
   set +e
-  RUN_OUTPUT="$(
-    PATH="$BIN_DIR" \
-    BUILDINGOS_PREFLIGHT_TEST_MODE=LOCAL_ISOLATED_ONLY \
-    PREFLIGHT_APP_DIR="$APP_DIR" PREFLIGHT_ENV_FILE="$ENV_FILE" PREFLIGHT_SSE_FILE="$SSE_FILE" PREFLIGHT_STATE_DIR="${PREFLIGHT_STATE_DIR_OVERRIDE:-$STATE_DIR}" \
-    PREFLIGHT_EXPECTED_ENV_OWNER="$(id -un)" PREFLIGHT_EXPECTED_ENV_GROUP="$(id -gn)" \
-    PREFLIGHT_EXPECTED_STATE_OWNER="$(id -un)" PREFLIGHT_EXPECTED_STATE_GROUP="$(id -gn)" \
-    PREFLIGHT_EXPECTED_SSE_OWNER="${PREFLIGHT_EXPECTED_SSE_OWNER_OVERRIDE:-$(id -un)}" PREFLIGHT_EXPECTED_SSE_GROUP="${PREFLIGHT_EXPECTED_SSE_GROUP_OVERRIDE:-$(id -gn)}" \
-    PREFLIGHT_APP_DIR="$APP_DIR" \
-    /bin/bash "$PREFLIGHT" 2>&1 "$CANDIDATE_SHA"
-  )"
+  RUN_OUTPUT="$(PATH="$BIN_DIR" BUILDINGOS_PREFLIGHT_TEST_MODE=LOCAL_ISOLATED_ONLY PREFLIGHT_ENV_FILE="$ENV_FILE" /bin/bash "$PREFLIGHT" 2>&1 '2ac603be8018ffc3df67fb4e84149aea4f780cea')"
   RUN_RC=$?
   set -e
 }
 
-CANDIDATE_SHA='2ac603be8018ffc3df67fb4e84149aea4f780cea'
-write_env buildingos-backup production
-write_sse
+write_env
 run_preflight
-assert_success 'happy path passes'
-assert_contains 'happy path emits PASS' 'PREFLIGHT_STATUS=PASS' "$RUN_OUTPUT"
-assert_contains 'happy path reports authoritative source endpoint' 'SOURCE_ENDPOINT_HOSTNAME=usc1.contabostorage.com' "$RUN_OUTPUT"
-assert_contains 'happy path reports authoritative source bucket' 'SOURCE_BUCKET=buildingos-production' "$RUN_OUTPUT"
-assert_contains 'happy path reports separate destinations' 'SOURCE_AND_BACKUP_SEPARATE=YES' "$RUN_OUTPUT"
-assert_contains 'happy path reports db82 destination compatibility' 'DEPLOYED_RUNTIME_SOURCE_AND_BACKUP_SEPARATE=YES' "$RUN_OUTPUT"
-assert_contains 'happy path reports db82 SSE compatibility' 'DEPLOYED_RUNTIME_SSE_ENDPOINT_MATCH=YES' "$RUN_OUTPUT"
-assert_contains 'happy path reports inactive backup' 'BACKUP_ALREADY_RUNNING=NO' "$RUN_OUTPUT"
-for sentinel in VERIFY_ACCESS_SENTINEL VERIFY_SECRET_SENTINEL WRITE_ACCESS_SENTINEL WRITE_SECRET_SENTINEL SOURCE_ACCESS_SENTINEL SOURCE_SECRET_SENTINEL; do
-  assert_absent "secret $sentinel is not emitted" "$sentinel" "$RUN_OUTPUT"
-done
+assert_success 'current topology passes with active timers and inactive services'
+assert_contains 'PostgreSQL timer enabled is accepted' 'POSTGRES_BACKUP_TIMER_ENABLED=YES' "$RUN_OUTPUT"
+assert_contains 'PostgreSQL timer active is accepted' 'POSTGRES_BACKUP_TIMER_ACTIVE=YES' "$RUN_OUTPUT"
+assert_contains 'PostgreSQL timer future trigger is accepted' 'POSTGRES_BACKUP_TIMER_FUTURE_TRIGGER=YES' "$RUN_OUTPUT"
+assert_contains 'PostgreSQL service inactive is accepted' 'POSTGRES_BACKUP_SERVICE_STATE=inactive' "$RUN_OUTPUT"
+assert_contains 'Object timer enabled is accepted' 'OBJECT_BACKUP_TIMER_ENABLED=YES' "$RUN_OUTPUT"
+assert_contains 'Object timer active is accepted' 'OBJECT_BACKUP_TIMER_ACTIVE=YES' "$RUN_OUTPUT"
+assert_contains 'Object timer future trigger is accepted' 'OBJECT_BACKUP_TIMER_FUTURE_TRIGGER=YES' "$RUN_OUTPUT"
+assert_contains 'Object service contract is accepted' 'OBJECT_BACKUP_SERVICE_CONTRACT=YES' "$RUN_OUTPUT"
+assert_contains 'Object environment contract is accepted' 'OBJECT_BACKUP_ENV=YES' "$RUN_OUTPUT"
+assert_contains 'backup concurrency is safe' 'BACKUP_CONCURRENCY_SAFE=YES' "$RUN_OUTPUT"
 
-CANDIDATE_SHA='db82d3d37fc6184a6d4063709b9a15b923371695' run_preflight
-assert_failure 'candidate mismatch fails runtime identity gate'
-assert_contains 'candidate mismatch reports inconsistent identity' 'RUNTIME_IDENTITY=INCONSISTENT' "$RUN_OUTPUT"
-assert_contains 'candidate mismatch reports failed preflight' 'PREFLIGHT_STATUS=FAIL' "$RUN_OUTPUT"
-CANDIDATE_SHA='2ac603be8018ffc3df67fb4e84149aea4f780cea'
+MOCK_POSTGRES_SERVICE_STATE=active run_preflight
+assert_failure 'active PostgreSQL backup fails closed'
+assert_contains 'active PostgreSQL backup is unsafe' 'BACKUP_CONCURRENCY_SAFE=NO' "$RUN_OUTPUT"
+unset MOCK_POSTGRES_SERVICE_STATE
 
-MOCK_API_REVISION='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' run_preflight
-assert_failure 'API revision mismatch fails runtime identity gate'
-assert_contains 'API mismatch reports inconsistent identity' 'RUNTIME_IDENTITY=INCONSISTENT' "$RUN_OUTPUT"
-unset MOCK_API_REVISION
+MOCK_POSTGRES_SERVICE_STATE=failed run_preflight
+assert_failure 'failed PostgreSQL backup service fails closed'
+unset MOCK_POSTGRES_SERVICE_STATE
 
-MOCK_WEB_REVISION='bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' run_preflight
-assert_failure 'Web revision mismatch fails runtime identity gate'
-assert_contains 'Web mismatch reports inconsistent identity' 'RUNTIME_IDENTITY=INCONSISTENT' "$RUN_OUTPUT"
-unset MOCK_WEB_REVISION
+MOCK_POSTGRES_SERVICE_STATE=unknown run_preflight
+assert_failure 'ambiguous PostgreSQL backup service fails closed'
+unset MOCK_POSTGRES_SERVICE_STATE
 
-MOCK_CHECKOUT_SHA='cccccccccccccccccccccccccccccccccccccccc' run_preflight
-assert_failure 'checkout revision mismatch fails runtime identity gate'
-assert_contains 'checkout mismatch reports inconsistent identity' 'RUNTIME_IDENTITY=INCONSISTENT' "$RUN_OUTPUT"
-unset MOCK_CHECKOUT_SHA
+MOCK_OBJECT_SERVICE_STATE=activating run_preflight
+assert_failure 'activating Object Storage backup fails closed'
+assert_contains 'activating Object Storage backup is unsafe' 'BACKUP_CONCURRENCY_SAFE=NO' "$RUN_OUTPUT"
+unset MOCK_OBJECT_SERVICE_STATE
 
-MOCK_DIRTY=YES run_preflight
-assert_failure 'dirty checkout fails runtime identity gate'
-assert_contains 'dirty checkout reports inconsistent identity' 'RUNTIME_IDENTITY=INCONSISTENT' "$RUN_OUTPUT"
-unset MOCK_DIRTY
+MOCK_MISSING_OBJECT_SERVICE=YES run_preflight
+assert_failure 'missing Object Storage service fails closed'
+assert_contains 'missing Object Storage service is reported' 'OBJECT_BACKUP_SERVICE_EXISTS=NO' "$RUN_OUTPUT"
+unset MOCK_MISSING_OBJECT_SERVICE
 
-rm "$ENV_FILE"
+MOCK_MISSING_OBJECT_TIMER=YES run_preflight
+assert_failure 'missing Object Storage timer fails closed'
+assert_contains 'missing Object Storage timer is reported' 'OBJECT_BACKUP_TIMER_EXISTS=NO' "$RUN_OUTPUT"
+unset MOCK_MISSING_OBJECT_TIMER
+
+MOCK_BAD_OBJECT_EXECSTART=YES run_preflight
+assert_failure 'wrong Object Storage ExecStart fails closed'
+unset MOCK_BAD_OBJECT_EXECSTART
+
+sed -i.bak 's|OBJECT_BACKUP_RECEIPT=/var/lib/buildingos-object-backup/object-backup-receipt.json|OBJECT_BACKUP_RECEIPT=/tmp/wrong-receipt.json|' "$ENV_FILE"
 run_preflight
-assert_failure 'missing environment fails closed'
-assert_contains 'missing environment reports unavailable names' 'REQUIRED_ENV_NAMES_PRESENT=NO' "$RUN_OUTPUT"
-assert_contains 'missing environment reaches final failure summary' 'PREFLIGHT_STATUS=FAIL' "$RUN_OUTPUT"
-assert_contains 'missing environment reports no writes' 'PRODUCTION_WRITES=0' "$RUN_OUTPUT"
-assert_contains 'missing environment reports no backup' 'BACKUP_STARTED=NO' "$RUN_OUTPUT"
-assert_contains 'missing environment reports unknown source endpoint' 'SOURCE_ENDPOINT_HOSTNAME=UNKNOWN' "$RUN_OUTPUT"
-assert_contains 'missing environment reports unknown SSE evidence' 'SSE_EVIDENCE_VALID=UNKNOWN' "$RUN_OUTPUT"
-assert_contains 'missing environment reports unknown database state' 'POSTGRES_CONTAINER_STATE=UNKNOWN' "$RUN_OUTPUT"
-assert_absent 'missing environment has no awk fatal' 'awk: fatal' "$RUN_OUTPUT"
-assert_absent 'missing environment has no awk open error' 'cannot open file' "$RUN_OUTPUT"
-write_env buildingos-backup production
+assert_failure 'wrong Object Storage receipt path fails closed'
+mv "$ENV_FILE.bak" "$ENV_FILE"
 
-MOCK_BACKUP_UNIT_MISSING=YES run_preflight
-assert_failure 'missing backup unit fails closed'
-assert_contains 'missing backup unit is reported' 'BACKUP_SERVICE_EXISTS=NO' "$RUN_OUTPUT"
-unset MOCK_BACKUP_UNIT_MISSING
-
-MOCK_BAD_EXECSTART=YES run_preflight
-assert_failure 'unexpected ExecStart fails closed'
-unset MOCK_BAD_EXECSTART
-
-MOCK_SERIALIZED_EXECSTART=YES run_preflight
-assert_success 'serialized ExecStart with whitespace passes'
-unset MOCK_SERIALIZED_EXECSTART
-
-MOCK_EXEC_CONDITION_MODE=ONE run_preflight
-assert_failure 'unexpected ExecCondition fails closed'
-unset MOCK_EXEC_CONDITION_MODE
-
-MOCK_EXEC_CONDITION_MODE=MALFORMED run_preflight
-assert_failure 'malformed ExecCondition fails closed'
-unset MOCK_EXEC_CONDITION_MODE
-
-MOCK_TIMEOUT_MODE=SHORTER run_preflight
-assert_failure 'shortened systemd timeout fails closed'
-unset MOCK_TIMEOUT_MODE
-
-MOCK_TIMEOUT_MODE=MALFORMED run_preflight
-assert_failure 'malformed systemd timeout fails closed'
-unset MOCK_TIMEOUT_MODE
-
-MOCK_TIMEOUT_MODE=MISSING run_preflight
-assert_failure 'missing systemd timeout fails closed'
-unset MOCK_TIMEOUT_MODE
-
-MOCK_SERIALIZED_EXECSTART=YES MOCK_IGNORE_ERRORS_MODE=YES run_preflight
-assert_failure 'ignored ExecStart failure fails closed'
-unset MOCK_SERIALIZED_EXECSTART MOCK_IGNORE_ERRORS_MODE
-
-MOCK_SERIALIZED_EXECSTART=YES MOCK_IGNORE_ERRORS_MODE=MISSING run_preflight
-assert_failure 'missing ExecStart ignore_errors fails closed'
-unset MOCK_SERIALIZED_EXECSTART MOCK_IGNORE_ERRORS_MODE
-
-MOCK_SERIALIZED_EXECSTART=YES MOCK_IGNORE_ERRORS_MODE=MALFORMED run_preflight
-assert_failure 'malformed ExecStart ignore_errors fails closed'
-unset MOCK_SERIALIZED_EXECSTART MOCK_IGNORE_ERRORS_MODE
-
-MOCK_SECOND_EXECSTART=YES run_preflight
-assert_failure 'additional ExecStart fails closed'
-unset MOCK_SECOND_EXECSTART
-
-MOCK_BAD_EXECSTARTPRE=YES run_preflight
-assert_failure 'unexpected ExecStartPre fails closed'
-unset MOCK_BAD_EXECSTARTPRE
-
-MOCK_BAD_EXECSTARTPOST=YES run_preflight
-assert_failure 'unexpected ExecStartPost fails closed'
-unset MOCK_BAD_EXECSTARTPOST
-
-MOCK_MALFORMED_EXECSTART=YES run_preflight
-assert_failure 'malformed serialized command list fails closed'
-unset MOCK_MALFORMED_EXECSTART
-
-MOCK_BAD_ENV_FILE=YES run_preflight
-assert_failure 'unexpected EnvironmentFile fails closed'
-unset MOCK_BAD_ENV_FILE
-
-MOCK_BACKUP_ACTIVE=YES run_preflight
-assert_failure 'active backup service fails closed'
-unset MOCK_BACKUP_ACTIVE
-
-MOCK_VERIFY_ACTIVE=YES run_preflight
-assert_failure 'active verification service fails closed'
-unset MOCK_VERIFY_ACTIVE
-
+write_env 'prod:buildingos-production/path' 'backup:buildingos-production-backup'
 run_preflight
-assert_contains 'happy path reports legacy overlap safety' 'LEGACY_BACKUP_OVERLAP_SAFE=YES' "$RUN_OUTPUT"
-MOCK_LEGACY_SERVICE_ACTIVE=YES run_preflight
-assert_failure 'active legacy PostgreSQL service fails closed'
-unset MOCK_LEGACY_SERVICE_ACTIVE
-
-MOCK_LEGACY_TIMER_ACTIVE=YES run_preflight
-assert_failure 'active legacy PostgreSQL timer fails closed'
-unset MOCK_LEGACY_TIMER_ACTIVE
-
-MOCK_LEGACY_TIMER_NEXT_TRIGGER='2026-09-03 00:00:01 UTC' run_preflight
-assert_failure 'scheduled legacy PostgreSQL timer fails closed'
-unset MOCK_LEGACY_TIMER_NEXT_TRIGGER
-
-MOCK_LEGACY_TIMER_AMBIGUOUS=YES run_preflight
-assert_failure 'ambiguous legacy PostgreSQL timer fails closed'
-unset MOCK_LEGACY_TIMER_AMBIGUOUS
-
-MOCK_LEGACY_SERVICE_MISSING=YES MOCK_LEGACY_TIMER_MISSING=YES run_preflight
-assert_success 'absent legacy PostgreSQL units are safe'
-unset MOCK_LEGACY_SERVICE_MISSING MOCK_LEGACY_TIMER_MISSING
-
-write_env buildingos-backup production VERIFY
+assert_failure 'bucket prefix fails closed'
+write_env 'prod:buildingos-production' 'backup:buildingos-production'
 run_preflight
-assert_failure 'missing secret name fails closed'
-write_env buildingos-backup production
+assert_failure 'same bucket names fail closed'
+write_env
 
-write_sse SSE_S3_SUPPORTED AES256 backup.example.invalid:443
-run_preflight
-assert_failure 'db82 rejects SSE evidence with an explicit default port'
-assert_contains 'canonical SSE comparison accepts the explicit default port' 'SSE_ENDPOINT_MATCH=YES' "$RUN_OUTPUT"
-assert_contains 'db82 SSE mismatch is explicit' 'DEPLOYED_RUNTIME_SSE_ENDPOINT_MATCH=NO' "$RUN_OUTPUT"
-write_sse
-
-write_env buildingos-backup production NO https://backup.example.invalid buildingos-backup contabowrite contaboverify ''
-run_preflight
-assert_success 'empty BACKUP_PREFIX uses runtime default'
-
-write_env buildingos-backup production NO https://backup.example.invalid buildingos-backup contabowrite contaboverify '../archive'
-run_preflight
-assert_failure 'unsafe BACKUP_PREFIX fails closed'
-write_env buildingos-backup production
-
-set_env_line SOURCE_ACCESS_KEY '""'
-run_preflight
-assert_failure 'double-quoted empty environment value fails closed'
-write_env buildingos-backup production
-
-set_env_line SOURCE_ACCESS_KEY "''"
-run_preflight
-assert_failure 'single-quoted empty environment value fails closed'
-write_env buildingos-backup production
-
-set_env_line SOURCE_ACCESS_KEY '   '
-run_preflight
-assert_failure 'whitespace-only environment value fails closed'
-write_env buildingos-backup production
-
-set_env_line SOURCE_ACCESS_KEY 'escaped\ value'
-run_preflight
-assert_success 'escaped nonempty environment value is parsed safely'
-write_env buildingos-backup production
-
-write_env buildingos-production production NO HTTPS://USC1.CONTABOSTORAGE.COM:443/
-write_sse SSE_S3_SUPPORTED AES256 usc1.contabostorage.com buildingos-production
-run_preflight
-assert_failure 'equivalent source and backup endpoints fail closed'
-write_env buildingos-backup production
-
-write_env buildingos-backup production NO https://backup.example.invalid buildingos-wrong-destination
-run_preflight
-assert_failure 'rclone destination prefix mismatch fails closed'
-write_env buildingos-backup production
-
-write_env buildingos-backup production NO https://backup.example.invalid buildingos-backup contabowrite contabowrite
-run_preflight
-assert_failure 'same rclone identities fail closed'
-write_env buildingos-backup production
-
-chmod 0644 "$ENV_FILE"
-run_preflight
-assert_failure 'unsafe environment permissions fail closed'
-chmod 0600 "$ENV_FILE"
-
-chmod 0660 "$SSE_FILE"
-run_preflight
-assert_failure 'unsafe SSE permissions fail closed'
-chmod 0640 "$SSE_FILE"
-
-chmod 0600 "$SSE_FILE"
-run_preflight
-assert_failure 'service-unreadable SSE permissions fail closed'
-chmod 0640 "$SSE_FILE"
-
-PREFLIGHT_EXPECTED_SSE_GROUP_OVERRIDE=wrong-group run_preflight
-assert_failure 'wrong SSE group fails closed'
-unset PREFLIGHT_EXPECTED_SSE_GROUP_OVERRIDE
-
-PREFLIGHT_EXPECTED_SSE_OWNER_OVERRIDE=wrong-owner run_preflight
-assert_failure 'wrong SSE owner fails closed'
-unset PREFLIGHT_EXPECTED_SSE_OWNER_OVERRIDE
-
-chmod 0750 "$STATE_DIR"
-run_preflight
-assert_failure 'unsafe state directory permissions fail closed'
-chmod 0700 "$STATE_DIR"
-
-write_sse
-
-write_env buildingos-production production
-run_preflight
-assert_failure 'source and backup bucket collision fails closed'
-write_env buildingos-backup production
-
-write_env buildingos-production production NO https://usc1.contabostorage.com buildingos-production
-set_env_line SOURCE_ENDPOINT 'http://usc1.contabostorage.com'
-write_sse SSE_S3_SUPPORTED AES256 usc1.contabostorage.com buildingos-production
-run_preflight
-assert_failure 'db82 endpoint compatibility collision fails closed'
-assert_contains 'canonical endpoint separation remains visible' 'SOURCE_AND_BACKUP_SEPARATE=YES' "$RUN_OUTPUT"
-assert_contains 'db82 endpoint collision is explicit' 'DEPLOYED_RUNTIME_SOURCE_AND_BACKUP_SEPARATE=NO' "$RUN_OUTPUT"
-write_env buildingos-backup production
-
-write_env buildingos-backup staging
-run_preflight
-assert_failure 'wrong source environment fails closed'
-write_env buildingos-backup production
-
-write_sse SSE_S3_UNKNOWN
-run_preflight
-assert_failure 'invalid SSE evidence fails closed'
-write_sse
-
-write_sse SSE_S3_SUPPORTED AES256 wrong.example.invalid
-run_preflight
-assert_failure 'SSE endpoint mismatch fails closed'
-write_sse
-
-write_sse SSE_S3_SUPPORTED AES256 backup.example.invalid another-bucket
-run_preflight
-assert_failure 'SSE bucket mismatch fails closed'
-write_sse
-
-write_sse SSE_S3_SUPPORTED AES256 backup.example.invalid buildingos-backup invalid-timestamp
-run_preflight
-assert_failure 'malformed SSE timestamp fails closed'
-write_sse
-
-PREFLIGHT_STATE_DIR_OVERRIDE="$TEST_ROOT/missing-state" run_preflight
-assert_failure 'bad state directory fails closed'
-unset PREFLIGHT_STATE_DIR_OVERRIDE
-
-MOCK_PG_HEALTH=unhealthy run_preflight
-assert_failure 'unhealthy PostgreSQL fails closed'
-unset MOCK_PG_HEALTH
-
-run_preflight
-assert_contains 'happy path reports PostgreSQL database size' 'POSTGRES_DATABASE_SIZE_BYTES=104857600' "$RUN_OUTPUT"
-assert_contains 'happy path reports byte-converted root space' 'POSTGRES_BACKUP_ROOT_FREE_BYTES=1024000000' "$RUN_OUTPUT"
-assert_contains 'happy path reports required PostgreSQL space' 'POSTGRES_BACKUP_REQUIRED_BYTES=209715200' "$RUN_OUTPUT"
-assert_contains 'happy path reports safe PostgreSQL space' 'POSTGRES_BACKUP_SPACE_SAFE=YES' "$RUN_OUTPUT"
-assert_contains 'happy path reports safe temporary space' 'TMP_SPACE_SAFE=YES' "$RUN_OUTPUT"
-
-MOCK_ROOT_FREE_KIB=204800 MOCK_DB_SIZE_BYTES=104857600 run_preflight
-assert_success 'exact PostgreSQL capacity boundary passes'
-MOCK_ROOT_FREE_KIB=204799 run_preflight
-assert_failure 'one KiB below PostgreSQL capacity boundary fails'
-unset MOCK_ROOT_FREE_KIB MOCK_DB_SIZE_BYTES
-
-MOCK_ROOT_FREE_KIB=1234 MOCK_DB_SIZE_BYTES=1 run_preflight
-assert_failure 'insufficient PostgreSQL capacity fails closed'
-assert_contains 'df KiB is converted to bytes' 'POSTGRES_BACKUP_ROOT_FREE_BYTES=1263616' "$RUN_OUTPUT"
-unset MOCK_ROOT_FREE_KIB MOCK_DB_SIZE_BYTES
-
-MOCK_DB_SIZE_UNAVAILABLE=YES run_preflight
-assert_failure 'unavailable PostgreSQL size estimate fails closed'
-assert_contains 'unavailable size estimate is explicit' 'POSTGRES_BACKUP_REQUIRED_BYTES=UNKNOWN' "$RUN_OUTPUT"
-unset MOCK_DB_SIZE_UNAVAILABLE
-
-MOCK_TMP_FREE_KIB=1 run_preflight
-assert_failure 'insufficient temporary capacity fails closed'
-unset MOCK_TMP_FREE_KIB
-
-MOCK_RUNTIME_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa run_preflight
-assert_failure 'runtime SHA mismatch fails closed'
-unset MOCK_RUNTIME_SHA
-
-MOCK_DIRTY=YES run_preflight
-assert_failure 'dirty checkout fails closed'
-unset MOCK_DIRTY
-
-rm "$BIN_DIR/rclone"
-run_preflight
-assert_failure 'missing dependency fails closed'
-assert_contains 'missing dependency is reported' 'required dependency is missing: rclone' "$RUN_OUTPUT"
-ln -s "$(command -v true)" "$BIN_DIR/rclone"
-
-launcher_control="$TEST_ROOT/installed-control"
-launcher_path="$TEST_ROOT/installed-launcher"
-launcher_stat="$TEST_ROOT/launcher-stat"
-mkdir -p "$launcher_control/lib"
-cat > "$launcher_control/production-backup-preflight.sh" <<'MOCK'
-#!/usr/bin/env bash
-set -Eeuo pipefail
-if IFS= read -r _; then
-  printf '%s\n' 'STDIN=CUSTOM'
-  exit 1
-fi
-printf 'CANDIDATE_SHA=%s\n' "$1"
-printf 'PREFLIGHT_APP_DIR=%s\n' "${PREFLIGHT_APP_DIR-UNSET}"
-printf 'PREFLIGHT_ENV_FILE=%s\n' "${PREFLIGHT_ENV_FILE-UNSET}"
-printf 'PREFLIGHT_SSE_FILE=%s\n' "${PREFLIGHT_SSE_FILE-UNSET}"
-printf 'PREFLIGHT_STATE_DIR=%s\n' "${PREFLIGHT_STATE_DIR-UNSET}"
-printf 'PREFLIGHT_EXPECTED_ENV_OWNER=%s\n' "${PREFLIGHT_EXPECTED_ENV_OWNER-UNSET}"
-printf 'PREFLIGHT_EXPECTED_ENV_GROUP=%s\n' "${PREFLIGHT_EXPECTED_ENV_GROUP-UNSET}"
-printf 'PREFLIGHT_EXPECTED_STATE_OWNER=%s\n' "${PREFLIGHT_EXPECTED_STATE_OWNER-UNSET}"
-printf 'PREFLIGHT_EXPECTED_STATE_GROUP=%s\n' "${PREFLIGHT_EXPECTED_STATE_GROUP-UNSET}"
-printf 'PREFLIGHT_EXPECTED_SSE_OWNER=%s\n' "${PREFLIGHT_EXPECTED_SSE_OWNER-UNSET}"
-printf 'PREFLIGHT_EXPECTED_SSE_GROUP=%s\n' "${PREFLIGHT_EXPECTED_SSE_GROUP-UNSET}"
-printf 'BUILDINGOS_PREFLIGHT_TEST_MODE=%s\n' "${BUILDINGOS_PREFLIGHT_TEST_MODE-UNSET}"
-printf 'PATH=%s\n' "$PATH"
-printf '%s\n' 'STDIN=CLOSED'
-MOCK
-printf '# endpoint fixture\n' > "$launcher_control/lib/endpoint-identity.sh"
-cat > "$launcher_stat" <<'MOCK'
-#!/bin/sh
-set -eu
-path=''
-for argument do path="$argument"; done
-case "$path" in
-  */endpoint-identity.sh) mode=644 ;;
-  *) mode=755 ;;
-esac
-printf '0:0:%s\n' "$mode"
-MOCK
-sed \
-  -e "s|/usr/local/libexec/buildingos-backup-preflight|$launcher_control|g" \
-  -e "s|/usr/local/sbin/buildingos-production-backup-preflight|$launcher_path|g" \
-  -e "s|/usr/bin/stat|$launcher_stat|g" \
-  "$PRIVILEGED_LAUNCHER" > "$launcher_path"
-chmod 0755 "$launcher_control" "$launcher_control/lib" "$launcher_control/production-backup-preflight.sh" "$launcher_path" "$launcher_stat"
-chmod 0644 "$launcher_control/lib/endpoint-identity.sh"
-
-run_launcher() {
-  set +e
-  LAUNCHER_OUTPUT="$("$launcher_path" "$@" 2>&1)"
-  LAUNCHER_RC=$?
-  set -e
-}
-
-run_launcher "$CANDIDATE_SHA"
-RUN_RC=$LAUNCHER_RC
-assert_success 'privileged launcher accepts exactly one lowercase SHA'
-assert_contains 'privileged launcher passes the exact SHA' "CANDIDATE_SHA=$CANDIDATE_SHA" "$LAUNCHER_OUTPUT"
-assert_contains 'privileged launcher closes caller stdin' 'STDIN=CLOSED' "$LAUNCHER_OUTPUT"
-
-run_launcher
-RUN_RC=$LAUNCHER_RC
-assert_failure 'privileged launcher rejects zero arguments'
-run_launcher "$CANDIDATE_SHA" id
-RUN_RC=$LAUNCHER_RC
-assert_failure 'privileged launcher rejects multiple arguments'
-run_launcher AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-RUN_RC=$LAUNCHER_RC
-assert_failure 'privileged launcher rejects uppercase SHA'
-run_launcher abc123
-RUN_RC=$LAUNCHER_RC
-assert_failure 'privileged launcher rejects short SHA'
-run_launcher 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;'
-RUN_RC=$LAUNCHER_RC
-assert_failure 'privileged launcher rejects shell metacharacters'
-run_launcher /tmp/preflight.sh
-RUN_RC=$LAUNCHER_RC
-assert_failure 'privileged launcher rejects path arguments'
-run_launcher id
-RUN_RC=$LAUNCHER_RC
-assert_failure 'privileged launcher rejects arbitrary commands'
-
-printf 'printf "BASH_ENV_EXECUTED\\n"; exit 99\n' > "$TEST_ROOT/attacker-bash-env"
-set +e
-LAUNCHER_OUTPUT="$(env \
-  BASH_ENV="$TEST_ROOT/attacker-bash-env" \
-  PATH="$TEST_ROOT:$PATH" \
-  PREFLIGHT_APP_DIR=/tmp/attacker-app \
-  PREFLIGHT_ENV_FILE=/tmp/attacker.env \
-  PREFLIGHT_SSE_FILE=/tmp/attacker-sse.json \
-  PREFLIGHT_STATE_DIR=/tmp/attacker-state \
-  PREFLIGHT_EXPECTED_ENV_OWNER=attacker \
-  PREFLIGHT_EXPECTED_ENV_GROUP=attacker \
-  PREFLIGHT_EXPECTED_STATE_OWNER=attacker \
-  PREFLIGHT_EXPECTED_STATE_GROUP=attacker \
-  PREFLIGHT_EXPECTED_SSE_OWNER=attacker \
-  PREFLIGHT_EXPECTED_SSE_GROUP=attacker \
-  BUILDINGOS_PREFLIGHT_TEST_MODE=LOCAL_ISOLATED_ONLY \
-  "$launcher_path" "$CANDIDATE_SHA" 2>&1)"
-LAUNCHER_RC=$?
-set -e
-RUN_RC=$LAUNCHER_RC
-assert_success 'privileged launcher ignores protected path and test-mode overrides'
-assert_contains 'app directory override is cleared' 'PREFLIGHT_APP_DIR=UNSET' "$LAUNCHER_OUTPUT"
-assert_contains 'environment path override is cleared' 'PREFLIGHT_ENV_FILE=UNSET' "$LAUNCHER_OUTPUT"
-assert_contains 'SSE path override is cleared' 'PREFLIGHT_SSE_FILE=UNSET' "$LAUNCHER_OUTPUT"
-assert_contains 'state path override is cleared' 'PREFLIGHT_STATE_DIR=UNSET' "$LAUNCHER_OUTPUT"
-assert_contains 'environment owner override is cleared' 'PREFLIGHT_EXPECTED_ENV_OWNER=UNSET' "$LAUNCHER_OUTPUT"
-assert_contains 'environment group override is cleared' 'PREFLIGHT_EXPECTED_ENV_GROUP=UNSET' "$LAUNCHER_OUTPUT"
-assert_contains 'state owner override is cleared' 'PREFLIGHT_EXPECTED_STATE_OWNER=UNSET' "$LAUNCHER_OUTPUT"
-assert_contains 'state group override is cleared' 'PREFLIGHT_EXPECTED_STATE_GROUP=UNSET' "$LAUNCHER_OUTPUT"
-assert_contains 'SSE owner override is cleared' 'PREFLIGHT_EXPECTED_SSE_OWNER=UNSET' "$LAUNCHER_OUTPUT"
-assert_contains 'SSE group override is cleared' 'PREFLIGHT_EXPECTED_SSE_GROUP=UNSET' "$LAUNCHER_OUTPUT"
-assert_contains 'test mode override is cleared' 'BUILDINGOS_PREFLIGHT_TEST_MODE=UNSET' "$LAUNCHER_OUTPUT"
-assert_contains 'launcher replaces caller PATH' 'PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin' "$LAUNCHER_OUTPUT"
-assert_absent 'launcher prevents BASH_ENV execution' 'BASH_ENV_EXECUTED' "$LAUNCHER_OUTPUT"
-
-launcher_text="$(< "$PRIVILEGED_LAUNCHER")"
-assert_contains 'launcher pins the installed control directory' "readonly CONTROL_DIR='/usr/local/libexec/buildingos-backup-preflight'" "$launcher_text"
-assert_contains 'launcher verifies root ownership and exact modes' '"0:0:$expected_mode"' "$launcher_text"
-assert_contains 'launcher executes only the installed preflight control' '/bin/bash --noprofile --norc "$PREFLIGHT_SCRIPT" "$candidate_sha" </dev/null' "$launcher_text"
-assert_absent 'launcher never executes mutable checkout scripts' '/opt/pawtech/apps/buildingos/buildingos-app' "$launcher_text"
-assert_absent 'launcher never evaluates caller input' 'eval ' "$launcher_text"
+MOCK_TIMER_ENABLED=disabled run_preflight
+assert_failure 'disabled timer fails closed'
+unset MOCK_TIMER_ENABLED
+MOCK_TIMER_STATE=inactive run_preflight
+assert_failure 'inactive timer fails closed'
+unset MOCK_TIMER_STATE
+MOCK_TIMER_STATE=failed run_preflight
+assert_failure 'failed timer fails closed'
+unset MOCK_TIMER_STATE
+MOCK_TIMER_STATE=unknown run_preflight
+assert_failure 'ambiguous timer fails closed'
+unset MOCK_TIMER_STATE
+MOCK_NEXT_TRIGGER=n/a run_preflight
+assert_failure 'missing future trigger fails closed'
+unset MOCK_NEXT_TRIGGER
+MOCK_OBJECT_SERVICE_STATE=failed run_preflight
+assert_failure 'failed Object Storage service fails closed'
+unset MOCK_OBJECT_SERVICE_STATE
 
 preflight_text="$(< "$PREFLIGHT")"
-static_text="$(printf '%s\n' "$preflight_text" | grep -v 'EXPECTED_PROPOSED_COMMAND')"
-if printf '%s\n' "$static_text" | grep -Eq 'systemctl (start|restart|stop|enable|disable|daemon-reload)|pg_dump|prisma|(^|[[:space:]])(INSERT|UPDATE|DELETE|CREATE)[[:space:]]|git (switch|pull|reset)|mc (mirror|cp|rm)|rclone (copy|copyto|delete|move)|(^|[[:space:]])(chmod|chown)[[:space:]]'; then
-  fail_test 'preflight implementation contains no write-capable operation'
-else
-  pass 'preflight implementation contains no write-capable operation'
-fi
-
-workflow_text="$(< "$WORKFLOW")"
-assert_contains 'workflow uses production environment' 'environment: production' "$workflow_text"
-assert_contains 'workflow uses operations concurrency group' 'group: production-operations' "$workflow_text"
-assert_contains 'workflow uses strict host key checking' 'StrictHostKeyChecking=yes' "$workflow_text"
-assert_contains 'workflow uses batch mode' 'BatchMode=yes' "$workflow_text"
-assert_contains 'workflow invokes only the installed privileged launcher' 'sudo -n /usr/local/sbin/buildingos-production-backup-preflight $quoted_candidate' "$workflow_text"
-assert_absent 'workflow does not authorize a streamed root bash' 'sudo -n -u root bash -s --' "$workflow_text"
-assert_absent 'workflow does not invoke bash over SSH stdin' 'bash -s --' "$workflow_text"
-assert_absent 'workflow does not stream executable checkout code' 'cat scripts/lib/endpoint-identity.sh scripts/production-backup-preflight.sh' "$workflow_text"
-assert_contains 'workflow uses protected SSH host secret' 'PRODUCTION_SSH_HOST' "$workflow_text"
-assert_contains 'workflow is manually dispatched' 'workflow_dispatch:' "$workflow_text"
-assert_absent 'workflow has no push trigger' 'push:' "$workflow_text"
-assert_absent 'workflow has no scheduled trigger' 'schedule:' "$workflow_text"
-assert_contains 'candidate input is a required string' 'required: true' "$workflow_text"
-assert_contains 'candidate input is typed as string' 'type: string' "$workflow_text"
-assert_contains 'workflow checks out its triggering SHA' 'ref: ${{ github.sha }}' "$workflow_text"
-assert_contains 'checkout does not persist credentials' 'persist-credentials: false' "$workflow_text"
-assert_contains 'concurrency does not cancel operations' 'cancel-in-progress: false' "$workflow_text"
-assert_absent 'workflow never uses ssh-keyscan' 'ssh-keyscan' "$workflow_text"
-assert_absent 'workflow has no automatic retry controls' 'continue-on-error' "$workflow_text"
-assert_absent 'workflow has no retry strategy' 'strategy:' "$workflow_text"
-assert_contains 'workflow has read-only permissions' 'contents: read' "$workflow_text"
-
-sudoers_text="$(< "$SUDOERS_POLICY")"
-assert_contains 'sudoers grants only the fixed launcher to yoryi' 'yoryi ALL=(root) NOPASSWD: NOSETENV: /usr/local/sbin/buildingos-production-backup-preflight *' "$sudoers_text"
-assert_contains 'sudoers resets the launcher environment' 'env_reset' "$sudoers_text"
-if printf '%s\n' "$sudoers_text" | grep -Eq '(^|[[:space:]])(/[^[:space:]]*/)?(bash|sh|env|cat)([[:space:]]|$)|(^|[[:space:]])(systemctl|docker)[[:space:]]+\*'; then
-  fail_test 'sudoers excludes generic interpreters and privileged commands'
-else
-  pass 'sudoers excludes generic interpreters and privileged commands'
-fi
-
-runbook_text="$(< "$ACTIVATION_RUNBOOK")"
-assert_contains 'runbook classifies privilege installation as a one-time mutation' 'one-time approved production mutation' "$runbook_text"
-assert_contains 'runbook enables strict installation failure handling' 'set -Eeuo pipefail' "$runbook_text"
-assert_contains 'runbook cleans staged artifacts on failure' 'trap cleanup EXIT' "$runbook_text"
-assert_contains 'runbook only removes launcher when this execution published it' 'if [[ "$launcher_published" == true ]]; then' "$runbook_text"
-assert_contains 'runbook only removes control when this execution published it' 'if [[ "$control_published" == true ]]; then' "$runbook_text"
-assert_contains 'runbook only removes sudoers when this execution published it' 'if [[ "$sudoers_published" == true ]]; then' "$runbook_text"
-assert_contains 'runbook only removes launcher staging when this execution created it' 'if [[ "$launcher_stage_created" == true ]]; then' "$runbook_text"
-assert_contains 'runbook only removes sudoers staging when this execution created it' 'if [[ "$sudoers_stage_created" == true ]]; then' "$runbook_text"
-assert_contains 'runbook sets the control staging directory mode to 0755' 'sudo chmod 0755 "$control_stage"' "$runbook_text"
-assert_contains 'runbook validates staged control directory metadata as root 0755' 'test "$(sudo stat -c' "$runbook_text"
-assert_contains 'runbook requires staged control directory mode 0755' "\"\$control_stage\")\" = '0:0:755'" "$runbook_text"
-assert_contains 'runbook validates staged sudoers before activation' 'sudo visudo -cf "$sudoers_stage"' "$runbook_text"
-assert_contains 'runbook installs preflight control as root' 'sudo install -o root -g root -m 0755' "$runbook_text"
-assert_contains 'runbook documents privilege-boundary rollback' 'sudo rm -- "$sudoers_policy"' "$runbook_text"
-assert_contains 'runbook distinguishes the current application runtime SHA' 'CURRENT_RUNTIME_SHA' "$runbook_text"
-assert_contains 'runbook requires an explicit control source SHA' 'CONTROL_SOURCE_SHA' "$runbook_text"
-assert_contains 'runbook permits control source SHA to differ from runtime' 'It may differ from `CURRENT_RUNTIME_SHA` during this bootstrap.' "$runbook_text"
-assert_contains 'runbook binds the first runtime candidate to current runtime' 'readonly RUNTIME_CANDIDATE_SHA="$CURRENT_RUNTIME_SHA"' "$runbook_text"
-assert_contains 'runbook fetches control source without updating active checkout' 'git -C "$app_dir" fetch --no-tags origin main' "$runbook_text"
-assert_contains 'runbook requires control source reachability from origin main' 'git -C "$app_dir" merge-base --is-ancestor "$CONTROL_SOURCE_SHA" origin/main' "$runbook_text"
-assert_contains 'runbook materializes a detached control source worktree' 'git -C "$app_dir" worktree add --detach "$source_tree" "$CONTROL_SOURCE_SHA"' "$runbook_text"
-assert_contains 'runbook removes the temporary control worktree' 'git -C "$app_dir" worktree remove --force "$source_tree"' "$runbook_text"
-assert_contains 'runbook derives preflight integrity from the exact control source commit' 'git -C "$app_dir" show "$CONTROL_SOURCE_SHA:scripts/production-backup-preflight.sh"' "$runbook_text"
-assert_contains 'runbook verifies staged privileged control integrity before publication' 'test "$(sudo sha256sum "$control_stage/production-backup-preflight.sh" | awk' "$runbook_text"
-assert_contains 'runbook revalidates active checkout after staged installation' 'active_checkout_end="$(git -C "$app_dir" rev-parse HEAD)"' "$runbook_text"
-assert_absent 'runbook never switches the active checkout' 'git -C "$app_dir" switch' "$runbook_text"
-assert_absent 'runbook never resets the active checkout' 'git -C "$app_dir" reset' "$runbook_text"
-assert_absent 'runbook never pulls the active checkout' 'git -C "$app_dir" pull' "$runbook_text"
-assert_order 'runbook fixes stage mode before publishing control directory' 'sudo chmod 0755 "$control_stage"' 'sudo mv -- "$control_stage" "$control_dir"' "$runbook_text"
-assert_order 'runbook validates staged sudoers before publishing it' 'sudo visudo -cf "$sudoers_stage"' 'sudo mv -- "$sudoers_stage" "$sudoers_policy"' "$runbook_text"
-assert_order 'runbook revalidates active checkout before authorizing launcher' 'active_checkout_end="$(git -C "$app_dir" rev-parse HEAD)"' 'sudo mv -- "$sudoers_stage" "$sudoers_policy"' "$runbook_text"
+for forbidden in \
+  'pawtech-buildingos-backup.service' \
+  'pawtech-buildingos-backup-verify.service' \
+  'backup-buildingos-production.sh' \
+  'backup-postgres-paired.sh' \
+  'backup-minio.sh' \
+  'verify-minio-backup.sh' \
+  'CONTROL_UPDATE' \
+  'BACKUP_READY=YES'; do
+  assert_absent "preflight no longer requires $forbidden" "$forbidden" "$preflight_text"
+done
 
 if (( FAIL_COUNT > 0 )); then
-  printf 'FAILED: %s test(s) failed; %s passed\n' "$FAIL_COUNT" "$PASS_COUNT" >&2
+  printf 'FAILED: %s failed, %s passed\n' "$FAIL_COUNT" "$PASS_COUNT" >&2
   exit 1
 fi
 printf 'PASSED: %s assertions\n' "$PASS_COUNT"

--- a/scripts/tests/production-backup-preflight.test.sh
+++ b/scripts/tests/production-backup-preflight.test.sh
@@ -334,7 +334,7 @@ unset MOCK_DIRTY
 MOCK_IGNORED_PATHS='infra/docker/.env' run_preflight
 assert_success 'approved ignored runtime environment remains clean'
 unset MOCK_IGNORED_PATHS
-for ignored_artifact in backup.dump debug.log snapshot.sql archive.backup secret.key certificate.pem; do
+for ignored_artifact in diagnostic.tmp cache/ foo.txt backup.dump debug.log snapshot.sql archive.backup secret.key certificate.pem; do
   MOCK_IGNORED_PATHS="$ignored_artifact" run_preflight
   assert_failure "ignored $ignored_artifact fails runtime identity gate"
 done

--- a/scripts/tests/production-backup-preflight.test.sh
+++ b/scripts/tests/production-backup-preflight.test.sh
@@ -4,9 +4,14 @@ set -Eeuo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 readonly ROOT_DIR
 readonly PREFLIGHT="$ROOT_DIR/scripts/production-backup-preflight.sh"
+readonly WORKFLOW="$ROOT_DIR/.github/workflows/production-backup-preflight.yml"
+readonly PRIVILEGED_LAUNCHER="$ROOT_DIR/infra/production/launchers/buildingos-production-backup-preflight"
+readonly SUDOERS_POLICY="$ROOT_DIR/infra/production/sudoers/buildingos-production-backup-preflight"
 readonly TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/buildingos-backup-preflight.XXXXXX")"
 readonly BIN_DIR="$TEST_ROOT/bin"
 readonly ENV_FILE="$TEST_ROOT/object-backup.env"
+readonly APP_DIR="$TEST_ROOT/app"
+readonly RCLONE_CONFIG_FILE="$TEST_ROOT/object-backup-rclone.conf"
 trap 'rm -rf "$TEST_ROOT"' EXIT
 
 PASS_COUNT=0
@@ -27,10 +32,34 @@ assert_absent() {
 assert_success() { local name="$1"; [[ "$RUN_RC" -eq 0 ]] && pass "$name" || fail_test "$name"; }
 assert_failure() { local name="$1"; [[ "$RUN_RC" -ne 0 ]] && pass "$name" || fail_test "$name"; }
 
-mkdir -p "$BIN_DIR"
-for command_name in awk bash date; do
+mkdir -p "$BIN_DIR" "$APP_DIR/.git"
+for command_name in awk bash date stat; do
   ln -s "$(command -v "$command_name")" "$BIN_DIR/$command_name"
 done
+
+cat > "$BIN_DIR/git" <<'MOCK'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+case "$*" in
+  *'rev-parse HEAD'*) printf '%s\n' "${MOCK_CHECKOUT_SHA:-2ac603be8018ffc3df67fb4e84149aea4f780cea}" ;;
+  *'status --porcelain'*) [[ "${MOCK_DIRTY:-NO}" == NO ]] || printf ' M application.env\n' ;;
+  *) exit 1 ;;
+esac
+MOCK
+chmod +x "$BIN_DIR/git"
+
+cat > "$BIN_DIR/docker" <<'MOCK'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+if [[ "$1 ${2:-}" == 'inspect --type' ]]; then
+  [[ "${@: -1}" == buildingos-api ]] && printf 'sha256:%064d\n' 1 || printf 'sha256:%064d\n' 2
+elif [[ "$1 ${2:-}" == 'image inspect' ]]; then
+  [[ "$3" == sha256:$(printf '%064d' 1) ]] && printf '%s\n' "${MOCK_API_REVISION:-2ac603be8018ffc3df67fb4e84149aea4f780cea}" || printf '%s\n' "${MOCK_WEB_REVISION:-2ac603be8018ffc3df67fb4e84149aea4f780cea}"
+else
+  exit 1
+fi
+MOCK
+chmod +x "$BIN_DIR/docker"
 
 cat > "$BIN_DIR/systemctl" <<'MOCK'
 #!/usr/bin/env bash
@@ -68,12 +97,28 @@ case "$property:$unit" in
   NextElapseUSecRealtime:*) printf '%s\n' "${MOCK_NEXT_TRIGGER:-2099-01-01 00:00:00 UTC}" ;;
   User:pawtech-buildingos-object-backup.service|Group:pawtech-buildingos-object-backup.service) printf 'yoryi\n' ;;
   EnvironmentFiles:pawtech-buildingos-object-backup.service) printf '%s\n' "${PREFLIGHT_ENV_FILE:-/etc/buildingos/object-backup.env}" ;;
-  WorkingDirectory:pawtech-buildingos-object-backup.service) printf '%s\n' '/opt/pawtech/apps/buildingos/buildingos-app' ;;
-  Type:pawtech-buildingos-object-backup.service) printf 'oneshot\n' ;;
+  WorkingDirectory:pawtech-buildingos-object-backup.service) printf '%s\n' "${PREFLIGHT_APP_DIR:-/opt/pawtech/apps/buildingos/buildingos-app}" ;;
+  Type:pawtech-postgres-backup.service|Type:pawtech-buildingos-object-backup.service) printf 'oneshot\n' ;;
+  ExecStart:pawtech-postgres-backup.service) printf '%s\n' '{ path=/opt/pawtech/backups/scripts/backup-postgres.sh ; argv[]=/opt/pawtech/backups/scripts/backup-postgres.sh ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=0 ; status=0 }' ;;
   ExecStart:pawtech-buildingos-object-backup.service)
-    if [[ "${MOCK_BAD_OBJECT_EXECSTART:-NO}" == YES ]]; then printf '%s\n' '/opt/wrong/backup.sh'; else printf '%s\n' '{ path=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh ; argv[]=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh ; ignore_errors=no }'; fi
+    case "${MOCK_OBJECT_EXECSTART_MODE:-NORMAL}" in
+      WRONG) printf '%s\n' '{ path=/opt/wrong/backup.sh ; argv[]=/opt/wrong/backup.sh ; ignore_errors=no }' ;;
+      SECOND) printf '%s\n' '{ path=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh ; argv[]=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh ; ignore_errors=no } { path=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh ; argv[]=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh ; ignore_errors=no }' ;;
+      IGNORE) printf '%s\n' '{ path=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh ; argv[]=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh ; ignore_errors=yes }' ;;
+      MALFORMED) printf '%s\n' '{ path=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh ; argv[]=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh' ;;
+      *) printf '%s\n' '{ path=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh ; argv[]=/opt/pawtech/apps/buildingos/buildingos-app/scripts/backup-object-storage.sh ; ignore_errors=no ; start_time=[n/a] ; stop_time=[n/a] ; pid=0 ; code=0 ; status=0 }' ;;
+    esac
     ;;
-  TimeoutStartUSec:pawtech-buildingos-object-backup.service) printf '21600000000\n' ;;
+  TimeoutStartUSec:pawtech-buildingos-object-backup.service)
+    case "${MOCK_TIMEOUT_MODE:-EXACT}" in
+      SIX_HOURS) printf '6h\n' ;;
+      SIX_HOURS_VERBOSE) printf '6h 0min 0s\n' ;;
+      SHORTER) printf '1000000\n' ;;
+      MALFORMED) printf 'not-a-timeout\n' ;;
+      MISSING) exit 1 ;;
+      *) printf '21600000000\n' ;;
+    esac
+    ;;
   *) exit 1 ;;
 esac
 MOCK
@@ -87,13 +132,17 @@ write_env() {
     printf 'OBJECT_BACKUP_SOURCE=%s\n' "$source"
     printf 'OBJECT_BACKUP_DESTINATION=%s\n' "$destination"
     printf 'OBJECT_BACKUP_RECEIPT=/var/lib/buildingos-object-backup/object-backup-receipt.json\n'
-    printf 'RCLONE_CONFIG=/etc/buildingos/object-backup-rclone.conf\n'
+    printf 'RCLONE_CONFIG=%s\n' "$RCLONE_CONFIG_FILE"
   } > "$ENV_FILE"
 }
 
+printf '[prod]\ntype = s3\n' > "$RCLONE_CONFIG_FILE"
+chmod 0600 "$RCLONE_CONFIG_FILE"
+
 run_preflight() {
+  local candidate="${1-2ac603be8018ffc3df67fb4e84149aea4f780cea}"
   set +e
-  RUN_OUTPUT="$(PATH="$BIN_DIR" BUILDINGOS_PREFLIGHT_TEST_MODE=LOCAL_ISOLATED_ONLY PREFLIGHT_ENV_FILE="$ENV_FILE" /bin/bash "$PREFLIGHT" 2>&1 '2ac603be8018ffc3df67fb4e84149aea4f780cea')"
+  RUN_OUTPUT="$(PATH="$BIN_DIR" BUILDINGOS_PREFLIGHT_TEST_MODE=LOCAL_ISOLATED_ONLY PREFLIGHT_APP_DIR="$APP_DIR" PREFLIGHT_ENV_FILE="$ENV_FILE" PREFLIGHT_RCLONE_CONFIG_FILE="$RCLONE_CONFIG_FILE" /bin/bash "$PREFLIGHT" 2>&1 "$candidate")"
   RUN_RC=$?
   set -e
 }
@@ -105,12 +154,32 @@ assert_contains 'PostgreSQL timer enabled is accepted' 'POSTGRES_BACKUP_TIMER_EN
 assert_contains 'PostgreSQL timer active is accepted' 'POSTGRES_BACKUP_TIMER_ACTIVE=YES' "$RUN_OUTPUT"
 assert_contains 'PostgreSQL timer future trigger is accepted' 'POSTGRES_BACKUP_TIMER_FUTURE_TRIGGER=YES' "$RUN_OUTPUT"
 assert_contains 'PostgreSQL service inactive is accepted' 'POSTGRES_BACKUP_SERVICE_STATE=inactive' "$RUN_OUTPUT"
+assert_contains 'runtime checkout is clean' 'PRODUCTION_CHECKOUT_STATUS=CLEAN' "$RUN_OUTPUT"
+assert_contains 'runtime identity is consistent' 'RUNTIME_IDENTITY=CONSISTENT' "$RUN_OUTPUT"
+assert_contains 'PostgreSQL service type is validated' 'POSTGRES_BACKUP_SERVICE_TYPE=oneshot' "$RUN_OUTPUT"
+assert_contains 'PostgreSQL ExecStart is validated' 'POSTGRES_BACKUP_SERVICE_EXECSTART_MATCH=YES' "$RUN_OUTPUT"
 assert_contains 'Object timer enabled is accepted' 'OBJECT_BACKUP_TIMER_ENABLED=YES' "$RUN_OUTPUT"
 assert_contains 'Object timer active is accepted' 'OBJECT_BACKUP_TIMER_ACTIVE=YES' "$RUN_OUTPUT"
 assert_contains 'Object timer future trigger is accepted' 'OBJECT_BACKUP_TIMER_FUTURE_TRIGGER=YES' "$RUN_OUTPUT"
 assert_contains 'Object service contract is accepted' 'OBJECT_BACKUP_SERVICE_CONTRACT=YES' "$RUN_OUTPUT"
 assert_contains 'Object environment contract is accepted' 'OBJECT_BACKUP_ENV=YES' "$RUN_OUTPUT"
 assert_contains 'backup concurrency is safe' 'BACKUP_CONCURRENCY_SAFE=YES' "$RUN_OUTPUT"
+
+run_preflight deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+assert_failure 'candidate SHA mismatch fails runtime identity gate'
+assert_contains 'candidate mismatch reports inconsistent runtime' 'RUNTIME_IDENTITY=INCONSISTENT' "$RUN_OUTPUT"
+MOCK_API_REVISION=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa run_preflight
+assert_failure 'API revision mismatch fails runtime identity gate'
+unset MOCK_API_REVISION
+MOCK_WEB_REVISION=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb run_preflight
+assert_failure 'Web revision mismatch fails runtime identity gate'
+unset MOCK_WEB_REVISION
+MOCK_CHECKOUT_SHA=cccccccccccccccccccccccccccccccccccccccc run_preflight
+assert_failure 'checkout SHA mismatch fails runtime identity gate'
+unset MOCK_CHECKOUT_SHA
+MOCK_DIRTY=YES run_preflight
+assert_failure 'dirty checkout fails runtime identity gate'
+unset MOCK_DIRTY
 
 MOCK_POSTGRES_SERVICE_STATE=active run_preflight
 assert_failure 'active PostgreSQL backup fails closed'
@@ -140,9 +209,34 @@ assert_failure 'missing Object Storage timer fails closed'
 assert_contains 'missing Object Storage timer is reported' 'OBJECT_BACKUP_TIMER_EXISTS=NO' "$RUN_OUTPUT"
 unset MOCK_MISSING_OBJECT_TIMER
 
-MOCK_BAD_OBJECT_EXECSTART=YES run_preflight
+MOCK_OBJECT_EXECSTART_MODE=WRONG run_preflight
 assert_failure 'wrong Object Storage ExecStart fails closed'
-unset MOCK_BAD_OBJECT_EXECSTART
+unset MOCK_OBJECT_EXECSTART_MODE
+MOCK_OBJECT_EXECSTART_MODE=SECOND run_preflight
+assert_failure 'second Object Storage ExecStart fails closed'
+unset MOCK_OBJECT_EXECSTART_MODE
+MOCK_OBJECT_EXECSTART_MODE=IGNORE run_preflight
+assert_failure 'ignored Object Storage ExecStart fails closed'
+unset MOCK_OBJECT_EXECSTART_MODE
+MOCK_OBJECT_EXECSTART_MODE=MALFORMED run_preflight
+assert_failure 'malformed Object Storage ExecStart fails closed'
+unset MOCK_OBJECT_EXECSTART_MODE
+
+MOCK_TIMEOUT_MODE=SIX_HOURS run_preflight
+assert_success 'six hour timeout representation passes'
+unset MOCK_TIMEOUT_MODE
+MOCK_TIMEOUT_MODE=SIX_HOURS_VERBOSE run_preflight
+assert_success 'verbose six hour timeout representation passes'
+unset MOCK_TIMEOUT_MODE
+MOCK_TIMEOUT_MODE=SHORTER run_preflight
+assert_failure 'shorter timeout fails closed'
+unset MOCK_TIMEOUT_MODE
+MOCK_TIMEOUT_MODE=MALFORMED run_preflight
+assert_failure 'malformed timeout fails closed'
+unset MOCK_TIMEOUT_MODE
+MOCK_TIMEOUT_MODE=MISSING run_preflight
+assert_failure 'missing timeout fails closed'
+unset MOCK_TIMEOUT_MODE
 
 sed -i.bak 's|OBJECT_BACKUP_RECEIPT=/var/lib/buildingos-object-backup/object-backup-receipt.json|OBJECT_BACKUP_RECEIPT=/tmp/wrong-receipt.json|' "$ENV_FILE"
 run_preflight
@@ -152,6 +246,9 @@ mv "$ENV_FILE.bak" "$ENV_FILE"
 write_env 'prod:buildingos-production/path' 'backup:buildingos-production-backup'
 run_preflight
 assert_failure 'bucket prefix fails closed'
+write_env 'prod:unrelated' 'backup:another-bucket'
+run_preflight
+assert_failure 'unrelated source bucket fails closed'
 write_env 'prod:buildingos-production' 'backup:buildingos-production'
 run_preflight
 assert_failure 'same bucket names fail closed'
@@ -176,7 +273,51 @@ MOCK_OBJECT_SERVICE_STATE=failed run_preflight
 assert_failure 'failed Object Storage service fails closed'
 unset MOCK_OBJECT_SERVICE_STATE
 
+rm "$RCLONE_CONFIG_FILE"
+run_preflight
+assert_failure 'missing rclone config fails closed'
+printf '[prod]\ntype = s3\n' > "$RCLONE_CONFIG_FILE"
+chmod 0600 "$RCLONE_CONFIG_FILE"
+ln -s "$TEST_ROOT/missing-rclone.conf" "$TEST_ROOT/rclone-symlink.conf"
+sed -i.bak "s|$RCLONE_CONFIG_FILE|$TEST_ROOT/rclone-symlink.conf|" "$ENV_FILE"
+run_preflight
+assert_failure 'symlink rclone config fails closed'
+mv "$ENV_FILE.bak" "$ENV_FILE"
+chmod 0660 "$RCLONE_CONFIG_FILE"
+run_preflight
+assert_failure 'writable rclone config fails closed'
+chmod 0600 "$RCLONE_CONFIG_FILE"
+
 preflight_text="$(< "$PREFLIGHT")"
+
+launcher_text="$(< "$PRIVILEGED_LAUNCHER")"
+assert_contains 'launcher closes caller stdin' '</dev/null' "$launcher_text"
+assert_contains 'launcher pins installed control directory' "readonly CONTROL_DIR='/usr/local/libexec/buildingos-backup-preflight'" "$launcher_text"
+assert_contains 'launcher clears BASH_ENV' 'unset BASH_ENV ENV' "$launcher_text"
+assert_contains 'launcher uses fixed PATH' 'PATH="$SAFE_PATH"' "$launcher_text"
+assert_absent 'launcher does not execute mutable checkout scripts' '/opt/pawtech/apps/buildingos/buildingos-app' "$launcher_text"
+assert_absent 'launcher does not evaluate caller input' 'eval ' "$launcher_text"
+
+workflow_text="$(< "$WORKFLOW")"
+assert_contains 'workflow is manually dispatched' 'workflow_dispatch:' "$workflow_text"
+assert_absent 'workflow has no push trigger' 'push:' "$workflow_text"
+assert_absent 'workflow has no scheduled trigger' 'schedule:' "$workflow_text"
+assert_contains 'workflow uses read-only production environment' 'environment: production' "$workflow_text"
+assert_contains 'workflow uses strict host key checking' 'StrictHostKeyChecking=yes' "$workflow_text"
+assert_contains 'workflow uses batch mode' 'BatchMode=yes' "$workflow_text"
+
+sudoers_text="$(< "$SUDOERS_POLICY")"
+assert_contains 'sudoers grants only fixed launcher' 'yoryi ALL=(root) NOPASSWD: NOSETENV: /usr/local/sbin/buildingos-production-backup-preflight *' "$sudoers_text"
+assert_absent 'sudoers excludes generic shell' '/bin/bash' "$sudoers_text"
+assert_absent 'sudoers excludes systemctl' 'systemctl' "$sudoers_text"
+assert_absent 'sudoers excludes docker' 'docker' "$sudoers_text"
+
+if printf '%s\n' "$preflight_text" | grep -Eq 'systemctl (start|restart|stop|enable|disable|daemon-reload)|pg_dump|rclone (copy|copyto|delete|move)|(^|[[:space:]])(chmod|chown)[[:space:]]'; then
+  fail_test 'preflight implementation contains no write-capable operation'
+else
+  pass 'preflight implementation contains no write-capable operation'
+fi
+
 for forbidden in \
   'pawtech-buildingos-backup.service' \
   'pawtech-buildingos-backup-verify.service' \

--- a/scripts/tests/production-backup-preflight.test.sh
+++ b/scripts/tests/production-backup-preflight.test.sh
@@ -123,8 +123,24 @@ case "$property:$unit" in
   NextElapseUSecRealtime:*)
     if [[ -n "${MOCK_NEXT_TRIGGER:-}" ]]; then printf '%s\n' "$MOCK_NEXT_TRIGGER"; else date -u -v+12H '+%Y-%m-%d %H:%M:%S UTC' 2>/dev/null || date -u -d '+12 hours' '+%Y-%m-%d %H:%M:%S UTC'; fi
     ;;
-  OnCalendar:pawtech-postgres-backup.timer) printf '%s\n' "${MOCK_POSTGRES_CALENDAR:-daily}" ;;
-  OnCalendar:pawtech-buildingos-object-backup.timer) printf '%s\n' "${MOCK_OBJECT_CALENDAR:-*-*-* 02:15:00}" ;;
+  TimersCalendar:pawtech-postgres-backup.timer)
+    case "${MOCK_POSTGRES_TIMER_CALENDAR_MODE:-NORMAL}" in
+      MISSING) printf '\n' ;;
+      MALFORMED) printf '%s\n' '{ OnCalendar=*-*-* 01:00:00 ; next_elapse=2026-09-06 01:00:00 UTC' ;;
+      AMBIGUOUS) printf '%s\n' '{ OnCalendar=*-*-* 01:00:00 ; OnCalendar=*-*-* 02:00:00 ; next_elapse=2026-09-06 01:00:00 UTC }' ;;
+      LOWERCASE) printf '%s\n' '{ calendar=*-*-* 01:00:00 ; next_elapse=2026-09-06 01:00:00 UTC }' ;;
+      *) printf '%s\n' "{ OnCalendar=${MOCK_POSTGRES_CALENDAR:-*-*-* 01:00:00} ; next_elapse=2026-09-06 01:00:00 UTC }" ;;
+    esac
+    ;;
+  TimersCalendar:pawtech-buildingos-object-backup.timer)
+    case "${MOCK_OBJECT_TIMER_CALENDAR_MODE:-NORMAL}" in
+      MISSING) printf '\n' ;;
+      MALFORMED) printf '%s\n' '{ OnCalendar=*-*-* 02:15:00 ; next_elapse=2026-09-06 02:15:00 UTC' ;;
+      AMBIGUOUS) printf '%s\n' '{ OnCalendar=*-*-* 02:15:00 ; OnCalendar=*-*-* 03:15:00 ; next_elapse=2026-09-06 02:15:00 UTC }' ;;
+      LOWERCASE) printf '%s\n' '{ calendar=*-*-* 02:15:00 ; next_elapse=2026-09-06 02:15:00 UTC }' ;;
+      *) printf '%s\n' "{ OnCalendar=${MOCK_OBJECT_CALENDAR:-*-*-* 02:15:00} ; next_elapse=2026-09-06 02:15:00 UTC }" ;;
+    esac
+    ;;
   Persistent:pawtech-buildingos-object-backup.timer) printf '%s\n' "${MOCK_OBJECT_PERSISTENT:-true}" ;;
   RandomizedDelayUSec:pawtech-buildingos-object-backup.timer) printf '%s\n' "${MOCK_OBJECT_RANDOMIZED_DELAY:-900000000}" ;;
   ExecCondition:pawtech-postgres-backup.service)
@@ -252,13 +268,25 @@ assert_contains 'backup concurrency is safe' 'BACKUP_CONCURRENCY_SAFE=YES' "$RUN
 MOCK_OBJECT_CALENDAR='*-*-* 03:15:00' run_preflight
 assert_failure 'wrong Object Storage timer calendar fails closed'
 unset MOCK_OBJECT_CALENDAR
+MOCK_OBJECT_TIMER_CALENDAR_MODE=MISSING run_preflight
+assert_failure 'missing Object Storage TimersCalendar fails closed'
+unset MOCK_OBJECT_TIMER_CALENDAR_MODE
+MOCK_OBJECT_TIMER_CALENDAR_MODE=MALFORMED run_preflight
+assert_failure 'malformed Object Storage TimersCalendar fails closed'
+unset MOCK_OBJECT_TIMER_CALENDAR_MODE
+MOCK_OBJECT_TIMER_CALENDAR_MODE=AMBIGUOUS run_preflight
+assert_failure 'ambiguous Object Storage TimersCalendar fails closed'
+unset MOCK_OBJECT_TIMER_CALENDAR_MODE
+MOCK_OBJECT_TIMER_CALENDAR_MODE=LOWERCASE run_preflight
+assert_failure 'lowercase calendar field fails closed'
+unset MOCK_OBJECT_TIMER_CALENDAR_MODE
 MOCK_OBJECT_PERSISTENT=false run_preflight
 assert_failure 'non-persistent Object Storage timer fails closed'
 unset MOCK_OBJECT_PERSISTENT
 MOCK_OBJECT_RANDOMIZED_DELAY=600000000 run_preflight
 assert_failure 'wrong Object Storage timer delay fails closed'
 unset MOCK_OBJECT_RANDOMIZED_DELAY
-MOCK_OBJECT_CALENDAR='calendar=*-*-* 02:15:00 ; next_elapse=2026-09-06T02:15:00Z' MOCK_OBJECT_RANDOMIZED_DELAY=15min run_preflight
+MOCK_OBJECT_CALENDAR='*-*-* 02:15:00' MOCK_OBJECT_RANDOMIZED_DELAY=15min run_preflight
 assert_success 'serialized calendar and 15min delay representations pass'
 unset MOCK_OBJECT_CALENDAR MOCK_OBJECT_RANDOMIZED_DELAY
 MOCK_OBJECT_RANDOMIZED_DELAY='15min 0s' run_preflight
@@ -267,6 +295,12 @@ unset MOCK_OBJECT_RANDOMIZED_DELAY
 MOCK_POSTGRES_CALENDAR=weekly run_preflight
 assert_failure 'non-daily PostgreSQL timer calendar fails closed'
 unset MOCK_POSTGRES_CALENDAR
+MOCK_POSTGRES_TIMER_CALENDAR_MODE=MISSING run_preflight
+assert_failure 'missing PostgreSQL TimersCalendar fails closed'
+unset MOCK_POSTGRES_TIMER_CALENDAR_MODE
+MOCK_POSTGRES_TIMER_CALENDAR_MODE=MALFORMED run_preflight
+assert_failure 'malformed PostgreSQL TimersCalendar fails closed'
+unset MOCK_POSTGRES_TIMER_CALENDAR_MODE
 MOCK_NEXT_TRIGGER='2099-01-01 00:00:00 UTC' run_preflight
 assert_failure 'absurd future Object Storage trigger fails closed'
 unset MOCK_NEXT_TRIGGER
@@ -484,6 +518,8 @@ for forbidden in \
   'BACKUP_READY=YES'; do
   assert_absent "preflight no longer requires $forbidden" "$forbidden" "$preflight_text"
 done
+assert_contains 'preflight queries exported TimersCalendar property' '--property=TimersCalendar' "$preflight_text"
+assert_absent 'preflight does not query deprecated OnCalendar property' '--property=OnCalendar' "$preflight_text"
 
 if (( FAIL_COUNT > 0 )); then
   printf 'FAILED: %s failed, %s passed\n' "$FAIL_COUNT" "$PASS_COUNT" >&2

--- a/scripts/tests/production-backup-preflight.test.sh
+++ b/scripts/tests/production-backup-preflight.test.sh
@@ -33,6 +33,7 @@ assert_success() { local name="$1"; [[ "$RUN_RC" -eq 0 ]] && pass "$name" || fai
 assert_failure() { local name="$1"; [[ "$RUN_RC" -ne 0 ]] && pass "$name" || fail_test "$name"; }
 
 mkdir -p "$BIN_DIR" "$APP_DIR/.git"
+printf '%s\n' '**/.env' > "$APP_DIR/.dockerignore"
 for command_name in awk bash date; do
   ln -s "$(command -v "$command_name")" "$BIN_DIR/$command_name"
 done
@@ -68,7 +69,14 @@ cat > "$BIN_DIR/git" <<'MOCK'
 set -Eeuo pipefail
 case "$*" in
   *'rev-parse HEAD'*) printf '%s\n' "${MOCK_CHECKOUT_SHA:-2ac603be8018ffc3df67fb4e84149aea4f780cea}" ;;
-  *'status --porcelain'*) [[ "${MOCK_DIRTY:-NO}" == NO ]] || printf ' M application.env\n' ;;
+  *'status --porcelain'*)
+    case "${MOCK_DIRTY:-NO}" in
+      NO) ;;
+      UNTRACKED) printf '?? ordinary.tmp\n' ;;
+      *) printf ' M application.env\n' ;;
+    esac
+    ;;
+  *'ls-files --others --ignored --exclude-standard'*) printf '%s\n' "${MOCK_IGNORED_PATHS:-}" ;;
   *) exit 1 ;;
 esac
 MOCK
@@ -320,6 +328,17 @@ unset MOCK_CHECKOUT_SHA
 MOCK_DIRTY=YES run_preflight
 assert_failure 'dirty checkout fails runtime identity gate'
 unset MOCK_DIRTY
+MOCK_DIRTY=UNTRACKED run_preflight
+assert_failure 'ordinary untracked file fails runtime identity gate'
+unset MOCK_DIRTY
+MOCK_IGNORED_PATHS='infra/docker/.env' run_preflight
+assert_success 'approved ignored runtime environment remains clean'
+unset MOCK_IGNORED_PATHS
+for ignored_artifact in backup.dump debug.log snapshot.sql archive.backup secret.key certificate.pem; do
+  MOCK_IGNORED_PATHS="$ignored_artifact" run_preflight
+  assert_failure "ignored $ignored_artifact fails runtime identity gate"
+done
+unset MOCK_IGNORED_PATHS
 
 MOCK_POSTGRES_SERVICE_STATE=active run_preflight
 assert_failure 'active PostgreSQL backup fails closed'
@@ -520,6 +539,8 @@ for forbidden in \
 done
 assert_contains 'preflight queries exported TimersCalendar property' '--property=TimersCalendar' "$preflight_text"
 assert_absent 'preflight does not query deprecated OnCalendar property' '--property=OnCalendar' "$preflight_text"
+assert_contains 'preflight inspects ignored checkout paths' 'ls-files --others --ignored --exclude-standard' "$preflight_text"
+assert_contains 'preflight preserves approved ignored runtime environment' "ALLOWED_IGNORED_RUNTIME_ENV='infra/docker/.env'" "$preflight_text"
 
 if (( FAIL_COUNT > 0 )); then
   printf 'FAILED: %s failed, %s passed\n' "$FAIL_COUNT" "$PASS_COUNT" >&2

--- a/scripts/tests/production-backup-preflight.test.sh
+++ b/scripts/tests/production-backup-preflight.test.sh
@@ -40,10 +40,24 @@ done
 cat > "$BIN_DIR/stat" <<'MOCK'
 #!/usr/bin/env bash
 set -Eeuo pipefail
+path="${!#}"
+case "$path" in
+  *object-backup.env)
+    owner="${MOCK_ENV_OWNER:-root}"
+    group="${MOCK_ENV_GROUP:-root}"
+    mode="${MOCK_ENV_MODE:-600}"
+    ;;
+  *object-backup-rclone.conf)
+    owner="${MOCK_CONFIG_OWNER:-yoryi}"
+    group="${MOCK_CONFIG_GROUP:-yoryi}"
+    mode="${MOCK_CONFIG_MODE:-600}"
+    ;;
+  *) exit 1 ;;
+esac
 case "$*" in
-  *'%U'*) printf '%s\n' "${MOCK_CONFIG_OWNER:-yoryi}" ;;
-  *'%G'*) printf '%s\n' "${MOCK_CONFIG_GROUP:-yoryi}" ;;
-  *'%a'*) printf '%s\n' "${MOCK_CONFIG_MODE:-600}" ;;
+  *'%U'*) printf '%s\n' "$owner" ;;
+  *'%G'*) printf '%s\n' "$group" ;;
+  *'%a'*) printf '%s\n' "$mode" ;;
   *) exit 1 ;;
 esac
 MOCK
@@ -113,6 +127,48 @@ case "$property:$unit" in
   OnCalendar:pawtech-buildingos-object-backup.timer) printf '%s\n' "${MOCK_OBJECT_CALENDAR:-*-*-* 02:15:00}" ;;
   Persistent:pawtech-buildingos-object-backup.timer) printf '%s\n' "${MOCK_OBJECT_PERSISTENT:-true}" ;;
   RandomizedDelayUSec:pawtech-buildingos-object-backup.timer) printf '%s\n' "${MOCK_OBJECT_RANDOMIZED_DELAY:-900000000}" ;;
+  ExecCondition:pawtech-postgres-backup.service)
+    case "${MOCK_POSTGRES_EXEC_CONDITION_MODE:-EMPTY}" in
+      COMMAND) printf '%s\n' '{ path=/usr/bin/test ; argv[]=/usr/bin/test ; ignore_errors=no }' ;;
+      MALFORMED) printf '%s\n' '{ path=/usr/bin/test ; argv[]=/usr/bin/test' ;;
+      *) printf '\n' ;;
+    esac
+    ;;
+  ExecStartPre:pawtech-postgres-backup.service)
+    case "${MOCK_POSTGRES_EXEC_START_PRE_MODE:-EMPTY}" in
+      COMMAND) printf '%s\n' '{ path=/bin/false ; argv[]=/bin/false ; ignore_errors=no }' ;;
+      MALFORMED) printf '%s\n' '{ path=/bin/false ; argv[]=/bin/false' ;;
+      *) printf '\n' ;;
+    esac
+    ;;
+  ExecStartPost:pawtech-postgres-backup.service)
+    case "${MOCK_POSTGRES_EXEC_START_POST_MODE:-EMPTY}" in
+      COMMAND) printf '%s\n' '{ path=/bin/true ; argv[]=/bin/true ; ignore_errors=no }' ;;
+      MALFORMED) printf '%s\n' '{ path=/bin/true ; argv[]=/bin/true' ;;
+      *) printf '\n' ;;
+    esac
+    ;;
+  ExecCondition:pawtech-buildingos-object-backup.service)
+    case "${MOCK_OBJECT_EXEC_CONDITION_MODE:-EMPTY}" in
+      COMMAND) printf '%s\n' '{ path=/usr/bin/test ; argv[]=/usr/bin/test ; ignore_errors=no }' ;;
+      MALFORMED) printf '%s\n' '{ path=/usr/bin/test ; argv[]=/usr/bin/test' ;;
+      *) printf '\n' ;;
+    esac
+    ;;
+  ExecStartPre:pawtech-buildingos-object-backup.service)
+    case "${MOCK_OBJECT_EXEC_START_PRE_MODE:-EMPTY}" in
+      COMMAND) printf '%s\n' '{ path=/bin/false ; argv[]=/bin/false ; ignore_errors=no }' ;;
+      MALFORMED) printf '%s\n' '{ path=/bin/false ; argv[]=/bin/false' ;;
+      *) printf '\n' ;;
+    esac
+    ;;
+  ExecStartPost:pawtech-buildingos-object-backup.service)
+    case "${MOCK_OBJECT_EXEC_START_POST_MODE:-EMPTY}" in
+      COMMAND) printf '%s\n' '{ path=/bin/true ; argv[]=/bin/true ; ignore_errors=no }' ;;
+      MALFORMED) printf '%s\n' '{ path=/bin/true ; argv[]=/bin/true' ;;
+      *) printf '\n' ;;
+    esac
+    ;;
   User:pawtech-buildingos-object-backup.service|Group:pawtech-buildingos-object-backup.service) printf 'yoryi\n' ;;
   EnvironmentFiles:pawtech-buildingos-object-backup.service) printf '%s\n' "${PREFLIGHT_ENV_FILE:-/etc/buildingos/object-backup.env}" ;;
   WorkingDirectory:pawtech-buildingos-object-backup.service) printf '%s\n' "${PREFLIGHT_APP_DIR:-/opt/pawtech/apps/buildingos/buildingos-app}" ;;
@@ -176,6 +232,9 @@ assert_contains 'runtime checkout is clean' 'PRODUCTION_CHECKOUT_STATUS=CLEAN' "
 assert_contains 'runtime identity is consistent' 'RUNTIME_IDENTITY=CONSISTENT' "$RUN_OUTPUT"
 assert_contains 'PostgreSQL service type is validated' 'POSTGRES_BACKUP_SERVICE_TYPE=oneshot' "$RUN_OUTPUT"
 assert_contains 'PostgreSQL ExecStart is validated' 'POSTGRES_BACKUP_SERVICE_EXECSTART_MATCH=YES' "$RUN_OUTPUT"
+assert_contains 'PostgreSQL ExecCondition is empty' 'POSTGRES_BACKUP_SERVICE_EXEC_CONDITION_EMPTY=YES' "$RUN_OUTPUT"
+assert_contains 'PostgreSQL ExecStartPre is empty' 'POSTGRES_BACKUP_SERVICE_EXEC_START_PRE_EMPTY=YES' "$RUN_OUTPUT"
+assert_contains 'PostgreSQL ExecStartPost is empty' 'POSTGRES_BACKUP_SERVICE_EXEC_START_POST_EMPTY=YES' "$RUN_OUTPUT"
 assert_contains 'Object timer enabled is accepted' 'OBJECT_BACKUP_TIMER_ENABLED=YES' "$RUN_OUTPUT"
 assert_contains 'Object timer active is accepted' 'OBJECT_BACKUP_TIMER_ACTIVE=YES' "$RUN_OUTPUT"
 assert_contains 'Object timer future trigger is accepted' 'OBJECT_BACKUP_TIMER_FUTURE_TRIGGER=YES' "$RUN_OUTPUT"
@@ -183,7 +242,11 @@ assert_contains 'Object timer calendar is accepted' 'OBJECT_BACKUP_TIMER_CALENDA
 assert_contains 'Object timer persistence is accepted' 'OBJECT_BACKUP_TIMER_PERSISTENT=YES' "$RUN_OUTPUT"
 assert_contains 'Object timer randomized delay is accepted' 'OBJECT_BACKUP_TIMER_RANDOMIZED_DELAY_MATCH=YES' "$RUN_OUTPUT"
 assert_contains 'Object service contract is accepted' 'OBJECT_BACKUP_SERVICE_CONTRACT=YES' "$RUN_OUTPUT"
+assert_contains 'Object ExecCondition is empty' 'OBJECT_BACKUP_SERVICE_EXEC_CONDITION_EMPTY=YES' "$RUN_OUTPUT"
+assert_contains 'Object ExecStartPre is empty' 'OBJECT_BACKUP_SERVICE_EXEC_START_PRE_EMPTY=YES' "$RUN_OUTPUT"
+assert_contains 'Object ExecStartPost is empty' 'OBJECT_BACKUP_SERVICE_EXEC_START_POST_EMPTY=YES' "$RUN_OUTPUT"
 assert_contains 'Object environment contract is accepted' 'OBJECT_BACKUP_ENV=YES' "$RUN_OUTPUT"
+assert_contains 'Object environment root ownership and 0600 mode pass' 'OBJECT_BACKUP_ENV=YES' "$RUN_OUTPUT"
 assert_contains 'backup concurrency is safe' 'BACKUP_CONCURRENCY_SAFE=YES' "$RUN_OUTPUT"
 
 MOCK_OBJECT_CALENDAR='*-*-* 03:15:00' run_preflight
@@ -255,6 +318,28 @@ unset MOCK_MISSING_OBJECT_TIMER
 MOCK_OBJECT_EXECSTART_MODE=WRONG run_preflight
 assert_failure 'wrong Object Storage ExecStart fails closed'
 unset MOCK_OBJECT_EXECSTART_MODE
+
+MOCK_POSTGRES_EXEC_CONDITION_MODE=COMMAND run_preflight
+assert_failure 'PostgreSQL ExecCondition command fails closed'
+unset MOCK_POSTGRES_EXEC_CONDITION_MODE
+MOCK_POSTGRES_EXEC_START_PRE_MODE=COMMAND run_preflight
+assert_failure 'PostgreSQL ExecStartPre command fails closed'
+unset MOCK_POSTGRES_EXEC_START_PRE_MODE
+MOCK_POSTGRES_EXEC_START_POST_MODE=COMMAND run_preflight
+assert_failure 'PostgreSQL ExecStartPost command fails closed'
+unset MOCK_POSTGRES_EXEC_START_POST_MODE
+MOCK_OBJECT_EXEC_CONDITION_MODE=COMMAND run_preflight
+assert_failure 'Object ExecCondition command fails closed'
+unset MOCK_OBJECT_EXEC_CONDITION_MODE
+MOCK_OBJECT_EXEC_START_PRE_MODE=COMMAND run_preflight
+assert_failure 'Object ExecStartPre command fails closed'
+unset MOCK_OBJECT_EXEC_START_PRE_MODE
+MOCK_OBJECT_EXEC_START_POST_MODE=COMMAND run_preflight
+assert_failure 'Object ExecStartPost command fails closed'
+unset MOCK_OBJECT_EXEC_START_POST_MODE
+MOCK_OBJECT_EXEC_START_PRE_MODE=MALFORMED run_preflight
+assert_failure 'malformed Object ExecStartPre fails closed'
+unset MOCK_OBJECT_EXEC_START_PRE_MODE
 MOCK_OBJECT_EXECSTART_MODE=SECOND run_preflight
 assert_failure 'second Object Storage ExecStart fails closed'
 unset MOCK_OBJECT_EXECSTART_MODE
@@ -296,6 +381,20 @@ write_env 'prod:buildingos-production' 'backup:buildingos-production'
 run_preflight
 assert_failure 'same bucket names fail closed'
 write_env
+
+MOCK_ENV_OWNER=yoryi MOCK_ENV_GROUP=root MOCK_ENV_MODE=600 run_preflight
+assert_failure 'yoryi-owned Object environment fails closed'
+MOCK_ENV_OWNER=root MOCK_ENV_GROUP=yoryi MOCK_ENV_MODE=660 run_preflight
+assert_failure 'group-writable Object environment fails closed'
+MOCK_ENV_OWNER=root MOCK_ENV_GROUP=root MOCK_ENV_MODE=644 run_preflight
+assert_failure 'world-readable Object environment fails closed'
+unset MOCK_ENV_OWNER MOCK_ENV_GROUP MOCK_ENV_MODE
+mv "$ENV_FILE" "$TEST_ROOT/object-backup.env.real"
+ln -s "$TEST_ROOT/object-backup.env.real" "$ENV_FILE"
+run_preflight
+assert_failure 'symlink Object environment fails closed'
+rm "$ENV_FILE"
+mv "$TEST_ROOT/object-backup.env.real" "$ENV_FILE"
 
 MOCK_TIMER_ENABLED=disabled run_preflight
 assert_failure 'disabled timer fails closed'

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -4,6 +4,7 @@ set -Eeuo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 readonly ROOT_DIR
 readonly AUDITOR="$ROOT_DIR/scripts/production-readonly-audit.sh"
+readonly WORKFLOW="$ROOT_DIR/.github/workflows/production-readonly-audit.yml"
 readonly TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/buildingos-readonly-audit.XXXXXX")"
 readonly RECEIPT="$TEST_ROOT/object-backup-receipt.json"
 readonly OUTPUT="$TEST_ROOT/output"
@@ -92,6 +93,68 @@ assert_invalid_receipt 'symlink receipt fails closed'
 rm -f "$RECEIPT"
 
 auditor_text="$(< "$AUDITOR")"
+workflow_text="$(< "$WORKFLOW")"
+assert_contains 'workflow is manually dispatched' 'workflow_dispatch:' "$workflow_text"
+assert_contains 'workflow uses read-only permissions' 'contents: read' "$workflow_text"
+assert_contains 'workflow uses production environment' 'environment: production' "$workflow_text"
+assert_contains 'workflow uses operations concurrency' 'production-operations' "$workflow_text"
+assert_contains 'workflow uses strict host key checking' 'StrictHostKeyChecking=yes' "$workflow_text"
+assert_contains 'workflow uses batch mode' 'BatchMode=yes' "$workflow_text"
+assert_contains 'workflow streams the auditor read-only' 'bash -s -- ${remote_args[*]}' "$workflow_text"
+assert_absent 'workflow has no push trigger' 'push:' "$workflow_text"
+assert_absent 'workflow has no scheduled trigger' 'schedule:' "$workflow_text"
+assert_absent 'workflow has no deployment invocation' 'bash "$control_dir/scripts/deploy-production.sh"' "$workflow_text"
+
+for forbidden in \
+  'docker compose up' \
+  'docker compose run' \
+  'docker restart' \
+  'prisma migrate deploy' \
+  'FOR UPDATE' \
+  'aws s3 sync' \
+  'aws s3 cp' \
+  'curl POST' \
+  'curl PUT' \
+  'curl PATCH' \
+  'curl DELETE' \
+  'printenv'; do
+  assert_absent "audit excludes mutation construct $forbidden" "$forbidden" "$auditor_text"
+done
+for marker in \
+  'readonly_query_stdin' \
+  'BEGIN READ ONLY;' \
+  'COMMIT;' \
+  'pg_restore --list' \
+  'S3_DEEP_AUDIT_UNAVAILABLE' \
+  'require.resolve("minio")' \
+  'nextContinuationToken' \
+  'isTruncated' \
+  'EXPECTED_AUTHORITATIVE_BUCKET' \
+  'TARGET_MIGRATION_STATUS' \
+  'PUBLIC_READYZ_STATUS' \
+  'ALLOWED_IGNORED_RUNTIME_ENV' \
+  'AUDIT_INTERNAL_FAILURES' \
+  'FAILED_STAGE' \
+  'FAILURE_CLASS' \
+  'RUNTIME_APP_SHA' \
+  'validate_backup_mechanism' \
+  'validate_backup_manifest' \
+  'validate_backup_script_file'; do
+  assert_contains "audit preserves safety marker $marker" "$marker" "$auditor_text"
+done
+for metric in \
+  'OVER_ALLOCATIONS_DEFINITE' \
+  'OVER_ALLOCATIONS_UNVERIFIABLE' \
+  'INCONSISTENT_SAME_CURRENCY_SHARES' \
+  'OVER_ALLOCATIONS_FUNCTIONAL_DEFINITE' \
+  'OVER_ALLOCATIONS_FUNCTIONAL_UNVERIFIABLE' \
+  'CURRENCY_MISMATCHES_DEFINITE' \
+  'CURRENCY_MISMATCHES_UNVERIFIABLE' \
+  'NEGATIVE_PAYMENT_ALLOCATIONS' \
+  'NEGATIVE_PAYMENT_ORIGINAL_ALLOCATIONS' \
+  'CHARGE_OVER_ALLOCATIONS'; do
+  assert_contains "audit preserves financial metric $metric" "$metric" "$auditor_text"
+done
 assert_contains 'audit keeps current PostgreSQL mechanism path' '/opt/pawtech/backups/scripts/backup-postgres.sh' "$auditor_text"
 assert_contains 'audit keeps PostgreSQL identity manifest' 'infra/production/backup-postgres.identity.v1' "$auditor_text"
 assert_contains 'audit uses the Object Storage receipt path' '/var/lib/buildingos-object-backup/object-backup-receipt.json' "$auditor_text"

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -86,6 +86,10 @@ write_receipt prod:buildingos-production backup:buildingos-production
 assert_invalid_receipt 'same bucket names fail closed'
 write_receipt prod:buildingos-production backup:buildingos-production-backup PASS PASS YES
 assert_invalid_receipt 'receipt claiming recovery validity fails closed'
+write_receipt prod:unrelated backup:buildingos-production-backup
+assert_invalid_receipt 'unrelated source bucket fails closed'
+REPORT_OUTPUT="$(report_object_backup_receipt "$RECEIPT")"
+assert_contains 'unrelated source bucket reports incomplete receipt' 'OBJECT_BACKUP_RECEIPT=INCOMPLETE' "$REPORT_OUTPUT"
 
 rm -f "$RECEIPT"
 ln -s "$TEST_ROOT/missing-receipt.json" "$RECEIPT"

--- a/scripts/tests/production-readonly-audit.test.sh
+++ b/scripts/tests/production-readonly-audit.test.sh
@@ -1,136 +1,108 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -Eeuo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-readonly WORKFLOW="$ROOT_DIR/.github/workflows/production-readonly-audit.yml"
+readonly ROOT_DIR
 readonly AUDITOR="$ROOT_DIR/scripts/production-readonly-audit.sh"
+readonly TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/buildingos-readonly-audit.XXXXXX")"
+readonly RECEIPT="$TEST_ROOT/object-backup-receipt.json"
+readonly OUTPUT="$TEST_ROOT/output"
+trap 'rm -rf "$TEST_ROOT"' EXIT
 
-node - "$WORKFLOW" "$AUDITOR" <<'NODE'
-const fs = require('fs');
-const yaml = require('js-yaml');
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); printf 'ok %s - %s\n' "$PASS_COUNT" "$1"; }
+fail_test() { FAIL_COUNT=$((FAIL_COUNT + 1)); printf 'not ok %s - %s\n' "$FAIL_COUNT" "$1" >&2; }
 
-const [workflowPath, auditorPath] = process.argv.slice(2);
-const workflowText = fs.readFileSync(workflowPath, 'utf8');
-const auditorText = fs.readFileSync(auditorPath, 'utf8');
-const workflow = yaml.load(workflowText);
-const trigger = workflow.on ?? workflow[true];
-
-if (!trigger?.workflow_dispatch || Object.keys(trigger).length !== 1) {
-  throw new Error('audit workflow must be workflow_dispatch only');
-}
-if (trigger.workflow_dispatch.inputs?.candidate_sha?.required !== true || trigger.workflow_dispatch.inputs?.candidate_sha?.type !== 'string') {
-  throw new Error('candidate_sha must be a required string input');
-}
-if (workflow.permissions?.contents !== 'read' || Object.keys(workflow.permissions).length !== 1) {
-  throw new Error('audit workflow must grant contents read only');
-}
-if (workflow.concurrency?.group !== 'production-operations' || workflow.concurrency?.['cancel-in-progress'] !== false) {
-  throw new Error('audit workflow concurrency policy is unsafe');
+assert_contains() {
+  local name="$1" value="$2" text="$3"
+  if [[ "$text" == *"$value"* ]]; then pass "$name"; else fail_test "$name"; fi
 }
 
-const job = workflow.jobs?.audit;
-if (job?.environment !== 'production') throw new Error('audit job must use production environment');
-if (!workflowText.includes('[[ "$GITHUB_REF" == "refs/heads/main" ]]')) throw new Error('audit must require refs/heads/main');
-if (!workflowText.includes('bash -s -- ${remote_args[*]}')) throw new Error('audit must stream the auditor to bash -s');
-if (/\b(?:bash|sh)\s+[^\n]*deploy-production\.sh\b/.test(workflowText)) throw new Error('audit workflow must not invoke deployment tooling');
-if (!workflowText.includes('PRODUCTION_SSH_HOST') || !workflowText.includes('PRODUCTION_SSH_USER') || !workflowText.includes('PRODUCTION_SSH_PRIVATE_KEY') || !workflowText.includes('PRODUCTION_SSH_KNOWN_HOSTS')) {
-  throw new Error('audit workflow must use the existing production SSH secrets');
-}
-if (workflowText.includes('echo "$SSH_PRIVATE_KEY"') || workflowText.includes('printf "%s" "$SSH_PRIVATE_KEY"')) {
-  throw new Error('audit workflow must not print the SSH private key');
+assert_absent() {
+  local name="$1" value="$2" text="$3"
+  if [[ "$text" != *"$value"* ]]; then pass "$name"; else fail_test "$name"; fi
 }
 
-const forbiddenAuditorPatterns = [
-  /git\s+(fetch|pull|switch|checkout|reset)\b/,
-  /docker\s+compose\s+(up|run|build|pull)\b/,
-  /docker\s+(restart|stop|start|rm)\b/,
-  /prisma\s+(migrate\s+deploy|db\s+push|migrate\s+resolve)\b/,
-  /npm\s+(install|ci)\b/,
-  /\b(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE)\b/,
-  /\b(UPSERT|MERGE|GRANT|REVOKE)\b/,
-  /\bFOR\s+UPDATE\b/,
-  /aws\s+s3\s+(cp|sync|rm)\b/,
-  /aws\s+s3api\s+(put-|delete-)/,
-  /curl\s+(POST|PUT|PATCH|DELETE)\b/,
-  /backup-(buildingos-production|postgres-paired)\.sh/,
-  /\benv\b\s*\|\s*(sort|uniq|sed|awk|cat|tee)/,
-  /printenv\b/,
-  /docker\s+compose\s+.*--force-recreate/,
-  /docker\s+compose\s+(up|down|run|build)\b/,
-  /docker\s+(restart|stop|start|rm)\b/,
-  /git\s+(checkout|reset|pull|fetch)\b/,
-  /\b(aws\s+s3|mc\s+(cp|rm|mirror))\b/,
-  /finance-staging-acceptance(?:\.mjs|\.sh)/,
-];
-for (const pattern of forbiddenAuditorPatterns) {
-  if (pattern.test(auditorText)) throw new Error(`forbidden auditor construct: ${pattern}`);
+assert_valid_receipt() {
+  local name="$1"
+  if validate_object_backup_receipt "$RECEIPT"; then pass "$name"; else fail_test "$name"; fi
 }
 
-const safeEnvAllowlist = [
-  'APP_ENV', 'NODE_ENV', 'STORAGE_BACKEND', 'S3_ENDPOINT', 'S3_BUCKET',
-  'S3_FORCE_PATH_STYLE', 'PAYMENT_PROVIDER', 'ENABLE_PAYMENT_WEBHOOKS',
-];
-for (const key of safeEnvAllowlist) {
-  if (!auditorText.includes(key)) throw new Error(`missing safe environment key ${key}`);
+assert_invalid_receipt() {
+  local name="$1"
+  if validate_object_backup_receipt "$RECEIPT"; then fail_test "$name"; else pass "$name"; fi
 }
-for (const secretName of ['DATABASE_URL', 'JWT_SECRET', 'SMTP_PASS', 'SSH_PRIVATE_KEY']) {
-  if (auditorText.includes(secretName)) throw new Error(`auditor must not read ${secretName}`);
-}
-if (!auditorText.includes('readonly_query_stdin')) throw new Error('database queries must use stdin transport');
-if (!auditorText.includes('BEGIN READ ONLY;')) throw new Error('database query sessions must begin read only');
-if ((auditorText.match(/psql/g) ?? []).length !== 1) throw new Error('all database queries must use one guarded psql helper');
-if (!auditorText.includes('COMMIT;')) throw new Error('read-only query sessions must terminate explicitly');
-if (auditorText.includes("report_query '") || auditorText.includes('readonly_query ')) throw new Error('fragile SQL argument transport must not remain');
-if (!auditorText.includes('pg_restore --list')) throw new Error('existing backups must be inspectable without creation');
-if (!auditorText.includes('S3_DEEP_AUDIT_UNAVAILABLE')) throw new Error('unsupported S3 clients must be reported');
-if (!auditorText.includes('require.resolve("minio")')) throw new Error('S3 audit must use the runtime MinIO SDK');
-if (!auditorText.includes('docker exec -i "$API_CONTAINER" node')) throw new Error('S3 node probe must receive its stdin script');
-if (!auditorText.includes('nextContinuationToken') || !auditorText.includes('isTruncated')) throw new Error('S3 object audit must paginate fully');
-if (!auditorText.includes('S3_DEEP_AUDIT=INCOMPLETE') || !auditorText.includes('AUDIT_EVIDENCE_FAILURES')) throw new Error('incomplete S3 evidence must fail the overall audit');
-for (const marker of ['checkout_status" == \'CLEAN\'', 'RUNTIME_IDENTITY=UNKNOWN', 'PUBLIC_READYZ_HTTP=FAIL', 'AUDIT_EVIDENCE_FAILURES=$((AUDIT_EVIDENCE_FAILURES + 1))']) {
-  if (!auditorText.includes(marker)) throw new Error(`missing fail-closed evidence marker ${marker}`);
-}
-if (!auditorText.includes('EXPECTED_AUTHORITATIVE_BUCKET') || !auditorText.includes("EXPECTED_BUCKET='buildingos-production'")) throw new Error('authoritative production bucket must be reported');
-if (!auditorText.includes('TENANT_REAL_BUSINESS=UNKNOWN')) throw new Error('real-business classification must fail closed');
-if (!auditorText.includes('TARGET_MIGRATION_STATUS')) throw new Error('target migration state must be reported');
-if (auditorText.includes("'CURRENCY_MISMATCHES'")) throw new Error('cross-currency audit must not use the old unconditional mismatch metric');
-for (const metric of ['OVER_ALLOCATIONS_DEFINITE', 'OVER_ALLOCATIONS_UNVERIFIABLE', 'INCONSISTENT_SAME_CURRENCY_SHARES', 'OVER_ALLOCATIONS_FUNCTIONAL_DEFINITE', 'OVER_ALLOCATIONS_FUNCTIONAL_UNVERIFIABLE', 'CURRENCY_MISMATCHES_DEFINITE', 'CURRENCY_MISMATCHES_UNVERIFIABLE']) {
-  if (!auditorText.includes(metric)) throw new Error(`missing cross-currency metric ${metric}`);
-}
-if (!auditorText.includes('functional_consumed')) throw new Error('functional-currency consumption must be checked');
-if (!auditorText.includes('inconsistent_same_currency_share') || !auditorText.includes('paymentOriginalAmountMinor" <> a.amount')) throw new Error('same-currency original shares must match charge-side amounts');
-if (!auditorText.includes('has_legacy_cross_currency') || !auditorText.includes('has_conversion_metadata')) throw new Error('legacy cross-currency classification must be exclusive');
-if (!auditorText.includes('production_sha" == "$api_revision"')) throw new Error('checkout and image revisions must match');
-if (!auditorText.includes('status_output="$(git -C "$APP_DIR" status')) throw new Error('git status failures must fail closed');
-if (!auditorText.includes('git -C "$APP_DIR" ls-files --others --ignored --exclude-standard 2>/dev/null')) throw new Error('ignored-file inspection failures must fail closed');
-if (!auditorText.includes('WHERE "canceledAt" IS NULL')) throw new Error('canceled charges must not count as duplicate active charges');
-if (!auditorText.includes('ALLOWED_IGNORED_RUNTIME_ENV')) throw new Error('ignored checkout files must use the production allowlist');
-if (!auditorText.includes('BACKUP_CHECKSUM_VERIFICATION=%s')) throw new Error('backup checksum state must be reported');
-if (!workflowText.includes('CERTIFIED_MIGRATION_COUNT=%s')) throw new Error('migration observation must be derived dynamically');
-if (workflowText.includes("certified_migration_count == '98'")) throw new Error('audit workflow must not pin a transient migration count');
-if (!auditorText.includes('PUBLIC_READYZ_STATUS')) throw new Error('readiness status must be reported');
-if (!auditorText.includes('p."buildingId" <> c."buildingId"') || !auditorText.includes('p."unitId" IS DISTINCT FROM c."unitId"')) throw new Error('allocation scope relationships must be audited');
-if (!workflowText.includes("awk -F '=' '/^[[:space:]]*readonly[[:space:]]+TARGET_APPLIED[[:space:]]*=/")) throw new Error('manifest target must parse the shell assignment');
-if (!auditorText.includes('validate_pg_restore_list') || !auditorText.includes('docker exec -i "$POSTGRES_CONTAINER" pg_restore --list')) throw new Error('pg_restore validation must use the existing PostgreSQL container when needed');
-if (!auditorText.includes("restore_status='INCOMPLETE'")) throw new Error('unavailable pg_restore validation must be incomplete');
-if (!auditorText.includes('validate_backup_mechanism') || !auditorText.includes('validate_backup_manifest') || !auditorText.includes('validate_backup_script_file')) throw new Error('backup mechanism identity must use in-stream validation');
-if (!auditorText.includes('BACKUP_MECHANISM_OWNER=%s') || !auditorText.includes('BACKUP_MECHANISM_GROUP=%s') || !auditorText.includes('BACKUP_MECHANISM_MODE=%s')) throw new Error('backup mechanism owner, group, and mode must be reported');
-if (!auditorText.includes('configured_bucket')) throw new Error('S3 audit must require the authoritative runtime bucket');
-if (!auditorText.includes('has_same_currency')) throw new Error('mixed allocation currency modes must be audited');
-if (!auditorText.includes('CHARGE_OVER_ALLOCATIONS')) throw new Error('charge-side over-allocation must be audited');
-if (!auditorText.includes("checksum_status='INCOMPLETE'")) throw new Error('missing backup checksums must fail closed');
-if (!auditorText.includes('BACKUP_STATE_DIR') || !auditorText.includes('paired-$backup_set_id.json')) throw new Error('backup readiness must use durable paired state');
-for (const metric of ['NEGATIVE_PAYMENT_ALLOCATIONS', 'NEGATIVE_PAYMENT_ORIGINAL_ALLOCATIONS']) {
-  if (!auditorText.includes(metric)) throw new Error(`missing negative allocation metric ${metric}`);
-}
-if (!auditorText.includes('"paymentOriginalAmountMinor" < 0')) throw new Error('negative original allocation shares must be audited');
-if (!auditorText.includes('WHERE amount <= 0')) throw new Error('zero-value allocations must be audited');
-if (!auditorText.includes('--arg completedAt "$completed_at"') || !auditorText.includes('.completed_at == $completedAt')) throw new Error('paired backup freshness must bind receipt and state timestamps');
-if (!auditorText.includes('RUNTIME_APP_SHA') || !auditorText.includes('.app_sha == $runtimeAppSha')) throw new Error('backup evidence must bind to the verified runtime SHA');
-if (!auditorText.includes('versioning" == \'Enabled\'')) throw new Error('S3 audit must require enabled versioning');
-if (!auditorText.includes('AUDIT_INTERNAL_FAILURES')) throw new Error('auditor internal failures must be reported');
-if (!auditorText.includes('FAILED_STAGE') || !auditorText.includes('FAILURE_CLASS')) throw new Error('controlled failure diagnostics must be reported');
-if (!auditorText.includes('BASH_SOURCE[0]-')) throw new Error('streamed execution must not require BASH_SOURCE');
 
-console.log('PASS: production read-only audit workflow and auditor are structurally fail-closed');
-NODE
+source "$AUDITOR"
+
+write_receipt() {
+  local source="${1-prod:buildingos-production}"
+  local destination="${2-backup:buildingos-production-backup}"
+  local copy_status="${3-PASS}"
+  local verification_status="${4-PASS}"
+  local recovery_point_valid="${5-NOT_EVALUATED}"
+  local completed_at="${6-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+  jq -n \
+    --arg source "$source" \
+    --arg destination "$destination" \
+    --arg copy_status "$copy_status" \
+    --arg verification_status "$verification_status" \
+    --arg recovery_point_valid "$recovery_point_valid" \
+    --arg completed_at "$completed_at" \
+    '{receipt_version:1,started_at_utc:$completed_at,completed_at_utc:$completed_at,source:$source,destination:$destination,copy_status:$copy_status,verification_status:$verification_status,status:"PASS",recovery_point_valid:$recovery_point_valid}' > "$RECEIPT"
+  chmod 0600 "$RECEIPT"
+}
+
+write_receipt
+assert_valid_receipt 'valid Object Storage PASS receipt is accepted'
+AUDIT_EVIDENCE_FAILURES=0
+report_object_backup_receipt "$RECEIPT" > "$OUTPUT"
+REPORT_OUTPUT="$(< "$OUTPUT")"
+assert_contains 'valid receipt reports PASS' 'OBJECT_BACKUP_RECEIPT=PASS' "$REPORT_OUTPUT"
+assert_contains 'valid receipt reports copy PASS' 'OBJECT_BACKUP_COPY=PASS' "$REPORT_OUTPUT"
+assert_contains 'reference reconciliation remains unimplemented' 'DB_OBJECT_REFERENCE_RECONCILIATION=NOT_IMPLEMENTED' "$REPORT_OUTPUT"
+assert_contains 'content identity remains unimplemented' 'DB_OBJECT_CONTENT_IDENTITY=NOT_IMPLEMENTED' "$REPORT_OUTPUT"
+assert_contains 'recovery point remains unevaluated' 'RECOVERY_POINT_VALID=NOT_EVALUATED' "$REPORT_OUTPUT"
+assert_contains 'backup readiness remains incomplete' 'BACKUP_READINESS=INCOMPLETE' "$REPORT_OUTPUT"
+[[ "$AUDIT_EVIDENCE_FAILURES" -gt 0 ]] && pass 'valid copy does not clear fail-closed evidence failure' || fail_test 'valid copy does not clear fail-closed evidence failure'
+
+printf '{malformed\n' > "$RECEIPT"
+assert_invalid_receipt 'malformed receipt fails closed'
+REPORT_OUTPUT="$(report_object_backup_receipt "$RECEIPT")"
+assert_contains 'malformed receipt is incomplete' 'OBJECT_BACKUP_RECEIPT=INCOMPLETE' "$REPORT_OUTPUT"
+
+write_receipt prod:buildingos-production backup:buildingos-production-backup PASS PASS NOT_EVALUATED 2010-01-01T00:00:00Z
+assert_invalid_receipt 'stale receipt fails closed'
+
+write_receipt prod:buildingos-production backup:buildingos-production-backup FAIL PASS
+assert_invalid_receipt 'copy failure receipt fails closed'
+write_receipt prod:buildingos-production backup:buildingos-production-backup PASS FAIL
+assert_invalid_receipt 'verification failure receipt fails closed'
+write_receipt ':s3,access_key_id=FAKE_SECRET,secret_access_key=FAKE_SECRET:bucket' backup:buildingos-production-backup
+assert_invalid_receipt 'unsafe source location fails closed'
+write_receipt prod:buildingos-production backup:buildingos-production
+assert_invalid_receipt 'same bucket names fail closed'
+write_receipt prod:buildingos-production backup:buildingos-production-backup PASS PASS YES
+assert_invalid_receipt 'receipt claiming recovery validity fails closed'
+
+rm -f "$RECEIPT"
+ln -s "$TEST_ROOT/missing-receipt.json" "$RECEIPT"
+assert_invalid_receipt 'symlink receipt fails closed'
+rm -f "$RECEIPT"
+
+auditor_text="$(< "$AUDITOR")"
+assert_contains 'audit keeps current PostgreSQL mechanism path' '/opt/pawtech/backups/scripts/backup-postgres.sh' "$auditor_text"
+assert_contains 'audit keeps PostgreSQL identity manifest' 'infra/production/backup-postgres.identity.v1' "$auditor_text"
+assert_contains 'audit uses the Object Storage receipt path' '/var/lib/buildingos-object-backup/object-backup-receipt.json' "$auditor_text"
+assert_contains 'audit exposes Object Storage receipt marker' 'OBJECT_BACKUP_RECEIPT=%s' "$auditor_text"
+assert_contains 'audit keeps PostgreSQL fresh evidence incomplete' 'POSTGRES_BACKUP_EVIDENCE=INCOMPLETE' "$auditor_text"
+assert_absent 'audit no longer requires paired receipt' 'paired-$backup_set_id.json' "$auditor_text"
+assert_absent 'audit no longer requires MinIO verification flag' 'minio_verified' "$auditor_text"
+assert_absent 'audit does not claim recovery validity' 'RECOVERY_POINT_VALID=YES' "$auditor_text"
+
+if (( FAIL_COUNT > 0 )); then
+  printf 'FAILED: %s failed, %s passed\n' "$FAIL_COUNT" "$PASS_COUNT" >&2
+  exit 1
+fi
+printf 'PASSED: %s assertions\n' "$PASS_COUNT"


### PR DESCRIPTION
## Scope
- Local/repository-only control migration.
- The old paired MinIO receipt is no longer the current readiness contract.
- The current PostgreSQL timer is preserved.
- The new Object Storage service and timer are recognized.
- The Object Storage copy receipt is validated read-only.
- RECOVERY_POINT_VALID remains NOT_EVALUATED.
- BACKUP_READINESS remains INCOMPLETE.
- DB/object reconciliation is deferred to OBJECT_BACKUP_01D.
- No production or staging connection.
- No backup, restore, or deploy executed.