### PR TITLE
fix: prevent staging fixture storage drift

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -359,12 +359,16 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
 
-      - name: Run E2E tests
+      - name: Run E2E tests (including exact receipt storage-version verification)
         id: e2e-tests
         run: npm run test:e2e -w apps/web -- --project=chromium
         env:
           BASE_URL: http://localhost:3000
           PORT: 3000
+
+      - name: Verify exact receipt storage cleanup
+        if: always()
+        run: node apps/api/scripts/verify-receipt-storage-cleanup.js
 
       - name: Stop API server
         if: always()

--- a/apps/api/prisma/seed.ts
+++ b/apps/api/prisma/seed.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Role, TenantType, BillingPlanId, DocumentCategory, DocumentVisibility, QuoteStatus, WorkOrderStatus, ChargeStatus, PaymentStatus, PaymentMethod, ChargeType } from "@prisma/client";
+import { PrismaClient, Role, TenantType, BillingPlanId, QuoteStatus, WorkOrderStatus, ChargeStatus, PaymentStatus, PaymentMethod, ChargeType } from "@prisma/client";
 import * as bcrypt from "bcrypt";
 
 const prisma = new PrismaClient();
@@ -807,83 +807,6 @@ async function main() {
   });
 
   // ============================================================================
-  // DOCUMENTS & FILES (MVP - Building rules, unit-specific docs, etc.)
-  // ============================================================================
-  // Get the admin membership for document creation audit trail
-  const adminMembership = await prisma.membership.findFirst({
-    where: {
-      userId: adminUser.id,
-      tenantId: tenantBuilding.id,
-    },
-  });
-
-  // Building-scoped document (e.g., building rules)
-  const buildingRulesFile = await prisma.file.upsert({
-    where: { id: "file-building-rules-demo" },
-    update: {},
-    create: {
-      id: "file-building-rules-demo",
-      tenantId: tenantBuilding.id,
-      bucket: "documents",
-      objectKey: `tenant-${tenantBuilding.id}/building-${building.id}/rules.pdf`,
-      originalName: "Reglamento_Edificio_Demo.pdf",
-      mimeType: "application/pdf",
-      size: 245632, // ~240KB
-      checksum: "sha256:abc123def456...",
-      createdByMembershipId: adminMembership?.id || undefined,
-    },
-  });
-
-  const buildingRulesDoc = await prisma.document.upsert({
-    where: { id: "doc-building-rules-demo" },
-    update: {},
-    create: {
-      id: "doc-building-rules-demo",
-      tenantId: tenantBuilding.id,
-      fileId: buildingRulesFile.id,
-      title: "Reglamento de Convivencia - Edificio Demo",
-      category: DocumentCategory.RULES,
-      visibility: DocumentVisibility.RESIDENTS, // Visible to all residents
-      buildingId: building.id,
-      unitId: undefined, // Building-scoped, not unit-scoped
-      createdByMembershipId: adminMembership?.id || undefined,
-    },
-  });
-
-  // Unit-scoped document (e.g., unit-specific instruction)
-  const unitDocFile = await prisma.file.upsert({
-    where: { id: "file-unit-doc-demo" },
-    update: {},
-    create: {
-      id: "file-unit-doc-demo",
-      tenantId: tenantBuilding.id,
-      bucket: "documents",
-      objectKey: `tenant-${tenantBuilding.id}/unit-${unit1.id}/maintenance-guide.pdf`,
-      originalName: "Guia_Mantenimiento_Unidad.pdf",
-      mimeType: "application/pdf",
-      size: 102400, // ~100KB
-      checksum: "sha256:xyz789uvw012...",
-      createdByMembershipId: adminMembership?.id || undefined,
-    },
-  });
-
-  const unitDoc = await prisma.document.upsert({
-    where: { id: "doc-unit-demo" },
-    update: {},
-    create: {
-      id: "doc-unit-demo",
-      tenantId: tenantBuilding.id,
-      fileId: unitDocFile.id,
-      title: `Guía de Mantenimiento - ${unit1.label}`,
-      category: DocumentCategory.OTHER,
-      visibility: DocumentVisibility.TENANT_ADMINS, // Only admins
-      buildingId: building.id,
-      unitId: unit1.id, // Unit-scoped
-      createdByMembershipId: adminMembership?.id || undefined,
-    },
-  });
-
-  // ============================================================================
   // VENDORS & OPERATIONS (Proveedores, Presupuestos, Órdenes de Trabajo)
   // ============================================================================
 
@@ -1062,21 +985,6 @@ async function main() {
     • Assigned to: ${operatorUser.name}
     • Unit: ${unit1.label}
     • Comment: Operator acknowledged the issue
-
-  DOCUMENTS & FILES:
-  - Building Document: "${buildingRulesDoc.title}"
-    • Category: ${buildingRulesDoc.category}
-    • Visibility: ${buildingRulesDoc.visibility} (visible to residents)
-    • Scope: Building-wide (${building.name})
-    • File: ${buildingRulesFile.originalName} (${buildingRulesFile.size} bytes)
-    • MinIO path: ${buildingRulesFile.objectKey}
-
-  - Unit Document: "${unitDoc.title}"
-    • Category: ${unitDoc.category}
-    • Visibility: ${unitDoc.visibility} (admin only)
-    • Scope: Unit ${unit1.label}
-    • File: ${unitDocFile.originalName} (${unitDocFile.size} bytes)
-    • MinIO path: ${unitDocFile.objectKey}
 
   VENDORS & OPERATIONS:
   - Vendor: "${vendor.name}"

--- a/apps/api/scripts/__tests__/verify-receipt-storage-cleanup.test.js
+++ b/apps/api/scripts/__tests__/verify-receipt-storage-cleanup.test.js
@@ -1,0 +1,29 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { isExactVersionAbsent, validateManifest, verifyExactVersionAbsent } = require('../verify-receipt-storage-cleanup');
+
+const manifest = { bucket: 'test-bucket', objectKey: 'tenant/payment/receipt.pdf', objectVersionId: 'exact-version' };
+const absent = [
+  { code: 'NoSuchKey', message: 'missing' },
+  { code: 'NoSuchVersion', message: 'missing version' },
+  { name: 'S3Error', $metadata: { httpStatusCode: 404 }, message: 'Not Found' },
+];
+for (const error of absent) test(`exact absence: ${error.code ?? 'structured 404'}`, () => assert.equal(isExactVersionAbsent(error, true, 'exact-version'), true));
+for (const [name, error] of Object.entries({ messageOnly: new Error('Not Found'), forbidden: { $metadata: { httpStatusCode: 403 }, message: 'Forbidden' }, server: { $metadata: { httpStatusCode: 500 }, message: 'Internal Error' }, network: new Error('connect ECONNREFUSED') })) test(`query failure: ${name}`, () => assert.equal(isExactVersionAbsent(error, true, 'exact-version'), false));
+test('exact version present fails after polling', async () => {
+  await assert.rejects(verifyExactVersionAbsent({ bucketExists: async () => true, statObject: async () => ({}) }, 'manifest.json', manifest), /EXACT_VERSION_STILL_PRESENT/);
+});
+test('missing version id fails closed', () => assert.throws(() => validateManifest('manifest.json', { ...manifest, objectVersionId: '' }), /invalid-objectVersionId/));
+test('stat request uses the exact version id', async () => {
+  let args;
+  await verifyExactVersionAbsent({ bucketExists: async () => true, statObject: async (...received) => { args = received; throw { code: 'NoSuchVersion' }; } }, 'manifest.json', manifest);
+  assert.deepEqual(args, ['test-bucket', 'tenant/payment/receipt.pdf', { versionId: 'exact-version' }]);
+});
+
+test('MinIO NotFound needs bucket confirmation and version id', () => {
+ const error={name:'S3Error',code:'NotFound',message:'Not Found'};
+ assert.equal(isExactVersionAbsent(error,true,'exact-version'),true);
+ assert.equal(isExactVersionAbsent(error,false,'exact-version'),false);
+ assert.equal(isExactVersionAbsent(error,true,''),false);
+});
+test('bucket absence fails closed', async () => { await assert.rejects(verifyExactVersionAbsent({bucketExists:async()=>false,statObject:async()=>({})},'manifest.json',manifest),/RECEIPT_STORAGE_QUERY_ERROR/); });

--- a/apps/api/scripts/verify-receipt-storage-cleanup.js
+++ b/apps/api/scripts/verify-receipt-storage-cleanup.js
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+
+const { readdir, readFile } = require('node:fs/promises');
+const path = require('node:path');
+const Minio = require('minio');
+
+const MANIFEST_DIRECTORY = path.resolve(__dirname, '../../web/test-results/receipt-cleanup-verification');
+const POLL_INTERVAL_MS = 250;
+const POLL_TIMEOUT_MS = 10_000;
+const MANIFEST_FILE_NAME = /^[A-Za-z0-9_-]+\.json$/;
+const MANIFEST_FIELDS = ['bucket', 'objectKey', 'objectVersionId'];
+
+const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+const isExactVersionAbsent = (error) => {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const { code, statusCode } = error;
+  return code === 'NotFound' || code === 'NoSuchKey' || code === 'NoSuchVersion' || statusCode === 404;
+};
+
+const errorDescription = (error) => {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+};
+
+const validateManifest = (manifestPath, parsed) => {
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`RECEIPT_CLEANUP_MANIFEST_INVALID file=${manifestPath} reason=not-an-object`);
+  }
+
+  const fields = Object.keys(parsed).sort();
+  const expectedFields = [...MANIFEST_FIELDS].sort();
+  if (fields.length !== expectedFields.length || fields.some((field, index) => field !== expectedFields[index])) {
+    throw new Error(`RECEIPT_CLEANUP_MANIFEST_INVALID file=${manifestPath} reason=unexpected-fields`);
+  }
+
+  for (const field of MANIFEST_FIELDS) {
+    if (typeof parsed[field] !== 'string' || parsed[field].trim().length === 0) {
+      throw new Error(`RECEIPT_CLEANUP_MANIFEST_INVALID file=${manifestPath} reason=invalid-${field}`);
+    }
+  }
+
+  return parsed;
+};
+
+const loadManifests = async () => {
+  let entries;
+  try {
+    entries = await readdir(MANIFEST_DIRECTORY, { withFileTypes: true });
+  } catch (error) {
+    if (error && typeof error === 'object' && error.code === 'ENOENT') {
+      return [];
+    }
+    throw new Error(`RECEIPT_CLEANUP_MANIFEST_READ_FAILED directory=${MANIFEST_DIRECTORY} reason=${errorDescription(error)}`);
+  }
+
+  const manifestPaths = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !MANIFEST_FILE_NAME.test(entry.name)) {
+      throw new Error(`RECEIPT_CLEANUP_MANIFEST_INVALID file=${entry.name} reason=unexpected-directory-entry`);
+    }
+    manifestPaths.push(path.join(MANIFEST_DIRECTORY, entry.name));
+  }
+
+  const manifests = [];
+  for (const manifestPath of manifestPaths.sort()) {
+    let parsed;
+    try {
+      parsed = JSON.parse(await readFile(manifestPath, 'utf8'));
+    } catch (error) {
+      throw new Error(`RECEIPT_CLEANUP_MANIFEST_INVALID file=${manifestPath} reason=${errorDescription(error)}`);
+    }
+    manifests.push({ manifestPath, value: validateManifest(manifestPath, parsed) });
+  }
+
+  return manifests;
+};
+
+const createClient = () => {
+  const endpoint = process.env.S3_ENDPOINT?.trim();
+  const accessKey = process.env.S3_ACCESS_KEY?.trim();
+  const secretKey = process.env.S3_SECRET_KEY?.trim();
+
+  if (!endpoint || !accessKey || !secretKey) {
+    throw new Error('RECEIPT_CLEANUP_STORAGE_CONFIGURATION_INVALID');
+  }
+
+  let url;
+  try {
+    url = new URL(endpoint);
+  } catch {
+    throw new Error('RECEIPT_CLEANUP_STORAGE_CONFIGURATION_INVALID');
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('RECEIPT_CLEANUP_STORAGE_CONFIGURATION_INVALID');
+  }
+
+  return new Minio.Client({
+    endPoint: url.hostname,
+    port: url.port ? Number.parseInt(url.port, 10) : url.protocol === 'https:' ? 443 : 80,
+    useSSL: url.protocol === 'https:',
+    accessKey,
+    secretKey,
+  });
+};
+
+const verifyExactVersionAbsent = async (client, manifestPath, manifest) => {
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+
+  while (true) {
+    try {
+      await client.statObject(manifest.bucket, manifest.objectKey, { versionId: manifest.objectVersionId });
+    } catch (error) {
+      if (isExactVersionAbsent(error)) {
+        console.log(`EXACT_VERSION_ABSENT manifest=${manifestPath}`);
+        return;
+      }
+      throw new Error(`RECEIPT_STORAGE_QUERY_ERROR manifest=${manifestPath} reason=${errorDescription(error)}`);
+    }
+
+    const remainingMilliseconds = deadline - Date.now();
+    if (remainingMilliseconds <= 0) {
+      throw new Error(`EXACT_VERSION_STILL_PRESENT manifest=${manifestPath}`);
+    }
+    await sleep(Math.min(POLL_INTERVAL_MS, remainingMilliseconds));
+  }
+};
+
+const main = async () => {
+  const manifests = await loadManifests();
+  if (manifests.length === 0) {
+    console.log('RECEIPT_STORAGE_CLEANUP_OK manifests=0');
+    return;
+  }
+
+  const client = createClient();
+  for (const manifest of manifests) {
+    await verifyExactVersionAbsent(client, manifest.manifestPath, manifest.value);
+  }
+
+  console.log(`RECEIPT_STORAGE_CLEANUP_OK manifests=${manifests.length}`);
+};
+
+main().catch((error) => {
+  console.error(errorDescription(error));
+  process.exitCode = 1;
+});

