### PR TITLE
fix(documents): reject stale object versions

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -47,6 +47,17 @@ jobs:
           git fetch --no-tags origin main
           git merge-base --is-ancestor "$DEPLOY_SHA" FETCH_HEAD
 
+      - name: Require versioned object storage readiness
+        shell: bash
+        env:
+          STAGING_OBJECT_VERSION_ID_READY: ${{ vars.STAGING_OBJECT_VERSION_ID_READY || '' }}
+        run: |
+          set -Eeuo pipefail
+          if [[ "${STAGING_OBJECT_VERSION_ID_READY,,}" != "true" ]]; then
+            echo "STAGING_OBJECT_VERSION_ID_READY must be explicitly set to true only after staging bucket versioning and x-amz-version-id CORS exposure are independently verified" >&2
+            exit 1
+          fi
+
       - name: Deploy over SSH
         shell: bash
         env:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -92,6 +92,7 @@ jobs:
             --network host \
             -e MINIO_ROOT_USER="$S3_ACCESS_KEY" \
             -e MINIO_ROOT_PASSWORD="$S3_SECRET_KEY" \
+            -e MINIO_API_CORS_ALLOW_ORIGIN="http://localhost:3000" \
             minio/minio:latest \
             server /data --address :9000 --console-address :9001
 
@@ -116,31 +117,13 @@ jobs:
             minio/mc:latest \
             -lc 'mc alias set local http://127.0.0.1:9000 "$S3_ACCESS_KEY" "$S3_SECRET_KEY" && mc mb --ignore-existing "local/$S3_BUCKET" && mc version enable "local/$S3_BUCKET" && version_info="$(mc version info --json "local/$S3_BUCKET")" && printf "%s\\n" "$version_info" && case "$version_info" in *"Enabled"*) echo "MinIO versioning is enabled" ;; *) echo "MinIO versioning is not enabled" >&2; exit 1 ;; esac'
 
-          cors_file="$RUNNER_TEMP/minio-e2e-cors.xml"
-          cat > "$cors_file" <<'EOF'
-          <?xml version="1.0" encoding="UTF-8"?>
-          <CORSConfiguration>
-            <CORSRule>
-              <AllowedOrigin>http://localhost:3000</AllowedOrigin>
-              <AllowedMethod>PUT</AllowedMethod>
-              <AllowedMethod>GET</AllowedMethod>
-              <AllowedMethod>HEAD</AllowedMethod>
-              <AllowedHeader>Content-Type</AllowedHeader>
-              <ExposeHeader>x-amz-version-id</ExposeHeader>
-              <MaxAgeSeconds>3600</MaxAgeSeconds>
-            </CORSRule>
-          </CORSConfiguration>
-          EOF
-
-          docker run --rm \
-            --network host \
-            --entrypoint /bin/sh \
-            -e S3_ACCESS_KEY="$S3_ACCESS_KEY" \
-            -e S3_SECRET_KEY="$S3_SECRET_KEY" \
-            -e S3_BUCKET="$S3_BUCKET" \
-            -v "$cors_file:/tmp/minio-e2e-cors.xml:ro" \
-            minio/mc:latest \
-            -lc 'mc alias set local http://127.0.0.1:9000 "$S3_ACCESS_KEY" "$S3_SECRET_KEY" && mc cors set "local/$S3_BUCKET" /tmp/minio-e2e-cors.xml && cors_info="$(mc cors get "local/$S3_BUCKET")" && printf "%s\\n" "$cors_info" && printf "%s\\n" "$cors_info" | grep -Fq "<ExposeHeader>x-amz-version-id</ExposeHeader>" && echo "MinIO CORS exposes x-amz-version-id"'
+          cors_response="$(curl -sS -D - -o /dev/null \
+            -H "Origin: http://localhost:3000" \
+            "http://127.0.0.1:9000/$S3_BUCKET/")"
+          printf '%s\n' "$cors_response"
+          printf '%s\n' "$cors_response" | grep -Eiq '^access-control-allow-origin:[[:space:]]*http://localhost:3000[[:space:]]*$'
+          printf '%s\n' "$cors_response" | grep -Eiq '^access-control-expose-headers:.*x-amz-version-id'
+          echo "MinIO global CORS exposes x-amz-version-id to http://localhost:3000"
 
       - name: Setup environment
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -114,7 +114,33 @@ jobs:
             -e S3_SECRET_KEY="$S3_SECRET_KEY" \
             -e S3_BUCKET="$S3_BUCKET" \
             minio/mc:latest \
-            -lc 'mc alias set local http://127.0.0.1:9000 "$S3_ACCESS_KEY" "$S3_SECRET_KEY" && mc mb --ignore-existing "local/$S3_BUCKET"'
+            -lc 'mc alias set local http://127.0.0.1:9000 "$S3_ACCESS_KEY" "$S3_SECRET_KEY" && mc mb --ignore-existing "local/$S3_BUCKET" && mc version enable "local/$S3_BUCKET" && version_info="$(mc version info --json "local/$S3_BUCKET")" && printf "%s\\n" "$version_info" && case "$version_info" in *"Enabled"*) echo "MinIO versioning is enabled" ;; *) echo "MinIO versioning is not enabled" >&2; exit 1 ;; esac'
+
+          cors_file="$RUNNER_TEMP/minio-e2e-cors.xml"
+          cat > "$cors_file" <<'EOF'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <CORSConfiguration>
+            <CORSRule>
+              <AllowedOrigin>http://localhost:3000</AllowedOrigin>
+              <AllowedMethod>PUT</AllowedMethod>
+              <AllowedMethod>GET</AllowedMethod>
+              <AllowedMethod>HEAD</AllowedMethod>
+              <AllowedHeader>Content-Type</AllowedHeader>
+              <ExposeHeader>x-amz-version-id</ExposeHeader>
+              <MaxAgeSeconds>3600</MaxAgeSeconds>
+            </CORSRule>
+          </CORSConfiguration>
+          EOF
+
+          docker run --rm \
+            --network host \
+            --entrypoint /bin/sh \
+            -e S3_ACCESS_KEY="$S3_ACCESS_KEY" \
+            -e S3_SECRET_KEY="$S3_SECRET_KEY" \
+            -e S3_BUCKET="$S3_BUCKET" \
+            -v "$cors_file:/tmp/minio-e2e-cors.xml:ro" \
+            minio/mc:latest \
+            -lc 'mc alias set local http://127.0.0.1:9000 "$S3_ACCESS_KEY" "$S3_SECRET_KEY" && mc cors set "local/$S3_BUCKET" /tmp/minio-e2e-cors.xml && cors_info="$(mc cors get "local/$S3_BUCKET")" && printf "%s\\n" "$cors_info" && printf "%s\\n" "$cors_info" | grep -Fq "<ExposeHeader>x-amz-version-id</ExposeHeader>" && echo "MinIO CORS exposes x-amz-version-id"'
 
       - name: Setup environment
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -122,7 +122,11 @@ jobs:
             "http://127.0.0.1:9000/$S3_BUCKET/")"
           printf '%s\n' "$cors_response"
           printf '%s\n' "$cors_response" | grep -Eiq '^access-control-allow-origin:[[:space:]]*http://localhost:3000[[:space:]]*$'
