### PR TITLE
feat(api): add operational historical inventory audit runner

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -105,6 +105,9 @@ COPY --from=builder --chown=appuser:appgroup /app/packages/permissions/dist ./pa
 # Copy compiled application from builder
 COPY --from=builder --chown=appuser:appgroup /app/apps/api/dist ./apps/api/dist
 
+# Fail the image build if the operational audit runner was not compiled into runtime.
+RUN test -f /app/apps/api/dist/reconciliation/historical-inventory/historical-inventory.operational.js
+
 # Expose port
 EXPOSE 3000
 

--- a/apps/api/scripts/reconciliation-historical-inventory-operational.ts
+++ b/apps/api/scripts/reconciliation-historical-inventory-operational.ts
@@ -1,0 +1,100 @@
+import { loadConfig } from '../src/config/config';
+import { ConfigService } from '../src/config/config.service';
+import { PrismaService } from '../src/prisma/prisma.service';
+import { PrismaDbToStorageDatabase } from '../src/reconciliation/db-to-storage/prisma-db-to-storage.database';
+import { HistoricalInventoryScanner } from '../src/reconciliation/historical-inventory/historical-inventory.scanner';
+import { MinioService } from '../src/storage/minio.service';
+import {
+  conciseHistoricalSummary,
+  HistoricalInventoryCliOptions,
+  parseHistoricalInventoryCliArgs,
+  writeHistoricalInventoryReceiptFile,
+} from './reconciliation-historical-inventory';
+
+export const OPERATIONAL_STAGING_CONFIRMATION_VARIABLE = 'HISTORICAL_INVENTORY_OPERATIONAL_STAGING_CONFIRMATION';
+export const OPERATIONAL_STAGING_CONFIRMATION_TOKEN = 'HISTORICAL-INVENTORY-STAGING-READ-ONLY';
+export const OPERATIONAL_PRODUCTION_CONFIRMATION_VARIABLE = 'HISTORICAL_INVENTORY_OPERATIONAL_PRODUCTION_CONFIRMATION';
+export const OPERATIONAL_PRODUCTION_CONFIRMATION_TOKEN = 'HISTORICAL-INVENTORY-PRODUCTION-READ-ONLY';
+
+export interface OperationalEnvironment {
+  readonly [key: string]: string | undefined;
+  readonly NODE_ENV?: string;
+  readonly HISTORICAL_INVENTORY_OPERATIONAL_STAGING_CONFIRMATION?: string;
+  readonly HISTORICAL_INVENTORY_OPERATIONAL_PRODUCTION_CONFIRMATION?: string;
+}
+
+/**
+ * Requires the runtime NODE_ENV and its environment-specific acknowledgement
+ * before the operational entrypoint can create any provider clients.
+ */
+export function assertOperationalNodeEnvironment(
+  nodeEnv: string,
+  environment: OperationalEnvironment = process.env,
+): void {
+  if (environment.NODE_ENV !== nodeEnv) {
+    throw new Error(`Operational historical inventory requires actual NODE_ENV=${nodeEnv}`);
+  }
+
+  if (nodeEnv === 'staging') {
+    if (environment.HISTORICAL_INVENTORY_OPERATIONAL_STAGING_CONFIRMATION !== OPERATIONAL_STAGING_CONFIRMATION_TOKEN) {
+      throw new Error(`${OPERATIONAL_STAGING_CONFIRMATION_VARIABLE} must be exactly ${OPERATIONAL_STAGING_CONFIRMATION_TOKEN}`);
+    }
+    return;
+  }
+
+  if (nodeEnv === 'production') {
+    if (environment.HISTORICAL_INVENTORY_OPERATIONAL_PRODUCTION_CONFIRMATION !== OPERATIONAL_PRODUCTION_CONFIRMATION_TOKEN) {
+      throw new Error(`${OPERATIONAL_PRODUCTION_CONFIRMATION_VARIABLE} must be exactly ${OPERATIONAL_PRODUCTION_CONFIRMATION_TOKEN}`);
+    }
+    return;
+  }
+
+  throw new Error('Operational historical inventory is restricted to staging or production');
+}
+
+export async function runOperationalCli(argv: readonly string[] = process.argv.slice(2)): Promise<number> {
+  let options: HistoricalInventoryCliOptions | null;
+  try {
+    options = parseHistoricalInventoryCliArgs(argv, 'reconciliation-historical-inventory-operational');
+  } catch (error: unknown) {
+    process.stderr.write(`${error instanceof Error ? error.message : 'Invalid CLI arguments'}\n`);
+    return 64;
+  }
+
+  if (!options) {
+    return 0;
+  }
+
+  let prisma: PrismaService | undefined;
+  try {
+    const config = new ConfigService(loadConfig());
+    assertOperationalNodeEnvironment(config.getValue('nodeEnv'));
+    prisma = new PrismaService();
+    await prisma.$connect();
+
+    const receipt = await new HistoricalInventoryScanner(
+      new PrismaDbToStorageDatabase(prisma),
+      new MinioService(config),
+      options,
+    ).scan();
+
+    if (options.outputPath) {
+      await writeHistoricalInventoryReceiptFile(options.outputPath, receipt);
+    }
+    process.stdout.write(`${JSON.stringify(conciseHistoricalSummary(receipt))}\n`);
+    return receipt.scanStatus === 'INCOMPLETE_OPERATIONAL_ERROR' ? 2 : 0;
+  } catch (_error: unknown) {
+    process.stderr.write('Operational historical inventory execution failed\n');
+    return 2;
+  } finally {
+    if (prisma) {
+      await prisma.$disconnect();
+    }
+  }
+}
+
+if (require.main === module) {
+  void runOperationalCli().then((exitCode) => {
+    process.exitCode = exitCode;
+  });
+}

--- a/apps/api/scripts/reconciliation-historical-inventory.ts
+++ b/apps/api/scripts/reconciliation-historical-inventory.ts
@@ -10,7 +10,7 @@ import {
 } from '../src/reconciliation/historical-inventory/historical-inventory.types';
 import { MinioService } from '../src/storage/minio.service';
 