--- a/apps/api/scripts/verify-receipt-storage-cleanup.js
+++ b/apps/api/scripts/verify-receipt-storage-cleanup.js
@@ -17,8 +17,8 @@ const isExactVersionAbsent = (error) => {
     return false;
   }
 
-  const { code, statusCode } = error;
-  return code === 'NotFound' || code === 'NoSuchKey' || code === 'NoSuchVersion' || statusCode === 404;
+  const { code } = error;
+  return code === 'NoSuchKey' || code === 'NoSuchVersion';
 };
 
 const errorDescription = (error) => {

--- a/apps/api/scripts/verify-receipt-storage-cleanup.js
+++ b/apps/api/scripts/verify-receipt-storage-cleanup.js
@@ -12,20 +12,34 @@ const MANIFEST_FIELDS = ['bucket', 'objectKey', 'objectVersionId'];
 
 const sleep = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
 
-const isExactVersionAbsent = (error) => {
-  if (!error || typeof error !== 'object') {
-    return false;
-  }
-
-  const { code } = error;
-  return code === 'NoSuchKey' || code === 'NoSuchVersion';
+const isExactVersionAbsent = (error, bucketConfirmed, versionId) => {
+  const { code, httpStatusCode, name } = errorDetails(error);
+  if (!bucketConfirmed || typeof versionId !== 'string' || versionId.trim().length === 0) return false;
+  return code === 'NoSuchKey' || code === 'NoSuchVersion' || httpStatusCode === 404 || (name === 'S3Error' && code === 'NotFound');
 };
 
-const errorDescription = (error) => {
-  if (error instanceof Error) {
-    return error.message;
+const errorDetails = (error) => {
+  if (!error || typeof error !== 'object') {
+    return { name: typeof error, code: undefined, httpStatusCode: undefined, message: String(error) };
   }
-  return String(error);
+
+  const candidate = error;
+  const metadata = candidate.$metadata;
+  return {
+    name: typeof candidate.name === 'string' ? candidate.name : undefined,
+    code: typeof candidate.code === 'string' ? candidate.code : typeof candidate.Code === 'string' ? candidate.Code : undefined,
+    httpStatusCode: metadata && typeof metadata === 'object' && typeof metadata.httpStatusCode === 'number'
+      ? metadata.httpStatusCode
+      : typeof candidate.statusCode === 'number' ? candidate.statusCode : undefined,
+    message: candidate instanceof Error ? candidate.message : String(error),
+  };
+};
+
+const errorDescription = (error) => errorDetails(error).message;
+
+const errorDiagnostic = (error) => {
+  const { name, code, httpStatusCode, message } = errorDetails(error);
+  return `name=${name ?? 'unknown'} code=${code ?? 'unknown'} httpStatusCode=${httpStatusCode ?? 'unknown'} message=${JSON.stringify(message)}`;
 };
 
 const validateManifest = (manifestPath, parsed) => {
@@ -110,18 +124,31 @@ const createClient = () => {
   });
 };
 
-const verifyExactVersionAbsent = async (client, manifestPath, manifest) => {
+const verifyExactVersionAbsent = async (client, manifestPath, manifest, bucketCache = new Map()) => {
+  let bucketConfirmed = bucketCache.get(manifest.bucket);
+  if (bucketConfirmed === undefined) {
+    try {
+      bucketConfirmed = await client.bucketExists(manifest.bucket);
+    } catch (error) {
+      throw new Error(`RECEIPT_STORAGE_QUERY_ERROR manifest=${manifestPath} bucket-check ${errorDiagnostic(error)}`);
+    }
+    bucketCache.set(manifest.bucket, bucketConfirmed);
+  }
+  if (!bucketConfirmed) {
+    throw new Error(`RECEIPT_STORAGE_QUERY_ERROR manifest=${manifestPath} bucket-check name=unknown code=NoSuchBucket httpStatusCode=unknown message="Bucket unavailable"`);
+  }
+
   const deadline = Date.now() + POLL_TIMEOUT_MS;
 
   while (true) {
     try {
       await client.statObject(manifest.bucket, manifest.objectKey, { versionId: manifest.objectVersionId });
     } catch (error) {
-      if (isExactVersionAbsent(error)) {
+      if (isExactVersionAbsent(error, bucketConfirmed, manifest.objectVersionId)) {
         console.log(`EXACT_VERSION_ABSENT manifest=${manifestPath}`);
         return;
       }
-      throw new Error(`RECEIPT_STORAGE_QUERY_ERROR manifest=${manifestPath} reason=${errorDescription(error)}`);
+      throw new Error(`RECEIPT_STORAGE_QUERY_ERROR manifest=${manifestPath} ${errorDiagnostic(error)}`);
     }
 
     const remainingMilliseconds = deadline - Date.now();
@@ -140,14 +167,19 @@ const main = async () => {
   }
 
   const client = createClient();
+  const bucketCache = new Map();
   for (const manifest of manifests) {
-    await verifyExactVersionAbsent(client, manifest.manifestPath, manifest.value);
+    await verifyExactVersionAbsent(client, manifest.manifestPath, manifest.value, bucketCache);
   }
 
   console.log(`RECEIPT_STORAGE_CLEANUP_OK manifests=${manifests.length}`);
 };
 
-main().catch((error) => {
-  console.error(errorDescription(error));
-  process.exitCode = 1;
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(errorDescription(error));
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { isExactVersionAbsent, validateManifest, verifyExactVersionAbsent, errorDetails };

--- a/apps/web/tests/e2e/resident/receipt-teardown.ts
+++ b/apps/web/tests/e2e/resident/receipt-teardown.ts
@@ -1,0 +1,169 @@
+export interface ReceiptTeardownPayment {
+  readonly id: string;
+  readonly reference?: string | null;
+  readonly status: string;
+  readonly receiptStatus: string;
+  readonly receiptDocumentId: string | null;
+}
+
+export interface ReceiptTeardownDocument {
+  readonly paymentId: string;
+  readonly documentId: string;
+  readonly fileId: string;
+  readonly bucket: string;
+  readonly objectKey: string;
+  readonly objectVersionId: string;
+}
+
+export interface ReceiptTeardownFixture {
+  receiptDocuments: ReceiptTeardownDocument[];
+}
+
+export interface ReceiptTeardownOperations {
+  readonly waitForReceipt: (payment: ReceiptTeardownPayment) => Promise<ReceiptTeardownDocument>;
+  readonly unlinkReceiptDocument: (receipt: ReceiptTeardownDocument) => Promise<void>;
+  readonly restoreReceiptDocument: (receipt: ReceiptTeardownDocument) => Promise<void>;
+  readonly writeReceiptCleanupManifest: (receipt: ReceiptTeardownDocument) => Promise<void>;
+  readonly deleteReceiptDocument: (receipt: ReceiptTeardownDocument) => Promise<void>;
+  readonly deletePaymentAllocations: (paymentIds: string[]) => Promise<void>;
+  readonly deletePayments: (paymentIds: string[]) => Promise<void>;
+}
+
+export interface ReceiptTeardownResult {
+  readonly hasPreservedPayments: boolean;
+  readonly failures: unknown[];
+}
+
+export class ReceiptTeardownFailedError extends Error {
+  constructor(paymentId: string) {
+    super(`E2E payment ${paymentId} receipt generation failed`);
+    this.name = 'ReceiptTeardownFailedError';
+  }
+}
+
+export class ReceiptTeardownTimeoutError extends Error {
+  constructor(paymentId: string, cause?: unknown) {
+    super(`Timed out waiting for receipt cleanup readiness for payment ${paymentId}`, { cause });
+    this.name = 'ReceiptTeardownTimeoutError';
+  }
+}
+
+function isPaymentAwaitingReceipt(payment: ReceiptTeardownPayment): boolean {
+  return payment.status === 'APPROVED' || payment.status === 'RECONCILED';
+}
+
+function receiptIsOwnedByPayment(
+  receipt: ReceiptTeardownDocument,
+  payment: ReceiptTeardownPayment | undefined,
+): boolean {
+  return payment?.receiptStatus === 'READY' && payment.receiptDocumentId === receipt.documentId;
+}
+
+function retainReceiptDocument(fixture: ReceiptTeardownFixture, receipt: ReceiptTeardownDocument): void {
+  const existingReceipt = fixture.receiptDocuments.find((candidate) => candidate.paymentId === receipt.paymentId);
+  if (existingReceipt && existingReceipt.documentId !== receipt.documentId) {
+    throw new Error(`Payment ${receipt.paymentId} changed receipt ownership during E2E cleanup`);
+  }
+  if (!existingReceipt) {
+    fixture.receiptDocuments.push(receipt);
+  }
+}
+
+/** Throws accumulated teardown failures after cleanup has finished. */
+export function throwReceiptTeardownFailures(failures: unknown[]): void {
+  if (failures.length === 1) {
+    throw failures[0];
+  }
+  if (failures.length > 1) {
+    throw new AggregateError(failures, 'E2E payment receipt cleanup failed');
+  }
+}
+
+/**
+ * Removes receipt-backed payment artifacts without deleting a payment whose
+ * receipt could not be safely detached. All I/O is injected so this teardown
+ * policy can be unit-tested without Playwright, Prisma, or object storage.
+ */
+export async function teardownPaymentReceipts(
+  fixture: ReceiptTeardownFixture,
+  payments: ReceiptTeardownPayment[],
+  operations: ReceiptTeardownOperations,
+): Promise<ReceiptTeardownResult> {
+  const waitedPayments = payments.filter(isPaymentAwaitingReceipt);
+  const receiptWaitResults = await Promise.allSettled(
+    waitedPayments.map(async (payment) => {
+      if (payment.receiptStatus === 'FAILED') {
+        throw new ReceiptTeardownFailedError(payment.id);
+      }
+      return operations.waitForReceipt(payment);
+    }),
+  );
+  const failures: unknown[] = [];
+  const preservedPaymentIds = new Set<string>();
+
+  for (const [index, result] of receiptWaitResults.entries()) {
+    const payment = waitedPayments[index];
+    if (!payment) {
+      throw new Error('Receipt cleanup result had no matching payment');
+    }
+    if (result.status === 'fulfilled') {
+      retainReceiptDocument(fixture, result.value);
+      continue;
+    }
+
+    failures.push(result.reason);
+    if (result.reason instanceof ReceiptTeardownTimeoutError) {
+      preservedPaymentIds.add(payment.id);
+    }
+  }
+
+  const paymentsById = new Map(payments.map((payment) => [payment.id, payment]));
+  const receipts = fixture.receiptDocuments.filter((receipt) =>
+    receiptIsOwnedByPayment(receipt, paymentsById.get(receipt.paymentId)),
+  );
+
+  for (const receipt of receipts) {
+    if (preservedPaymentIds.has(receipt.paymentId)) {
+      continue;
+    }
+
+    let unlinked = false;
+    try {
+      await operations.unlinkReceiptDocument(receipt);
+      unlinked = true;
+      await operations.writeReceiptCleanupManifest(receipt);
+      await operations.deleteReceiptDocument(receipt);
+      fixture.receiptDocuments = fixture.receiptDocuments.filter(
+        (candidate) => candidate.documentId !== receipt.documentId,
+      );
+    } catch (deleteFailure: unknown) {
+      preservedPaymentIds.add(receipt.paymentId);
+      if (!unlinked) {
+        failures.push(deleteFailure);
+        continue;
+      }
+
+      try {
+        await operations.restoreReceiptDocument(receipt);
+        failures.push(deleteFailure);
+      } catch (restoreFailure: unknown) {
+        failures.push(
+          new AggregateError(
+            [deleteFailure, restoreFailure],
+            `E2E receipt document ${receipt.documentId} deletion and payment relation restoration both failed`,
+          ),
+        );
+      }
+    }
+  }
+
+  const paymentIds = payments
+    .map((payment) => payment.id)
+    .filter((paymentId) => !preservedPaymentIds.has(paymentId));
+  if (paymentIds.length > 0) {
+    await operations.deletePaymentAllocations(paymentIds);
+    await operations.deletePayments(paymentIds);
+  }
+
+  return { hasPreservedPayments: preservedPaymentIds.size > 0, failures };
+}

--- a/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
@@ -6,6 +6,14 @@ import { expect, test, type Page } from '@playwright/test';
 import { PrismaClient, Prisma, ChargeType, ChargeStatus, PaymentStatus, ReceiptStatus } from '@prisma/client';
 
 import { login, TEST_USERS } from '../helpers/auth';
+import {
+  ReceiptTeardownFailedError,
+  ReceiptTeardownTimeoutError,
+  teardownPaymentReceipts,
+  throwReceiptTeardownFailures,
+  type ReceiptTeardownDocument,
+  type ReceiptTeardownPayment,
+} from './receipt-teardown';
 
 const API_ORIGIN = process.env.NEXT_PUBLIC_API_URL?.trim() || 'http://localhost:4000';
 const PRISMA = new PrismaClient();
@@ -80,23 +88,14 @@ interface E2EArtifactContext {
   receiptDocuments: ReceiptDocumentArtifact[];
 }
 
-interface PaymentArtifact {
-  id: string;
+interface PaymentArtifact extends ReceiptTeardownPayment {
   reference: string | null;
   proofFileId: string | null;
   status: PaymentStatus;
   receiptStatus: ReceiptStatus;
-  receiptDocumentId: string | null;
 }
 
-interface ReceiptDocumentArtifact {
-  paymentId: string;
-  documentId: string;
-  fileId: string;
-  bucket: string;
-  objectKey: string;
-  objectVersionId: string;
-}
+type ReceiptDocumentArtifact = ReceiptTeardownDocument;
 
 function arsAmount(buckets: Array<{ currency: string; amountMinor: number }> | undefined): number {
   return (buckets ?? []).find((b) => b.currency === 'ARS')?.amountMinor ?? 0;
@@ -381,7 +380,7 @@ async function waitForPaymentReceipt(
         throw new Error(`E2E payment ${paymentId} disappeared while waiting for receipt`);
       }
       if (payment.receiptStatus === ReceiptStatus.FAILED) {
-        throw new Error(`E2E payment ${paymentId} receipt generation failed`);
+        throw new ReceiptTeardownFailedError(paymentId);
       }
       if (payment.receiptStatus !== ReceiptStatus.READY || !payment.receiptDocumentId) {
         return false;
@@ -460,65 +459,68 @@ async function deleteReceiptDocumentViaApi(
   }
 }
 
-function retainReceiptDocument(fixture: E2EArtifactContext, receipt: ReceiptDocumentArtifact): void {
-  const existingReceipt = fixture.receiptDocuments.find((candidate) => candidate.paymentId === receipt.paymentId);
-  if (existingReceipt && existingReceipt.documentId !== receipt.documentId) {
-    throw new Error(`Payment ${receipt.paymentId} changed receipt ownership during E2E cleanup`);
-  }
-  if (!existingReceipt) {
-    fixture.receiptDocuments.push(receipt);
-  }
-}
-
 async function clearE2EArtifacts(page: Page, fixture: E2EArtifactContext): Promise<void> {
   const { tenantId, buildingId, unitId } = fixture;
   const payments = await getE2EPaymentArtifacts(tenantId, buildingId, unitId);
-  const receiptWaitResults = await Promise.allSettled(
-    payments
-      .filter((payment) => payment.status === PaymentStatus.APPROVED || payment.status === PaymentStatus.RECONCILED)
-      .map(async (payment) => {
-        if (!payment.reference) {
-          throw new Error(`E2E payment ${payment.id} has no reference`);
+  const paymentCleanup = await teardownPaymentReceipts(fixture, payments, {
+    waitForReceipt: async (payment) => {
+      if (!payment.reference) {
+        throw new Error(`E2E payment ${payment.id} has no reference`);
+      }
+      try {
+        return await waitForPaymentReceipt(tenantId, buildingId, unitId, payment.id, payment.reference);
+      } catch (error: unknown) {
+        if (error instanceof ReceiptTeardownFailedError) {
+          throw error;
         }
-        return waitForPaymentReceipt(tenantId, buildingId, unitId, payment.id, payment.reference);
-      }),
-  );
-  const receiptWaitFailure = receiptWaitResults.find((result) => result.status === 'rejected');
+        throw new ReceiptTeardownTimeoutError(payment.id, error);
+      }
+    },
+    unlinkReceiptDocument: async (receipt) => {
+      const result = await PRISMA.payment.updateMany({
+        where: {
+          id: receipt.paymentId,
+          tenantId,
+          buildingId,
+          unitId,
+          receiptDocumentId: receipt.documentId,
+        },
+        data: { receiptDocumentId: null },
+      });
+      if (result.count !== 1) {
+        throw new Error(`Receipt document ${receipt.documentId} is no longer owned by payment ${receipt.paymentId}`);
+      }
+    },
+    restoreReceiptDocument: async (receipt) => {
+      const result = await PRISMA.payment.updateMany({
+        where: { id: receipt.paymentId, tenantId, buildingId, unitId, receiptDocumentId: null },
+        data: { receiptDocumentId: receipt.documentId },
+      });
+      if (result.count !== 1) {
+        throw new Error(`Receipt document ${receipt.documentId} relation could not be restored for payment ${receipt.paymentId}`);
+      }
+    },
+    writeReceiptCleanupManifest,
+    deleteReceiptDocument: async (receipt) => deleteReceiptDocumentViaApi(page, tenantId, receipt),
+    deletePaymentAllocations: async (paymentIds) => {
+      await PRISMA.paymentAllocation.deleteMany({ where: { paymentId: { in: paymentIds } } });
+    },
+    deletePayments: async (paymentIds) => {
+      await PRISMA.payment.deleteMany({
+        where: { id: { in: paymentIds }, tenantId, buildingId, unitId },
+      });
+    },
+  });
 
-  for (const result of receiptWaitResults) {
-    if (result.status === 'fulfilled') {
-      retainReceiptDocument(fixture, result.value);
-    }
+  if (paymentCleanup.hasPreservedPayments) {
+    throwReceiptTeardownFailures(paymentCleanup.failures);
+    throw new Error('E2E payment cleanup preserved a payment without reporting a failure');
   }
 
-  const paymentIds = payments.map((payment) => payment.id);
   const proofFileIds = new Set([
     ...fixture.proofFileIds,
     ...payments.flatMap((payment) => (payment.proofFileId ? [payment.proofFileId] : [])),
   ]);
-
-  if (paymentIds.length > 0) {
-    await PRISMA.paymentAllocation.deleteMany({
-      where: { paymentId: { in: paymentIds } },
-    });
-    await PRISMA.payment.deleteMany({
-      where: { id: { in: paymentIds }, tenantId, buildingId, unitId },
-    });
-  }
-
-  let receiptDeletionFailure: unknown;
-  for (const receipt of [...fixture.receiptDocuments]) {
-    try {
-      await writeReceiptCleanupManifest(receipt);
-      await deleteReceiptDocumentViaApi(page, tenantId, receipt);
-      fixture.receiptDocuments = fixture.receiptDocuments.filter(
-        (candidate) => candidate.documentId !== receipt.documentId,
-      );
-    } catch (error: unknown) {
-      receiptDeletionFailure ??= error;
-    }
-  }
-
   const knownProofObjectKeys = E2E_PROOF_FILENAMES.map(
     (fileName) => `e2e/payments/${TEST_REFERENCE}/${buildingId}/${unitId}/${fileName}`,
   );
@@ -559,12 +561,7 @@ async function clearE2EArtifacts(page: Page, fixture: E2EArtifactContext): Promi
     });
   }
 
-  if (receiptWaitFailure?.status === 'rejected') {
-    throw receiptWaitFailure.reason;
-  }
-  if (receiptDeletionFailure) {
-    throw receiptDeletionFailure;
-  }
+  throwReceiptTeardownFailures(paymentCleanup.failures);
 }
 
 async function getUnitLedger(page: Page, tenantId: string, unitId: string): Promise<UnitLedgerResponse> {
@@ -955,5 +952,196 @@ test.describe('Resident finance oldest-first flow', () => {
       },
     });
     expect(foreignTenantLedgerResponse.status()).toBeGreaterThanOrEqual(400);
+
+      });
+
+      test.describe('receipt teardown safeguards', () => {
+        const clearE2EPaymentArtifacts = teardownPaymentReceipts;
+        const ReceiptCleanupFailedError = ReceiptTeardownFailedError;
+        const ReceiptCleanupTimeoutError = ReceiptTeardownTimeoutError;
+        const throwCleanupFailures = throwReceiptTeardownFailures;
+
+        function payment(overrides: Partial<PaymentArtifact> = {}): PaymentArtifact {
+          return {
+            id: 'payment-1',
+            reference: TEST_REFERENCE,
+            proofFileId: 'proof-1',
+            status: PaymentStatus.APPROVED,
+            receiptStatus: ReceiptStatus.READY,
+            receiptDocumentId: 'document-1',
+            ...overrides,
+          };
+        }
+
+        function receipt(overrides: Partial<ReceiptDocumentArtifact> = {}): ReceiptDocumentArtifact {
+          return {
+            paymentId: 'payment-1',
+            documentId: 'document-1',
+            fileId: 'file-1',
+            bucket: 'e2e-payments',
+            objectKey: 'e2e/payments/receipt-1.pdf',
+            objectVersionId: 'version-1',
+            ...overrides,
+          };
+        }
+
+        function fixture(receiptDocuments: ReceiptDocumentArtifact[] = []): E2EArtifactContext {
+          return {
+            tenantId: 'tenant-1',
+            buildingId: 'building-1',
+            unitId: 'unit-1',
+            chargeIds: [],
+            proofFileIds: [],
+            receiptDocuments,
+          };
+        }
+
+        test('cleans FAILED payments and reports the receipt failure only after cleanup', async () => {
+          const calls: string[] = [];
+          const failedPayment = payment({
+            id: 'payment-failed',
+            receiptStatus: ReceiptStatus.FAILED,
+            receiptDocumentId: null,
+          });
+          const result = await clearE2EPaymentArtifacts(fixture(), [failedPayment], {
+            waitForReceipt: async () => {
+              throw new Error('waitForReceipt must not run for FAILED receipts');
+            },
+            unlinkReceiptDocument: async () => { calls.push('unlink'); },
+            restoreReceiptDocument: async () => { calls.push('restore'); },
+            writeReceiptCleanupManifest: async () => { calls.push('manifest'); },
+            deleteReceiptDocument: async () => { calls.push('delete-document'); },
+            deletePaymentAllocations: async (paymentIds) => { calls.push(`allocations:${paymentIds.join(',')}`); },
+            deletePayments: async (paymentIds) => { calls.push(`payments:${paymentIds.join(',')}`); },
+          });
+
+          expect(calls).toEqual(['allocations:payment-failed', 'payments:payment-failed']);
+          expect(result.hasPreservedPayments).toBe(false);
+          expect(() => throwCleanupFailures(result.failures)).toThrow(ReceiptCleanupFailedError);
+        });
+
+        test('detaches a READY receipt, deletes its document, then deletes only its payment artifacts', async () => {
+          const calls: string[] = [];
+          const readyReceipt = receipt();
+          const unrelatedReceipt = receipt({ paymentId: 'payment-unrelated', documentId: 'document-unrelated' });
+          const result = await clearE2EPaymentArtifacts(fixture([readyReceipt, unrelatedReceipt]), [payment()], {
+            waitForReceipt: async () => readyReceipt,
+            unlinkReceiptDocument: async (candidate) => { calls.push(`unlink:${candidate.documentId}`); },
+            restoreReceiptDocument: async (candidate) => { calls.push(`restore:${candidate.documentId}`); },
+            writeReceiptCleanupManifest: async (candidate) => { calls.push(`manifest:${candidate.documentId}`); },
+            deleteReceiptDocument: async (candidate) => { calls.push(`delete-document:${candidate.documentId}`); },
+            deletePaymentAllocations: async (paymentIds) => { calls.push(`allocations:${paymentIds.join(',')}`); },
+            deletePayments: async (paymentIds) => { calls.push(`payments:${paymentIds.join(',')}`); },
+          });
+
+          expect(calls).toEqual([
+            'unlink:document-1',
+            'manifest:document-1',
+            'delete-document:document-1',
+            'allocations:payment-1',
+            'payments:payment-1',
+          ]);
+          expect(result.hasPreservedPayments).toBe(false);
+          expect(result.failures).toEqual([]);
+          expect(unrelatedReceipt).toEqual(receipt({ paymentId: 'payment-unrelated', documentId: 'document-unrelated' }));
+        });
+
+        test('restores the READY payment relation and allocation when receipt document deletion fails', async () => {
+          const calls: string[] = [];
+          const readyReceipt = receipt();
+          const deleteFailure = new Error('document delete failed');
+          const result = await clearE2EPaymentArtifacts(fixture([readyReceipt]), [payment()], {
+            waitForReceipt: async () => readyReceipt,
+            unlinkReceiptDocument: async () => { calls.push('unlink'); },
+            restoreReceiptDocument: async () => { calls.push('restore'); },
+            writeReceiptCleanupManifest: async () => { calls.push('manifest'); },
+            deleteReceiptDocument: async () => {
+              calls.push('delete-document');
+              throw deleteFailure;
+            },
+            deletePaymentAllocations: async () => { calls.push('allocations'); },
+            deletePayments: async () => { calls.push('payments'); },
+          });
+
+          expect(calls).toEqual(['unlink', 'manifest', 'delete-document', 'restore']);
+          expect(result.hasPreservedPayments).toBe(true);
+          expect(result.failures).toEqual([deleteFailure]);
+          expect(readyReceipt.paymentId).toBe('payment-1');
+        });
+
+        test('preserves the document deletion and relation restoration errors when restoration fails', async () => {
+          const documentDeleteFailure = new Error('document delete failed');
+          const restoreFailure = new Error('relation restore failed');
+          const result = await clearE2EPaymentArtifacts(fixture([receipt()]), [payment()], {
+            waitForReceipt: async () => receipt(),
+            unlinkReceiptDocument: async () => undefined,
+            restoreReceiptDocument: async () => {
+              throw restoreFailure;
+            },
+            writeReceiptCleanupManifest: async () => undefined,
+            deleteReceiptDocument: async () => {
+              throw documentDeleteFailure;
+            },
+            deletePaymentAllocations: async () => {
+              throw new Error('payment allocations must remain after document deletion failure');
+            },
+            deletePayments: async () => {
+              throw new Error('payment must remain after document deletion failure');
+            },
+          });
+
+          expect(result.hasPreservedPayments).toBe(true);
+          expect(result.failures).toHaveLength(1);
+          expect(result.failures[0]).toBeInstanceOf(AggregateError);
+          expect((result.failures[0] as AggregateError).errors).toEqual([documentDeleteFailure, restoreFailure]);
+        });
+
+        test('safely deletes a FAILED payment with no receipt document', async () => {
+          const calls: string[] = [];
+          const result = await clearE2EPaymentArtifacts(
+            fixture(),
+            [payment({ receiptStatus: ReceiptStatus.FAILED, receiptDocumentId: null })],
+            {
+              waitForReceipt: async () => {
+                throw new Error('waitForReceipt must not run for FAILED receipts');
+              },
+              unlinkReceiptDocument: async () => { calls.push('unlink'); },
+              restoreReceiptDocument: async () => { calls.push('restore'); },
+              writeReceiptCleanupManifest: async () => { calls.push('manifest'); },
+              deleteReceiptDocument: async () => { calls.push('delete-document'); },
+              deletePaymentAllocations: async () => { calls.push('allocations'); },
+              deletePayments: async () => { calls.push('payments'); },
+            },
+          );
+
+          expect(calls).toEqual(['allocations', 'payments']);
+          expect(result.hasPreservedPayments).toBe(false);
+          expect(result.failures[0]).toBeInstanceOf(ReceiptCleanupFailedError);
+        });
+
+        test('preserves a payment and its allocation when receipt readiness times out', async () => {
+              await test.step('keeps the payment allocation untouched', async () => {
+          const calls: string[] = [];
+          const pendingPayment = payment({
+            receiptStatus: ReceiptStatus.PENDING,
+            receiptDocumentId: null,
+          });
+          const result = await clearE2EPaymentArtifacts(fixture(), [pendingPayment], {
+            waitForReceipt: async (candidate) => {
+              throw new ReceiptCleanupTimeoutError(candidate.id);
+            },
+            unlinkReceiptDocument: async () => { calls.push('unlink'); },
+            restoreReceiptDocument: async () => { calls.push('restore'); },
+            writeReceiptCleanupManifest: async () => { calls.push('manifest'); },
+            deleteReceiptDocument: async () => { calls.push('delete-document'); },
+            deletePaymentAllocations: async () => { calls.push('allocations'); },
+            deletePayments: async () => { calls.push('payments'); },
+          });
+
+          expect(calls).toEqual([]);
+          expect(result.hasPreservedPayments).toBe(true);
+          expect(result.failures[0]).toBeInstanceOf(ReceiptCleanupTimeoutError);
+        });
+      });
   });
 });

--- a/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
@@ -53,6 +53,12 @@ interface FinancialSummaryResponse {
   delinquentUnitsCount: number;
 }
 
+interface E2EArtifactContext {
+  tenantId: string;
+  buildingId: string;
+  unitId: string;
+}
+
 function arsAmount(buckets: Array<{ currency: string; amountMinor: number }> | undefined): number {
   return (buckets ?? []).find((b) => b.currency === 'ARS')?.amountMinor ?? 0;
 }
@@ -367,6 +373,15 @@ async function fetchPaymentByReference(reference: string): Promise<{
 }
 
 test.describe('Resident finance oldest-first flow', () => {
+  let fixtureContext: E2EArtifactContext | undefined;
+
+  test.afterEach(async () => {
+    if (fixtureContext) {
+      await clearE2EArtifacts(fixtureContext.tenantId, fixtureContext.buildingId, fixtureContext.unitId);
+      fixtureContext = undefined;
+    }
+  });
+
   test.afterAll(async () => {
     await PRISMA.$disconnect();
   });
@@ -388,6 +403,7 @@ test.describe('Resident finance oldest-first flow', () => {
       throw new Error('Expected resident B to have an active building and unit');
     }
 
+    fixtureContext = { tenantId: residentTenantId, buildingId, unitId };
     await clearE2EArtifacts(residentTenantId, buildingId, unitId);
 
     const otherUnit = await PRISMA.unit.findFirst({

--- a/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
@@ -1,12 +1,22 @@
 import { expect, test, type Page } from '@playwright/test';
-import { PrismaClient, ChargeType, ChargeStatus, PaymentStatus } from '@prisma/client';
+import { PrismaClient, ChargeType, ChargeStatus, PaymentStatus, ReceiptStatus } from '@prisma/client';
 
 import { login, TEST_USERS } from '../helpers/auth';
 
 const API_ORIGIN = process.env.NEXT_PUBLIC_API_URL?.trim() || 'http://localhost:4000';
 const PRISMA = new PrismaClient();
 const TEST_REFERENCE = 'E2E-FIN-01';
+const AUGUST_PAYMENT_REFERENCE = `${TEST_REFERENCE}-AUG`;
+const PAYMENT_REFERENCES = [TEST_REFERENCE, AUGUST_PAYMENT_REFERENCE] as const;
 const FIAT_PERIODS = ['2026-06', '2026-07', '2026-08'] as const;
+const E2E_CHARGE_CONCEPTS = [
+  `${TEST_REFERENCE} - Expensas Junio 2026`,
+  `${TEST_REFERENCE} - Expensas Julio 2026`,
+  `${TEST_REFERENCE} - Expensas Agosto 2026`,
+  `${TEST_REFERENCE} - Expensas Unidad Vecina`,
+] as const;
+const E2E_PROOF_FILENAMES = ['proof.pdf', 'proof-august.pdf'] as const;
+const RECEIPT_POLL_TIMEOUT_MS = 30_000;
 
 /**
  * Deterministic relative dates: overdue semantics (dueDate < now) must not
@@ -57,6 +67,23 @@ interface E2EArtifactContext {
   tenantId: string;
   buildingId: string;
   unitId: string;
+  chargeIds: string[];
+  proofFileIds: string[];
+}
+
+interface PaymentArtifact {
+  id: string;
+  reference: string | null;
+  proofFileId: string | null;
+  status: PaymentStatus;
+  receiptStatus: ReceiptStatus;
+  receiptDocumentId: string | null;
+}
+
+interface ReceiptDocumentArtifact {
+  paymentId: string;
+  documentId: string;
+  fileId: string;
 }
 
 function arsAmount(buckets: Array<{ currency: string; amountMinor: number }> | undefined): number {
@@ -220,77 +247,205 @@ async function rejectPaymentViaApi(
   }
 }
 
-async function clearE2EArtifacts(tenantId: string, buildingId: string, unitId: string): Promise<void> {
-  const payments = await PRISMA.payment.findMany({
-    where: {
-      tenantId,
-      reference: { startsWith: TEST_REFERENCE },
-    },
-    select: { id: true },
-  });
-
-  if (payments.length > 0) {
-    const paymentIds = payments.map((payment) => payment.id);
-    await PRISMA.paymentAllocation.deleteMany({
-      where: { paymentId: { in: paymentIds } },
-    });
-    await PRISMA.payment.deleteMany({
-      where: { id: { in: paymentIds } },
-    });
-  }
-
-  const charges = await PRISMA.charge.findMany({
+async function getE2EPaymentArtifacts(
+  tenantId: string,
+  buildingId: string,
+  unitId: string,
+): Promise<PaymentArtifact[]> {
+  return PRISMA.payment.findMany({
     where: {
       tenantId,
       buildingId,
       unitId,
-      period: { in: [...FIAT_PERIODS] },
+      reference: { in: [...PAYMENT_REFERENCES] },
+    },
+    select: {
+      id: true,
+      reference: true,
+      proofFileId: true,
+      status: true,
+      receiptStatus: true,
+      receiptDocumentId: true,
+    },
+  });
+}
+
+async function captureReceiptDocument(
+  tenantId: string,
+  payment: PaymentArtifact,
+): Promise<ReceiptDocumentArtifact> {
+  if (payment.receiptStatus !== ReceiptStatus.READY || !payment.receiptDocumentId) {
+    throw new Error(`Payment ${payment.id} has no ready receipt document`);
+  }
+
+  const document = await PRISMA.document.findFirst({
+    where: {
+      id: payment.receiptDocumentId,
+      tenantId,
+    },
+    select: {
+      id: true,
+      file: { select: { id: true } },
+    },
+  });
+
+  if (!document) {
+    throw new Error(`Receipt document ${payment.receiptDocumentId} for payment ${payment.id} was not found`);
+  }
+
+  return {
+    paymentId: payment.id,
+    documentId: document.id,
+    fileId: document.file.id,
+  };
+}
+
+async function waitForPaymentReceipt(
+  tenantId: string,
+  buildingId: string,
+  unitId: string,
+  paymentId: string,
+  reference: string,
+): Promise<ReceiptDocumentArtifact> {
+  let receipt: ReceiptDocumentArtifact | undefined;
+
+  await expect.poll(
+    async () => {
+      const payment = await PRISMA.payment.findFirst({
+        where: {
+          id: paymentId,
+          tenantId,
+          buildingId,
+          unitId,
+          reference,
+        },
+        select: {
+          id: true,
+          reference: true,
+          proofFileId: true,
+          status: true,
+          receiptStatus: true,
+          receiptDocumentId: true,
+        },
+      });
+
+      if (!payment) {
+        throw new Error(`E2E payment ${paymentId} disappeared while waiting for receipt`);
+      }
+      if (payment.receiptStatus === ReceiptStatus.FAILED) {
+        throw new Error(`E2E payment ${paymentId} receipt generation failed`);
+      }
+      if (payment.receiptStatus !== ReceiptStatus.READY || !payment.receiptDocumentId) {
+        return false;
+      }
+
+      receipt = await captureReceiptDocument(tenantId, payment);
+      return true;
+    },
+    { timeout: RECEIPT_POLL_TIMEOUT_MS, intervals: [250, 500, 1_000] },
+  ).toBe(true);
+
+  if (!receipt) {
+    throw new Error(`Receipt for payment ${paymentId} was not captured`);
+  }
+
+  return receipt;
+}
+
+async function deleteReceiptDocumentViaApi(
+  page: Page,
+  tenantId: string,
+  receipt: ReceiptDocumentArtifact,
+): Promise<void> {
+  const response = await page.request.delete(
+    `${API_ORIGIN}/tenants/${tenantId}/documents/${receipt.documentId}`,
+    {
+      headers: {
+        'X-Tenant-Id': tenantId,
+        'x-portal-context': 'admin',
+        Accept: 'application/json',
+      },
+    },
+  );
+
+  if (!response.ok()) {
+    throw new Error(
+      `Failed to delete receipt document ${receipt.documentId} for payment ${receipt.paymentId} ` +
+        `(${response.status()} ${response.statusText()}): ${await response.text()}`,
+    );
+  }
+}
+
+async function clearE2EArtifacts(page: Page, fixture: E2EArtifactContext): Promise<void> {
+  const { tenantId, buildingId, unitId } = fixture;
+  const payments = await getE2EPaymentArtifacts(tenantId, buildingId, unitId);
+  const receipts = await Promise.all(
+    payments
+      .filter((payment) => payment.status === PaymentStatus.APPROVED || payment.status === PaymentStatus.RECONCILED)
+      .map((payment) => {
+        if (!payment.reference) {
+          throw new Error(`E2E payment ${payment.id} has no reference`);
+        }
+        return waitForPaymentReceipt(tenantId, buildingId, unitId, payment.id, payment.reference);
+      }),
+  );
+
+  const paymentIds = payments.map((payment) => payment.id);
+  const proofFileIds = new Set([
+    ...fixture.proofFileIds,
+    ...payments.flatMap((payment) => (payment.proofFileId ? [payment.proofFileId] : [])),
+  ]);
+
+  if (paymentIds.length > 0) {
+    await PRISMA.paymentAllocation.deleteMany({
+      where: { paymentId: { in: paymentIds } },
+    });
+    await PRISMA.payment.deleteMany({
+      where: { id: { in: paymentIds }, tenantId, buildingId, unitId },
+    });
+  }
+
+  for (const receipt of receipts) {
+    await deleteReceiptDocumentViaApi(page, tenantId, receipt);
+  }
+
+  const knownProofObjectKeys = E2E_PROOF_FILENAMES.map(
+    (fileName) => `e2e/payments/${TEST_REFERENCE}/${buildingId}/${unitId}/${fileName}`,
+  );
+  const residualProofFiles = await PRISMA.file.findMany({
+    where: {
+      tenantId,
+      objectKey: { in: knownProofObjectKeys },
     },
     select: { id: true },
   });
 
-  if (charges.length > 0) {
-    const chargeIds = charges.map((charge) => charge.id);
-    await PRISMA.paymentAllocation.deleteMany({
-      where: { chargeId: { in: chargeIds } },
-    });
-    await PRISMA.charge.deleteMany({
-      where: { id: { in: chargeIds } },
+  for (const file of residualProofFiles) {
+    proofFileIds.add(file.id);
+  }
+
+  if (proofFileIds.size > 0) {
+    await PRISMA.file.deleteMany({
+      where: { id: { in: [...proofFileIds] }, tenantId },
     });
   }
 
-  const taggedCharges = await PRISMA.charge.findMany({
+  const residualCharges = await PRISMA.charge.findMany({
     where: {
       tenantId,
       buildingId,
-      concept: { startsWith: TEST_REFERENCE },
+      concept: { in: [...E2E_CHARGE_CONCEPTS] },
     },
     select: { id: true },
   });
+  const chargeIds = new Set([...fixture.chargeIds, ...residualCharges.map((charge) => charge.id)]);
 
-  if (taggedCharges.length > 0) {
-    const taggedChargeIds = taggedCharges.map((charge) => charge.id);
+  if (chargeIds.size > 0) {
     await PRISMA.paymentAllocation.deleteMany({
-      where: { chargeId: { in: taggedChargeIds } },
+      where: { chargeId: { in: [...chargeIds] } },
     });
     await PRISMA.charge.deleteMany({
-      where: { id: { in: taggedChargeIds } },
-    });
-  }
-
-  const taggedFiles = await PRISMA.file.findMany({
-    where: {
-      tenantId,
-      objectKey: { startsWith: `e2e/payments/${TEST_REFERENCE}` },
-    },
-    select: { id: true },
-  });
-
-  if (taggedFiles.length > 0) {
-    await PRISMA.file.deleteMany({
-      where: {
-        id: { in: taggedFiles.map((file) => file.id) },
-      },
+      where: { id: { in: [...chargeIds] }, tenantId, buildingId },
     });
   }
 }
@@ -337,7 +492,12 @@ async function getTenantDelinquencyCount(page: Page, tenantId: string, buildingI
   return payload.total;
 }
 
-async function fetchPaymentByReference(reference: string): Promise<{
+async function fetchPaymentByReference(
+  tenantId: string,
+  buildingId: string,
+  unitId: string,
+  reference: string,
+): Promise<{
   id: string;
   status: PaymentStatus;
   amount: number;
@@ -348,7 +508,7 @@ async function fetchPaymentByReference(reference: string): Promise<{
   }>;
 }> {
   const payment = await PRISMA.payment.findFirst({
-    where: { reference },
+    where: { tenantId, buildingId, unitId, reference },
     include: {
       paymentAllocations: {
         include: {
@@ -375,9 +535,17 @@ async function fetchPaymentByReference(reference: string): Promise<{
 test.describe('Resident finance oldest-first flow', () => {
   let fixtureContext: E2EArtifactContext | undefined;
 
-  test.afterEach(async () => {
-    if (fixtureContext) {
-      await clearE2EArtifacts(fixtureContext.tenantId, fixtureContext.buildingId, fixtureContext.unitId);
+  test.afterEach(async ({ page }) => {
+    const fixture = fixtureContext;
+    if (!fixture) {
+      return;
+    }
+
+    try {
+      const cleanupTenantId = await login(page, TEST_USERS.tenantAdminB);
+      expect(cleanupTenantId).toBe(fixture.tenantId);
+      await clearE2EArtifacts(page, fixture);
+    } finally {
       fixtureContext = undefined;
     }
   });
@@ -403,8 +571,13 @@ test.describe('Resident finance oldest-first flow', () => {
       throw new Error('Expected resident B to have an active building and unit');
     }
 
-    fixtureContext = { tenantId: residentTenantId, buildingId, unitId };
-    await clearE2EArtifacts(residentTenantId, buildingId, unitId);
+    fixtureContext = {
+      tenantId: residentTenantId,
+      buildingId,
+      unitId,
+      chargeIds: [],
+      proofFileIds: [],
+    };
 
     const otherUnit = await PRISMA.unit.findFirst({
       where: {
@@ -440,24 +613,56 @@ test.describe('Resident finance oldest-first flow', () => {
     const adminTenantId = await login(adminPage, TEST_USERS.tenantAdminB);
     expect(adminTenantId).toBe(residentTenantId);
 
-    const createdCharges = await Promise.all([
-      createCharge(adminPage, residentTenantId, buildingId, unitId, '2026-06', pastDate(90), 'Expensas Junio 2026', 10000),
-      createCharge(adminPage, residentTenantId, buildingId, unitId, '2026-07', pastDate(60), 'Expensas Julio 2026', 10000),
-      createCharge(adminPage, residentTenantId, buildingId, unitId, '2026-08', futureDate(30), 'Expensas Agosto 2026', 10000),
-    ]);
+    await clearE2EArtifacts(adminPage, fixtureContext);
+
+    const juneCharge = await createCharge(
+      adminPage,
+      residentTenantId,
+      buildingId,
+      unitId,
+      FIAT_PERIODS[0],
+      pastDate(90),
+      E2E_CHARGE_CONCEPTS[0],
+      10000,
+    );
+    fixtureContext.chargeIds.push(juneCharge.id);
+    const julyCharge = await createCharge(
+      adminPage,
+      residentTenantId,
+      buildingId,
+      unitId,
+      FIAT_PERIODS[1],
+      pastDate(60),
+      E2E_CHARGE_CONCEPTS[1],
+      10000,
+    );
+    fixtureContext.chargeIds.push(julyCharge.id);
+    const augustCharge = await createCharge(
+      adminPage,
+      residentTenantId,
+      buildingId,
+      unitId,
+      FIAT_PERIODS[2],
+      futureDate(30),
+      E2E_CHARGE_CONCEPTS[2],
+      10000,
+    );
+    fixtureContext.chargeIds.push(augustCharge.id);
+    const createdCharges = [juneCharge, julyCharge, augustCharge];
 
     expect(createdCharges.map((charge) => charge.period)).toEqual(['2026-06', '2026-07', '2026-08']);
 
-    await createCharge(
+    const otherUnitCharge = await createCharge(
       adminPage,
       residentTenantId,
       buildingId,
       otherUnit.id,
       '2026-09',
       futureDate(60),
-      `${TEST_REFERENCE} - Expensas Unidad Vecina`,
+      E2E_CHARGE_CONCEPTS[3],
       5000,
     );
+    fixtureContext.chargeIds.push(otherUnitCharge.id);
 
     await page.goto(`/${residentTenantId}/resident/payments`);
     await expect(page).toHaveURL(new RegExp(`/${residentTenantId}/resident/payments$`));
@@ -476,10 +681,11 @@ test.describe('Resident finance oldest-first flow', () => {
       residentTenantId,
       buildingId,
       unitId,
-      'proof.pdf',
+      E2E_PROOF_FILENAMES[0],
       'application/pdf',
       Buffer.from([1, 2, 3, 4]),
     );
+    fixtureContext.proofFileIds.push(firstPaymentProofFileId);
     await submitPaymentViaApi(
       page,
       residentTenantId,
@@ -491,7 +697,7 @@ test.describe('Resident finance oldest-first flow', () => {
       firstPaymentProofFileId,
     );
 
-    const submittedPayment = await fetchPaymentByReference(TEST_REFERENCE);
+    const submittedPayment = await fetchPaymentByReference(residentTenantId, buildingId, unitId, TEST_REFERENCE);
     expect(submittedPayment.status).toBe(PaymentStatus.SUBMITTED);
     expect(submittedPayment.amount).toBe(20000);
     expect(submittedPayment.paymentAllocations).toHaveLength(2);
@@ -516,8 +722,18 @@ test.describe('Resident finance oldest-first flow', () => {
     await expect(adminPage.getByText('Comprobante sin procesar')).toBeVisible();
     await approvePaymentViaApi(adminPage, residentTenantId, buildingId, submittedPayment.id);
 
-    const approvedPayment = await fetchPaymentByReference(TEST_REFERENCE);
+    const approvedPayment = await fetchPaymentByReference(residentTenantId, buildingId, unitId, TEST_REFERENCE);
     expect(approvedPayment.status).toMatch(/APPROVED|RECONCILED/);
+    const approvedPaymentReceipt = await waitForPaymentReceipt(
+      residentTenantId,
+      buildingId,
+      unitId,
+      approvedPayment.id,
+      TEST_REFERENCE,
+    );
+    expect(approvedPaymentReceipt.paymentId).toBe(approvedPayment.id);
+    expect(approvedPaymentReceipt.documentId).toBeTruthy();
+    expect(approvedPaymentReceipt.fileId).toBeTruthy();
     expect(approvedPayment.paymentAllocations).toHaveLength(2);
     expect(approvedPayment.paymentAllocations.map((allocation) => allocation.charge.period)).toEqual([
       '2026-06',
@@ -539,10 +755,11 @@ test.describe('Resident finance oldest-first flow', () => {
       residentTenantId,
       buildingId,
       unitId,
-      'proof-august.pdf',
+      E2E_PROOF_FILENAMES[1],
       'application/pdf',
       Buffer.from([9, 8, 7, 6]),
     );
+    fixtureContext.proofFileIds.push(augustPaymentProofFileId);
     await submitPaymentViaApi(
       page,
       residentTenantId,
@@ -550,11 +767,16 @@ test.describe('Resident finance oldest-first flow', () => {
       unitId,
       [createdCharges[2].id],
       10000,
-      `${TEST_REFERENCE}-AUG`,
+      AUGUST_PAYMENT_REFERENCE,
       augustPaymentProofFileId,
     );
 
-    const augustPayment = await fetchPaymentByReference(`${TEST_REFERENCE}-AUG`);
+    const augustPayment = await fetchPaymentByReference(
+      residentTenantId,
+      buildingId,
+      unitId,
+      AUGUST_PAYMENT_REFERENCE,
+    );
     expect(augustPayment.status).toBe(PaymentStatus.SUBMITTED);
     expect(augustPayment.paymentAllocations).toHaveLength(1);
     expect(augustPayment.paymentAllocations[0]?.charge.period).toBe('2026-08');
@@ -562,7 +784,12 @@ test.describe('Resident finance oldest-first flow', () => {
     await adminPage.goto(`/${residentTenantId}/finanzas?tab=payments`);
     await rejectPaymentViaApi(adminPage, residentTenantId, buildingId, augustPayment.id, 'MONTO_INCORRECTO');
 
-    const rejectedAugustPayment = await fetchPaymentByReference(`${TEST_REFERENCE}-AUG`);
+    const rejectedAugustPayment = await fetchPaymentByReference(
+      residentTenantId,
+      buildingId,
+      unitId,
+      AUGUST_PAYMENT_REFERENCE,
+    );
     expect(rejectedAugustPayment.status).toBe(PaymentStatus.REJECTED);
     expect(rejectedAugustPayment.paymentAllocations).toHaveLength(0);
 

--- a/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
+++ b/apps/web/tests/e2e/resident/resident-finance-oldest-first.spec.ts
@@ -1,5 +1,9 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, rename, writeFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
 import { expect, test, type Page } from '@playwright/test';
-import { PrismaClient, ChargeType, ChargeStatus, PaymentStatus, ReceiptStatus } from '@prisma/client';
+import { PrismaClient, Prisma, ChargeType, ChargeStatus, PaymentStatus, ReceiptStatus } from '@prisma/client';
 
 import { login, TEST_USERS } from '../helpers/auth';
 
@@ -17,6 +21,10 @@ const E2E_CHARGE_CONCEPTS = [
 ] as const;
 const E2E_PROOF_FILENAMES = ['proof.pdf', 'proof-august.pdf'] as const;
 const RECEIPT_POLL_TIMEOUT_MS = 30_000;
+const RECEIPT_CLEANUP_MANIFEST_DIRECTORY = resolve(
+  __dirname,
+  '../../../test-results/receipt-cleanup-verification',
+);
 
 /**
  * Deterministic relative dates: overdue semantics (dueDate < now) must not
@@ -69,6 +77,7 @@ interface E2EArtifactContext {
   unitId: string;
   chargeIds: string[];
   proofFileIds: string[];
+  receiptDocuments: ReceiptDocumentArtifact[];
 }
 
 interface PaymentArtifact {
@@ -84,6 +93,9 @@ interface ReceiptDocumentArtifact {
   paymentId: string;
   documentId: string;
   fileId: string;
+  bucket: string;
+  objectKey: string;
+  objectVersionId: string;
 }
 
 function arsAmount(buckets: Array<{ currency: string; amountMinor: number }> | undefined): number {
@@ -285,7 +297,13 @@ async function captureReceiptDocument(
     },
     select: {
       id: true,
-      file: { select: { id: true } },
+      file: {
+        select: {
+          id: true,
+          bucket: true,
+          objectKey: true,
+        },
+      },
     },
   });
 
@@ -293,11 +311,41 @@ async function captureReceiptDocument(
     throw new Error(`Receipt document ${payment.receiptDocumentId} for payment ${payment.id} was not found`);
   }
 
+  const [storageIdentity] = await PRISMA.$queryRaw<Array<{ objectVersionId: string | null }>>(
+    Prisma.sql`SELECT "objectVersionId" FROM "File" WHERE "id" = ${document.file.id}`,
+  );
+  const objectVersionId = storageIdentity?.objectVersionId?.trim();
+  if (!objectVersionId) {
+    throw new Error(`Receipt document ${document.id} for payment ${payment.id} has no exact storage version`);
+  }
+
   return {
     paymentId: payment.id,
     documentId: document.id,
     fileId: document.file.id,
+    bucket: document.file.bucket,
+    objectKey: document.file.objectKey,
+    objectVersionId,
   };
+}
+
+async function writeReceiptCleanupManifest(receipt: ReceiptDocumentArtifact): Promise<void> {
+  if (!/^[A-Za-z0-9_-]+$/.test(receipt.documentId)) {
+    throw new Error(`Receipt document ID ${receipt.documentId} is unsafe for a cleanup manifest path`);
+  }
+
+  await mkdir(RECEIPT_CLEANUP_MANIFEST_DIRECTORY, { recursive: true });
+
+  const manifestPath = join(RECEIPT_CLEANUP_MANIFEST_DIRECTORY, `${receipt.documentId}.json`);
+  const temporaryManifestPath = `${manifestPath}.${randomUUID()}.tmp`;
+  const manifest = JSON.stringify({
+    bucket: receipt.bucket,
+    objectKey: receipt.objectKey,
+    objectVersionId: receipt.objectVersionId,
+  });
+
+  await writeFile(temporaryManifestPath, manifest, 'utf8');
+  await rename(temporaryManifestPath, manifestPath);
 }
 
 async function waitForPaymentReceipt(
@@ -352,6 +400,42 @@ async function waitForPaymentReceipt(
   return receipt;
 }
 
+async function verifyReceiptStorageVersion(
+  page: Page,
+  tenantId: string,
+  receipt: ReceiptDocumentArtifact,
+): Promise<void> {
+  const response = await page.request.get(
+    `${API_ORIGIN}/tenants/${tenantId}/documents/${receipt.documentId}/download`,
+    {
+      headers: {
+        'X-Tenant-Id': tenantId,
+        'x-portal-context': 'admin',
+        Accept: 'application/json',
+      },
+    },
+  );
+
+  if (!response.ok()) {
+    throw new Error(
+      `Failed to create a download URL for receipt document ${receipt.documentId} ` +
+        `(${response.status()} ${response.statusText()}): ${await response.text()}`,
+    );
+  }
+
+  const payload = (await response.json()) as { url?: unknown };
+  if (typeof payload.url !== 'string') {
+    throw new Error(`Receipt document ${receipt.documentId} download URL was missing`);
+  }
+
+  const storageUrl = new URL(payload.url);
+  expect(storageUrl.searchParams.get('versionId')).toBe(receipt.objectVersionId);
+
+  const storageResponse = await page.request.get(storageUrl.toString());
+  expect(storageResponse.ok()).toBe(true);
+  expect(storageResponse.headers()['x-amz-version-id']).toBe(receipt.objectVersionId);
+}
+
 async function deleteReceiptDocumentViaApi(
   page: Page,
   tenantId: string,
@@ -376,19 +460,36 @@ async function deleteReceiptDocumentViaApi(
   }
 }
 
+function retainReceiptDocument(fixture: E2EArtifactContext, receipt: ReceiptDocumentArtifact): void {
+  const existingReceipt = fixture.receiptDocuments.find((candidate) => candidate.paymentId === receipt.paymentId);
+  if (existingReceipt && existingReceipt.documentId !== receipt.documentId) {
+    throw new Error(`Payment ${receipt.paymentId} changed receipt ownership during E2E cleanup`);
+  }
+  if (!existingReceipt) {
+    fixture.receiptDocuments.push(receipt);
+  }
+}
+
 async function clearE2EArtifacts(page: Page, fixture: E2EArtifactContext): Promise<void> {
   const { tenantId, buildingId, unitId } = fixture;
   const payments = await getE2EPaymentArtifacts(tenantId, buildingId, unitId);
-  const receipts = await Promise.all(
+  const receiptWaitResults = await Promise.allSettled(
     payments
       .filter((payment) => payment.status === PaymentStatus.APPROVED || payment.status === PaymentStatus.RECONCILED)
-      .map((payment) => {
+      .map(async (payment) => {
         if (!payment.reference) {
           throw new Error(`E2E payment ${payment.id} has no reference`);
         }
         return waitForPaymentReceipt(tenantId, buildingId, unitId, payment.id, payment.reference);
       }),
   );
+  const receiptWaitFailure = receiptWaitResults.find((result) => result.status === 'rejected');
+
+  for (const result of receiptWaitResults) {
+    if (result.status === 'fulfilled') {
+      retainReceiptDocument(fixture, result.value);
+    }
+  }
 
   const paymentIds = payments.map((payment) => payment.id);
   const proofFileIds = new Set([
@@ -405,8 +506,17 @@ async function clearE2EArtifacts(page: Page, fixture: E2EArtifactContext): Promi
     });
   }
 
-  for (const receipt of receipts) {
-    await deleteReceiptDocumentViaApi(page, tenantId, receipt);
+  let receiptDeletionFailure: unknown;
+  for (const receipt of [...fixture.receiptDocuments]) {
+    try {
+      await writeReceiptCleanupManifest(receipt);
+      await deleteReceiptDocumentViaApi(page, tenantId, receipt);
+      fixture.receiptDocuments = fixture.receiptDocuments.filter(
+        (candidate) => candidate.documentId !== receipt.documentId,
+      );
+    } catch (error: unknown) {
+      receiptDeletionFailure ??= error;
+    }
   }
 
   const knownProofObjectKeys = E2E_PROOF_FILENAMES.map(
@@ -447,6 +557,13 @@ async function clearE2EArtifacts(page: Page, fixture: E2EArtifactContext): Promi
     await PRISMA.charge.deleteMany({
       where: { id: { in: [...chargeIds] }, tenantId, buildingId },
     });
+  }
+
+  if (receiptWaitFailure?.status === 'rejected') {
+    throw receiptWaitFailure.reason;
+  }
+  if (receiptDeletionFailure) {
+    throw receiptDeletionFailure;
   }
 }
 
@@ -544,7 +661,21 @@ test.describe('Resident finance oldest-first flow', () => {
     try {
       const cleanupTenantId = await login(page, TEST_USERS.tenantAdminB);
       expect(cleanupTenantId).toBe(fixture.tenantId);
-      await clearE2EArtifacts(page, fixture);
+      try {
+        await clearE2EArtifacts(page, fixture);
+      } catch (cleanupFailure: unknown) {
+        if (fixture.receiptDocuments.length > 0) {
+          try {
+            await clearE2EArtifacts(page, fixture);
+          } catch (retryFailure: unknown) {
+            throw new AggregateError(
+              [cleanupFailure, retryFailure],
+              'E2E artifact cleanup and exact receipt document cleanup retry both failed',
+            );
+          }
+        }
+        throw cleanupFailure;
+      }
     } finally {
       fixtureContext = undefined;
     }
@@ -577,6 +708,7 @@ test.describe('Resident finance oldest-first flow', () => {
       unitId,
       chargeIds: [],
       proofFileIds: [],
+      receiptDocuments: [],
     };
 
     const otherUnit = await PRISMA.unit.findFirst({
@@ -734,6 +866,8 @@ test.describe('Resident finance oldest-first flow', () => {
     expect(approvedPaymentReceipt.paymentId).toBe(approvedPayment.id);
     expect(approvedPaymentReceipt.documentId).toBeTruthy();
     expect(approvedPaymentReceipt.fileId).toBeTruthy();
+    expect(approvedPaymentReceipt.objectVersionId).toBeTruthy();
+    await verifyReceiptStorageVersion(page, residentTenantId, approvedPaymentReceipt);
     expect(approvedPayment.paymentAllocations).toHaveLength(2);
     expect(approvedPayment.paymentAllocations.map((allocation) => allocation.charge.period)).toEqual([
       '2026-06',

--- a/apps/web/tests/receipt-teardown.spec.ts
+++ b/apps/web/tests/receipt-teardown.spec.ts
@@ -1,0 +1,224 @@
+import {
+  ReceiptTeardownFailedError,
+  ReceiptTeardownTimeoutError,
+  teardownPaymentReceipts,
+  throwReceiptTeardownFailures,
+  type ReceiptTeardownDocument,
+  type ReceiptTeardownFixture,
+  type ReceiptTeardownOperations,
+  type ReceiptTeardownPayment,
+} from './e2e/resident/receipt-teardown';
+
+function payment(overrides: Partial<ReceiptTeardownPayment> = {}): ReceiptTeardownPayment {
+  return {
+    id: 'payment-1',
+    status: 'APPROVED',
+    receiptStatus: 'READY',
+    receiptDocumentId: 'document-1',
+    ...overrides,
+  };
+}
+
+function receipt(overrides: Partial<ReceiptTeardownDocument> = {}): ReceiptTeardownDocument {
+  return {
+    paymentId: 'payment-1',
+    documentId: 'document-1',
+    fileId: 'file-1',
+    bucket: 'e2e-payments',
+    objectKey: 'e2e/payments/receipt-1.pdf',
+    objectVersionId: 'version-1',
+    ...overrides,
+  };
+}
+
+function fixture(receiptDocuments: ReceiptTeardownDocument[] = []): ReceiptTeardownFixture {
+  return { receiptDocuments };
+}
+
+function operations(calls: string[], overrides: Partial<ReceiptTeardownOperations> = {}): ReceiptTeardownOperations {
+  return {
+    waitForReceipt: async () => receipt(),
+    unlinkReceiptDocument: async (candidate) => { calls.push(`unlink:${candidate.documentId}`); },
+    restoreReceiptDocument: async (candidate) => { calls.push(`restore:${candidate.documentId}`); },
+    writeReceiptCleanupManifest: async (candidate) => { calls.push(`manifest:${candidate.documentId}`); },
+    deleteReceiptDocument: async (candidate) => { calls.push(`delete-document:${candidate.documentId}`); },
+    deletePaymentAllocations: async (paymentIds) => { calls.push(`allocations:${paymentIds.join(',')}`); },
+    deletePayments: async (paymentIds) => { calls.push(`payments:${paymentIds.join(',')}`); },
+    ...overrides,
+  };
+}
+
+describe('receipt teardown helper', () => {
+  it('reports a FAILED receipt only after deleting its payment artifacts', async () => {
+    const calls: string[] = [];
+    const result = await teardownPaymentReceipts(
+      fixture(),
+      [payment({ id: 'payment-failed', receiptStatus: 'FAILED', receiptDocumentId: null })],
+      operations(calls, {
+        waitForReceipt: async () => { throw new Error('waitForReceipt must not run for FAILED receipts'); },
+      }),
+    );
+
+    expect(calls).toEqual(['allocations:payment-failed', 'payments:payment-failed']);
+    expect(result.hasPreservedPayments).toBe(false);
+    expect(() => throwReceiptTeardownFailures(result.failures)).toThrow(ReceiptTeardownFailedError);
+  });
+
+  it('detaches, manifests, and deletes a READY receipt before its payment artifacts', async () => {
+    const calls: string[] = [];
+    const readyReceipt = receipt();
+    const result = await teardownPaymentReceipts(
+      fixture([readyReceipt]),
+      [payment()],
+      operations(calls, { waitForReceipt: async () => readyReceipt }),
+    );
+
+    expect(calls).toEqual([
+      'unlink:document-1',
+      'manifest:document-1',
+      'delete-document:document-1',
+      'allocations:payment-1',
+      'payments:payment-1',
+    ]);
+    expect(result).toEqual({ hasPreservedPayments: false, failures: [] });
+  });
+
+  it('preserves the payment when receipt detachment fails', async () => {
+    const calls: string[] = [];
+    const detachFailure = new Error('relation update failed');
+    const result = await teardownPaymentReceipts(
+      fixture([receipt()]),
+      [payment()],
+      operations(calls, {
+        unlinkReceiptDocument: async () => {
+          calls.push('unlink');
+          throw detachFailure;
+        },
+      }),
+    );
+
+    expect(calls).toEqual(['unlink']);
+    expect(result.hasPreservedPayments).toBe(true);
+    expect(result.failures).toEqual([detachFailure]);
+  });
+
+  it('restores the receipt relation and preserves the payment when document deletion fails', async () => {
+    const calls: string[] = [];
+    const deleteFailure = new Error('document delete failed');
+    const result = await teardownPaymentReceipts(
+      fixture([receipt()]),
+      [payment()],
+      operations(calls, {
+        deleteReceiptDocument: async () => {
+          calls.push('delete-document');
+          throw deleteFailure;
+        },
+      }),
+    );
+
+    expect(calls).toEqual(['unlink:document-1', 'manifest:document-1', 'delete-document', 'restore:document-1']);
+    expect(result.hasPreservedPayments).toBe(true);
+    expect(result.failures).toEqual([deleteFailure]);
+  });
+
+  it('preserves both deletion and restoration failures', async () => {
+    const documentDeleteFailure = new Error('document delete failed');
+    const restoreFailure = new Error('relation restore failed');
+    const result = await teardownPaymentReceipts(
+      fixture([receipt()]),
+      [payment()],
+      operations([], {
+        deleteReceiptDocument: async () => { throw documentDeleteFailure; },
+        restoreReceiptDocument: async () => { throw restoreFailure; },
+      }),
+    );
+
+    expect(result.hasPreservedPayments).toBe(true);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]).toBeInstanceOf(AggregateError);
+    expect((result.failures[0] as AggregateError).errors).toEqual([documentDeleteFailure, restoreFailure]);
+  });
+
+  it('preserves payment artifacts when receipt readiness times out', async () => {
+    const calls: string[] = [];
+    const pendingPayment = payment({ receiptStatus: 'PENDING', receiptDocumentId: null });
+    const result = await teardownPaymentReceipts(
+      fixture(),
+      [pendingPayment],
+      operations(calls, {
+        waitForReceipt: async (candidate) => { throw new ReceiptTeardownTimeoutError(candidate.id); },
+      }),
+    );
+
+    expect(calls).toEqual([]);
+    expect(result.hasPreservedPayments).toBe(true);
+    expect(result.failures[0]).toBeInstanceOf(ReceiptTeardownTimeoutError);
+  });
+
+  it('is idempotent after a successful document teardown', async () => {
+    const calls: string[] = [];
+    const teardownFixture = fixture([receipt()]);
+    const cleanup = operations(calls);
+
+    await teardownPaymentReceipts(teardownFixture, [payment()], cleanup);
+    await teardownPaymentReceipts(teardownFixture, [], cleanup);
+
+    expect(teardownFixture.receiptDocuments).toEqual([]);
+    expect(calls).toEqual([
+      'unlink:document-1',
+      'manifest:document-1',
+      'delete-document:document-1',
+      'allocations:payment-1',
+      'payments:payment-1',
+    ]);
+  });
+
+  it('retries a failed receipt deletion with the retained fixture document', async () => {
+    const calls: string[] = [];
+    const teardownFixture = fixture([receipt()]);
+    let attempt = 0;
+    const cleanup = operations(calls, {
+      deleteReceiptDocument: async (candidate) => {
+        calls.push(`delete-document:${candidate.documentId}`);
+        attempt += 1;
+        if (attempt === 1) {
+          throw new Error('transient storage error');
+        }
+      },
+    });
+
+    const firstResult = await teardownPaymentReceipts(teardownFixture, [payment()], cleanup);
+    const retryResult = await teardownPaymentReceipts(teardownFixture, [payment()], cleanup);
+
+    expect(firstResult.hasPreservedPayments).toBe(true);
+    expect(retryResult).toEqual({ hasPreservedPayments: false, failures: [] });
+    expect(teardownFixture.receiptDocuments).toEqual([]);
+    expect(calls).toContain('payments:payment-1');
+  });
+
+  it('does not touch unrelated fixture receipts', async () => {
+    const calls: string[] = [];
+    const unrelatedReceipt = receipt({ paymentId: 'payment-unrelated', documentId: 'document-unrelated' });
+    const teardownFixture = fixture([receipt(), unrelatedReceipt]);
+
+    await teardownPaymentReceipts(teardownFixture, [payment()], operations(calls));
+
+    expect(calls).not.toContain('unlink:document-unrelated');
+    expect(teardownFixture.receiptDocuments).toEqual([unrelatedReceipt]);
+  });
+
+  it('does not touch a receipt whose document is no longer owned by the payment', async () => {
+    const calls: string[] = [];
+    const unownedReceipt = receipt({ documentId: 'document-reassigned' });
+    const teardownFixture = fixture([unownedReceipt]);
+
+    await teardownPaymentReceipts(
+      teardownFixture,
+      [payment({ status: 'SUBMITTED' })],
+      operations(calls),
+    );
+
+    expect(calls).toEqual(['allocations:payment-1', 'payments:payment-1']);
+    expect(teardownFixture.receiptDocuments).toEqual([unownedReceipt]);
+  });
+});


### PR DESCRIPTION
## Root cause
- General seed created DB-only File references in nonexistent `documents` bucket.
- Resident finance E2E could leave DB-only `e2e-payments` File rows after its final run.
- Historical `payments` QA residue is separately classified and is not cleaned by this PR.

## Solution
- Remove invalid demo Document/File fixture chains from general seed.
- Add guaranteed fixture teardown to resident finance E2E.
- Scanner and S3 listing behavior are unchanged.

## Safety
- No migrations, dependencies, storage delete logic, production changes, or historical financial cleanup.

## Validation
- `npm run lint:ci -w apps/api`
- `apps/web/node_modules/.bin/eslint tests/e2e/resident/resident-finance-oldest-first.spec.ts`
- TypeScript check for `apps/api/prisma/seed.ts`
- `git diff --check`
- Full E2E execution blocked locally because `TEST_E2E_PASSWORD` is unavailable.