### PR TITLE
OBJECT-BACKUP-01D-1B1: persist receipt object VersionId

### DIFF
--- a/apps/api/src/documents/documents.service.spec.ts
+++ b/apps/api/src/documents/documents.service.spec.ts
@@ -398,7 +398,13 @@ describe('DocumentsService', () => {
           passwordHash: 'secret-detail-hash',
         },
       },
-      file: { bucket: 'tenant-legacy-bucket', objectKey: 'receipt.pdf', originalName: 'receipt.pdf', mimeType: 'application/pdf' },
+      file: {
+        bucket: 'tenant-legacy-bucket',
+        objectKey: 'receipt.pdf',
+        originalName: 'receipt.pdf',
+        mimeType: 'application/pdf',
+        objectVersionId: 'version-1',
+      },
     } as never);
 
     const result = await service.getDocument('tenant-1', 'document-1', 'resident-1', ['RESIDENT'], false);
@@ -424,6 +430,7 @@ describe('DocumentsService', () => {
       email: 'resident@example.com',
       name: 'Resident One',
     });
+    expect(result.file).not.toHaveProperty('objectVersionId');
     expectNoPasswordHashDeep(result);
   });
 
@@ -1098,6 +1105,40 @@ describe('DocumentsService', () => {
     });
   });
 
