### PR TITLE
fix(storage): persist exact ImportJob object versions

### DIFF
--- a/apps/api/src/onboarding-imports/onboarding-imports.constants.ts
+++ b/apps/api/src/onboarding-imports/onboarding-imports.constants.ts
@@ -1,7 +1,8 @@
 import { ImportType } from '@prisma/client';
 
 export const ONBOARDING_IMPORT_SCHEMA_VERSION = 'v1';
-export const ONBOARDING_IMPORT_PREVIEW_VERSION = 3;
+export const ONBOARDING_IMPORT_PREVIEW_VERSION = 4;
+export const ONBOARDING_IMPORT_EXACT_OBJECT_IDENTITY_PREVIEW_VERSION = 4;
 export const ONBOARDING_IMPORT_TYPE = ImportType.INITIAL_ONBOARDING;
 export const ONBOARDING_IMPORT_TEMPLATE_FILENAME = 'buildingos-importacion-inicial-v1.xlsx';
 export const ONBOARDING_IMPORT_TEMPLATE_CONTENT_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';

--- a/apps/api/src/onboarding-imports/onboarding-imports.service.spec.ts
+++ b/apps/api/src/onboarding-imports/onboarding-imports.service.spec.ts
@@ -732,6 +732,105 @@ describe('OnboardingImportsService', () => {
     );
   });
 
+  it('does not cache an original upload timeout as a failed import', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
+    prisma.importJob.findUnique.mockResolvedValue(null);
+    minio.uploadBuffer.mockRejectedValueOnce(new Error('storage timeout'));
+
+    await expect(
+      service.previewImport(
+        { tenantId, user: buildUser(['TENANT_ADMIN']) },
+        {
+          buffer: Buffer.from('xlsx-data'),
+          originalname: 'import.xlsx',
+          mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          size: 9,
+        } as UploadableSpreadsheetFile,
+      ),
+    ).rejects.toThrow('storage timeout');
+
+    expect(prisma.importJob.create).not.toHaveBeenCalled();
+    expect(transactionCreate).not.toHaveBeenCalled();
+  });
+
+  it('does not cache an original provider 5xx as a failed import', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
+    prisma.importJob.findUnique.mockResolvedValue(null);
+    minio.uploadBuffer.mockRejectedValueOnce(new Error('storage 503'));
+
+    await expect(
+      service.previewImport(
+        { tenantId, user: buildUser(['TENANT_ADMIN']) },
+        {
+          buffer: Buffer.from('xlsx-data'),
+          originalname: 'import.xlsx',
+          mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          size: 9,
+        } as UploadableSpreadsheetFile,
+      ),
+    ).rejects.toThrow('storage 503');
+
+    expect(prisma.importJob.create).not.toHaveBeenCalled();
+    expect(transactionCreate).not.toHaveBeenCalled();
+  });
+
+  it('allows a retry after an original upload failure without a cached failed import', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
+    prisma.importJob.findUnique.mockResolvedValue(null);
+    minio.uploadBuffer
+      .mockRejectedValueOnce(new Error('storage timeout'))
+      .mockResolvedValue({ etag: 'etag-1', versionId: 'version-1' });
+
+    const file = {
+      buffer: Buffer.from('xlsx-data'),
+      originalname: 'import.xlsx',
+      mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      size: 9,
+    } as UploadableSpreadsheetFile;
+
+    await expect(
+      service.previewImport(
+        { tenantId, user: buildUser(['TENANT_ADMIN']) },
+        file,
+      ),
+    ).rejects.toThrow('storage timeout');
+
+    expect(prisma.importJob.create).not.toHaveBeenCalled();
+
+    parserService.parseWorkbook.mockReturnValue({ data: buildParsedData(currentPeriod), issues: [] });
+    jest.spyOn(service as any, 'validateWorkbook').mockResolvedValue({
+      summary: createSummary(),
+      issues: [],
+    });
+    transactionCreate.mockResolvedValue({
+      id: 'retried-import',
+      tenantId,
+      type: 'INITIAL_ONBOARDING',
+      fileName: 'import.xlsx',
+      fileHash: 'retry-hash',
+      schemaVersion: 'v1',
+      previewVersion: 4,
+      status: ImportJobStatus.READY,
+      canConfirm: true,
+      expiresAt: new Date(Date.now() + 86_400_000),
+      createdAt: new Date('2026-07-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+      summary: createSummary(),
+      counts: createSummary(),
+      issues: [],
+    });
+
+    await expect(
+      service.previewImport(
+        { tenantId, user: buildUser(['TENANT_ADMIN']) },
+        file,
+      ),
+    ).resolves.toMatchObject({ importId: 'retried-import' });
+
+    expect(minio.uploadBuffer).toHaveBeenCalledTimes(3);
+    expect(transactionCreate).toHaveBeenCalledTimes(1);
+  });
+
   it('fails closed when the original upload has no provider version and never deletes by key', async () => {
     prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
     prisma.importJob.findUnique.mockResolvedValue(null);
@@ -750,12 +849,8 @@ describe('OnboardingImportsService', () => {
       ),
     ).rejects.toThrow('Storage did not return a version id');
 
-    expect(prisma.importJob.create).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        previewVersion: 4,
-        originalObjectVersionId: null,
-      }),
-    }));
+    expect(prisma.importJob.create).not.toHaveBeenCalled();
+    expect(transactionCreate).not.toHaveBeenCalled();
     expect(minio.deleteObject).not.toHaveBeenCalled();
   });
 
@@ -810,9 +905,8 @@ describe('OnboardingImportsService', () => {
       ),
     ).rejects.toThrow('Storage did not return a version id');
 
