### PR TITLE
feat(storage): add storage-to-db reconciliation semantics

### DIFF
--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.scanner.spec.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.scanner.spec.ts
@@ -181,6 +181,73 @@ describe('HistoricalInventoryScanner', () => {
     expect(receipt.detailedFindings).toHaveLength(1);
   });
 
+  it('uses bounded bucket summaries and commits no conclusions after a later page failure', async () => {
+    const storage = createStorage([
+      [version('unowned/first-page-secret.pdf', 'first-page-secret', true)],
+      [version('unowned/second-page-secret.pdf', 'second-page-secret', false)],
+    ]);
+    const scanner = new HistoricalInventoryScanner(createDatabase(), storage, { storagePageSize: 1 });
+    let inspectedEntries = 0;
+    const summary = await (scanner as unknown as {
+      scanStorageBucket(
+        bucket: string,
+        inspect: (entry: HistoricalObjectVersion) => void,
+      ): Promise<{ readonly storageEntriesScanned: number }>;
+    }).scanStorageBucket('buildingos-local', () => {
+      inspectedEntries += 1;
+    });
+
+    expect(inspectedEntries).toBe(2);
+    expect(summary.storageEntriesScanned).toBe(2);
+    expect(JSON.stringify(summary)).not.toContain('first-page-secret');
+    expect(JSON.stringify(summary)).not.toContain('second-page-secret');
+
+    const failingStorage = createStorage([]);
+    failingStorage.listCalls
+      .mockResolvedValueOnce({
+        items: [version('unowned/provisional.pdf', 'provisional-version', true)],
+        isTruncated: true,
+        nextKeyMarker: 'page-1',
+        nextVersionIdMarker: 'version-page-1',
+      })
+      .mockRejectedValueOnce(new Error('second page failed'));
+
+    const receipt = await new HistoricalInventoryScanner(createDatabase(), failingStorage, {
+      storagePageSize: 1,
+    }).scan();
+
+    expect(receipt.scanStatus).toBe('INCOMPLETE_OPERATIONAL_ERROR');
+    expect(receipt.storageEntriesScanned).toBe(0);
+    expect(receipt.storageOutcomeCounts.CURRENT_ORPHAN_OBJECT).toBe(0);
+    expect(receipt.detailedFindings).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ outcome: 'CURRENT_ORPHAN_OBJECT' }),
+    ]));
+  });
+
+  it('accepts a non-empty whitespace-only provider object key', async () => {
+    const database = createDatabase();
+    const storage = createStorage([[version('   ', 'whitespace-version', true)]]);
+
+    const receipt = await new HistoricalInventoryScanner(database, storage).scan();
+
+    expect(receipt.scanStatus).toBe('COMPLETE_WITH_FINDINGS');
+    expect(receipt.storageEntriesScanned).toBe(1);
+    expect(receipt.storageOutcomeCounts.CURRENT_ORPHAN_OBJECT).toBe(1);
+    expect(receipt.operationalErrorCount).toBe(0);
+  });
+
+  it('accepts a non-empty whitespace-only provider version ID', async () => {
+    const database = createDatabase();
+    const storage = createStorage([[version('unowned/whitespace-version.pdf', '   ', true)]]);
+
+    const receipt = await new HistoricalInventoryScanner(database, storage).scan();
+
+    expect(receipt.scanStatus).toBe('COMPLETE_WITH_FINDINGS');
+    expect(receipt.storageEntriesScanned).toBe(1);
+    expect(receipt.storageOutcomeCounts.CURRENT_ORPHAN_OBJECT).toBe(1);
+    expect(receipt.operationalErrorCount).toBe(0);
+  });
+
   it.each([
     [{ code: 'AccessDenied', statusCode: 403 }, 'AUTHORIZATION'],
     [{ code: 'ETIMEDOUT' }, 'TIMEOUT'],

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.scanner.spec.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.scanner.spec.ts
@@ -206,7 +206,45 @@ describe('HistoricalInventoryScanner', () => {
     ]));
   });
 