+  it('binds a presigned download URL to the persisted file version', async () => {
+    prisma.document.findFirst.mockResolvedValueOnce({
+      id: 'document-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      visibility: 'RESIDENTS',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      createdByMembership: { userId: 'admin-1' },
+      file: {
+        bucket: 'tenant-versioned-bucket',
+        objectKey: 'receipt.pdf',
+        objectVersionId: 'version-1',
+      },
+    } as never);
+    minio.presignDownload.mockResolvedValue('https://download.example/receipt.pdf');
+
+    await service.getDownloadUrl(
+      'tenant-1',
+      'document-1',
+      'resident-1',
+      ['RESIDENT'],
+      false,
+    );
+
+    expect(minio.presignDownload).toHaveBeenCalledWith(
+      'tenant-versioned-bucket',
+      'receipt.pdf',
+      86400,
+      'version-1',
+    );
+  });
+
   it('streams a protected document download using the persisted bucket and sanitized filename', async () => {
     minio.objectExists.mockResolvedValue(true);
     minio.statObject.mockResolvedValue({ size: 2048 } as never);
@@ -1119,6 +1160,52 @@ describe('DocumentsService', () => {
     expect(result.fileName).toBe('receipt.pdf');
     expect(result.disposition).toBe('inline');
     expect(result.stream.readable).toBe(true);
+  });
+
+  it('stats and streams the same persisted file version for document content', async () => {
+    prisma.document.findFirst.mockResolvedValueOnce({
+      id: 'document-1',
+      tenantId: 'tenant-1',
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+      visibility: 'RESIDENTS',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      createdByMembership: { userId: 'admin-1' },
+      file: {
+        bucket: 'tenant-versioned-bucket',
+        objectKey: 'receipt.pdf',
+        originalName: 'receipt.pdf',
+        mimeType: 'application/pdf',
+        objectVersionId: 'version-1',
+      },
+    } as never);
+    minio.statObject.mockResolvedValue({ size: 2048, versionId: 'version-1' } as never);
+    minio.getObjectStream.mockResolvedValue(Readable.from(['pdf-bytes']) as never);
+
+    const result = await service.getDocumentContent(
+      'tenant-1',
+      'document-1',
+      'resident-1',
+      ['RESIDENT'],
+      false,
+    );
+
+    expect(minio.objectExists).not.toHaveBeenCalled();
+    expect(minio.statObject).toHaveBeenCalledWith(
+      'tenant-versioned-bucket',
+      'receipt.pdf',
+      'version-1',
+    );
+    expect(minio.getObjectStream).toHaveBeenCalledWith(
+      'tenant-versioned-bucket',
+      'receipt.pdf',
+      'version-1',
+    );
+    expect(minio.statObject.mock.calls[0][2]).toBe(
+      minio.getObjectStream.mock.calls[0][2],
+    );
+    expect(result.contentLength).toBe(2048);
   });
 
   it('rejects downloads when the file no longer exists in MinIO', async () => {

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -43,6 +43,19 @@ type DocumentNotificationTarget = Prisma.DocumentGetPayload<{
   };
 }>;
 
+type AccessibleDocument = Prisma.DocumentGetPayload<{
+  include: {
+    file: true;
+    createdByMembership: {
+      include: {
+        user: {
+          select: typeof publicUserSelect;
+        };
+      };
+    };
+  };
+}>;
+
 type DocumentWithPublicMembershipUser = {
   createdByMembership?: {
     user?: {
@@ -466,6 +479,24 @@ export class DocumentsService {
     userRoles: string[],
     isSuperAdmin: boolean,
   ): Promise<DocumentWithFileResponseDto> {
+    const document = await this.loadAccessibleDocument(
+      tenantId,
+      documentId,
+      userId,
+      userRoles,
+      isSuperAdmin,
+    );
+
+    return this.sanitizeDocumentResponse(document);
+  }
+
+  private async loadAccessibleDocument(
+    tenantId: string,
+    documentId: string,
+    userId: string,
+    userRoles: string[],
+    isSuperAdmin: boolean,
+  ): Promise<AccessibleDocument> {
     const document = await this.prisma.document.findFirst({
       where: { id: documentId, tenantId },
       include: {
@@ -514,7 +545,7 @@ export class DocumentsService {
       );
     }
 
-    return this.sanitizeDocumentResponse(document);
+    return document;
   }
 
   /**
@@ -720,7 +751,7 @@ export class DocumentsService {
     isSuperAdmin: boolean,
   ): Promise<DownloadUrlResponseDto> {
     // First, validate document is accessible
-    const document = await this.getDocument(
+    const document = await this.loadAccessibleDocument(
       tenantId,
       documentId,
       userId,
@@ -734,11 +765,18 @@ export class DocumentsService {
 
     // Generate presigned URL from MinIO (24 hours expiration)
     const expirySeconds = 24 * 60 * 60;
-    const url = await this.minio.presignDownload(
-      document.file.bucket,
-      document.file.objectKey,
-      expirySeconds,
-    );
+    const url = document.file.objectVersionId
+      ? await this.minio.presignDownload(
+          document.file.bucket,
+          document.file.objectKey,
+          expirySeconds,
+          document.file.objectVersionId,
+        )
+      : await this.minio.presignDownload(
+          document.file.bucket,
+          document.file.objectKey,
+          expirySeconds,
+        );
 
     return {
       url,
@@ -758,7 +796,7 @@ export class DocumentsService {
     userRoles: string[],
     isSuperAdmin: boolean,
   ): Promise<DocumentContentResponse> {
-    const document = await this.getDocument(
+    const document = await this.loadAccessibleDocument(
       tenantId,
       documentId,
       userId,
@@ -772,17 +810,21 @@ export class DocumentsService {
 
     const bucket = document.file.bucket;
     const objectKey = document.file.objectKey;
-    const exists = await this.minio.objectExists(bucket, objectKey);
-    if (!exists) {
+    const versionId = document.file.objectVersionId ?? undefined;
+    if (!versionId && !(await this.minio.objectExists(bucket, objectKey))) {
       throw new NotFoundException('Document file not found');
     }
 
-    const uploadedObject = await this.minio.statObject(bucket, objectKey);
+    const uploadedObject = versionId
+      ? await this.minio.statObject(bucket, objectKey, versionId)
+      : await this.minio.statObject(bucket, objectKey);
     if (uploadedObject.size <= 0) {
       throw new NotFoundException('Document file not found');
     }
 
-    const stream = await this.minio.getObjectStream(bucket, objectKey);
+    const stream = versionId
+      ? await this.minio.getObjectStream(bucket, objectKey, versionId)
+      : await this.minio.getObjectStream(bucket, objectKey);
     const contentType = document.file.mimeType || 'application/octet-stream';
 
     return {
@@ -1235,15 +1277,27 @@ export class DocumentsService {
   private sanitizeDocumentResponse(
     document: DocumentWithPublicMembershipUser & Record<string, unknown>,
   ): DocumentWithFileResponseDto {
-    if (!document.createdByMembership) {
-      return document as unknown as DocumentWithFileResponseDto;
+    const file = document.file;
+    const sanitizedDocument = {
+      ...document,
+      ...(file && typeof file === 'object'
+        ? {
+            file: Object.fromEntries(
+              Object.entries(file).filter(([key]) => key !== 'objectVersionId'),
+            ),
+          }
+        : {}),
+    };
+
+    if (!sanitizedDocument.createdByMembership) {
+      return sanitizedDocument as unknown as DocumentWithFileResponseDto;
     }
 
     return {
-      ...document,
+      ...sanitizedDocument,
       createdByMembership: {
-        ...document.createdByMembership,
-        user: toPublicUser(document.createdByMembership.user) ?? undefined,
+        ...sanitizedDocument.createdByMembership,
+        user: toPublicUser(sanitizedDocument.createdByMembership.user) ?? undefined,
       },
     } as unknown as DocumentWithFileResponseDto;
   }

--- a/apps/api/src/receipts/payment-receipt-concurrency.postgres.spec.ts
+++ b/apps/api/src/receipts/payment-receipt-concurrency.postgres.spec.ts
@@ -48,14 +48,29 @@ class LocalReceiptStorage {
     content: Buffer,
     contentType = 'application/pdf',
   ): Promise<boolean> {
+    return (await this.uploadBufferIfAbsentWithMetadata(
+      bucket,
+      objectKey,
+      content,
+      contentType,
+    )) !== null;
+  }
+
+  async uploadBufferIfAbsentWithMetadata(
+    bucket: string,
+    objectKey: string,
+    content: Buffer,
+    contentType = 'application/pdf',
+  ): Promise<{ etag: string; versionId: string } | null> {
     if (this.delayMs > 0) {
       await new Promise((resolve) => setTimeout(resolve, this.delayMs));
     }
     const key = `${bucket}/${objectKey}`;
-    if (this.objects.has(key)) return false;
+    if (this.objects.has(key)) return null;
     this.uploadCalls.push(key);
-    this.objects.set(key, this.objectMetadata(content, contentType));
-    return true;
+    const metadata = this.objectMetadata(content, contentType);
+    this.objects.set(key, metadata);
+    return { etag: metadata.etag, versionId: 'local-test-version' };
   }
 
   private objectMetadata(content: Buffer, contentType: string) {

--- a/apps/api/src/receipts/payment-receipt-recovery.minio.postgres.spec.ts
+++ b/apps/api/src/receipts/payment-receipt-recovery.minio.postgres.spec.ts
@@ -30,6 +30,12 @@ interface ReceiptStorage {
   getDefaultBucket(): string;
   uploadBuffer(bucket: string, objectKey: string, content: Buffer, contentType: string): Promise<void>;
   uploadBufferIfAbsent(bucket: string, objectKey: string, content: Buffer, contentType: string): Promise<boolean>;
+  uploadBufferIfAbsentWithMetadata(
+    bucket: string,
+    objectKey: string,
+    content: Buffer,
+    contentType: string,
+  ): Promise<{ etag: string; versionId: string | null } | null>;
   objectExists(bucket: string, objectKey: string): Promise<boolean>;
   statObject(bucket: string, objectKey: string): Promise<{
     size: number;
@@ -126,20 +132,34 @@ class MinioReceiptStorage implements ReceiptStorage {
     content: Buffer,
     contentType: string,
   ): Promise<boolean> {
+    return (await this.uploadBufferIfAbsentWithMetadata(
+      bucket,
+      objectKey,
+      content,
+      contentType,
+    )) !== null;
+  }
+
+  async uploadBufferIfAbsentWithMetadata(
+    bucket: string,
+    objectKey: string,
+    content: Buffer,
+    contentType: string,
+  ): Promise<{ etag: string; versionId: string | null } | null> {
     this.putCalls.push(`${bucket}/${objectKey}`);
     try {
-      await this.client.putObject(
+      const result = await this.client.putObject(
         bucket,
         objectKey,
         Readable.from([content]),
         content.length,
         { 'Content-Type': contentType, 'If-None-Match': '*' },
       );
-      return true;
+      return { etag: result.etag, versionId: result.versionId };
     } catch (error: unknown) {
       const errorLike = error as { code?: string; statusCode?: number };
       if (errorLike.code === 'PreconditionFailed' || errorLike.statusCode === 412) {
-        return false;
+        return null;
       }
       throw error;
     }

--- a/apps/api/src/receipts/payment-receipt-recovery.minio.postgres.spec.ts
+++ b/apps/api/src/receipts/payment-receipt-recovery.minio.postgres.spec.ts
@@ -42,8 +42,9 @@ interface ReceiptStorage {
     etag?: string;
     lastModified?: Date;
     metaData?: Record<string, string>;
+    versionId?: string | null;
   }>;
-  getObjectBuffer(bucket: string, objectKey: string): Promise<Buffer>;
+  getObjectBuffer(bucket: string, objectKey: string, versionId?: string): Promise<Buffer>;
   presignDownload(bucket: string, objectKey: string, expirySeconds: number): Promise<string>;
   deleteObject(bucket: string, objectKey: string): Promise<void>;
   listObjects(bucket: string, prefix: string): Promise<string[]>;
@@ -52,6 +53,7 @@ interface ReceiptStorage {
 class MinioReceiptStorage implements ReceiptStorage {
   private readonly client: Minio.Client;
   readonly putCalls: string[] = [];
+  readonly versionedGetCalls: string[] = [];
 
   constructor(
     private readonly bucket: string,
@@ -165,17 +167,23 @@ class MinioReceiptStorage implements ReceiptStorage {
     }
   }
 
-  async statObject(bucket: string, objectKey: string): Promise<{
+  async statObject(bucket: string, objectKey: string, versionId?: string): Promise<{
     size: number;
     etag?: string;
     lastModified?: Date;
     metaData?: Record<string, string>;
+    versionId?: string | null;
   }> {
-    return this.client.statObject(bucket, objectKey);
+    return versionId
+      ? this.client.statObject(bucket, objectKey, { versionId })
+      : this.client.statObject(bucket, objectKey);
   }
 
-  async getObjectBuffer(bucket: string, objectKey: string): Promise<Buffer> {
-    const stream = await this.client.getObject(bucket, objectKey);
+  async getObjectBuffer(bucket: string, objectKey: string, versionId?: string): Promise<Buffer> {
+    if (versionId) this.versionedGetCalls.push(`${bucket}/${objectKey}:${versionId}`);
+    const stream = versionId
+      ? await this.client.getObject(bucket, objectKey, { versionId })
+      : await this.client.getObject(bucket, objectKey);
     const chunks: Buffer[] = [];
     return new Promise<Buffer>((resolve, reject) => {
       stream.on('data', (chunk: Buffer | string) => {
@@ -601,6 +609,9 @@ describeMinioRecovery('Payment receipt PostgreSQL/MinIO recovery', () => {
       storage.getDefaultBucket(),
       objectKey,
     );
+    const firstStat = await storage.statObject(storage.getDefaultBucket(), objectKey);
+    expect(firstStat.versionId).toBeDefined();
+    const versionsBeforeRetry = await storage.countObjectVersions(objectKey);
 
     const freshStorage = new MinioReceiptStorage(
       storage.getDefaultBucket(),
@@ -658,6 +669,11 @@ describeMinioRecovery('Payment receipt PostgreSQL/MinIO recovery', () => {
       objectKey,
     );
     expect(recoveredPdf).toEqual(firstPdf);
+    expect(files[0].objectVersionId).toBe(firstStat.versionId);
+    expect(freshStorage.versionedGetCalls).toContain(
+      `${storage.getDefaultBucket()}/${objectKey}:${firstStat.versionId}`,
+    );
+    expect(await freshStorage.countObjectVersions(objectKey)).toBe(versionsBeforeRetry);
   }, 30000);
 
   it('adopts a legacy orphan concurrently without creating a new MinIO version', async () => {

--- a/apps/api/src/receipts/payment-receipt-recovery.minio.postgres.spec.ts
+++ b/apps/api/src/receipts/payment-receipt-recovery.minio.postgres.spec.ts
@@ -45,7 +45,12 @@ interface ReceiptStorage {
     versionId?: string | null;
   }>;
   getObjectBuffer(bucket: string, objectKey: string, versionId?: string): Promise<Buffer>;
-  presignDownload(bucket: string, objectKey: string, expirySeconds: number): Promise<string>;
+  presignDownload(
+    bucket: string,
+    objectKey: string,
+    expirySeconds: number,
+    versionId?: string,
+  ): Promise<string>;
   deleteObject(bucket: string, objectKey: string): Promise<void>;
   listObjects(bucket: string, prefix: string): Promise<string[]>;
 }
@@ -198,8 +203,11 @@ class MinioReceiptStorage implements ReceiptStorage {
     bucket: string,
     objectKey: string,
     expirySeconds: number,
+    versionId?: string,
   ): Promise<string> {
-    return this.client.presignedGetObject(bucket, objectKey, expirySeconds);
+    return versionId
+      ? this.client.presignedGetObject(bucket, objectKey, expirySeconds, { versionId })
+      : this.client.presignedGetObject(bucket, objectKey, expirySeconds);
   }
 
   async deleteObject(bucket: string, objectKey: string): Promise<void> {

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -449,15 +449,25 @@ describe('PaymentReceiptService', () => {
       expect(pdfInfo.status).toBe(0);
       expect(pdfInfo.stdout).toContain('Pages:');
     }
-     expect(prisma.file.create).toHaveBeenCalledWith(expect.objectContaining({
-       data: expect.objectContaining({
-         bucket: DEFAULT_BUCKET,
-         objectVersionId: 'receipt-version-1',
-         originalName: expect.stringMatching(/\.pdf$/),
-         mimeType: 'application/pdf',
-         size: uploadedBuffer.length,
-       }),
+    expect(prisma.file.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        bucket: DEFAULT_BUCKET,
+        objectVersionId: 'receipt-version-1',
+        originalName: expect.stringMatching(/\.pdf$/),
+        mimeType: 'application/pdf',
+        size: uploadedBuffer.length,
+      }),
     }));
+    expect(minio.statObject).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      expect.stringContaining('/receipts/R-'),
+      'receipt-version-1',
+    );
+    expect(minio.getObjectBuffer).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      expect.stringContaining('/receipts/R-'),
+      'receipt-version-1',
+    );
     expect(prisma.$transaction).toHaveBeenCalledTimes(2);
     expect(transactionQueryRawMock).toHaveBeenCalledTimes(5);
      expect(prisma.payment.updateMany).toHaveBeenCalledWith(
@@ -1206,6 +1216,38 @@ describe('PaymentReceiptService', () => {
     expect(defaultPaymentState.receiptGeneratedAt).toEqual(lastModified);
   });
 
+  it('persists a version returned by legacy orphan validation only after reading that exact version', async () => {
+    Object.assign(defaultPaymentState, {
+      receiptStatus: ReceiptStatus.FAILED,
+      receiptNumber: 'R-COMPLE-2026-000001',
+    });
+    const legacyPdf = Buffer.from('%PDF-versioned-legacy-orphan');
+    const lastModified = new Date('2026-08-30T12:00:00.000Z');
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({
+      size: legacyPdf.length,
+      versionId: 'legacy-version-1',
+      etag: 'legacy-etag',
+      lastModified,
+      metaData: { 'content-type': 'application/pdf' },
+    });
+    minio.getObjectBuffer.mockImplementation(async (_bucket, _key, versionId) => {
+      expect(versionId).toBe('legacy-version-1');
+      return legacyPdf;
+    });
+
+    await service.ensureReceiptForPayment('tenant-1', 'payment-1');
+
+    expect(minio.getObjectBuffer).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      canonicalReceiptKey(),
+      'legacy-version-1',
+    );
+    expect(prisma.file.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ objectVersionId: 'legacy-version-1' }),
+    }));
+  });
+
   it("atomically takes over an expired orphan recovery claim", async () => {
     const expiredLease = new Date("2026-08-30T23:59:59.000Z");
     const lastModified = new Date("2026-08-30T12:00:00.000Z");
@@ -1807,6 +1849,16 @@ describe('PaymentReceiptService', () => {
       },
     });
     expect(prisma.file.updateMany.mock.calls[0][0].data.objectVersionId).toBeUndefined();
+    expect(minio.statObject).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      canonicalReceiptKey(),
+      'receipt-version-existing',
+    );
+    expect(minio.getObjectBuffer).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      canonicalReceiptKey(),
+      'receipt-version-existing',
+    );
   });
 
   it('persists the exact VersionId when reconciling an existing File after creating its missing object', async () => {
@@ -1975,16 +2027,28 @@ describe('PaymentReceiptService', () => {
       building: { name: "Complejo Horizonte" },
     } as never;
     let storedObject: Buffer | null = null;
+    let storedVersionId: string | null = null;
     prisma.payment.findUnique.mockImplementation(async () => paymentState);
     prisma.payment.update.mockImplementation(async ({ data }) => {
       paymentState = { ...paymentState, ...data } as never;
       return paymentState;
     });
     minio.objectExists.mockImplementation(async () => storedObject !== null);
-    minio.statObject.mockImplementation(async () => ({ size: storedObject?.length ?? 0 }));
-    minio.getObjectBuffer.mockImplementation(async () => storedObject!);
+    minio.statObject.mockImplementation(async () => ({
+      size: storedObject?.length ?? 0,
+      versionId: storedVersionId,
+    }));
+    minio.getObjectBuffer.mockImplementation(async (_bucket, _key, versionId) => {
+      expect(versionId).toBe(storedVersionId);
+      return storedObject!;
+    });
     minio.uploadBuffer.mockImplementation(async (_bucket, _key, content) => {
       storedObject = content;
+    });
+    minio.uploadBufferIfAbsentWithMetadata.mockImplementationOnce(async (...args: unknown[]) => {
+      await minio.uploadBuffer(...args);
+      storedVersionId = 'receipt-version-1';
+      return { etag: 'receipt-etag', versionId: storedVersionId };
     });
     prisma.document.create.mockRejectedValueOnce(
       new Error("database unavailable"),
@@ -2024,6 +2088,11 @@ describe('PaymentReceiptService', () => {
     expect(storedObject?.includes(Buffer.from("MUTATED"))).toBe(false);
     expect(paymentState.receiptStatus).toBe(ReceiptStatus.READY);
     expect(prisma.paymentAuditLog.create).toHaveBeenCalledTimes(1);
+    expect(minio.getObjectBuffer).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      expect.stringContaining('/receipts/R-'),
+      'receipt-version-1',
+    );
   });
 
   it('renews a live receipt lease using the database timestamp', async () => {
@@ -2226,6 +2295,72 @@ describe('PaymentReceiptService', () => {
     );
     expect(prisma.payment.updateMany).not.toHaveBeenCalled();
     expect(prisma.payment.update).not.toHaveBeenCalled();
+  });
+
+  it('validates an existing object through the VersionId returned by stat', async () => {
+    const pdf = Buffer.from('%PDF-existing-version');
+    const ensureStorage = Reflect.get(service, 'ensureReceiptStorageObject') as (
+      bucket: string,
+      fileKey: string,
+      content: Buffer,
+      expectedVersionId?: string | null,
+    ) => Promise<{ versionId?: string }>;
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: pdf.length, versionId: 'version-a' });
+    minio.getObjectBuffer.mockImplementation(async (_bucket, _key, versionId) => {
+      expect(versionId).toBe('version-a');
+      return pdf;
+    });
+
+    await expect(
+      ensureStorage.call(service, DEFAULT_BUCKET, 'tenant-1/existing.pdf', pdf),
+    ).resolves.toEqual(expect.objectContaining({ versionId: 'version-a' }));
+    expect(minio.getObjectBuffer).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      'tenant-1/existing.pdf',
+      'version-a',
+    );
+  });
+
+  it('preserves legacy nullable identity when stat has no VersionId', async () => {
+    const pdf = Buffer.from('%PDF-legacy-unversioned');
+    const ensureStorage = Reflect.get(service, 'ensureReceiptStorageObject') as (
+      bucket: string,
+      fileKey: string,
+      content: Buffer,
+    ) => Promise<{ versionId?: string }>;
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: pdf.length, versionId: null });
+    minio.getObjectBuffer.mockResolvedValue(pdf);
+
+    await expect(
+      ensureStorage.call(service, DEFAULT_BUCKET, 'tenant-1/legacy.pdf', pdf),
+    ).resolves.toEqual(expect.objectContaining({ versionId: undefined }));
+    expect(minio.getObjectBuffer).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      'tenant-1/legacy.pdf',
+    );
+  });
+
+  it('fails closed when the exact validated version content does not match', async () => {
+    const expectedPdf = Buffer.from('%PDF-expected-version');
+    const wrongPdf = Buffer.from('%PDF-wrong-version!');
+    const ensureStorage = Reflect.get(service, 'ensureReceiptStorageObject') as (
+      bucket: string,
+      fileKey: string,
+      content: Buffer,
+    ) => Promise<unknown>;
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: expectedPdf.length, versionId: 'version-a' });
+    minio.getObjectBuffer.mockImplementation(async (_bucket, _key, versionId) => {
+      expect(versionId).toBe('version-a');
+      return wrongPdf;
+    });
+
+    await expect(
+      ensureStorage.call(service, DEFAULT_BUCKET, 'tenant-1/mismatch.pdf', expectedPdf),
+    ).rejects.toThrow('content mismatch');
+    expect(prisma.file.create).not.toHaveBeenCalled();
   });
 
   it('fails closed when a conditional canonical object-create race returns no identity', async () => {

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -80,6 +80,7 @@ describe('PaymentReceiptService', () => {
     getDefaultBucket: jest.fn(() => DEFAULT_BUCKET),
     uploadBuffer: jest.fn(),
     uploadBufferIfAbsent: jest.fn(),
+    uploadBufferIfAbsentWithMetadata: jest.fn(),
     objectExists: jest.fn(),
     statObject: jest.fn(),
     getObjectBuffer: jest.fn(),
@@ -224,6 +225,10 @@ describe('PaymentReceiptService', () => {
     minio.uploadBufferIfAbsent.mockImplementation(async (...args: unknown[]) => {
       await minio.uploadBuffer(...args);
       return true;
+    });
+    minio.uploadBufferIfAbsentWithMetadata.mockImplementation(async (...args: unknown[]) => {
+      await minio.uploadBuffer(...args);
+      return { etag: 'receipt-etag', versionId: 'receipt-version-1' };
     });
     minio.presignDownload.mockImplementation(async () => {
       expect(insideTransaction).toBe(false);
@@ -410,7 +415,7 @@ describe('PaymentReceiptService', () => {
     const uploadedBuffer = minio.uploadBuffer.mock.calls[0][2] as Buffer;
     const tmpReceiptPath = '/tmp/buildingos-payment-receipt-test.pdf';
 
-    expect(minio.uploadBuffer).toHaveBeenCalledWith(
+    expect(minio.uploadBufferIfAbsentWithMetadata).toHaveBeenCalledWith(
       DEFAULT_BUCKET,
       expect.stringContaining('/receipts/R-'),
       expect.any(Buffer),
@@ -447,6 +452,7 @@ describe('PaymentReceiptService', () => {
      expect(prisma.file.create).toHaveBeenCalledWith(expect.objectContaining({
        data: expect.objectContaining({
          bucket: DEFAULT_BUCKET,
+         objectVersionId: 'receipt-version-1',
          originalName: expect.stringMatching(/\.pdf$/),
          mimeType: 'application/pdf',
          size: uploadedBuffer.length,
@@ -478,6 +484,18 @@ describe('PaymentReceiptService', () => {
       3600,
     );
     expect(result?.fileKey).toContain('/receipts/R-');
+  });
+
+  it('fails closed before creating File when the provider omits VersionId', async () => {
+    minio.uploadBufferIfAbsentWithMetadata.mockResolvedValueOnce({
+      etag: 'etag-without-version',
+      versionId: null,
+    });
+
+    await expect(
+      service.ensureReceiptForPayment('tenant-1', 'payment-1'),
+    ).rejects.toThrow('did not return a VersionId');
+    expect(prisma.file.create).not.toHaveBeenCalled();
   });
 
   it('reuses the reserved receipt number after an upload failure', async () => {
@@ -1018,7 +1036,7 @@ describe('PaymentReceiptService', () => {
       },
     });
     expect(minio.presignDownload).not.toHaveBeenCalled();
-    expect(minio.uploadBuffer).not.toHaveBeenCalled();
+    expect(minio.uploadBufferIfAbsentWithMetadata).not.toHaveBeenCalled();
     expect(minio.uploadBufferIfAbsent).not.toHaveBeenCalled();
     expect(prisma.file.create).not.toHaveBeenCalled();
   });
@@ -1590,7 +1608,7 @@ describe('PaymentReceiptService', () => {
     expect(prisma.file.create).not.toHaveBeenCalled();
     expect(prisma.document.create).not.toHaveBeenCalled();
     expect(prisma.paymentAuditLog.create).not.toHaveBeenCalled();
-    expect(minio.uploadBuffer).not.toHaveBeenCalled();
+    expect(minio.uploadBufferIfAbsentWithMetadata).not.toHaveBeenCalled();
   });
 
   it('fails closed when a READY snapshot-backed receipt lacks its issuance timestamp', async () => {
@@ -1769,6 +1787,7 @@ describe('PaymentReceiptService', () => {
       mimeType: 'application/octet-stream',
       size: 1,
       checksum: 'stale-checksum',
+      objectVersionId: 'receipt-version-existing',
     });
     minio.objectExists.mockResolvedValue(true);
     minio.statObject.mockResolvedValue({ size: canonicalPdf.length });
@@ -1785,6 +1804,73 @@ describe('PaymentReceiptService', () => {
         mimeType: 'application/pdf',
         size: canonicalPdf.length,
         checksum: createHash('sha256').update(canonicalPdf).digest('hex'),
+      },
+    });
+    expect(prisma.file.updateMany.mock.calls[0][0].data.objectVersionId).toBeUndefined();
+  });
+
+  it('persists the exact VersionId when reconciling an existing File after creating its missing object', async () => {
+    const payment = readyReceiptPayment({ receiptStatus: ReceiptStatus.PENDING });
+    const generateReceiptPDF = Reflect.get(service, 'generateReceiptPDF') as (
+      payment: unknown,
+      receiptNumber: string,
+      approvedByUserName: string,
+      tenantDisplayName: string,
+    ) => Promise<Buffer>;
+    const canonicalPdf = await generateReceiptPDF.call(
+      service,
+      payment,
+      'R-COMPLE-2026-000001',
+      'Admin',
+      'Complejo Horizonte',
+    );
+    const snapshot = Reflect.get(service, 'createReceiptSnapshot') as (
+      payment: unknown,
+      receiptNumber: string,
+      tenantDisplayName: string,
+      approvedByUserName: string,
+      createdAt: Date,
+    ) => unknown;
+    const hashSnapshot = Reflect.get(service, 'hashReceiptSnapshot') as (
+      snapshotValue: unknown,
+    ) => string;
+    const receiptSnapshot = snapshot.call(
+      service,
+      payment,
+      'R-COMPLE-2026-000001',
+      'Complejo Horizonte',
+      'Admin',
+      new Date('2026-08-31T00:00:00.000Z'),
+    );
+    configureExistingReadyReceipt({
+      receiptStatus: ReceiptStatus.PENDING,
+      receiptSnapshot,
+      receiptSnapshotVersion: 'PAYMENT_RECEIPT_V1',
+      receiptSnapshotHash: hashSnapshot.call(service, receiptSnapshot),
+      receiptSnapshotCreatedAt: new Date('2026-08-31T00:00:00.000Z'),
+    }, {
+      objectVersionId: 'receipt-version-old',
+    });
+    minio.objectExists.mockResolvedValue(false);
+    minio.uploadBufferIfAbsentWithMetadata.mockResolvedValueOnce({
+      etag: 'receipt-etag-new',
+      versionId: 'receipt-version-new',
+    });
+    minio.statObject.mockResolvedValue({ size: canonicalPdf.length });
+    minio.getObjectBuffer.mockResolvedValue(canonicalPdf);
+
+    const result = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
+
+    expect(result?.receiptNumber).toBe('R-COMPLE-2026-000001');
+    expect(prisma.file.updateMany).toHaveBeenCalledWith({
+      where: { id: 'file-1', tenantId: 'tenant-1' },
+      data: {
+        bucket: DEFAULT_BUCKET,
+        objectKey: canonicalReceiptKey(),
+        mimeType: 'application/pdf',
+        size: canonicalPdf.length,
+        checksum: createHash('sha256').update(canonicalPdf).digest('hex'),
+        objectVersionId: 'receipt-version-new',
       },
     });
   });
@@ -1859,8 +1945,9 @@ describe('PaymentReceiptService', () => {
     );
 
     expect(result?.receiptNumber).toBe("R-COMPLE-2026-000001");
-    expect(minio.uploadBuffer).not.toHaveBeenCalled();
+    expect(minio.uploadBufferIfAbsentWithMetadata).not.toHaveBeenCalled();
     expect(prisma.file.create).toHaveBeenCalledTimes(1);
+    expect(prisma.file.create.mock.calls[0][0].data.objectVersionId).toBeUndefined();
     expect(prisma.document.create).toHaveBeenCalledTimes(1);
   });
 
@@ -2141,12 +2228,9 @@ describe('PaymentReceiptService', () => {
     expect(prisma.payment.update).not.toHaveBeenCalled();
   });
 
-  it('validates the winner after a conditional canonical object-create race', async () => {
+  it('fails closed when a conditional canonical object-create race returns no identity', async () => {
     const pdf = Buffer.from('%PDF-race-winner');
-    minio.objectExists.mockResolvedValueOnce(false);
-    minio.uploadBufferIfAbsent.mockResolvedValueOnce(false);
-    minio.statObject.mockResolvedValueOnce({ size: pdf.length });
-    minio.getObjectBuffer.mockResolvedValueOnce(pdf);
+    minio.uploadBufferIfAbsentWithMetadata.mockResolvedValueOnce(null);
     const ensureStorage = Reflect.get(service, 'ensureReceiptStorageObject') as (
       bucket: string,
       fileKey: string,
@@ -2155,17 +2239,13 @@ describe('PaymentReceiptService', () => {
 
     await expect(
       ensureStorage.call(service, DEFAULT_BUCKET, 'tenant-1/race.pdf', pdf),
-    ).resolves.toEqual(expect.objectContaining({
-      objectKey: 'tenant-1/race.pdf',
-      size: pdf.length,
-    }));
-    expect(minio.uploadBufferIfAbsent).toHaveBeenCalledWith(
+    ).rejects.toThrow('already exists without a VersionId claim');
+    expect(minio.uploadBufferIfAbsentWithMetadata).toHaveBeenCalledWith(
       DEFAULT_BUCKET,
       'tenant-1/race.pdf',
       pdf,
       'application/pdf',
     );
-    expect(minio.uploadBuffer).not.toHaveBeenCalled();
   });
 
   it('marks the heartbeat lost when the database no longer recognizes its lease', async () => {

--- a/apps/api/src/receipts/payment-receipt.service.spec.ts
+++ b/apps/api/src/receipts/payment-receipt.service.spec.ts
@@ -492,6 +492,7 @@ describe('PaymentReceiptService', () => {
       DEFAULT_BUCKET,
       expect.stringContaining('/receipts/R-'),
       3600,
+      'receipt-version-1',
     );
     expect(result?.fileKey).toContain('/receipts/R-');
   });
@@ -1246,6 +1247,12 @@ describe('PaymentReceiptService', () => {
     expect(prisma.file.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({ objectVersionId: 'legacy-version-1' }),
     }));
+    expect(minio.presignDownload).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      canonicalReceiptKey(),
+      3600,
+      'legacy-version-1',
+    );
   });
 
   it("atomically takes over an expired orphan recovery claim", async () => {
@@ -1278,6 +1285,11 @@ describe('PaymentReceiptService', () => {
     expect(defaultPaymentState.receiptGeneratedAt).toEqual(lastModified);
     expect(prisma.file.create).toHaveBeenCalledTimes(1);
     expect(prisma.document.create).toHaveBeenCalledTimes(1);
+    expect(minio.presignDownload).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      canonicalReceiptKey(),
+      3600,
+    );
     expect(prisma.paymentAuditLog.create).toHaveBeenCalledTimes(1);
     expect(prisma.payment.updateMany).toHaveBeenNthCalledWith(
       1,
@@ -1570,16 +1582,37 @@ describe('PaymentReceiptService', () => {
     configureExistingReadyReceipt({}, {
       size: validPdf.length,
       checksum,
+      objectVersionId: 'receipt-version-1',
     });
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: validPdf.length });
-    minio.getObjectBuffer.mockResolvedValue(validPdf);
+    minio.statObject.mockImplementation(async (_bucket, _key, versionId) => {
+      expect(versionId).toBe('receipt-version-1');
+      return { size: validPdf.length, versionId: 'receipt-version-1' };
+    });
+    minio.getObjectBuffer.mockImplementation(async (_bucket, _key, versionId) => {
+      expect(versionId).toBe('receipt-version-1');
+      return validPdf;
+    });
 
     const first = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
     const second = await service.ensureReceiptForPayment('tenant-1', 'payment-1');
 
     expect(first).toEqual(second);
     expect(minio.presignDownload).toHaveBeenCalledTimes(2);
+    expect(minio.presignDownload).toHaveBeenNthCalledWith(
+      1,
+      DEFAULT_BUCKET,
+      canonicalReceiptKey(),
+      3600,
+      'receipt-version-1',
+    );
+    expect(minio.presignDownload).toHaveBeenNthCalledWith(
+      2,
+      DEFAULT_BUCKET,
+      canonicalReceiptKey(),
+      3600,
+      'receipt-version-1',
+    );
     expect(minio.uploadBuffer).not.toHaveBeenCalled();
     expect(prisma.file.updateMany).not.toHaveBeenCalled();
     expect(prisma.paymentAuditLog.create).not.toHaveBeenCalled();
@@ -2001,6 +2034,11 @@ describe('PaymentReceiptService', () => {
     expect(prisma.file.create).toHaveBeenCalledTimes(1);
     expect(prisma.file.create.mock.calls[0][0].data.objectVersionId).toBeUndefined();
     expect(prisma.document.create).toHaveBeenCalledTimes(1);
+    expect(minio.presignDownload).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      canonicalReceiptKey(),
+      3600,
+    );
   });
 
   it("recovers after storage succeeds but DB finalization fails, reusing the number and object", async () => {
@@ -2091,6 +2129,12 @@ describe('PaymentReceiptService', () => {
     expect(minio.getObjectBuffer).toHaveBeenCalledWith(
       DEFAULT_BUCKET,
       expect.stringContaining('/receipts/R-'),
+      'receipt-version-1',
+    );
+    expect(minio.presignDownload).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      expect.stringContaining('/receipts/R-'),
+      3600,
       'receipt-version-1',
     );
   });
@@ -2271,11 +2315,18 @@ describe('PaymentReceiptService', () => {
       receiptDocument({
         size: validPdf.length,
         checksum: createHash('sha256').update(validPdf).digest('hex'),
+        objectVersionId: 'receipt-version-1',
       }) as never,
     );
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: validPdf.length });
-    minio.getObjectBuffer.mockResolvedValue(validPdf);
+    minio.statObject.mockImplementation(async (_bucket, _key, versionId) => {
+      expect(versionId).toBe('receipt-version-1');
+      return { size: validPdf.length, versionId: 'receipt-version-1' };
+    });
+    minio.getObjectBuffer.mockImplementation(async (_bucket, _key, versionId) => {
+      expect(versionId).toBe('receipt-version-1');
+      return validPdf;
+    });
 
     const waitForReceiptGeneration = Reflect.get(
       service,
@@ -2295,6 +2346,12 @@ describe('PaymentReceiptService', () => {
     );
     expect(prisma.payment.updateMany).not.toHaveBeenCalled();
     expect(prisma.payment.update).not.toHaveBeenCalled();
+    expect(minio.presignDownload).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      canonicalReceiptKey(),
+      3600,
+      'receipt-version-1',
+    );
   });
 
   it('validates an existing object through the VersionId returned by stat', async () => {

--- a/apps/api/src/receipts/payment-receipt.service.ts
+++ b/apps/api/src/receipts/payment-receipt.service.ts
@@ -147,6 +147,7 @@ interface ReceiptFileArtifact {
   readonly size: number;
   readonly mimeType: string;
   readonly checksum: string | null;
+  readonly objectVersionId?: string | null;
 }
 
 interface ReceiptStorageMetadata {
@@ -342,6 +343,7 @@ export class PaymentReceiptService {
           preparedReceipt.bucket,
           preparedReceipt.fileKey,
           pdfContent,
+          preparedReceipt.existingFile?.objectVersionId,
         );
         heartbeat.assertOwned();
         finalizedReceipt = await this.finalizeReceipt(
@@ -1066,6 +1068,9 @@ export class PaymentReceiptService {
           mimeType: RECEIPT_MIME_TYPE,
           size: storageMetadata.size,
           checksum: storageMetadata.checksum,
+          ...(storageMetadata.versionId
+            ? { objectVersionId: storageMetadata.versionId }
+            : {}),
         },
       });
       const document = await tx.document.create({
@@ -1227,6 +1232,7 @@ export class PaymentReceiptService {
           currentPayment.tenantId,
           existingDocument.file.id,
           storageMetadata,
+          existingDocument.file.objectVersionId,
         );
       } else {
         if (storageMetadata.createdByCurrentProcess && !storageMetadata.versionId) {
@@ -1916,14 +1922,16 @@ export class PaymentReceiptService {
     if (!(await this.minio.objectExists(file.bucket, file.objectKey))) {
       return false;
     }
-    const stat = await this.minio.statObject(file.bucket, file.objectKey);
+    const stat = file.objectVersionId
+      ? await this.minio.statObject(file.bucket, file.objectKey, file.objectVersionId)
+      : await this.minio.statObject(file.bucket, file.objectKey);
     if (!this.isValidReceiptObjectStat(stat, file.size)) {
       return false;
     }
-    const content = await this.minio.getObjectBuffer(
-      file.bucket,
-      file.objectKey,
-    );
+    const versionId = stat.versionId ?? file.objectVersionId ?? undefined;
+    const content = versionId
+      ? await this.minio.getObjectBuffer(file.bucket, file.objectKey, versionId)
+      : await this.minio.getObjectBuffer(file.bucket, file.objectKey);
     return (
       this.isPdfContent(content) &&
       content.length === stat.size &&
@@ -1941,6 +1949,7 @@ export class PaymentReceiptService {
       );
     }
     const beforeRead = await this.minio.statObject(bucket, fileKey);
+    const versionId = beforeRead.versionId ?? undefined;
     const beforeReadContentType =
       beforeRead.metaData?.["content-type"] ??
       beforeRead.metaData?.["Content-Type"];
@@ -1953,7 +1962,9 @@ export class PaymentReceiptService {
         `Legacy receipt storage object metadata is invalid for ${bucket}/${fileKey}`,
       );
     }
-    const content = await this.minio.getObjectBuffer(bucket, fileKey);
+    const content = versionId
+      ? await this.minio.getObjectBuffer(bucket, fileKey, versionId)
+      : await this.minio.getObjectBuffer(bucket, fileKey);
     if (
       !this.isPdfContent(content) ||
       content.length !== beforeRead.size ||
@@ -1963,7 +1974,9 @@ export class PaymentReceiptService {
         `Legacy receipt storage object content is invalid for ${bucket}/${fileKey}`,
       );
     }
-    const afterRead = await this.minio.statObject(bucket, fileKey);
+    const afterRead = versionId
+      ? await this.minio.statObject(bucket, fileKey, versionId)
+      : await this.minio.statObject(bucket, fileKey);
     const afterReadContentType =
       afterRead.metaData?.["content-type"] ??
       afterRead.metaData?.["Content-Type"];
@@ -1974,6 +1987,7 @@ export class PaymentReceiptService {
       beforeRead.size !== afterRead.size ||
       beforeRead.lastModified.getTime() !== afterRead.lastModified.getTime() ||
       beforeRead.etag !== afterRead.etag
+      || (versionId && afterRead.versionId && afterRead.versionId !== versionId)
     ) {
       throw new ReceiptConsistencyError(
         `Legacy receipt storage object changed during recovery for ${bucket}/${fileKey}`,
@@ -1987,6 +2001,7 @@ export class PaymentReceiptService {
       size: content.length,
       checksum: this.sha256(content),
       etag: afterRead.etag,
+      versionId: afterRead.versionId ?? versionId,
       createdByCurrentProcess: false,
       lastModified: afterRead.lastModified,
     };
@@ -1996,6 +2011,7 @@ export class PaymentReceiptService {
     bucket: string,
     fileKey: string,
     pdfContent: Buffer,
+    expectedVersionId?: string | null,
   ): Promise<ReceiptStorageMetadata> {
     if (!this.isPdfContent(pdfContent) || pdfContent.length > MAX_RECEIPT_OBJECT_BYTES) {
       throw new Error(`Generated receipt PDF exceeds the supported storage contract`);
@@ -2025,13 +2041,20 @@ export class PaymentReceiptService {
       versionId = uploadResult.versionId;
       createdByCurrentProcess = true;
     }
-    const stat = await this.minio.statObject(bucket, fileKey);
+    const stat = versionId
+      ? await this.minio.statObject(bucket, fileKey, versionId)
+      : expectedVersionId
+        ? await this.minio.statObject(bucket, fileKey, expectedVersionId)
+        : await this.minio.statObject(bucket, fileKey);
     if (!this.isValidReceiptObjectStat(stat, pdfContent.length)) {
       throw new ReceiptConsistencyError(
         `Receipt storage object metadata mismatch for ${bucket}/${fileKey}`,
       );
     }
-    const storedContent = await this.minio.getObjectBuffer(bucket, fileKey);
+    const validatedVersionId = stat.versionId ?? versionId ?? expectedVersionId ?? undefined;
+    const storedContent = validatedVersionId
+      ? await this.minio.getObjectBuffer(bucket, fileKey, validatedVersionId)
+      : await this.minio.getObjectBuffer(bucket, fileKey);
     if (
       !this.isPdfContent(storedContent) ||
       storedContent.length !== stat.size ||
@@ -2047,7 +2070,7 @@ export class PaymentReceiptService {
       mimeType: RECEIPT_MIME_TYPE,
       size: storedContent.length,
       checksum: this.sha256(storedContent),
-      versionId,
+      versionId: validatedVersionId,
       createdByCurrentProcess,
     };
 
@@ -2075,6 +2098,7 @@ export class PaymentReceiptService {
     tenantId: string,
     fileId: string,
     metadata: ReceiptStorageMetadata,
+    existingVersionId?: string | null,
   ): Promise<void> {
     const result = await tx.file.updateMany({
       where: { id: fileId, tenantId },
@@ -2084,7 +2108,7 @@ export class PaymentReceiptService {
         mimeType: metadata.mimeType,
         size: metadata.size,
         checksum: metadata.checksum,
-        ...(metadata.createdByCurrentProcess && metadata.versionId
+        ...(metadata.versionId && (metadata.createdByCurrentProcess || !existingVersionId)
           ? { objectVersionId: metadata.versionId }
           : {}),
       },

--- a/apps/api/src/receipts/payment-receipt.service.ts
+++ b/apps/api/src/receipts/payment-receipt.service.ts
@@ -156,6 +156,8 @@ interface ReceiptStorageMetadata {
   readonly size: number;
   readonly checksum: string;
   readonly etag?: string;
+  readonly versionId?: string;
+  readonly createdByCurrentProcess: boolean;
   readonly lastModified?: Date;
 }
 
@@ -1227,6 +1229,11 @@ export class PaymentReceiptService {
           storageMetadata,
         );
       } else {
+        if (storageMetadata.createdByCurrentProcess && !storageMetadata.versionId) {
+          throw new ReceiptConsistencyError(
+            `Receipt storage object has no provider VersionId for ${this.bucket}/${fileKey}`,
+          );
+        }
         const existingFile = await tx.file.findFirst({
           where: {
             tenantId: currentPayment.tenantId,
@@ -1245,6 +1252,9 @@ export class PaymentReceiptService {
             tenantId: currentPayment.tenantId,
             bucket: this.bucket,
             objectKey: fileKey,
+            ...(storageMetadata.versionId
+              ? { objectVersionId: storageMetadata.versionId }
+              : {}),
             originalName: `receipt_${preparedReceipt.receiptNumber}.pdf`,
             mimeType: RECEIPT_MIME_TYPE,
             size: storageMetadata.size,
@@ -1977,6 +1987,7 @@ export class PaymentReceiptService {
       size: content.length,
       checksum: this.sha256(content),
       etag: afterRead.etag,
+      createdByCurrentProcess: false,
       lastModified: afterRead.lastModified,
     };
   }
@@ -1990,15 +2001,29 @@ export class PaymentReceiptService {
       throw new Error(`Generated receipt PDF exceeds the supported storage contract`);
     }
 
-    // Conditional creation prevents a racing worker from replacing a
-    // canonical receipt object after it has been written.
+    let versionId: string | undefined;
+    let createdByCurrentProcess = false;
     if (!(await this.minio.objectExists(bucket, fileKey))) {
-      await this.minio.uploadBufferIfAbsent(
+      // Conditional creation prevents a racing worker from replacing a
+      // canonical receipt object after it has been written.
+      const uploadResult = await this.minio.uploadBufferIfAbsentWithMetadata(
         bucket,
         fileKey,
         pdfContent,
         RECEIPT_MIME_TYPE,
       );
+      if (!uploadResult) {
+        throw new ReceiptConsistencyError(
+          `Receipt storage object already exists without a VersionId claim for ${bucket}/${fileKey}`,
+        );
+      }
+      if (!uploadResult.versionId) {
+        throw new ReceiptConsistencyError(
+          `Receipt storage provider did not return a VersionId for ${bucket}/${fileKey}`,
+        );
+      }
+      versionId = uploadResult.versionId;
+      createdByCurrentProcess = true;
     }
     const stat = await this.minio.statObject(bucket, fileKey);
     if (!this.isValidReceiptObjectStat(stat, pdfContent.length)) {
@@ -2022,6 +2047,8 @@ export class PaymentReceiptService {
       mimeType: RECEIPT_MIME_TYPE,
       size: storedContent.length,
       checksum: this.sha256(storedContent),
+      versionId,
+      createdByCurrentProcess,
     };
 
   }
@@ -2057,6 +2084,9 @@ export class PaymentReceiptService {
         mimeType: metadata.mimeType,
         size: metadata.size,
         checksum: metadata.checksum,
+        ...(metadata.createdByCurrentProcess && metadata.versionId
+          ? { objectVersionId: metadata.versionId }
+          : {}),
       },
     });
     if (result.count !== 1) {

--- a/apps/api/src/receipts/payment-receipt.service.ts
+++ b/apps/api/src/receipts/payment-receipt.service.ts
@@ -135,6 +135,7 @@ type ReceiptPreparation =
 
 interface FinalizedReceipt extends PreparedReceiptGeneration {
   documentId: string;
+  objectVersionId?: string | null;
   wasGenerated: boolean;
   shouldNotify: boolean;
 }
@@ -295,10 +296,10 @@ export class PaymentReceiptService {
           documentId: finalizedReceipt.documentId,
           fileKey: finalizedReceipt.fileKey,
           bucket: finalizedReceipt.bucket,
-          url: await this.minio.presignDownload(
+          url: await this.presignReceiptDownload(
             finalizedReceipt.bucket,
             finalizedReceipt.fileKey,
-            3600,
+            finalizedReceipt.objectVersionId,
           ),
         };
       }
@@ -313,7 +314,11 @@ export class PaymentReceiptService {
             `Legacy receipt ${preparedReceipt.receiptNumber} has no trustworthy snapshot or complete artifact`,
           );
         }
-        const url = await this.minio.presignDownload(preparedReceipt.bucket, preparedReceipt.fileKey, 3600);
+        const url = await this.presignReceiptDownload(
+          preparedReceipt.bucket,
+          preparedReceipt.fileKey,
+          preparedReceipt.existingFile.objectVersionId,
+        );
 
         return {
           receiptNumber: preparedReceipt.receiptNumber,
@@ -357,7 +362,11 @@ export class PaymentReceiptService {
         await heartbeat.stop();
       }
 
-      const url = await this.minio.presignDownload(finalizedReceipt.bucket, finalizedReceipt.fileKey, 3600);
+      const url = await this.presignReceiptDownload(
+        finalizedReceipt.bucket,
+        finalizedReceipt.fileKey,
+        finalizedReceipt.objectVersionId,
+      );
 
       if (finalizedReceipt.shouldNotify) {
         // Receipt persistence is authoritative; delivery remains best-effort outside the transaction.
@@ -1132,6 +1141,7 @@ export class PaymentReceiptService {
         ...preparedReceipt,
         payment: currentPayment,
         documentId: document.id,
+        objectVersionId: storageMetadata.versionId ?? null,
         wasGenerated: false,
         shouldNotify: false,
       };
@@ -1337,6 +1347,8 @@ export class PaymentReceiptService {
         payment: currentPayment,
         snapshot,
         documentId,
+        objectVersionId:
+          storageMetadata.versionId ?? existingDocument?.file.objectVersionId ?? null,
         wasGenerated: !auditExists,
       };
     });
@@ -1812,10 +1824,10 @@ export class PaymentReceiptService {
     }
     this.getVerifiedReceiptSnapshot(payment);
 
-    const url = await this.minio.presignDownload(
+    const url = await this.presignReceiptDownload(
       document.file.bucket,
       document.file.objectKey,
-      3600,
+      document.file.objectVersionId,
     );
     return {
       receiptNumber: payment.receiptNumber,
@@ -1824,6 +1836,21 @@ export class PaymentReceiptService {
       bucket: document.file.bucket,
       url,
     };
+  }
+
+  private async presignReceiptDownload(
+    bucket: string,
+    objectKey: string,
+    objectVersionId?: string | null,
+  ): Promise<string> {
+    return objectVersionId
+      ? this.minio.presignDownload(
+          bucket,
+          objectKey,
+          3600,
+          objectVersionId,
+        )
+      : this.minio.presignDownload(bucket, objectKey, 3600);
   }
 
   private hashJsonValue(value: unknown): string {

--- a/apps/api/src/storage/minio.service.spec.ts
+++ b/apps/api/src/storage/minio.service.spec.ts
@@ -160,6 +160,49 @@ describe('MinioService', () => {
     );
   });
 
+  it('passes an exact version id to stream reads when requested', async () => {
+    const internalClient = createClientMock();
+    const publicClient = createClientMock();
+    const stream = Readable.from([Buffer.from('%PDF-versioned')]);
+    internalClient.getObject.mockResolvedValue(stream);
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => publicClient);
+
+    const service = new MinioService(createConfig());
+
+    await expect(
+      service.getObjectStream('buildingos-staging', 'tenant-a/proof.pdf', 'version-1'),
+    ).resolves.toBe(stream);
+
+    expect(internalClient.getObject).toHaveBeenCalledWith(
+      'buildingos-staging',
+      'tenant-a/proof.pdf',
+      { versionId: 'version-1' },
+    );
+  });
+
+  it('keeps stream reads unversioned when no version id is provided', async () => {
+    const internalClient = createClientMock();
+    const publicClient = createClientMock();
+    const stream = Readable.from([Buffer.from('%PDF-legacy')]);
+    internalClient.getObject.mockResolvedValue(stream);
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => publicClient);
+
+    const service = new MinioService(createConfig());
+
+    await expect(
+      service.getObjectStream('buildingos-staging', 'tenant-a/proof.pdf'),
+    ).resolves.toBe(stream);
+
+    expect(internalClient.getObject).toHaveBeenCalledWith(
+      'buildingos-staging',
+      'tenant-a/proof.pdf',
+    );
+  });
+
   it('creates an object conditionally and treats an existing key as a non-create', async () => {
     const internalClient = createClientMock();
     const publicClient = createClientMock();

--- a/apps/api/src/storage/minio.service.spec.ts
+++ b/apps/api/src/storage/minio.service.spec.ts
@@ -1,6 +1,7 @@
 import { ConfigService } from '../config/config.service';
 import { MinioService } from './minio.service';
 import * as Minio from 'minio';
+import { Readable } from 'node:stream';
 
 jest.mock('minio', () => ({
   Client: jest.fn(),
@@ -8,6 +9,7 @@ jest.mock('minio', () => ({
 
 interface ClientMock {
   readonly statObject: jest.Mock;
+  readonly getObject: jest.Mock;
   readonly putObject: jest.Mock;
   readonly presignedPutObject: jest.Mock;
   readonly presignedGetObject: jest.Mock;
@@ -18,6 +20,7 @@ const minioClientConstructor = Minio.Client as unknown as jest.Mock;
 function createClientMock(): ClientMock {
   return {
     statObject: jest.fn(),
+    getObject: jest.fn(),
     putObject: jest.fn(),
     presignedPutObject: jest.fn(),
     presignedGetObject: jest.fn(),
@@ -97,6 +100,38 @@ describe('MinioService', () => {
       'buildingos-staging',
       'tenant-a/proof.pdf',
       3600,
+    );
+  });
+
+  it('passes an exact version id to stat and buffer reads when requested', async () => {
+    const internalClient = createClientMock();
+    const publicClient = createClientMock();
+    const content = Buffer.from('%PDF-versioned');
+    internalClient.statObject.mockResolvedValue({
+      size: content.length,
+      versionId: 'version-1',
+    });
+    internalClient.getObject.mockResolvedValue(Readable.from([content]));
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => publicClient);
+
+    const service = new MinioService(createConfig());
+
+    await expect(service.statObject('buildingos-staging', 'tenant-a/proof.pdf', 'version-1'))
+      .resolves.toEqual({ size: content.length, versionId: 'version-1' });
+    await expect(service.getObjectBuffer('buildingos-staging', 'tenant-a/proof.pdf', 'version-1'))
+      .resolves.toEqual(content);
+
+    expect(internalClient.statObject).toHaveBeenCalledWith(
+      'buildingos-staging',
+      'tenant-a/proof.pdf',
+      { versionId: 'version-1' },
+    );
+    expect(internalClient.getObject).toHaveBeenCalledWith(
+      'buildingos-staging',
+      'tenant-a/proof.pdf',
+      { versionId: 'version-1' },
     );
   });
 

--- a/apps/api/src/storage/minio.service.spec.ts
+++ b/apps/api/src/storage/minio.service.spec.ts
@@ -103,6 +103,31 @@ describe('MinioService', () => {
     );
   });
 
+  it('binds a presigned download URL to an exact object version when requested', async () => {
+    const internalClient = createClientMock();
+    const publicClient = createClientMock();
+    publicClient.presignedGetObject.mockResolvedValue('https://download.example/proof.pdf');
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => publicClient);
+
+    const service = new MinioService(createConfig());
+
+    await service.presignDownload(
+      'buildingos-staging',
+      'tenant-a/proof.pdf',
+      3600,
+      'version-1',
+    );
+
+    expect(publicClient.presignedGetObject).toHaveBeenCalledWith(
+      'buildingos-staging',
+      'tenant-a/proof.pdf',
+      3600,
+      { versionId: 'version-1' },
+    );
+  });
+
   it('passes an exact version id to stat and buffer reads when requested', async () => {
     const internalClient = createClientMock();
     const publicClient = createClientMock();

--- a/apps/api/src/storage/minio.service.ts
+++ b/apps/api/src/storage/minio.service.ts
@@ -424,9 +424,12 @@ export class MinioService {
   async getObjectStream(
     bucketName: string = this.bucket,
     objectKey: string,
+    versionId?: string,
   ): Promise<Readable> {
     try {
-      return await this.minioClient.getObject(bucketName, objectKey);
+      return versionId
+        ? await this.minioClient.getObject(bucketName, objectKey, { versionId })
+        : await this.minioClient.getObject(bucketName, objectKey);
     } catch (error: unknown) {
       this.logger.error(
         `Failed to open object stream: ${this.getErrorMessage(error)}`,

--- a/apps/api/src/storage/minio.service.ts
+++ b/apps/api/src/storage/minio.service.ts
@@ -15,6 +15,7 @@ export interface MinioObjectStat {
   etag?: string;
   lastModified?: Date;
   metaData?: Record<string, string>;
+  versionId?: string | null;
 }
 
 export interface MinioUploadResult {
@@ -215,9 +216,13 @@ export class MinioService {
   async statObject(
     bucketName: string = this.bucket,
     objectKey: string,
+    versionId?: string,
   ): Promise<MinioObjectStat> {
     try {
-      return await this.minioClient.statObject(bucketName, objectKey) as MinioObjectStat;
+      const stat = versionId
+        ? await this.minioClient.statObject(bucketName, objectKey, { versionId })
+        : await this.minioClient.statObject(bucketName, objectKey);
+      return stat as MinioObjectStat;
     } catch (error: unknown) {
       this.logger.error(
         `Failed to stat object: ${this.getErrorMessage(error)}`,
@@ -370,9 +375,12 @@ export class MinioService {
   async getObjectBuffer(
     bucketName: string = this.bucket,
     objectKey: string,
+    versionId?: string,
   ): Promise<Buffer> {
     try {
-      const stream = await this.minioClient.getObject(bucketName, objectKey);
+      const stream = versionId
+        ? await this.minioClient.getObject(bucketName, objectKey, { versionId })
+        : await this.minioClient.getObject(bucketName, objectKey);
       const chunks: Buffer[] = [];
 
       return await new Promise<Buffer>((resolve, reject) => {

--- a/apps/api/src/storage/minio.service.ts
+++ b/apps/api/src/storage/minio.service.ts
@@ -178,6 +178,7 @@ export class MinioService {
    * @param bucketName - Bucket name (or undefined to use default)
    * @param objectKey - Object path in bucket
    * @param expirySeconds - URL expiration time in seconds (default: 1 hour = 3600s)
+   * @param versionId - Optional exact object version to bind to the URL
    * @returns Presigned URL for GET request
    *
    * @example
@@ -189,13 +190,21 @@ export class MinioService {
     bucketName: string = this.bucket,
     objectKey: string,
     expirySeconds: number = 3600,
+    versionId?: string,
   ): Promise<string> {
     try {
-      const url = await this.presignClient.presignedGetObject(
-        bucketName,
-        objectKey,
-        expirySeconds,
-      );
+      const url = versionId
+        ? await this.presignClient.presignedGetObject(
+            bucketName,
+            objectKey,
+            expirySeconds,
+            { versionId },
+          )
+        : await this.presignClient.presignedGetObject(
+            bucketName,
+            objectKey,
+            expirySeconds,
+          );
       this.logger.debug(`Generated presigned GET URL for ${bucketName}/${objectKey}`);
       return url;
     } catch (error) {

--- a/infra/docker/.env.production.example
+++ b/infra/docker/.env.production.example
@@ -6,6 +6,7 @@ API_ENV_FILE=/opt/pawtech/env/buildingos.env
 WEB_ENV_FILE=/opt/pawtech/env/buildingos-web.env
 
 # API runtime storage contract. Values are design-only placeholders.
+# The configured bucket must have S3 object versioning enabled for exact object-version identity.
 S3_ENDPOINT=https://usc1.contabostorage.com
 S3_REGION=default
 S3_ACCESS_KEY=replace-with-production-storage-access-key

--- a/infra/docker/.env.staging.example
+++ b/infra/docker/.env.staging.example
@@ -34,6 +34,7 @@ JWT_SECRET=REPLACE_WITH_STAGING_JWT_SECRET_64_CHARS_MINIMUM
 JWT_EXPIRES_IN=24h
 
 # --- Storage / External S3 ---
+# The configured bucket must have S3 object versioning enabled for exact object-version identity.
 S3_ENDPOINT=https://REPLACE_WITH_STAGING_S3_ENDPOINT
 S3_REGION=REPLACE_WITH_STAGING_S3_REGION
 S3_ACCESS_KEY=REPLACE_WITH_STAGING_S3_ACCESS_KEY

--- a/infra/docker/docker-compose.release-staging.yml
+++ b/infra/docker/docker-compose.release-staging.yml
@@ -95,9 +95,9 @@ services:
       - /bin/sh
       - -c
       - >
-        mc alias set myminio http://minio:9000 ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required} ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required};
-        mc mb --ignore-existing myminio/${S3_BUCKET:?S3_BUCKET is required};
-        exit 0;
+        mc alias set myminio http://minio:9000 ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required} ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required} &&
+        mc mb --ignore-existing myminio/${S3_BUCKET:?S3_BUCKET is required} &&
+        mc version enable myminio/${S3_BUCKET:?S3_BUCKET is required}
     restart: on-failure
 
   mailpit:

--- a/infra/docker/docker-compose.yml
+++ b/infra/docker/docker-compose.yml
@@ -76,9 +76,9 @@ services:
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required}
     entrypoint: >
       /bin/sh -c "
-      mc alias set myminio http://minio:9000 ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required} ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required};
-      mc mb --ignore-existing myminio/${S3_BUCKET:?S3_BUCKET is required};
-      exit 0;
+      mc alias set myminio http://minio:9000 ${MINIO_ROOT_USER:?MINIO_ROOT_USER is required} ${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required} &&
+      mc mb --ignore-existing myminio/${S3_BUCKET:?S3_BUCKET is required} &&
+      mc version enable myminio/${S3_BUCKET:?S3_BUCKET is required}
       "
     restart: on-failure
 

--- a/scripts/tests/production-compose-storage.test.sh
+++ b/scripts/tests/production-compose-storage.test.sh
@@ -3,11 +3,13 @@ set -Eeuo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 readonly COMPOSE_FILE="$ROOT_DIR/infra/docker/docker-compose.production.yml"
+readonly RELEASE_STAGING_COMPOSE_FILE="$ROOT_DIR/infra/docker/docker-compose.release-staging.yml"
 readonly TEST_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/buildingos-production-compose.XXXXXX")"
 trap 'rm -rf "$TEST_ROOT"' EXIT
 
 readonly API_ENV_FILE="$TEST_ROOT/api.env"
 readonly WEB_ENV_FILE="$TEST_ROOT/web.env"
+readonly RELEASE_STAGING_ENV_FILE="$TEST_ROOT/release-staging.env"
 printf '%s\n' 'APP_ENV=production' > "$API_ENV_FILE"
 printf '%s\n' 'APP_ENV=production' > "$WEB_ENV_FILE"
 
@@ -48,3 +50,35 @@ run_config_case() {
 run_config_case 'MINIO runtime env renders without MinIO service ownership' http://buildingos-minio:9000
 run_config_case 'EXTERNAL S3 runtime env renders without MinIO-specific variables' https://usc1.contabostorage.com
 printf 'PASS: production Compose storage topology and controlled env rendering\n'
+
+printf '%s\n' \
+  'POSTGRES_USER=buildingos' \
+  'POSTGRES_PASSWORD=local-password' \
+  'POSTGRES_DB=buildingos_release_staging_test' \
+  'MINIO_ROOT_USER=local-root' \
+  'MINIO_ROOT_PASSWORD=local-password' \
+  'S3_BUCKET=buildingos-release-staging-test' \
+  'NODE_ENV=production' \
+  'REDIS_URL=redis://redis:6379' \
+  'WEB_ORIGIN=https://web.example.invalid' \
+  'APP_BASE_URL=https://web.example.invalid' \
+  'S3_REGION=us-east-1' \
+  'S3_PUBLIC_BASE_URL=https://files.example.invalid' \
+  'JWT_SECRET=local-jwt-secret' \
+  'JWT_EXPIRES_IN=24h' \
+  'MAIL_PROVIDER=none' \
+  'MAIL_FROM=BuildingOS <no-reply@example.invalid>' \
+  'PAYMENT_PROVIDER=none' \
+  'AI_PROVIDER=none' \
+  'FEATURE_PORTAL_RESIDENT=true' \
+  'FEATURE_PAYMENTS_MVP=true' \
+  'LOG_LEVEL=info' \
+  'API_URL=https://api.example.invalid' > "$RELEASE_STAGING_ENV_FILE"
+
+release_staging_rendered="$(docker compose \
+  --project-name buildingos-release-staging-compose-test \
+  --env-file "$RELEASE_STAGING_ENV_FILE" \
+  --file "$RELEASE_STAGING_COMPOSE_FILE" config)"
+[[ "$release_staging_rendered" == *'mc alias set myminio http://minio:9000 local-root local-password && mc mb --ignore-existing myminio/buildingos-release-staging-test && mc version enable myminio/buildingos-release-staging-test'* ]]
+[[ "$release_staging_rendered" != *'exit 0'* ]]
+printf 'PASS: release-staging bucket bootstrap is idempotent and fail-closed with versioning enabled\n'


### PR DESCRIPTION
## Scope

Persists exact provider-issued object VersionId for File-backed payment receipt objects.

### Included

- newly created receipt objects persist exact provider VersionId
- existing File + missing storage object persists VersionId when recreated by the current call
- fail-closed behavior when a newly created object has no VersionId
- legacy/pre-existing objects preserve nullable identity without fabricating VersionId
- known existing objectVersionId is never overwritten with null
- conditional creation race fails closed
- PostgreSQL/MinIO test doubles updated

### Explicitly deferred

- Documents presigned PUT VersionId gap
- ImportJob original/normalized VersionId persistence
- DB<->object reconciliation
- recovery-point validation
- post-PUT/pre-DB orphan identity recovery
- backup/readiness changes
- staging/production changes

### Local validation

- focused tests: 71 PASS
- PostgreSQL integration: 7/7 PASS
- MinIO recovery integration: 4/4 PASS
- test:forbid-only: PASS
- TypeScript: PASS
- ESLint: PASS
- Prisma validate: PASS
- git diff --check: PASS

### Recovery state

DB_OBJECT_REFERENCE_RECONCILIATION=NOT_IMPLEMENTED
DB_OBJECT_CONTENT_IDENTITY=NOT_IMPLEMENTED
RECOVERY_POINT_VALID=NOT_EVALUATED
BACKUP_READINESS=INCOMPLETE