### PR TITLE
fix(ci): restore MinIO E2E storage bootstrap

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -93,7 +93,7 @@ jobs:
             -e MINIO_ROOT_USER="$S3_ACCESS_KEY" \
             -e MINIO_ROOT_PASSWORD="$S3_SECRET_KEY" \
             -e MINIO_API_CORS_ALLOW_ORIGIN="http://localhost:3000" \
-            minio/minio:latest \
+            quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z \
             server /data --address :9000 --console-address :9001
 
           for i in {1..30}; do
@@ -114,7 +114,7 @@ jobs:
             -e S3_ACCESS_KEY="$S3_ACCESS_KEY" \
             -e S3_SECRET_KEY="$S3_SECRET_KEY" \
             -e S3_BUCKET="$S3_BUCKET" \
-            minio/mc:latest \
+            quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z \
             -lc 'mc alias set local http://127.0.0.1:9000 "$S3_ACCESS_KEY" "$S3_SECRET_KEY" && mc mb --ignore-existing "local/$S3_BUCKET" && mc version enable "local/$S3_BUCKET" && version_info="$(mc version info --json "local/$S3_BUCKET")" && printf "%s\\n" "$version_info" && case "$version_info" in *"Enabled"*) echo "MinIO versioning is enabled" ;; *) echo "MinIO versioning is not enabled" >&2; exit 1 ;; esac'
 
           cors_response="$(curl -sS -D - -o /dev/null \


### PR DESCRIPTION
Closes #249

## Summary

- Replaces unreliable floating Docker Hub MinIO images in the E2E workflow with verified official Quay release tags.
- Preserves the existing S3 bootstrap checks for health, bucket creation, versioning, CORS, and `x-amz-version-id` exposure.
- This is a CI-only maintenance slice. No Phase 3C finance code, schema, migration, staging, production, or merge changes are included.

## Images

| Component | Image |
|---|---|
| MinIO server | `quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z` |
| MinIO client | `quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z` |

Both images were pulled successfully from Quay and validated locally with the existing bootstrap behavior.

## Validation

- [x] Server image pull: PASS
- [x] `mc` image pull: PASS
- [x] MinIO health endpoint: PASS
- [x] Bucket creation: PASS
- [x] Versioning enable and verification: PASS
- [x] Required CORS: PASS
- [x] `x-amz-version-id` exposure: PASS
- [x] `git diff --check`: PASS
- [ ] Full GitHub Actions E2E: pending on this PR
- [ ] CI Build/Test Gate: pending on this PR
- [ ] Fresh Codex review: pending on this PR

## Constraints

- No Phase 3C finance code changes.
- No schema or migration changes.
- No staging or production access.
- Merge is not authorized by this PR.