-    expect(prisma.importJob.create).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({ originalObjectVersionId: null }),
-    }));
+    expect(prisma.importJob.create).not.toHaveBeenCalled();
+    expect(transactionCreate).not.toHaveBeenCalled();
     expect(minio.deleteObject).not.toHaveBeenCalled();
   });
 
@@ -879,13 +973,18 @@ describe('OnboardingImportsService', () => {
         originalObjectVersionId: 'version-1',
       }),
     }));
-    expect(minio.deleteObject).not.toHaveBeenCalled();
+    expect(minio.deleteObject).toHaveBeenCalledWith(
+      undefined,
+      expect.stringContaining('/original.xlsx'),
+      'version-1',
+    );
+    expect(minio.deleteObject.mock.calls).toHaveLength(1);
+    expect(transactionCreate).not.toHaveBeenCalled();
   });
 
-  it('does not overwrite a concurrent winner when original VersionId validation fails after the initial lookup', async () => {
+  it('does not cache an original upload without a VersionId after the initial lookup', async () => {
     prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
     prisma.importJob.findUnique.mockResolvedValue(null);
-    prisma.importJob.create.mockRejectedValue(createPrismaKnownError('P2002'));
     minio.uploadBuffer.mockResolvedValue({ etag: 'etag-without-version', versionId: null });
 
     await expect(
@@ -900,12 +999,27 @@ describe('OnboardingImportsService', () => {
       ),
     ).rejects.toThrow('Storage did not return a version id');
 
-    expect(prisma.importJob.create).toHaveBeenCalledWith(expect.objectContaining({
-      data: expect.objectContaining({
-        status: ImportJobStatus.FAILED,
-        originalObjectVersionId: null,
-      }),
-    }));
+    expect(prisma.importJob.create).not.toHaveBeenCalled();
+    expect(transactionCreate).not.toHaveBeenCalled();
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it('does not delete by key when failed-job persistence loses a race without a version', async () => {
+    prisma.importJob.create.mockRejectedValue(createPrismaKnownError('P2002'));
+
+    await (service as any).persistFailedImport({
+      tenantId,
+      membershipId: null,
+      importId: 'failed-import',
+      fileName: 'import.xlsx',
+      fileSize: 9,
+      fileHash: 'file-hash',
+      fileMimeType: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+      originalObjectKey: 'tenant-imports/tenant-1/failed-import/original.xlsx',
+      originalObjectVersionId: null,
+      error: new Error('parse failed'),
+    });
+
     expect(minio.deleteObject).not.toHaveBeenCalled();
   });
 

--- a/apps/api/src/onboarding-imports/onboarding-imports.service.spec.ts
+++ b/apps/api/src/onboarding-imports/onboarding-imports.service.spec.ts
@@ -5,6 +5,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { MinioService } from '../storage/minio.service';
 import {
   ImportJobStatus,
+  Prisma,
   type Role,
 } from '@prisma/client';
 import { OnboardingImportsService } from './onboarding-imports.service';
@@ -259,11 +260,18 @@ function buildParsedData(currentPeriod: string): ParsedWorkbookData {
   };
 }
 
+function createPrismaKnownError(code: string): Prisma.PrismaClientKnownRequestError {
+  const error = new Error(`Prisma ${code}`);
+  Object.assign(error, { code, meta: { target: ['tenantId', 'fileHash'] } });
+  Object.setPrototypeOf(error, Prisma.PrismaClientKnownRequestError.prototype);
+  return error as Prisma.PrismaClientKnownRequestError;
+}
+
 describe('OnboardingImportsService', () => {
   let service: OnboardingImportsService;
   let prisma: {
     tenant: { findUnique: jest.Mock };
-    importJob: { findUnique: jest.Mock; upsert: jest.Mock };
+    importJob: { findUnique: jest.Mock; create: jest.Mock };
     importIssue: { findMany: jest.Mock; count: jest.Mock };
     building: { findMany: jest.Mock };
     unitCategory: { findMany: jest.Mock };
@@ -331,7 +339,7 @@ describe('OnboardingImportsService', () => {
 
     prisma = {
       tenant: { findUnique: jest.fn() },
-      importJob: { findUnique: jest.fn(), upsert: jest.fn() },
+      importJob: { findUnique: jest.fn(), create: jest.fn() },
       importIssue: { findMany: jest.fn(), count: jest.fn() },
       building: { findMany: jest.fn(), ...businessWrites.building },
       unitCategory: { findMany: jest.fn(), ...businessWrites.unitCategory },
@@ -356,7 +364,7 @@ describe('OnboardingImportsService', () => {
     };
 
     minio = {
-      uploadBuffer: jest.fn().mockResolvedValue(undefined),
+      uploadBuffer: jest.fn().mockResolvedValue({ etag: 'etag-1', versionId: 'version-1' }),
       deleteObject: jest.fn().mockResolvedValue(undefined),
     };
 
@@ -465,7 +473,7 @@ describe('OnboardingImportsService', () => {
       fileName: 'import.xlsx',
       fileHash: 'current-hash',
       schemaVersion: 'v1',
-      previewVersion: 3,
+      previewVersion: 4,
       status: ImportJobStatus.READY,
       canConfirm: true,
       expiresAt: new Date(Date.now() + 86_400_000),
@@ -493,7 +501,7 @@ describe('OnboardingImportsService', () => {
             tenantId,
             type: 'INITIAL_ONBOARDING',
             schemaVersion: 'v1',
-            previewVersion: 3,
+            previewVersion: 4,
             fileHash: expect.any(String),
           },
         },
@@ -559,11 +567,83 @@ describe('OnboardingImportsService', () => {
 
     expect(result.status).toBe(ImportJobStatus.READY);
     expect(minio.uploadBuffer).toHaveBeenCalledTimes(2);
+    expect(transactionCreate).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        originalObjectVersionId: 'version-1',
+        normalizedObjectVersionId: 'version-1',
+      }),
+    }));
+    expect(result).not.toHaveProperty('originalObjectVersionId');
+    expect(result).not.toHaveProperty('normalizedObjectVersionId');
     expect(transactionCreate).toHaveBeenCalledTimes(1);
     expect(transactionIssueCreateMany).not.toHaveBeenCalled();
     expect(auditService.createLog).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'IMPORT_PREVIEW_READY' }),
     );
+  });
+
+  it('cleans only current request versions and returns the concurrent winner after P2002', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
+    const winner = {
+      id: 'winner-import',
+      tenantId,
+      type: 'INITIAL_ONBOARDING',
+      fileName: 'winner.xlsx',
+      fileHash: 'winner-hash',
+      schemaVersion: 'v1',
+      previewVersion: 4,
+      status: ImportJobStatus.READY,
+      canConfirm: true,
+      expiresAt: new Date(Date.now() + 86_400_000),
+      confirmedAt: null,
+      confirmedByMembershipId: null,
+      createdAt: new Date('2026-07-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+      summary: createSummary(),
+      counts: createSummary(),
+      issues: [],
+    };
+    prisma.importJob.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(winner);
+    parserService.parseWorkbook.mockReturnValue({ data: buildParsedData(currentPeriod), issues: [] });
+    jest.spyOn(service as any, 'validateWorkbook').mockResolvedValue({
+      summary: createSummary(),
+      issues: [],
+    });
+    transactionCreate.mockRejectedValue(createPrismaKnownError('P2002'));
+    minio.uploadBuffer
+      .mockResolvedValueOnce({ etag: 'current-original-etag', versionId: 'v-current-original' })
+      .mockResolvedValueOnce({ etag: 'current-normalized-etag', versionId: 'v-current-normalized' });
+
+    const result = await service.previewImport(
+      { tenantId, user: buildUser(['TENANT_ADMIN']) },
+      {
+        buffer: Buffer.from('xlsx-data'),
+        originalname: 'import.xlsx',
+        mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        size: 9,
+      } as UploadableSpreadsheetFile,
+    );
+
+    expect(result.importId).toBe('winner-import');
+    expect(minio.deleteObject).toHaveBeenNthCalledWith(
+      1,
+      undefined,
+      expect.stringContaining('/original.xlsx'),
+      'v-current-original',
+    );
+    expect(minio.deleteObject).toHaveBeenNthCalledWith(
+      2,
+      undefined,
+      expect.stringContaining('/normalized.json'),
+      'v-current-normalized',
+    );
+    expect(minio.deleteObject).not.toHaveBeenCalledWith(
+      undefined,
+      expect.any(String),
+    );
+    expect(prisma.importJob.create).not.toHaveBeenCalled();
   });
 
   it('persists a blocked preview without storing the normalized payload', async () => {
@@ -625,7 +705,7 @@ describe('OnboardingImportsService', () => {
     parserService.parseWorkbook.mockImplementation(() => {
       throw new BadRequestException('Archivo inválido');
     });
-    prisma.importJob.upsert.mockResolvedValue(undefined);
+    prisma.importJob.create.mockResolvedValue(undefined);
 
     await expect(
       service.previewImport(
@@ -640,30 +720,193 @@ describe('OnboardingImportsService', () => {
     ).rejects.toThrow(BadRequestException);
 
     expect(minio.uploadBuffer).toHaveBeenCalledTimes(1);
-    expect(prisma.importJob.upsert).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: {
-          tenantId_type_schemaVersion_previewVersion_fileHash: {
-            tenantId,
-            type: 'INITIAL_ONBOARDING',
-            schemaVersion: 'v1',
-            previewVersion: 3,
-            fileHash: expect.any(String),
-          },
-        },
-        update: expect.objectContaining({
-          status: ImportJobStatus.FAILED,
-          previewVersion: 3,
-        }),
-        create: expect.objectContaining({
-          status: ImportJobStatus.FAILED,
-          previewVersion: 3,
-        }),
+    expect(prisma.importJob.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        status: ImportJobStatus.FAILED,
+        previewVersion: 4,
+        originalObjectVersionId: 'version-1',
       }),
-    );
+    }));
     expect(auditService.createLog).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'IMPORT_PREVIEW_FAILED' }),
     );
+  });
+
+  it('fails closed when the original upload has no provider version and never deletes by key', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
+    prisma.importJob.findUnique.mockResolvedValue(null);
+    prisma.importJob.create.mockResolvedValue(undefined);
+    minio.uploadBuffer.mockResolvedValue({ etag: 'etag-without-version', versionId: null });
+
+    await expect(
+      service.previewImport(
+        { tenantId, user: buildUser(['TENANT_ADMIN']) },
+        {
+          buffer: Buffer.from('xlsx-data'),
+          originalname: 'import.xlsx',
+          mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          size: 9,
+        } as UploadableSpreadsheetFile,
+      ),
+    ).rejects.toThrow('Storage did not return a version id');
+
+    expect(prisma.importJob.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        previewVersion: 4,
+        originalObjectVersionId: null,
+      }),
+    }));
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it('preserves the original version and skips unsafe normalized cleanup when normalized upload lacks a version', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
+    prisma.importJob.findUnique.mockResolvedValue(null);
+    parserService.parseWorkbook.mockReturnValue({ data: buildParsedData(currentPeriod), issues: [] });
+    jest.spyOn(service as any, 'validateWorkbook').mockResolvedValue({
+      summary: createSummary(),
+      issues: [],
+    });
+    prisma.importJob.create.mockResolvedValue(undefined);
+    minio.uploadBuffer
+      .mockResolvedValueOnce({ etag: 'original-etag', versionId: 'original-version-1' })
+      .mockResolvedValueOnce({ etag: 'normalized-etag', versionId: null });
+
+    await expect(
+      service.previewImport(
+        { tenantId, user: buildUser(['TENANT_ADMIN']) },
+        {
+          buffer: Buffer.from('xlsx-data'),
+          originalname: 'import.xlsx',
+          mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          size: 9,
+        } as UploadableSpreadsheetFile,
+      ),
+    ).rejects.toThrow('Storage did not return a version id');
+
+    expect(prisma.importJob.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        originalObjectVersionId: 'original-version-1',
+      }),
+    }));
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for a whitespace-only original provider version without using the ETag', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
+    prisma.importJob.findUnique.mockResolvedValue(null);
+    prisma.importJob.create.mockResolvedValue(undefined);
+    minio.uploadBuffer.mockResolvedValue({ etag: 'etag-valid-looking', versionId: '   ' });
+
+    await expect(
+      service.previewImport(
+        { tenantId, user: buildUser(['TENANT_ADMIN']) },
+        {
+          buffer: Buffer.from('xlsx-data'),
+          originalname: 'import.xlsx',
+          mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          size: 9,
+        } as UploadableSpreadsheetFile,
+      ),
+    ).rejects.toThrow('Storage did not return a version id');
+
+    expect(prisma.importJob.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ originalObjectVersionId: null }),
+    }));
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it('deletes only the exact normalized version when persistence fails after both uploads', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
+    prisma.importJob.findUnique.mockResolvedValue(null);
+    parserService.parseWorkbook.mockReturnValue({ data: buildParsedData(currentPeriod), issues: [] });
+    jest.spyOn(service as any, 'validateWorkbook').mockResolvedValue({
+      summary: createSummary(),
+      issues: [],
+    });
+    transactionCreate.mockRejectedValue(new Error('database unavailable'));
+    prisma.importJob.create.mockResolvedValue(undefined);
+    minio.uploadBuffer
+      .mockResolvedValueOnce({ etag: 'original-etag', versionId: 'original-version-1' })
+      .mockResolvedValueOnce({ etag: 'normalized-etag', versionId: 'normalized-version-1' });
+
+    await expect(
+      service.previewImport(
+        { tenantId, user: buildUser(['TENANT_ADMIN']) },
+        {
+          buffer: Buffer.from('xlsx-data'),
+          originalname: 'import.xlsx',
+          mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          size: 9,
+        } as UploadableSpreadsheetFile,
+      ),
+    ).rejects.toThrow('database unavailable');
+
+    expect(minio.deleteObject).toHaveBeenCalledWith(
+      undefined,
+      expect.stringContaining('/normalized.json'),
+      'normalized-version-1',
+    );
+    expect(minio.deleteObject).not.toHaveBeenCalledWith(
+      undefined,
+      expect.stringContaining('/normalized.json'),
+    );
+  });
+
+  it('does not overwrite a concurrent READY winner when failed-job persistence races with it', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
+    prisma.importJob.findUnique.mockResolvedValue(null);
+    parserService.parseWorkbook.mockImplementation(() => {
+      throw new BadRequestException('Archivo inválido');
+    });
+    prisma.importJob.create.mockRejectedValue(createPrismaKnownError('P2002'));
+
+    await expect(
+      service.previewImport(
+        { tenantId, user: buildUser(['TENANT_ADMIN']) },
+        {
+          buffer: Buffer.from('xlsx-data'),
+          originalname: 'import.xlsx',
+          mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          size: 9,
+        } as UploadableSpreadsheetFile,
+      ),
+    ).rejects.toThrow(BadRequestException);
+
+    expect(prisma.importJob.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        status: ImportJobStatus.FAILED,
+        originalObjectVersionId: 'version-1',
+      }),
+    }));
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it('does not overwrite a concurrent winner when original VersionId validation fails after the initial lookup', async () => {
+    prisma.tenant.findUnique.mockResolvedValue({ id: tenantId, currency: 'ARS' });
+    prisma.importJob.findUnique.mockResolvedValue(null);
+    prisma.importJob.create.mockRejectedValue(createPrismaKnownError('P2002'));
+    minio.uploadBuffer.mockResolvedValue({ etag: 'etag-without-version', versionId: null });
+
+    await expect(
+      service.previewImport(
+        { tenantId, user: buildUser(['TENANT_ADMIN']) },
+        {
+          buffer: Buffer.from('xlsx-data'),
+          originalname: 'import.xlsx',
+          mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          size: 9,
+        } as UploadableSpreadsheetFile,
+      ),
+    ).rejects.toThrow('Storage did not return a version id');
+
+    expect(prisma.importJob.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        status: ImportJobStatus.FAILED,
+        originalObjectVersionId: null,
+      }),
+    }));
+    expect(minio.deleteObject).not.toHaveBeenCalled();
   });
 
   it('rejects residents before reading or persisting the import', async () => {

--- a/apps/api/src/onboarding-imports/onboarding-imports.service.ts
+++ b/apps/api/src/onboarding-imports/onboarding-imports.service.ts
@@ -19,6 +19,7 @@ import { isAllowedMediaType } from '@buildingos/contracts';
 import { AuditService } from '../audit/audit.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { MinioService } from '../storage/minio.service';
+import type { MinioUploadResult } from '../storage/minio.service';
 import { ONBOARDING_IMPORT_ALLOWED_MIME_TYPES, ONBOARDING_IMPORT_EXPIRES_DAYS, ONBOARDING_IMPORT_ISSUE_PAGE_SIZE_MAX, ONBOARDING_IMPORT_MAX_FILE_SIZE_BYTES, ONBOARDING_IMPORT_OBJECT_KEY_PREFIX, ONBOARDING_IMPORT_PREVIEW_VERSION, ONBOARDING_IMPORT_SCHEMA_VERSION, ONBOARDING_IMPORT_TYPE } from './onboarding-imports.constants';
 import { OnboardingImportConfirmationService } from './services/onboarding-import-confirmation.service';
 import { OnboardingImportNormalizerService } from './services/onboarding-import-normalizer.service';
@@ -128,7 +129,9 @@ interface JobCreatePayload {
   readonly fileHash: string;
   readonly fileMimeType: string;
   readonly originalObjectKey: string;
+  readonly originalObjectVersionId: string;
   readonly normalizedObjectKey: string | null;
+  readonly normalizedObjectVersionId: string | null;
   readonly summary: ImportPreviewSummary;
   readonly issues: ImportIssueRecord[];
   readonly canConfirm: boolean;
@@ -232,11 +235,13 @@ export class OnboardingImportsService {
 
     const importId = randomUUID();
     const keys = this.buildObjectKeys(input.tenantId, importId);
-    let normalizedUploaded = false;
-
-    await this.uploadOriginalFile(keys.originalObjectKey, uploadedFile.buffer, uploadedFile.mimetype);
+    let originalObjectVersionId: string | null = null;
+    let normalizedObjectVersionId: string | null = null;
 
     try {
+      const originalUpload = await this.uploadOriginalFile(keys.originalObjectKey, uploadedFile.buffer, uploadedFile.mimetype);
+      originalObjectVersionId = this.requireObjectVersionId(originalUpload, keys.originalObjectKey);
+
       const parsed = this.parserService.parseWorkbook(uploadedFile.buffer);
       const validation = await this.validateWorkbook(input.tenantId, access.tenantCurrency, parsed.data, parsed.issues);
       const status = validation.summary.blockingIssues > 0 ? ImportJobStatus.BLOCKED : ImportJobStatus.READY;
@@ -246,8 +251,8 @@ export class OnboardingImportsService {
 
       if (normalizedObjectKey) {
         const normalizedPayload = this.buildNormalizedPayload(input.tenantId, importId, fileHash, fileName, validation, parsed.data);
-        await this.minio.uploadBuffer(undefined, normalizedObjectKey, Buffer.from(JSON.stringify(normalizedPayload), 'utf8'), 'application/json');
-        normalizedUploaded = true;
+        const normalizedUpload = await this.minio.uploadBuffer(undefined, normalizedObjectKey, Buffer.from(JSON.stringify(normalizedPayload), 'utf8'), 'application/json');
+        normalizedObjectVersionId = this.requireObjectVersionId(normalizedUpload, normalizedObjectKey);
       }
 
       const created = await this.persistJob({
@@ -260,7 +265,9 @@ export class OnboardingImportsService {
         fileHash,
         fileMimeType: uploadedFile.mimetype,
         originalObjectKey: keys.originalObjectKey,
+        originalObjectVersionId,
         normalizedObjectKey,
+        normalizedObjectVersionId,
         summary: validation.summary,
         issues: validation.issues,
         canConfirm: status === ImportJobStatus.READY,
@@ -286,7 +293,11 @@ export class OnboardingImportsService {
       return created;
     } catch (error) {
       if (this.isUniqueConflict(error)) {
-        await this.cleanupImportObjects(keys);
+        await this.cleanupImportObjects({
+          ...keys,
+          originalObjectVersionId,
+          normalizedObjectVersionId,
+        });
         const existingAfterConflict = await this.findExistingJob(input.tenantId, fileHash);
         if (existingAfterConflict) {
           const reusedAction =
@@ -313,10 +324,12 @@ export class OnboardingImportsService {
 
           return existingAfterConflict;
         }
+
+        throw error;
       }
 
-      if (normalizedUploaded) {
-        await this.minio.deleteObject(undefined, keys.normalizedObjectKey);
+      if (normalizedObjectVersionId) {
+        await this.minio.deleteObject(undefined, keys.normalizedObjectKey, normalizedObjectVersionId);
       }
 
       await this.persistFailedImport({
@@ -328,6 +341,7 @@ export class OnboardingImportsService {
         fileHash,
         fileMimeType: uploadedFile.mimetype,
         originalObjectKey: keys.originalObjectKey,
+        originalObjectVersionId,
         error,
       });
 
@@ -979,66 +993,57 @@ export class OnboardingImportsService {
   }
 
   private async persistJob(payload: JobCreatePayload): Promise<ImportJobView> {
-    try {
-      const job = await this.prisma.$transaction(async (tx) => {
-        const created = await tx.importJob.create({
-          data: {
-            id: payload.importId,
-            tenantId: payload.tenantId,
-            type: ONBOARDING_IMPORT_TYPE,
-            status: payload.status,
-            schemaVersion: ONBOARDING_IMPORT_SCHEMA_VERSION,
-            previewVersion: payload.previewVersion,
-            fileName: payload.fileName,
-            fileSize: payload.fileSize,
-            fileMimeType: payload.fileMimeType,
-            fileHash: payload.fileHash,
-            previewHash: payload.previewHash,
-            originalObjectKey: payload.originalObjectKey,
-            normalizedObjectKey: payload.normalizedObjectKey,
-            summary: payload.summary as unknown as Prisma.JsonObject,
-            counts: payload.summary as unknown as Prisma.JsonObject,
-            canConfirm: payload.canConfirm,
-            expiresAt: this.getExpirationDate(),
+    const job = await this.prisma.$transaction(async (tx) => {
+      const created = await tx.importJob.create({
+        data: {
+          id: payload.importId,
+          tenantId: payload.tenantId,
+          type: ONBOARDING_IMPORT_TYPE,
+          status: payload.status,
+          schemaVersion: ONBOARDING_IMPORT_SCHEMA_VERSION,
+          previewVersion: payload.previewVersion,
+          fileName: payload.fileName,
+          fileSize: payload.fileSize,
+          fileMimeType: payload.fileMimeType,
+          fileHash: payload.fileHash,
+          previewHash: payload.previewHash,
+          originalObjectKey: payload.originalObjectKey,
+          originalObjectVersionId: payload.originalObjectVersionId,
+          normalizedObjectKey: payload.normalizedObjectKey,
+          normalizedObjectVersionId: payload.normalizedObjectVersionId,
+          summary: payload.summary as unknown as Prisma.JsonObject,
+          counts: payload.summary as unknown as Prisma.JsonObject,
+          canConfirm: payload.canConfirm,
+          expiresAt: this.getExpirationDate(),
+        },
+        include: {
+          issues: {
+            select: { id: true },
           },
-          include: {
-            issues: {
-              select: { id: true },
-            },
-          },
-        });
-
-        if (payload.issues.length > 0) {
-          await tx.importIssue.createMany({
-            data: payload.issues.map((issue) => ({
-              tenantId: payload.tenantId,
-              importJobId: created.id,
-              sheet: issue.sheet,
-              row: issue.row,
-              column: issue.column,
-              code: issue.code,
-              severity: issue.severity,
-              message: issue.message,
-              receivedValue: issue.receivedValue,
-              normalizedValue: issue.normalizedValue,
-            })),
-          });
-        }
-
-        return created;
+        },
       });
 
-      return this.mapJobView(job);
-    } catch (error) {
-      if (this.isUniqueConflict(error)) {
-        const existing = await this.findExistingJob(payload.tenantId, payload.fileHash);
-        if (existing) {
-          return existing;
-        }
+      if (payload.issues.length > 0) {
+        await tx.importIssue.createMany({
+          data: payload.issues.map((issue) => ({
+            tenantId: payload.tenantId,
+            importJobId: created.id,
+            sheet: issue.sheet,
+            row: issue.row,
+            column: issue.column,
+            code: issue.code,
+            severity: issue.severity,
+            message: issue.message,
+            receivedValue: issue.receivedValue,
+            normalizedValue: issue.normalizedValue,
+          })),
+        });
       }
 
-      throw error;
-    }
+      return created;
+    });
+
+    return this.mapJobView(job);
   }
 
   private async persistFailedImport(input: {
@@ -1050,6 +1055,7 @@ export class OnboardingImportsService {
     fileHash: string;
     fileMimeType: string;
     originalObjectKey: string;
+    originalObjectVersionId: string | null;
     error: unknown;
   }): Promise<void> {
     try {
@@ -1057,33 +1063,8 @@ export class OnboardingImportsService {
       const errorCode = this.sanitizeErrorCode(input.error);
       const errorMessage = this.sanitizeErrorMessage(input.error);
 
-      await this.prisma.importJob.upsert({
-        where: {
-          tenantId_type_schemaVersion_previewVersion_fileHash: {
-            tenantId: input.tenantId,
-            type: ONBOARDING_IMPORT_TYPE,
-            schemaVersion: ONBOARDING_IMPORT_SCHEMA_VERSION,
-            previewVersion: ONBOARDING_IMPORT_PREVIEW_VERSION,
-            fileHash: input.fileHash,
-          },
-        },
-        update: {
-          status: ImportJobStatus.FAILED,
-          errorCode,
-          errorMessage,
-          previewVersion: ONBOARDING_IMPORT_PREVIEW_VERSION,
-          previewHash: null,
-          summary: summary as unknown as Prisma.JsonObject,
-          counts: summary as unknown as Prisma.JsonObject,
-          canConfirm: false,
-          fileName: input.fileName,
-          fileSize: input.fileSize,
-          fileMimeType: input.fileMimeType,
-          originalObjectKey: input.originalObjectKey,
-          normalizedObjectKey: null,
-          createdByMembershipId: input.membershipId,
-        },
-        create: {
+      await this.prisma.importJob.create({
+        data: {
           id: input.importId,
           tenantId: input.tenantId,
           type: ONBOARDING_IMPORT_TYPE,
@@ -1096,7 +1077,9 @@ export class OnboardingImportsService {
           fileHash: input.fileHash,
           previewHash: null,
           originalObjectKey: input.originalObjectKey,
+          originalObjectVersionId: input.originalObjectVersionId,
           normalizedObjectKey: null,
+          normalizedObjectVersionId: null,
           summary: summary as unknown as Prisma.JsonObject,
           counts: summary as unknown as Prisma.JsonObject,
           canConfirm: false,
@@ -1106,8 +1089,12 @@ export class OnboardingImportsService {
           createdByMembershipId: input.membershipId,
         },
       });
-    } catch {
-      // Best effort only.
+    } catch (error) {
+      if (this.isUniqueConflict(error)) {
+        return;
+      }
+
+      // Best effort only; preserve the original preview failure.
     }
   }
 
@@ -1132,7 +1119,7 @@ export class OnboardingImportsService {
     return job ? this.mapJobView(job) : null;
   }
 
-  private async uploadOriginalFile(objectKey: string, buffer: Buffer, mimeType: string): Promise<void> {
+  private async uploadOriginalFile(objectKey: string, buffer: Buffer, mimeType: string): Promise<MinioUploadResult> {
     if (!isAllowedMediaType(mimeType, ONBOARDING_IMPORT_ALLOWED_MIME_TYPES)) {
       throw new UnsupportedMediaTypeException('Solo se permite subir archivos .xlsx');
     }
@@ -1141,7 +1128,15 @@ export class OnboardingImportsService {
       throw new PayloadTooLargeException(`El archivo supera el máximo de ${ONBOARDING_IMPORT_MAX_FILE_SIZE_BYTES} bytes`);
     }
 
-    await this.minio.uploadBuffer(undefined, objectKey, buffer, mimeType);
+    return this.minio.uploadBuffer(undefined, objectKey, buffer, mimeType);
+  }
+
+  private requireObjectVersionId(result: MinioUploadResult, objectKey: string): string {
+    if (!result || typeof result.versionId !== 'string' || result.versionId.trim().length === 0) {
+      throw new Error(`Storage did not return a version id for ${objectKey}`);
+    }
+
+    return result.versionId;
   }
 
   private assertFile(file: UploadableSpreadsheetFile | undefined): UploadableSpreadsheetFile {
@@ -1386,11 +1381,20 @@ export class OnboardingImportsService {
     throw new Error(this.sanitizeErrorMessage(error));
   }
 
-  private async cleanupImportObjects(keys: StoredImportObjectKeys): Promise<void> {
-    await Promise.allSettled([
-      this.minio.deleteObject(undefined, keys.originalObjectKey),
-      this.minio.deleteObject(undefined, keys.normalizedObjectKey),
-    ]);
+  private async cleanupImportObjects(objects: StoredImportObjectKeys & {
+    readonly originalObjectVersionId: string | null;
+    readonly normalizedObjectVersionId: string | null;
+  }): Promise<void> {
+    const deletions: Array<Promise<void>> = [];
+
+    if (objects.originalObjectVersionId) {
+      deletions.push(this.minio.deleteObject(undefined, objects.originalObjectKey, objects.originalObjectVersionId));
+    }
+    if (objects.normalizedObjectVersionId) {
+      deletions.push(this.minio.deleteObject(undefined, objects.normalizedObjectKey, objects.normalizedObjectVersionId));
+    }
+
+    await Promise.allSettled(deletions);
   }
 
   private sameCalendarDate(left: Date, rightIsoDate: string): boolean {

--- a/apps/api/src/onboarding-imports/onboarding-imports.service.ts
+++ b/apps/api/src/onboarding-imports/onboarding-imports.service.ts
@@ -235,13 +235,11 @@ export class OnboardingImportsService {
 
     const importId = randomUUID();
     const keys = this.buildObjectKeys(input.tenantId, importId);
-    let originalObjectVersionId: string | null = null;
+    const originalUpload = await this.uploadOriginalFile(keys.originalObjectKey, uploadedFile.buffer, uploadedFile.mimetype);
+    const originalObjectVersionId = this.requireObjectVersionId(originalUpload, keys.originalObjectKey);
     let normalizedObjectVersionId: string | null = null;
 
     try {
-      const originalUpload = await this.uploadOriginalFile(keys.originalObjectKey, uploadedFile.buffer, uploadedFile.mimetype);
-      originalObjectVersionId = this.requireObjectVersionId(originalUpload, keys.originalObjectKey);
-
       const parsed = this.parserService.parseWorkbook(uploadedFile.buffer);
       const validation = await this.validateWorkbook(input.tenantId, access.tenantCurrency, parsed.data, parsed.issues);
       const status = validation.summary.blockingIssues > 0 ? ImportJobStatus.BLOCKED : ImportJobStatus.READY;
@@ -1091,6 +1089,17 @@ export class OnboardingImportsService {
       });
     } catch (error) {
       if (this.isUniqueConflict(error)) {
+        const originalObjectVersionId = input.originalObjectVersionId;
+        if (originalObjectVersionId) {
+          await Promise.allSettled([
+            Promise.resolve().then(() => this.minio.deleteObject(
+              undefined,
+              input.originalObjectKey,
+              originalObjectVersionId,
+            )),
+          ]);
+        }
+
         return;
       }
 

--- a/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.spec.ts
+++ b/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.spec.ts
@@ -6,6 +6,7 @@ import { PrismaService } from '../../../prisma/prisma.service';
 import { MinioService } from '../../../storage/minio.service';
 import { OnboardingImportNormalizerService } from './onboarding-import-normalizer.service';
 import { OnboardingImportConfirmationService } from './onboarding-import-confirmation.service';
+import { ONBOARDING_IMPORT_EXACT_OBJECT_IDENTITY_PREVIEW_VERSION } from '../onboarding-imports.constants';
 import type {
   ConfirmOnboardingImportSummary,
   ImportPreviewSummary,
@@ -203,6 +204,7 @@ function createCurrentJob(overrides: Partial<Record<string, unknown>> = {}) {
     previewHash: 'preview-hash',
     originalObjectKey: 'imports/import-1/original.xlsx',
     normalizedObjectKey: 'imports/import-1/normalized.json',
+    normalizedObjectVersionId: 'normalized-version-1',
     summary: createPreviewSummary(),
     counts: createPreviewSummary(),
     canConfirm: true,
@@ -309,7 +311,7 @@ describe('OnboardingImportConfirmationService', () => {
   });
 
   it('confirms a ready import transactionally and persists the confirmation result', async () => {
-    const currentJob = createCurrentJob();
+    const currentJob = createCurrentJob({ previewVersion: 4 });
     const { payload, serialized } = createPayload(currentJob.id, currentJob.tenantId, currentJob.fileHash);
     const previewHash = createHash('sha256').update(serialized, 'utf8').digest('hex');
     currentJob.previewHash = previewHash;
@@ -338,7 +340,7 @@ describe('OnboardingImportConfirmationService', () => {
       roles: [Role.TENANT_ADMIN],
       isSuperAdmin: false,
       importId: currentJob.id,
-      expectedPreviewVersion: 1,
+      expectedPreviewVersion: 4,
     });
 
     expect(result).toMatchObject({
@@ -379,6 +381,11 @@ describe('OnboardingImportConfirmationService', () => {
         confirmingByMembershipId: 'membership-1',
       },
     });
+    expect(minio.getObjectBuffer).toHaveBeenCalledWith(
+      undefined,
+      currentJob.normalizedObjectKey,
+      currentJob.normalizedObjectVersionId,
+    );
     expect(tx.importJob.update).toHaveBeenCalledWith({
       where: { id: currentJob.id },
       data: expect.objectContaining({
@@ -906,5 +913,46 @@ describe('OnboardingImportConfirmationService', () => {
 
     expect(minio.getObjectBuffer).not.toHaveBeenCalled();
     expect(prisma.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('keeps legacy normalized payload reads key-only when the stored version is null', async () => {
+    const legacyJob = createCurrentJob({ previewVersion: 3, normalizedObjectVersionId: null });
+    const { serialized } = createPayload(legacyJob.id, legacyJob.tenantId, legacyJob.fileHash);
+    (minio.getObjectBuffer as jest.Mock).mockResolvedValue(Buffer.from(serialized, 'utf8'));
+
+    await (service as any).loadNormalizedPayload(legacyJob);
+
+    expect(minio.getObjectBuffer).toHaveBeenCalledWith(
+      undefined,
+      legacyJob.normalizedObjectKey,
+      undefined,
+    );
+  });
+
+  it('fails closed before reading latest for a new exact-identity job without a version', async () => {
+    const newJob = createCurrentJob({ previewVersion: 4, normalizedObjectVersionId: null });
+
+    await expect((service as any).loadNormalizedPayload(newJob)).rejects.toThrow(
+      'La importación no tiene una versión exacta del payload normalizado',
+    );
+
+    expect(minio.getObjectBuffer).not.toHaveBeenCalled();
+  });
+
+  it('keeps preview version 4 exact-identity even if the current preview version advances', async () => {
+    const exactIdentityJob = createCurrentJob({
+      previewVersion: ONBOARDING_IMPORT_EXACT_OBJECT_IDENTITY_PREVIEW_VERSION,
+      normalizedObjectVersionId: null,
+    });
+
+    expect(ONBOARDING_IMPORT_EXACT_OBJECT_IDENTITY_PREVIEW_VERSION).toBe(4);
+    expect(ONBOARDING_IMPORT_EXACT_OBJECT_IDENTITY_PREVIEW_VERSION + 1).toBeGreaterThan(
+      ONBOARDING_IMPORT_EXACT_OBJECT_IDENTITY_PREVIEW_VERSION,
+    );
+
+    await expect((service as any).loadNormalizedPayload(exactIdentityJob)).rejects.toThrow(
+      'La importación no tiene una versión exacta del payload normalizado',
+    );
+    expect(minio.getObjectBuffer).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.ts
+++ b/apps/api/src/onboarding-imports/services/onboarding-import-confirmation.service.ts
@@ -26,6 +26,7 @@ import {
   ONBOARDING_IMPORT_CONFIRM_LOCK_TIMEOUT_MS,
   ONBOARDING_IMPORT_CONFIRM_TRANSACTION_MAX_WAIT_MS,
   ONBOARDING_IMPORT_CONFIRM_TRANSACTION_TIMEOUT_MS,
+  ONBOARDING_IMPORT_EXACT_OBJECT_IDENTITY_PREVIEW_VERSION,
   ONBOARDING_IMPORT_SCHEMA_VERSION,
 } from '../onboarding-imports.constants';
 import type {
@@ -86,6 +87,7 @@ interface ImportJobConfirmationRecord {
   readonly fileHash: string;
   readonly previewHash: string | null;
   readonly normalizedObjectKey: string | null;
+  readonly normalizedObjectVersionId: string | null;
   readonly canConfirm: boolean;
   readonly expiresAt: Date;
   readonly confirmingAt: Date | null;
@@ -954,7 +956,19 @@ export class OnboardingImportConfirmationService {
       throw new ConflictException('La importación no tiene payload normalizado disponible');
     }
 
-    const buffer = await this.minio.getObjectBuffer(undefined, job.normalizedObjectKey);
+    const versionId = job.normalizedObjectVersionId;
+    if (
+      job.previewVersion >= ONBOARDING_IMPORT_EXACT_OBJECT_IDENTITY_PREVIEW_VERSION
+      && (typeof versionId !== 'string' || versionId.trim().length === 0)
+    ) {
+      throw new ConflictException('La importación no tiene una versión exacta del payload normalizado');
+    }
+
+    const buffer = await this.minio.getObjectBuffer(
+      undefined,
+      job.normalizedObjectKey,
+      typeof versionId === 'string' && versionId.trim().length > 0 ? versionId : undefined,
+    );
     const payload = this.parseJson(buffer);
 
     if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {


### PR DESCRIPTION
## Scope
- OBJECT-BACKUP-01D-1B3
- Persist exact original and normalized provider VersionIds for ImportJob objects.
- Confirmation reads normalized payloads using the exact stored VersionId.
- Preserve legacy preview versions <=3 with key-only compatibility.
- Enforce the preview >=4 fail-closed exact-identity contract.
- Cleanup deletes only the exact uploaded object versions.
- Preserve concurrent winner behavior after P2002 conflicts.
- No historical backfill.
- No recovery-point validation.

## Contract Boundary
- Current preview version: 4.
- Permanent exact-identity minimum preview version: 4.
- Legacy maximum preview version: 3.

## Validation
- Focused onboarding tests: 38 passed.
- API typecheck, lint, test:forbid-only, build, and git diff --check passed.
- Full API suite passed in V2: 190 suites and 3,100 tests passed; not rerun solely for this constant substitution.

No staging or production access was performed. Do not merge without PM review.