### PR TITLE
OBJECT-BACKUP-01D-1A: add object version identity foundation

### DIFF
--- a/apps/api/prisma/migrations/20260905000000_add_object_version_identity/migration.sql
+++ b/apps/api/prisma/migrations/20260905000000_add_object_version_identity/migration.sql
@@ -1,0 +1,7 @@
+-- Preserve provider-issued object identity without requiring a backfill.
+ALTER TABLE "File"
+  ADD COLUMN "objectVersionId" TEXT;
+
+ALTER TABLE "ImportJob"
+  ADD COLUMN "originalObjectVersionId" TEXT,
+  ADD COLUMN "normalizedObjectVersionId" TEXT;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -1351,6 +1351,7 @@ model File {
   // MinIO metadata
   bucket       String // Bucket name in MinIO
   objectKey    String // Full path/key in MinIO (e.g., "tenant-a/documents/rules.pdf")
+  objectVersionId String? // Provider-issued immutable object version identity, when available
   originalName String // Original filename (for download)
   mimeType     String // MIME type (e.g., "application/pdf")
   size         Int // File size in bytes
@@ -1431,7 +1432,9 @@ model ImportJob {
   fileHash              String
   previewHash           String?
   originalObjectKey     String
+  originalObjectVersionId String?
   normalizedObjectKey   String?
+  normalizedObjectVersionId String?
   summary               Json?
   counts                Json?
   canConfirm            Boolean          @default(false)

--- a/apps/api/src/storage/minio.service.spec.ts
+++ b/apps/api/src/storage/minio.service.spec.ts
@@ -134,6 +134,90 @@ describe('MinioService', () => {
     )).resolves.toBe(false);
   });
 