-  it('does not list storage for a cross-tenant-only non-default bucket reference', async () => {
+  it('does not emit missing conclusions after a database pagination failure', async () => {
+        const database = createDatabase([
+          file('exact', 'tenant-tenant-1/private/exact.pdf', 'exact-version'),
+        ]);
+        jest.spyOn(database, 'findFileBatch')
+          .mockResolvedValueOnce([file('exact', 'tenant-tenant-1/private/exact.pdf', 'exact-version')])
+          .mockRejectedValueOnce(new Error('database cursor failed'));
+        const storage = createStorage([[]]);
+
+        const receipt = await new HistoricalInventoryScanner(database, storage).scan();
+
+        expect(receipt.scanStatus).toBe('INCOMPLETE_OPERATIONAL_ERROR');
+        expect(receipt.referenceOutcomeCounts.EXACT_REFERENCED_VERSION_MISSING).toBe(0);
+        expect(receipt.storageOutcomeCounts.CURRENT_ORPHAN_OBJECT).toBe(0);
+        expect(receipt.storageOutcomeCounts.ORPHAN_HISTORICAL_VERSION).toBe(0);
+      });
+
+      it('discards a bucket inventory when a later provider page is malformed', async () => {
+        const database = createDatabase();
+        const storage = createStorage([]);
+        storage.listCalls
+          .mockResolvedValueOnce({
+            items: [version('unowned/first-page.pdf', 'first-page-version', true)],
+            isTruncated: true,
+            nextKeyMarker: 'page-1',
+            nextVersionIdMarker: 'version-page-1',
+          })
+          .mockResolvedValueOnce({ isTruncated: false });
+
+        const receipt = await new HistoricalInventoryScanner(database, storage).scan();
+
+        expect(receipt.scanStatus).toBe('INCOMPLETE_OPERATIONAL_ERROR');
+        expect(receipt.operationalErrorCount).toBe(1);
+        expect(receipt.storageEntriesScanned).toBe(0);
+        expect(receipt.storageOutcomeCounts.CURRENT_ORPHAN_OBJECT).toBe(0);
+        expect(receipt.storageOutcomeCounts.ORPHAN_HISTORICAL_VERSION).toBe(0);
+      });
+
+      it('does not list storage for a cross-tenant-only non-default bucket reference', async () => {
     const database = createDatabase([{
       id: 'cross',
       tenantId: 'tenant-1',
@@ -242,7 +280,45 @@ describe('HistoricalInventoryScanner', () => {
     expect(storage.listCalls).toHaveBeenCalledTimes(2);
   });
 
-  it('handles import exact and legacy references without storage reads other than version inventory', async () => {
+  it('keeps bucketless Expense and Income keys unproven and storage-only findings tenant-unattributed', async () => {
+        const database = createDatabase(
+          [],
+          [],
+          [{ id: 'expense', tenantId: 'tenant-1', attachmentFileKey: 'receipts/expense.pdf' }],
+        );
+        jest.spyOn(database, 'findIncomeBatch').mockResolvedValueOnce([
+          { id: 'income', tenantId: 'tenant-1', attachmentFileKey: 'receipts/income.pdf' },
+        ]);
+        const storage = createStorage([[
+          version('receipts/expense.pdf', 'expense-version', true),
+          version('receipts/income.pdf', 'income-version', false),
+        ]]);
+
+        const receipt = await new HistoricalInventoryScanner(database, storage).scan();
+        const storageFindings = receipt.detailedFindings.filter((finding) => finding.source === 'STORAGE');
+
+        expect(receipt.referenceOutcomeCounts.LEGACY_KEY_ONLY_REFERENCE).toBe(2);
+        expect(receipt.storageOutcomeCounts.CURRENT_ORPHAN_OBJECT).toBe(1);
+        expect(receipt.storageOutcomeCounts.ORPHAN_HISTORICAL_VERSION).toBe(1);
+        expect(storageFindings.every((finding) => !('tenantId' in finding))).toBe(true);
+      });
+
+      it('counts shared exact File authority once in inventory without duplicating the storage identity', async () => {
+        const sharedKey = 'tenant-tenant-1/shared/file.pdf';
+        const database = createDatabase([
+          file('file-a', sharedKey, 'shared-version'),
+          file('file-b', sharedKey, 'shared-version'),
+        ]);
+        const storage = createStorage([[version(sharedKey, 'shared-version', true)]]);
+
+        const receipt = await new HistoricalInventoryScanner(database, storage).scan();
+
+        expect(receipt.referenceOutcomeCounts.EXACT_REFERENCED_VERSION_PRESENT).toBe(2);
+        expect(receipt.storageOutcomeCounts.CURRENT_OBJECT).toBe(1);
+        expect(receipt.storageEntriesScanned).toBe(1);
+      });
+
+      it('handles import exact and legacy references without storage reads other than version inventory', async () => {
     const importRows: readonly ImportJobReferenceRecord[] = [{
       id: 'job',
       tenantId: 'tenant-1',

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.scanner.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.scanner.ts
@@ -25,6 +25,7 @@ import {
   HistoricalInventoryScannerOptions,
   HistoricalInventoryStorage,
   HistoricalObjectVersion,
+  HistoricalObjectVersionPage,
   HistoricalReferenceOutcome,
   HistoricalStorageOutcome,
 } from './historical-inventory.types';
@@ -39,6 +40,21 @@ interface ValidatedReference {
   readonly bucket: string;
   readonly objectKey: string;
   readonly versionId?: string;
+}
+
+interface HistoricalObjectVersionPageLike {
+  readonly items?: unknown;
+  readonly isTruncated?: unknown;
+  readonly nextKeyMarker?: unknown;
+  readonly nextVersionIdMarker?: unknown;
+}
+
+interface HistoricalObjectVersionLike {
+  readonly objectKey?: unknown;
+  readonly versionId?: unknown;
+  readonly isLatest?: unknown;
+  readonly isDeleteMarker?: unknown;
+  readonly size?: unknown;
 }
 
 interface MutableState {
@@ -136,6 +152,38 @@ function isCrossTenantReference(tenantId: string, key: string | null): boolean {
 
   const keyTenant = tenantFromRecognizedKey(key);
   return keyTenant !== undefined && keyTenant !== tenantId;
+}
+
+function isHistoricalObjectVersionShape(value: unknown): value is HistoricalObjectVersion {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const entry = value as HistoricalObjectVersionLike;
+  return typeof entry.objectKey === 'string'
+    && entry.objectKey.trim().length > 0
+    && typeof entry.versionId === 'string'
+    && entry.versionId.trim().length > 0
+    && typeof entry.isLatest === 'boolean'
+    && typeof entry.isDeleteMarker === 'boolean'
+    && (entry.size === undefined || typeof entry.size === 'number' && Number.isFinite(entry.size) && entry.size >= 0);
+}
+
+function isHistoricalObjectVersionPage(
+  value: unknown,
+  maximumEntries: number,
+): value is HistoricalObjectVersionPage {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  const page = value as HistoricalObjectVersionPageLike;
+  return Array.isArray(page.items)
+    && page.items.length <= maximumEntries
+    && page.items.every(isHistoricalObjectVersionShape)
+    && typeof page.isTruncated === 'boolean'
+    && (page.nextKeyMarker === undefined || typeof page.nextKeyMarker === 'string')
+    && (page.nextVersionIdMarker === undefined || typeof page.nextVersionIdMarker === 'string');
 }
 
 function normalizeInteger(
@@ -428,7 +476,8 @@ export class HistoricalInventoryScanner {
     const buckets = [...state.buckets].sort();
     for (const bucket of buckets) {
       try {
-        await this.scanStorageBucket(state, bucket);
+        const entries = await this.scanStorageBucket(bucket);
+        entries.forEach((entry) => this.inspectStorageEntry(state, bucket, entry));
         state.successfullyListedBuckets.add(bucket);
       } catch (error: unknown) {
         this.recordOperationalError(state, 'STORAGE', error);
@@ -436,7 +485,8 @@ export class HistoricalInventoryScanner {
     }
   }
 
-  private async scanStorageBucket(state: MutableState, bucket: string): Promise<void> {
+  private async scanStorageBucket(bucket: string): Promise<HistoricalObjectVersion[]> {
+    const entries: HistoricalObjectVersion[] = [];
     let keyMarker: string | undefined;
     let versionIdMarker: string | undefined;
 
@@ -447,10 +497,13 @@ export class HistoricalInventoryScanner {
         ...(keyMarker ? { keyMarker } : {}),
         ...(versionIdMarker ? { versionIdMarker } : {}),
       });
+      if (!isHistoricalObjectVersionPage(page, this.storagePageSize)) {
+        throw new Error('Historical storage listing returned an invalid page');
+      }
 
-      page.items.forEach((entry) => this.inspectStorageEntry(state, bucket, entry));
+      entries.push(...page.items);
       if (!page.isTruncated) {
-        return;
+        return entries;
       }
 
       const nextKeyMarker = page.nextKeyMarker;
@@ -501,6 +554,10 @@ export class HistoricalInventoryScanner {
   }
 
   private finishExactReferenceCorrelation(state: MutableState): void {
+    if (!state.databaseComplete) {
+      return;
+    }
+
     for (const reference of state.exactReferences) {
       if (!state.successfullyListedBuckets.has(reference.bucket)) {
         continue;

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.scanner.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.scanner.ts
@@ -76,12 +76,40 @@ interface MutableState {
   databaseComplete: boolean;
 }
 
+interface StorageListingSummary {
+  readonly storageEntriesScanned: number;
+}
+
+interface MutableStorageBucketSummary {
+  readonly detailedFindingCapacity: number;
+  readonly foundExactIdentities: Set<string>;
+  readonly storageOutcomeCounts: Record<HistoricalStorageOutcome, number>;
+  readonly dispositionCounts: Record<Exclude<HistoricalDisposition, 'NONE'>, number>;
+  readonly detailedFindings: HistoricalInventoryFinding[];
+  findingsCount: number;
+}
+
 function createReferenceCounts(): Record<HistoricalReferenceOutcome, number> {
   return Object.fromEntries(HISTORICAL_REFERENCE_OUTCOMES.map((outcome) => [outcome, 0])) as Record<HistoricalReferenceOutcome, number>;
 }
 
 function createStorageCounts(): Record<HistoricalStorageOutcome, number> {
   return Object.fromEntries(HISTORICAL_STORAGE_OUTCOMES.map((outcome) => [outcome, 0])) as Record<HistoricalStorageOutcome, number>;
+}
+
+function createStorageBucketSummary(maxFindings: number): MutableStorageBucketSummary {
+  return {
+    detailedFindingCapacity: maxFindings,
+    foundExactIdentities: new Set<string>(),
+    storageOutcomeCounts: createStorageCounts(),
+    dispositionCounts: {
+      PRESERVE: 0,
+      REPAIR_REQUIRED_LATER: 0,
+      OPERATIONAL_ERROR: 0,
+    },
+    detailedFindings: [],
+    findingsCount: 0,
+  };
 }
 
 function createState(defaultBucket: string): MutableState {
@@ -161,9 +189,9 @@ function isHistoricalObjectVersionShape(value: unknown): value is HistoricalObje
 
   const entry = value as HistoricalObjectVersionLike;
   return typeof entry.objectKey === 'string'
-    && entry.objectKey.trim().length > 0
+    && entry.objectKey.length > 0
     && typeof entry.versionId === 'string'
-    && entry.versionId.trim().length > 0
+    && entry.versionId.length > 0
     && typeof entry.isLatest === 'boolean'
     && typeof entry.isDeleteMarker === 'boolean'
     && (entry.size === undefined || typeof entry.size === 'number' && Number.isFinite(entry.size) && entry.size >= 0);
@@ -475,9 +503,12 @@ export class HistoricalInventoryScanner {
   private async scanStorage(state: MutableState): Promise<void> {
     const buckets = [...state.buckets].sort();
     for (const bucket of buckets) {
+      const bucketSummary = createStorageBucketSummary(this.maxFindings - state.detailedFindings.length);
       try {
-        const entries = await this.scanStorageBucket(bucket);
-        entries.forEach((entry) => this.inspectStorageEntry(state, bucket, entry));
+        const listingSummary = await this.scanStorageBucket(bucket, (entry) => {
+          this.inspectStorageEntry(state, bucket, bucketSummary, entry);
+        });
+        this.commitStorageBucketSummary(state, bucketSummary, listingSummary);
         state.successfullyListedBuckets.add(bucket);
       } catch (error: unknown) {
         this.recordOperationalError(state, 'STORAGE', error);
@@ -485,8 +516,11 @@ export class HistoricalInventoryScanner {
     }
   }
 
-  private async scanStorageBucket(bucket: string): Promise<HistoricalObjectVersion[]> {
-    const entries: HistoricalObjectVersion[] = [];
+  private async scanStorageBucket(
+    bucket: string,
+    inspect: (entry: HistoricalObjectVersion) => void,
+  ): Promise<StorageListingSummary> {
+    let storageEntriesScanned = 0;
     let keyMarker: string | undefined;
     let versionIdMarker: string | undefined;
 
@@ -501,9 +535,10 @@ export class HistoricalInventoryScanner {
         throw new Error('Historical storage listing returned an invalid page');
       }
 
-      entries.push(...page.items);
+      page.items.forEach(inspect);
+      storageEntriesScanned += page.items.length;
       if (!page.isTruncated) {
-        return entries;
+        return { storageEntriesScanned };
       }
 
       const nextKeyMarker = page.nextKeyMarker;
@@ -521,14 +556,35 @@ export class HistoricalInventoryScanner {
     }
   }
 
-  private inspectStorageEntry(state: MutableState, bucket: string, entry: HistoricalObjectVersion): void {
-    state.storageEntriesScanned += 1;
+  private commitStorageBucketSummary(
+    state: MutableState,
+    bucketSummary: MutableStorageBucketSummary,
+    listingSummary: StorageListingSummary,
+  ): void {
+    state.storageEntriesScanned += listingSummary.storageEntriesScanned;
+    bucketSummary.foundExactIdentities.forEach((identity) => state.foundExactIdentities.add(identity));
+    HISTORICAL_STORAGE_OUTCOMES.forEach((outcome) => {
+      state.storageOutcomeCounts[outcome] += bucketSummary.storageOutcomeCounts[outcome];
+    });
+    state.dispositionCounts.PRESERVE += bucketSummary.dispositionCounts.PRESERVE;
+    state.dispositionCounts.REPAIR_REQUIRED_LATER += bucketSummary.dispositionCounts.REPAIR_REQUIRED_LATER;
+    state.dispositionCounts.OPERATIONAL_ERROR += bucketSummary.dispositionCounts.OPERATIONAL_ERROR;
+    state.findingsCount += bucketSummary.findingsCount;
+    state.detailedFindings.push(...bucketSummary.detailedFindings);
+  }
+
+  private inspectStorageEntry(
+    state: MutableState,
+    bucket: string,
+    bucketSummary: MutableStorageBucketSummary,
+    entry: HistoricalObjectVersion,
+  ): void {
     const exactIdentity = identityKey(bucket, entry.objectKey, entry.versionId);
     const exactReferenced = state.exactIdentities.has(exactIdentity);
     const legacyReferenced = entry.isLatest && state.legacyKeys.has(objectKey(bucket, entry.objectKey));
 
     if (!entry.isDeleteMarker && exactReferenced) {
-      state.foundExactIdentities.add(exactIdentity);
+      bucketSummary.foundExactIdentities.add(exactIdentity);
     }
 
     let outcome: HistoricalStorageOutcome;
@@ -550,7 +606,7 @@ export class HistoricalInventoryScanner {
       disposition = 'PRESERVE';
     }
 
-    this.recordStorageOutcome(state, outcome, disposition, entry.objectKey, entry.versionId);
+    this.recordStorageOutcome(bucketSummary, outcome, disposition, entry.objectKey, entry.versionId);
   }
 
   private finishExactReferenceCorrelation(state: MutableState): void {
@@ -598,20 +654,35 @@ export class HistoricalInventoryScanner {
   }
 
   private recordStorageOutcome(
-    state: MutableState,
+    bucketSummary: MutableStorageBucketSummary,
     outcome: HistoricalStorageOutcome,
     disposition: HistoricalDisposition,
     key: string,
     versionId: string,
   ): void {
-    state.storageOutcomeCounts[outcome] += 1;
-    this.recordFinding(state, {
+    bucketSummary.storageOutcomeCounts[outcome] += 1;
+    this.recordBucketFinding(bucketSummary, {
       source: 'STORAGE',
       outcome,
       disposition,
       objectReference: redactObjectReference(key),
       versionReference: redactVersionReference(versionId),
     });
+  }
+
+  private recordBucketFinding(
+    bucketSummary: MutableStorageBucketSummary,
+    finding: HistoricalInventoryFinding,
+  ): void {
+    if (finding.disposition === 'NONE') {
+      return;
+    }
+
+    bucketSummary.findingsCount += 1;
+    bucketSummary.dispositionCounts[finding.disposition] += 1;
+    if (bucketSummary.detailedFindings.length < bucketSummary.detailedFindingCapacity) {
+      bucketSummary.detailedFindings.push(finding);
+    }
   }
 
   private recordOperationalError(state: MutableState, source: 'DATABASE' | 'STORAGE', error: unknown): void {


### PR DESCRIPTION
Closes #241

## Description

- Adds read-only Storage → DB reconciliation to the historical inventory.
- Uses exact bucket + key + `VersionId` authority for current and noncurrent version semantics; legacy key-only authority applies only to current objects.
- Bucketless Expense/Income references remain unproven. Shared File-backed authority is reused without duplicate storage identities.
- Current and historical orphans, plus latest and noncurrent delete markers, are preserved; orphan never means disposable.
- Preserves tenant-safe attribution, cross-tenant rejection, redaction, fail-closed DB/storage/pagination/provider behavior, and `MOVING_WINDOW` semantics.
- No migrations and no staging, production, or VPS access.

## Validation

- Historical inventory tests: 15 PASS
- DB→Storage regression: 105 PASS
- MinioService: 19 PASS
- Full API suite: 3234 PASS
- No new typecheck regression

## Tipo de cambio

- [ ] Bug fix
- [x] Nueva funcionalidad
- [ ] Refactor
- [ ] Cambio de documentación
- [ ] Otro: ___

## Checklist de validación local obligatoria

- [x] Tests unitarios pasan
- [x] Tests de integración pasan
- [ ] Tests E2E pasan (si aplica)
- [ ] Typecheck (`tsc --noEmit`) sin errores
- [ ] Lint sin errores nuevos
- [ ] Build exitoso
- [x] `git diff --check` limpio
- [x] Confirmé que todos los cambios fueron implementados y probados localmente
- [ ] Confirmé que el merge a main activará automáticamente el deploy a staging
- [ ] El despliegue automático a staging está autorizado para este PR
- [x] Las migraciones incluidas fueron validadas localmente (no migrations)
- [x] No se requiere preservar ningún archivo temporal dentro del checkout de staging
- [ ] La validación funcional en staging está definida para después del merge

## Notas

This PR does not authorize a merge, staging access, production access, or VPS access.
