### PR TITLE
feat(storage): add historical version inventory reconciliation

### DIFF
--- a/apps/api/scripts/reconciliation-historical-inventory.ts
+++ b/apps/api/scripts/reconciliation-historical-inventory.ts
@@ -1,0 +1,156 @@
+import { chmod, writeFile } from 'node:fs/promises';
+import { loadConfig } from '../src/config/config';
+import { ConfigService } from '../src/config/config.service';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { PrismaDbToStorageDatabase } from '../src/reconciliation/db-to-storage/prisma-db-to-storage.database';
+import { HistoricalInventoryScanner } from '../src/reconciliation/historical-inventory/historical-inventory.scanner';
+import {
+  HistoricalInventoryReceipt,
+  HistoricalScanStatus,
+} from '../src/reconciliation/historical-inventory/historical-inventory.types';
+import { MinioService } from '../src/storage/minio.service';
+
+interface CliOptions {
+  readonly databaseBatchSize: number;
+  readonly storagePageSize: number;
+  readonly maxFindings: number;
+  readonly outputPath?: string;
+}
+
+class CliUsageError extends Error {}
+
+function parseInteger(value: string, optionName: string, minimum: number, maximum?: number): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < minimum || maximum !== undefined && parsed > maximum) {
+    const range = maximum === undefined ? `>= ${minimum}` : `between ${minimum} and ${maximum}`;
+    throw new CliUsageError(`${optionName} must be an integer ${range}`);
+  }
+  return parsed;
+}
+
+function parseArgs(argv: readonly string[]): CliOptions | null {
+  let databaseBatchSize = 100;
+  let storagePageSize = 100;
+  let maxFindings = 1000;
+  let outputPath: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--help' || argument === '-h') {
+      process.stdout.write(
+        'Usage: reconciliation-historical-inventory [--database-batch-size N] [--storage-page-size N] [--max-findings N] [--output PATH]\n',
+      );
+      return null;
+    }
+
+    if (
+      argument !== '--database-batch-size'
+      && argument !== '--storage-page-size'
+      && argument !== '--max-findings'
+      && argument !== '--output'
+    ) {
+      throw new CliUsageError(`Unknown option: ${argument}`);
+    }
+
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new CliUsageError(`${argument} requires a value`);
+    }
+
+    if (argument === '--database-batch-size') {
+      databaseBatchSize = parseInteger(value, argument, 1);
+    } else if (argument === '--storage-page-size') {
+      storagePageSize = parseInteger(value, argument, 1, 1000);
+    } else if (argument === '--max-findings') {
+      maxFindings = parseInteger(value, argument, 0);
+    } else {
+      outputPath = value;
+    }
+    index += 1;
+  }
+
+  return {
+    databaseBatchSize,
+    storagePageSize,
+    maxFindings,
+    ...(outputPath ? { outputPath } : {}),
+  };
+}
+
+export function assertLocalNodeEnvironment(nodeEnv: string): void {
+  if (nodeEnv !== 'development' && nodeEnv !== 'test') {
+    throw new Error('Historical inventory is restricted to local development/test environments');
+  }
+}
+
+function exitCodeForStatus(status: HistoricalScanStatus): 0 | 2 {
+  return status === 'INCOMPLETE_OPERATIONAL_ERROR' ? 2 : 0;
+}
+
+export function conciseHistoricalSummary(receipt: HistoricalInventoryReceipt): Record<string, unknown> {
+  return {
+    scannerName: receipt.scannerName,
+    consistencyModel: receipt.consistencyModel,
+    databaseRowsScanned: receipt.databaseRowsScanned,
+    databaseReferencesScanned: receipt.databaseReferencesScanned,
+    storageEntriesScanned: receipt.storageEntriesScanned,
+    bucketsScanned: receipt.bucketsScanned,
+    referenceOutcomeCounts: receipt.referenceOutcomeCounts,
+    storageOutcomeCounts: receipt.storageOutcomeCounts,
+    dispositionCounts: receipt.dispositionCounts,
+    operationalErrorCount: receipt.operationalErrorCount,
+    scanStatus: receipt.scanStatus,
+  };
+}
+
+async function writeReceiptFile(outputPath: string, receipt: HistoricalInventoryReceipt): Promise<void> {
+  await writeFile(outputPath, `${JSON.stringify(receipt, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  await chmod(outputPath, 0o600);
+}
+
+export async function runCli(argv: readonly string[] = process.argv.slice(2)): Promise<number> {
+  let options: CliOptions | null;
+  try {
+    options = parseArgs(argv);
+  } catch (error: unknown) {
+    process.stderr.write(`${error instanceof CliUsageError ? error.message : 'Invalid CLI arguments'}\n`);
+    return 64;
+  }
+
+  if (!options) {
+    return 0;
+  }
+
+  let prisma: PrismaService | undefined;
+  try {
+    const config = new ConfigService(loadConfig());
+    assertLocalNodeEnvironment(config.getValue('nodeEnv'));
+    prisma = new PrismaService();
+    await prisma.$connect();
+
+    const receipt = await new HistoricalInventoryScanner(
+      new PrismaDbToStorageDatabase(prisma),
+      new MinioService(config),
+      options,
+    ).scan();
+
+    if (options.outputPath) {
+      await writeReceiptFile(options.outputPath, receipt);
+    }
+    process.stdout.write(`${JSON.stringify(conciseHistoricalSummary(receipt))}\n`);
+    return exitCodeForStatus(receipt.scanStatus);
+  } catch (_error: unknown) {
+    process.stderr.write('Historical inventory execution failed\n');
+    return 2;
+  } finally {
+    if (prisma) {
+      await prisma.$disconnect();
+    }
+  }
+}
+
+if (require.main === module) {
+  void runCli().then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.cli.spec.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.cli.spec.ts
@@ -1,0 +1,76 @@
+import {
+  assertLocalNodeEnvironment,
+  conciseHistoricalSummary,
+  runCli,
+} from '../../../scripts/reconciliation-historical-inventory';
+import { HistoricalInventoryReceipt } from './historical-inventory.types';
+
+function receipt(): HistoricalInventoryReceipt {
+  return {
+    schemaVersion: '1.0',
+    scannerName: 'historical-object-inventory',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    completedAt: '2026-01-01T00:00:01.000Z',
+    consistencyModel: 'MOVING_WINDOW',
+    databaseRowsScanned: 1,
+    databaseReferencesScanned: 1,
+    storageEntriesScanned: 1,
+    bucketsScanned: 1,
+    referenceOutcomeCounts: {
+      EXACT_REFERENCED_VERSION_PRESENT: 0,
+      EXACT_REFERENCED_VERSION_MISSING: 1,
+      LEGACY_KEY_ONLY_REFERENCE: 0,
+      INVALID_REFERENCE: 0,
+      CROSS_TENANT_REFERENCE: 0,
+      PROVIDER_OPERATIONAL_ERROR: 0,
+    },
+    storageOutcomeCounts: {
+      CURRENT_OBJECT: 0,
+      NONCURRENT_VERSION: 0,
+      LATEST_DELETE_MARKER: 0,
+      NONCURRENT_DELETE_MARKER: 0,
+      CURRENT_ORPHAN_OBJECT: 1,
+      ORPHAN_HISTORICAL_VERSION: 0,
+    },
+    dispositionCounts: {
+      PRESERVE: 1,
+      REPAIR_REQUIRED_LATER: 1,
+      OPERATIONAL_ERROR: 0,
+    },
+    operationalErrorCount: 0,
+    scanStatus: 'COMPLETE_WITH_FINDINGS',
+    detailedFindings: [{
+      source: 'File',
+      outcome: 'EXACT_REFERENCED_VERSION_MISSING',
+      disposition: 'REPAIR_REQUIRED_LATER',
+      objectReference: '[redacted:4-segments:leaf-length-18]',
+      versionReference: '[redacted-version:length-32]',
+    }],
+  };
+}
+
+describe('reconciliation-historical-inventory CLI', () => {
+  it('enforces local-only execution', () => {
+    expect(() => assertLocalNodeEnvironment('development')).not.toThrow();
+    expect(() => assertLocalNodeEnvironment('test')).not.toThrow();
+    expect(() => assertLocalNodeEnvironment('staging')).toThrow('restricted to local');
+    expect(() => assertLocalNodeEnvironment('production')).toThrow('restricted to local');
+  });
+
+  it('returns help before loading runtime configuration', async () => {
+    await expect(runCli(['--help'])).resolves.toBe(0);
+  });
+
+  it('returns usage errors for invalid bounded listing arguments', async () => {
+    await expect(runCli(['--storage-page-size', '1001'])).resolves.toBe(64);
+    await expect(runCli(['--database-batch-size', '0'])).resolves.toBe(64);
+  });
+
+  it('keeps concise output aggregate-only', () => {
+    const summary = conciseHistoricalSummary(receipt());
+
+    expect(summary).not.toHaveProperty('detailedFindings');
+    expect(JSON.stringify(summary)).not.toContain('redacted-version');
+    expect(JSON.stringify(summary)).not.toContain('redacted:');
+  });
+});

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.scanner.spec.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.scanner.spec.ts
@@ -1,0 +1,268 @@
+import { ImportJobStatus } from '@prisma/client';
+import {
+  ExpenseReferenceRecord,
+  FileReferenceRecord,
+  ImportJobReferenceRecord,
+  ReadOnlyReconciliationDatabase,
+} from '../db-to-storage/db-to-storage.types';
+import { HistoricalInventoryScanner } from './historical-inventory.scanner';
+import {
+  HistoricalInventoryStorage,
+  HistoricalObjectVersion,
+} from './historical-inventory.types';
+
+function page<T extends { id: string }>(rows: readonly T[], afterId: string | undefined, take: number): readonly T[] {
+  const ordered = [...rows].sort((left, right) => left.id.localeCompare(right.id));
+  const start = afterId ? ordered.findIndex((row) => row.id > afterId) : 0;
+  return ordered.slice(start < 0 ? ordered.length : start, (start < 0 ? ordered.length : start) + take);
+}
+
+function createDatabase(
+  files: readonly FileReferenceRecord[] = [],
+  imports: readonly ImportJobReferenceRecord[] = [],
+  expenses: readonly ExpenseReferenceRecord[] = [],
+): ReadOnlyReconciliationDatabase & { readonly mutation: jest.Mock } {
+  const mutation = jest.fn();
+  return {
+    findFileBatch: jest.fn(({ afterId, take }) => Promise.resolve(page(files, afterId, take))),
+    findImportJobBatch: jest.fn(({ afterId, take }) => Promise.resolve(page(imports, afterId, take))),
+    findExpenseBatch: jest.fn(({ afterId, take }) => Promise.resolve(page(expenses, afterId, take))),
+    findIncomeBatch: jest.fn().mockResolvedValue([]),
+    mutation,
+  };
+}
+
+function createStorage(pages: readonly (readonly HistoricalObjectVersion[])[]): HistoricalInventoryStorage & {
+  readonly listCalls: jest.Mock;
+  readonly removeObject: jest.Mock;
+  readonly putObject: jest.Mock;
+} {
+  const listCalls = jest.fn().mockImplementation((
+    _bucket: string,
+    options: { readonly keyMarker?: string; readonly versionIdMarker?: string },
+  ) => {
+    const index = options.keyMarker ? Number(options.keyMarker.slice('page-'.length)) : 0;
+    const items = pages[index] ?? [];
+    const nextIndex = index + 1;
+    return Promise.resolve({
+      items,
+      isTruncated: nextIndex < pages.length,
+      ...(nextIndex < pages.length
+        ? { nextKeyMarker: `page-${nextIndex}`, nextVersionIdMarker: `version-page-${nextIndex}` }
+        : {}),
+    });
+  });
+
+  return {
+    getDefaultBucket: () => 'buildingos-local',
+    listObjectVersionsPage: listCalls,
+    listCalls,
+    removeObject: jest.fn(),
+    putObject: jest.fn(),
+  };
+}
+
+function file(id: string, objectKey: string, objectVersionId: string | null): FileReferenceRecord {
+  return {
+    id,
+    tenantId: 'tenant-1',
+    bucket: 'buildingos-local',
+    objectKey,
+    objectVersionId,
+  };
+}
+
+function version(
+  objectKey: string,
+  versionId: string,
+  isLatest: boolean,
+  isDeleteMarker = false,
+): HistoricalObjectVersion {
+  return { objectKey, versionId, isLatest, isDeleteMarker };
+}
+
+describe('HistoricalInventoryScanner', () => {
+  it('correlates exact references and classifies current, noncurrent, delete-marker, orphan, legacy, invalid, and cross-tenant inventory', async () => {
+    const secretKey = 'tenant-tenant-1/private/exact-present.pdf';
+    const secretVersion = 'provider-version-secret-123456';
+    const database = createDatabase(
+      [
+        file('exact-present', secretKey, secretVersion),
+        file('exact-missing', 'tenant-tenant-1/private/exact-missing.pdf', 'missing-version-secret'),
+        file('noncurrent-present', 'tenant-tenant-1/private/noncurrent.pdf', 'noncurrent-secret'),
+        file('legacy', 'tenant-tenant-1/private/legacy.pdf', null),
+        file('invalid', '/invalid/key.pdf', 'invalid-version'),
+        file('cross-tenant', 'tenant-tenant-2/private/cross.pdf', 'cross-version'),
+      ],
+      [],
+      [{ id: 'expense-key-only', tenantId: 'tenant-1', attachmentFileKey: 'receipts/legacy.pdf' }],
+    );
+    const storage = createStorage([[
+      version(secretKey, secretVersion, true),
+      version('tenant-tenant-1/private/noncurrent.pdf', 'noncurrent-secret', false),
+      version('tenant-tenant-1/private/noncurrent.pdf', 'new-current-secret', true),
+      version('tenant-tenant-1/private/legacy.pdf', 'legacy-current-secret', true),
+      version('unowned/current-object.pdf', 'orphan-current-secret', true),
+      version('unowned/current-object.pdf', 'orphan-old-secret', false),
+      version('unowned/deleted-object.pdf', 'delete-marker-secret', true, true),
+      version('unowned/deleted-object.pdf', 'old-delete-marker-secret', false, true),
+    ]]);
+
+    const receipt = await new HistoricalInventoryScanner(database, storage, {
+      databaseBatchSize: 2,
+      storagePageSize: 50,
+    }).scan();
+
+    expect(receipt.referenceOutcomeCounts).toMatchObject({
+      EXACT_REFERENCED_VERSION_PRESENT: 2,
+      EXACT_REFERENCED_VERSION_MISSING: 1,
+      LEGACY_KEY_ONLY_REFERENCE: 2,
+      INVALID_REFERENCE: 1,
+      CROSS_TENANT_REFERENCE: 1,
+    });
+    expect(receipt.storageOutcomeCounts).toMatchObject({
+      CURRENT_OBJECT: 2,
+      NONCURRENT_VERSION: 1,
+      LATEST_DELETE_MARKER: 1,
+      NONCURRENT_DELETE_MARKER: 1,
+      CURRENT_ORPHAN_OBJECT: 2,
+      ORPHAN_HISTORICAL_VERSION: 1,
+    });
+    expect(receipt.dispositionCounts).toMatchObject({
+      PRESERVE: 5,
+      REPAIR_REQUIRED_LATER: 5,
+      OPERATIONAL_ERROR: 0,
+    });
+    expect(receipt.scanStatus).toBe('COMPLETE_WITH_FINDINGS');
+    expect(receipt.consistencyModel).toBe('MOVING_WINDOW');
+
+    const serialized = JSON.stringify(receipt);
+    expect(serialized).not.toContain(secretKey);
+    expect(serialized).not.toContain(secretVersion);
+    expect(serialized).not.toContain('missing-version-secret');
+    expect(receipt.detailedFindings).toEqual(expect.arrayContaining([
+      expect.objectContaining({ outcome: 'EXACT_REFERENCED_VERSION_MISSING' }),
+      expect.objectContaining({ outcome: 'LEGACY_KEY_ONLY_REFERENCE', disposition: 'REPAIR_REQUIRED_LATER' }),
+      expect.objectContaining({ outcome: 'CROSS_TENANT_REFERENCE' }),
+      expect.objectContaining({ outcome: 'CURRENT_ORPHAN_OBJECT', disposition: 'PRESERVE' }),
+      expect.objectContaining({ outcome: 'ORPHAN_HISTORICAL_VERSION', disposition: 'PRESERVE' }),
+      expect.objectContaining({ outcome: 'LATEST_DELETE_MARKER', disposition: 'PRESERVE' }),
+      expect.objectContaining({ outcome: 'NONCURRENT_DELETE_MARKER', disposition: 'PRESERVE' }),
+    ]));
+    expect(database.mutation).not.toHaveBeenCalled();
+    expect(storage.removeObject).not.toHaveBeenCalled();
+    expect(storage.putObject).not.toHaveBeenCalled();
+  });
+
+  it('paginates version listing with bounded pages and opaque provider markers', async () => {
+    const database = createDatabase();
+    const storage = createStorage([
+      [version('orphan/a.pdf', 'version-a', true)],
+      [version('orphan/b.pdf', 'version-b', false)],
+    ]);
+
+    const receipt = await new HistoricalInventoryScanner(database, storage, {
+      databaseBatchSize: 1,
+      storagePageSize: 1,
+      maxFindings: 1,
+    }).scan();
+
+    expect(storage.listCalls).toHaveBeenNthCalledWith(1, 'buildingos-local', {
+      prefix: '',
+      maxKeys: 1,
+    });
+    expect(storage.listCalls).toHaveBeenNthCalledWith(2, 'buildingos-local', {
+      prefix: '',
+      maxKeys: 1,
+      keyMarker: 'page-1',
+      versionIdMarker: 'version-page-1',
+    });
+    expect(receipt.storageEntriesScanned).toBe(2);
+    expect(receipt.detailedFindings).toHaveLength(1);
+  });
+
+  it.each([
+    [{ code: 'AccessDenied', statusCode: 403 }, 'AUTHORIZATION'],
+    [{ code: 'ETIMEDOUT' }, 'TIMEOUT'],
+  ] as const)('marks historical listing failure %j as operational and never reports exact missing', async (error, category) => {
+    const database = createDatabase([
+      file('exact', 'tenant-tenant-1/private/exact.pdf', 'exact-version'),
+    ]);
+    const storage = createStorage([]);
+    storage.listCalls.mockRejectedValue(error);
+
+    const receipt = await new HistoricalInventoryScanner(database, storage).scan();
+
+    expect(receipt.scanStatus).toBe('INCOMPLETE_OPERATIONAL_ERROR');
+    expect(receipt.operationalErrorCount).toBe(1);
+    expect(receipt.referenceOutcomeCounts.EXACT_REFERENCED_VERSION_MISSING).toBe(0);
+    expect(receipt.referenceOutcomeCounts.PROVIDER_OPERATIONAL_ERROR).toBe(1);
+    expect(receipt.detailedFindings).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        outcome: 'PROVIDER_OPERATIONAL_ERROR',
+        disposition: 'OPERATIONAL_ERROR',
+        providerErrorCategory: category,
+      }),
+    ]));
+  });
+
+  it('does not list storage for a cross-tenant-only non-default bucket reference', async () => {
+    const database = createDatabase([{
+      id: 'cross',
+      tenantId: 'tenant-1',
+      bucket: 'other-bucket',
+      objectKey: 'tenant-tenant-2/private/cross.pdf',
+      objectVersionId: 'cross-version',
+    }]);
+    const storage = createStorage([[]]);
+
+    await new HistoricalInventoryScanner(database, storage).scan();
+
+    expect(storage.listCalls).toHaveBeenCalledTimes(1);
+    expect(storage.listCalls).toHaveBeenCalledWith('buildingos-local', expect.anything());
+  });
+
+  it('validates options and rejects non-advancing historical pagination', async () => {
+    const database = createDatabase();
+    const storage = createStorage([]);
+
+    expect(() => new HistoricalInventoryScanner(database, storage, { storagePageSize: 1001 })).toThrow(
+      'storagePageSize must be an integer between 1 and 1000',
+    );
+
+    storage.listCalls.mockResolvedValue({
+      items: [],
+      isTruncated: true,
+      nextKeyMarker: 'same',
+      nextVersionIdMarker: 'same',
+    });
+    const receipt = await new HistoricalInventoryScanner(database, storage).scan();
+
+    expect(receipt.scanStatus).toBe('INCOMPLETE_OPERATIONAL_ERROR');
+    expect(storage.listCalls).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles import exact and legacy references without storage reads other than version inventory', async () => {
+    const importRows: readonly ImportJobReferenceRecord[] = [{
+      id: 'job',
+      tenantId: 'tenant-1',
+      status: ImportJobStatus.READY,
+      previewVersion: 3,
+      originalObjectKey: 'tenant-imports/tenant-1/job/original.xlsx',
+      originalObjectVersionId: 'import-version',
+      normalizedObjectKey: 'tenant-imports/tenant-1/job/normalized.json',
+      normalizedObjectVersionId: null,
+    }];
+    const database = createDatabase([], importRows);
+    const storage = createStorage([[
+      version('tenant-imports/tenant-1/job/original.xlsx', 'import-version', true),
+      version('tenant-imports/tenant-1/job/normalized.json', 'normalized-current', true),
+    ]]);
+
+    const receipt = await new HistoricalInventoryScanner(database, storage).scan();
+
+    expect(receipt.referenceOutcomeCounts.EXACT_REFERENCED_VERSION_PRESENT).toBe(1);
+    expect(receipt.referenceOutcomeCounts.LEGACY_KEY_ONLY_REFERENCE).toBe(1);
+    expect(receipt.storageOutcomeCounts.CURRENT_OBJECT).toBe(2);
+  });
+});

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.scanner.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.scanner.ts
@@ -1,0 +1,582 @@
+import {
+  classifyExpenseAttachmentReference,
+  classifyFileReference,
+  classifyImportNormalizedReference,
+  classifyImportOriginalReference,
+  classifyIncomeAttachmentReference,
+  redactObjectReference,
+} from '../db-to-storage/db-to-storage.classifier';
+import { classifyProviderError } from '../db-to-storage/db-to-storage.errors';
+import {
+  ClassificationDecision,
+  ExpenseReferenceRecord,
+  FileReferenceRecord,
+  ImportJobReferenceRecord,
+  IncomeReferenceRecord,
+  ReferenceSource,
+} from '../db-to-storage/db-to-storage.types';
+import {
+  HISTORICAL_REFERENCE_OUTCOMES,
+  HISTORICAL_STORAGE_OUTCOMES,
+  HistoricalDisposition,
+  HistoricalInventoryDatabase,
+  HistoricalInventoryFinding,
+  HistoricalInventoryReceipt,
+  HistoricalInventoryScannerOptions,
+  HistoricalInventoryStorage,
+  HistoricalObjectVersion,
+  HistoricalReferenceOutcome,
+  HistoricalStorageOutcome,
+} from './historical-inventory.types';
+
+const DEFAULT_DATABASE_BATCH_SIZE = 100;
+const DEFAULT_STORAGE_PAGE_SIZE = 100;
+const DEFAULT_MAX_FINDINGS = 1000;
+const TENANT_NAMESPACES = ['tenant-imports/', 'pilot-data-pack/', 'tenant/', 'tenant-'] as const;
+
+interface ValidatedReference {
+  readonly source: ReferenceSource;
+  readonly bucket: string;
+  readonly objectKey: string;
+  readonly versionId?: string;
+}
+
+interface MutableState {
+  readonly exactReferences: ValidatedReference[];
+  readonly exactIdentities: Set<string>;
+  readonly legacyKeys: Set<string>;
+  readonly buckets: Set<string>;
+  readonly successfullyListedBuckets: Set<string>;
+  readonly foundExactIdentities: Set<string>;
+  readonly referenceOutcomeCounts: Record<HistoricalReferenceOutcome, number>;
+  readonly storageOutcomeCounts: Record<HistoricalStorageOutcome, number>;
+  readonly dispositionCounts: Record<Exclude<HistoricalDisposition, 'NONE'>, number>;
+  readonly detailedFindings: HistoricalInventoryFinding[];
+  databaseRowsScanned: number;
+  databaseReferencesScanned: number;
+  storageEntriesScanned: number;
+  operationalErrorCount: number;
+  findingsCount: number;
+  databaseComplete: boolean;
+}
+
+function createReferenceCounts(): Record<HistoricalReferenceOutcome, number> {
+  return Object.fromEntries(HISTORICAL_REFERENCE_OUTCOMES.map((outcome) => [outcome, 0])) as Record<HistoricalReferenceOutcome, number>;
+}
+
+function createStorageCounts(): Record<HistoricalStorageOutcome, number> {
+  return Object.fromEntries(HISTORICAL_STORAGE_OUTCOMES.map((outcome) => [outcome, 0])) as Record<HistoricalStorageOutcome, number>;
+}
+
+function createState(defaultBucket: string): MutableState {
+  return {
+    exactReferences: [],
+    exactIdentities: new Set<string>(),
+    legacyKeys: new Set<string>(),
+    buckets: new Set<string>([defaultBucket]),
+    successfullyListedBuckets: new Set<string>(),
+    foundExactIdentities: new Set<string>(),
+    referenceOutcomeCounts: createReferenceCounts(),
+    storageOutcomeCounts: createStorageCounts(),
+    dispositionCounts: {
+      PRESERVE: 0,
+      REPAIR_REQUIRED_LATER: 0,
+      OPERATIONAL_ERROR: 0,
+    },
+    detailedFindings: [],
+    databaseRowsScanned: 0,
+    databaseReferencesScanned: 0,
+    storageEntriesScanned: 0,
+    operationalErrorCount: 0,
+    findingsCount: 0,
+    databaseComplete: true,
+  };
+}
+
+function identityKey(bucket: string, objectKey: string, versionId: string): string {
+  return JSON.stringify([bucket, objectKey, versionId]);
+}
+
+function objectKey(bucket: string, key: string): string {
+  return JSON.stringify([bucket, key]);
+}
+
+function redactVersionReference(versionId: string | undefined): string | undefined {
+  return versionId === undefined ? undefined : `[redacted-version:length-${versionId.length}]`;
+}
+
+function isValidBucketName(bucket: string): boolean {
+  return bucket.length >= 3
+    && bucket.length <= 63
+    && /^[a-z0-9][a-z0-9.-]*[a-z0-9]$/u.test(bucket)
+    && !bucket.includes('..')
+    && !bucket.includes('.-')
+    && !bucket.includes('-.');
+}
+
+function tenantFromRecognizedKey(key: string): string | undefined {
+  const namespace = TENANT_NAMESPACES.find((candidate) => key.startsWith(candidate));
+  if (!namespace) {
+    return undefined;
+  }
+
+  const remainder = key.slice(namespace.length);
+  const slashIndex = remainder.indexOf('/');
+  if (slashIndex <= 0 || slashIndex === remainder.length - 1) {
+    return undefined;
+  }
+
+  return remainder.slice(0, slashIndex);
+}
+
+function isCrossTenantReference(tenantId: string, key: string | null): boolean {
+  if (typeof key !== 'string' || tenantId.trim().length === 0) {
+    return false;
+  }
+
+  const keyTenant = tenantFromRecognizedKey(key);
+  return keyTenant !== undefined && keyTenant !== tenantId;
+}
+
+function normalizeInteger(
+  value: number | undefined,
+  fallback: number,
+  name: string,
+  minimum: number,
+  maximum?: number,
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  if (!Number.isInteger(value) || value < minimum || maximum !== undefined && value > maximum) {
+    const range = maximum === undefined ? `at least ${minimum}` : `between ${minimum} and ${maximum}`;
+    throw new Error(`${name} must be an integer ${range}`);
+  }
+
+  return value;
+}
+
+/**
+ * Produces a read-only moving-window inventory of database references and all
+ * provider-visible object versions. It never reads object bodies or mutates
+ * database/storage state.
+ */
+export class HistoricalInventoryScanner {
+  private readonly databaseBatchSize: number;
+  private readonly storagePageSize: number;
+  private readonly maxFindings: number;
+
+  constructor(
+    private readonly database: HistoricalInventoryDatabase,
+    private readonly storage: HistoricalInventoryStorage,
+    options: HistoricalInventoryScannerOptions = {},
+  ) {
+    this.databaseBatchSize = normalizeInteger(
+      options.databaseBatchSize,
+      DEFAULT_DATABASE_BATCH_SIZE,
+      'databaseBatchSize',
+      1,
+    );
+    this.storagePageSize = normalizeInteger(
+      options.storagePageSize,
+      DEFAULT_STORAGE_PAGE_SIZE,
+      'storagePageSize',
+      1,
+      1000,
+    );
+    this.maxFindings = normalizeInteger(options.maxFindings, DEFAULT_MAX_FINDINGS, 'maxFindings', 0);
+  }
+
+  async scan(): Promise<HistoricalInventoryReceipt> {
+    const startedAt = new Date().toISOString();
+    const state = createState(this.storage.getDefaultBucket());
+
+    await this.scanDatabase(state);
+    await this.scanStorage(state);
+    this.finishExactReferenceCorrelation(state);
+
+    const scanStatus = state.operationalErrorCount > 0
+      ? 'INCOMPLETE_OPERATIONAL_ERROR'
+      : state.findingsCount > 0
+        ? 'COMPLETE_WITH_FINDINGS'
+        : 'COMPLETE_CLEAN';
+
+    return {
+      schemaVersion: '1.0',
+      scannerName: 'historical-object-inventory',
+      startedAt,
+      completedAt: new Date().toISOString(),
+      consistencyModel: 'MOVING_WINDOW',
+      databaseRowsScanned: state.databaseRowsScanned,
+      databaseReferencesScanned: state.databaseReferencesScanned,
+      storageEntriesScanned: state.storageEntriesScanned,
+      bucketsScanned: state.successfullyListedBuckets.size,
+      referenceOutcomeCounts: state.referenceOutcomeCounts,
+      storageOutcomeCounts: state.storageOutcomeCounts,
+      dispositionCounts: state.dispositionCounts,
+      operationalErrorCount: state.operationalErrorCount,
+      scanStatus,
+      detailedFindings: state.detailedFindings,
+    };
+  }
+
+  private async scanDatabase(state: MutableState): Promise<void> {
+    await this.scanDatabaseSource(
+      state,
+      () => this.scanBatches(
+        (afterId) => this.database.findFileBatch({ afterId, take: this.databaseBatchSize }),
+        (row) => {
+          state.databaseRowsScanned += 1;
+          this.inspectFileReference(state, row);
+        },
+      ),
+    );
+    await this.scanDatabaseSource(
+      state,
+      () => this.scanBatches(
+        (afterId) => this.database.findImportJobBatch({ afterId, take: this.databaseBatchSize }),
+        (row) => {
+          state.databaseRowsScanned += 1;
+          this.inspectImportReferences(state, row);
+        },
+      ),
+    );
+    await this.scanDatabaseSource(
+      state,
+      () => this.scanBatches(
+        (afterId) => this.database.findExpenseBatch({ afterId, take: this.databaseBatchSize }),
+        (row) => {
+          state.databaseRowsScanned += 1;
+          this.inspectAttachmentReference(
+            state,
+            'Expense.attachment',
+            row,
+            classifyExpenseAttachmentReference(row.tenantId, row.attachmentFileKey),
+          );
+        },
+      ),
+    );
+    await this.scanDatabaseSource(
+      state,
+      () => this.scanBatches(
+        (afterId) => this.database.findIncomeBatch({ afterId, take: this.databaseBatchSize }),
+        (row) => {
+          state.databaseRowsScanned += 1;
+          this.inspectAttachmentReference(
+            state,
+            'Income.attachment',
+            row,
+            classifyIncomeAttachmentReference(row.tenantId, row.attachmentFileKey),
+          );
+        },
+      ),
+    );
+  }
+
+  private async scanDatabaseSource(state: MutableState, operation: () => Promise<void>): Promise<void> {
+    try {
+      await operation();
+    } catch (error: unknown) {
+      state.databaseComplete = false;
+      this.recordOperationalError(state, 'DATABASE', error);
+    }
+  }
+
+  private async scanBatches<T extends { readonly id: string }>(
+    fetchBatch: (afterId: string | undefined) => Promise<readonly T[]>,
+    inspect: (row: T) => void,
+  ): Promise<void> {
+    let afterId: string | undefined;
+
+    while (true) {
+      const batch = await fetchBatch(afterId);
+      if (batch.length === 0) {
+        return;
+      }
+
+      batch.forEach(inspect);
+      const nextAfterId = batch[batch.length - 1]?.id;
+      if (!nextAfterId || nextAfterId === afterId) {
+        throw new Error('Database pagination did not advance');
+      }
+      afterId = nextAfterId;
+    }
+  }
+
+  private inspectFileReference(state: MutableState, row: FileReferenceRecord): void {
+    const decision = classifyFileReference(row.tenantId, row.bucket, row.objectKey, row.objectVersionId);
+    this.inspectReference(
+      state,
+      'File',
+      row.tenantId,
+      row.bucket,
+      row.objectKey,
+      row.objectVersionId,
+      decision,
+    );
+  }
+
+  private inspectImportReferences(state: MutableState, row: ImportJobReferenceRecord): void {
+    const bucket = this.storage.getDefaultBucket();
+    this.inspectReference(
+      state,
+      'ImportJob.original',
+      row.tenantId,
+      bucket,
+      row.originalObjectKey,
+      row.originalObjectVersionId,
+      classifyImportOriginalReference(
+        row.tenantId,
+        row.previewVersion,
+        row.originalObjectKey,
+        row.originalObjectVersionId,
+      ),
+    );
+    this.inspectReference(
+      state,
+      'ImportJob.normalized',
+      row.tenantId,
+      bucket,
+      row.normalizedObjectKey,
+      row.normalizedObjectVersionId,
+      classifyImportNormalizedReference(
+        row.tenantId,
+        row.previewVersion,
+        row.status,
+        row.normalizedObjectKey,
+        row.normalizedObjectVersionId,
+      ),
+    );
+  }
+
+  private inspectAttachmentReference(
+    state: MutableState,
+    source: 'Expense.attachment' | 'Income.attachment',
+    row: ExpenseReferenceRecord | IncomeReferenceRecord,
+    decision: ClassificationDecision,
+  ): void {
+    this.inspectReference(
+      state,
+      source,
+      row.tenantId,
+      null,
+      row.attachmentFileKey,
+      null,
+      decision,
+    );
+  }
+
+  private inspectReference(
+    state: MutableState,
+    source: ReferenceSource,
+    tenantId: string,
+    bucket: string | null,
+    key: string | null,
+    versionId: string | null,
+    decision: ClassificationDecision,
+  ): void {
+    if (decision.identityClass === 'NOT_APPLICABLE') {
+      return;
+    }
+
+    state.databaseReferencesScanned += 1;
+    if (isCrossTenantReference(tenantId, key)) {
+      this.recordReferenceOutcome(state, source, 'CROSS_TENANT_REFERENCE', 'REPAIR_REQUIRED_LATER', key, versionId ?? undefined);
+      return;
+    }
+
+    if (
+      decision.identityClass === 'INVALID_REFERENCE'
+      || decision.identityClass === 'CONTRACT_VIOLATION'
+      || bucket !== null && !isValidBucketName(bucket)
+    ) {
+      this.recordReferenceOutcome(state, source, 'INVALID_REFERENCE', 'REPAIR_REQUIRED_LATER', key, versionId ?? undefined);
+      return;
+    }
+
+    if (
+      decision.identityClass === 'LEGACY_OR_UNKNOWN'
+      || decision.identityClass === 'LEGACY_KEY_ONLY'
+      || decision.identityClass === 'KEY_ONLY_UNVERSIONED'
+    ) {
+      this.recordReferenceOutcome(state, source, 'LEGACY_KEY_ONLY_REFERENCE', 'REPAIR_REQUIRED_LATER', key);
+      if (decision.storageCheck === 'CURRENT' && bucket !== null && key !== null) {
+        state.buckets.add(bucket);
+        state.legacyKeys.add(objectKey(bucket, key));
+      }
+      return;
+    }
+
+    if (
+      decision.identityClass === 'EXACT_VERSIONED'
+      && bucket !== null
+      && key !== null
+      && versionId !== null
+    ) {
+      const reference = { source, bucket, objectKey: key, versionId };
+      state.exactReferences.push(reference);
+      state.exactIdentities.add(identityKey(bucket, key, versionId));
+      state.buckets.add(bucket);
+      return;
+    }
+
+    this.recordReferenceOutcome(state, source, 'INVALID_REFERENCE', 'REPAIR_REQUIRED_LATER', key, versionId ?? undefined);
+  }
+
+  private async scanStorage(state: MutableState): Promise<void> {
+    const buckets = [...state.buckets].sort();
+    for (const bucket of buckets) {
+      try {
+        await this.scanStorageBucket(state, bucket);
+        state.successfullyListedBuckets.add(bucket);
+      } catch (error: unknown) {
+        this.recordOperationalError(state, 'STORAGE', error);
+      }
+    }
+  }
+
+  private async scanStorageBucket(state: MutableState, bucket: string): Promise<void> {
+    let keyMarker: string | undefined;
+    let versionIdMarker: string | undefined;
+
+    while (true) {
+      const page = await this.storage.listObjectVersionsPage(bucket, {
+        prefix: '',
+        maxKeys: this.storagePageSize,
+        ...(keyMarker ? { keyMarker } : {}),
+        ...(versionIdMarker ? { versionIdMarker } : {}),
+      });
+
+      page.items.forEach((entry) => this.inspectStorageEntry(state, bucket, entry));
+      if (!page.isTruncated) {
+        return;
+      }
+
+      const nextKeyMarker = page.nextKeyMarker;
+      const nextVersionIdMarker = page.nextVersionIdMarker;
+      if (
+        !nextKeyMarker
+        || !nextVersionIdMarker
+        || nextKeyMarker === keyMarker && nextVersionIdMarker === versionIdMarker
+      ) {
+        throw new Error('Historical storage pagination did not advance');
+      }
+
+      keyMarker = nextKeyMarker;
+      versionIdMarker = nextVersionIdMarker;
+    }
+  }
+
+  private inspectStorageEntry(state: MutableState, bucket: string, entry: HistoricalObjectVersion): void {
+    state.storageEntriesScanned += 1;
+    const exactIdentity = identityKey(bucket, entry.objectKey, entry.versionId);
+    const exactReferenced = state.exactIdentities.has(exactIdentity);
+    const legacyReferenced = entry.isLatest && state.legacyKeys.has(objectKey(bucket, entry.objectKey));
+
+    if (!entry.isDeleteMarker && exactReferenced) {
+      state.foundExactIdentities.add(exactIdentity);
+    }
+
+    let outcome: HistoricalStorageOutcome;
+    let disposition: HistoricalDisposition = 'NONE';
+    if (entry.isDeleteMarker) {
+      outcome = entry.isLatest ? 'LATEST_DELETE_MARKER' : 'NONCURRENT_DELETE_MARKER';
+      disposition = 'PRESERVE';
+    } else if (entry.isLatest) {
+      if (exactReferenced || legacyReferenced || !state.databaseComplete) {
+        outcome = 'CURRENT_OBJECT';
+      } else {
+        outcome = 'CURRENT_ORPHAN_OBJECT';
+        disposition = 'PRESERVE';
+      }
+    } else if (exactReferenced || !state.databaseComplete) {
+      outcome = 'NONCURRENT_VERSION';
+    } else {
+      outcome = 'ORPHAN_HISTORICAL_VERSION';
+      disposition = 'PRESERVE';
+    }
+
+    this.recordStorageOutcome(state, outcome, disposition, entry.objectKey, entry.versionId);
+  }
+
+  private finishExactReferenceCorrelation(state: MutableState): void {
+    for (const reference of state.exactReferences) {
+      if (!state.successfullyListedBuckets.has(reference.bucket)) {
+        continue;
+      }
+
+      const identity = identityKey(reference.bucket, reference.objectKey, reference.versionId ?? '');
+      if (state.foundExactIdentities.has(identity)) {
+        state.referenceOutcomeCounts.EXACT_REFERENCED_VERSION_PRESENT += 1;
+      } else {
+        this.recordReferenceOutcome(
+          state,
+          reference.source,
+          'EXACT_REFERENCED_VERSION_MISSING',
+          'REPAIR_REQUIRED_LATER',
+          reference.objectKey,
+          reference.versionId,
+        );
+      }
+    }
+  }
+
+  private recordReferenceOutcome(
+    state: MutableState,
+    source: ReferenceSource,
+    outcome: HistoricalReferenceOutcome,
+    disposition: HistoricalDisposition,
+    key?: string | null,
+    versionId?: string,
+  ): void {
+    state.referenceOutcomeCounts[outcome] += 1;
+    this.recordFinding(state, {
+      source,
+      outcome,
+      disposition,
+      ...(key !== undefined && key !== null ? { objectReference: redactObjectReference(key) } : {}),
+      ...(redactVersionReference(versionId) ? { versionReference: redactVersionReference(versionId) } : {}),
+    });
+  }
+
+  private recordStorageOutcome(
+    state: MutableState,
+    outcome: HistoricalStorageOutcome,
+    disposition: HistoricalDisposition,
+    key: string,
+    versionId: string,
+  ): void {
+    state.storageOutcomeCounts[outcome] += 1;
+    this.recordFinding(state, {
+      source: 'STORAGE',
+      outcome,
+      disposition,
+      objectReference: redactObjectReference(key),
+      versionReference: redactVersionReference(versionId),
+    });
+  }
+
+  private recordOperationalError(state: MutableState, source: 'DATABASE' | 'STORAGE', error: unknown): void {
+    state.operationalErrorCount += 1;
+    state.referenceOutcomeCounts.PROVIDER_OPERATIONAL_ERROR += 1;
+    this.recordFinding(state, {
+      source,
+      outcome: 'PROVIDER_OPERATIONAL_ERROR',
+      disposition: 'OPERATIONAL_ERROR',
+      providerErrorCategory: classifyProviderError(error),
+    });
+  }
+
+  private recordFinding(state: MutableState, finding: HistoricalInventoryFinding): void {
+    if (finding.disposition === 'NONE') {
+      return;
+    }
+
+    state.findingsCount += 1;
+    state.dispositionCounts[finding.disposition] += 1;
+    if (state.detailedFindings.length < this.maxFindings) {
+      state.detailedFindings.push(finding);
+    }
+  }
+}

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.types.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.types.ts
@@ -1,0 +1,96 @@
+import {
+  ProviderErrorCategory,
+  ReadOnlyReconciliationDatabase,
+  ReferenceSource,
+} from '../db-to-storage/db-to-storage.types';
+
+export const HISTORICAL_REFERENCE_OUTCOMES = [
+  'EXACT_REFERENCED_VERSION_PRESENT',
+  'EXACT_REFERENCED_VERSION_MISSING',
+  'LEGACY_KEY_ONLY_REFERENCE',
+  'INVALID_REFERENCE',
+  'CROSS_TENANT_REFERENCE',
+  'PROVIDER_OPERATIONAL_ERROR',
+] as const;
+
+export type HistoricalReferenceOutcome = (typeof HISTORICAL_REFERENCE_OUTCOMES)[number];
+
+export const HISTORICAL_STORAGE_OUTCOMES = [
+  'CURRENT_OBJECT',
+  'NONCURRENT_VERSION',
+  'LATEST_DELETE_MARKER',
+  'NONCURRENT_DELETE_MARKER',
+  'CURRENT_ORPHAN_OBJECT',
+  'ORPHAN_HISTORICAL_VERSION',
+] as const;
+
+export type HistoricalStorageOutcome = (typeof HISTORICAL_STORAGE_OUTCOMES)[number];
+export type HistoricalInventoryOutcome = HistoricalReferenceOutcome | HistoricalStorageOutcome;
+export type HistoricalDisposition = 'NONE' | 'PRESERVE' | 'REPAIR_REQUIRED_LATER' | 'OPERATIONAL_ERROR';
+export type HistoricalScanStatus = 'COMPLETE_CLEAN' | 'COMPLETE_WITH_FINDINGS' | 'INCOMPLETE_OPERATIONAL_ERROR';
+
+export interface HistoricalObjectVersion {
+  readonly objectKey: string;
+  readonly versionId: string;
+  readonly isLatest: boolean;
+  readonly isDeleteMarker: boolean;
+  readonly size?: number;
+}
+
+export interface HistoricalListingOptions {
+  readonly prefix: string;
+  readonly maxKeys: number;
+  readonly keyMarker?: string;
+  readonly versionIdMarker?: string;
+}
+
+export interface HistoricalObjectVersionPage {
+  readonly items: readonly HistoricalObjectVersion[];
+  readonly isTruncated: boolean;
+  readonly nextKeyMarker?: string;
+  readonly nextVersionIdMarker?: string;
+}
+
+/** Read-only storage surface intentionally excludes every mutation and object-body API. */
+export interface HistoricalInventoryStorage {
+  getDefaultBucket(): string;
+  listObjectVersionsPage(
+    bucketName: string,
+    options: HistoricalListingOptions,
+  ): Promise<HistoricalObjectVersionPage>;
+}
+
+export interface HistoricalInventoryFinding {
+  readonly source: ReferenceSource | 'DATABASE' | 'STORAGE';
+  readonly outcome: HistoricalInventoryOutcome;
+  readonly disposition: HistoricalDisposition;
+  readonly objectReference?: string;
+  readonly versionReference?: string;
+  readonly providerErrorCategory?: ProviderErrorCategory;
+}
+
+export interface HistoricalInventoryReceipt {
+  readonly schemaVersion: '1.0';
+  readonly scannerName: 'historical-object-inventory';
+  readonly startedAt: string;
+  readonly completedAt: string;
+  readonly consistencyModel: 'MOVING_WINDOW';
+  readonly databaseRowsScanned: number;
+  readonly databaseReferencesScanned: number;
+  readonly storageEntriesScanned: number;
+  readonly bucketsScanned: number;
+  readonly referenceOutcomeCounts: Record<HistoricalReferenceOutcome, number>;
+  readonly storageOutcomeCounts: Record<HistoricalStorageOutcome, number>;
+  readonly dispositionCounts: Record<Exclude<HistoricalDisposition, 'NONE'>, number>;
+  readonly operationalErrorCount: number;
+  readonly scanStatus: HistoricalScanStatus;
+  readonly detailedFindings: readonly HistoricalInventoryFinding[];
+}
+
+export interface HistoricalInventoryScannerOptions {
+  readonly databaseBatchSize?: number;
+  readonly storagePageSize?: number;
+  readonly maxFindings?: number;
+}
+
+export type HistoricalInventoryDatabase = ReadOnlyReconciliationDatabase;

--- a/apps/api/src/storage/minio.service.spec.ts
+++ b/apps/api/src/storage/minio.service.spec.ts
@@ -14,6 +14,8 @@ interface ClientMock {
   readonly putObject: jest.Mock;
   readonly presignedPutObject: jest.Mock;
   readonly presignedGetObject: jest.Mock;
+  readonly listObjectsQuery: jest.Mock;
+  readonly listObjects: jest.Mock;
 }
 
 const minioClientConstructor = Minio.Client as unknown as jest.Mock;
@@ -26,6 +28,8 @@ function createClientMock(): ClientMock {
     putObject: jest.fn(),
     presignedPutObject: jest.fn(),
     presignedGetObject: jest.fn(),
+    listObjectsQuery: jest.fn(),
+    listObjects: jest.fn(),
   };
 }
 
@@ -170,6 +174,95 @@ describe('MinioService', () => {
       'tenant-a/proof.pdf',
       { versionId: 'version-1' },
     );
+  });
+
+  it('lists and normalizes a bounded page of object versions with provider markers', async () => {
+    const internalClient = createClientMock();
+    const publicClient = createClientMock();
+    internalClient.listObjectsQuery.mockResolvedValue({
+      objects: [
+        {
+          name: 'tenant-a/private/current.pdf',
+          versionId: 'current-version-secret',
+          isLatest: true,
+          isDeleteMarker: false,
+          size: 42,
+        },
+        {
+          name: 'tenant-a/private/deleted.pdf',
+          versionId: 'delete-marker-secret',
+          isLatest: 'true',
+          isDeleteMarker: true,
+        },
+      ],
+      isTruncated: true,
+      keyMarker: 'next-key-marker',
+      versionIdMarker: 'next-version-marker',
+    });
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => publicClient);
+
+    const service = new MinioService(createConfig());
+
+    await expect(service.listObjectVersionsPage('buildingos-staging', {
+      prefix: 'tenant-a/',
+      maxKeys: 25,
+      keyMarker: 'key-marker',
+      versionIdMarker: 'version-marker',
+    })).resolves.toEqual({
+      items: [
+        {
+          objectKey: 'tenant-a/private/current.pdf',
+          versionId: 'current-version-secret',
+          isLatest: true,
+          isDeleteMarker: false,
+          size: 42,
+        },
+        {
+          objectKey: 'tenant-a/private/deleted.pdf',
+          versionId: 'delete-marker-secret',
+          isLatest: true,
+          isDeleteMarker: true,
+        },
+      ],
+      isTruncated: true,
+      nextKeyMarker: 'next-key-marker',
+      nextVersionIdMarker: 'next-version-marker',
+    });
+    expect(internalClient.listObjectsQuery).toHaveBeenCalledWith(
+      'buildingos-staging',
+      'tenant-a/',
+      undefined,
+      {
+        Delimiter: '',
+        MaxKeys: 25,
+        IncludeVersion: true,
+        keyMarker: 'key-marker',
+        versionIdMarker: 'version-marker',
+      },
+    );
+    expect(internalClient.listObjects).not.toHaveBeenCalled();
+  });
+
+  it('rejects malformed historical entries and never falls back to current-object listing', async () => {
+    const internalClient = createClientMock();
+    const publicClient = createClientMock();
+    internalClient.listObjectsQuery.mockResolvedValue({
+      objects: [{ name: 'private.pdf' }],
+      isTruncated: false,
+    });
+    minioClientConstructor
+      .mockImplementationOnce(() => internalClient)
+      .mockImplementationOnce(() => publicClient);
+
+    const service = new MinioService(createConfig());
+
+    await expect(service.listObjectVersionsPage('buildingos-staging', {
+      prefix: '',
+      maxKeys: 100,
+    })).rejects.toThrow('Historical object listing returned an invalid entry');
+    expect(internalClient.listObjects).not.toHaveBeenCalled();
   });
 
   it('deletes an exact object version when requested', async () => {

--- a/apps/api/src/storage/minio.service.ts
+++ b/apps/api/src/storage/minio.service.ts
@@ -23,6 +23,43 @@ export interface MinioUploadResult {
   readonly versionId: string | null;
 }
 
+export interface MinioHistoricalObjectVersion {
+  readonly objectKey: string;
+  readonly versionId: string;
+  readonly isLatest: boolean;
+  readonly isDeleteMarker: boolean;
+  readonly size?: number;
+}
+
+export interface MinioHistoricalListingOptions {
+  readonly prefix: string;
+  readonly maxKeys: number;
+  readonly keyMarker?: string;
+  readonly versionIdMarker?: string;
+}
+
+export interface MinioHistoricalObjectVersionPage {
+  readonly items: readonly MinioHistoricalObjectVersion[];
+  readonly isTruncated: boolean;
+  readonly nextKeyMarker?: string;
+  readonly nextVersionIdMarker?: string;
+}
+
+interface HistoricalObjectEntryLike {
+  readonly name?: unknown;
+  readonly versionId?: unknown;
+  readonly isLatest?: unknown;
+  readonly isDeleteMarker?: unknown;
+  readonly size?: unknown;
+}
+
+interface HistoricalListingResultLike {
+  readonly objects?: unknown;
+  readonly isTruncated?: unknown;
+  readonly keyMarker?: unknown;
+  readonly versionIdMarker?: unknown;
+}
+
 /**
  * MinIO Service: Wrapper around Minio SDK for presigned URLs and object operations
  *
@@ -311,6 +348,95 @@ export class MinioService {
       );
       throw error;
     }
+  }
+
+  /**
+   * List one bounded provider page including current versions, noncurrent
+   * versions, and delete markers. This method never falls back to the
+   * current-object-only listing API.
+   */
+  async listObjectVersionsPage(
+    bucketName: string = this.bucket,
+    options: MinioHistoricalListingOptions,
+  ): Promise<MinioHistoricalObjectVersionPage> {
+    if (!Number.isInteger(options.maxKeys) || options.maxKeys < 1 || options.maxKeys > 1000) {
+      throw new Error('Historical listing maxKeys must be an integer between 1 and 1000');
+    }
+
+    try {
+      const rawResult: unknown = await this.minioClient.listObjectsQuery(
+        bucketName,
+        options.prefix,
+        undefined,
+        {
+          Delimiter: '',
+          MaxKeys: options.maxKeys,
+          IncludeVersion: true,
+          ...(options.keyMarker ? { keyMarker: options.keyMarker } : {}),
+          ...(options.versionIdMarker ? { versionIdMarker: options.versionIdMarker } : {}),
+        },
+      );
+      const result = this.normalizeHistoricalListingResult(rawResult);
+      return result;
+    } catch (error: unknown) {
+      this.logger.error('Failed to list historical object inventory');
+      throw error;
+    }
+  }
+
+  private normalizeHistoricalListingResult(rawResult: unknown): MinioHistoricalObjectVersionPage {
+    if (typeof rawResult !== 'object' || rawResult === null) {
+      throw new Error('Historical object listing returned an invalid page');
+    }
+
+    const result = rawResult as HistoricalListingResultLike;
+    const rawObjects = result.objects ?? [];
+    if (!Array.isArray(rawObjects)) {
+      throw new Error('Historical object listing returned an invalid page');
+    }
+
+    const items = rawObjects.map((rawEntry): MinioHistoricalObjectVersion => {
+      if (typeof rawEntry !== 'object' || rawEntry === null) {
+        throw new Error('Historical object listing returned an invalid entry');
+      }
+
+      const entry = rawEntry as HistoricalObjectEntryLike;
+      if (
+        typeof entry.name !== 'string'
+        || entry.name.length === 0
+        || typeof entry.versionId !== 'string'
+        || entry.versionId.length === 0
+      ) {
+        throw new Error('Historical object listing returned an invalid entry');
+      }
+
+      const size = typeof entry.size === 'number' && Number.isFinite(entry.size) && entry.size >= 0
+        ? entry.size
+        : undefined;
+
+      return {
+        objectKey: entry.name,
+        versionId: entry.versionId,
+        isLatest: entry.isLatest === true || entry.isLatest === 'true',
+        isDeleteMarker: entry.isDeleteMarker === true || entry.isDeleteMarker === 'true',
+        ...(size !== undefined ? { size } : {}),
+      };
+    });
+
+    const isTruncated = result.isTruncated === true || result.isTruncated === 'true';
+    const nextKeyMarker = typeof result.keyMarker === 'string' && result.keyMarker.length > 0
+      ? result.keyMarker
+      : undefined;
+    const nextVersionIdMarker = typeof result.versionIdMarker === 'string' && result.versionIdMarker.length > 0
+      ? result.versionIdMarker
+      : undefined;
+
+    return {
+      items,
+      isTruncated,
+      ...(nextKeyMarker ? { nextKeyMarker } : {}),
+      ...(nextVersionIdMarker ? { nextVersionIdMarker } : {}),
+    };
   }
 
   /**


### PR DESCRIPTION
Closes #239

## Description

- Adds a read-only historical/versioned inventory reconciliation for active and legacy storage buckets.
- Covers current and noncurrent versions, delete markers, exact `VersionId` correlation, legacy key-only references, orphan preservation, tenant isolation, redaction, and `MOVING_WINDOW` semantics.
- No migrations and no staging or production access.

## Validation

- Historical inventory focused tests: PASS
- DB→Storage regression tests: PASS
- MinIO service tests: PASS
- Local MinIO versioned integration: PASS
- Full API suite: 3230 PASS
- `git diff --check`: PASS

## Tipo de cambio

- [ ] Bug fix
- [x] Nueva funcionalidad
- [ ] Refactor
- [ ] Cambio de documentación
- [ ] Otro: ___

## Checklist de validación local obligatoria

- [x] Tests unitarios pasan
- [x] Tests de integración pasan
- [ ] Tests E2E pasan (si aplica)
- [ ] Typecheck (`tsc --noEmit`) sin errores
- [ ] Lint sin errores nuevos
- [ ] Build exitoso
- [x] `git diff --check` limpio
- [x] Confirmé que todos los cambios fueron implementados y probados localmente
- [ ] Confirmé que el merge a main activará automáticamente el deploy a staging
- [ ] El despliegue automático a staging está autorizado para este PR
- [x] Las migraciones incluidas fueron validadas localmente (no migrations)
- [x] No se requiere preservar ningún archivo temporal dentro del checkout de staging
- [ ] La validación funcional en staging está definida para después del merge

## Notas

This PR does not authorize a merge, staging access, or production access.