+  it('returns the exact provider version id from a buffer upload', async () => {
+    const internalClient = createClientMock();
+    const publicClient = createClientMock();
+    internalClient.putObject.mockResolvedValue({
+      etag: 'etag-1',
+      versionId: 'version-1',
+    });
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => publicClient);
+
+    const service = new MinioService(createConfig());
+
+    await expect(
+      service.uploadBuffer('buildingos-staging', 'tenant-a/object.pdf', Buffer.from('%PDF-test'), 'application/pdf'),
+    ).resolves.toEqual({ etag: 'etag-1', versionId: 'version-1' });
+  });
+
+  it('preserves an absent provider version id instead of substituting the ETag', async () => {
+    const internalClient = createClientMock();
+    const publicClient = createClientMock();
+    internalClient.putObject.mockResolvedValue({
+      etag: 'etag-without-version',
+      versionId: null,
+    });
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => publicClient);
+
+    const service = new MinioService(createConfig());
+
+    await expect(
+      service.uploadBuffer(
+        'buildingos-staging',
+        'tenant-a/object.pdf',
+        Buffer.from('%PDF-test'),
+        'application/pdf',
+      ),
+    ).resolves.toEqual({ etag: 'etag-without-version', versionId: null });
+  });
+
+  it('returns exact provider metadata from a conditional upload', async () => {
+    const internalClient = createClientMock();
+    const publicClient = createClientMock();
+    internalClient.putObject.mockResolvedValue({
+      etag: 'conditional-etag',
+      versionId: 'conditional-version',
+    });
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => publicClient);
+
+    const service = new MinioService(createConfig());
+
+    await expect(
+      service.uploadBufferIfAbsentWithMetadata(
+        'buildingos-staging',
+        'tenant-a/object.pdf',
+        Buffer.from('%PDF-test'),
+        'application/pdf',
+      ),
+    ).resolves.toEqual({ etag: 'conditional-etag', versionId: 'conditional-version' });
+  });
+
+  it('returns null from the metadata variant when the provider rejects an existing object', async () => {
+    const internalClient = createClientMock();
+    const publicClient = createClientMock();
+    internalClient.putObject.mockRejectedValue({ statusCode: 412 });
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => publicClient);
+
+    const service = new MinioService(createConfig());
+
+    await expect(
+      service.uploadBufferIfAbsentWithMetadata(
+        'buildingos-staging',
+        'tenant-a/object.pdf',
+        Buffer.from('%PDF-test'),
+        'application/pdf',
+      ),
+    ).resolves.toBeNull();
+  });
+
   it('uses the protocol default port for a public HTTP endpoint', async () => {
     const internalClient = createClientMock();
     const publicClient = createClientMock();

--- a/apps/api/src/storage/minio.service.ts
+++ b/apps/api/src/storage/minio.service.ts
@@ -17,6 +17,11 @@ export interface MinioObjectStat {
   metaData?: Record<string, string>;
 }
 
+export interface MinioUploadResult {
+  readonly etag: string;
+  readonly versionId: string | null;
+}
+
 /**
  * MinIO Service: Wrapper around Minio SDK for presigned URLs and object operations
  *
@@ -430,7 +435,7 @@ export class MinioService {
     objectKey: string,
     buffer: Buffer,
     contentType: string = 'application/octet-stream',
-  ): Promise<void> {
+  ): Promise<MinioUploadResult> {
     try {
       // Convert buffer to stream
       const stream = require('stream');
@@ -438,15 +443,19 @@ export class MinioService {
       readable._read = () => {};
       readable.push(buffer);
       readable.push(null);
-      
-      await this.minioClient.putObject(
-        bucketName, 
-        objectKey, 
-        readable, 
+
+      const result = await this.minioClient.putObject(
+        bucketName,
+        objectKey,
+        readable,
         buffer.length,
         { 'Content-Type': contentType }
       );
       this.logger.debug(`Uploaded buffer to ${bucketName}/${objectKey} (${buffer.length} bytes)`);
+      return {
+        etag: result.etag,
+        versionId: result.versionId,
+      };
     } catch (error: unknown) {
       this.logger.error(
         `Failed to upload buffer: ${this.getErrorMessage(error)}`,
@@ -468,6 +477,19 @@ export class MinioService {
     buffer: Buffer,
     contentType: string = 'application/octet-stream',
   ): Promise<boolean> {
+    return (await this.uploadBufferIfAbsentWithMetadata(bucketName, objectKey, buffer, contentType)) !== null;
+  }
+
+  /**
+   * Create an object only when the canonical key does not already exist and
+   * return the provider-issued identity for the object that was created.
+   */
+  async uploadBufferIfAbsentWithMetadata(
+    bucketName: string = this.bucket,
+    objectKey: string,
+    buffer: Buffer,
+    contentType: string = 'application/octet-stream',
+  ): Promise<MinioUploadResult | null> {
     try {
       const stream = require('stream');
       const readable = new stream.Readable();
@@ -475,7 +497,7 @@ export class MinioService {
       readable.push(buffer);
       readable.push(null);
 
-      await this.minioClient.putObject(
+      const result = await this.minioClient.putObject(
         bucketName,
         objectKey,
         readable,
@@ -486,11 +508,14 @@ export class MinioService {
         },
       );
       this.logger.debug(`Created buffer object ${bucketName}/${objectKey} (${buffer.length} bytes)`);
-      return true;
+      return {
+        etag: result.etag,
+        versionId: result.versionId,
+      };
     } catch (error: unknown) {
       if (this.isPreconditionFailedError(error)) {
         this.logger.debug(`Object already exists: ${bucketName}/${objectKey}`);
-        return false;
+        return null;
       }
       this.logger.error(
         `Failed to create buffer object: ${this.getErrorMessage(error)}`,

--- a/apps/api/src/storage/object-version-identity-migration.spec.ts
+++ b/apps/api/src/storage/object-version-identity-migration.spec.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('object version identity schema foundation', () => {
+  const schemaPath = join(__dirname, '../../prisma/schema.prisma');
+  const migrationPath = join(
+    __dirname,
+    '../../prisma/migrations/20260905000000_add_object_version_identity/migration.sql',
+  );
+
+  it('declares nullable provider version identity fields for file and import objects', () => {
+    const schema = readFileSync(schemaPath, 'utf8');
+
+    expect(schema).toMatch(/model File \{[\s\S]*?objectVersionId String\?/);
+    expect(schema).toMatch(/model ImportJob \{[\s\S]*?originalObjectVersionId String\?/);
+    expect(schema).toMatch(/model ImportJob \{[\s\S]*?normalizedObjectVersionId String\?/);
+  });
+
+  it('adds only nullable columns without a backfill or destructive operation', () => {
+    const migration = readFileSync(migrationPath, 'utf8');
+
+    expect(migration).toContain('ADD COLUMN "objectVersionId" TEXT;');
+    expect(migration).toContain('ADD COLUMN "originalObjectVersionId" TEXT,');
+    expect(migration).toContain('ADD COLUMN "normalizedObjectVersionId" TEXT;');
+    expect(migration).not.toMatch(/\b(UPDATE|DELETE|DROP|SET NOT NULL)\b/);
+  });
+});


### PR DESCRIPTION
## Scope

Foundation for exact object-version identity in BuildingOS recovery.

### Adds

- nullable File.objectVersionId
- nullable ImportJob original/normalized object VersionId fields
- forward-only nullable Prisma migration
- storage upload result exposing exact provider VersionId
- metadata-returning conditional upload helper
- focused schema/migration/storage tests

### Explicitly not included

- no historical VersionId backfill
- no Documents write-path persistence
- no Payment Receipt write-path persistence
- no Import write-path persistence
- no DB↔object reconciliation
- no recovery-point validation
- no backup/readiness changes
- no staging/production changes

### Local validation

- focused tests: 69 PASS
- ESLint: PASS
- TypeScript: PASS
- Prisma validate: PASS
- git diff --check: PASS

### Current recovery state

DB_OBJECT_REFERENCE_RECONCILIATION=NOT_IMPLEMENTED
DB_OBJECT_CONTENT_IDENTITY=NOT_IMPLEMENTED
RECOVERY_POINT_VALID=NOT_EVALUATED
BACKUP_READINESS=INCOMPLETE