### PR TITLE
fix(documents): delete exact storage object version

### DIFF
--- a/apps/api/src/documents/documents.local.integration.spec.ts
+++ b/apps/api/src/documents/documents.local.integration.spec.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from 'node:crypto';
+import { ConfigService } from '../config/config.service';
+import { loadConfig } from '../config/config';
+import { PrismaService } from '../prisma/prisma.service';
+import { MinioService } from '../storage/minio.service';
+import { ResidentAccessService } from '../resident-access/resident-access.service';
+import { DocumentsService } from './documents.service';
+import { DocumentsValidators } from './documents.validators';
+
+const runLocalIntegration = process.env.RUN_LOCAL_DOCUMENT_DELETE_INTEGRATION === '1';
+const localDescribe = runLocalIntegration ? describe : describe.skip;
+
+interface CreatedObjectVersion {
+  readonly objectKey: string;
+  readonly versionId: string;
+}
+
+localDescribe('Documents exact-delete local integration', () => {
+  let prisma: PrismaService;
+  let storage: MinioService;
+  let service: DocumentsService;
+  const createdObjectVersions: CreatedObjectVersion[] = [];
+  const createdDocumentIds: string[] = [];
+  const createdFileIds: string[] = [];
+
+  beforeAll(async () => {
+    const config = new ConfigService(loadConfig());
+    prisma = new PrismaService();
+    storage = new MinioService(config);
+    await prisma.$connect();
+
+    const residentAccess = {
+      shouldEnforce: () => false,
+    } as unknown as ResidentAccessService;
+    const validators = new DocumentsValidators(prisma, residentAccess);
+    service = new DocumentsService(
+      prisma,
+      validators,
+      storage,
+      { createNotification: async () => undefined } as never,
+      { createLog: async () => undefined } as never,
+      residentAccess,
+    );
+  });
+
+  afterAll(async () => {
+    if (!prisma || !storage) {
+      return;
+    }
+
+    await prisma.document.deleteMany({ where: { id: { in: createdDocumentIds } } });
+    await prisma.file.deleteMany({ where: { id: { in: createdFileIds } } });
+
+    for (const object of createdObjectVersions) {
+      try {
+        await storage.deleteObject(undefined, object.objectKey, object.versionId);
+      } catch (error: unknown) {
+        if (!storage.isNotFoundError(error)) {
+          throw error;
+        }
+      }
+    }
+
+    await prisma.$disconnect();
+  });
+
+  it('deletes only the referenced version and preserves the current successor', async () => {
+    const tenant = await prisma.tenant.findFirst({ select: { id: true } });
+    if (!tenant) {
+      throw new Error('Local integration requires at least one local tenant');
+    }
+
+    const objectKey = `tenant-${tenant.id}/documents/${randomUUID()}.pdf`;
+    const upload = async (content: string): Promise<string> => {
+      const result = await storage.uploadBuffer(undefined, objectKey, Buffer.from(content, 'utf8'));
+      if (!result.versionId) {
+        throw new Error(`Local MinIO did not return a VersionId for ${objectKey}`);
+      }
+      createdObjectVersions.push({ objectKey, versionId: result.versionId });
+      return result.versionId;
+    };
+
+    const version1 = await upload('version-one');
+    const version2 = await upload('version-two');
+    const file = await prisma.file.create({
+      data: {
+        tenantId: tenant.id,
+        bucket: storage.getDefaultBucket(),
+        objectKey,
+        objectVersionId: version1,
+        originalName: 'file.pdf',
+        mimeType: 'application/pdf',
+        size: 11,
+      },
+      select: { id: true },
+    });
+    createdFileIds.push(file.id);
+    const document = await prisma.document.create({
+      data: {
+        tenantId: tenant.id,
+        fileId: file.id,
+        title: 'Exact delete integration document',
+        category: 'OTHER',
+        visibility: 'TENANT_ADMINS',
+      },
+      select: { id: true },
+    });
+    createdDocumentIds.push(document.id);
+
+    await service.deleteDocument(tenant.id, document.id, 'local-integration-admin', ['TENANT_ADMIN']);
+    await flushStorageCleanup();
+
+    expect(await prisma.document.findUnique({ where: { id: document.id } })).toBeNull();
+    expect(await prisma.file.findUnique({ where: { id: file.id } })).toBeNull();
+    await expectMissingVersion(objectKey, version1);
+    await expectPresentVersion(objectKey, version2, true);
+  });
+
+  it('deletes legacy metadata while preserving its storage object', async () => {
+    const tenant = await prisma.tenant.findFirst({ select: { id: true } });
+    if (!tenant) {
+      throw new Error('Local integration requires at least one local tenant');
+    }
+
+    const objectKey = `tenant-${tenant.id}/documents/${randomUUID()}-legacy.pdf`;
+    const result = await storage.uploadBuffer(undefined, objectKey, Buffer.from('legacy', 'utf8'));
+    if (!result.versionId) {
+      throw new Error(`Local MinIO did not return a VersionId for ${objectKey}`);
+    }
+    createdObjectVersions.push({ objectKey, versionId: result.versionId });
+
+    const file = await prisma.file.create({
+      data: {
+        tenantId: tenant.id,
+        bucket: storage.getDefaultBucket(),
+        objectKey,
+        objectVersionId: null,
+        originalName: 'legacy.pdf',
+        mimeType: 'application/pdf',
+        size: 6,
+      },
+      select: { id: true },
+    });
+    createdFileIds.push(file.id);
+    const document = await prisma.document.create({
+      data: {
+        tenantId: tenant.id,
+        fileId: file.id,
+        title: 'Legacy delete integration document',
+        category: 'OTHER',
+        visibility: 'TENANT_ADMINS',
+      },
+      select: { id: true },
+    });
+    createdDocumentIds.push(document.id);
+
+    await service.deleteDocument(tenant.id, document.id, 'local-integration-admin', ['TENANT_ADMIN']);
+    await flushStorageCleanup();
+
+    expect(await prisma.document.findUnique({ where: { id: document.id } })).toBeNull();
+    expect(await prisma.file.findUnique({ where: { id: file.id } })).toBeNull();
+    await expectPresentVersion(objectKey, result.versionId, true);
+  });
+
+  async function expectMissingVersion(objectKey: string, versionId: string): Promise<void> {
+    try {
+      await storage.statObject(undefined, objectKey, versionId);
+      throw new Error(`Expected storage version to be missing: ${objectKey}/${versionId}`);
+    } catch (error: unknown) {
+      expect(storage.isNotFoundError(error)).toBe(true);
+    }
+  }
+
+  async function expectPresentVersion(objectKey: string, versionId: string, expectCurrent: boolean): Promise<void> {
+    const stat = await storage.statObject(undefined, objectKey, versionId);
+    expect(stat.versionId).toBe(versionId);
+
+    if (expectCurrent) {
+      const current = await storage.statObject(undefined, objectKey);
+      expect(current.versionId).toBe(versionId);
+    }
+  }
+
+  async function flushStorageCleanup(): Promise<void> {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+});

--- a/apps/api/src/documents/documents.local.integration.spec.ts
+++ b/apps/api/src/documents/documents.local.integration.spec.ts
@@ -22,6 +22,8 @@ localDescribe('Documents exact-delete local integration', () => {
   const createdObjectVersions: CreatedObjectVersion[] = [];
   const createdDocumentIds: string[] = [];
   const createdFileIds: string[] = [];
+  const createdQuoteIds: string[] = [];
+  const createdVendorIds: string[] = [];
 
   beforeAll(async () => {
     const config = new ConfigService(loadConfig());
@@ -48,8 +50,10 @@ localDescribe('Documents exact-delete local integration', () => {
       return;
     }
 
+    await prisma.quote.deleteMany({ where: { id: { in: createdQuoteIds } } });
     await prisma.document.deleteMany({ where: { id: { in: createdDocumentIds } } });
     await prisma.file.deleteMany({ where: { id: { in: createdFileIds } } });
+    await prisma.vendor.deleteMany({ where: { id: { in: createdVendorIds } } });
 
     for (const object of createdObjectVersions) {
       try {
@@ -159,6 +163,79 @@ localDescribe('Documents exact-delete local integration', () => {
 
     expect(await prisma.document.findUnique({ where: { id: document.id } })).toBeNull();
     expect(await prisma.file.findUnique({ where: { id: file.id } })).toBeNull();
+    await expectPresentVersion(objectKey, result.versionId, true);
+  });
+
+  it('preserves a shared Quote File and its storage object', async () => {
+    const tenant = await prisma.tenant.findFirst({ select: { id: true } });
+    if (!tenant) {
+      throw new Error('Local integration requires at least one local tenant');
+    }
+    const building = await prisma.building.findFirst({
+      where: { tenantId: tenant.id },
+      select: { id: true },
+    });
+    if (!building) {
+      throw new Error('Local integration requires at least one local building');
+    }
+
+    const objectKey = `tenant-${tenant.id}/documents/${randomUUID()}-shared.pdf`;
+    const result = await storage.uploadBuffer(undefined, objectKey, Buffer.from('shared', 'utf8'));
+    if (!result.versionId) {
+      throw new Error(`Local MinIO did not return a VersionId for ${objectKey}`);
+    }
+    createdObjectVersions.push({ objectKey, versionId: result.versionId });
+
+    const file = await prisma.file.create({
+      data: {
+        tenantId: tenant.id,
+        bucket: storage.getDefaultBucket(),
+        objectKey,
+        objectVersionId: result.versionId,
+        originalName: 'shared.pdf',
+        mimeType: 'application/pdf',
+        size: 6,
+      },
+      select: { id: true },
+    });
+    createdFileIds.push(file.id);
+    const document = await prisma.document.create({
+      data: {
+        tenantId: tenant.id,
+        fileId: file.id,
+        title: 'Shared quote integration document',
+        category: 'OTHER',
+        visibility: 'TENANT_ADMINS',
+      },
+      select: { id: true },
+    });
+    createdDocumentIds.push(document.id);
+    const vendor = await prisma.vendor.create({
+      data: {
+        tenantId: tenant.id,
+        name: `Exact delete integration vendor ${randomUUID()}`,
+      },
+      select: { id: true },
+    });
+    createdVendorIds.push(vendor.id);
+    const quote = await prisma.quote.create({
+      data: {
+        tenantId: tenant.id,
+        buildingId: building.id,
+        vendorId: vendor.id,
+        fileId: file.id,
+        amount: 1,
+      },
+      select: { id: true, fileId: true },
+    });
+    createdQuoteIds.push(quote.id);
+
+    await service.deleteDocument(tenant.id, document.id, 'local-integration-admin', ['TENANT_ADMIN']);
+    await flushStorageCleanup();
+
+    expect(await prisma.document.findUnique({ where: { id: document.id } })).toBeNull();
+    expect(await prisma.file.findUnique({ where: { id: file.id } })).not.toBeNull();
+    expect(await prisma.quote.findUnique({ where: { id: quote.id }, select: { fileId: true } })).toEqual({ fileId: file.id });
     await expectPresentVersion(objectKey, result.versionId, true);
   });
 

--- a/apps/api/src/documents/documents.service.spec.ts
+++ b/apps/api/src/documents/documents.service.spec.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   ConflictException,
   ForbiddenException,
+  Logger,
   NotFoundException,
   PayloadTooLargeException,
 } from '@nestjs/common';
@@ -58,6 +59,7 @@ describe('DocumentsService', () => {
     file: {
       findFirst: jest.fn(),
       create: jest.fn(),
+      delete: jest.fn(),
     },
     payment: {
       findFirst: jest.fn(),
@@ -114,6 +116,29 @@ describe('DocumentsService', () => {
     size: 1024,
     checksum: 'checksum-123',
   };
+
+  const documentForDeletion = (objectVersionId: string | null | undefined) => ({
+    id: 'document-delete',
+    fileId: 'file-delete',
+    tenantId: 'tenant-1',
+    buildingId: 'building-1',
+    unitId: 'unit-1',
+    visibility: 'RESIDENTS',
+    title: 'Receipt',
+    category: 'RECEIPT',
+    createdByMembership: {
+      id: 'membership-1',
+      userId: 'user-1',
+    },
+    file: {
+      id: 'file-delete',
+      bucket: 'buildingos',
+      objectKey: 'tenant-tenant-1/documents/file.pdf',
+      objectVersionId,
+      originalName: 'file.pdf',
+      mimeType: 'application/pdf',
+    },
+  });
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -577,29 +602,74 @@ describe('DocumentsService', () => {
     expect(notifications.createNotification).not.toHaveBeenCalled();
   });
 
-  it('deletes unlinked documents normally', async () => {
-    prisma.document.findFirst.mockResolvedValueOnce({
-      id: 'document-delete',
-      fileId: 'file-delete',
-      tenantId: 'tenant-1',
-      buildingId: 'building-1',
-      unitId: 'unit-1',
-      visibility: 'RESIDENTS',
-      title: 'Receipt',
-      category: 'RECEIPT',
-      createdByMembership: {
-        id: 'membership-1',
-        userId: 'user-1',
-      },
-      file: { bucket: 'tenant-delete-bucket', objectKey: 'receipt.pdf', originalName: 'receipt.pdf', mimeType: 'application/pdf' },
-    } as never);
+  it('deletes the Document and File, then removes the exact storage version', async () => {
+    const document = documentForDeletion('version-1');
+    prisma.document.findFirst.mockResolvedValueOnce(document as never).mockResolvedValueOnce(document as never);
     prisma.document.delete.mockResolvedValueOnce({} as never);
+    prisma.file.delete.mockResolvedValueOnce({} as never);
 
     await expect(service.deleteDocument('tenant-1', 'document-delete', 'user-1', ['TENANT_ADMIN'])).resolves.toBeUndefined();
 
     expect(transactionQueryRawMock).toHaveBeenCalledTimes(1);
     expect(prisma.document.delete).toHaveBeenCalledWith({ where: { id: 'document-delete' } });
-    expect(minio.deleteObject).toHaveBeenCalledWith('tenant-delete-bucket', 'receipt.pdf');
+    expect(prisma.file.delete).toHaveBeenCalledWith({ where: { id: 'file-delete' } });
+    expect(prisma.document.delete.mock.invocationCallOrder[0]).toBeLessThan(prisma.file.delete.mock.invocationCallOrder[0]);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(minio.deleteObject).toHaveBeenCalledWith(
+      'buildingos',
+      'tenant-tenant-1/documents/file.pdf',
+      'version-1',
+    );
+  });
+
+  it.each([null, undefined, '  '])('deletes Document and File but skips storage cleanup without exact version: %s', async (objectVersionId) => {
+    const document = documentForDeletion(objectVersionId);
+    prisma.document.findFirst.mockResolvedValueOnce(document as never).mockResolvedValueOnce(document as never);
+    prisma.document.delete.mockResolvedValueOnce({} as never);
+    prisma.file.delete.mockResolvedValueOnce({} as never);
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation();
+
+    await expect(service.deleteDocument('tenant-1', 'document-delete', 'user-1', ['TENANT_ADMIN'])).resolves.toBeUndefined();
+
+    expect(prisma.document.delete).toHaveBeenCalledTimes(1);
+    expect(prisma.file.delete).toHaveBeenCalledTimes(1);
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('exact object version is unavailable'));
+    warnSpy.mockRestore();
+  });
+
+  it('keeps a completed DB deletion successful when exact storage cleanup fails', async () => {
+    const document = documentForDeletion('version-1');
+    prisma.document.findFirst.mockResolvedValueOnce(document as never).mockResolvedValueOnce(document as never);
+    prisma.document.delete.mockResolvedValueOnce({} as never);
+    prisma.file.delete.mockResolvedValueOnce({} as never);
+    minio.deleteObject.mockRejectedValueOnce(new Error('storage unavailable'));
+    const errorSpy = jest.spyOn(Logger.prototype, 'error').mockImplementation();
+
+    await expect(service.deleteDocument('tenant-1', 'document-delete', 'user-1', ['TENANT_ADMIN'])).resolves.toBeUndefined();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(prisma.document.delete).toHaveBeenCalledTimes(1);
+    expect(prisma.file.delete).toHaveBeenCalledTimes(1);
+    expect(minio.deleteObject).toHaveBeenCalledTimes(1);
+    expect(minio.deleteObject).toHaveBeenCalledWith('buildingos', 'tenant-tenant-1/documents/file.pdf', 'version-1');
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('exact MinIO object buildingos/tenant-tenant-1/documents/file.pdf version version-1'),
+      expect.any(String),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it('does not attempt storage cleanup when the DB transaction fails', async () => {
+    const document = documentForDeletion('version-1');
+    prisma.document.findFirst.mockResolvedValueOnce(document as never);
+    prisma.$transaction.mockRejectedValueOnce(new Error('database unavailable'));
+
+    await expect(service.deleteDocument('tenant-1', 'document-delete', 'user-1', ['TENANT_ADMIN'])).rejects.toThrow('database unavailable');
+
+    expect(prisma.document.delete).not.toHaveBeenCalled();
+    expect(prisma.file.delete).not.toHaveBeenCalled();
+    expect(minio.deleteObject).not.toHaveBeenCalled();
   });
 
   it('blocks document deletes when the file is linked to a payment proof or receipt', async () => {
@@ -634,6 +704,7 @@ describe('DocumentsService', () => {
       select: { id: true },
     }));
     expect(prisma.document.delete).not.toHaveBeenCalled();
+    expect(prisma.file.delete).not.toHaveBeenCalled();
     expect(minio.deleteObject).not.toHaveBeenCalled();
   });
 
@@ -1715,6 +1786,7 @@ describe('DocumentsService', () => {
 
     expect(transactionQueryRawMock).toHaveBeenCalledTimes(1);
     expect(prisma.document.delete).not.toHaveBeenCalled();
+    expect(prisma.file.delete).not.toHaveBeenCalled();
   });
 
   describe('Payment enrichment (functionalType / origin / payment)', () => {

--- a/apps/api/src/documents/documents.service.spec.ts
+++ b/apps/api/src/documents/documents.service.spec.ts
@@ -65,6 +65,9 @@ describe('DocumentsService', () => {
       findFirst: jest.fn(),
       findMany: jest.fn(),
     },
+    quote: {
+      count: jest.fn(),
+    },
     tenant: {
       findUnique: jest.fn(),
     },
@@ -149,6 +152,7 @@ describe('DocumentsService', () => {
         file: prisma.file,
         document: prisma.document,
         payment: prisma.payment,
+        quote: prisma.quote,
         $queryRaw: transactionQueryRawMock,
       } as never;
 
@@ -163,6 +167,7 @@ describe('DocumentsService', () => {
     minio.isNotFoundError.mockReturnValue(false);
     prisma.file.findFirst.mockResolvedValue(null);
     prisma.payment.findMany.mockResolvedValue([]);
+    prisma.quote.count.mockResolvedValue(0);
     prisma.unitOccupant.findMany.mockResolvedValue([]);
     prisma.document.findFirst.mockResolvedValue({
       id: 'document-1',
@@ -620,6 +625,40 @@ describe('DocumentsService', () => {
       'tenant-tenant-1/documents/file.pdf',
       'version-1',
     );
+  });
+
+  it('preserves a File shared with a Quote and skips storage cleanup', async () => {
+    const document = documentForDeletion('version-1');
+    const quoteReference = { id: 'quote-1', fileId: 'file-delete' };
+    prisma.document.findFirst.mockResolvedValueOnce(document as never).mockResolvedValueOnce(document as never);
+    prisma.quote.count.mockResolvedValueOnce(1);
+    prisma.document.delete.mockResolvedValueOnce({} as never);
+
+    await expect(service.deleteDocument('tenant-1', 'document-delete', 'user-1', ['TENANT_ADMIN'])).resolves.toBeUndefined();
+
+    expect(prisma.quote.count).toHaveBeenCalledWith({ where: { fileId: 'file-delete' } });
+    expect(prisma.document.delete).toHaveBeenCalledTimes(1);
+    expect(prisma.file.delete).not.toHaveBeenCalled();
+    expect(quoteReference.fileId).toBe('file-delete');
+    expect(minio.deleteObject).not.toHaveBeenCalled();
+  });
+
+  it('preserves a File referenced by multiple Quotes', async () => {
+    const document = documentForDeletion('version-1');
+    const quoteReferences = [
+      { id: 'quote-1', fileId: 'file-delete' },
+      { id: 'quote-2', fileId: 'file-delete' },
+    ];
+    prisma.document.findFirst.mockResolvedValueOnce(document as never).mockResolvedValueOnce(document as never);
+    prisma.quote.count.mockResolvedValueOnce(quoteReferences.length);
+    prisma.document.delete.mockResolvedValueOnce({} as never);
+
+    await expect(service.deleteDocument('tenant-1', 'document-delete', 'user-1', ['TENANT_ADMIN'])).resolves.toBeUndefined();
+
+    expect(prisma.document.delete).toHaveBeenCalledTimes(1);
+    expect(prisma.file.delete).not.toHaveBeenCalled();
+    expect(quoteReferences.every((quote) => quote.fileId === 'file-delete')).toBe(true);
+    expect(minio.deleteObject).not.toHaveBeenCalled();
   });
 
   it.each([null, undefined, '  '])('deletes Document and File but skips storage cleanup without exact version: %s', async (objectVersionId) => {

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -740,7 +740,7 @@ export class DocumentsService {
       );
     }
 
-    const cleanupIdentity = await this.prisma.$transaction(async (tx): Promise<DocumentStorageCleanupIdentity> => {
+    const cleanupIdentity = await this.prisma.$transaction(async (tx): Promise<DocumentStorageCleanupIdentity | null> => {
       await throwIfPaymentLinkedDocumentIsMutable(tx, tenantId, documentId, document.fileId);
 
       const lockedDocument = await tx.document.findFirst({
@@ -756,9 +756,16 @@ export class DocumentsService {
       }
 
       const lockedFile = lockedDocument.file;
+      const quoteReferenceCount = await tx.quote.count({
+        where: { fileId: lockedDocument.fileId },
+      });
       await tx.document.delete({
         where: { id: documentId },
       });
+
+      if (quoteReferenceCount > 0) {
+        return null;
+      }
 
       await tx.file.delete({
         where: { id: lockedDocument.fileId },
@@ -783,6 +790,10 @@ export class DocumentsService {
         category: document.category,
       },
     });
+
+    if (!cleanupIdentity) {
+      return;
+    }
 
     const objectVersionId = cleanupIdentity.objectVersionId;
     if (typeof objectVersionId !== 'string' || objectVersionId.trim().length === 0) {

--- a/apps/api/src/documents/documents.service.ts
+++ b/apps/api/src/documents/documents.service.ts
@@ -88,6 +88,12 @@ type DocumentContentResponse = {
   disposition: 'inline' | 'attachment';
 };
 
+interface DocumentStorageCleanupIdentity {
+  readonly bucket: string;
+  readonly objectKey: string;
+  readonly objectVersionId: string | null;
+}
+
 const ALLOWED_UPLOAD_MIME_TYPES = new Set([
   'application/pdf',
   'image/jpeg',
@@ -130,7 +136,7 @@ const PAYMENT_PROOF_MAX_BYTES = 10 * 1024 * 1024;
  *
  * 6. Client can delete (DELETE /documents/:id)
  *    → Validates creator/admin only
- *    → Deletes Document (cascade → File)
+ *    → Deletes Document and owned File metadata atomically
  *    → Separate async job handles MinIO cleanup
  */
 @Injectable()
@@ -691,8 +697,8 @@ export class DocumentsService {
    * Delete Document
    *
    * Only creator or admin can delete
-   * Document deletion cascades to File deletion
-   * MinIO cleanup should be done asynchronously (separate job)
+   * Deletes Document and owned File metadata in one transaction
+   * MinIO cleanup remains best-effort after the transaction commits
    */
   async deleteDocument(
     tenantId: string,
@@ -734,10 +740,7 @@ export class DocumentsService {
       );
     }
 
-    // Get file info before delete (for MinIO cleanup)
-    const fileInfo = document.file;
-
-    await this.prisma.$transaction(async (tx) => {
+    const cleanupIdentity = await this.prisma.$transaction(async (tx): Promise<DocumentStorageCleanupIdentity> => {
       await throwIfPaymentLinkedDocumentIsMutable(tx, tenantId, documentId, document.fileId);
 
       const lockedDocument = await tx.document.findFirst({
@@ -752,10 +755,20 @@ export class DocumentsService {
         throw new NotFoundException('Document not found');
       }
 
-      // Delete Document (cascades to File)
+      const lockedFile = lockedDocument.file;
       await tx.document.delete({
         where: { id: documentId },
       });
+
+      await tx.file.delete({
+        where: { id: lockedDocument.fileId },
+      });
+
+      return {
+        bucket: lockedFile.bucket,
+        objectKey: lockedFile.objectKey,
+        objectVersionId: lockedFile.objectVersionId,
+      };
     });
 
     // [PHASE 2 QUICK #7] Audit: DOCUMENT_DELETE
@@ -771,16 +784,27 @@ export class DocumentsService {
       },
     });
 
-    // Delete file from MinIO asynchronously (fire-and-forget)
-    // Don't await or throw if it fails - document is already deleted
-    void Promise.resolve(
-      this.minio.deleteObject(fileInfo.bucket, fileInfo.objectKey),
-    ).catch((error) => {
-      this.logger.error(
-        `Failed to delete file from MinIO: ${fileInfo.bucket}/${fileInfo.objectKey}`,
-        error,
+    const objectVersionId = cleanupIdentity.objectVersionId;
+    if (typeof objectVersionId !== 'string' || objectVersionId.trim().length === 0) {
+      this.logger.warn(
+        `Skipped MinIO cleanup for ${cleanupIdentity.bucket}/${cleanupIdentity.objectKey}: exact object version is unavailable`,
       );
-    });
+      return;
+    }
+
+    // Cleanup is deliberately best-effort after the DB transaction commits.
+    void Promise.resolve()
+      .then(() => this.minio.deleteObject(
+        cleanupIdentity.bucket,
+        cleanupIdentity.objectKey,
+        objectVersionId,
+      ))
+      .catch((error: unknown) => {
+        this.logger.error(
+          `Failed to delete exact MinIO object ${cleanupIdentity.bucket}/${cleanupIdentity.objectKey} version ${objectVersionId}`,
+          error instanceof Error ? error.stack : String(error),
+        );
+      });
   }
 
   /**


### PR DESCRIPTION
## Summary

- Delete `Document` and its owned `File` metadata in the same Prisma transaction.
- Versioned cleanup uses the exact `bucket`, `objectKey`, and `objectVersionId`.
- Legacy key-only references delete DB metadata but preserve the storage object.
- No key-only fallback occurs after storage cleanup failure.
- Payment-linked document protection remains intact.
- Files referenced by one or more `Quote` records are preserved; `Quote.fileId` is not modified and no storage cleanup is attempted.
- `Payment.proofFileId` remains protected by the existing payment-linked lock.

## Validation

- Local MinIO validation proved V1 deletion while V2 remains present and current.
- Legacy local object remained preserved.
- Shared Quote/File local validation preserved the File, Quote reference, and storage object.
- Documents focused tests: 91 passed.
- Reconciliation tests: 105 passed.
- Local integration: 3 passed.
- Full API Jest: 195 suites / 3217 tests passed; 14 suites and 201 tests skipped.
- API typecheck, lint, focused-test guard, and `git diff --check` passed.
- No schema changes or migrations.
- Staging and production were not accessed.

This PR is intentionally not merged.