-interface CliOptions {
+export interface HistoricalInventoryCliOptions {
   readonly databaseBatchSize: number;
   readonly storagePageSize: number;
   readonly maxFindings: number;
@@ -28,7 +28,10 @@ function parseInteger(value: string, optionName: string, minimum: number, maximu
   return parsed;
 }
 
-function parseArgs(argv: readonly string[]): CliOptions | null {
+export function parseHistoricalInventoryCliArgs(
+  argv: readonly string[],
+  executableName = 'reconciliation-historical-inventory',
+): HistoricalInventoryCliOptions | null {
   let databaseBatchSize = 100;
   let storagePageSize = 100;
   let maxFindings = 1000;
@@ -38,7 +41,7 @@ function parseArgs(argv: readonly string[]): CliOptions | null {
     const argument = argv[index];
     if (argument === '--help' || argument === '-h') {
       process.stdout.write(
-        'Usage: reconciliation-historical-inventory [--database-batch-size N] [--storage-page-size N] [--max-findings N] [--output PATH]\n',
+        `Usage: ${executableName} [--database-batch-size N] [--storage-page-size N] [--max-findings N] [--output PATH]\n`,
       );
       return null;
     }
@@ -103,15 +106,18 @@ export function conciseHistoricalSummary(receipt: HistoricalInventoryReceipt): R
   };
 }
 
-async function writeReceiptFile(outputPath: string, receipt: HistoricalInventoryReceipt): Promise<void> {
+export async function writeHistoricalInventoryReceiptFile(
+  outputPath: string,
+  receipt: HistoricalInventoryReceipt,
+): Promise<void> {
   await writeFile(outputPath, `${JSON.stringify(receipt, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
   await chmod(outputPath, 0o600);
 }
 
 export async function runCli(argv: readonly string[] = process.argv.slice(2)): Promise<number> {
-  let options: CliOptions | null;
+  let options: HistoricalInventoryCliOptions | null;
   try {
-    options = parseArgs(argv);
+    options = parseHistoricalInventoryCliArgs(argv);
   } catch (error: unknown) {
     process.stderr.write(`${error instanceof CliUsageError ? error.message : 'Invalid CLI arguments'}\n`);
     return 64;
@@ -135,7 +141,7 @@ export async function runCli(argv: readonly string[] = process.argv.slice(2)): P
     ).scan();
 
     if (options.outputPath) {
-      await writeReceiptFile(options.outputPath, receipt);
+      await writeHistoricalInventoryReceiptFile(options.outputPath, receipt);
     }
     process.stdout.write(`${JSON.stringify(conciseHistoricalSummary(receipt))}\n`);
     return exitCodeForStatus(receipt.scanStatus);

--- a/apps/api/scripts/reconciliation-historical-inventory.ts
+++ b/apps/api/scripts/reconciliation-historical-inventory.ts
@@ -1,84 +1,17 @@
-import { chmod, writeFile } from 'node:fs/promises';
 import { loadConfig } from '../src/config/config';
 import { ConfigService } from '../src/config/config.service';
 import { PrismaService } from '../src/prisma/prisma.service';
 import { PrismaDbToStorageDatabase } from '../src/reconciliation/db-to-storage/prisma-db-to-storage.database';
 import { HistoricalInventoryScanner } from '../src/reconciliation/historical-inventory/historical-inventory.scanner';
 import {
-  HistoricalInventoryReceipt,
-  HistoricalScanStatus,
-} from '../src/reconciliation/historical-inventory/historical-inventory.types';
+  conciseHistoricalSummary,
+  exitCodeForStatus,
+  HistoricalInventoryCliUsageError,
+  parseHistoricalInventoryCliArgs,
+  writeHistoricalInventoryReceiptFile,
+} from '../src/reconciliation/historical-inventory/historical-inventory.operational.shared';
+import type { HistoricalInventoryCliOptions } from '../src/reconciliation/historical-inventory/historical-inventory.operational.shared';
 import { MinioService } from '../src/storage/minio.service';
-
-export interface HistoricalInventoryCliOptions {
-  readonly databaseBatchSize: number;
-  readonly storagePageSize: number;
-  readonly maxFindings: number;
-  readonly outputPath?: string;
-}
-
-class CliUsageError extends Error {}
-
-function parseInteger(value: string, optionName: string, minimum: number, maximum?: number): number {
-  const parsed = Number(value);
-  if (!Number.isInteger(parsed) || parsed < minimum || maximum !== undefined && parsed > maximum) {
-    const range = maximum === undefined ? `>= ${minimum}` : `between ${minimum} and ${maximum}`;
-    throw new CliUsageError(`${optionName} must be an integer ${range}`);
-  }
-  return parsed;
-}
-
-export function parseHistoricalInventoryCliArgs(
-  argv: readonly string[],
-  executableName = 'reconciliation-historical-inventory',
-): HistoricalInventoryCliOptions | null {
-  let databaseBatchSize = 100;
-  let storagePageSize = 100;
-  let maxFindings = 1000;
-  let outputPath: string | undefined;
-
-  for (let index = 0; index < argv.length; index += 1) {
-    const argument = argv[index];
-    if (argument === '--help' || argument === '-h') {
-      process.stdout.write(
-        `Usage: ${executableName} [--database-batch-size N] [--storage-page-size N] [--max-findings N] [--output PATH]\n`,
-      );
-      return null;
-    }
-
-    if (
-      argument !== '--database-batch-size'
-      && argument !== '--storage-page-size'
-      && argument !== '--max-findings'
-      && argument !== '--output'
-    ) {
-      throw new CliUsageError(`Unknown option: ${argument}`);
-    }
-
-    const value = argv[index + 1];
-    if (!value || value.startsWith('--')) {
-      throw new CliUsageError(`${argument} requires a value`);
-    }
-
-    if (argument === '--database-batch-size') {
-      databaseBatchSize = parseInteger(value, argument, 1);
-    } else if (argument === '--storage-page-size') {
-      storagePageSize = parseInteger(value, argument, 1, 1000);
-    } else if (argument === '--max-findings') {
-      maxFindings = parseInteger(value, argument, 0);
-    } else {
-      outputPath = value;
-    }
-    index += 1;
-  }
-
-  return {
-    databaseBatchSize,
-    storagePageSize,
-    maxFindings,
-    ...(outputPath ? { outputPath } : {}),
-  };
-}
 
 export function assertLocalNodeEnvironment(nodeEnv: string): void {
   if (nodeEnv !== 'development' && nodeEnv !== 'test') {
@@ -86,40 +19,19 @@ export function assertLocalNodeEnvironment(nodeEnv: string): void {
   }
 }
 
-function exitCodeForStatus(status: HistoricalScanStatus): 0 | 2 {
-  return status === 'INCOMPLETE_OPERATIONAL_ERROR' ? 2 : 0;
-}
-
-export function conciseHistoricalSummary(receipt: HistoricalInventoryReceipt): Record<string, unknown> {
-  return {
-    scannerName: receipt.scannerName,
-    consistencyModel: receipt.consistencyModel,
-    databaseRowsScanned: receipt.databaseRowsScanned,
-    databaseReferencesScanned: receipt.databaseReferencesScanned,
-    storageEntriesScanned: receipt.storageEntriesScanned,
-    bucketsScanned: receipt.bucketsScanned,
-    referenceOutcomeCounts: receipt.referenceOutcomeCounts,
-    storageOutcomeCounts: receipt.storageOutcomeCounts,
-    dispositionCounts: receipt.dispositionCounts,
-    operationalErrorCount: receipt.operationalErrorCount,
-    scanStatus: receipt.scanStatus,
-  };
-}
-
-export async function writeHistoricalInventoryReceiptFile(
-  outputPath: string,
-  receipt: HistoricalInventoryReceipt,
-): Promise<void> {
-  await writeFile(outputPath, `${JSON.stringify(receipt, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
-  await chmod(outputPath, 0o600);
-}
+export {
+  conciseHistoricalSummary,
+  parseHistoricalInventoryCliArgs,
+  writeHistoricalInventoryReceiptFile,
+};
+export type { HistoricalInventoryCliOptions };
 
 export async function runCli(argv: readonly string[] = process.argv.slice(2)): Promise<number> {
   let options: HistoricalInventoryCliOptions | null;
   try {
     options = parseHistoricalInventoryCliArgs(argv);
   } catch (error: unknown) {
-    process.stderr.write(`${error instanceof CliUsageError ? error.message : 'Invalid CLI arguments'}\n`);
+    process.stderr.write(`${error instanceof HistoricalInventoryCliUsageError ? error.message : 'Invalid CLI arguments'}\n`);
     return 64;
   }
 

--- a/apps/api/src/config/config-production.spec.ts
+++ b/apps/api/src/config/config-production.spec.ts
@@ -3,7 +3,7 @@
  * Task 1.2: Config validation for payment, email, and AI provider env vars
  */
 
-import { createConfigSchema } from './config';
+import { createConfigSchema, loadConfig, loadConfigOrThrow } from './config';
 
 describe('Production Readiness Config Validation', () => {
   const baseEnv: Record<string, string> = {
@@ -31,6 +31,44 @@ describe('Production Readiness Config Validation', () => {
     FEATURE_PORTAL_RESIDENT: 'true',
     FEATURE_PAYMENTS_MVP: 'true',
   };
+
+  describe('non-terminating operational configuration loading', () => {
+    const originalEnvironment = process.env;
+
+    beforeEach(() => {
+      process.env = { ...baseEnv, NODE_ENV: 'staging', JWT_SECRET: 'a'.repeat(64) };
+    });
+
+    afterEach(() => {
+      process.env = originalEnvironment;
+      jest.restoreAllMocks();
+    });
+
+    it('throws for real schema failures without terminating the process', () => {
+      process.env = {
+        ...process.env,
+        DATABASE_URL: 'postgresql://audit-user:VERY_SECRET_PASSWORD@db.example.test:5432/audit',
+        S3_SECRET_KEY: 'VERY_SECRET_S3_KEY',
+      };
+      delete process.env.WEB_ORIGIN;
+
+      expect(() => loadConfigOrThrow()).toThrow();
+    });
+
+    it('throws for real staging conditional failures without terminating the process', () => {
+      process.env = { ...process.env, JWT_SECRET: 'a'.repeat(40) };
+
+      expect(() => loadConfigOrThrow()).toThrow('Configuration validation failed');
+    });
+
+    it('preserves normal startup termination for invalid configuration', () => {
+      delete process.env.WEB_ORIGIN;
+      const exit = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+      expect(() => loadConfig()).toThrow();
+      expect(exit).toHaveBeenCalledWith(1);
+    });
+  });
 
   describe('NODE_ENV env var', () => {
     it('requires NODE_ENV to be explicitly provided', () => {

--- a/apps/api/src/config/config.ts
+++ b/apps/api/src/config/config.ts
@@ -399,11 +399,17 @@ function isValidVapidSubject(value: string): boolean {
 
 type ParsedConfig = z.infer<ReturnType<typeof createConfigSchema>>;
 
+class ConfigValidationError extends Error {
+  constructor(readonly messages: readonly string[]) {
+    super('Configuration validation failed');
+  }
+}
+
 /**
  * Load and validate configuration from process.env
  * Throws descriptive error if validation fails
  */
-export function loadConfig(): AppConfig {
+export function loadConfigOrThrow(): AppConfig {
   const nodeEnv = resolveNodeEnv(process.env.NODE_ENV);
 
   writeStdout(`[Config] Loading configuration for environment: ${nodeEnv}`);
@@ -504,13 +510,26 @@ export function loadConfig(): AppConfig {
 
     logConfigLoaded(config, nodeEnv);
     return config;
-  } catch (error) {
+  } catch (error: unknown) {
+    throw error;
+  }
+}
+
+/** Preserves normal API startup diagnostics and termination semantics. */
+export function loadConfig(): AppConfig {
+  try {
+    return loadConfigOrThrow();
+  } catch (error: unknown) {
     if (error instanceof z.ZodError) {
       writeStderr('[Config] ❌ Configuration validation failed:');
-      error.issues.forEach((err) => {
-        const path = err.path.join('.');
-        writeStderr(`  - ${path}: ${err.message}`);
+      error.issues.forEach((issue) => {
+        writeStderr(`  - ${issue.path.join('.')}: ${issue.message}`);
       });
+      process.exit(1);
+    }
+    if (error instanceof ConfigValidationError) {
+      writeStderr('[Config] ❌ Configuration validation failed:');
+      error.messages.forEach((message) => writeStderr(`  - ${message}`));
       process.exit(1);
     }
     throw error;
@@ -582,11 +601,7 @@ function validateConditionalConfig(config: ParsedConfig, nodeEnv: NodeEnv): void
   }
 
   if (errors.length > 0) {
-    writeStderr('[Config] ❌ Configuration validation failed:');
-    errors.forEach((err) => {
-      writeStderr(`  - ${err}`);
-    });
-    process.exit(1);
+    throw new ConfigValidationError(errors);
   }
 }
 

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.cli.spec.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.cli.spec.ts
@@ -1,0 +1,60 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import {
+  assertOperationalNodeEnvironment,
+  OPERATIONAL_PRODUCTION_CONFIRMATION_TOKEN,
+  OPERATIONAL_PRODUCTION_CONFIRMATION_VARIABLE,
+  OPERATIONAL_STAGING_CONFIRMATION_TOKEN,
+  OPERATIONAL_STAGING_CONFIRMATION_VARIABLE,
+} from '../../../scripts/reconciliation-historical-inventory-operational';
+
+describe('reconciliation-historical-inventory-operational CLI', () => {
+  it.each([
+    [
+      'staging',
+      {
+        NODE_ENV: 'staging',
+        [OPERATIONAL_STAGING_CONFIRMATION_VARIABLE]: OPERATIONAL_STAGING_CONFIRMATION_TOKEN,
+      },
+    ],
+    [
+      'production',
+      {
+        NODE_ENV: 'production',
+        [OPERATIONAL_PRODUCTION_CONFIRMATION_VARIABLE]: OPERATIONAL_PRODUCTION_CONFIRMATION_TOKEN,
+      },
+    ],
+  ] as const)('authorizes %s only with its matching runtime confirmation', (nodeEnv, environment) => {
+    expect(() => assertOperationalNodeEnvironment(nodeEnv, environment)).not.toThrow();
+  });
+
+  it.each([
+    ['staging', { NODE_ENV: 'staging' }],
+    ['staging', { NODE_ENV: 'staging', [OPERATIONAL_STAGING_CONFIRMATION_VARIABLE]: 'wrong' }],
+    ['staging', { NODE_ENV: 'staging', [OPERATIONAL_PRODUCTION_CONFIRMATION_VARIABLE]: OPERATIONAL_PRODUCTION_CONFIRMATION_TOKEN }],
+    ['production', { NODE_ENV: 'production' }],
+    ['production', { NODE_ENV: 'production', [OPERATIONAL_PRODUCTION_CONFIRMATION_VARIABLE]: 'wrong' }],
+    ['production', { NODE_ENV: 'production', [OPERATIONAL_STAGING_CONFIRMATION_VARIABLE]: OPERATIONAL_STAGING_CONFIRMATION_TOKEN }],
+    ['development', { NODE_ENV: 'development' }],
+    ['test', { NODE_ENV: 'test' }],
+    ['preview', { NODE_ENV: 'preview' }],
+  ] as const)('denies unsupported or unconfirmed %s environments', (nodeEnv, environment) => {
+    expect(() => assertOperationalNodeEnvironment(nodeEnv, environment)).toThrow();
+  });
+
+  it('denies environment spoofing when configured and runtime NODE_ENV differ', () => {
+    expect(() => assertOperationalNodeEnvironment('staging', {
+      NODE_ENV: 'production',
+      [OPERATIONAL_STAGING_CONFIRMATION_VARIABLE]: OPERATIONAL_STAGING_CONFIRMATION_TOKEN,
+    })).toThrow('NODE_ENV=staging');
+  });
+
+  it('contains no direct mutation interfaces', async () => {
+    const source = await readFile(join(__dirname, '../../../scripts/reconciliation-historical-inventory-operational.ts'), 'utf8');
+
+    expect(source).not.toMatch(/\.(?:create|update|upsert|delete|removeObject|putObject|uploadBuffer|\$executeRaw)\b/u);
+    expect(source).toContain('HistoricalInventoryScanner');
+    expect(source).toContain('PrismaDbToStorageDatabase');
+    expect(source).toContain('MinioService');
+  });
+});

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.cli.spec.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.cli.spec.ts
@@ -1,14 +1,158 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
+import { AppConfig } from '../../config/config.types';
+import { loadConfig } from '../../config/config';
+import { PrismaService } from '../../prisma/prisma.service';
+import { HistoricalInventoryScanner } from './historical-inventory.scanner';
+import { HistoricalInventoryReceipt } from './historical-inventory.types';
 import {
   assertOperationalNodeEnvironment,
+  formatOperationalFailure,
+  OperationalFailureCategory,
   OPERATIONAL_PRODUCTION_CONFIRMATION_TOKEN,
   OPERATIONAL_PRODUCTION_CONFIRMATION_VARIABLE,
   OPERATIONAL_STAGING_CONFIRMATION_TOKEN,
   OPERATIONAL_STAGING_CONFIRMATION_VARIABLE,
-} from '../../../scripts/reconciliation-historical-inventory-operational';
+  runOperationalCli,
+} from './historical-inventory.operational';
+import { MinioService } from '../../storage/minio.service';
+
+jest.mock('../../config/config', () => ({ loadConfig: jest.fn() }));
+jest.mock('../../prisma/prisma.service', () => ({ PrismaService: jest.fn() }));
+jest.mock('../../storage/minio.service', () => ({ MinioService: jest.fn() }));
+jest.mock('./historical-inventory.scanner', () => ({ HistoricalInventoryScanner: jest.fn() }));
+
+const mockedLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>;
+const mockedPrismaService = PrismaService as jest.MockedClass<typeof PrismaService>;
+const mockedMinioService = MinioService as jest.MockedClass<typeof MinioService>;
+const mockedScanner = HistoricalInventoryScanner as jest.MockedClass<typeof HistoricalInventoryScanner>;
+
+function operationalReceipt(): HistoricalInventoryReceipt {
+  return {
+    schemaVersion: '1.0',
+    scannerName: 'historical-object-inventory',
+    startedAt: '2026-01-01T00:00:00.000Z',
+    completedAt: '2026-01-01T00:00:01.000Z',
+    consistencyModel: 'MOVING_WINDOW',
+    databaseRowsScanned: 0,
+    databaseReferencesScanned: 0,
+    storageEntriesScanned: 0,
+    bucketsScanned: 0,
+    referenceOutcomeCounts: {
+      EXACT_REFERENCED_VERSION_PRESENT: 0,
+      EXACT_REFERENCED_VERSION_MISSING: 0,
+      LEGACY_KEY_ONLY_REFERENCE: 0,
+      INVALID_REFERENCE: 0,
+      CROSS_TENANT_REFERENCE: 0,
+      PROVIDER_OPERATIONAL_ERROR: 0,
+    },
+    storageOutcomeCounts: {
+      CURRENT_OBJECT: 0,
+      NONCURRENT_VERSION: 0,
+      LATEST_DELETE_MARKER: 0,
+      NONCURRENT_DELETE_MARKER: 0,
+      CURRENT_ORPHAN_OBJECT: 0,
+      ORPHAN_HISTORICAL_VERSION: 0,
+    },
+    dispositionCounts: {
+      PRESERVE: 0,
+      REPAIR_REQUIRED_LATER: 0,
+      OPERATIONAL_ERROR: 0,
+    },
+    operationalErrorCount: 0,
+    scanStatus: 'COMPLETE_CLEAN',
+    detailedFindings: [],
+  };
+}
 
 describe('reconciliation-historical-inventory-operational CLI', () => {
+  const originalEnvironment = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = {
+      ...originalEnvironment,
+      NODE_ENV: 'staging',
+      [OPERATIONAL_STAGING_CONFIRMATION_VARIABLE]: OPERATIONAL_STAGING_CONFIRMATION_TOKEN,
+    };
+    mockedLoadConfig.mockReturnValue({ nodeEnv: 'staging' } as AppConfig);
+    mockedPrismaService.mockImplementation(() => ({
+      $connect: jest.fn().mockResolvedValue(undefined),
+      $disconnect: jest.fn().mockResolvedValue(undefined),
+    } as unknown as PrismaService));
+    mockedMinioService.mockImplementation(() => ({
+      getDefaultBucket: jest.fn().mockReturnValue('historical-inventory'),
+    } as unknown as MinioService));
+    mockedScanner.mockImplementation(() => ({
+      scan: jest.fn().mockResolvedValue(operationalReceipt()),
+    } as unknown as HistoricalInventoryScanner));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  afterAll(() => {
+    process.env = originalEnvironment;
+  });
+
+  it.each([
+    ['CONFIG', () => mockedLoadConfig.mockImplementation(() => { throw new Error('DATABASE_URL=postgresql://user:secret@example.test/db'); })],
+    ['AUTHORIZATION', () => { delete process.env[OPERATIONAL_STAGING_CONFIRMATION_VARIABLE]; }],
+    ['DB_CONNECT', () => mockedPrismaService.mockImplementation(() => ({
+      $connect: jest.fn().mockRejectedValue(new Error('password=secret-database-password')),
+      $disconnect: jest.fn().mockResolvedValue(undefined),
+    } as unknown as PrismaService))],
+    ['SCANNER', () => mockedScanner.mockImplementation(() => ({
+      scan: jest.fn().mockRejectedValue(new Error('storage-secret=never-print')),
+    } as unknown as HistoricalInventoryScanner))],
+    ['RECEIPT_WRITE', () => undefined],
+  ] as const)('reports %s failures without exposing raw errors', async (phase, configureFailure) => {
+    configureFailure();
+    const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    const exitCode = await runOperationalCli(phase === 'RECEIPT_WRITE' ? ['--output', '/tmp'] : []);
+    const output = stderr.mock.calls.map(([message]) => String(message)).join('');
+
+    expect(exitCode).toBe(2);
+    expect(output).toBe(`Operational historical inventory failed [${phase === 'CONFIG' ? 'CONFIG' : phase}]\n`);
+    expect(output).not.toContain('secret');
+  });
+
+  it('formats unknown failures without exposing synthetic provider secrets', () => {
+    const syntheticError = new Error('postgresql://user:SUPER_SECRET@example/db S3_SECRET_KEY=SUPER_SECRET');
+    const output = formatOperationalFailure(OperationalFailureCategory.UNKNOWN);
+
+    expect(output).toBe('Operational historical inventory failed [UNKNOWN]\n');
+    expect(output).toContain('UNKNOWN');
+    expect(output).not.toContain('SUPER_SECRET');
+    expect(output).not.toContain('postgresql://');
+    expect(output).not.toContain('S3_SECRET_KEY=');
+    expect(output).not.toContain(syntheticError.message);
+    expect(output).not.toContain(syntheticError.stack ?? 'stack trace');
+  });
+
+  it('returns help before loading configuration or creating providers', async () => {
+    await expect(runOperationalCli(['--help'])).resolves.toBe(0);
+
+    expect(mockedLoadConfig).not.toHaveBeenCalled();
+    expect(mockedPrismaService).not.toHaveBeenCalled();
+    expect(mockedMinioService).not.toHaveBeenCalled();
+    expect(mockedScanner).not.toHaveBeenCalled();
+  });
+
+  it('denies an unconfirmed environment before creating providers', async () => {
+    delete process.env[OPERATIONAL_STAGING_CONFIRMATION_VARIABLE];
+    const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await expect(runOperationalCli([])).resolves.toBe(2);
+
+    expect(stderr).toHaveBeenLastCalledWith('Operational historical inventory failed [AUTHORIZATION]\n');
+    expect(mockedPrismaService).not.toHaveBeenCalled();
+    expect(mockedMinioService).not.toHaveBeenCalled();
+    expect(mockedScanner).not.toHaveBeenCalled();
+  });
+
   it.each([
     [
       'staging',
@@ -50,11 +194,13 @@ describe('reconciliation-historical-inventory-operational CLI', () => {
   });
 
   it('contains no direct mutation interfaces', async () => {
-    const source = await readFile(join(__dirname, '../../../scripts/reconciliation-historical-inventory-operational.ts'), 'utf8');
+    const source = await readFile(join(__dirname, 'historical-inventory.operational.ts'), 'utf8');
 
     expect(source).not.toMatch(/\.(?:create|update|upsert|delete|removeObject|putObject|uploadBuffer|\$executeRaw)\b/u);
     expect(source).toContain('HistoricalInventoryScanner');
     expect(source).toContain('PrismaDbToStorageDatabase');
     expect(source).toContain('MinioService');
+    expect(source).toContain("./historical-inventory.operational.shared");
+    expect(source).not.toContain('scripts/');
   });
 });

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.cli.spec.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.cli.spec.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { AppConfig } from '../../config/config.types';
-import { loadConfig } from '../../config/config';
+import { loadConfigOrThrow } from '../../config/config';
 import { PrismaService } from '../../prisma/prisma.service';
 import { HistoricalInventoryScanner } from './historical-inventory.scanner';
 import { HistoricalInventoryReceipt } from './historical-inventory.types';
@@ -17,12 +17,12 @@ import {
 } from './historical-inventory.operational';
 import { MinioService } from '../../storage/minio.service';
 
-jest.mock('../../config/config', () => ({ loadConfig: jest.fn() }));
+jest.mock('../../config/config', () => ({ loadConfigOrThrow: jest.fn() }));
 jest.mock('../../prisma/prisma.service', () => ({ PrismaService: jest.fn() }));
 jest.mock('../../storage/minio.service', () => ({ MinioService: jest.fn() }));
 jest.mock('./historical-inventory.scanner', () => ({ HistoricalInventoryScanner: jest.fn() }));
 
-const mockedLoadConfig = loadConfig as jest.MockedFunction<typeof loadConfig>;
+const mockedLoadConfig = loadConfigOrThrow as jest.MockedFunction<typeof loadConfigOrThrow>;
 const mockedPrismaService = PrismaService as jest.MockedClass<typeof PrismaService>;
 const mockedMinioService = MinioService as jest.MockedClass<typeof MinioService>;
 const mockedScanner = HistoricalInventoryScanner as jest.MockedClass<typeof HistoricalInventoryScanner>;

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.cli.spec.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.cli.spec.ts
@@ -119,6 +119,23 @@ describe('reconciliation-historical-inventory-operational CLI', () => {
     expect(output).not.toContain('secret');
   });
 
+  it('reports cleanup failures without rejecting or exposing provider secrets', async () => {
+    mockedPrismaService.mockImplementation(() => ({
+      $connect: jest.fn().mockResolvedValue(undefined),
+      $disconnect: jest.fn().mockRejectedValue(new Error('postgresql://user:SUPER_SECRET@example/db password=SUPER_SECRET')),
+    } as unknown as PrismaService));
+    const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    await expect(runOperationalCli([])).resolves.toBe(2);
+
+    const output = stderr.mock.calls.map(([message]) => String(message)).join('');
+    expect(output).toBe('Operational historical inventory failed [CLEANUP]\n');
+    expect(output).not.toContain('SUPER_SECRET');
+    expect(output).not.toContain('postgresql://');
+    expect(output).not.toContain('password=');
+    expect(output).not.toContain('stack trace');
+  });
+
   it('formats unknown failures without exposing synthetic provider secrets', () => {
     const syntheticError = new Error('postgresql://user:SUPER_SECRET@example/db S3_SECRET_KEY=SUPER_SECRET');
     const output = formatOperationalFailure(OperationalFailureCategory.UNKNOWN);

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.config.integration.spec.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.config.integration.spec.ts
@@ -1,0 +1,90 @@
+import { PrismaService } from '../../prisma/prisma.service';
+import { MinioService } from '../../storage/minio.service';
+import { HistoricalInventoryScanner } from './historical-inventory.scanner';
+import { runOperationalCli } from './historical-inventory.operational';
+
+jest.mock('../../prisma/prisma.service', () => ({ PrismaService: jest.fn() }));
+jest.mock('../../storage/minio.service', () => ({ MinioService: jest.fn() }));
+jest.mock('./historical-inventory.scanner', () => ({ HistoricalInventoryScanner: jest.fn() }));
+
+const mockedPrismaService = PrismaService as jest.MockedClass<typeof PrismaService>;
+const mockedMinioService = MinioService as jest.MockedClass<typeof MinioService>;
+const mockedScanner = HistoricalInventoryScanner as jest.MockedClass<typeof HistoricalInventoryScanner>;
+
+function stagingEnvironment(): NodeJS.ProcessEnv {
+  return {
+    NODE_ENV: 'staging',
+    HISTORICAL_INVENTORY_OPERATIONAL_STAGING_CONFIRMATION: 'HISTORICAL-INVENTORY-STAGING-READ-ONLY',
+    DATABASE_URL: 'postgresql://audit-user:VERY_SECRET_PASSWORD@db.example.test:5432/audit',
+    JWT_SECRET: 'a'.repeat(64),
+    JWT_EXPIRES_IN: '7d',
+    WEB_ORIGIN: 'https://web.example.test',
+    APP_BASE_URL: 'https://web.example.test',
+    S3_ENDPOINT: 'https://storage.example.test',
+    S3_REGION: 'us-east-1',
+    S3_ACCESS_KEY: 'audit-access-key',
+    S3_SECRET_KEY: 'VERY_SECRET_S3_KEY',
+    S3_BUCKET: 'audit-bucket',
+    S3_FORCE_PATH_STYLE: 'true',
+    S3_PUBLIC_BASE_URL: 'https://storage.example.test/audit-bucket',
+    FEATURE_PORTAL_RESIDENT: 'false',
+    FEATURE_PAYMENTS_MVP: 'false',
+    MAIL_PROVIDER: 'none',
+    PAYMENT_PROVIDER: 'none',
+    AI_PROVIDER: 'none',
+    ENABLE_WEB_PUSH: 'false',
+  };
+}
+
+function expectSanitizedConfigFailure(output: string): void {
+  expect(output).toBe('Operational historical inventory failed [CONFIG]\n');
+  expect(output).not.toContain('VERY_SECRET_PASSWORD');
+  expect(output).not.toContain('VERY_SECRET_S3_KEY');
+  expect(output).not.toContain('postgresql://');
+  expect(output).not.toContain('DATABASE_URL');
+  expect(output).not.toContain('JWT_SECRET');
+  expect(output).not.toContain('S3_SECRET_KEY');
+  expect(output).not.toContain('stack');
+}
+
+describe('operational CLI real configuration failure path', () => {
+  const originalEnvironment = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = stagingEnvironment();
+  });
+
+  afterEach(() => {
+    process.env = originalEnvironment;
+    jest.restoreAllMocks();
+  });
+
+  it('maps a real schema validation failure to a sanitized CONFIG result', async () => {
+    delete process.env.WEB_ORIGIN;
+    const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const exit = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    await expect(runOperationalCli([])).resolves.toBe(2);
+
+    expectSanitizedConfigFailure(stderr.mock.calls.map(([message]) => String(message)).join(''));
+    expect(exit).not.toHaveBeenCalled();
+    expect(mockedPrismaService).not.toHaveBeenCalled();
+    expect(mockedMinioService).not.toHaveBeenCalled();
+    expect(mockedScanner).not.toHaveBeenCalled();
+  });
+
+  it('maps a real staging conditional validation failure to a sanitized CONFIG result', async () => {
+    process.env.JWT_SECRET = 'a'.repeat(40);
+    const stderr = jest.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const exit = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    await expect(runOperationalCli([])).resolves.toBe(2);
+
+    expectSanitizedConfigFailure(stderr.mock.calls.map(([message]) => String(message)).join(''));
+    expect(exit).not.toHaveBeenCalled();
+    expect(mockedPrismaService).not.toHaveBeenCalled();
+    expect(mockedMinioService).not.toHaveBeenCalled();
+    expect(mockedScanner).not.toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.shared.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.shared.ts
@@ -1,0 +1,107 @@
+import { chmod, writeFile } from 'node:fs/promises';
+import type {
+  HistoricalInventoryReceipt,
+  HistoricalScanStatus,
+} from './historical-inventory.types';
+
+export interface HistoricalInventoryCliOptions {
+  readonly databaseBatchSize: number;
+  readonly storagePageSize: number;
+  readonly maxFindings: number;
+  readonly outputPath?: string;
+}
+
+export class HistoricalInventoryCliUsageError extends Error {}
+
+function parseInteger(value: string, optionName: string, minimum: number, maximum?: number): number {
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < minimum || maximum !== undefined && parsed > maximum) {
+    const range = maximum === undefined ? `>= ${minimum}` : `between ${minimum} and ${maximum}`;
+    throw new HistoricalInventoryCliUsageError(`${optionName} must be an integer ${range}`);
+  }
+  return parsed;
+}
+
+/**
+ * Parses bounded, read-only scanner options before loading configuration or
+ * creating database and object-storage providers.
+ */
+export function parseHistoricalInventoryCliArgs(
+  argv: readonly string[],
+  executableName = 'reconciliation-historical-inventory',
+): HistoricalInventoryCliOptions | null {
+  let databaseBatchSize = 100;
+  let storagePageSize = 100;
+  let maxFindings = 1000;
+  let outputPath: string | undefined;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--help' || argument === '-h') {
+      process.stdout.write(
+        `Usage: ${executableName} [--database-batch-size N] [--storage-page-size N] [--max-findings N] [--output PATH]\n`,
+      );
+      return null;
+    }
+
+    if (
+      argument !== '--database-batch-size'
+      && argument !== '--storage-page-size'
+      && argument !== '--max-findings'
+      && argument !== '--output'
+    ) {
+      throw new HistoricalInventoryCliUsageError(`Unknown option: ${argument}`);
+    }
+
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new HistoricalInventoryCliUsageError(`${argument} requires a value`);
+    }
+
+    if (argument === '--database-batch-size') {
+      databaseBatchSize = parseInteger(value, argument, 1);
+    } else if (argument === '--storage-page-size') {
+      storagePageSize = parseInteger(value, argument, 1, 1000);
+    } else if (argument === '--max-findings') {
+      maxFindings = parseInteger(value, argument, 0);
+    } else {
+      outputPath = value;
+    }
+    index += 1;
+  }
+
+  return {
+    databaseBatchSize,
+    storagePageSize,
+    maxFindings,
+    ...(outputPath ? { outputPath } : {}),
+  };
+}
+
+export function conciseHistoricalSummary(receipt: HistoricalInventoryReceipt): Record<string, unknown> {
+  return {
+    scannerName: receipt.scannerName,
+    consistencyModel: receipt.consistencyModel,
+    databaseRowsScanned: receipt.databaseRowsScanned,
+    databaseReferencesScanned: receipt.databaseReferencesScanned,
+    storageEntriesScanned: receipt.storageEntriesScanned,
+    bucketsScanned: receipt.bucketsScanned,
+    referenceOutcomeCounts: receipt.referenceOutcomeCounts,
+    storageOutcomeCounts: receipt.storageOutcomeCounts,
+    dispositionCounts: receipt.dispositionCounts,
+    operationalErrorCount: receipt.operationalErrorCount,
+    scanStatus: receipt.scanStatus,
+  };
+}
+
+export function exitCodeForStatus(status: HistoricalScanStatus): 0 | 2 {
+  return status === 'INCOMPLETE_OPERATIONAL_ERROR' ? 2 : 0;
+}
+
+export async function writeHistoricalInventoryReceiptFile(
+  outputPath: string,
+  receipt: HistoricalInventoryReceipt,
+): Promise<void> {
+  await writeFile(outputPath, `${JSON.stringify(receipt, null, 2)}\n`, { encoding: 'utf8', mode: 0o600 });
+  await chmod(outputPath, 0o600);
+}

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.ts
@@ -1,4 +1,4 @@
-import { loadConfig } from '../../config/config';
+import { loadConfigOrThrow } from '../../config/config';
 import { ConfigService } from '../../config/config.service';
 import { PrismaService } from '../../prisma/prisma.service';
 import { MinioService } from '../../storage/minio.service';
@@ -93,7 +93,7 @@ export async function runOperationalCli(argv: readonly string[] = process.argv.s
 
   let config: ConfigService;
   try {
-    config = new ConfigService(loadConfig());
+    config = new ConfigService(loadConfigOrThrow());
   } catch (_error: unknown) {
     return reportOperationalFailure(OperationalFailureCategory.CONFIG);
   }

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.ts
@@ -132,7 +132,11 @@ export async function runOperationalCli(argv: readonly string[] = process.argv.s
   } catch (_error: unknown) {
     return reportOperationalFailure(OperationalFailureCategory.SCANNER);
   } finally {
-    await prisma.$disconnect();
+    try {
+      await prisma.$disconnect();
+    } catch (_error: unknown) {
+      return reportOperationalFailure(OperationalFailureCategory.CLEANUP);
+    }
   }
 }
 

--- a/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.ts
+++ b/apps/api/src/reconciliation/historical-inventory/historical-inventory.operational.ts
@@ -1,15 +1,17 @@
-import { loadConfig } from '../src/config/config';
-import { ConfigService } from '../src/config/config.service';
-import { PrismaService } from '../src/prisma/prisma.service';
-import { PrismaDbToStorageDatabase } from '../src/reconciliation/db-to-storage/prisma-db-to-storage.database';
-import { HistoricalInventoryScanner } from '../src/reconciliation/historical-inventory/historical-inventory.scanner';
-import { MinioService } from '../src/storage/minio.service';
+import { loadConfig } from '../../config/config';
+import { ConfigService } from '../../config/config.service';
+import { PrismaService } from '../../prisma/prisma.service';
+import { MinioService } from '../../storage/minio.service';
+import { PrismaDbToStorageDatabase } from '../db-to-storage/prisma-db-to-storage.database';
+import { HistoricalInventoryScanner } from './historical-inventory.scanner';
 import {
   conciseHistoricalSummary,
-  HistoricalInventoryCliOptions,
+  exitCodeForStatus,
+  HistoricalInventoryCliUsageError,
   parseHistoricalInventoryCliArgs,
   writeHistoricalInventoryReceiptFile,
-} from './reconciliation-historical-inventory';
+} from './historical-inventory.operational.shared';
+import type { HistoricalInventoryCliOptions } from './historical-inventory.operational.shared';
 
 export const OPERATIONAL_STAGING_CONFIRMATION_VARIABLE = 'HISTORICAL_INVENTORY_OPERATIONAL_STAGING_CONFIRMATION';
 export const OPERATIONAL_STAGING_CONFIRMATION_TOKEN = 'HISTORICAL-INVENTORY-STAGING-READ-ONLY';
@@ -23,9 +25,20 @@ export interface OperationalEnvironment {
   readonly HISTORICAL_INVENTORY_OPERATIONAL_PRODUCTION_CONFIRMATION?: string;
 }
 
+export enum OperationalFailureCategory {
+  CONFIG = 'CONFIG',
+  AUTHORIZATION = 'AUTHORIZATION',
+  DB_CONNECT = 'DB_CONNECT',
+  STORAGE_CONNECT = 'STORAGE_CONNECT',
+  SCANNER = 'SCANNER',
+  RECEIPT_WRITE = 'RECEIPT_WRITE',
+  CLEANUP = 'CLEANUP',
+  UNKNOWN = 'UNKNOWN',
+}
+
 /**
- * Requires the runtime NODE_ENV and its environment-specific acknowledgement
- * before the operational entrypoint can create any provider clients.
+ * Requires the actual runtime NODE_ENV and its environment-specific explicit
+ * acknowledgement before the CLI creates database or storage providers.
  */
 export function assertOperationalNodeEnvironment(
   nodeEnv: string,
@@ -52,12 +65,25 @@ export function assertOperationalNodeEnvironment(
   throw new Error('Operational historical inventory is restricted to staging or production');
 }
 
+export function formatOperationalFailure(category: OperationalFailureCategory): string {
+  return `Operational historical inventory failed [${category}]\n`;
+}
+
+function reportOperationalFailure(category: OperationalFailureCategory): 2 {
+  process.stderr.write(formatOperationalFailure(category));
+  return 2;
+}
+
+/**
+ * Runs the operational scanner from compiled application source. The gate is
+ * evaluated before creating database or object-storage provider clients.
+ */
 export async function runOperationalCli(argv: readonly string[] = process.argv.slice(2)): Promise<number> {
   let options: HistoricalInventoryCliOptions | null;
   try {
-    options = parseHistoricalInventoryCliArgs(argv, 'reconciliation-historical-inventory-operational');
+    options = parseHistoricalInventoryCliArgs(argv, 'historical-inventory-operational');
   } catch (error: unknown) {
-    process.stderr.write(`${error instanceof Error ? error.message : 'Invalid CLI arguments'}\n`);
+    process.stderr.write(`${error instanceof HistoricalInventoryCliUsageError ? error.message : 'Invalid CLI arguments'}\n`);
     return 64;
   }
 
@@ -65,13 +91,28 @@ export async function runOperationalCli(argv: readonly string[] = process.argv.s
     return 0;
   }
 
-  let prisma: PrismaService | undefined;
+  let config: ConfigService;
   try {
-    const config = new ConfigService(loadConfig());
+    config = new ConfigService(loadConfig());
+  } catch (_error: unknown) {
+    return reportOperationalFailure(OperationalFailureCategory.CONFIG);
+  }
+
+  try {
     assertOperationalNodeEnvironment(config.getValue('nodeEnv'));
+  } catch (_error: unknown) {
+    return reportOperationalFailure(OperationalFailureCategory.AUTHORIZATION);
+  }
+
+  let prisma: PrismaService;
+  try {
     prisma = new PrismaService();
     await prisma.$connect();
+  } catch (_error: unknown) {
+    return reportOperationalFailure(OperationalFailureCategory.DB_CONNECT);
+  }
 
+  try {
     const receipt = await new HistoricalInventoryScanner(
       new PrismaDbToStorageDatabase(prisma),
       new MinioService(config),
@@ -79,17 +120,19 @@ export async function runOperationalCli(argv: readonly string[] = process.argv.s
     ).scan();
 
     if (options.outputPath) {
-      await writeHistoricalInventoryReceiptFile(options.outputPath, receipt);
+      try {
+        await writeHistoricalInventoryReceiptFile(options.outputPath, receipt);
+      } catch (_error: unknown) {
+        return reportOperationalFailure(OperationalFailureCategory.RECEIPT_WRITE);
+      }
     }
+
     process.stdout.write(`${JSON.stringify(conciseHistoricalSummary(receipt))}\n`);
-    return receipt.scanStatus === 'INCOMPLETE_OPERATIONAL_ERROR' ? 2 : 0;
+    return exitCodeForStatus(receipt.scanStatus);
   } catch (_error: unknown) {
-    process.stderr.write('Operational historical inventory execution failed\n');
-    return 2;
+    return reportOperationalFailure(OperationalFailureCategory.SCANNER);
   } finally {
-    if (prisma) {
-      await prisma.$disconnect();
-    }
+    await prisma.$disconnect();
   }
 }
 

--- a/infra/docker/docker-compose.production.yml
+++ b/infra/docker/docker-compose.production.yml
@@ -43,6 +43,25 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  api-historical-inventory-audit:
+    profiles: ["audit"]
+    image: buildingos-api:${IMAGE_TAG:?IMAGE_TAG is required}
+    build:
+      context: ../../
+      dockerfile: apps/api/Dockerfile
+      target: runtime
+      args:
+        BUILD_REVISION: ${BUILD_REVISION:?BUILD_REVISION is required}
+        BUILD_VERSION: ${IMAGE_TAG:?IMAGE_TAG is required}
+    env_file:
+      - ${API_ENV_FILE:-/opt/pawtech/env/buildingos.env}
+    networks:
+      - pawtech_internal
+    environment:
+      NODE_ENV: production
+    command: ["node", "apps/api/dist/reconciliation/historical-inventory/historical-inventory.operational.js"]
+    restart: "no"
+
   buildingos-web:
     image: buildingos-web:${IMAGE_TAG:?IMAGE_TAG is required}
     build:

--- a/infra/docker/docker-compose.production.yml
+++ b/infra/docker/docker-compose.production.yml
@@ -43,6 +43,9 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # Audit confirmation is intentionally not persisted: inject it only for a one-shot run.
+  # Normal and audit-profile rendering must not require it:
+  # docker compose --profile audit run --rm -e HISTORICAL_INVENTORY_OPERATIONAL_PRODUCTION_CONFIRMATION=<confirmation> api-historical-inventory-audit
   api-historical-inventory-audit:
     profiles: ["audit"]
     image: buildingos-api:${IMAGE_TAG:?IMAGE_TAG is required}

--- a/infra/docker/docker-compose.staging.yml
+++ b/infra/docker/docker-compose.staging.yml
@@ -88,6 +88,36 @@ services:
     command: ["npm", "run", "seed:staging:golden", "-w", "apps/api"]
     restart: "no"
 
+  api-historical-inventory-audit:
+    profiles: ["audit"]
+    build:
+      context: ../../
+      dockerfile: apps/api/Dockerfile
+      target: runtime
+    networks:
+      - buildingos_staging_net
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      APP_ENV: staging
+      NODE_ENV: staging
+      DATABASE_URL: postgresql://${POSTGRES_USER:?POSTGRES_USER is required}:${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}@postgres:5432/${POSTGRES_DB:?POSTGRES_DB is required}
+      WEB_ORIGIN: ${WEB_ORIGIN:?WEB_ORIGIN is required}
+      APP_BASE_URL: ${APP_BASE_URL:?APP_BASE_URL is required}
+      S3_ENDPOINT: ${S3_ENDPOINT:?S3_ENDPOINT is required}
+      S3_REGION: ${S3_REGION:?S3_REGION is required}
+      S3_ACCESS_KEY: ${S3_ACCESS_KEY:?S3_ACCESS_KEY is required}
+      S3_SECRET_KEY: ${S3_SECRET_KEY:?S3_SECRET_KEY is required}
+      S3_BUCKET: ${S3_BUCKET:?S3_BUCKET is required}
+      S3_FORCE_PATH_STYLE: ${S3_FORCE_PATH_STYLE:?S3_FORCE_PATH_STYLE is required}
+      S3_PUBLIC_BASE_URL: ${S3_PUBLIC_BASE_URL:?S3_PUBLIC_BASE_URL is required}
+      JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
+      FEATURE_PORTAL_RESIDENT: ${FEATURE_PORTAL_RESIDENT:?FEATURE_PORTAL_RESIDENT is required}
+      FEATURE_PAYMENTS_MVP: ${FEATURE_PAYMENTS_MVP:?FEATURE_PAYMENTS_MVP is required}
+    command: ["node", "apps/api/dist/reconciliation/historical-inventory/historical-inventory.operational.js"]
+    restart: "no"
+
   buildingos-api:
     build:
       context: ../../

--- a/infra/docker/docker-compose.staging.yml
+++ b/infra/docker/docker-compose.staging.yml
@@ -88,6 +88,9 @@ services:
     command: ["npm", "run", "seed:staging:golden", "-w", "apps/api"]
     restart: "no"
 
+  # Audit confirmation is intentionally not persisted: inject it only for a one-shot run.
+  # Normal and audit-profile rendering must not require it:
+  # docker compose --profile audit run --rm -e HISTORICAL_INVENTORY_OPERATIONAL_STAGING_CONFIRMATION=<confirmation> api-historical-inventory-audit
   api-historical-inventory-audit:
     profiles: ["audit"]
     build:


### PR DESCRIPTION
Closes #243

## Descripción

Adds a dedicated operational read-only entrypoint for the existing `HistoricalInventoryScanner` so it can be executed legitimately in STAGING/PRODUCTION without spoofing `NODE_ENV` and without weakening the existing development/test-only CLI guard.

## Safety guarantees

- `HistoricalInventoryScanner` semantics unchanged
- existing local CLI remains development/test only
- operational runner accepts only staging/production
- staging and production require distinct explicit confirmations
- authorization fails closed before DB/storage connection
- no DB mutation path is reachable
- no storage mutation/delete path is reachable
- no automatic repair or orphan deletion is reachable
- no `NODE_ENV` spoofing

## Validation

- focused operational tests: PASS — 18
- historical inventory tests: PASS
- reconciliation tests: PASS — 136 passed, 1 skipped
- lint: PASS
- `git diff --check`: PASS
- API typecheck baseline: IDENTICAL — 82 vs 82
- feature-only API diagnostics: 0
- operational script direct type errors: 0
- local CLI direct type errors: 0
- new transitive type errors: 0
- `package.json` unchanged
- lockfiles unchanged
- Prisma schema unchanged
- tsconfig unchanged

## Environment safety

- no STAGING access during implementation
- no PRODUCTION access during implementation
- no deployment performed

Merge is intentionally not authorized at this stage because merge to `main` can trigger the official STAGING deployment workflow.