-          printf '%s\n' "$cors_response" | grep -Eiq '^access-control-expose-headers:.*x-amz-version-id'
+          expose_headers="$(printf '%s\n' "$cors_response" | awk 'tolower($0) ~ /^access-control-expose-headers[[:space:]]*:/ { sub(/^[^:]*:[[:space:]]*/, ""); print }')"
+          if ! printf '%s\n' "$expose_headers" | tr ',' '\n' | awk '{ gsub(/\r/, ""); gsub(/^[[:space:]]+|[[:space:]]+$/, ""); token = tolower($0); if (token == "*" || token == "x-amz-version-id") found = 1 } END { exit(found ? 0 : 1) }'; then
+            echo "MinIO CORS does not expose x-amz-version-id or a standalone wildcard token" >&2
+            exit 1
+          fi
           echo "MinIO global CORS exposes x-amz-version-id to http://localhost:3000"
 
       - name: Setup environment

--- a/apps/api/src/documents/documents.service.spec.ts
+++ b/apps/api/src/documents/documents.service.spec.ts
@@ -107,6 +107,7 @@ describe('DocumentsService', () => {
   const uploadFile = {
     bucket: DEFAULT_BUCKET,
     objectKey: 'tenant-tenant-1/documents/proof.pdf',
+    objectVersionId: 'version-1',
     originalName: 'proof.pdf',
     mimeType: 'application/pdf',
     size: 1024,
@@ -233,7 +234,7 @@ describe('DocumentsService', () => {
   it('preserves double dots inside generated filenames and accepts the generated key', async () => {
     minio.presignUpload.mockResolvedValue('https://upload.example/expensas.pdf');
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    minio.statObject.mockResolvedValue({ size: 1024, versionId: 'version-1' } as never);
     prisma.file.create.mockResolvedValueOnce({ id: 'file-1' } as never);
     prisma.document.create.mockResolvedValueOnce({
       id: 'document-1',
@@ -257,6 +258,7 @@ describe('DocumentsService', () => {
       file: {
         bucket: DEFAULT_BUCKET,
         objectKey: 'tenant-tenant-1/documents/generated-expensas..julio.pdf',
+        objectVersionId: 'version-1',
         originalName: 'expensas..julio.pdf',
         mimeType: 'application/pdf',
         size: 1024,
@@ -271,7 +273,7 @@ describe('DocumentsService', () => {
 
   it('sanitizes createdByMembership.user in createDocument responses', async () => {
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    minio.statObject.mockResolvedValue({ size: 1024, versionId: 'version-1' } as never);
     prisma.file.create.mockResolvedValueOnce({ id: 'file-create' } as never);
     prisma.document.create.mockResolvedValueOnce({
       id: 'document-create',
@@ -544,7 +546,7 @@ describe('DocumentsService', () => {
 
   it('does not notify anyone for payment proofs', async () => {
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    minio.statObject.mockResolvedValue({ size: 1024, versionId: 'version-1' } as never);
     prisma.file.create.mockResolvedValueOnce({ id: 'file-proof' } as never);
     prisma.document.create.mockResolvedValueOnce({
       id: 'document-proof',
@@ -635,7 +637,7 @@ describe('DocumentsService', () => {
 
   it('excludes the uploading resident from general resident document notifications', async () => {
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    minio.statObject.mockResolvedValue({ size: 1024, versionId: 'version-1' } as never);
     prisma.file.create.mockResolvedValueOnce({ id: 'file-doc' } as never);
     prisma.document.create.mockResolvedValueOnce({
       id: 'document-general',
@@ -678,7 +680,7 @@ describe('DocumentsService', () => {
 
   it('rejects empty uploads before creating the document record', async () => {
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: 0 } as never);
+    minio.statObject.mockResolvedValue({ size: 0, versionId: 'version-1' } as never);
 
     await expect(service.createDocument('tenant-1', 'membership-1', {
       title: 'Receipt',
@@ -689,7 +691,11 @@ describe('DocumentsService', () => {
       unitId: 'unit-1',
     })).rejects.toBeInstanceOf(BadRequestException);
 
-    expect(minio.deleteObject).toHaveBeenCalledWith(DEFAULT_BUCKET, uploadFile.objectKey);
+    expect(minio.deleteObject).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      uploadFile.objectKey,
+      uploadFile.objectVersionId,
+    );
     expect(prisma.file.create).not.toHaveBeenCalled();
     expect(prisma.document.create).not.toHaveBeenCalled();
   });
@@ -753,7 +759,7 @@ describe('DocumentsService', () => {
 
   it('preserves the uploaded object when a concurrent create already persisted the file row', async () => {
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    minio.statObject.mockResolvedValue({ size: 1024, versionId: 'version-1' } as never);
     prisma.file.create.mockRejectedValueOnce(createPrismaKnownRequestError('P2002'));
     prisma.file.findFirst.mockResolvedValueOnce(null).mockResolvedValueOnce({ id: 'file-1' } as never);
 
@@ -789,7 +795,7 @@ describe('DocumentsService', () => {
     let documentCreateCount = 0;
 
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    minio.statObject.mockResolvedValue({ size: 1024, versionId: 'version-1' } as never);
     prisma.file.findFirst.mockImplementation(async () => {
       fileLookupCount += 1;
       return fileLookupCount <= 2 ? null as never : winnerFile as never;
@@ -847,7 +853,11 @@ describe('DocumentsService', () => {
       },
       select: { id: true },
     });
-    expect(minio.statObject).toHaveBeenCalledWith(DEFAULT_BUCKET, paymentProof.objectKey);
+    expect(minio.statObject).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      paymentProof.objectKey,
+      'version-1',
+    );
     expect(minio.deleteObject).not.toHaveBeenCalled();
 
     releaseWinnerDocument();
@@ -861,7 +871,7 @@ describe('DocumentsService', () => {
     };
 
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    minio.statObject.mockResolvedValue({ size: 1024, versionId: 'version-1' } as never);
     prisma.file.create.mockRejectedValueOnce(createPrismaKnownRequestError('P2002'));
     prisma.file.findFirst.mockResolvedValue(null);
 
@@ -882,7 +892,11 @@ describe('DocumentsService', () => {
       },
       select: { id: true },
     });
-    expect(minio.deleteObject).toHaveBeenCalledWith(DEFAULT_BUCKET, paymentProof.objectKey);
+    expect(minio.deleteObject).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      paymentProof.objectKey,
+      paymentProof.objectVersionId,
+    );
   });
 
   it('rejects payment-proof keys from another tenant before storage or cleanup', async () => {
@@ -920,7 +934,7 @@ describe('DocumentsService', () => {
 
   it('rejects uploaded files that exceed the backend limit using the real storage size', async () => {
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: GENERAL_DOCUMENT_MAX_BYTES + 1 } as never);
+    minio.statObject.mockResolvedValue({ size: GENERAL_DOCUMENT_MAX_BYTES + 1, versionId: 'version-1' } as never);
 
     await expect(service.createDocument('tenant-1', 'membership-1', {
       title: 'Receipt',
@@ -931,14 +945,18 @@ describe('DocumentsService', () => {
       unitId: 'unit-1',
     })).rejects.toBeInstanceOf(PayloadTooLargeException);
 
-    expect(minio.deleteObject).toHaveBeenCalledWith(DEFAULT_BUCKET, uploadFile.objectKey);
+    expect(minio.deleteObject).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      uploadFile.objectKey,
+      uploadFile.objectVersionId,
+    );
     expect(prisma.file.create).not.toHaveBeenCalled();
     expect(prisma.document.create).not.toHaveBeenCalled();
   });
 
   it('persists uploaded files using the configured bucket', async () => {
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    minio.statObject.mockResolvedValue({ size: 1024, versionId: 'version-1' } as never);
     prisma.file.create.mockResolvedValueOnce({ id: 'file-1' } as never);
     prisma.document.create.mockResolvedValueOnce({
       id: 'document-1',
@@ -962,7 +980,11 @@ describe('DocumentsService', () => {
     });
 
     expect(minio.objectExists).toHaveBeenCalledWith(DEFAULT_BUCKET, uploadFile.objectKey);
-    expect(minio.statObject).toHaveBeenCalledWith(DEFAULT_BUCKET, uploadFile.objectKey);
+    expect(minio.statObject).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      uploadFile.objectKey,
+      uploadFile.objectVersionId,
+    );
     expect(prisma.file.create).toHaveBeenCalledWith(expect.objectContaining({
       data: expect.objectContaining({
         bucket: DEFAULT_BUCKET,
@@ -972,9 +994,171 @@ describe('DocumentsService', () => {
     expect(result.file.bucket).toBe(DEFAULT_BUCKET);
   });
 
+  it('persists the exact provider version returned for the uploaded object', async () => {
+    const currentUploadFile = { ...uploadFile, objectVersionId: 'version-2' };
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject
+      .mockResolvedValueOnce({ size: 1024, versionId: 'version-2' } as never)
+      .mockResolvedValueOnce({ size: 1024, versionId: 'version-2' } as never);
+    prisma.file.create.mockResolvedValueOnce({ id: 'file-1' } as never);
+    prisma.document.create.mockResolvedValueOnce({
+      id: 'document-1',
+      tenantId: 'tenant-1',
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      file: { bucket: DEFAULT_BUCKET, objectKey: uploadFile.objectKey, objectVersionId: 'version-2' },
+    } as never);
+
+    await service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      file: currentUploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    });
+
+    expect(minio.statObject).toHaveBeenNthCalledWith(
+      1,
+      DEFAULT_BUCKET,
+      currentUploadFile.objectKey,
+      currentUploadFile.objectVersionId,
+    );
+    expect(minio.statObject).toHaveBeenNthCalledWith(
+      2,
+      DEFAULT_BUCKET,
+      currentUploadFile.objectKey,
+    );
+    expect(prisma.file.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ objectVersionId: 'version-2' }),
+    }));
+  });
+
+  it('rejects a valid historical version when the same key has a newer current version', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject
+      .mockResolvedValueOnce({ size: 1024, versionId: 'version-1' } as never)
+      .mockResolvedValueOnce({ size: 1024, versionId: 'version-2' } as never);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(minio.statObject).toHaveBeenNthCalledWith(
+      1,
+      DEFAULT_BUCKET,
+      uploadFile.objectKey,
+      uploadFile.objectVersionId,
+    );
+    expect(minio.statObject).toHaveBeenNthCalledWith(
+      2,
+      DEFAULT_BUCKET,
+      uploadFile.objectKey,
+    );
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+    expect(prisma.file.create).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the current object version is missing', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject
+      .mockResolvedValueOnce({ size: 1024, versionId: 'version-1' } as never)
+      .mockResolvedValueOnce({ size: 1024, versionId: null } as never);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(prisma.file.create).not.toHaveBeenCalled();
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when a new upload omits the provider version identity', async () => {
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      file: { ...uploadFile, objectVersionId: undefined } as never,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(minio.objectExists).not.toHaveBeenCalled();
+    expect(minio.statObject).not.toHaveBeenCalled();
+    expect(prisma.file.create).not.toHaveBeenCalled();
+  });
+
+  it('does not substitute an ETag when the provider omits the version identity', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({
+      size: 1024,
+      etag: 'etag-only',
+      versionId: null,
+    } as never);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(prisma.file.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a tampered version identity', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockResolvedValue({ size: 1024, versionId: 'actual-version' } as never);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      file: { ...uploadFile, objectVersionId: 'tampered-version' },
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(prisma.file.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects a version identity belonging to another object key', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject.mockRejectedValue(new Error('NoSuchVersion'));
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(minio.statObject).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      uploadFile.objectKey,
+      uploadFile.objectVersionId,
+    );
+    expect(prisma.file.create).not.toHaveBeenCalled();
+  });
+
   it('cleans up the uploaded object if the document row cannot be persisted', async () => {
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    minio.statObject.mockResolvedValue({ size: 1024, versionId: 'version-1' } as never);
     prisma.file.create.mockResolvedValueOnce({ id: 'file-1' } as never);
     prisma.document.create.mockRejectedValueOnce(new Error('DB down'));
 
@@ -989,12 +1173,16 @@ describe('DocumentsService', () => {
 
     expect(prisma.file.create).toHaveBeenCalled();
     expect(prisma.document.create).toHaveBeenCalled();
-    expect(minio.deleteObject).toHaveBeenCalledWith(DEFAULT_BUCKET, uploadFile.objectKey);
+    expect(minio.deleteObject).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      uploadFile.objectKey,
+      uploadFile.objectVersionId,
+    );
   });
 
   it('accepts a 100 MiB general document using the real storage size', async () => {
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: GENERAL_DOCUMENT_MAX_BYTES } as never);
+    minio.statObject.mockResolvedValue({ size: GENERAL_DOCUMENT_MAX_BYTES, versionId: 'version-1' } as never);
     prisma.file.create.mockResolvedValueOnce({ id: 'file-1' } as never);
     prisma.document.create.mockResolvedValueOnce({
       id: 'document-1',
@@ -1021,7 +1209,7 @@ describe('DocumentsService', () => {
     [PAYMENT_PROOF_MAX_BYTES + 1, false],
   ])('enforces the 10 MiB real-storage limit for payment proofs (%i bytes)', async (size, allowed) => {
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size } as never);
+    minio.statObject.mockResolvedValue({ size, versionId: 'version-1' } as never);
     const paymentProof = {
       ...uploadFile,
       objectKey: 'tenant-tenant-1/payment-proofs/proof.pdf',
@@ -1058,12 +1246,16 @@ describe('DocumentsService', () => {
       buildingId: 'building-1',
       unitId: 'unit-1',
     })).rejects.toThrow('10 MB');
-    expect(minio.deleteObject).toHaveBeenCalledWith(DEFAULT_BUCKET, paymentProof.objectKey);
+    expect(minio.deleteObject).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      paymentProof.objectKey,
+      paymentProof.objectVersionId,
+    );
   });
 
   it('rejects unsafe MIME types and cleans up the uploaded object', async () => {
     minio.objectExists.mockResolvedValue(true);
-    minio.statObject.mockResolvedValue({ size: 1024 } as never);
+    minio.statObject.mockResolvedValue({ size: 1024, versionId: 'version-1' } as never);
 
     await expect(service.createDocument('tenant-1', 'membership-1', {
       title: 'Receipt',
@@ -1074,7 +1266,11 @@ describe('DocumentsService', () => {
       unitId: 'unit-1',
     })).rejects.toThrow('File type not allowed');
 
-    expect(minio.deleteObject).toHaveBeenCalledWith(DEFAULT_BUCKET, uploadFile.objectKey);
+    expect(minio.deleteObject).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      uploadFile.objectKey,
+      uploadFile.objectVersionId,
+    );
     expect(prisma.file.create).not.toHaveBeenCalled();
     expect(prisma.document.create).not.toHaveBeenCalled();
   });

--- a/apps/api/src/documents/documents.service.spec.ts
+++ b/apps/api/src/documents/documents.service.spec.ts
@@ -84,6 +84,7 @@ describe('DocumentsService', () => {
     presignDownload: jest.fn(),
     objectExists: jest.fn(),
     statObject: jest.fn(),
+    isNotFoundError: jest.fn(),
     getObjectStream: jest.fn(),
   };
   const notifications = {
@@ -134,6 +135,7 @@ describe('DocumentsService', () => {
     validators.canAccessDocument.mockReturnValue(true);
     validators.validateResidentDocumentAccess.mockResolvedValue(undefined);
     residentAccess.shouldEnforce.mockReturnValue(false);
+    minio.isNotFoundError.mockReturnValue(false);
     prisma.file.findFirst.mockResolvedValue(null);
     prisma.payment.findMany.mockResolvedValue([]);
     prisma.unitOccupant.findMany.mockResolvedValue([]);
@@ -1137,6 +1139,7 @@ describe('DocumentsService', () => {
 
   it('rejects a version identity belonging to another object key', async () => {
     minio.objectExists.mockResolvedValue(true);
+    minio.isNotFoundError.mockReturnValue(true);
     minio.statObject.mockRejectedValue(new Error('NoSuchVersion'));
 
     await expect(service.createDocument('tenant-1', 'membership-1', {
@@ -1154,6 +1157,88 @@ describe('DocumentsService', () => {
       uploadFile.objectVersionId,
     );
     expect(prisma.file.create).not.toHaveBeenCalled();
+  });
+
+  it('maps confirmed missing exact versions to a client error', async () => {
+    const missingVersion = Object.assign(new Error('NoSuchVersion'), {
+      code: 'NoSuchVersion',
+      statusCode: 404,
+    });
+    minio.objectExists.mockResolvedValue(true);
+    minio.isNotFoundError.mockReturnValue(true);
+    minio.statObject.mockRejectedValue(missingVersion);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('maps a confirmed missing current version to a client error', async () => {
+    const missingCurrentVersion = Object.assign(new Error('NotFound'), {
+      code: 'NotFound',
+      statusCode: 404,
+    });
+    minio.objectExists.mockResolvedValue(true);
+    minio.isNotFoundError.mockReturnValue(true);
+    minio.statObject
+      .mockResolvedValueOnce({ size: 1024, versionId: 'version-1' } as never)
+      .mockRejectedValueOnce(missingCurrentVersion);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['timeout', new Error('ETIMEDOUT')],
+    ['provider 5xx', Object.assign(new Error('ServiceUnavailable'), { statusCode: 503 })],
+    ['access denied', Object.assign(new Error('AccessDenied'), { code: 'AccessDenied', statusCode: 403 })],
+  ])('propagates %s during exact version stat', async (_label, storageError) => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.isNotFoundError.mockReturnValue(false);
+    minio.statObject.mockRejectedValue(storageError);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBe(storageError);
+  });
+
+  it.each([
+    ['timeout', new Error('ETIMEDOUT')],
+    ['provider 5xx', Object.assign(new Error('InternalError'), { statusCode: 500 })],
+    ['access denied', Object.assign(new Error('InvalidAccessKeyId'), { code: 'InvalidAccessKeyId', statusCode: 403 })],
+  ])('propagates %s during current version stat', async (_label, storageError) => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.isNotFoundError.mockReturnValue(false);
+    minio.statObject
+      .mockResolvedValueOnce({ size: 1024, versionId: 'version-1' } as never)
+      .mockRejectedValueOnce(storageError);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBe(storageError);
   });
 
   it('cleans up the uploaded object if the document row cannot be persisted', async () => {

--- a/apps/api/src/documents/documents.service.spec.ts
+++ b/apps/api/src/documents/documents.service.spec.ts
@@ -1180,6 +1180,29 @@ describe('DocumentsService', () => {
     );
   });
 
+  it('cleans up the exact version when document persistence returns no document', async () => {
+    minio.objectExists.mockResolvedValue(true);
+    minio.statObject
+      .mockResolvedValueOnce({ size: 1024, versionId: 'version-1' } as never)
+      .mockResolvedValueOnce({ size: 1024, versionId: 'version-1' } as never);
+    prisma.$transaction.mockResolvedValueOnce(null);
+
+    await expect(service.createDocument('tenant-1', 'membership-1', {
+      title: 'Receipt',
+      category: 'RECEIPT',
+      visibility: 'TENANT_ADMINS',
+      file: uploadFile,
+      buildingId: 'building-1',
+      unitId: 'unit-1',
+    })).rejects.toBeInstanceOf(BadRequestException);
+
+    expect(minio.deleteObject).toHaveBeenCalledWith(
+      DEFAULT_BUCKET,
+      uploadFile.objectKey,
+      uploadFile.objectVersionId,
+    );
+  });
+
   it('accepts a 100 MiB general document using the real storage size', async () => {
     minio.objectExists.mockResolvedValue(true);
     minio.statObject.mockResolvedValue({ size: GENERAL_DOCUMENT_MAX_BYTES, versionId: 'version-1' } as never);

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -273,10 +273,13 @@ export class DocumentsService {
         uploadFile.objectKey,
         objectVersionId,
       );
-    } catch {
-      throw new BadRequestException(
-        'The uploaded file version does not belong to the uploaded object',
-      );
+    } catch (error: unknown) {
+      if (this.minio.isNotFoundError(error)) {
+        throw new BadRequestException(
+          'The uploaded file version does not belong to the uploaded object',
+        );
+      }
+      throw error;
     }
 
     if (uploadedObject.versionId !== objectVersionId) {
@@ -300,10 +303,13 @@ export class DocumentsService {
     let currentObject: MinioObjectStat;
     try {
       currentObject = await this.minio.statObject(bucket, uploadFile.objectKey);
-    } catch {
-      throw new BadRequestException(
-        'The uploaded file is no longer the current version of the object',
-      );
+    } catch (error: unknown) {
+      if (this.minio.isNotFoundError(error)) {
+        throw new BadRequestException(
+          'The uploaded file is no longer the current version of the object',
+        );
+      }
+      throw error;
     }
 
     if (currentObject.versionId !== objectVersionId) {

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -12,7 +12,7 @@ import { isAllowedMediaType } from '@buildingos/contracts';
 import { posix as pathPosix } from 'node:path';
 import type { Readable } from 'node:stream';
 import { PrismaService } from '../prisma/prisma.service';
-import { MinioService } from '../storage/minio.service';
+import { MinioService, MinioObjectStat } from '../storage/minio.service';
 import { NotificationsService } from '../notifications/notifications.service';
 import { AuditService } from '../audit/audit.service';
 import { DocumentsValidators } from './documents.validators';
@@ -202,6 +202,13 @@ export class DocumentsService {
     dto: CreateDocumentDto,
   ): Promise<DocumentWithFileResponseDto> {
     const uploadFile = dto.file;
+    const objectVersionId = uploadFile.objectVersionId?.trim();
+
+    if (!objectVersionId) {
+      throw new BadRequestException(
+        'The uploaded file is missing its exact storage version identity',
+      );
+    }
 
     // Validate scope constraint
     this.validators.validateDocumentScope(dto.buildingId, dto.unitId);
@@ -245,7 +252,7 @@ export class DocumentsService {
     try {
       this.validateMimeType(uploadFile.mimeType);
     } catch (error) {
-      await this.deleteUploadedObject(uploadFile.objectKey);
+      await this.deleteUploadedObject(uploadFile.objectKey, objectVersionId);
       throw error;
     }
 
@@ -259,16 +266,49 @@ export class DocumentsService {
       );
     }
 
-    const uploadedObject = await this.minio.statObject(bucket, uploadFile.objectKey);
+    let uploadedObject: MinioObjectStat;
+    try {
+      uploadedObject = await this.minio.statObject(
+        bucket,
+        uploadFile.objectKey,
+        objectVersionId,
+      );
+    } catch {
+      throw new BadRequestException(
+        'The uploaded file version does not belong to the uploaded object',
+      );
+    }
+
+    if (uploadedObject.versionId !== objectVersionId) {
+      throw new BadRequestException(
+        'The storage provider did not confirm the exact uploaded file version',
+      );
+    }
+
     if (uploadedObject.size <= 0) {
-      await this.deleteUploadedObject(uploadFile.objectKey);
+      await this.deleteUploadedObject(uploadFile.objectKey, objectVersionId);
       throw new BadRequestException('El archivo no puede estar vacío');
     }
 
     if (uploadedObject.size > this.maxUploadBytesFor(uploadPurpose)) {
-      await this.deleteUploadedObject(uploadFile.objectKey);
+      await this.deleteUploadedObject(uploadFile.objectKey, objectVersionId);
       throw new PayloadTooLargeException(
         `El archivo supera el máximo de ${this.maxUploadMegabytesFor(uploadPurpose)} MB`,
+      );
+    }
+
+    let currentObject: MinioObjectStat;
+    try {
+      currentObject = await this.minio.statObject(bucket, uploadFile.objectKey);
+    } catch {
+      throw new BadRequestException(
+        'The uploaded file is no longer the current version of the object',
+      );
+    }
+
+    if (currentObject.versionId !== objectVersionId) {
+      throw new BadRequestException(
+        'The uploaded file is no longer the current version of the object',
       );
     }
 
@@ -281,6 +321,7 @@ export class DocumentsService {
             tenantId,
             bucket,
             objectKey: uploadFile.objectKey,
+            objectVersionId,
             originalName: this.sanitizeFileName(uploadFile.originalName),
             mimeType: uploadFile.mimeType,
             size: uploadedObject.size,
@@ -314,7 +355,7 @@ export class DocumentsService {
       });
     } catch (error) {
       if (!(await this.shouldPreserveUploadedObject(tenantId, bucket, uploadFile.objectKey, error))) {
-        await this.deleteUploadedObject(uploadFile.objectKey);
+        await this.deleteUploadedObject(uploadFile.objectKey, objectVersionId);
       }
       throw error;
     }
@@ -916,9 +957,9 @@ export class DocumentsService {
     return this.maxUploadBytesFor(purpose) / 1024 / 1024;
   }
 
-  private async deleteUploadedObject(objectKey: string): Promise<void> {
+  private async deleteUploadedObject(objectKey: string, objectVersionId?: string): Promise<void> {
     try {
-      await this.minio.deleteObject(this.minio.getDefaultBucket(), objectKey);
+      await this.minio.deleteObject(this.minio.getDefaultBucket(), objectKey, objectVersionId);
     } catch (error) {
       this.logger.warn(`Unable to clean up rejected upload ${objectKey}: ${error instanceof Error ? error.message : String(error)}`);
     }

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -361,7 +361,7 @@ export class DocumentsService {
     }
 
     if (!document) {
-      await this.deleteUploadedObject(uploadFile.objectKey);
+      await this.deleteUploadedObject(uploadFile.objectKey, objectVersionId);
       throw new BadRequestException('Failed to persist document metadata');
     }
 

--- a/apps/api/src/documents/dto/create-document.dto.ts
+++ b/apps/api/src/documents/dto/create-document.dto.ts
@@ -15,6 +15,10 @@ export class DocumentUploadFileDto {
   objectKey!: string;
 
   @IsString()
+  @Length(1, 1024)
+  objectVersionId!: string;
+
+  @IsString()
   @Length(1, 255)
   originalName!: string;
 

--- a/apps/api/src/storage/minio.service.spec.ts
+++ b/apps/api/src/storage/minio.service.spec.ts
@@ -10,6 +10,7 @@ jest.mock('minio', () => ({
 interface ClientMock {
   readonly statObject: jest.Mock;
   readonly getObject: jest.Mock;
+  readonly removeObject: jest.Mock;
   readonly putObject: jest.Mock;
   readonly presignedPutObject: jest.Mock;
   readonly presignedGetObject: jest.Mock;
@@ -21,6 +22,7 @@ function createClientMock(): ClientMock {
   return {
     statObject: jest.fn(),
     getObject: jest.fn(),
+    removeObject: jest.fn(),
     putObject: jest.fn(),
     presignedPutObject: jest.fn(),
     presignedGetObject: jest.fn(),
@@ -154,6 +156,24 @@ describe('MinioService', () => {
       { versionId: 'version-1' },
     );
     expect(internalClient.getObject).toHaveBeenCalledWith(
+      'buildingos-staging',
+      'tenant-a/proof.pdf',
+      { versionId: 'version-1' },
+    );
+  });
+
+  it('deletes an exact object version when requested', async () => {
+    const internalClient = createClientMock();
+    const publicClient = createClientMock();
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => publicClient);
+
+    const service = new MinioService(createConfig());
+
+    await service.deleteObject('buildingos-staging', 'tenant-a/proof.pdf', 'version-1');
+
+    expect(internalClient.removeObject).toHaveBeenCalledWith(
       'buildingos-staging',
       'tenant-a/proof.pdf',
       { versionId: 'version-1' },

--- a/apps/api/src/storage/minio.service.spec.ts
+++ b/apps/api/src/storage/minio.service.spec.ts
@@ -105,6 +105,16 @@ describe('MinioService', () => {
     );
   });
 
+  it('classifies only confirmed missing object or version errors as not found', () => {
+    const service = new MinioService(createConfig());
+
+    expect(service.isNotFoundError({ code: 'NoSuchVersion' })).toBe(true);
+    expect(service.isNotFoundError({ statusCode: 404 })).toBe(true);
+    expect(service.isNotFoundError({ code: 'AccessDenied', statusCode: 403 })).toBe(false);
+    expect(service.isNotFoundError({ statusCode: 500 })).toBe(false);
+    expect(service.isNotFoundError(new Error('ETIMEDOUT'))).toBe(false);
+  });
+
   it('binds a presigned download URL to an exact object version when requested', async () => {
     const internalClient = createClientMock();
     const publicClient = createClientMock();

--- a/apps/api/src/storage/minio.service.ts
+++ b/apps/api/src/storage/minio.service.ts
@@ -246,6 +246,7 @@ export class MinioService {
    *
    * @param bucketName - Bucket name (or undefined to use default)
    * @param objectKey - Object path in bucket
+   * @param versionId - Optional exact object version to delete
    *
    * @example
    * await minioService.deleteObject(minioService.getDefaultBucket(), 'tenant-123/docs/file.pdf');
@@ -253,9 +254,14 @@ export class MinioService {
   async deleteObject(
     bucketName: string = this.bucket,
     objectKey: string,
+    versionId?: string,
   ): Promise<void> {
     try {
-      await this.minioClient.removeObject(bucketName, objectKey);
+      if (versionId) {
+        await this.minioClient.removeObject(bucketName, objectKey, { versionId });
+      } else {
+        await this.minioClient.removeObject(bucketName, objectKey);
+      }
       this.logger.debug(`Deleted object: ${bucketName}/${objectKey}`);
     } catch (error: unknown) {
       this.logger.error(

--- a/apps/api/src/storage/minio.service.ts
+++ b/apps/api/src/storage/minio.service.ts
@@ -52,11 +52,18 @@ export class MinioService {
     return this.getErrorLike(error)?.stack;
   }
 
-  private isNotFoundError(error: unknown): boolean {
+  /**
+   * Identify storage errors that conclusively mean the requested object/version is absent.
+   */
+  isNotFoundError(error: unknown): boolean {
     const errorLike = this.getErrorLike(error);
     return errorLike?.code === 'NotFound'
+      || errorLike?.code === 'NoSuchKey'
+      || errorLike?.code === 'NoSuchVersion'
       || errorLike?.statusCode === 404
-      || errorLike?.message?.includes('NotFound') === true;
+      || errorLike?.message?.includes('NotFound') === true
+      || errorLike?.message?.includes('NoSuchKey') === true
+      || errorLike?.message?.includes('NoSuchVersion') === true;
   }
 
   private isPreconditionFailedError(error: unknown): boolean {

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.test.tsx
@@ -254,7 +254,7 @@ describe('ResidentPaymentsPage', () => {
       objectKey: 'tenant-1/documents/proof.pdf',
       expiresAt: '2026-07-24T00:00:00.000Z',
     });
-    mockedUploadFileToMinio.mockResolvedValue(undefined);
+    mockedUploadFileToMinio.mockResolvedValue({ versionId: 'version-1' });
     mockedCreateDocument.mockResolvedValue({
       id: 'document-1',
       tenantId: 'tenant-1',
@@ -878,6 +878,12 @@ describe('ResidentPaymentsPage', () => {
     });
 
     await waitFor(() => expect(mockedCreateDocument).toHaveBeenCalled());
+    expect(mockedCreateDocument).toHaveBeenCalledWith(
+      'tenant-1',
+      expect.objectContaining({
+        file: expect.objectContaining({ objectVersionId: 'version-1' }),
+      }),
+    );
 
     mockedUseResidentContext.mockReturnValue({
       data: {

--- a/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
+++ b/apps/web/app/(tenant)/[tenantId]/resident/payments/page.tsx
@@ -723,7 +723,7 @@ export const ResidentPaymentsPage = () => {
         file.size,
         'PAYMENT_PROOF',
       );
-      await uploadFileToMinio(presignRes.url, file);
+      const uploadResult = await uploadFileToMinio(presignRes.url, file);
       const createdDocument = await createDocument(tenantId, {
         title: `Comprobante pago - ${file.name}`,
         category: 'RECEIPT',
@@ -731,6 +731,7 @@ export const ResidentPaymentsPage = () => {
         file: {
           bucket: presignRes.bucket,
           objectKey: presignRes.objectKey,
+          objectVersionId: uploadResult.versionId,
           originalName: file.name,
           mimeType: file.type,
           size: file.size,

--- a/apps/web/features/buildings/components/documents/DocumentUploadModal.tsx
+++ b/apps/web/features/buildings/components/documents/DocumentUploadModal.tsx
@@ -106,7 +106,11 @@ export function DocumentUploadModal({
       toast('URL de carga generada', 'success');
 
       // Step 2: Upload to MinIO
-      await uploadFileToMinio(presignResponse.url, selectedFile, setProgress);
+      const uploadResult = await uploadFileToMinio(
+        presignResponse.url,
+        selectedFile,
+        setProgress,
+      );
 
       toast('Archivo subido', 'success');
       setStep('create');
@@ -119,6 +123,7 @@ export function DocumentUploadModal({
         file: {
           bucket: presignResponse.bucket,
           objectKey: presignResponse.objectKey,
+          objectVersionId: uploadResult.versionId,
           originalName: selectedFile.name,
           mimeType: selectedFile.type,
           size: selectedFile.size,

--- a/apps/web/features/buildings/services/documents.api.test.ts
+++ b/apps/web/features/buildings/services/documents.api.test.ts
@@ -2,6 +2,7 @@ import { apiClient, apiClientWithResponse } from '@/shared/lib/http/client';
 import {
   downloadDocumentContent,
   downloadProtectedDocumentContent,
+  uploadFileToMinio,
   type DocumentCategory,
 } from './documents.api';
 
@@ -85,5 +86,79 @@ describe('documents api', () => {
     const result = await downloadDocumentContent('tenant-1', 'document-3');
 
     expect(result).toBe(blob);
+  });
+
+  it('returns the exact object version exposed by the storage PUT response', async () => {
+    let loadHandler: (() => void) | undefined;
+    const xhr = {
+      upload: { addEventListener: jest.fn() },
+      addEventListener: jest.fn((event: string, handler: () => void) => {
+        if (event === 'load') loadHandler = handler;
+      }),
+      open: jest.fn(),
+      setRequestHeader: jest.fn(),
+      send: jest.fn(),
+      status: 200,
+      statusText: 'OK',
+      getResponseHeader: jest.fn().mockReturnValue('version-1'),
+    };
+    const originalXMLHttpRequest = globalThis.XMLHttpRequest;
+    Object.defineProperty(globalThis, 'XMLHttpRequest', {
+      configurable: true,
+      value: jest.fn(() => xhr),
+    });
+
+    try {
+      const upload = uploadFileToMinio(
+        'https://storage.example/upload',
+        new File(['pdf'], 'receipt.pdf', { type: 'application/pdf' }),
+      );
+      loadHandler?.();
+
+      await expect(upload).resolves.toEqual({ versionId: 'version-1' });
+      expect(xhr.open).toHaveBeenCalledWith('PUT', 'https://storage.example/upload', true);
+      expect(xhr.getResponseHeader).toHaveBeenCalledWith('x-amz-version-id');
+    } finally {
+      Object.defineProperty(globalThis, 'XMLHttpRequest', {
+        configurable: true,
+        value: originalXMLHttpRequest,
+      });
+    }
+  });
+
+  it('rejects a successful PUT when storage does not expose an object version', async () => {
+    let loadHandler: (() => void) | undefined;
+    const xhr = {
+      upload: { addEventListener: jest.fn() },
+      addEventListener: jest.fn((event: string, handler: () => void) => {
+        if (event === 'load') loadHandler = handler;
+      }),
+      open: jest.fn(),
+      setRequestHeader: jest.fn(),
+      send: jest.fn(),
+      status: 200,
+      statusText: 'OK',
+      getResponseHeader: jest.fn().mockReturnValue(null),
+    };
+    const originalXMLHttpRequest = globalThis.XMLHttpRequest;
+    Object.defineProperty(globalThis, 'XMLHttpRequest', {
+      configurable: true,
+      value: jest.fn(() => xhr),
+    });
+
+    try {
+      const upload = uploadFileToMinio(
+        'https://storage.example/upload',
+        new File(['pdf'], 'receipt.pdf', { type: 'application/pdf' }),
+      );
+      loadHandler?.();
+
+      await expect(upload).rejects.toThrow('exact object version');
+    } finally {
+      Object.defineProperty(globalThis, 'XMLHttpRequest', {
+        configurable: true,
+        value: originalXMLHttpRequest,
+      });
+    }
   });
 });

--- a/apps/web/features/buildings/services/documents.api.ts
+++ b/apps/web/features/buildings/services/documents.api.ts
@@ -111,6 +111,7 @@ export interface CreateDocumentInput {
   file: {
     bucket: string;
     objectKey: string;
+    objectVersionId: string;
     originalName: string;
     mimeType: string;
     size: number;
@@ -234,7 +235,7 @@ export async function uploadFileToMinio(
   presignedUrl: string,
   file: File,
   onProgress?: (progress: number) => void,
-): Promise<void> {
+): Promise<{ versionId: string }> {
   const xhr = new XMLHttpRequest();
 
   return new Promise((resolve, reject) => {
@@ -247,7 +248,12 @@ export async function uploadFileToMinio(
 
     xhr.addEventListener('load', () => {
       if (xhr.status >= 200 && xhr.status < 300) {
-        resolve();
+        const versionId = xhr.getResponseHeader('x-amz-version-id')?.trim();
+        if (!versionId) {
+          reject(new Error('Upload failed: storage did not return an exact object version'));
+          return;
+        }
+        resolve({ versionId });
       } else {
         reject(new Error(`Upload failed: ${xhr.statusText}`));
       }

--- a/apps/web/tests/e2e/resident/resident-journeys.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-journeys.spec.ts
@@ -124,6 +124,10 @@ async function ensureResidentDocumentFixture(
   });
 
   expect(uploadResponse.ok()).toBe(true);
+  const objectVersionId = uploadResponse.headers()['x-amz-version-id']?.trim();
+  if (!objectVersionId) {
+    throw new Error('Resident document upload did not return x-amz-version-id');
+  }
 
   const createResponse = await page.request.post(`${API_ORIGIN}/tenants/${tenantId}/documents`, {
     headers: {
@@ -137,6 +141,7 @@ async function ensureResidentDocumentFixture(
       file: {
         bucket: presign.bucket,
         objectKey: presign.objectKey,
+        objectVersionId,
         originalName: fixtureName,
         mimeType: fixtureMimeType,
         size: fixtureBytes.length,

--- a/docs/release/STORAGE_01_PHASE_D_STAGING_ROLLOUT_PREPARATION.md
+++ b/docs/release/STORAGE_01_PHASE_D_STAGING_ROLLOUT_PREPARATION.md
@@ -94,6 +94,7 @@ specification only; the bucket must not be created as part of this preparation.
 | Object keys | Preserve all 46 active-bucket keys exactly |
 | CORS methods | `PUT` required; `GET` and `HEAD` allowed for compatible read/stat flows |
 | CORS request headers | `Content-Type` required by the browser upload XHR |
+| CORS exposed response headers | `x-amz-version-id` required so the browser can bind the exact uploaded version |
 | CORS credentials | Not required for direct presigned object requests |
 | Tenant isolation | API authorizes before presigning; bucket remains private; keys remain tenant-scoped |
 
@@ -105,9 +106,11 @@ used to broaden access policy.
 
 Versioning, lifecycle, and encryption controls:
 
-- Recommend enabling object versioning before cutover if supported by the
-  Contabo target, because it improves recovery from accidental replacement.
-  The current staging MinIO bucket reported no enabled versioning status.
+- Object versioning is required before cutover because the browser upload flow
+  persists the exact provider VersionId returned by the successful `PUT`.
+  Confirm that the Contabo target has versioning enabled and exposes
+  `x-amz-version-id` through CORS. The current staging MinIO bucket reported no
+  enabled versioning status.
 - Configure no lifecycle expiration for active application objects or the six
   preserved orphans. Any later noncurrent-version retention rule requires a
   separate review.

--- a/docs/release/STORAGE_01_PHASE_D_STAGING_ROLLOUT_PREPARATION.md
+++ b/docs/release/STORAGE_01_PHASE_D_STAGING_ROLLOUT_PREPARATION.md
@@ -124,6 +124,12 @@ was functionally accepted, while the provider returned
 not permit credentials, and does not weaken BuildingOS API CORS. It must be
 recorded as a Contabo-specific semantic deviation only.
 
+The staging deployment workflow fails closed unless the GitHub environment
+variable `STAGING_OBJECT_VERSION_ID_READY` is explicitly set to `true`. That
+variable may only be enabled after independently verifying staging bucket
+versioning and CORS exposure of `x-amz-version-id`; this code change does not
+set the variable or mutate provider configuration.
+
 ### Manual input required
 
 - exact Contabo endpoint host;

--- a/scripts/finance-staging-acceptance.mjs
+++ b/scripts/finance-staging-acceptance.mjs
@@ -410,6 +410,8 @@ async function createPaymentProof() {
   });
   await upload.arrayBuffer();
   assert(upload.ok, "payment proof upload failed");
+  const objectVersionId = upload.headers.get("x-amz-version-id")?.trim();
+  assert(objectVersionId, "payment proof upload did not return x-amz-version-id");
   const document = await request("POST", `/tenants/${tenantId}/documents`, {
     title: `${marker}:payment-proof`,
     category: "RECEIPT",
@@ -418,6 +420,7 @@ async function createPaymentProof() {
     unitId,
     file: {
       objectKey: presign.objectKey,
+      objectVersionId,
       originalName,
       mimeType: "application/pdf",
       size: proof.length,


### PR DESCRIPTION
## Summary
- capture and persist the exact provider object VersionId from browser uploads
- validate exact identity plus current-version freshness before finalizing Documents
- make rejected-upload cleanup version-aware so newer same-key versions are not deleted

## Validation
- API Documents: 75 passed
- MinIO: 16 passed
- Web upload API: 6 passed
- Resident payments: 34 passed
- API typecheck, lint, forbid-only, Prisma validate, and git diff --check passed
- Web typecheck has only the pre-existing IncomesTab.test.tsx error reproduced on clean main
- Web targeted lint has 0 errors and 2 pre-existing warnings

No staging or production access was performed. This PR is not approved for merge.